### PR TITLE
chore: release v0.2.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **What this is**: A research knowledge graph runtime. Typed entities, closed edge ontology,
 hybrid search, GQL/SPARQL queries — all in a single 7.7MB Rust binary over MCP stdio.
 
-**v0.2.3** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
+**v0.2.8** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
 
 ---
 

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive/cli",
-  "version": "0.2.5",
+  "version": "0.2.8",
   "description": "khive — research knowledge graph CLI",
   "license": "Apache-2.0",
   "tasks": {

--- a/cli/version.ts
+++ b/cli/version.ts
@@ -1,3 +1,3 @@
-export const CLI_VERSION = "0.2.6";
+export const CLI_VERSION = "0.2.8";
 export const KG_ARCHIVE_FORMAT = "khive-kg";
 export const KG_ARCHIVE_VERSION = "0.1";

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -39,7 +39,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.8"
 edition = "2021"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 
 [dependencies]
-khive-score = { version = "0.2.5", path = "../khive-score" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "SQLite storage backend: entities, edges, notes, events, FTS5, sqlite-vec vectors."
 
 [dependencies]
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -31,8 +31,8 @@ sqlite-vec = { version = "0.1.9", optional = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -17,10 +17,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.2.5", path = "../khive-score" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic scoring"
 
 [dependencies]
-khive-score = { version = "0.2.5", path = "../khive-score" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -12,11 +12,11 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.2.5", path = "../khive-gate" }
+khive-gate = { version = "0.2.8", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 quantized two-phase search"
 
 [dependencies]
-khive-score = { version = "0.2.6", path = "../khive-score" }
-khive-types = { version = "0.2.6", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.2.6", path = "../khive-fold", optional = true }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.2.8", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 description = "khive stdio MCP server — the only user-facing Rust binary"
 
 [dependencies]
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-request = { version = "0.2.5", path = "../khive-request" }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.2.5", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.2.5", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.2.5", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.2.5", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.2.5", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.2.5", path = "../khive-pack-knowledge" }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-request = { version = "0.2.8", path = "../khive-request" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.2.8", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.2.8", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.2.8", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.2.8", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.2.8", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.2.8", path = "../khive-pack-knowledge" }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
 tokio = { workspace = true }
@@ -35,11 +35,11 @@ async-trait = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
-khive-types = { version = "0.2.5", path = "../khive-types" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
 async-trait = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.2.5", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.2.8", path = "../khive-pack-knowledge" }
 
 [[bin]]
 name = "khive-mcp"

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "khive-merge"
-version = "0.2.6"
+version = "0.2.8"
 edition = "2021"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.2.6", path = "../khive-runtime" }
-khive-storage = { version = "0.2.6", path = "../khive-storage" }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "Brain pack — profile-oriented orchestration via Fold + Objective (ADR-032)"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-fold = { version = "0.2.5", path = "../khive-fold" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-fold = { version = "0.2.8", path = "../khive-fold" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -26,4 +26,4 @@ rand_distr = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "Communication pack — inter-agent messaging (send, inbox, read, reply, thread) (ADR-040)"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "GTD verb pack — task lifecycle (assign/next/complete/transition) over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search for research knowledge graphs"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-query = { version = "0.2.5", path = "../khive-query" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-query = { version = "0.2.8", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retrieval, concept registration"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-fold = { version = "0.2.5", path = "../khive-fold" }
-khive-fusion = { version = "0.2.5", path = "../khive-fusion" }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-vamana = { version = "0.2.5", path = "../khive-vamana" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-fold = { version = "0.2.8", path = "../khive-fold" }
+khive-fusion = { version = "0.2.8", path = "../khive-fusion" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-vamana = { version = "0.2.8", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -28,8 +28,8 @@ tracing = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 description = "Memory verb pack — remember/recall semantics with decay-aware ranking"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-fusion = { version = "0.2.5", path = "../khive-fusion" }
-khive-retrieval = { version = "0.2.5", path = "../khive-retrieval" }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-pack-brain = { version = "0.2.5", path = "../khive-pack-brain" }
-khive-vamana = { version = "0.2.5", path = "../khive-vamana" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-fusion = { version = "0.2.8", path = "../khive-fusion" }
+khive-retrieval = { version = "0.2.8", path = "../khive-retrieval" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-pack-brain = { version = "0.2.8", path = "../khive-pack-brain" }
+khive-vamana = { version = "0.2.8", path = "../khive-vamana" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -31,8 +31,8 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.2.5", path = "../khive-db" }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-db = { version = "0.2.8", path = "../khive-db" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "Schedule pack — time-triggered intent storage (remind, schedule, agenda, cancel) (ADR-040)"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-request = { version = "0.2.5", path = "../khive-request" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-request = { version = "0.2.8", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "GQL and SPARQL parsers with SQL compiler for knowledge graph queries."
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-encoder) with deterministic scoring"
 
 [dependencies]
-khive-hnsw    = { version = "0.2.5", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.2.5", path = "../khive-bm25" }
-khive-fusion  = { version = "0.2.5", path = "../khive-fusion" }
-khive-score   = { version = "0.2.5", path = "../khive-score" }
-khive-types   = { version = "0.2.5", path = "../khive-types" }
-khive-fold    = { version = "0.2.5", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.2.5", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.2.5", path = "../khive-db" }
-khive-gate    = { version = "0.2.5", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.2.8", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.2.8", path = "../khive-bm25" }
+khive-fusion  = { version = "0.2.8", path = "../khive-fusion" }
+khive-score   = { version = "0.2.8", path = "../khive-score" }
+khive-types   = { version = "0.2.8", path = "../khive-types" }
+khive-fold    = { version = "0.2.8", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.2.8", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.2.8", path = "../khive-db" }
+khive-gate    = { version = "0.2.8", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -60,8 +60,8 @@ graph-legacy = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-fusion = { version = "0.2.5", path = "../khive-fusion" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-fusion = { version = "0.2.8", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -11,14 +11,14 @@ categories.workspace = true
 description = "Composable Service API: entity/note CRUD, graph traversal, hybrid search, curation."
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-fusion = { version = "0.2.5", path = "../khive-fusion" }
-khive-fold = { version = "0.2.5", path = "../khive-fold" }
-khive-db = { version = "0.2.5", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.2.5", path = "../khive-query" }
-khive-gate = { version = "0.2.5", path = "../khive-gate" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-fusion = { version = "0.2.8", path = "../khive-fusion" }
+khive-fold = { version = "0.2.8", path = "../khive-fold" }
+khive-db = { version = "0.2.8", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.2.8", path = "../khive-query" }
+khive-gate = { version = "0.2.8", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -14,7 +14,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-types = { version = "0.2.5", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-types = { version = "0.2.8", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.2.5", path = "../khive-types" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -9,9 +9,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-types = { version = "0.2.5", path = "../khive-types" }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -25,4 +25,4 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.2.5", path = "../khive-vcs-adapters" }
+khive-vcs-adapters = { version = "0.2.8", path = "../khive-vcs-adapters" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -11,20 +11,20 @@ categories.workspace = true
 description = "khive kernel — admin/management Rust binary (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.2.5", path = "../khive-runtime" }
-khive-score = { version = "0.2.5", path = "../khive-score" }
-khive-db = { version = "0.2.5", path = "../khive-db" }
-khive-storage = { version = "0.2.5", path = "../khive-storage" }
-khive-types = { version = "0.2.5", path = "../khive-types" }
-khive-vcs = { version = "0.2.5", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.2.5", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.2.5", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.2.5", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.2.5", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.2.5", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.2.5", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.2.5", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.2.5", path = "../khive-pack-knowledge" }
+khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-score = { version = "0.2.8", path = "../khive-score" }
+khive-db = { version = "0.2.8", path = "../khive-db" }
+khive-storage = { version = "0.2.8", path = "../khive-storage" }
+khive-types = { version = "0.2.8", path = "../khive-types" }
+khive-vcs = { version = "0.2.8", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.2.8", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.2.8", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.2.8", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.2.8", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.2.8", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.2.8", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.2.8", path = "../khive-pack-knowledge" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/marketplace/brain/.claude-plugin/plugin.json
+++ b/marketplace/brain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brain",
   "description": "Bayesian adaptive tuning for khive — profile-oriented auto-tuning of recall weights. Inspect current posteriors, emit explicit feedback, and manage profiles that shape how memory recall is scored.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/comm/.claude-plugin/plugin.json
+++ b/marketplace/comm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "comm",
   "description": "Inter-agent messaging for khive — send messages, check inbox, reply in threads, and view conversation history.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/gtd/.claude-plugin/plugin.json
+++ b/marketplace/gtd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtd",
   "description": "GTD-style task lifecycle for AI agents — assign, next, complete, transition. Tasks live alongside your knowledge graph; `search(kind=\"note\", ...)` surfaces them like any other note.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/kg/.claude-plugin/plugin.json
+++ b/marketplace/kg/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kg",
   "description": "Persistent knowledge graph for AI agents — typed entities, closed edge ontology, hybrid search, GQL queries.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/knowledge/.claude-plugin/plugin.json
+++ b/marketplace/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge",
   "description": "Research concept management for AI agents — register concepts, record provenance, and browse by domain on top of the kg substrate.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/memory/.claude-plugin/plugin.json
+++ b/marketplace/memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memory",
   "description": "Persistent agent memory for khive — remember durable context and recall it with decay-aware ranking.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/schedule/.claude-plugin/plugin.json
+++ b/marketplace/schedule/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "schedule",
   "description": "Time-based scheduling for khive — set reminders, schedule future verb dispatches, view agenda, and cancel events.",
-  "version": "0.2.2",
+  "version": "0.2.8",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/npm/cli-alias/package.json
+++ b/npm/cli-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/cli",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "Alias for the khive package — research knowledge graph runtime",
   "license": "Apache-2.0",
   "repository": {
@@ -8,7 +8,7 @@
     "url": "https://github.com/ohdearquant/khive"
   },
   "dependencies": {
-    "khive": "0.2.6"
+    "khive": "0.2.8"
   },
   "bin": {
     "khive": "./node_modules/khive/bin/khive",

--- a/npm/kernel-darwin-arm64/package.json
+++ b/npm/kernel-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-darwin-arm64",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for macOS Apple Silicon (arm64)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-darwin-x64/package.json
+++ b/npm/kernel-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-darwin-x64",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for macOS Intel (x64)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-arm64/package.json
+++ b/npm/kernel-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-arm64",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for Linux ARM64 glibc",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-x64-gnu/package.json
+++ b/npm/kernel-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-x64-gnu",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for Linux x86_64 glibc",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-linux-x64-musl/package.json
+++ b/npm/kernel-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-linux-x64-musl",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for Linux x86_64 musl (Alpine etc.)",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/kernel-win32-x64/package.json
+++ b/npm/kernel-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/kernel-win32-x64",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "khive Rust binaries for Windows x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "description": "Research knowledge graph CLI — git-native KG versioning",
   "license": "Apache-2.0",
   "repository": {
@@ -36,11 +36,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.2.6",
-    "@khive-ai/kernel-darwin-x64": "0.2.6",
-    "@khive-ai/kernel-linux-x64-gnu": "0.2.6",
-    "@khive-ai/kernel-linux-x64-musl": "0.2.6",
-    "@khive-ai/kernel-linux-arm64": "0.2.6",
-    "@khive-ai/kernel-win32-x64": "0.2.6"
+    "@khive-ai/kernel-darwin-arm64": "0.2.8",
+    "@khive-ai/kernel-darwin-x64": "0.2.8",
+    "@khive-ai/kernel-linux-x64-gnu": "0.2.8",
+    "@khive-ai/kernel-linux-x64-musl": "0.2.8",
+    "@khive-ai/kernel-linux-arm64": "0.2.8",
+    "@khive-ai/kernel-win32-x64": "0.2.8"
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -46,6 +46,7 @@ CRATES=(
     khive-score
     khive-vamana
     khive-fold
+    khive-text
     khive-storage
     khive-bm25
     khive-fusion


### PR DESCRIPTION
## Summary
- Bump all versions to 0.2.8 across workspace, 29 crate deps, npm, Deno CLI, marketplace plugins
- Add khive-text to publish script
- All 28 crates published to crates.io