### PR TITLE
fix: input validation guards and pack hardening

### DIFF
--- a/cli/tests/golden/help_toplevel.txt
+++ b/cli/tests/golden/help_toplevel.txt
@@ -1,4 +1,4 @@
-khive 0.2.6 — research knowledge graph CLI
+khive 0.2.8 — research knowledge graph CLI
 
 Usage:
   khive mcp [flags]         Start the MCP stdio server (auto-spawns daemon)

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -459,6 +459,24 @@ impl EntityStore for SqlEntityStore {
         .await
     }
 
+    async fn get_entity_including_deleted(&self, id: Uuid) -> Result<Option<Entity>, StorageError> {
+        let id_str = id.to_string();
+
+        self.with_reader("get_entity_including_deleted", move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
+                 created_at, updated_at, deleted_at, merged_into, merge_event_id \
+                 FROM entities WHERE id = ?1",
+            )?;
+            let mut rows = stmt.query(rusqlite::params![id_str])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_entity(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
     async fn count_entities(
         &self,
         namespace: &str,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -174,7 +174,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "signal",
                 param_type: "string",
                 required: true,
-                description: "Feedback signal: \"useful\" | \"not_useful\" | \"wrong\".",
+                description: "Feedback signal: \"useful\" | \"not_useful\" | \"wrong\" | \"explicit_positive\" | \"explicit_negative\" | \"implicit_positive\" | \"implicit_negative\" | \"correction\".",
             },
             khive_types::ParamDef {
                 name: "served_by_profile_id",

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -84,7 +84,11 @@ pub(crate) async fn handle_inbox(
     params: Value,
 ) -> Result<Value, RuntimeError> {
     let p: InboxParams = deser(params)?;
-    let limit = p.limit.unwrap_or(20).clamp(1, 200) as usize;
+    let raw_limit = p.limit.unwrap_or(20);
+    if raw_limit == 0 {
+        return Ok(json!({ "messages": [], "count": 0 }));
+    }
+    let limit = raw_limit.clamp(1, 200) as usize;
 
     let status = match p.status.as_deref().unwrap_or("unread") {
         s @ ("unread" | "read" | "all") => s,

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -84,12 +84,21 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
         description: "Fetch any record by UUID",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
-        params: &[ParamDef {
-            name: "id",
-            param_type: "uuid",
-            required: true,
-            description: "UUID of the entity, note, or edge to fetch.",
-        }],
+        params: &[
+            ParamDef {
+                name: "id",
+                param_type: "uuid",
+                required: true,
+                description: "UUID of the entity, note, or edge to fetch.",
+            },
+            ParamDef {
+                name: "include_deleted",
+                param_type: "bool",
+                required: false,
+                description:
+                    "If true, return soft-deleted entities (with deleted_at populated). Default false.",
+            },
+        ],
     },
     // Assertive: retrieves and presents filtered records
     HandlerDef {

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -96,7 +96,9 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
                 param_type: "bool",
                 required: false,
                 description:
-                    "If true, return soft-deleted entities (with deleted_at populated). Default false.",
+                    "If true, return soft-deleted entities (with deleted_at populated). Default false. \
+                     Requires a full UUID — short prefix resolution filters deleted records; \
+                     the delete response always returns the full UUID for this purpose.",
             },
         ],
     },

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -209,6 +209,7 @@ pub(crate) struct CreateParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetParams {
     pub(crate) id: String,
+    pub(crate) include_deleted: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -156,6 +156,9 @@ impl KgPack {
                 let name = p.name.ok_or_else(|| {
                     RuntimeError::InvalidInput("kind=entity requires 'name'".into())
                 })?;
+                if name.trim().is_empty() {
+                    return Err(RuntimeError::InvalidInput("name must not be empty".into()));
+                }
                 let tags = p.tags.unwrap_or_default();
                 let validated_type = validate_entity_type(&canonical, p.entity_type.as_deref())?;
                 let entity = self

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -35,8 +35,30 @@ impl KgPack {
             return Err(RuntimeError::NotFound(format!("not found: {}", p.id)));
         };
 
-        if let Ok(entity) = self.runtime.get_entity(graph_token, id).await {
-            return flatten_get_result("entity", normalize_entity_timestamps(to_json(&entity)?));
+        let include_deleted = p.include_deleted.unwrap_or(false);
+
+        match self.runtime.get_entity(graph_token, id).await {
+            Ok(entity) => {
+                return flatten_get_result(
+                    "entity",
+                    normalize_entity_timestamps(to_json(&entity)?),
+                );
+            }
+            Err(RuntimeError::NotFound(_) | RuntimeError::NamespaceMismatch { .. }) => {
+                if include_deleted {
+                    if let Some(deleted) = self
+                        .runtime
+                        .get_entity_including_deleted(graph_token, id)
+                        .await?
+                    {
+                        return flatten_get_result(
+                            "entity",
+                            normalize_entity_timestamps(to_json(&deleted)?),
+                        );
+                    }
+                }
+            }
+            Err(e) => return Err(e),
         }
 
         if let Some(note) = self

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -156,11 +156,6 @@ impl KgPack {
         })?;
         let source = resolve_uuid_async(&source_id_str, &self.runtime, token).await?;
         let target = resolve_uuid_async(&target_id_str, &self.runtime, token).await?;
-        if source == target {
-            return Err(RuntimeError::InvalidInput(
-                "self-loop edges are not allowed: source_id and target_id must be different".into(),
-            ));
-        }
         let weight = validate_weight(p.weight)?;
         let relation = parse_relation(&relation_str)?;
         let metadata = merge_entry_metadata(p.metadata, p.dependency_kind)?;

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -156,6 +156,11 @@ impl KgPack {
         })?;
         let source = resolve_uuid_async(&source_id_str, &self.runtime, token).await?;
         let target = resolve_uuid_async(&target_id_str, &self.runtime, token).await?;
+        if source == target {
+            return Err(RuntimeError::InvalidInput(
+                "self-loop edges are not allowed: source_id and target_id must be different".into(),
+            ));
+        }
         let weight = validate_weight(p.weight)?;
         let relation = parse_relation(&relation_str)?;
         let metadata = merge_entry_metadata(p.metadata, p.dependency_kind)?;

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -2543,6 +2543,67 @@ async fn recall_tags_filter_any_all_and_no_filter() {
     );
 }
 
+/// B7: raw_score must be present (possibly null) in every result returned by
+/// memory.recall, including when tag filters narrow the result set with tag_mode="all".
+/// The field is null for text-only hits (no vector index) and a float for vector hits.
+#[tokio::test]
+async fn recall_raw_score_field_always_present_with_tag_filter() {
+    let registry = make_registry(make_runtime());
+
+    registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "raw score presence check alpha beta gamma delta epsilon",
+                "salience": 0.9,
+                "tags": ["team:alpha", "project:khive"]
+            }),
+        )
+        .await
+        .expect("remember tagged memory");
+
+    registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "raw score presence check alpha beta gamma delta epsilon",
+                "salience": 0.9,
+                "tags": ["team:alpha", "project:khive"]
+            }),
+        )
+        .await
+        .expect("remember second tagged memory");
+
+    for tag_mode in &["any", "all"] {
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                json!({
+                    "query": "raw score presence check alpha beta gamma",
+                    "limit": 20,
+                    "tags": ["team:alpha", "project:khive"],
+                    "tag_mode": tag_mode
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("recall tag_mode={tag_mode} failed: {e}"));
+
+        let hits = result.as_array().expect("results must be an array");
+        assert!(
+            !hits.is_empty(),
+            "tag_mode={tag_mode}: expected at least one result"
+        );
+        for (i, hit) in hits.iter().enumerate() {
+            let obj = hit.as_object().expect("each hit must be a JSON object");
+            assert!(
+                obj.contains_key("raw_score"),
+                "tag_mode={tag_mode} result[{i}] missing raw_score field; got keys: {:?}",
+                obj.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+}
+
 /// #515 metadata: memory.recall handler must advertise tags and tag_mode params.
 #[test]
 fn recall_handler_metadata_advertises_tags_and_tag_mode() {

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{micros_to_iso, KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{micros_to_iso, KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::note::{FilterOp, Note, NoteFilter, PropertyFilter, SortDir};
 use khive_storage::types::{PageRequest, SqlValue};
 
@@ -149,15 +149,15 @@ fn validate_repeat(repeat: &str) -> Result<(), RuntimeError> {
 /// Validate that `action` is parseable DSL via `khive_request::parse_request`.
 ///
 /// This catches garbage like `"x"` or `"bogus-not-a-valid-verb()"` at write
-/// time rather than at trigger time, when nobody is watching.
-fn validate_action(action: &str) -> Result<(), RuntimeError> {
+/// time rather than at trigger time, when nobody is watching. Returns the
+/// parsed request so callers can inspect the verb names without re-parsing.
+fn validate_action(action: &str) -> Result<khive_request::ParsedRequest, RuntimeError> {
     khive_request::parse_request(action).map_err(|e| {
         RuntimeError::InvalidInput(format!(
             "schedule.action: invalid DSL ({e}); \
              provide a valid verb call (e.g. \"remind(content=\\\"hello\\\")\")"
         ))
-    })?;
-    Ok(())
+    })
 }
 
 // ── param structs ────────────────────────────────────────────────────────────
@@ -265,6 +265,7 @@ pub(crate) async fn handle_remind(
 pub(crate) async fn handle_schedule(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
+    registry: &VerbRegistry,
     params: Value,
 ) -> Result<Value, RuntimeError> {
     let p: ScheduleParams = deser(params)?;
@@ -280,7 +281,19 @@ pub(crate) async fn handle_schedule(
     }
     // Validate DSL parseability at write time (C4). Garbage like "x" or
     // "bogus-not-a-valid-verb()" is rejected before it enters storage.
-    validate_action(p.action.trim())?;
+    let parsed = validate_action(p.action.trim())?;
+    // Validate that each verb in the action string is registered. This catches
+    // nonexistent verbs at schedule-creation time rather than at trigger time
+    // when nobody is watching.
+    for op in &parsed.ops {
+        registry.describe_verb(&op.tool).map_err(|_| {
+            RuntimeError::InvalidInput(format!(
+                "schedule.action: verb {:?} is not registered; \
+                 provide a valid verb call (e.g. \"remind(content=\\\"hello\\\")\")",
+                op.tool
+            ))
+        })?;
+    }
 
     // Validate RFC 3339 and reject past timestamps (C3).
     // Preserve the caller's original string as `trigger_at` so the

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -285,14 +285,20 @@ pub(crate) async fn handle_schedule(
     // Validate that each verb in the action string is registered. This catches
     // nonexistent verbs at schedule-creation time rather than at trigger time
     // when nobody is watching.
+    //
+    // The DSL allows bare verb names (e.g. "remind(...)") as shorthand for
+    // pack-prefixed verbs (e.g. "schedule.remind(...)"). Try the bare form
+    // first, then the "schedule.{verb}" form, so both are accepted.
     for op in &parsed.ops {
-        registry.describe_verb(&op.tool).map_err(|_| {
-            RuntimeError::InvalidInput(format!(
+        let qualified = format!("schedule.{}", op.tool);
+        if registry.describe_verb(&op.tool).is_err() && registry.describe_verb(&qualified).is_err()
+        {
+            return Err(RuntimeError::InvalidInput(format!(
                 "schedule.action: verb {:?} is not registered; \
-                 provide a valid verb call (e.g. \"remind(content=\\\"hello\\\")\")",
+                 provide a valid verb call (e.g. \"schedule.remind(content=\\\"hello\\\")\")",
                 op.tool
-            ))
-        })?;
+            )));
+        }
     }
 
     // Validate RFC 3339 and reject past timestamps (C3).

--- a/crates/khive-pack-schedule/src/pack.rs
+++ b/crates/khive-pack-schedule/src/pack.rs
@@ -87,12 +87,14 @@ impl PackRuntime for SchedulePack {
         &self,
         verb: &str,
         params: Value,
-        _registry: &VerbRegistry,
+        registry: &VerbRegistry,
         token: &NamespaceToken,
     ) -> Result<Value, RuntimeError> {
         match verb {
             "schedule.remind" => handlers::handle_remind(self.runtime(), token, params).await,
-            "schedule.schedule" => handlers::handle_schedule(self.runtime(), token, params).await,
+            "schedule.schedule" => {
+                handlers::handle_schedule(self.runtime(), token, registry, params).await
+            }
             "schedule.agenda" => handlers::handle_agenda(self.runtime(), token, params).await,
             "schedule.cancel" => handlers::handle_cancel(self.runtime(), token, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -588,6 +588,11 @@ impl KhiveRuntime {
         target_id: Uuid,
         relation: EdgeRelation,
     ) -> RuntimeResult<()> {
+        if source_id == target_id {
+            return Err(RuntimeError::InvalidInput(
+                "self-loop edges are not allowed: source_id and target_id must be different".into(),
+            ));
+        }
         if relation == EdgeRelation::Annotates {
             // Source must be a note in namespace.
             match self.resolve(token, source_id).await? {
@@ -3661,7 +3666,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn link_phantom_self_loop_returns_not_found() {
+    async fn link_phantom_self_loop_returns_invalid_input() {
         let rt = rt();
         let tok = NamespaceToken::local();
         let phantom = Uuid::new_v4();
@@ -3670,13 +3675,13 @@ mod tests {
             .link(&tok, phantom, phantom, EdgeRelation::Extends, 1.0, None)
             .await;
         match result {
-            Err(RuntimeError::NotFound(msg)) => {
+            Err(RuntimeError::InvalidInput(msg)) => {
                 assert!(
-                    msg.contains("source"),
-                    "self-loop must fail on source first: {msg}"
+                    msg.contains("self-loop"),
+                    "self-loop must be rejected with self-loop message: {msg}"
                 );
             }
-            other => panic!("expected NotFound for phantom self-loop, got {other:?}"),
+            other => panic!("expected InvalidInput for self-loop, got {other:?}"),
         }
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -391,6 +391,31 @@ impl KhiveRuntime {
         Ok(entity)
     }
 
+    /// Retrieve an entity by ID including soft-deleted rows, enforcing namespace isolation.
+    ///
+    /// Returns `Ok(Some(entity))` when the entity exists in the caller's namespace
+    /// regardless of `deleted_at`. Returns `Ok(None)` when the UUID was never created
+    /// or belongs to a different namespace. Callers use this to distinguish
+    /// "soft-deleted" from "never existed".
+    pub async fn get_entity_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<Entity>> {
+        let entity = match self
+            .entities(token)?
+            .get_entity_including_deleted(id)
+            .await?
+        {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+        if entity.namespace != token.namespace().as_str() {
+            return Ok(None);
+        }
+        Ok(Some(entity))
+    }
+
     /// Fetch multiple entities by ID, returning only those that exist in the
     /// caller's namespace.  Missing or namespace-mismatched IDs are silently
     /// omitted so that batch lookups don't abort on a single stale reference.

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -110,4 +110,9 @@ pub trait EntityStore: Send + Sync + 'static {
     ) -> StorageResult<Page<Entity>>;
     /// Count entities in a namespace matching the given filter.
     async fn count_entities(&self, namespace: &str, filter: EntityFilter) -> StorageResult<u64>;
+    /// Fetch an entity by UUID regardless of soft-deletion state.
+    ///
+    /// Returns the entity row even when `deleted_at` is set. Callers use this
+    /// to distinguish "soft-deleted" from "never existed".
+    async fn get_entity_including_deleted(&self, id: Uuid) -> StorageResult<Option<Entity>>;
 }


### PR DESCRIPTION
## Summary
- Reject empty/whitespace entity names on `create`
- Reject self-loop edges where `source_id == target_id` on `link`
- Add `include_deleted` flag to `get` for soft-deleted entity inspection
- Expand `brain.feedback` help text from 3 → 8 signal values
- Validate scheduled action verbs exist in registry at creation time
- Fix `comm.inbox(limit=0)` returning 1 message instead of 0
- Add `raw_score` regression test for tag-filtered `memory.recall`
- Add `get_entity_including_deleted` to EntityStore trait + runtime

## Test plan
- [x] `create(kind="concept", name="")` → `"name must not be empty"`
- [x] `link(source_id=X, target_id=X)` → `"self-loop edges are not allowed"`
- [x] `get(id=X)` after delete → "not found"; `get(id=X, include_deleted=true)` → returns entity with deleted_at
- [x] `brain.feedback(help=true)` → lists all 8 signals
- [x] `schedule.schedule(action="fake_verb()")` → rejected
- [x] `comm.inbox(limit=0)` → `{messages: [], count: 0}`
- [x] cargo check + clippy clean