### PR TITLE
docs(marketplace): update all pack docs to match actual verb behavior

### DIFF
--- a/cli/tests/golden/help_toplevel.txt
+++ b/cli/tests/golden/help_toplevel.txt
@@ -1,4 +1,4 @@
-khive 0.2.6 — research knowledge graph CLI
+khive 0.2.8 — research knowledge graph CLI
 
 Usage:
   khive mcp [flags]         Start the MCP stdio server (auto-spawns daemon)

--- a/marketplace/brain/README.md
+++ b/marketplace/brain/README.md
@@ -49,13 +49,13 @@ Default is `agent` (token-efficient) for MCP callers.
 | `brain.activate(profile_id)`                               | Move a profile to Active — starts the live update loop.         |
 | `brain.deactivate(profile_id)`                             | Move a profile to Inactive — stops live updates, retains state. |
 | `brain.archive(profile_id)`                                | Move a profile to Archived — read-only, audit-retained.         |
-| `brain.feedback(target_id, signal, served_by_profile_id?)` | Emit a FeedbackExplicit event and update posteriors.            |
+| `brain.feedback(target_id, signal, served_by_profile_id?, section_signals?)` | Emit a FeedbackExplicit event and update posteriors. |
 
 ### Write binding / declaration
 
 | Verb                                                                    | What it does                                              |
 | ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| `brain.create_profile(name, description?, consumer_kind?)`              | Create a new Bayesian profile; starts in Inactive state.  |
+| `brain.create_profile(name, description?, consumer_kind?, seed_priors?)` | Create a new Bayesian profile; starts in Inactive state. |
 | `brain.bind(profile_id, actor?, namespace?, consumer_kind?, priority?)` | Write a row in the profile resolution table.              |
 | `brain.unbind(profile_id?, actor?, namespace?, consumer_kind?)`         | Remove rows (at least one filter required).               |
 | `brain.reset(profile_id?)`                                              | Reset posteriors to priors; increments exploration_epoch. |

--- a/marketplace/brain/skills/inspect/SKILL.md
+++ b/marketplace/brain/skills/inspect/SKILL.md
@@ -31,7 +31,7 @@ for each profile.
 Get the full record including the latest state snapshot:
 
 ```
-request(ops="brain.profile(id=\"balanced-recall-v1\")")
+request(ops="brain.profile(profile_id=\"balanced-recall-v1\")")
 ```
 
 The `state_snapshot` field contains the current posterior means and variances for each weight

--- a/marketplace/brain/skills/manage/SKILL.md
+++ b/marketplace/brain/skills/manage/SKILL.md
@@ -67,7 +67,7 @@ request(ops="brain.deactivate(profile_id=\"balanced-recall-v1\")")
 Inspect the frozen state:
 
 ```
-request(ops="brain.profile(id=\"balanced-recall-v1\")")
+request(ops="brain.profile(profile_id=\"balanced-recall-v1\")")
 ```
 
 Reactivate:

--- a/marketplace/brain/skills/profiles/SKILL.md
+++ b/marketplace/brain/skills/profiles/SKILL.md
@@ -16,7 +16,7 @@ applies for a given caller.
 | `brain.profile(profile_id)`                                       | Full profile record with state snapshot.             |
 | `brain.resolve(consumer_kind, actor?, namespace?)`                | Which profile would serve this caller?               |
 | `brain.bindings(profile_id?, actor?, namespace?, consumer_kind?)` | List binding rows, optionally filtered.              |
-| `brain.create_profile(name, description?, consumer_kind?)`        | Create a new Bayesian profile (starts Inactive).     |
+| `brain.create_profile(name, description?, consumer_kind?, seed_priors?)` | Create a new Bayesian profile (starts Inactive). |
 
 ## Workflow
 
@@ -93,7 +93,7 @@ calling `brain.resolve`.
 ### brain.create_profile — create a new profile
 
 Required arg: `name` (alphanumeric and hyphens, e.g. `"my-profile-v1"`). Optional: `description`,
-`consumer_kind` (default `"recall"`).
+`consumer_kind` (default `"recall"`), `seed_priors` (object to override default Beta priors).
 
 ```
 request(ops="brain.create_profile(name=\"my-profile-v1\", consumer_kind=\"recall\")")

--- a/marketplace/brain/skills/tune/SKILL.md
+++ b/marketplace/brain/skills/tune/SKILL.md
@@ -52,10 +52,11 @@ Optional: attribute the feedback to a specific profile (useful when multiple pro
 request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\", served_by_profile_id=\"balanced-recall-v1\")")
 ```
 
-Optional: send per-section signals (object mapping section names to signal strings):
+Optional: send per-section signals (object mapping section names to signal strings). Section signals
+only accept `"useful"`, `"not_useful"`, or `"wrong"` — the top-level signal enum values do not apply here:
 
 ```
-request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\", section_signals={relevance: \"explicit_positive\", salience: \"implicit_negative\"})")
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\", section_signals={relevance: \"useful\", salience: \"not_useful\"})")
 ```
 
 The response includes `emitted: true`, the event ID, and the signal that was recorded.

--- a/marketplace/brain/skills/tune/SKILL.md
+++ b/marketplace/brain/skills/tune/SKILL.md
@@ -13,30 +13,49 @@ drifted and you want to return to the prior.
 ### 1. Emit explicit feedback on a recalled memory
 
 After a `recall` call returns a memory, note its `note_id` from the result. Emit feedback with one
-of three signals: `useful`, `not_useful`, or `wrong`.
+of eight signals:
+
+| Signal | Meaning |
+| --- | --- |
+| `useful` | Memory was relevant and helpful |
+| `not_useful` | Memory was returned but unhelpful |
+| `wrong` | Memory content was incorrect (strongest negative) |
+| `explicit_positive` | Strong positive signal (equivalent to `useful`) |
+| `explicit_negative` | Strong negative signal (equivalent to `not_useful`) |
+| `implicit_positive` | Weak positive signal inferred from agent behavior |
+| `implicit_negative` | Weak negative signal inferred from agent behavior |
+| `correction` | Memory was returned with errors that were corrected |
+
+`target_id` must be the **full UUID** of the memory note — short prefix IDs are not accepted.
 
 Mark a memory as useful:
 
 ```
-request(ops="brain.feedback(target_id=\"<note-uuid>\", signal=\"useful\")")
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\")")
 ```
 
 Mark a memory as not useful:
 
 ```
-request(ops="brain.feedback(target_id=\"<note-uuid>\", signal=\"not_useful\")")
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"not_useful\")")
 ```
 
 Mark a memory as wrong (strongest negative signal):
 
 ```
-request(ops="brain.feedback(target_id=\"<note-uuid>\", signal=\"wrong\")")
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"wrong\")")
 ```
 
 Optional: attribute the feedback to a specific profile (useful when multiple profiles are in play):
 
 ```
-request(ops="brain.feedback(target_id=\"<note-uuid>\", signal=\"useful\", served_by_profile_id=\"balanced-recall-v1\")")
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\", served_by_profile_id=\"balanced-recall-v1\")")
+```
+
+Optional: send per-section signals (object mapping section names to signal strings):
+
+```
+request(ops="brain.feedback(target_id=\"<full-note-uuid>\", signal=\"useful\", section_signals={relevance: \"explicit_positive\", salience: \"implicit_negative\"})")
 ```
 
 The response includes `emitted: true`, the event ID, and the signal that was recorded.
@@ -46,7 +65,7 @@ The response includes `emitted: true`, the event ID, and the signal that was rec
 Inspect the profile to confirm the state snapshot updated:
 
 ```
-request(ops="brain.profile(id=\"balanced-recall-v1\")")
+request(ops="brain.profile(profile_id=\"balanced-recall-v1\")")
 ```
 
 Read the `state_snapshot.balanced_recall` field. Weight means should have shifted toward the
@@ -70,13 +89,13 @@ Reset does not affect profile bindings or lifecycle state.
 ### Feedback loop after a recall session
 
 ```
-request(ops="[brain.feedback(target_id=\"<id-1>\", signal=\"useful\"), brain.feedback(target_id=\"<id-2>\", signal=\"not_useful\")]")
+request(ops="[brain.feedback(target_id=\"<full-uuid-1>\", signal=\"useful\"), brain.feedback(target_id=\"<full-uuid-2>\", signal=\"not_useful\")]")
 ```
 
 ### Verify posterior state before and after reset
 
 ```
-request(ops="brain.profile(id=\"balanced-recall-v1\")")
+request(ops="brain.profile(profile_id=\"balanced-recall-v1\")")
 ```
 
 Record the `exploration_epoch`. Then reset:
@@ -91,8 +110,8 @@ prior (~0.7 for relevance, ~0.2 for salience, ~0.1 for temporal with the default
 
 ## Anti-patterns
 
-- **Emitting feedback on the wrong target.** Use the `note_id` from the recall response, not an
-  entity UUID.
+- **Using a short UUID prefix for `target_id`.** `brain.feedback` requires the full UUID — short
+  prefix IDs are rejected. Use the complete `note_id` from the recall response.
 - **Resetting during an active session.** Reset discards posteriors accumulated during the current
   session. Use it between sessions or after deliberate behavioral experiments.
 - **Over-emitting wrong signal.** A single `wrong` event is sufficient; duplicate signals on the

--- a/marketplace/gtd/README.md
+++ b/marketplace/gtd/README.md
@@ -21,7 +21,7 @@ to verbose JSON — readable prose is a CLI-layer concern, not an MCP-layer one.
 
 | Verb                                                                                                     | What it does                                                                                    |
 | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `gtd.assign(title, priority?, status?, assignee?, due?, start?, end?, depends_on?, tags?, description?)` | Create a task. Defaults: `status=inbox`, `priority=p2`.                                         |
+| `gtd.assign(title, priority?, status?, assignee?, due?, depends_on?, context_entity_id?, tags?)` | Create a task. Defaults: `status=inbox`, `priority=p2`. `depends_on` is an array of UUIDs that creates real `depends_on` graph edges. `context_entity_id` links the task to a KG entity at creation time. |
 | `gtd.next(limit?, assignee?)`                                                                            | Actionable tasks (status in `{next, active}`), sorted by priority (p0 first) then most-recent.  |
 | `gtd.complete(id, result?, status?)`                                                                     | Mark done (or `status="cancelled"`). Records `completed_at`. Terminal — no further transitions. |
 | `gtd.tasks(status?, assignee?, priority?, limit?, offset?)`                                              | Filtered listing.                                                                               |

--- a/marketplace/gtd/skills/capture/SKILL.md
+++ b/marketplace/gtd/skills/capture/SKILL.md
@@ -29,13 +29,7 @@ request(ops="gtd.assign(title=\"<title>\", priority=\"p2\")")
 Default priority is `p2`. Use `p0`/`p1` only if you genuinely want it pushed up in `next` listings.
 `p3` for "nice to have, no pressure".
 
-### 3. Add context if it's not in your head
-
-If you might forget _why_ this matters, add a description:
-
-```
-request(ops="gtd.assign(title=\"<title>\", priority=\"p1\", description=\"<one-sentence why>\")")
-```
+### 3. Add a deadline if it's real
 
 If there's a deadline, set it — but only if it's a real deadline, not aspirational:
 
@@ -70,7 +64,7 @@ Resist:
 | Situation                                               | Verb                                                                                                                                                                   |
 | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | "Can I act on this right now?" — actually start working | `gtd.transition(id=..., status="active")`                                                                                                                              |
-| "I know I can't do this yet, blocked by X"              | `gtd.assign(..., status="waiting")` + describe blocker in `description`                                                                                                |
+| "I know I can't do this yet, blocked by X"              | `gtd.assign(..., status="waiting")` — note the blocker in the title or a `gtd.transition` note later                                                                  |
 | "Maybe someday, not now"                                | `gtd.assign(..., status="someday")`                                                                                                                                    |
 | Need to record several together and link dependencies   | capture the blocker first, then `gtd.assign(..., depends_on=[blocker_full_id])` for the dependent task — the property and the `depends_on` graph edge both get written |
 

--- a/marketplace/gtd/skills/plan/SKILL.md
+++ b/marketplace/gtd/skills/plan/SKILL.md
@@ -95,13 +95,13 @@ request(ops="gtd.transition(id=\"<id>\", status=\"cancelled\", note=\"weekly pla
 If the review reveals work that is not already captured, create concrete tasks immediately:
 
 ```
-request(ops="gtd.assign(title=\"Write release notes for memory plugin\", priority=\"p1\", status=\"next\", description=\"Follow-up from weekly planning\")")
+request(ops="gtd.assign(title=\"Write release notes for memory plugin\", priority=\"p1\", status=\"next\", tags=[\"weekly-plan\"])")
 ```
 
 When delegating, set an assignee:
 
 ```
-request(ops="gtd.assign(title=\"Verify KG agent queue syntax\", assignee=\"critic\", priority=\"p1\", status=\"next\", tags=[\"weekly-plan\",\"verification\"])")
+request(ops="gtd.assign(title=\"Verify KG agent queue syntax\", assignee=\"critic\", priority=\"p1\", status=\"next\", tags=[\"weekly-plan\", \"verification\"])")
 ```
 
 ### 6. Confirm the plan

--- a/marketplace/kg/README.md
+++ b/marketplace/kg/README.md
@@ -50,22 +50,22 @@ request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"LoRA\")")
 request(ops="[search(kind=\"entity\", query=\"LoRA\"), neighbors(node_id=\"<id>\")]")  # parallel batch
 ```
 
-| Verb        | What it does                                |
-| ----------- | ------------------------------------------- |
-| `create`    | Create entities or notes                    |
-| `get`       | Fetch any record by UUID (or 8-char prefix) |
-| `list`      | Browse with filters                         |
-| `update`    | Patch entity, note, or edge fields          |
-| `delete`    | Soft or hard delete                         |
-| `merge`     | Deduplicate two entities                    |
-| `search`    | Hybrid FTS5 + vector search                 |
-| `link`      | Create typed directed edges                 |
-| `neighbors` | Immediate graph neighbors                   |
-| `traverse`  | Multi-hop BFS                               |
-| `query`     | GQL/SPARQL pattern matching                 |
-| `propose`   | Create an event-sourced change proposal     |
-| `review`    | Review a proposal                           |
-| `withdraw`  | Withdraw an open proposal                   |
+| Verb        | Key params                                                                                                          | What it does                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `create`    | `kind` (req), `name?`, `entity_kind?`, `note_kind?`, `content?`, `description?`, `tags?`, `properties?`, `annotates?` | Create entities or notes                    |
+| `get`       | `id` (req, UUID)                                                                                                    | Fetch any record by UUID                    |
+| `list`      | `kind` (req), `limit?`, `offset?`, `entity_kind?`, `tags?`, `note_kind?`, `source_id?`, `target_id?`, `relations?`, `min_weight?`, `max_weight?`, `direction?` | Browse with filters                         |
+| `update`    | `id` (req), `kind?`, `name?`, `description?`, `content?`, `relation?`, `weight?`, `properties?`, `tags?`           | Patch entity, note, or edge fields          |
+| `delete`    | `id` (req), `kind?`, `hard?`                                                                                        | Soft (default) or hard delete               |
+| `merge`     | `into_id` (req), `from_id` (req)                                                                                    | Deduplicate two entities                    |
+| `search`    | `kind` (req), `query` (req), `limit?`, `entity_kind?`, `note_kind?`, `tags?`, `properties?`, `include_superseded?`, `min_score?` | Hybrid FTS5 + vector search                 |
+| `link`      | `source_id` (req), `target_id` (req), `relation` (req), `weight?`                                                  | Create typed directed edge (self-loops rejected) |
+| `neighbors` | `node_id` (req), `direction?` (default `"out"`), `relations?`, `min_weight?`                                        | Immediate graph neighbors                   |
+| `traverse`  | `roots` (req, array), `max_depth?` (default 3), `relations?`, `direction?`                                          | Multi-hop BFS                               |
+| `query`     | `query` (req, GQL string), `limit?` (default 500, cap 10000)                                                        | GQL/SPARQL pattern matching                 |
+| `propose`   | `title` (req), `description` (req), `changeset` (req), `reviewers?`, `expiry?`, `parent_id?`                        | Create an event-sourced change proposal     |
+| `review`    | `proposal_id` (req), `decision` (req), `comment?`                                                                   | Review a proposal                           |
+| `withdraw`  | `proposal_id` (req), `rationale?`                                                                                   | Withdraw an open proposal                   |
 
 **Proposal lifecycle**: `open → approved → applying → applied` (happy path). Terminal states:
 `rejected`, `withdrawn`. `applying` is a transient in-flight state; `withdraw` is rejected while the

--- a/marketplace/kg/README.md
+++ b/marketplace/kg/README.md
@@ -41,7 +41,7 @@ Or add to your project's `.mcp.json`:
 
 ## What You Get
 
-### 1 MCP tool (`request`), 14 verbs inside it
+### 1 MCP tool (`request`), 16 verbs inside it
 
 The MCP server exposes a single tool, `request`, that takes the verb call as a string:
 
@@ -52,20 +52,22 @@ request(ops="[search(kind=\"entity\", query=\"LoRA\"), neighbors(node_id=\"<id>\
 
 | Verb        | Key params                                                                                                          | What it does                                |
 | ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `create`    | `kind` (req), `name?`, `entity_kind?`, `note_kind?`, `content?`, `description?`, `tags?`, `properties?`, `annotates?` | Create entities or notes                    |
-| `get`       | `id` (req, UUID)                                                                                                    | Fetch any record by UUID                    |
-| `list`      | `kind` (req), `limit?`, `offset?`, `entity_kind?`, `tags?`, `note_kind?`, `source_id?`, `target_id?`, `relations?`, `min_weight?`, `max_weight?`, `direction?` | Browse with filters                         |
-| `update`    | `id` (req), `kind?`, `name?`, `description?`, `content?`, `relation?`, `weight?`, `properties?`, `tags?`           | Patch entity, note, or edge fields          |
+| `create`    | `kind` (req), `name?`, `entity_kind?`, `entity_type?`, `note_kind?`, `content?`, `description?`, `tags?`, `properties?`, `annotates?` | Create entities or notes                    |
+| `get`       | `id` (req, UUID), `include_deleted?`                                                                                | Fetch any record by UUID                    |
+| `list`      | `kind` (req), `limit?`, `offset?`, `entity_kind?`, `entity_type?`, `tags?`, `note_kind?`, `source_id?`, `target_id?`, `relations?`, `min_weight?`, `max_weight?`, `direction?`, `event_kind?`, `event_kinds?` | Browse with filters                         |
+| `update`    | `id` (req), `kind?`, `name?`, `description?`, `content?`, `salience?`, `decay_factor?`, `relation?`, `weight?`, `properties?`, `tags?` | Patch entity, note, or edge fields          |
 | `delete`    | `id` (req), `kind?`, `hard?`                                                                                        | Soft (default) or hard delete               |
 | `merge`     | `into_id` (req), `from_id` (req)                                                                                    | Deduplicate two entities                    |
-| `search`    | `kind` (req), `query` (req), `limit?`, `entity_kind?`, `note_kind?`, `tags?`, `properties?`, `include_superseded?`, `min_score?` | Hybrid FTS5 + vector search                 |
+| `search`    | `kind` (req), `query` (req), `limit?`, `entity_kind?`, `entity_type?`, `note_kind?`, `tags?`, `properties?`, `include_superseded?`, `min_score?` | Hybrid FTS5 + vector search                 |
 | `link`      | `source_id` (req), `target_id` (req), `relation` (req), `weight?`                                                  | Create typed directed edge (self-loops rejected) |
-| `neighbors` | `node_id` (req), `direction?` (default `"out"`), `relations?`, `min_weight?`                                        | Immediate graph neighbors                   |
+| `neighbors` | `node_id` (req), `direction?` (default `"both"`), `relations?`, `min_weight?`                                       | Immediate graph neighbors                   |
 | `traverse`  | `roots` (req, array), `max_depth?` (default 3), `relations?`, `direction?`                                          | Multi-hop BFS                               |
 | `query`     | `query` (req, GQL string), `limit?` (default 500, cap 10000)                                                        | GQL/SPARQL pattern matching                 |
 | `propose`   | `title` (req), `description` (req), `changeset` (req), `reviewers?`, `expiry?`, `parent_id?`                        | Create an event-sourced change proposal     |
 | `review`    | `proposal_id` (req), `decision` (req), `comment?`                                                                   | Review a proposal                           |
 | `withdraw`  | `proposal_id` (req), `rationale?`                                                                                   | Withdraw an open proposal                   |
+| `stats`     | (none)                                                                                                              | Aggregate entity, edge, and note counts     |
+| `verbs`     | `category?`, `pack?`                                                                                                | List all registered MCP-callable verbs      |
 
 **Proposal lifecycle**: `open → approved → applying → applied` (happy path). Terminal states:
 `rejected`, `withdrawn`. `applying` is a transient in-flight state; `withdraw` is rejected while the

--- a/marketplace/kg/agents/digester.md
+++ b/marketplace/kg/agents/digester.md
@@ -157,7 +157,7 @@ gtd.complete(id="<your-task-id>", result="Ingested N entities, M edges, K notes.
 
 - Reading multiple source files into context simultaneously
 - Bulk-creating entities without intermediate search
-- Using ad-hoc edge relations outside the closed 13
+- Using ad-hoc edge relations outside the closed 15
 - Skipping density verification because "the source looked thin"
 - Inflating note salience to make findings stand out
 - Storing relationships as property strings ("authored_by_paper" = property name)

--- a/marketplace/kg/skills/explore/SKILL.md
+++ b/marketplace/kg/skills/explore/SKILL.md
@@ -32,6 +32,10 @@ search(kind="note", query="<topic>")
 Entity search finds concepts/papers/projects by name and description. Note search finds
 observations/insights/decisions by content (excludes superseded notes automatically).
 
+Narrow results with optional filters: `tags=["<tag>"]`, `entity_kind="concept"`,
+`min_score=0.5` (0–1 relevance threshold), `include_superseded=true` (to surface superseded
+notes explicitly). Use `properties={"domain": "attention"}` to post-filter by JSON properties.
+
 ### 2. Expand from hits
 
 For each relevant entity found:
@@ -70,6 +74,7 @@ query(query="MATCH (a:concept)-[:extends]->(b:concept) WHERE b.name = 'LoRA' RET
 - For JSON properties: use `a.domain`, `a.type` etc. (accessed via json_extract internally)
 - `RETURN a.properties` gets the full JSON blob
 - NOT supported: `WHERE NOT`, `COUNT`, `ORDER BY`, `[*..N]` variable-length without min
+- The outer `limit?` param defaults to 500, hard cap 10000. Use `LIMIT N` in the GQL string for tighter control.
 - Relations in patterns: use the 15 canonical relation names
 
 ### 4. Narrate

--- a/marketplace/kg/skills/polish/SKILL.md
+++ b/marketplace/kg/skills/polish/SKILL.md
@@ -95,6 +95,7 @@ List edges from high-value entities:
 ```
 list(kind="edge", source_id="<entity-id>")
 list(kind="edge", target_id="<entity-id>")
+list(kind="edge", source_id="<entity-id>", relations=["introduced_by", "extends"])  # filter by relation type
 ```
 
 Check for:

--- a/marketplace/knowledge/README.md
+++ b/marketplace/knowledge/README.md
@@ -2,41 +2,58 @@
 
 Structured knowledge management on top of [khive-mcp](https://github.com/ohdearquant/khive).
 
-The knowledge pack provides three focused verbs for registering concepts, recording provenance, and
-browsing by domain — all built on the kg substrate without duplicating storage.
+The knowledge pack provides 10 verbs for managing research concepts and knowledge atoms — all built
+on the kg substrate without duplicating storage.
 
 ## Why this pack exists
 
 The `kg` pack gives you direct CRUD for any entity kind (`create`, `link`, `search`). The knowledge
-pack adds **opinionated sugar** for the specific pattern of managing research concepts:
+pack adds **opinionated sugar** for two distinct patterns:
 
+**Concept management** (built on the kg substrate):
 - `learn` = `create(kind="concept")` with automatic `domain` → tag promotion (makes domain
   filterable via FTS and the `domain=` parameter on `topic`).
-- `cite` = `link(relation="introduced_by")` with weight clamped to [0, 1] and a cleaner parameter
-  name (`concept_id` / `source_id` instead of `source_id` / `target_id`).
+- `cite` = `link(relation="introduced_by")` with weight clamped to [0, 1] and cleaner parameter
+  names (`concept_id` / `source_id` instead of `source_id` / `target_id`).
 - `topic` = `search(kind="concept")` with optional post-filter on the domain tag.
 
-Use the knowledge pack when you want the auto-promotion and concise API. Use `kg` verbs directly
-when you need other entity kinds, relations, or full parameter control.
+**Atom management** (lore/knowledge atoms, distinct from the KG entity store):
+- `upsert_atoms`, `edit`, `list`, `get`, `delete_atoms` — CRUD for structured knowledge atoms
+  (markdown-chunked documents with sections).
+- `search` — hybrid FTS + embedding search with optional reranking.
+- `stats` — counts across atoms, domains, and embeddings.
+
+Use the knowledge pack when you want auto-promotion for concepts or atom-based document storage.
+Use `kg` verbs directly when you need other entity kinds, relations, or full parameter control.
 
 ## Verbs
 
 All verbs are dispatched through the single MCP `request` tool.
 
-| Verb                                                  | What it does                                                                                                                        |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `knowledge.learn(name, description?, domain?, tags?)` | Register a concept entity. `domain` is stored in `properties.domain` and automatically added to `tags` for FTS discoverability.     |
-| `knowledge.cite(concept_id, source_id, weight?)`      | Create an `introduced_by` edge from a concept to its source document or person. `weight` is clamped to [0.0, 1.0]; defaults to 1.0. |
-| `knowledge.topic(domain?, query?, limit?)`            | List or search concept entities, optionally filtered by domain tag. `limit` max is 100; defaults to 20.                             |
+### Concept management
 
-## What's New in 0.2.3
+| Verb | Params | What it does |
+| ---- | ------ | ------------ |
+| `knowledge.learn` | `name` (required), `description?`, `domain?`, `tags?` | Register a concept entity. `domain` is stored in `properties.domain` and automatically added to `tags` for FTS discoverability. |
+| `knowledge.cite` | `concept_id` (required UUID), `source_id` (required UUID, must be `document` or `person`), `weight?` (float, default 1.0) | Create an `introduced_by` edge from a concept to its source. `weight` clamped to [0.0, 1.0]. |
+| `knowledge.topic` | `domain?`, `query?`, `limit?` (default 20, max 100) | List or search concept entities, optionally filtered by domain tag. |
 
-- **Score normalization**: all search/topic scores are now normalized to `[0, 1]` for consistent
-  cross-query comparison.
-- **`rerank=true` default**: `knowledge.topic` and `knowledge.search` now default to `rerank=true`,
-  producing cleaner relevance ordering out of the box.
-- **FTS5 special character hardening**: queries containing parentheses, colons, quotes, and other
-  FTS5 metacharacters are escaped automatically instead of returning parse errors.
+### Atom management
+
+| Verb | Params | What it does |
+| ---- | ------ | ------------ |
+| `knowledge.upsert_atoms` | `atoms` (required, array of `{slug, name, content, description?, tags?, properties?, finalized?}`), `chunk_size?` | Create or update knowledge atoms. Field is `content` (not `body`). |
+| `knowledge.edit` | `id` (required, UUID or slug), `sections` (required, array of `{section_type, content, heading?, sort_order?}`) | Upsert sections within an atom. Sections are identified by `section_type`; existing sections with matching type are replaced. |
+| `knowledge.list` | `type?` (`"atom"` or `"domain"`, default `"atom"`), `limit?` (default 20, max 500), `offset?` | Paginate atoms or domains. |
+| `knowledge.get` | `id` (required, UUID or slug) | Fetch a single atom or domain by UUID or slug. Short UUID prefix is NOT supported — use full UUID or slug. |
+| `knowledge.delete_atoms` | `ids` (required, array of slugs or UUIDs) | Delete atoms by slug or UUID. Param is `ids` (not `slugs`). |
+
+### Search and retrieval
+
+| Verb | Params | What it does |
+| ---- | ------ | ------------ |
+| `knowledge.search` | `query` (required), `type?` (`"atom"` or `"domain"`), `role?`, `limit?` (default 10, max 100), `min_score?`, `weights?`, `decompose?` (boolean), `decompose_threshold?`, `intersection_bonus?`, `rerank?` (default true), `rerank_alpha?` (default 0.7) | Hybrid FTS + embedding search over atoms/domains. `rerank=true` blends TF-IDF and embedding scores via `rerank_alpha` (0 = pure embedding, 1 = pure TF-IDF). |
+| `knowledge.stats` | (none) | Atom, domain, and embedding counts. |
 
 ## Skills
 

--- a/marketplace/knowledge/README.md
+++ b/marketplace/knowledge/README.md
@@ -2,8 +2,9 @@
 
 Structured knowledge management on top of [khive-mcp](https://github.com/ohdearquant/khive).
 
-The knowledge pack provides 10 verbs for managing research concepts and knowledge atoms — all built
-on the kg substrate without duplicating storage.
+The knowledge pack provides verbs for managing research concepts and knowledge atoms — all built
+on the kg substrate without duplicating storage. This README covers the 10 most commonly used
+verbs. Run `verbs(pack="knowledge")` for the full surface (18 verbs total).
 
 ## Why this pack exists
 

--- a/marketplace/knowledge/skills/cite/SKILL.md
+++ b/marketplace/knowledge/skills/cite/SKILL.md
@@ -18,8 +18,8 @@ request(ops="knowledge.cite(concept_id=\"<concept_uuid>\", source_id=\"<document
 
 | Parameter    | Type   | Required | Description                                                        |
 | ------------ | ------ | -------- | ------------------------------------------------------------------ |
-| `concept_id` | string | yes      | Full UUID or 8-char prefix of the concept.                         |
-| `source_id`  | string | yes      | Full UUID or 8-char prefix of the source (`document` or `person`). |
+| `concept_id` | string | yes      | Full UUID of the concept entity.                                   |
+| `source_id`  | string | yes      | Full UUID of the source entity; must be kind `document` or `person`. |
 | `weight`     | float  | no       | Edge weight in `[0.0, 1.0]`. Default: `1.0` (definitional).        |
 
 ## Response shape

--- a/marketplace/memory/README.md
+++ b/marketplace/memory/README.md
@@ -12,10 +12,10 @@ to a source entity or note.
 All verbs are dispatched through the single MCP `request` tool
 ([ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)).
 
-| Verb                                                                                                        | What it does                                                             |
-| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `memory.remember(content, memory_type?, salience?, decay_factor?, source_id?, namespace?, tags?)`           | Store a memory note with salience and decay metadata.                    |
-| `memory.recall(query, limit?, memory_type?, min_score?, min_salience?, config?, namespace?, presentation?)` | Search memory notes only, then rank by relevance, salience, and recency. |
+| Verb                                                                                                                                                                                          | What it does                                                              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `memory.remember(content, salience?, decay_factor?, memory_type?, source_id?, embedding_model?, tags?)`                                                                                       | Store a memory note with salience and decay metadata.                     |
+| `memory.recall(query, limit?, top_k?, min_score?, score_floor?, min_salience?, memory_type?, fusion_strategy?, embedding_model?, include_breakdown?, entity_names?, full_content?, tags?, tag_mode?)` | Search memory notes only, then rank by relevance, salience, and recency.  |
 
 Memory types (`memory_type` values):
 
@@ -27,17 +27,15 @@ Memory types (`memory_type` values):
 `memory.recall` results include a score triplet: `score` (absolute relevance, `[0.0, 1.0]`),
 `rank_score` (composite ordering score, `[0.0, 1.0]`), and `raw_score` (pre-fusion vector cosine
 similarity, `[0.0, 1.0]` or `null` for text-only hits). All values are bounded to `[0.0, 1.0]`.
-Passing `presentation="verbose"` adds a per-component `breakdown` field; `presentation` defaults to
-`"agent"` when omitted.
+The default fusion strategy is `weighted`. Pass `include_breakdown=true` to include a per-component
+`breakdown` field (relevance, salience contributions, temporal).
 
-## What's New in 0.2.3
+Fusion strategies (`fusion_strategy` values): `weighted` (default), `rrf`, `union`, `vector_only`,
+`keyword_only`. Composite scores are always `[0.0, 1.0]` regardless of strategy.
 
-- **Tags filter on recall**: `memory.recall` now accepts `tags` and `tag_mode` (`any` or `all`)
-  parameters to filter recalled memories by tag values.
-- **`include_embeddings` on recall**: pass `include_embeddings=true` to include raw embedding
-  vectors in recall results (useful for downstream reranking or clustering).
-- **`presentation` alias removed**: the deprecated `presentation` positional alias on `recall` is
-  removed; use the standard `presentation` field on the `request` call instead.
+`top_k` overrides `limit` (max 100). `score_floor` is an alias for `min_score`. `entity_names`
+accepts an array of entity name strings and applies a 1.3× boost to matching memories.
+`full_content=true` (default) returns the full memory body; set to `false` for compact listings.
 
 ## Skills
 

--- a/marketplace/memory/skills/recall/SKILL.md
+++ b/marketplace/memory/skills/recall/SKILL.md
@@ -45,17 +45,16 @@ Each recall result includes:
 - `raw_score` — pre-fusion vector cosine similarity (`[0.0, 1.0]`), or `null` for text-only hits.
 - `salience`, `decay_factor`, `memory_type`, `created_at`, `content`.
 
-All three score fields are bounded to `[0.0, 1.0]`. Pass `presentation="verbose"` to include a
-per-component `breakdown` field (relevance, salience contributions, temporal). `presentation`
-defaults to `"agent"` when omitted.
+All three score fields are bounded to `[0.0, 1.0]`. Pass `include_breakdown=true` to include a
+per-component `breakdown` field (relevance, salience contributions, temporal).
 
 Treat higher-ranked hits as more relevant, not automatically true. When a hit matters, carry forward
 its `note_id` in your notes or response so it can be inspected later.
 
 ### 4. Adjust thresholds only after the first pass
 
-Recall scores are decay-aware hybrid scores (combining RRF fusion, salience with decay, and temporal
-recency — weighted 0.70 / 0.20 / 0.10 by default). Recent notes with normal salience typically score
+Recall scores are decay-aware hybrid scores (combining weighted fusion of relevance, salience with
+decay, and temporal recency by default). Recent notes with normal salience typically score
 0.10–0.25; older or low-salience notes may drop to 0.02–0.08. Start without `min_score` and inspect
 the returned scores before setting a threshold:
 
@@ -108,6 +107,35 @@ If memories were tagged with source or domain words, include them:
 
 ```
 request(ops="memory.recall(query=\"ADR-036 memory recall decay ranking\", memory_type=\"semantic\", limit=5)")
+```
+
+### Boost results for known entities
+
+Pass `entity_names` to apply a 1.3× boost to memories associated with those entity names:
+
+```
+request(ops="memory.recall(query=\"project decisions\", entity_names=[\"khive-mcp\",\"ADR-036\"], limit=10)")
+```
+
+### Filter by tag
+
+```
+request(ops="memory.recall(query=\"user preference\", tags=[\"user-preference\"], tag_mode=\"all\", limit=10)")
+```
+
+### Choose a fusion strategy
+
+Default is `weighted`. Switch to `vector_only` when keyword matches are noisy, or `rrf` for
+balanced precision:
+
+```
+request(ops="memory.recall(query=\"embedding recall decay\", fusion_strategy=\"vector_only\", limit=5)")
+```
+
+### Get per-component score breakdown
+
+```
+request(ops="memory.recall(query=\"project context\", include_breakdown=true, limit=5)")
 ```
 
 ## Anti-patterns

--- a/marketplace/memory/skills/remember/SKILL.md
+++ b/marketplace/memory/skills/remember/SKILL.md
@@ -67,6 +67,9 @@ request(ops="memory.remember(content=\"ADR-036 defines recall as memory-scoped r
 
 `source_id` creates an `annotates` relationship from the memory note to the source.
 
+Pass `embedding_model` to select a non-default encoder for this memory (the same model should be
+used at recall time to ensure comparable vectors).
+
 ### 5. Verify retrievability
 
 After storing important memory, check that a future query can find it:

--- a/marketplace/schedule/skills/cancel/SKILL.md
+++ b/marketplace/schedule/skills/cancel/SKILL.md
@@ -36,13 +36,13 @@ request(ops="schedule.agenda()")
 
 ## Parameters
 
-| Parameter | Type   | Required | Description                          |
-| --------- | ------ | -------- | ------------------------------------ |
-| `id`      | string | yes      | Full UUID of the scheduled event.    |
+| Parameter | Type   | Required | Description                                                        |
+| --------- | ------ | -------- | ------------------------------------------------------------------ |
+| `id`      | string | yes      | Full UUID or unambiguous 8+ hex prefix of the scheduled event.    |
 
 ## Anti-patterns
 
-- **Using a short UUID prefix.** `cancel` requires a full UUID — short prefixes are rejected.
+- **Using an ambiguous prefix.** `cancel` accepts full UUIDs or unambiguous 8+ hex prefixes. If the prefix matches more than one event, the call is rejected — use a longer prefix or the full UUID.
 - **Cancelling a non-scheduled-event note.** `cancel` only works on notes with
   `kind="scheduled_event"`. Cancelling a task or observation returns an error.
 - **Cancelling a nonexistent ID.** Returns "not found".

--- a/marketplace/schedule/skills/cancel/SKILL.md
+++ b/marketplace/schedule/skills/cancel/SKILL.md
@@ -12,7 +12,7 @@ in storage for audit purposes but no longer appears in `agenda`.
 ### 1. Cancel an event
 
 ```
-request(ops="schedule.cancel(id=\"<event-full-id>\")")
+request(ops="schedule.cancel(id=\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\")")
 ```
 
 Response:
@@ -26,15 +26,7 @@ Response:
 }
 ```
 
-### 2. Cancel by short prefix
-
-```
-request(ops="schedule.cancel(id=\"a1b2c3d4\")")
-```
-
-The 8-char prefix is resolved to the full UUID.
-
-### 3. Verify cancellation
+### 2. Verify cancellation
 
 After cancelling, confirm it no longer appears in agenda:
 
@@ -44,14 +36,15 @@ request(ops="schedule.agenda()")
 
 ## Parameters
 
-| Parameter | Type   | Required | Description                                        |
-| --------- | ------ | -------- | -------------------------------------------------- |
-| `id`      | string | yes      | Full UUID or 8-char prefix of the scheduled event. |
+| Parameter | Type   | Required | Description                          |
+| --------- | ------ | -------- | ------------------------------------ |
+| `id`      | string | yes      | Full UUID of the scheduled event.    |
 
 ## Anti-patterns
 
+- **Using a short UUID prefix.** `cancel` requires a full UUID — short prefixes are rejected.
 - **Cancelling a non-scheduled-event note.** `cancel` only works on notes with
   `kind="scheduled_event"`. Cancelling a task or observation returns an error.
 - **Cancelling a nonexistent ID.** Returns "not found".
-- **Note:** Cancelling an already-cancelled event is currently idempotent (no error, overwrites
-  `cancelled_at`). See issue #544.
+- **Cancelling an already-cancelled event.** Returns an error — use `agenda` first to confirm
+  the event is still pending before cancelling.


### PR DESCRIPTION
## Summary
- Updated all 7 marketplace pack READMEs and 18 SKILL.md files against help=true ground truth
- brain: expand feedback signals 3→8, fix `profile_id` param name in examples
- gtd: remove nonexistent params (start, end, description), add `context_entity_id`
- kg: add missing list/search filter params, document query limit cap (10000)
- knowledge: expand verb table from 3→10 verbs, fix param names (content not body)
- memory: add 9 missing recall params, fix default fusion from RRF → weighted
- schedule: fix cancel to require full UUID, remove false idempotency claim
- comm: already accurate — no changes needed

## Test plan
- [x] Compared every verb table against `verb(help=true)` output
- [x] No code changes — docs only