### PR TITLE
feat(kkernel): unify into a single binary (kkernel mcp) + non-mutating db check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ !matrix.cross }}
         working-directory: crates
         run: |
-          cargo build --release --target ${{ matrix.target }} -p kkernel -p khive-mcp
+          cargo build --release --target ${{ matrix.target }} -p kkernel
 
       - name: Build binaries (zigbuild cross)
         if: ${{ matrix.cross }}
@@ -109,7 +109,7 @@ jobs:
           CFLAGS_x86_64_unknown_linux_musl: "-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
           CFLAGS_aarch64_unknown_linux_gnu: "-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
         run: |
-          cargo zigbuild --release --target ${{ matrix.target }} -p kkernel -p khive-mcp
+          cargo zigbuild --release --target ${{ matrix.target }} -p kkernel
 
       - name: Stage binaries into subpackage bin/
         shell: bash
@@ -119,12 +119,10 @@ jobs:
           # Remove the placeholder so it is not shipped in the published tarball (MIN-1).
           rm -f "${PKG_DIR}/.gitkeep"
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            cp "${SRC}/kkernel.exe"    "${PKG_DIR}/kkernel.exe"
-            cp "${SRC}/khive-mcp.exe" "${PKG_DIR}/khive-mcp.exe"
+            cp "${SRC}/kkernel.exe" "${PKG_DIR}/kkernel.exe"
           else
-            cp "${SRC}/kkernel"    "${PKG_DIR}/kkernel"
-            cp "${SRC}/khive-mcp" "${PKG_DIR}/khive-mcp"
-            chmod +x "${PKG_DIR}/kkernel" "${PKG_DIR}/khive-mcp"
+            cp "${SRC}/kkernel" "${PKG_DIR}/kkernel"
+            chmod +x "${PKG_DIR}/kkernel"
           fi
 
       - name: Upload subpackage artifact

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	cd crates && cargo test --workspace
 
 contract-test:
-	cd crates && cargo build --release -p khive-mcp
+	cd crates && cargo build --release -p kkernel
 	python3 tests/contract_test.py
 
 fmt:
@@ -42,22 +42,22 @@ publish:
 	./scripts/publish.sh --live
 
 local:
-	@echo "==> Building khive-mcp (release)..."
-	@cd crates && cargo build --release -p khive-mcp
-	@SRC=crates/target/release/khive-mcp; \
-	DEST=$$HOME/.cargo/bin/khive-mcp; \
+	@echo "==> Building kkernel (release)..."
+	@cd crates && cargo build --release -p kkernel
+	@SRC=crates/target/release/kkernel; \
+	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \
 	SRC_HASH=$$(md5 -q "$$SRC"); \
 	SRC_SIZE=$$(stat -f '%z' "$$SRC"); \
 	echo "==> Source:  $$SRC ($$SRC_HASH, $$SRC_SIZE bytes)"; \
-	echo "==> Killing running khive-mcp processes..."; \
-	pkill -f 'khive-mcp' 2>/dev/null || true; \
+	echo "==> Killing running kkernel processes..."; \
+	pkill -f 'kkernel' 2>/dev/null || true; \
 	for i in 1 2 3 4 5; do \
-	  if pgrep -f 'khive-mcp' >/dev/null 2>&1; then sleep 1; else break; fi; \
+	  if pgrep -f 'kkernel' >/dev/null 2>&1; then sleep 1; else break; fi; \
 	done; \
-	if pgrep -f 'khive-mcp' >/dev/null 2>&1; then \
+	if pgrep -f 'kkernel' >/dev/null 2>&1; then \
 	  echo "==> WARNING: still running after 5s — SIGKILL"; \
-	  pkill -9 -f 'khive-mcp' 2>/dev/null || true; \
+	  pkill -9 -f 'kkernel' 2>/dev/null || true; \
 	  sleep 1; \
 	fi; \
 	echo "==> Staging + codesigning $$DEST.new..."; \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ No language SDK to learn.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  khive-mcp       — Rust binary (stdio MCP server)            │
+│  kkernel mcp      — stdio MCP server (the `kkernel` binary)   │
 │  khived           — persistent daemon (ADR-049): warm runtime │
 │                     auto-spawned on first request             │
 │  1 tool: `request` (ADR-020 + ADR-027) — parses DSL,         │
@@ -119,28 +119,29 @@ HTTP gateway, CLI, and visual frontend are planned for future releases.
 
 ## Crates
 
-| Crate                  | Purpose                                                                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| `khive-types`          | Domain types, Pack trait, closed enums                                                                 |
-| `khive-score`          | Deterministic i64 fixed-point scoring                                                                  |
-| `khive-storage`        | Trait-only capability surface (zero implementations)                                                   |
-| `khive-db`             | SQLite backend: entity/note/edge tables, FTS5 TextSearch, current sqlite-vec VectorStore compatibility |
-| `khive-retrieval`      | Hybrid retrieval primitives                                                                            |
-| `khive-fusion`         | RRF, weighted, union, vector-only, and keyword-only fusion strategies                                  |
-| `khive-bm25`           | BM25 keyword index                                                                                     |
-| `khive-hnsw`           | HNSW vector index                                                                                      |
-| `khive-vamana`         | Vamana ANN index used by knowledge search                                                              |
-| `khive-query`          | SPARQL / GQL → SQL compiler                                                                            |
-| `khive-runtime`        | Service API + VerbRegistry + PackRuntime trait                                                         |
-| `khive-request`        | Request DSL parser (function-call, JSON; pipe / LNDL planned). Transport-agnostic AST.                 |
-| `khive-pack-kg`        | KG pack: vocabulary, verb handlers, kind validation                                                    |
-| `khive-pack-gtd`       | GTD pack: task lifecycle over the notes substrate                                                      |
-| `khive-pack-memory`    | Memory pack: salience-weighted remember/recall with decay                                              |
-| `khive-pack-brain`     | Brain pack: Bayesian user profiles, feedback, resolution                                               |
-| `khive-pack-comm`      | Comm pack: threaded messaging with inbox                                                               |
-| `khive-pack-schedule`  | Schedule pack: reminders and scheduled verb execution                                                  |
-| `khive-pack-knowledge` | Knowledge pack: atom-based KB with embedding rerank search                                             |
-| `khive-mcp`            | Stdio MCP binary — single `request` tool dispatching through the VerbRegistry                          |
+| Crate                  | Purpose                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| `khive-types`          | Domain types, Pack trait, closed enums                                                                    |
+| `khive-score`          | Deterministic i64 fixed-point scoring                                                                     |
+| `khive-storage`        | Trait-only capability surface (zero implementations)                                                      |
+| `khive-db`             | SQLite backend: entity/note/edge tables, FTS5 TextSearch, current sqlite-vec VectorStore compatibility    |
+| `khive-retrieval`      | Hybrid retrieval primitives                                                                               |
+| `khive-fusion`         | RRF, weighted, union, vector-only, and keyword-only fusion strategies                                     |
+| `khive-bm25`           | BM25 keyword index                                                                                        |
+| `khive-hnsw`           | HNSW vector index                                                                                         |
+| `khive-vamana`         | Vamana ANN index used by knowledge search                                                                 |
+| `khive-query`          | SPARQL / GQL → SQL compiler                                                                               |
+| `khive-runtime`        | Service API + VerbRegistry + PackRuntime trait                                                            |
+| `khive-request`        | Request DSL parser (function-call, JSON; pipe / LNDL planned). Transport-agnostic AST.                    |
+| `khive-pack-kg`        | KG pack: vocabulary, verb handlers, kind validation                                                       |
+| `khive-pack-gtd`       | GTD pack: task lifecycle over the notes substrate                                                         |
+| `khive-pack-memory`    | Memory pack: salience-weighted remember/recall with decay                                                 |
+| `khive-pack-brain`     | Brain pack: Bayesian user profiles, feedback, resolution                                                  |
+| `khive-pack-comm`      | Comm pack: threaded messaging with inbox                                                                  |
+| `khive-pack-schedule`  | Schedule pack: reminders and scheduled verb execution                                                     |
+| `khive-pack-knowledge` | Knowledge pack: atom-based KB with embedding rerank search                                                |
+| `khive-mcp`            | MCP server library — single `request` tool dispatching through the VerbRegistry (served by `kkernel mcp`) |
+| `kkernel`              | The single shipped binary — `kkernel mcp` serves MCP; admin subcommands (exec, reindex, db, …)            |
 
 Dependency direction (storage stack): `types → score → storage → db → query → runtime → packs → mcp`.
 Side input: `request → mcp` (the DSL parser is consumed only at the MCP dispatch boundary;
@@ -173,17 +174,21 @@ warm, and Claude Code discovers the `request` tool with the full 63-verb catalog
 If you prefer Rust tooling or need to build from source:
 
 ```bash
-cargo install khive-mcp                        # from crates.io
+cargo install kkernel                          # from crates.io — installs the `kkernel` binary
 # or:
 git clone https://github.com/ohdearquant/khive.git && cd khive
-cd crates && cargo build --release -p khive-mcp
+cd crates && cargo build --release -p kkernel
 ```
 
-Then point your MCP config at the binary directly:
+Then point your MCP config at the binary's `mcp` subcommand:
 
 ```json
-{ "mcpServers": { "khive": { "command": "khive-mcp" } } }
+{ "mcpServers": { "khive": { "command": "kkernel", "args": ["mcp"] } } }
 ```
+
+`kkernel` is the single shipped binary; `kkernel mcp` serves the MCP `request`
+surface. The npm package installs a thin `khive` (and a `khive-mcp` compatibility)
+shim that forwards to `kkernel mcp` — the Cargo path invokes `kkernel` directly.
 
 ### Usage
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -25,6 +25,7 @@ import { runSync } from "./kg/sync.ts";
 import { runStatus } from "./kg/status.ts";
 import { runValidate } from "./kg/validate.ts";
 import { getRepoRoot } from "./lib/git.ts";
+import { kkernelPath } from "./lib/kernel.ts";
 import { CLI_VERSION } from "./version.ts";
 
 function printUsage(): void {
@@ -241,36 +242,17 @@ if (!group || group === "--help" || group === "-h") {
 } else if (group === "pack") {
   await dispatchPack(groupArgs);
 } else if (group === "mcp") {
-  // Delegate to the khive-mcp Rust binary. Resolve from PATH, cargo bin,
-  // or the platform subpackage (same locations the npm shim checks).
-  const candidates = [
-    "khive-mcp",
-    Deno.env.get("HOME") + "/.cargo/bin/khive-mcp",
-  ];
-  let found: string | undefined;
-  for (const c of candidates) {
-    try {
-      const s = Deno.statSync(c);
-      if (s.isFile) {
-        found = c;
-        break;
-      }
-    } catch { /* next */ }
+  // `khive mcp [flags]` delegates to `kkernel mcp [flags]` — the MCP server
+  // lives under the kkernel `mcp` subcommand (single-binary distribution).
+  let repoRoot: string | undefined;
+  try {
+    repoRoot = await getRepoRoot();
+  } catch {
+    // Not in a git repo — production resolution (npm subpackage) does not need it.
   }
-  if (!found) {
-    // Try PATH resolution via `which`
-    try {
-      const p = new Deno.Command("which", { args: ["khive-mcp"], stdout: "piped", stderr: "null" });
-      const out = new TextDecoder().decode((await p.output()).stdout).trim();
-      if (out) found = out;
-    } catch { /* not found */ }
-  }
-  if (!found) {
-    console.error("khive-mcp not found. Install with: cargo install khive-mcp");
-    Deno.exit(1);
-  }
-  const proc = new Deno.Command(found, {
-    args: groupArgs,
+  const bin = kkernelPath(repoRoot);
+  const proc = new Deno.Command(bin, {
+    args: ["mcp", ...groupArgs],
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -21,8 +21,8 @@ pub mod stores;
 pub use backend::StorageBackend;
 pub use error::SqliteError;
 pub use migrations::{
-    query_embedding_models, run_migrations, EmbeddingModelRegistryRecord, Migration,
-    ServiceSchemaPlan, VersionedMigration, MIGRATIONS,
+    inspect_schema_version, query_embedding_models, read_schema_version, run_migrations,
+    EmbeddingModelRegistryRecord, Migration, ServiceSchemaPlan, VersionedMigration, MIGRATIONS,
 };
 pub use pool::{ConnectionPool, PoolConfig, ReaderGuard, WriterGuard};
 pub use sql_bridge::SqlBridge;

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -151,6 +151,30 @@ const MIGRATION_TRACKING_TABLE: &str = "\
 
 /// Apply all unapplied migrations in order. Idempotent; each migration runs in its own transaction.
 /// Errors on non-contiguous version array or failed migration.
+/// Read the applied schema version from an open connection **without** running
+/// migrations. Returns 0 when the `_schema_migrations` ledger is absent (an
+/// un-migrated or empty database). Never writes.
+pub fn read_schema_version(conn: &Connection) -> u32 {
+    conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
+        [],
+        |row| row.get(0),
+    )
+    .unwrap_or(0)
+}
+
+/// Open `path` read-only and report its applied schema version without creating
+/// or migrating the file. The caller must ensure `path` exists — opening a
+/// missing file read-only errors rather than creating it. This is the path used
+/// by schema-inspection commands that must not mutate the database.
+pub fn inspect_schema_version(path: &std::path::Path) -> Result<u32, SqliteError> {
+    let conn = Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    Ok(read_schema_version(&conn))
+}
+
 pub fn run_migrations(conn: &mut Connection) -> Result<u32, SqliteError> {
     conn.execute_batch(MIGRATION_TRACKING_TABLE)?;
 

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "khive stdio MCP server — the only user-facing Rust binary"
+description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
 khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
@@ -40,7 +40,3 @@ async-trait = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }
 khive-pack-knowledge = { version = "0.2.8", path = "../khive-pack-knowledge" }
-
-[[bin]]
-name = "khive-mcp"
-path = "src/main.rs"

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -1,20 +1,15 @@
-//! CLI argument definition and namespace resolution for `khive-mcp`.
+//! Serve-time argument definition and namespace resolution for `kkernel mcp`.
 //!
-//! Extracted from `main.rs` so integration tests can exercise the real `Args`
-//! parser with `Args::try_parse_from` without spawning the binary.
+//! These are the args the `kkernel mcp` subcommand flattens. Logging is owned by
+//! the binary's global `--log`, so it is intentionally absent here.
 
 use std::path::PathBuf;
 
 use clap::Parser;
 use khive_runtime::Namespace;
 
-/// Parsed command-line arguments for the `khive-mcp` binary.
+/// Parsed serve-time arguments for the `kkernel mcp` subcommand.
 #[derive(Parser, Debug)]
-#[command(
-    name = "khive-mcp",
-    version,
-    about = "khive MCP server (stdio) — the only user-facing Rust binary"
-)]
 pub struct Args {
     /// Path to the khive database. Use \":memory:\" for an ephemeral in-memory database.
     #[arg(long, env = "KHIVE_DB")]
@@ -46,10 +41,6 @@ pub struct Args {
     #[arg(long, env = "KHIVE_NO_EMBED")]
     pub no_embed: bool,
 
-    /// Log level for stderr output (stdout is reserved for the MCP protocol).
-    #[arg(long, env = "KHIVE_LOG", default_value = "warn")]
-    pub log: String,
-
     /// Pack to load into the verb registry. Repeat for multiple
     /// (e.g. `--pack kg --pack gtd`). Falls back to `KHIVE_PACKS` env
     /// (comma- or whitespace-separated) or `["kg"]` if neither is set.
@@ -70,13 +61,24 @@ pub struct Args {
     #[arg(long = "config", env = "KHIVE_CONFIG")]
     pub config: Option<PathBuf>,
 
-    /// Run as a persistent daemon over a Unix socket instead of stdio.
+    /// Run as a persistent daemon over a Unix socket instead of a foreground transport.
     ///
     /// The daemon owns the warm pack registry (ANN indexes) and serves request
     /// frames from thin stdio clients that auto-spawn it. Bound to
-    /// `~/.khive/khived.sock`.
+    /// `~/.khive/khived.sock`. Takes precedence over `--transport`.
     #[arg(long)]
     pub daemon: bool,
+
+    /// Foreground serving transport (registry name). Defaults to `stdio`.
+    ///
+    /// Additional transports (e.g. Streamable HTTP) can be registered before
+    /// serving; an unknown name errors with the registered set.
+    #[arg(long)]
+    pub transport: Option<String>,
+
+    /// Bind address for network transports (e.g. `0.0.0.0:8080`). Ignored by stdio.
+    #[arg(long)]
+    pub bind: Option<String>,
 }
 
 /// Resolve CLI namespace from `Args`. Returns `(explicit, namespace)`; errors on invalid namespace string.

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -42,8 +42,9 @@ pub struct Args {
     pub no_embed: bool,
 
     /// Pack to load into the verb registry. Repeat for multiple
-    /// (e.g. `--pack kg --pack gtd`). Falls back to `KHIVE_PACKS` env
-    /// (comma- or whitespace-separated) or `["kg"]` if neither is set.
+    /// (e.g. `--pack kg --pack gtd`). When unset, falls back to `KHIVE_PACKS`
+    /// (comma- or whitespace-separated), and if that is also unset to the full
+    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge`.
     #[arg(long = "pack")]
     pub pack: Vec<String>,
 

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -73,8 +73,11 @@ fn map_response(resp: DaemonResponseFrame) -> Option<Result<String, McpError>> {
 
 fn spawn_daemon() -> std::io::Result<()> {
     let exe = std::env::current_exe()?;
+    // The binary is `kkernel`; the MCP server (and its daemon mode) live under
+    // the `mcp` subcommand.
     let mut cmd = std::process::Command::new(exe);
-    cmd.arg("--daemon")
+    cmd.arg("mcp")
+        .arg("--daemon")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -45,6 +45,10 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
     fn namespace(&self) -> &str {
         self.default_namespace()
     }
+
+    fn config_id(&self) -> &str {
+        crate::server::KhiveMcpServer::config_id(self)
+    }
 }
 
 // ── client ────────────────────────────────────────────────────────────────────
@@ -58,7 +62,7 @@ async fn try_forward(frame: &DaemonRequestFrame) -> Option<DaemonResponseFrame> 
 }
 
 fn map_response(resp: DaemonResponseFrame) -> Option<Result<String, McpError>> {
-    if resp.namespace_mismatch {
+    if resp.namespace_mismatch || resp.config_mismatch {
         return None;
     }
     if resp.ok {
@@ -181,6 +185,19 @@ mod tests {
             result: None,
             error: None,
             namespace_mismatch: true,
+            config_mismatch: false,
+        };
+        assert!(map_response(resp).is_none());
+    }
+
+    #[test]
+    fn map_response_config_mismatch_yields_none() {
+        let resp = DaemonResponseFrame {
+            ok: false,
+            result: None,
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: true,
         };
         assert!(map_response(resp).is_none());
     }
@@ -192,6 +209,7 @@ mod tests {
             result: Some("the-result".to_string()),
             error: None,
             namespace_mismatch: false,
+            config_mismatch: false,
         };
         match map_response(resp) {
             Some(Ok(s)) => assert_eq!(s, "the-result"),
@@ -206,6 +224,7 @@ mod tests {
             result: None,
             error: None,
             namespace_mismatch: false,
+            config_mismatch: false,
         };
         match map_response(resp) {
             Some(Ok(s)) => assert_eq!(s, ""),
@@ -220,6 +239,7 @@ mod tests {
             result: None,
             error: Some("boom: bad verb".to_string()),
             namespace_mismatch: false,
+            config_mismatch: false,
         };
         match map_response(resp) {
             Some(Err(McpError { message, .. })) => {
@@ -236,6 +256,7 @@ mod tests {
             result: None,
             error: None,
             namespace_mismatch: false,
+            config_mismatch: false,
         };
         match map_response(resp) {
             Some(Err(McpError { message, .. })) => {
@@ -262,6 +283,7 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            config_id: "test".to_string(),
         };
         let out = forward_or_spawn(&frame).await;
         assert!(out.is_none());
@@ -284,6 +306,7 @@ mod tests {
         std::env::remove_var("KHIVE_NO_DAEMON");
 
         let reference = make_test_server();
+        let config_id = reference.config_id().to_string();
         let daemon_server = reference.clone();
 
         let handle = tokio::spawn(async move {
@@ -293,16 +316,18 @@ mod tests {
         let _ready = connect_when_ready(&sock).await;
         drop(_ready);
 
-        // (a) valid same-namespace op
+        // (a) valid same-namespace, same-config op
         let req = DaemonRequestFrame {
             ops: "stats()".to_string(),
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             namespace: "test".to_string(),
+            config_id: config_id.clone(),
         };
         let resp = exchange(&sock, &req).await;
         assert!(resp.ok, "valid op must succeed; error={:?}", resp.error);
         assert!(!resp.namespace_mismatch);
+        assert!(!resp.config_mismatch);
 
         let reference_result = reference
             .dispatch_request_local(RequestParams {
@@ -315,16 +340,34 @@ mod tests {
         assert_eq!(resp.result.as_deref(), Some(reference_result.as_str()));
         assert!(reference_result.contains("\"entities\""));
 
-        // (b) different namespace → namespace_mismatch
+        // (b) different namespace → namespace_mismatch (config matches)
         let other = DaemonRequestFrame {
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
             namespace: "other".to_string(),
+            config_id: config_id.clone(),
         };
         let resp_other = exchange(&sock, &other).await;
         assert!(resp_other.namespace_mismatch);
         assert!(!resp_other.ok);
+
+        // (c) same namespace but different config (e.g. a `--pack kg` client
+        // hitting the broader daemon) → config_mismatch, no dispatch.
+        let mismatched_config = DaemonRequestFrame {
+            ops: "stats()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "test".to_string(),
+            config_id: "packs=[kg];db=:memory:;embed=none;extra=[];backend=main".to_string(),
+        };
+        let resp_cfg = exchange(&sock, &mismatched_config).await;
+        assert!(
+            resp_cfg.config_mismatch,
+            "differing config must be rejected"
+        );
+        assert!(!resp_cfg.namespace_mismatch);
+        assert!(!resp_cfg.ok);
 
         handle.abort();
         let _ = handle.await;

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -61,8 +61,17 @@ async fn try_forward(frame: &DaemonRequestFrame) -> Option<DaemonResponseFrame> 
     serde_json::from_slice::<DaemonResponseFrame>(&resp).ok()
 }
 
-fn map_response(resp: DaemonResponseFrame) -> Option<Result<String, McpError>> {
+fn map_response(
+    resp: DaemonResponseFrame,
+    expected_config_id: &str,
+) -> Option<Result<String, McpError>> {
     if resp.namespace_mismatch || resp.config_mismatch {
+        return None;
+    }
+    // Fail closed: only trust a result the daemon positively confirms it served
+    // under our exact config. A legacy daemon omits `served_config_id` (→ None)
+    // and a config-drifted daemon echoes a different id — both fall back local.
+    if resp.served_config_id.as_deref() != Some(expected_config_id) {
         return None;
     }
     if resp.ok {
@@ -103,7 +112,7 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
     }
 
     if let Some(resp) = try_forward(frame).await {
-        return map_response(resp);
+        return map_response(resp, &frame.config_id);
     }
 
     if spawn_daemon().is_err() {
@@ -114,7 +123,9 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     while tokio::time::Instant::now() < deadline {
         if UnixStream::connect(&sock).await.is_ok() {
-            return try_forward(frame).await.and_then(map_response);
+            return try_forward(frame)
+                .await
+                .and_then(|resp| map_response(resp, &frame.config_id));
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
@@ -178,6 +189,8 @@ mod tests {
 
     // ── map_response (pure, MCP-specific) ─────────────────────────────────────
 
+    const CFG: &str = "packs=[kg];db=:memory:;embed=none;extra=[];backend=main";
+
     #[test]
     fn map_response_namespace_mismatch_yields_none() {
         let resp = DaemonResponseFrame {
@@ -186,8 +199,9 @@ mod tests {
             error: None,
             namespace_mismatch: true,
             config_mismatch: false,
+            served_config_id: Some(CFG.to_string()),
         };
-        assert!(map_response(resp).is_none());
+        assert!(map_response(resp, CFG).is_none());
     }
 
     #[test]
@@ -198,8 +212,41 @@ mod tests {
             error: None,
             namespace_mismatch: false,
             config_mismatch: true,
+            served_config_id: Some(CFG.to_string()),
         };
-        assert!(map_response(resp).is_none());
+        assert!(map_response(resp, CFG).is_none());
+    }
+
+    #[test]
+    fn map_response_legacy_daemon_missing_echo_yields_none() {
+        // A pre-config_id daemon omits served_config_id (→ None). Even on an
+        // ok=true result the client MUST fall back to local dispatch.
+        let resp = DaemonResponseFrame {
+            ok: true,
+            result: Some("served-by-broad-registry".to_string()),
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id: None,
+        };
+        assert!(map_response(resp, CFG).is_none());
+    }
+
+    #[test]
+    fn map_response_echo_drift_yields_none() {
+        // A daemon serving under a different config (echo != expected) is not
+        // trusted, even without an explicit config_mismatch flag.
+        let resp = DaemonResponseFrame {
+            ok: true,
+            result: Some("served-by-other-config".to_string()),
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: false,
+            served_config_id: Some(
+                "packs=[kg,gtd];db=/x;embed=none;extra=[];backend=main".to_string(),
+            ),
+        };
+        assert!(map_response(resp, CFG).is_none());
     }
 
     #[test]
@@ -210,8 +257,9 @@ mod tests {
             error: None,
             namespace_mismatch: false,
             config_mismatch: false,
+            served_config_id: Some(CFG.to_string()),
         };
-        match map_response(resp) {
+        match map_response(resp, CFG) {
             Some(Ok(s)) => assert_eq!(s, "the-result"),
             other => panic!("expected Some(Ok(\"the-result\")), got {other:?}"),
         }
@@ -225,8 +273,9 @@ mod tests {
             error: None,
             namespace_mismatch: false,
             config_mismatch: false,
+            served_config_id: Some(CFG.to_string()),
         };
-        match map_response(resp) {
+        match map_response(resp, CFG) {
             Some(Ok(s)) => assert_eq!(s, ""),
             other => panic!("expected Some(Ok(\"\")), got {other:?}"),
         }
@@ -240,8 +289,9 @@ mod tests {
             error: Some("boom: bad verb".to_string()),
             namespace_mismatch: false,
             config_mismatch: false,
+            served_config_id: Some(CFG.to_string()),
         };
-        match map_response(resp) {
+        match map_response(resp, CFG) {
             Some(Err(McpError { message, .. })) => {
                 assert!(message.contains("boom: bad verb"));
             }
@@ -257,8 +307,9 @@ mod tests {
             error: None,
             namespace_mismatch: false,
             config_mismatch: false,
+            served_config_id: Some(CFG.to_string()),
         };
-        match map_response(resp) {
+        match map_response(resp, CFG) {
             Some(Err(McpError { message, .. })) => {
                 assert!(!message.is_empty());
             }
@@ -328,6 +379,11 @@ mod tests {
         assert!(resp.ok, "valid op must succeed; error={:?}", resp.error);
         assert!(!resp.namespace_mismatch);
         assert!(!resp.config_mismatch);
+        assert_eq!(
+            resp.served_config_id.as_deref(),
+            Some(config_id.as_str()),
+            "daemon must echo the config it served under"
+        );
 
         let reference_result = reference
             .dispatch_request_local(RequestParams {

--- a/crates/khive-mcp/src/lib.rs
+++ b/crates/khive-mcp/src/lib.rs
@@ -1,9 +1,13 @@
-//! khive stdio MCP server library — exports the server, args, pack bootstrap,
-//! and tool parameter types for the single `request` tool.
+//! khive MCP server library — exports the server, serve bootstrap, transports,
+//! args, pack bootstrap, and tool parameter types for the single `request` tool.
+//!
+//! The binary frontend is `kkernel mcp`; this crate ships no binary of its own.
 
 pub mod args;
 #[cfg(unix)]
 pub mod daemon;
 pub mod pack;
+pub mod serve;
 pub mod server;
 pub mod tools;
+pub mod transport;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1,26 +1,49 @@
-//! khive-mcp binary entry point — parses CLI args, builds a `KhiveRuntime`,
-//! and serves over stdio (or runs as a daemon with `--daemon` on Unix).
+//! Build the runtime + server from CLI args and serve over the selected transport.
+//!
+//! This is the bootstrap that the `kkernel mcp` subcommand drives. Logging is
+//! initialized by the binary, not here.
 
 use std::path::PathBuf;
 
-use clap::Parser;
-use khive_mcp::args::{resolve_cli_namespace, Args};
-use khive_mcp::server::KhiveMcpServer;
 use khive_runtime::{
     config_from_env, runtime_config_from_khive_config, KhiveConfig, KhiveRuntime, RuntimeConfig,
 };
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
+use crate::args::{resolve_cli_namespace, Args};
+use crate::server::KhiveMcpServer;
+use crate::transport::{ServeOptions, TransportRegistry};
 
-    // Tracing goes to stderr — stdout is MCP JSON-RPC.
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(args.log.clone())
-        .with_ansi(false)
-        .init();
+/// Build a server from `args`, then serve it over `--daemon` or the named transport.
+pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()> {
+    let server = build_server(&args)?;
 
+    #[cfg(unix)]
+    if args.daemon {
+        khive_runtime::daemon::run_daemon(server).await?;
+        return Ok(());
+    }
+    #[cfg(not(unix))]
+    if args.daemon {
+        anyhow::bail!(
+            "--daemon mode requires Unix (macOS/Linux). On Windows, use the stdio transport."
+        );
+    }
+
+    let transport_name = args.transport.as_deref().unwrap_or("stdio");
+    let transport = registry.get(transport_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "unknown transport {transport_name:?}; registered: {}",
+            registry.names().join(", ")
+        )
+    })?;
+    let opts = ServeOptions {
+        bind: args.bind.clone(),
+    };
+    transport.serve(server, &opts).await
+}
+
+/// Build a fully-configured server from parsed args (without serving).
+pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
     let db_path = match args.db.as_deref() {
         Some(":memory:") => None,
         Some(path) => Some(PathBuf::from(path)),
@@ -30,18 +53,15 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // Namespace resolution — see resolve_cli_namespace in khive_mcp::args for semantics.
     let (cli_namespace_explicit, cli_namespace) =
-        resolve_cli_namespace(&args).map_err(|e| anyhow::anyhow!("{e}"))?;
+        resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    // CLI `--pack` overrides env-derived default. Empty means "use default".
     let packs = if args.pack.is_empty() {
         RuntimeConfig::default().packs
     } else {
-        args.pack
+        args.pack.clone()
     };
 
-    // Build base config before embedding engine resolution.
     let base_config = RuntimeConfig {
         db_path,
         default_namespace: cli_namespace,
@@ -49,10 +69,7 @@ async fn main() -> anyhow::Result<()> {
         ..RuntimeConfig::default()
     };
 
-    // Resolve full config: embedding engines + actor namespace from config file.
     let config = if args.no_embed {
-        // --no-embed takes priority: zero out embedding.
-        // Still apply config-file actor if no CLI actor was given.
         let no_embed_base = RuntimeConfig {
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -68,18 +85,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let runtime = KhiveRuntime::new(config)?;
-    let server = KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))?;
-    #[cfg(unix)]
-    if args.daemon {
-        khive_runtime::daemon::run_daemon(server).await?;
-        return Ok(());
-    }
-    #[cfg(not(unix))]
-    if args.daemon {
-        anyhow::bail!("--daemon mode requires Unix (macOS/Linux). On Windows, khive-mcp runs in stdio mode only.");
-    }
-    server.serve_stdio().await?;
-    Ok(())
+    KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 /// Resolve the full config (embedding engines + actor namespace) from file or env.
@@ -101,7 +107,6 @@ fn resolve_config(
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
     {
         Some(khive_cfg) => {
-            // Config file present — check if env vars are also set and warn.
             let env_primary = std::env::var("KHIVE_EMBEDDING_MODEL").ok();
             let env_additional = std::env::var("KHIVE_ADDITIONAL_EMBEDDING_MODELS").ok();
             if env_primary.is_some() || env_additional.is_some() {
@@ -111,9 +116,6 @@ fn resolve_config(
                 );
             }
 
-            // When the caller supplied --actor or --namespace, the CLI value wins
-            // over [actor] id in the config file. Nullify config actor so
-            // runtime_config_from_khive_config does not overwrite the base namespace.
             let effective_cfg = if cli_namespace_explicit {
                 let mut c = khive_cfg;
                 c.actor.id = None;
@@ -125,7 +127,6 @@ fn resolve_config(
             Ok(runtime_config_from_khive_config(&effective_cfg, base))
         }
         None => {
-            // No config file — fall back to env-var embedding path.
             let env_cfg = config_from_env();
             if env_cfg.engines.is_empty() {
                 Ok(base)
@@ -137,9 +138,6 @@ fn resolve_config(
 }
 
 /// Resolve only the actor namespace from a config file (no-embed path).
-///
-/// Used when `--no-embed` zeroed out embedding; we still want config-file
-/// `[actor] id` to apply if no CLI actor was given.
 fn resolve_actor_from_config(
     config_path: Option<&std::path::Path>,
     base: RuntimeConfig,
@@ -152,10 +150,6 @@ fn resolve_actor_from_config(
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
     {
         Some(khive_cfg) => {
-            // KhiveConfig::validate() already ran inside load_with_home_fallback,
-            // so actor.id is guaranteed valid here. runtime_config_from_khive_config
-            // applies the actor, but we zero out embedding fields after the fact to
-            // preserve the --no-embed contract.
             let resolved = runtime_config_from_khive_config(&khive_cfg, base);
             Ok(RuntimeConfig {
                 embedding_model: None,

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -20,11 +20,47 @@ use serde_json::{json, Value};
 
 use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
 use khive_runtime::{
-    present, KhiveRuntime, PackLoadError, PackRegistry, PresentationMode, RuntimeError,
-    VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder,
+    present, KhiveRuntime, PackLoadError, PackRegistry, PresentationMode, RuntimeConfig,
+    RuntimeError, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder,
 };
 
 use crate::tools::request::RequestParams;
+
+/// Fingerprint the dispatch-affecting parts of a resolved [`RuntimeConfig`].
+///
+/// Two servers produce the same id iff they would dispatch identically: same
+/// pack set (order-independent), same storage target, and same embedders. The
+/// daemon compares this against each forwarded request's `config_id` and rejects
+/// mismatches so a restricted client (e.g. `--pack kg`, `--db :memory:`) cannot
+/// execute through the broader default daemon. Namespace is carried separately.
+pub fn compute_config_id(config: &RuntimeConfig) -> String {
+    let mut packs = config.packs.clone();
+    packs.sort();
+    let db = config
+        .db_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| ":memory:".to_string());
+    let primary = config
+        .embedding_model
+        .as_ref()
+        .map(|m| format!("{m:?}"))
+        .unwrap_or_else(|| "none".to_string());
+    let mut extra: Vec<String> = config
+        .additional_embedding_models
+        .iter()
+        .map(|m| format!("{m:?}"))
+        .collect();
+    extra.sort();
+    format!(
+        "packs=[{}];db={};embed={};extra=[{}];backend={:?}",
+        packs.join(","),
+        db,
+        primary,
+        extra.join(","),
+        config.backend_id,
+    )
+}
 
 /// Build a sorted, human-readable verb catalog from `(pack_name, verb_name, description)` triples.
 ///
@@ -78,6 +114,11 @@ pub struct KhiveMcpServer {
     /// Namespace this registry was built for. The stdio client passes it to the
     /// daemon; a namespace mismatch triggers local-dispatch fallback.
     default_namespace: String,
+    /// Fingerprint of the resolved runtime config (packs, db target, embedders).
+    /// The stdio client passes it to the daemon; a config mismatch triggers
+    /// local-dispatch fallback so a restricted client never runs through the
+    /// broader default daemon.
+    config_id: String,
 }
 
 /// Failure reason inside a [`PackRegError`].
@@ -156,6 +197,7 @@ impl KhiveMcpServer {
     pub fn with_packs(runtime: KhiveRuntime, packs: &[String]) -> Result<Self, PackRegError> {
         let gate = runtime.config().gate.clone();
         let default_namespace = runtime.config().default_namespace.clone();
+        let config_id = compute_config_id(runtime.config());
         let mut builder = VerbRegistryBuilder::new();
         builder.with_gate(gate);
         builder.with_default_namespace(default_namespace.as_str());
@@ -193,6 +235,7 @@ impl KhiveMcpServer {
         Ok(Self {
             registry,
             default_namespace: default_namespace.as_str().to_string(),
+            config_id,
         })
     }
 
@@ -206,12 +249,21 @@ impl KhiveMcpServer {
         Self {
             registry,
             default_namespace: "local".to_string(),
+            // A registry injected directly has no resolved RuntimeConfig; use a
+            // sentinel that matches no real daemon so such servers always
+            // dispatch locally rather than forward.
+            config_id: "registry-only".to_string(),
         }
     }
 
     /// Namespace this server's registry was built for.
     pub fn default_namespace(&self) -> &str {
         &self.default_namespace
+    }
+
+    /// Fingerprint of the runtime config this server's registry was built for.
+    pub fn config_id(&self) -> &str {
+        &self.config_id
     }
 
     /// Warm every pack's in-memory state. Called by the daemon in a background
@@ -674,6 +726,7 @@ result (e.g. create then link with the new entity's id)."#)]
                 presentation: p.presentation.clone(),
                 presentation_per_op: p.presentation_per_op.clone(),
                 namespace: self.default_namespace.clone(),
+                config_id: self.config_id.clone(),
             };
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
                 return res;

--- a/crates/khive-mcp/src/transport.rs
+++ b/crates/khive-mcp/src/transport.rs
@@ -1,0 +1,92 @@
+//! Registerable MCP serving transports.
+//!
+//! A [`Transport`] owns the wire protocol used to serve the `request` surface.
+//! Built-ins are registered via [`TransportRegistry::with_builtins`]; additional
+//! transports (e.g. Streamable HTTP) register with [`TransportRegistry::register`]
+//! before serving, so the serve path never hard-codes a transport enum.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+
+use crate::server::KhiveMcpServer;
+
+/// Options passed to a transport at serve time.
+#[derive(Debug, Default, Clone)]
+pub struct ServeOptions {
+    /// Bind address for network transports (e.g. `0.0.0.0:8080`). Ignored by stdio.
+    pub bind: Option<String>,
+}
+
+/// A way to serve the MCP `request` surface.
+#[async_trait]
+pub trait Transport: Send + Sync {
+    /// Name selected via `--transport <name>`.
+    fn name(&self) -> &'static str;
+
+    /// One-line description for help and listing.
+    fn about(&self) -> &'static str;
+
+    /// Serve until the connection closes. Consumes the server.
+    async fn serve(&self, server: KhiveMcpServer, opts: &ServeOptions) -> anyhow::Result<()>;
+}
+
+/// MCP over stdio — the default transport, used by the deno/npm wrapper.
+pub struct StdioTransport;
+
+#[async_trait]
+impl Transport for StdioTransport {
+    fn name(&self) -> &'static str {
+        "stdio"
+    }
+
+    fn about(&self) -> &'static str {
+        "MCP over stdio (default)"
+    }
+
+    async fn serve(&self, server: KhiveMcpServer, _opts: &ServeOptions) -> anyhow::Result<()> {
+        server.serve_stdio().await
+    }
+}
+
+/// Named registry of serving transports.
+pub struct TransportRegistry {
+    transports: BTreeMap<&'static str, Box<dyn Transport>>,
+}
+
+impl TransportRegistry {
+    /// Empty registry — no transports.
+    pub fn new() -> Self {
+        Self {
+            transports: BTreeMap::new(),
+        }
+    }
+
+    /// Registry pre-populated with the built-in transports (`stdio`).
+    pub fn with_builtins() -> Self {
+        let mut registry = Self::new();
+        registry.register(Box::new(StdioTransport));
+        registry
+    }
+
+    /// Add (or replace) a transport. Keyed by [`Transport::name`].
+    pub fn register(&mut self, transport: Box<dyn Transport>) {
+        self.transports.insert(transport.name(), transport);
+    }
+
+    /// Look up a transport by name.
+    pub fn get(&self, name: &str) -> Option<&dyn Transport> {
+        self.transports.get(name).map(|t| t.as_ref())
+    }
+
+    /// All registered transport names, sorted.
+    pub fn names(&self) -> Vec<&'static str> {
+        self.transports.keys().copied().collect()
+    }
+}
+
+impl Default for TransportRegistry {
+    fn default() -> Self {
+        Self::with_builtins()
+    }
+}

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -65,6 +65,12 @@ pub struct DaemonRequestFrame {
     pub presentation: Option<String>,
     pub presentation_per_op: Option<Vec<Option<String>>>,
     pub namespace: String,
+    /// Fingerprint of the client's resolved runtime config (packs, db target,
+    /// embedders). The daemon rejects a request whose `config_id` differs from
+    /// its own so a restricted client (e.g. `--pack kg`, `--db :memory:`) never
+    /// dispatches through the broader default daemon. See ADR-027 / ADR-049.
+    #[serde(default)]
+    pub config_id: String,
 }
 
 /// Response frame sent from the daemon back to a client.
@@ -74,6 +80,11 @@ pub struct DaemonResponseFrame {
     pub result: Option<String>,
     pub error: Option<String>,
     pub namespace_mismatch: bool,
+    /// Set when the request's `config_id` does not match the daemon's. Like
+    /// `namespace_mismatch`, this signals the client to fall back to local
+    /// dispatch rather than execute under a different runtime/config.
+    #[serde(default)]
+    pub config_mismatch: bool,
 }
 
 // ── framing ───────────────────────────────────────────────────────────────────
@@ -133,6 +144,12 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
 
     /// The namespace this dispatcher was configured for.
     fn namespace(&self) -> &str;
+
+    /// Fingerprint of this dispatcher's resolved runtime config (packs, db
+    /// target, embedders). Used to reject forwarded requests from clients whose
+    /// config differs, so a restricted client cannot dispatch through a broader
+    /// daemon.
+    fn config_id(&self) -> &str;
 }
 
 // ── server ────────────────────────────────────────────────────────────────────
@@ -159,6 +176,15 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             result: None,
             error: None,
             namespace_mismatch: true,
+            config_mismatch: false,
+        }
+    } else if frame.config_id != dispatcher.config_id() {
+        DaemonResponseFrame {
+            ok: false,
+            result: None,
+            error: None,
+            namespace_mismatch: false,
+            config_mismatch: true,
         }
     } else {
         match dispatcher
@@ -170,12 +196,14 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 result: Some(result),
                 error: None,
                 namespace_mismatch: false,
+                config_mismatch: false,
             },
             Err(e) => DaemonResponseFrame {
                 ok: false,
                 result: None,
                 error: Some(e),
                 namespace_mismatch: false,
+                config_mismatch: false,
             },
         }
     };

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -85,6 +85,14 @@ pub struct DaemonResponseFrame {
     /// dispatch rather than execute under a different runtime/config.
     #[serde(default)]
     pub config_mismatch: bool,
+    /// The `config_id` the daemon dispatched under, echoed back so the client
+    /// can positively confirm the result came from a matching runtime. A
+    /// pre-`config_id` daemon omits this field (deserializes to `None`), which
+    /// the client treats as a mismatch and falls back to local dispatch — this
+    /// closes the upgrade window where a new restricted client could otherwise
+    /// trust a still-warm legacy daemon's broader registry.
+    #[serde(default)]
+    pub served_config_id: Option<String>,
 }
 
 // ── framing ───────────────────────────────────────────────────────────────────
@@ -170,6 +178,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
         }
     };
 
+    let served_config_id = Some(dispatcher.config_id().to_string());
     let resp = if frame.namespace != dispatcher.namespace() {
         DaemonResponseFrame {
             ok: false,
@@ -177,6 +186,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             error: None,
             namespace_mismatch: true,
             config_mismatch: false,
+            served_config_id,
         }
     } else if frame.config_id != dispatcher.config_id() {
         DaemonResponseFrame {
@@ -185,6 +195,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             error: None,
             namespace_mismatch: false,
             config_mismatch: true,
+            served_config_id,
         }
     } else {
         match dispatcher
@@ -197,6 +208,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 error: None,
                 namespace_mismatch: false,
                 config_mismatch: false,
+                served_config_id,
             },
             Err(e) => DaemonResponseFrame {
                 ok: false,
@@ -204,6 +216,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 error: Some(e),
                 namespace_mismatch: false,
                 config_mismatch: false,
+                served_config_id,
             },
         }
     };

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -12,6 +12,7 @@ description = "khive kernel — admin/management Rust binary (sync, pack introsp
 
 [dependencies]
 khive-runtime = { version = "0.2.8", path = "../khive-runtime" }
+khive-mcp = { version = "0.2.8", path = "../khive-mcp" }
 khive-score = { version = "0.2.8", path = "../khive-score" }
 khive-db = { version = "0.2.8", path = "../khive-db" }
 khive-storage = { version = "0.2.8", path = "../khive-storage" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -40,6 +40,7 @@ toml = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+serial_test = { workspace = true }
 
 [[bin]]
 name = "kkernel"

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -1,0 +1,195 @@
+# kkernel — usage patterns
+
+`kkernel` is the single khive Rust binary. It is both the **admin/management CLI**
+(sync, schema migrations, pack/backend introspection, reindex) and the **MCP server**
+(`kkernel mcp`). There is no separate `khive-mcp` binary — `khive-mcp` is now a
+library crate consumed by `kkernel`.
+
+All subcommands emit JSON on stdout by default; pass `--human` where supported for a
+readable table. `--log <level>` (env `KHIVE_LOG`, default `warn`) is global and goes
+to stderr — stdout stays clean for JSON / MCP traffic.
+
+```
+kkernel <command> [flags]
+
+  sync      Build a working SQLite DB from .khive/kg/*.ndjson sources
+  pack      Introspect registered packs (list, handler <name>)
+  kg        KG validation, init, hook management
+  db        Schema migration lifecycle (migrate, check)
+  engine    Embedding model lifecycle (list, status, migrate, drift-check)
+  vector    Vector store capabilities and orphan sweep
+  reindex   Re-embed all entities and notes
+  exec      Run a verb DSL expression through the pack registry
+  mcp       Serve the MCP `request` surface (stdio / daemon / transports)
+  backend   Inspect registered backends (list, info <name>)
+```
+
+The default database is `~/.khive/khive.db`. Override per-command with `--db`
+(or `KHIVE_DB` for `mcp`/`exec`). Use `:memory:` for an ephemeral database.
+
+---
+
+## `kkernel mcp` — serve the MCP request surface
+
+This is the production entrypoint. The deno/npm distribution invokes it:
+`khive mcp …` → `kkernel mcp …`, and the `khive-mcp` command alias → `kkernel mcp …`.
+
+```bash
+# stdio MCP server (default transport) — what MCP clients spawn
+kkernel mcp --db ~/.khive/khive.db
+
+# pick packs explicitly (default loads all 7 production packs)
+kkernel mcp --pack kg --pack gtd --pack knowledge
+
+# warm Unix-socket daemon (owns ANN indexes; stdio clients auto-spawn + forward to it)
+kkernel mcp --daemon
+
+# ephemeral in-memory server, no embedding (fast tests)
+kkernel mcp --db :memory: --no-embed
+```
+
+Key flags: `--db`, `--actor`/`--namespace`, `--no-embed`, `--pack` (repeatable),
+`--config`, `--daemon`, `--transport <name>`, `--bind <addr>`.
+
+### Transports are registerable
+
+`--transport` selects a foreground transport by name from a registry
+(`khive_mcp::transport::TransportRegistry`). `stdio` is the only built-in today;
+additional transports (e.g. Streamable HTTP) register with `registry.register(...)`
+before serving. An unknown name errors with the registered set. `--bind` is reserved
+for network transports and is ignored by stdio.
+
+`--daemon` is a deployment mode, not a transport: it runs the warm Unix-socket server
+(`~/.khive/khived.sock`) and takes precedence over `--transport`. On first use, stdio
+clients auto-spawn `kkernel mcp --daemon` and forward request frames to it; set
+`KHIVE_NO_DAEMON=1` to force local dispatch (used by the smoke/contract tests).
+
+---
+
+## `kkernel exec` — run a verb directly through the registry
+
+Same DSL as the MCP `request` tool, but in-process against a chosen DB and namespace —
+ideal for admin verb calls without standing up an MCP client. Defaults to namespace
+`local`.
+
+```bash
+kkernel exec 'knowledge.stats()'
+kkernel exec 'knowledge.stats()' --db ~/.khive/khive.db
+kkernel exec '[knowledge.list(limit=5), stats()]'                 # parallel batch
+kkernel exec 'create(kind="entity", entity_kind="concept", name="X") | link(source_id=$prev.id, target_id="<id>", relation="extends")'   # chain ($prev)
+kkernel exec 'knowledge.index(help=true)'                         # param schema for any verb
+kkernel exec 'knowledge.search(query="...", rerank=true)' --presentation verbose
+```
+
+Flags: `--db`, `--namespace`, `--presentation <agent|verbose|human>`.
+
+---
+
+## Reindex workflows
+
+Embeddings/FTS are rebuilt by two distinct paths, because entity/note vectors and
+knowledge atoms live in different stores:
+
+### Entities + notes — `kkernel reindex`
+
+Walks all entities and notes and (re-)embeds them. Namespace-scoped, so run once per
+namespace your data spans.
+
+```bash
+kkernel reindex --db ~/.khive/khive.db --namespace local
+kkernel reindex --db ~/.khive/khive.db --namespace khive
+# flags: --model, --batch-size (default 100), --keep-existing, --human
+```
+
+`--keep-existing` skips records that already have a vector (incremental top-up).
+Omit it to drop-and-rebuild.
+
+### Knowledge atoms — `kkernel exec 'knowledge.index(...)'`
+
+The knowledge corpus is reindexed through its own handler. It embeds atoms and
+(optionally) rebuilds the Vamana ANN. Also namespace-scoped via `--namespace`.
+
+```bash
+# embed all atoms in a namespace + rebuild the ANN snapshot
+kkernel exec 'knowledge.index(rebuild_ann=true)' --db ~/.khive/khive.db --namespace local
+
+# embed only specific atoms (by slug or id), no ANN rebuild
+kkernel exec 'knowledge.index(ids=["my-slug", "<uuid>"])' --db ~/.khive/khive.db
+
+# batch sizing (clamped 1..1000, default 500)
+kkernel exec 'knowledge.index(batch_size=1000, rebuild_ann=true)' --db ~/.khive/khive.db
+```
+
+`knowledge.index` indexes **atoms** (not sections) and reports
+`{indexed, skipped, total, ann_vectors}`. It is a no-op returning
+`"no embedding model configured"` when no embedder is set.
+
+> Stop the MCP daemon before a large reindex to avoid SQLite write contention:
+> `pkill -f 'kkernel.*--daemon'` (or `KHIVE_NO_DAEMON=1`), then reindex, then let
+> the next stdio client re-spawn the daemon.
+
+---
+
+## `kkernel db` — schema lifecycle
+
+```bash
+kkernel db check --db ~/.khive/khive.db --human     # report current vs latest version
+kkernel db check --strict                            # exit nonzero if behind
+kkernel db migrate --db ~/.khive/khive.db            # apply pending migrations
+kkernel db migrate --dry-run                         # show pending without applying
+```
+
+The consolidated baseline is a single migration (V1, from `khive-db/sql/schema.sql`).
+A database whose `_schema_migrations` version is **ahead** of the latest known
+migration is rejected at open time — it predates the consolidation or was written by a
+newer build. Recreate it from the current schema; in-place downgrade is unsupported.
+
+---
+
+## `kkernel sync` — build a DB from NDJSON sources
+
+```bash
+kkernel sync --repo . --db ~/.khive/working.db --namespace local
+```
+
+Reads `.khive/kg/{entities,edges}.ndjson`, builds a queryable SQLite DB, and replaces
+the target atomically (tmp + rename). Consumed by the deno CLI's `khive kg sync`.
+
+---
+
+## Introspection
+
+```bash
+kkernel pack list --human                 # all packs: verbs, note kinds, entity kinds
+kkernel pack handler knowledge --human     # full handler surface for one pack
+kkernel backend list --human               # registered backends
+kkernel backend info main --human
+kkernel engine list                        # embedding engines + model history
+kkernel engine status                      # active model + migration status
+kkernel vector --help                      # vector store capabilities, orphan sweep
+kkernel kg --help                          # KG validation, init, pre-commit hook
+```
+
+---
+
+## Distribution model
+
+`kkernel` is the only published binary. The npm package `khive` ships per-platform
+`@khive-ai/kernel-<platform>` subpackages that each contain `bin/kkernel`. Two command
+names route to it:
+
+- `khive <cmd>` → `kkernel <cmd>` (and `khive mcp` → `kkernel mcp`)
+- `khive-mcp [args]` → `kkernel mcp [args]` (compat alias for existing MCP configs)
+
+Binary resolution order (npm shims and `cli/lib/kernel.ts` agree): `KKERNEL_BINARY`
+env override → `@khive-ai/kernel-<platform>/bin/kkernel` → monorepo
+`crates/target/{release,debug}/kkernel`.
+
+### Local development
+
+```bash
+make local          # build release kkernel, kill stale procs, codesign, install to ~/.cargo/bin
+make ci             # full gate (fmt, clippy -D warnings, tests, contract + smoke)
+```
+
+After `make local`, run `/mcp` in Claude Code to reconnect to the rebuilt server.

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1,0 +1,61 @@
+//! `kkernel exec` — run a verb DSL expression directly through the pack registry.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use khive_mcp::server::KhiveMcpServer;
+use khive_mcp::tools::request::RequestParams;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+
+/// Arguments for `kkernel exec` — execute a verb DSL expression against a chosen
+/// database and namespace, the same syntax accepted by the MCP `request` tool.
+#[derive(Parser, Debug)]
+pub struct ExecArgs {
+    /// DSL expression to execute (same syntax as MCP `request` tool).
+    ///
+    /// Examples:
+    ///   kkernel exec 'knowledge.stats()'
+    ///   kkernel exec 'knowledge.index(rebuild_ann=true)'
+    ///   kkernel exec '[knowledge.list(limit=5), knowledge.stats()]'
+    pub ops: String,
+
+    /// Database path (defaults to `~/.khive/khive.db`).
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+
+    /// Namespace to operate in.
+    #[arg(long, default_value = "local")]
+    pub namespace: String,
+
+    /// Presentation mode: `agent` (default), `verbose`, or `human`.
+    #[arg(long)]
+    pub presentation: Option<String>,
+}
+
+/// Execute the DSL expression in-process and print the JSON result to stdout.
+pub async fn run_exec(args: ExecArgs) -> Result<()> {
+    let mut cfg = RuntimeConfig::default();
+    if let Some(ref db) = args.db {
+        cfg.db_path = Some(db.clone());
+    }
+    cfg.default_namespace =
+        Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let server = KhiveMcpServer::new(rt).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let params = RequestParams {
+        ops: args.ops,
+        presentation: args.presentation,
+        presentation_per_op: None,
+    };
+
+    let output = server
+        .dispatch_request_local(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("{output}");
+    Ok(())
+}

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -21,9 +21,10 @@ pub struct ExecArgs {
     ///   kkernel exec '[knowledge.list(limit=5), knowledge.stats()]'
     pub ops: String,
 
-    /// Database path (defaults to `~/.khive/khive.db`).
-    #[arg(long)]
-    pub db: Option<PathBuf>,
+    /// Database path (defaults to `~/.khive/khive.db`). `:memory:` selects an
+    /// ephemeral in-memory database, matching `kkernel mcp`.
+    #[arg(long, env = "KHIVE_DB")]
+    pub db: Option<String>,
 
     /// Namespace to operate in.
     #[arg(long, default_value = "local")]
@@ -35,10 +36,22 @@ pub struct ExecArgs {
 }
 
 /// Execute the DSL expression in-process and print the JSON result to stdout.
+/// Resolve the `--db`/`KHIVE_DB` value into a `db_path` override, mirroring
+/// `kkernel mcp`: an explicit `:memory:` means the ephemeral in-memory db
+/// (`None`), not a file literally named ":memory:" (which SQLite treats as a
+/// per-connection file → empty schema). `None` leaves the default in place.
+fn resolve_db_override(db: Option<&str>) -> Option<Option<PathBuf>> {
+    match db {
+        Some(":memory:") => Some(None),
+        Some(path) => Some(Some(PathBuf::from(path))),
+        None => None,
+    }
+}
+
 pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let mut cfg = RuntimeConfig::default();
-    if let Some(ref db) = args.db {
-        cfg.db_path = Some(db.clone());
+    if let Some(db_path) = resolve_db_override(args.db.as_deref()) {
+        cfg.db_path = db_path;
     }
     cfg.default_namespace =
         Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -58,4 +71,41 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     println!("{output}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use serial_test::serial;
+
+    #[test]
+    fn memory_sentinel_maps_to_none() {
+        // `:memory:` must become db_path=None (ephemeral), not a file path.
+        assert_eq!(resolve_db_override(Some(":memory:")), Some(None));
+    }
+
+    #[test]
+    fn explicit_path_maps_to_some() {
+        assert_eq!(
+            resolve_db_override(Some("/tmp/kkernel-exec-test.db")),
+            Some(Some(PathBuf::from("/tmp/kkernel-exec-test.db")))
+        );
+    }
+
+    #[test]
+    fn absent_db_leaves_default() {
+        // None → no override; run_exec keeps RuntimeConfig::default().db_path.
+        assert_eq!(resolve_db_override(None), None);
+    }
+
+    #[test]
+    #[serial]
+    fn khive_db_env_binds_to_db_arg() {
+        // clap reads KHIVE_DB for `--db` (parity with `kkernel mcp`).
+        std::env::set_var("KHIVE_DB", "/tmp/kkernel-exec-env.db");
+        let args = ExecArgs::parse_from(["exec", "stats()"]);
+        std::env::remove_var("KHIVE_DB");
+        assert_eq!(args.db.as_deref(), Some("/tmp/kkernel-exec-env.db"));
+    }
 }

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod coordinator;
 pub mod engine;
+pub mod exec;
 pub mod kg;
 pub mod pack_introspect;
 pub mod reindex;

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -11,6 +11,8 @@
 //! - `engine`  — embedding model lifecycle: list/status/migrate/drift-check
 //! - `vector`  — vector store capabilities and orphan sweep
 //! - `reindex` — rebuild embedding vectors for entities and notes
+//! - `exec`    — run a verb DSL expression through the pack registry
+//! - `mcp`     — serve the MCP `request` surface (stdio / daemon / transports)
 //! - `backend` — inspect registered backends (`list`, `info <name>`)
 //!
 //! All subcommands emit JSON on stdout by default for easy piping/parsing.
@@ -22,7 +24,9 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use khive_runtime::{BackendId, KhiveRuntime, RuntimeConfig};
-use kkernel::{coordinator::BackendRegistry, engine, kg, pack_introspect, reindex, sync, vector};
+use kkernel::{
+    coordinator::BackendRegistry, engine, exec, kg, pack_introspect, reindex, sync, vector,
+};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -66,6 +70,13 @@ enum Command {
 
     /// Re-embed all entities and notes using the configured embedding model.
     Reindex(reindex::ReindexArgs),
+
+    /// Execute a verb DSL expression (same syntax as MCP `request` tool).
+    Exec(exec::ExecArgs),
+
+    /// Serve the MCP `request` surface (stdio by default; `--daemon` for the
+    /// warm Unix-socket server; `--transport` selects a registered transport).
+    Mcp(khive_mcp::args::Args),
 
     /// Inspect registered backends.
     #[command(subcommand)]
@@ -193,6 +204,11 @@ async fn main() -> Result<()> {
         Command::Engine(e) => engine::run_engine(e).await,
         Command::Vector(v) => vector::run_vector(v),
         Command::Reindex(r) => reindex::run_reindex(r).await,
+        Command::Exec(e) => exec::run_exec(e).await,
+        Command::Mcp(a) => {
+            khive_mcp::serve::run(a, &khive_mcp::transport::TransportRegistry::with_builtins())
+                .await
+        }
         Command::Backend(b) => cmd_backend(b),
     }
 }

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -278,60 +278,61 @@ async fn cmd_db_migrate(args: DbMigrateArgs) -> Result<()> {
 }
 
 async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
-    use khive_storage::types::{SqlStatement, SqlValue};
-
-    let mut cfg = RuntimeConfig::default();
-    if let Some(ref db) = args.db {
-        cfg.db_path = Some(db.clone());
-    }
-
-    // Use read-only constructor so we don't write if just checking.
-    let rt = KhiveRuntime::new_readonly(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     let latest = khive_db::MIGRATIONS.len() as u32;
 
-    let sql = rt.sql();
-    let mut reader = sql.reader().await.context("open SQL reader for db check")?;
+    // A schema check must never mutate the database. Resolve the effective path
+    // and read `_schema_migrations` read-only — opening through a runtime would
+    // run migrations and bring an out-of-date database current before reporting,
+    // masking the pending state this command exists to detect.
+    let resolved: Option<PathBuf> = match args.db {
+        Some(p) => Some(p),
+        None => std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join(".khive/khive.db")),
+    };
 
-    let current_version: u32 = reader
-        .query_all(SqlStatement {
-            sql: "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations".into(),
-            params: vec![],
-            label: Some("db_check_version".into()),
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .ok()
-        .and_then(|rows| {
-            rows.first()
-                .and_then(|r| match r.get("COALESCE(MAX(version), 0)") {
-                    Some(SqlValue::Integer(v)) => Some(*v as u32),
-                    _ => None,
-                })
-        })
-        .unwrap_or(0);
+    // An absent file is an un-migrated database (version 0); do not create it.
+    let current_version: u32 = match resolved {
+        Some(ref p) if p.exists() => {
+            khive_db::inspect_schema_version(p).map_err(|e| anyhow::anyhow!("{e}"))?
+        }
+        _ => 0,
+    };
 
-    let is_current = current_version >= latest;
+    let is_current = current_version == latest;
+    // A version beyond the latest known migration is a stale ledger: the database
+    // predates the consolidated V1 baseline (ADR-015) or was written by a newer
+    // build. Report it rather than treating it as current.
+    let ahead = current_version > latest;
 
     if args.human {
-        println!(
-            "main:    V{current_version} ({})",
-            if is_current {
-                "current"
-            } else {
-                "behind — run: kkernel db migrate"
-            }
-        );
+        let state = if ahead {
+            "ahead — predates the consolidated baseline (ADR-015) or written by a newer build; recreate it"
+        } else if is_current {
+            "current"
+        } else {
+            "behind — run: kkernel db migrate"
+        };
+        println!("main:    V{current_version} ({state})");
     } else {
         let json = serde_json::json!({
             "current_version": current_version,
             "latest_version": latest,
             "current": is_current,
-            "pending": if is_current { 0 } else { latest - current_version },
+            "ahead": ahead,
+            "pending": latest.saturating_sub(current_version),
         });
         println!("{}", serde_json::to_string(&json).expect("serialize"));
     }
 
     if args.strict && !is_current {
+        if ahead {
+            anyhow::bail!(
+                "schema version {current_version} is ahead of the latest known migration {latest} — \
+                 this database predates the consolidated baseline (ADR-015) or was written by a newer \
+                 build; recreate it from the current schema"
+            );
+        }
         anyhow::bail!(
             "schema is behind: V{current_version} applied, V{latest} is current — \
              run `kkernel db migrate` to bring the schema up to date"
@@ -484,5 +485,55 @@ fn cmd_backend(cmd: BackendCommand) -> Result<()> {
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // A schema check must be read-only: it must not create a missing database,
+    // and it must not migrate (mutate) an existing one. Regression for the codex
+    // finding that `db check` ran migrations via the read-only runtime path.
+    #[tokio::test]
+    async fn db_check_does_not_create_missing_file() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("missing.db");
+        assert!(!path.exists());
+        cmd_db_check(DbCheckArgs {
+            db: Some(path.clone()),
+            strict: false,
+            human: false,
+        })
+        .await
+        .expect("db check succeeds on a missing file");
+        assert!(!path.exists(), "db check must not create the database file");
+    }
+
+    #[tokio::test]
+    async fn db_check_does_not_mutate_existing_db() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("real.db");
+        cmd_db_migrate(DbMigrateArgs {
+            db: Some(path.clone()),
+            backend: None,
+            dry_run: false,
+            check: false,
+            human: false,
+        })
+        .await
+        .expect("migrate creates the database");
+        let before = std::fs::read(&path).expect("read db before check");
+        // strict passes only when the db is already current — proves the read sees V1.
+        cmd_db_check(DbCheckArgs {
+            db: Some(path.clone()),
+            strict: true,
+            human: false,
+        })
+        .await
+        .expect("db check passes on a current db");
+        let after = std::fs::read(&path).expect("read db after check");
+        assert_eq!(before, after, "db check must not mutate the database");
     }
 }

--- a/docs/_templates/RELEASE.md
+++ b/docs/_templates/RELEASE.md
@@ -43,7 +43,7 @@
 ## Install
 
 ```bash
-cargo install khive-mcp@{VERSION}
+cargo install kkernel@{VERSION}
 ```
 
 ## MCP configuration
@@ -52,8 +52,8 @@ cargo install khive-mcp@{VERSION}
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": []
+      "command": "kkernel",
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,8 +16,11 @@ through 63 verbs across 7 packs, dispatched through a single MCP tool.
 ### From crates.io (Rust)
 
 ```bash
-cargo install khive-mcp
+cargo install kkernel
 ```
+
+`kkernel` is the single shipped binary; `kkernel mcp` serves the MCP `request`
+surface.
 
 ### From npm
 
@@ -27,13 +30,15 @@ npm install -g khive
 npm install -g @khive-ai/cli
 ```
 
+The npm package installs `khive` / `khive-mcp` shims that forward to `kkernel mcp`.
+
 ### From source
 
 ```bash
 git clone https://github.com/ohdearquant/khive
 cd khive
 cargo build --workspace --release
-# Binary at crates/target/release/khive-mcp
+# Binary at crates/target/release/kkernel
 ```
 
 ## Connect to your MCP client
@@ -46,8 +51,8 @@ Add to your MCP configuration (`.claude/settings.json` or equivalent):
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": []
+      "command": "kkernel",
+      "args": ["mcp"]
     }
   }
 }
@@ -61,8 +66,8 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": []
+      "command": "kkernel",
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -181,7 +181,7 @@ patterns.
 
 - **Cold start**: the first search in a session loads the ANN index and
   embedding model. The daemon keeps these warm for subsequent calls.
-- **Daemon**: khive auto-spawns `khive-mcp --daemon` on first request. The
+- **Daemon**: khive auto-spawns `kkernel mcp --daemon` on first request. The
   daemon keeps indexes hot across sessions.
 - **Vector search without embeddings**: if running with `--no-embed`, only FTS
   results are returned (no vector similarity).

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -1,54 +1,47 @@
 # khive Marketplace Plugin Installation
 
 This document covers how to install khive plugins for Claude Code and verify they are wired
-correctly to a running `khive-mcp` server.
+correctly to a running `kkernel mcp` server.
 
 ## Version compatibility
 
-| Plugin    | Version | khive-mcp |
-| --------- | ------- | --------- |
-| kg        | 0.2.4   | ≥ 0.2.4   |
-| gtd       | 0.2.4   | ≥ 0.2.4   |
-| memory    | 0.2.4   | ≥ 0.2.4   |
-| brain     | 0.2.4   | ≥ 0.2.4   |
-| comm      | 0.2.4   | ≥ 0.2.4   |
-| schedule  | 0.2.4   | ≥ 0.2.4   |
-| knowledge | 0.2.4   | ≥ 0.2.4   |
+| Plugin    | Version | kkernel |
+| --------- | ------- | ------- |
+| kg        | 0.2.4   | ≥ 0.2.4 |
+| gtd       | 0.2.4   | ≥ 0.2.4 |
+| memory    | 0.2.4   | ≥ 0.2.4 |
+| brain     | 0.2.4   | ≥ 0.2.4 |
+| comm      | 0.2.4   | ≥ 0.2.4 |
+| schedule  | 0.2.4   | ≥ 0.2.4 |
+| knowledge | 0.2.4   | ≥ 0.2.4 |
 
-## Step 1 — Install khive-mcp
-
-```bash
-cargo install khive-mcp
-```
-
-That is all you need. Add the MCP server config (Step 2), and you are ready to go.
-
-Verify:
-
-```bash
-khive-mcp --version
-```
-
-### Daemon (warm startup)
-
-`khive-mcp` automatically spawns a background daemon on first use. The daemon keeps embedding models
-and the ANN index warm in memory so that subsequent requests start instantly instead of reloading
-from disk. No user action is needed — install, configure, and the daemon lifecycle is handled for
-you.
-
-If you need manual control:
-
-- **Start explicitly**: `khive-mcp --daemon` launches the daemon in the foreground.
-- **Stop**: send `SIGTERM` (the daemon shuts down cleanly).
-
-### kkernel (optional admin CLI)
-
-`kkernel` is a separate admin binary for pack introspection, reindexing, and engine management. Most
-users never need it. If you do:
+## Step 1 — Install kkernel
 
 ```bash
 cargo install kkernel
 ```
+
+`kkernel` is the single shipped binary; `kkernel mcp` serves the MCP `request` surface (the npm
+package additionally installs `khive` / `khive-mcp` shims that forward to `kkernel mcp`). Add the
+MCP server config (Step 2), and you are ready to go.
+
+Verify:
+
+```bash
+kkernel --version
+```
+
+### Daemon (warm startup)
+
+`kkernel mcp` automatically spawns a background daemon on first use. The daemon keeps embedding
+models and the ANN index warm in memory so that subsequent requests start instantly instead of
+reloading from disk. No user action is needed — install, configure, and the daemon lifecycle is
+handled for you.
+
+If you need manual control:
+
+- **Start explicitly**: `kkernel mcp --daemon` launches the daemon in the foreground.
+- **Stop**: send `SIGTERM` (the daemon shuts down cleanly).
 
 ## Step 2 — Register the MCP server in Claude Code
 
@@ -60,8 +53,9 @@ Create or update `.mcp.json` in your project root:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
+      "command": "kkernel",
       "args": [
+        "mcp",
         "--pack",
         "kg",
         "--pack",
@@ -86,28 +80,28 @@ Create or update `.mcp.json` in your project root:
 
 ```bash
 # KG only
-claude mcp add --transport stdio khive -- khive-mcp --pack kg
+claude mcp add --transport stdio khive -- kkernel mcp --pack kg
 
 # GTD only
-claude mcp add --transport stdio khive -- khive-mcp --pack gtd
+claude mcp add --transport stdio khive -- kkernel mcp --pack gtd
 
 # Memory only
-claude mcp add --transport stdio khive -- khive-mcp --pack memory
+claude mcp add --transport stdio khive -- kkernel mcp --pack memory
 
 # Brain only (kg dependency resolved automatically)
-claude mcp add --transport stdio khive -- khive-mcp --pack brain
+claude mcp add --transport stdio khive -- kkernel mcp --pack brain
 
 # Comm only
-claude mcp add --transport stdio khive -- khive-mcp --pack comm
+claude mcp add --transport stdio khive -- kkernel mcp --pack comm
 
 # Schedule only
-claude mcp add --transport stdio khive -- khive-mcp --pack schedule
+claude mcp add --transport stdio khive -- kkernel mcp --pack schedule
 
 # Knowledge only
-claude mcp add --transport stdio khive -- khive-mcp --pack knowledge
+claude mcp add --transport stdio khive -- kkernel mcp --pack knowledge
 
 # All packs (recommended)
-claude mcp add --transport stdio khive -- khive-mcp \
+claude mcp add --transport stdio khive -- kkernel mcp \
   --pack kg --pack gtd --pack memory --pack brain \
   --pack comm --pack schedule --pack knowledge
 ```
@@ -204,10 +198,10 @@ All examples should report `invalid=0`.
 
 | Symptom                          | Fix                                                           |
 | -------------------------------- | ------------------------------------------------------------- |
-| `khive-mcp: command not found`   | Run `cargo install khive-mcp` or add `~/.cargo/bin` to `PATH` |
+| `kkernel: command not found`     | Run `cargo install kkernel` or add `~/.cargo/bin` to `PATH`   |
 | MCP tool not appearing in Claude | Check `.mcp.json` is in the project root; restart Claude Code |
 | `Unknown verb` error             | Confirm `--pack` flag includes the right pack for the verb    |
-| `Pack not loaded` error          | Verify `khive-mcp --version` matches the plugin version       |
+| `Pack not loaded` error          | Verify `kkernel --version` matches the plugin version         |
 
 ## Links
 

--- a/marketplace/brain/README.md
+++ b/marketplace/brain/README.md
@@ -26,7 +26,7 @@ All verbs are dispatched through the single MCP `request` tool
 Enable the brain pack by passing `--pack brain` (the kg pack dependency is resolved automatically):
 
 ```bash
-khive-mcp --pack brain
+kkernel mcp --pack brain
 ```
 
 The `request` tool also accepts an optional `presentation` field (`agent` | `verbose` | `human`) per
@@ -44,21 +44,21 @@ Default is `agent` (token-efficient) for MCP callers.
 
 ### Write lifecycle (commissive)
 
-| Verb                                                       | What it does                                                    |
-| ---------------------------------------------------------- | --------------------------------------------------------------- |
-| `brain.activate(profile_id)`                               | Move a profile to Active — starts the live update loop.         |
-| `brain.deactivate(profile_id)`                             | Move a profile to Inactive — stops live updates, retains state. |
-| `brain.archive(profile_id)`                                | Move a profile to Archived — read-only, audit-retained.         |
-| `brain.feedback(target_id, signal, served_by_profile_id?, section_signals?)` | Emit a FeedbackExplicit event and update posteriors. |
+| Verb                                                                         | What it does                                                    |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `brain.activate(profile_id)`                                                 | Move a profile to Active — starts the live update loop.         |
+| `brain.deactivate(profile_id)`                                               | Move a profile to Inactive — stops live updates, retains state. |
+| `brain.archive(profile_id)`                                                  | Move a profile to Archived — read-only, audit-retained.         |
+| `brain.feedback(target_id, signal, served_by_profile_id?, section_signals?)` | Emit a FeedbackExplicit event and update posteriors.            |
 
 ### Write binding / declaration
 
-| Verb                                                                    | What it does                                              |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| `brain.create_profile(name, description?, consumer_kind?, seed_priors?)` | Create a new Bayesian profile; starts in Inactive state. |
-| `brain.bind(profile_id, actor?, namespace?, consumer_kind?, priority?)` | Write a row in the profile resolution table.              |
-| `brain.unbind(profile_id?, actor?, namespace?, consumer_kind?)`         | Remove rows (at least one filter required).               |
-| `brain.reset(profile_id?)`                                              | Reset posteriors to priors; increments exploration_epoch. |
+| Verb                                                                     | What it does                                              |
+| ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `brain.create_profile(name, description?, consumer_kind?, seed_priors?)` | Create a new Bayesian profile; starts in Inactive state.  |
+| `brain.bind(profile_id, actor?, namespace?, consumer_kind?, priority?)`  | Write a row in the profile resolution table.              |
+| `brain.unbind(profile_id?, actor?, namespace?, consumer_kind?)`          | Remove rows (at least one filter required).               |
+| `brain.reset(profile_id?)`                                               | Reset posteriors to priors; increments exploration_epoch. |
 
 ### Convenience
 
@@ -92,15 +92,15 @@ Default is `agent` (token-efficient) for MCP callers.
 
 ## Prerequisites
 
-This plugin provides skills only — it does **not** bundle an MCP server. Install `khive-mcp` and
+This plugin provides skills only — it does **not** bundle an MCP server. Install `kkernel` and
 register it with the `brain` pack before using any skill.
 
 ```bash
 # Install the binary
-cargo install khive-mcp
+cargo install kkernel
 
 # Register in your harness (Claude Code example)
-claude mcp add --transport stdio khive -- khive-mcp --pack brain
+claude mcp add --transport stdio khive -- kkernel mcp --pack brain
 ```
 
 Or add to your project's `.mcp.json`:
@@ -109,8 +109,8 @@ Or add to your project's `.mcp.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": ["--pack", "brain"]
+      "command": "kkernel",
+      "args": ["mcp", "--pack", "brain"]
     }
   }
 }

--- a/marketplace/gtd/README.md
+++ b/marketplace/gtd/README.md
@@ -19,13 +19,13 @@ Add `presentation="agent"` (default, compact) or `"verbose"` (full UUIDs + ISO t
 `request` call to control response shape (ADR-045). `"human"` is accepted but over MCP is identical
 to verbose JSON — readable prose is a CLI-layer concern, not an MCP-layer one.
 
-| Verb                                                                                                     | What it does                                                                                    |
-| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Verb                                                                                             | What it does                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gtd.assign(title, priority?, status?, assignee?, due?, depends_on?, context_entity_id?, tags?)` | Create a task. Defaults: `status=inbox`, `priority=p2`. `depends_on` is an array of UUIDs that creates real `depends_on` graph edges. `context_entity_id` links the task to a KG entity at creation time. |
-| `gtd.next(limit?, assignee?)`                                                                            | Actionable tasks (status in `{next, active}`), sorted by priority (p0 first) then most-recent.  |
-| `gtd.complete(id, result?, status?)`                                                                     | Mark done (or `status="cancelled"`). Records `completed_at`. Terminal — no further transitions. |
-| `gtd.tasks(status?, assignee?, priority?, limit?, offset?)`                                              | Filtered listing.                                                                               |
-| `gtd.transition(id, status, note?)`                                                                      | Explicit GTD state change with lifecycle validation.                                            |
+| `gtd.next(limit?, assignee?)`                                                                    | Actionable tasks (status in `{next, active}`), sorted by priority (p0 first) then most-recent.                                                                                                            |
+| `gtd.complete(id, result?, status?)`                                                             | Mark done (or `status="cancelled"`). Records `completed_at`. Terminal — no further transitions.                                                                                                           |
+| `gtd.tasks(status?, assignee?, priority?, limit?, offset?)`                                      | Filtered listing.                                                                                                                                                                                         |
+| `gtd.transition(id, status, note?)`                                                              | Explicit GTD state change with lifecycle validation.                                                                                                                                                      |
 
 Statuses accept canonical names _or_ aliases: `in_progress → active`, `todo → inbox`,
 `blocked → waiting`, `later → someday`, `finished → done`.
@@ -48,15 +48,15 @@ Statuses accept canonical names _or_ aliases: `in_progress → active`, `todo �
 ## Prerequisites
 
 This plugin provides skills only — it does **not** bundle an MCP server. You must install the
-`khive-mcp` binary and register it as an MCP server in your harness **before** using any of the
+`kkernel` binary and register it as an MCP server in your harness **before** using any of the
 skills below.
 
 ```bash
 # Install the binary
-cargo install khive-mcp
+cargo install kkernel
 
 # Register in your harness (Claude Code example)
-claude mcp add --transport stdio khive -- khive-mcp --pack gtd
+claude mcp add --transport stdio khive -- kkernel mcp --pack gtd
 ```
 
 Or add to your project's `.mcp.json`:
@@ -65,15 +65,15 @@ Or add to your project's `.mcp.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": ["--pack", "gtd"]
+      "command": "kkernel",
+      "args": ["mcp", "--pack", "gtd"]
     }
   }
 }
 ```
 
 Install the `kg` pack alongside if you want knowledge graph verbs in the same session:
-`"args": ["--pack", "kg", "--pack", "gtd"]`
+`"args": ["mcp", "--pack", "kg", "--pack", "gtd"]`
 
 ## Install
 

--- a/marketplace/kg/README.md
+++ b/marketplace/kg/README.md
@@ -8,15 +8,15 @@ Part of the [khive](https://github.com/ohdearquant/khive) marketplace.
 ## Prerequisites
 
 This plugin provides skills and agents only — it does **not** bundle an MCP server. You must install
-the `khive-mcp` binary and register it as an MCP server in your harness **before** using any of the
+the `kkernel` binary and register it as an MCP server in your harness **before** using any of the
 skills or agents below.
 
 ```bash
 # Install the binary
-cargo install khive-mcp
+cargo install kkernel
 
 # Register in your harness (Claude Code example)
-claude mcp add --transport stdio khive -- khive-mcp --pack kg
+claude mcp add --transport stdio khive -- kkernel mcp --pack kg
 ```
 
 Or add to your project's `.mcp.json`:
@@ -25,8 +25,8 @@ Or add to your project's `.mcp.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": ["--pack", "kg"]
+      "command": "kkernel",
+      "args": ["mcp", "--pack", "kg"]
     }
   }
 }
@@ -50,24 +50,24 @@ request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"LoRA\")")
 request(ops="[search(kind=\"entity\", query=\"LoRA\"), neighbors(node_id=\"<id>\")]")  # parallel batch
 ```
 
-| Verb        | Key params                                                                                                          | What it does                                |
-| ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `create`    | `kind` (req), `name?`, `entity_kind?`, `entity_type?`, `note_kind?`, `content?`, `description?`, `tags?`, `properties?`, `annotates?` | Create entities or notes                    |
-| `get`       | `id` (req, UUID), `include_deleted?`                                                                                | Fetch any record by UUID                    |
-| `list`      | `kind` (req), `limit?`, `offset?`, `entity_kind?`, `entity_type?`, `tags?`, `note_kind?`, `source_id?`, `target_id?`, `relations?`, `min_weight?`, `max_weight?`, `direction?`, `event_kind?`, `event_kinds?` | Browse with filters                         |
-| `update`    | `id` (req), `kind?`, `name?`, `description?`, `content?`, `salience?`, `decay_factor?`, `relation?`, `weight?`, `properties?`, `tags?` | Patch entity, note, or edge fields          |
-| `delete`    | `id` (req), `kind?`, `hard?`                                                                                        | Soft (default) or hard delete               |
-| `merge`     | `into_id` (req), `from_id` (req)                                                                                    | Deduplicate two entities                    |
-| `search`    | `kind` (req), `query` (req), `limit?`, `entity_kind?`, `entity_type?`, `note_kind?`, `tags?`, `properties?`, `include_superseded?`, `min_score?` | Hybrid FTS5 + vector search                 |
-| `link`      | `source_id` (req), `target_id` (req), `relation` (req), `weight?`                                                  | Create typed directed edge (self-loops rejected) |
-| `neighbors` | `node_id` (req), `direction?` (default `"both"`), `relations?`, `min_weight?`                                       | Immediate graph neighbors                   |
-| `traverse`  | `roots` (req, array), `max_depth?` (default 3), `relations?`, `direction?`                                          | Multi-hop BFS                               |
-| `query`     | `query` (req, GQL string), `limit?` (default 500, cap 10000)                                                        | GQL/SPARQL pattern matching                 |
-| `propose`   | `title` (req), `description` (req), `changeset` (req), `reviewers?`, `expiry?`, `parent_id?`                        | Create an event-sourced change proposal     |
-| `review`    | `proposal_id` (req), `decision` (req), `comment?`                                                                   | Review a proposal                           |
-| `withdraw`  | `proposal_id` (req), `rationale?`                                                                                   | Withdraw an open proposal                   |
-| `stats`     | (none)                                                                                                              | Aggregate entity, edge, and note counts     |
-| `verbs`     | `category?`, `pack?`                                                                                                | List all registered MCP-callable verbs      |
+| Verb        | Key params                                                                                                                                                                                                    | What it does                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `create`    | `kind` (req), `name?`, `entity_kind?`, `entity_type?`, `note_kind?`, `content?`, `description?`, `tags?`, `properties?`, `annotates?`                                                                         | Create entities or notes                         |
+| `get`       | `id` (req, UUID), `include_deleted?`                                                                                                                                                                          | Fetch any record by UUID                         |
+| `list`      | `kind` (req), `limit?`, `offset?`, `entity_kind?`, `entity_type?`, `tags?`, `note_kind?`, `source_id?`, `target_id?`, `relations?`, `min_weight?`, `max_weight?`, `direction?`, `event_kind?`, `event_kinds?` | Browse with filters                              |
+| `update`    | `id` (req), `kind?`, `name?`, `description?`, `content?`, `salience?`, `decay_factor?`, `relation?`, `weight?`, `properties?`, `tags?`                                                                        | Patch entity, note, or edge fields               |
+| `delete`    | `id` (req), `kind?`, `hard?`                                                                                                                                                                                  | Soft (default) or hard delete                    |
+| `merge`     | `into_id` (req), `from_id` (req)                                                                                                                                                                              | Deduplicate two entities                         |
+| `search`    | `kind` (req), `query` (req), `limit?`, `entity_kind?`, `entity_type?`, `note_kind?`, `tags?`, `properties?`, `include_superseded?`, `min_score?`                                                              | Hybrid FTS5 + vector search                      |
+| `link`      | `source_id` (req), `target_id` (req), `relation` (req), `weight?`                                                                                                                                             | Create typed directed edge (self-loops rejected) |
+| `neighbors` | `node_id` (req), `direction?` (default `"both"`), `relations?`, `min_weight?`                                                                                                                                 | Immediate graph neighbors                        |
+| `traverse`  | `roots` (req, array), `max_depth?` (default 3), `relations?`, `direction?`                                                                                                                                    | Multi-hop BFS                                    |
+| `query`     | `query` (req, GQL string), `limit?` (default 500, cap 10000)                                                                                                                                                  | GQL/SPARQL pattern matching                      |
+| `propose`   | `title` (req), `description` (req), `changeset` (req), `reviewers?`, `expiry?`, `parent_id?`                                                                                                                  | Create an event-sourced change proposal          |
+| `review`    | `proposal_id` (req), `decision` (req), `comment?`                                                                                                                                                             | Review a proposal                                |
+| `withdraw`  | `proposal_id` (req), `rationale?`                                                                                                                                                                             | Withdraw an open proposal                        |
+| `stats`     | (none)                                                                                                                                                                                                        | Aggregate entity, edge, and note counts          |
+| `verbs`     | `category?`, `pack?`                                                                                                                                                                                          | List all registered MCP-callable verbs           |
 
 **Proposal lifecycle**: `open → approved → applying → applied` (happy path). Terminal states:
 `rejected`, `withdrawn`. `applying` is a transient in-flight state; `withdraw` is rejected while the
@@ -125,7 +125,7 @@ packs:
 MCP server config (both packs):
 
 ```json
-{ "args": ["--pack", "kg", "--pack", "gtd"] }
+{ "args": ["mcp", "--pack", "kg", "--pack", "gtd"] }
 ```
 
 Each agent file documents its `Pickup protocol` and `Handoff protocol` sections — read those to

--- a/marketplace/knowledge/README.md
+++ b/marketplace/knowledge/README.md
@@ -12,6 +12,7 @@ The `kg` pack gives you direct CRUD for any entity kind (`create`, `link`, `sear
 pack adds **opinionated sugar** for two distinct patterns:
 
 **Concept management** (built on the kg substrate):
+
 - `learn` = `create(kind="concept")` with automatic `domain` → tag promotion (makes domain
   filterable via FTS and the `domain=` parameter on `topic`).
 - `cite` = `link(relation="introduced_by")` with weight clamped to [0, 1] and cleaner parameter
@@ -19,6 +20,7 @@ pack adds **opinionated sugar** for two distinct patterns:
 - `topic` = `search(kind="concept")` with optional post-filter on the domain tag.
 
 **Atom management** (lore/knowledge atoms, distinct from the KG entity store):
+
 - `upsert_atoms`, `edit`, `list`, `get`, `delete_atoms` — CRUD for structured knowledge atoms
   (markdown-chunked documents with sections).
 - `search` — hybrid FTS + embedding search with optional reranking.
@@ -33,28 +35,28 @@ All verbs are dispatched through the single MCP `request` tool.
 
 ### Concept management
 
-| Verb | Params | What it does |
-| ---- | ------ | ------------ |
-| `knowledge.learn` | `name` (required), `description?`, `domain?`, `tags?` | Register a concept entity. `domain` is stored in `properties.domain` and automatically added to `tags` for FTS discoverability. |
-| `knowledge.cite` | `concept_id` (required UUID), `source_id` (required UUID, must be `document` or `person`), `weight?` (float, default 1.0) | Create an `introduced_by` edge from a concept to its source. `weight` clamped to [0.0, 1.0]. |
-| `knowledge.topic` | `domain?`, `query?`, `limit?` (default 20, max 100) | List or search concept entities, optionally filtered by domain tag. |
+| Verb              | Params                                                                                                                    | What it does                                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge.learn` | `name` (required), `description?`, `domain?`, `tags?`                                                                     | Register a concept entity. `domain` is stored in `properties.domain` and automatically added to `tags` for FTS discoverability. |
+| `knowledge.cite`  | `concept_id` (required UUID), `source_id` (required UUID, must be `document` or `person`), `weight?` (float, default 1.0) | Create an `introduced_by` edge from a concept to its source. `weight` clamped to [0.0, 1.0].                                    |
+| `knowledge.topic` | `domain?`, `query?`, `limit?` (default 20, max 100)                                                                       | List or search concept entities, optionally filtered by domain tag.                                                             |
 
 ### Atom management
 
-| Verb | Params | What it does |
-| ---- | ------ | ------------ |
-| `knowledge.upsert_atoms` | `atoms` (required, array of `{slug, name, content, description?, tags?, properties?, finalized?}`), `chunk_size?` | Create or update knowledge atoms. Field is `content` (not `body`). |
-| `knowledge.edit` | `id` (required, UUID or slug), `sections` (required, array of `{section_type, content, heading?, sort_order?}`) | Upsert sections within an atom. Sections are identified by `section_type`; existing sections with matching type are replaced. |
-| `knowledge.list` | `type?` (`"atom"` or `"domain"`, default `"atom"`), `limit?` (default 20, max 500), `offset?` | Paginate atoms or domains. |
-| `knowledge.get` | `id` (required, UUID or slug) | Fetch a single atom or domain by UUID or slug. Short UUID prefix is NOT supported — use full UUID or slug. |
-| `knowledge.delete_atoms` | `ids` (required, array of slugs or UUIDs) | Delete atoms by slug or UUID. Param is `ids` (not `slugs`). |
+| Verb                     | Params                                                                                                            | What it does                                                                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge.upsert_atoms` | `atoms` (required, array of `{slug, name, content, description?, tags?, properties?, finalized?}`), `chunk_size?` | Create or update knowledge atoms. Field is `content` (not `body`).                                                            |
+| `knowledge.edit`         | `id` (required, UUID or slug), `sections` (required, array of `{section_type, content, heading?, sort_order?}`)   | Upsert sections within an atom. Sections are identified by `section_type`; existing sections with matching type are replaced. |
+| `knowledge.list`         | `type?` (`"atom"` or `"domain"`, default `"atom"`), `limit?` (default 20, max 500), `offset?`                     | Paginate atoms or domains.                                                                                                    |
+| `knowledge.get`          | `id` (required, UUID or slug)                                                                                     | Fetch a single atom or domain by UUID or slug. Short UUID prefix is NOT supported — use full UUID or slug.                    |
+| `knowledge.delete_atoms` | `ids` (required, array of slugs or UUIDs)                                                                         | Delete atoms by slug or UUID. Param is `ids` (not `slugs`).                                                                   |
 
 ### Search and retrieval
 
-| Verb | Params | What it does |
-| ---- | ------ | ------------ |
+| Verb               | Params                                                                                                                                                                                                                                                  | What it does                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `knowledge.search` | `query` (required), `type?` (`"atom"` or `"domain"`), `role?`, `limit?` (default 10, max 100), `min_score?`, `weights?`, `decompose?` (boolean), `decompose_threshold?`, `intersection_bonus?`, `rerank?` (default true), `rerank_alpha?` (default 0.7) | Hybrid FTS + embedding search over atoms/domains. `rerank=true` blends TF-IDF and embedding scores via `rerank_alpha` (0 = pure embedding, 1 = pure TF-IDF). |
-| `knowledge.stats` | (none) | Atom, domain, and embedding counts. |
+| `knowledge.stats`  | (none)                                                                                                                                                                                                                                                  | Atom, domain, and embedding counts.                                                                                                                          |
 
 ## Skills
 
@@ -64,20 +66,20 @@ All verbs are dispatched through the single MCP `request` tool.
 
 ## Install
 
-`khive-mcp` ships with the knowledge pack bundled. The knowledge pack requires the `kg` pack as a
+`kkernel` ships with the knowledge pack bundled. The knowledge pack requires the `kg` pack as a
 dependency — both must be listed explicitly when launching the server:
 
 ```bash
-cargo install khive-mcp
+cargo install kkernel
 
 # Claude Code
-claude mcp add --transport stdio khive -- khive-mcp --pack kg --pack knowledge
+claude mcp add --transport stdio khive -- kkernel mcp --pack kg --pack knowledge
 ```
 
 Or using the `KHIVE_PACKS` environment variable:
 
 ```bash
-claude mcp add --transport stdio khive -- env KHIVE_PACKS=kg,knowledge khive-mcp
+claude mcp add --transport stdio khive -- env KHIVE_PACKS=kg,knowledge kkernel mcp
 ```
 
 Or add to `.mcp.json`:
@@ -86,8 +88,8 @@ Or add to `.mcp.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": ["--pack", "kg", "--pack", "knowledge"]
+      "command": "kkernel",
+      "args": ["mcp", "--pack", "kg", "--pack", "knowledge"]
     }
   }
 }

--- a/marketplace/memory/README.md
+++ b/marketplace/memory/README.md
@@ -12,10 +12,10 @@ to a source entity or note.
 All verbs are dispatched through the single MCP `request` tool
 ([ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)).
 
-| Verb                                                                                                                                                                                          | What it does                                                              |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `memory.remember(content, salience?, decay_factor?, memory_type?, source_id?, embedding_model?, tags?)`                                                                                       | Store a memory note with salience and decay metadata.                     |
-| `memory.recall(query, limit?, top_k?, min_score?, score_floor?, min_salience?, memory_type?, fusion_strategy?, embedding_model?, include_breakdown?, entity_names?, full_content?, tags?, tag_mode?)` | Search memory notes only, then rank by relevance, salience, and recency.  |
+| Verb                                                                                                                                                                                                  | What it does                                                             |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `memory.remember(content, salience?, decay_factor?, memory_type?, source_id?, embedding_model?, tags?)`                                                                                               | Store a memory note with salience and decay metadata.                    |
+| `memory.recall(query, limit?, top_k?, min_score?, score_floor?, min_salience?, memory_type?, fusion_strategy?, embedding_model?, include_breakdown?, entity_names?, full_content?, tags?, tag_mode?)` | Search memory notes only, then rank by relevance, salience, and recency. |
 
 Memory types (`memory_type` values):
 
@@ -45,15 +45,15 @@ accepts an array of entity name strings and applies a 1.3× boost to matching me
 ## Prerequisites
 
 This plugin provides skills only — it does **not** bundle an MCP server. You must install the
-`khive-mcp` binary and register it as an MCP server in your harness **before** using any of the
+`kkernel` binary and register it as an MCP server in your harness **before** using any of the
 skills below.
 
 ```bash
 # Install the binary
-cargo install khive-mcp
+cargo install kkernel
 
 # Register in your harness (Claude Code example)
-claude mcp add --transport stdio khive -- khive-mcp --pack memory
+claude mcp add --transport stdio khive -- kkernel mcp --pack memory
 ```
 
 Or add to your project's `.mcp.json`:
@@ -62,8 +62,8 @@ Or add to your project's `.mcp.json`:
 {
   "mcpServers": {
     "khive": {
-      "command": "khive-mcp",
-      "args": ["--pack", "memory"]
+      "command": "kkernel",
+      "args": ["mcp", "--pack", "memory"]
     }
   }
 }

--- a/npm/bin/khive
+++ b/npm/bin/khive
@@ -179,16 +179,11 @@ function getBinaryPath(binaryName) {
   process.exit(1);
 }
 
-// `khive mcp [args]` dispatches to the khive-mcp binary (MCP stdio server).
-// All other subcommands dispatch to kkernel (admin CLI).
-const subcommand = process.argv[2];
-const isMcp = subcommand === "mcp";
-const binaryName = isMcp ? "khive-mcp" : "kkernel";
-const args = isMcp ? process.argv.slice(3) : process.argv.slice(2);
-
+// Every subcommand dispatches to the single `kkernel` binary. `khive mcp [args]`
+// maps to `kkernel mcp [args]` — the MCP server lives under the `mcp` subcommand.
 try {
-  const binary = getBinaryPath(binaryName);
-  execFileSync(binary, args, {
+  const binary = getBinaryPath("kkernel");
+  execFileSync(binary, process.argv.slice(2), {
     stdio: "inherit",
     env: process.env,
   });

--- a/npm/bin/khive-mcp
+++ b/npm/bin/khive-mcp
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 
-// khive-mcp — per-platform binary shim for the MCP stdio server (ADR-026)
+// khive-mcp — compat shim aliasing `kkernel mcp` (ADR-026)
 //
-// Resolves the host platform to the matching @khive-ai/kernel-{platform}
-// optional dependency and execs the khive-mcp binary from its bin/ directory.
-// Falls back to a local cargo build directory for monorepo development.
+// The MCP server was folded into the single `kkernel` binary. This shim
+// resolves the host platform's `kkernel` (from the @khive-ai/kernel-{platform}
+// optional dependency, or a local cargo build) and execs `kkernel mcp [args]`.
 //
-// This shim is the companion to npm/bin/khive. Both use the same
-// `getBinaryPath()` logic — see npm/bin/khive for comments and rationale.
-// Keep detection order and platform mapping in sync between the two shims.
+// It is the companion to npm/bin/khive and shares the same `getBinaryPath()`
+// logic — keep detection order and platform mapping in sync between the two.
 //
 // Users configure this binary in Claude Code's MCP config:
 //   {"mcpServers": {"khive": {"command": "khive-mcp"}}}
@@ -147,9 +146,12 @@ function getBinaryPath(binaryName) {
   process.exit(1);
 }
 
+// Compat shim: `khive-mcp` is now an alias for `kkernel mcp`. The MCP server
+// was folded into the single `kkernel` binary; this preserves existing MCP
+// configs that spawn `khive-mcp` directly.
 try {
-  const binary = getBinaryPath("khive-mcp");
-  execFileSync(binary, process.argv.slice(2), {
+  const binary = getBinaryPath("kkernel");
+  execFileSync(binary, ["mcp", ...process.argv.slice(2)], {
     stdio: "inherit",
     env: process.env,
   });

--- a/npm/kernel-darwin-arm64/package.json
+++ b/npm/kernel-darwin-arm64/package.json
@@ -14,8 +14,7 @@
     "arm64"
   ],
   "bin": {
-    "kkernel": "bin/kkernel",
-    "khive-mcp": "bin/khive-mcp"
+    "kkernel": "bin/kkernel"
   },
   "files": [
     "bin/"

--- a/npm/kernel-darwin-x64/package.json
+++ b/npm/kernel-darwin-x64/package.json
@@ -14,8 +14,7 @@
     "x64"
   ],
   "bin": {
-    "kkernel": "bin/kkernel",
-    "khive-mcp": "bin/khive-mcp"
+    "kkernel": "bin/kkernel"
   },
   "files": [
     "bin/"

--- a/npm/kernel-linux-arm64/package.json
+++ b/npm/kernel-linux-arm64/package.json
@@ -17,8 +17,7 @@
     "glibc"
   ],
   "bin": {
-    "kkernel": "bin/kkernel",
-    "khive-mcp": "bin/khive-mcp"
+    "kkernel": "bin/kkernel"
   },
   "files": [
     "bin/"

--- a/npm/kernel-linux-x64-gnu/package.json
+++ b/npm/kernel-linux-x64-gnu/package.json
@@ -17,8 +17,7 @@
     "glibc"
   ],
   "bin": {
-    "kkernel": "bin/kkernel",
-    "khive-mcp": "bin/khive-mcp"
+    "kkernel": "bin/kkernel"
   },
   "files": [
     "bin/"

--- a/npm/kernel-linux-x64-musl/package.json
+++ b/npm/kernel-linux-x64-musl/package.json
@@ -17,8 +17,7 @@
     "musl"
   ],
   "bin": {
-    "kkernel": "bin/kkernel",
-    "khive-mcp": "bin/khive-mcp"
+    "kkernel": "bin/kkernel"
   },
   "files": [
     "bin/"

--- a/npm/kernel-win32-x64/package.json
+++ b/npm/kernel-win32-x64/package.json
@@ -14,8 +14,7 @@
     "x64"
   ],
   "bin": {
-    "kkernel": "bin/kkernel.exe",
-    "khive-mcp": "bin/khive-mcp.exe"
+    "kkernel": "bin/kkernel.exe"
   },
   "files": [
     "bin/"

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Behavioral-contract tests for the khive-mcp binary (GitHub issue #21).
+"""Behavioral-contract tests for the MCP surface, served by `kkernel mcp` (GitHub issue #21).
 
 CONTRACT vs SMOKE
 -----------------
@@ -33,7 +33,8 @@ How to run
 Each test function is named `test_<contract>` and prints [pass] / [FAIL].
 Exit code is 0 if every test passes, 1 if any fail.
 
-The KHIVE_MCP_BINARY env var overrides the default binary path.
+The KKERNEL_BINARY env var overrides the default binary path. The server is the
+`mcp` subcommand of the unified kkernel binary.
 """
 
 import json
@@ -184,7 +185,7 @@ def _tool_expect_error(proc: subprocess.Popen, name: str, args: dict) -> str:
 # ---------------------------------------------------------------------------
 
 def _start_server(db_path: str) -> subprocess.Popen:
-    """Spawn a fresh khive-mcp process backed by a temp SQLite file."""
+    """Spawn a fresh `kkernel mcp` process backed by a temp SQLite file."""
     env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
     proc = subprocess.Popen(
         [BINARY, "mcp", "--db", db_path, "--no-embed", "--log", "error"],

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -49,9 +49,9 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
+    "KKERNEL_BINARY",
     os.path.join(
-        os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"
+        os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"
     ),
 )
 
@@ -187,7 +187,7 @@ def _start_server(db_path: str) -> subprocess.Popen:
     """Spawn a fresh khive-mcp process backed by a temp SQLite file."""
     env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
     proc = subprocess.Popen(
-        [BINARY, "--db", db_path, "--no-embed", "--log", "error"],
+        [BINARY, "mcp", "--db", db_path, "--no-embed", "--log", "error"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -848,7 +848,7 @@ def test_annotates_source_must_be_note(proc: subprocess.Popen) -> None:
 def main() -> int:
     assert os.path.exists(BINARY), (
         f"Binary not found at {BINARY!r}.\n"
-        f"Build with: cd crates && cargo build --release -p khive-mcp"
+        f"Build with: cd crates && cargo build --release -p kkernel"
     )
     print(f"Binary: {BINARY}")
     print()

--- a/tests/khive-contract/README.md
+++ b/tests/khive-contract/README.md
@@ -44,7 +44,7 @@ The client looks for the `kkernel` binary in this order:
 
 1. `binary=` argument to `KhiveMcpSession`
 2. `KKERNEL_BINARY` environment variable (`KHIVE_MCP_BINARY` is accepted as a deprecated alias)
-3. `<repo-root>/crates/target/release/kkernel`
+3. `<repo-root>/crates/target/release/kkernel`, then `<repo-root>/crates/target/debug/kkernel`
 
 The session invokes it as `kkernel mcp …`. If the binary is missing, build it first:
 

--- a/tests/khive-contract/README.md
+++ b/tests/khive-contract/README.md
@@ -1,6 +1,6 @@
 # khive-contract
 
-ADR-organized contract tests for the `khive-mcp` binary.
+ADR-organized contract tests for the MCP surface, served by the `kkernel mcp` subcommand.
 
 ## What this is
 
@@ -40,16 +40,16 @@ uv run pytest -v -m "not slow"
 
 ## Binary resolution
 
-The client looks for the `khive-mcp` binary in this order:
+The client looks for the `kkernel` binary in this order:
 
 1. `binary=` argument to `KhiveMcpSession`
-2. `KHIVE_MCP_BINARY` environment variable
-3. `<repo-root>/crates/target/release/khive-mcp`
+2. `KKERNEL_BINARY` environment variable (`KHIVE_MCP_BINARY` is accepted as a deprecated alias)
+3. `<repo-root>/crates/target/release/kkernel`
 
-If the binary is missing, build it first:
+The session invokes it as `kkernel mcp …`. If the binary is missing, build it first:
 
 ```bash
-cd crates && cargo build --release -p khive-mcp
+cd crates && cargo build --release -p kkernel
 ```
 
 ## Organization

--- a/tests/khive-contract/khive_contract/client.py
+++ b/tests/khive-contract/khive_contract/client.py
@@ -81,20 +81,22 @@ def _find_repo_root(start: Path) -> Path | None:
 def _resolve_binary(binary: str | Path | None) -> Path:
     if binary is not None:
         return Path(binary)
-    env_val = os.environ.get("KHIVE_MCP_BINARY")
+    # KKERNEL_BINARY is canonical after the binary unification; KHIVE_MCP_BINARY
+    # is retained as a deprecated alias.
+    env_val = os.environ.get("KKERNEL_BINARY") or os.environ.get("KHIVE_MCP_BINARY")
     if env_val:
         return Path(env_val)
     repo_root = _find_repo_root(Path(__file__).parent)
     if repo_root is not None:
-        release = repo_root / "crates" / "target" / "release" / "khive-mcp"
+        release = repo_root / "crates" / "target" / "release" / "kkernel"
         if release.exists():
             return release
-        debug = repo_root / "crates" / "target" / "debug" / "khive-mcp"
+        debug = repo_root / "crates" / "target" / "debug" / "kkernel"
         if debug.exists():
             return debug
     raise FileNotFoundError(
-        "khive-mcp binary not found. "
-        "Set KHIVE_MCP_BINARY or build with: cd crates && cargo build --release -p khive-mcp"
+        "kkernel binary not found. "
+        "Set KKERNEL_BINARY or build with: cd crates && cargo build --release -p kkernel"
     )
 
 
@@ -141,10 +143,11 @@ class KhiveMcpSession:
         binary = self._binary
         if not binary.exists():
             raise FileNotFoundError(
-                f"khive-mcp binary not found at {binary}. "
-                "Build with: cd crates && cargo build --release -p khive-mcp"
+                f"kkernel binary not found at {binary}. "
+                "Build with: cd crates && cargo build --release -p kkernel"
             )
-        cmd = [str(binary), "--db", str(self._db)]
+        # The MCP server is the `mcp` subcommand of the unified kkernel binary.
+        cmd = [str(binary), "mcp", "--db", str(self._db)]
         if self._no_embed:
             cmd.append("--no-embed")
         cmd += ["--log", self._log]

--- a/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
+++ b/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
@@ -163,29 +163,20 @@ def test_unknown_pack_fails_startup() -> None:
     from khive_contract.client import _resolve_binary
 
     binary = _resolve_binary(None)
+    # The MCP server is the `mcp` subcommand of the unified kkernel binary. An
+    # unknown pack must fail initialization with a non-empty error, not hang.
     proc = subprocess.Popen(
-        [str(binary), "--db", ":memory:", "--no-embed", "--log", "error",
+        [str(binary), "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
          "--pack", "kg", "--pack", "does_not_exist"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        bufsize=1,
     )
-    # Either the process exits quickly, or initialize fails
     try:
-        # Try to initialize — it should fail either at process exit or at response level
-        with KhiveMcpSession(packs=("kg", "does_not_exist")) as _session:
-            pass
-        pytest.fail("Expected startup failure for unknown pack 'does_not_exist'")
-    except Exception as exc:
-        # Any exception (FileNotFoundError, KhiveRpcError, RuntimeError) is acceptable
-        # as long as it's attributable — check it's not a silent empty message
-        err_msg = str(exc)
-        assert err_msg, "Startup failure must produce a non-empty error message"
-    finally:
-        try:
-            proc.kill()
-            proc.wait(timeout=2)
-        except Exception:
-            pass
+        _, stderr = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        pytest.fail("kkernel mcp with an unknown pack should fail fast, not hang")
+    assert proc.returncode != 0, "unknown pack must cause a nonzero exit"
+    assert stderr.strip(), "startup failure must produce a non-empty error message"

--- a/tests/smoke_brain.py
+++ b/tests/smoke_brain.py
@@ -18,8 +18,8 @@ import sys
 import os
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
-    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"),
+    "KKERNEL_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"),
 )
 
 request_id = 0
@@ -100,7 +100,7 @@ def spawn_brain_proc():
     proc = subprocess.Popen(
         [
             BINARY,
-            "--db", ":memory:",
+            "mcp", "--db", ":memory:",
             "--no-embed",
             "--log", "error",
             "--namespace", "local",

--- a/tests/smoke_comm.py
+++ b/tests/smoke_comm.py
@@ -17,8 +17,8 @@ import os
 import uuid
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
-    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"),
+    "KKERNEL_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"),
 )
 
 request_id = 0
@@ -110,7 +110,7 @@ def init_proc(proc, client_name="comm-smoke"):
 def spawn():
     """Spawn the MCP binary with kg + comm packs loaded."""
     return subprocess.Popen(
-        [BINARY, "--db", ":memory:", "--no-embed", "--log", "error",
+        [BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
          "--pack", "kg", "--pack", "comm"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/tests/smoke_knowledge.py
+++ b/tests/smoke_knowledge.py
@@ -15,8 +15,8 @@ import sys
 import os
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
-    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"),
+    "KKERNEL_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"),
 )
 
 request_id = 0
@@ -97,7 +97,7 @@ def spawn():
     proc = subprocess.Popen(
         [
             BINARY,
-            "--db", ":memory:",
+            "mcp", "--db", ":memory:",
             "--no-embed",
             "--log", "error",
             "--pack", "kg",

--- a/tests/smoke_schedule.py
+++ b/tests/smoke_schedule.py
@@ -18,8 +18,8 @@ import os
 import uuid
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
-    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"),
+    "KKERNEL_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"),
 )
 
 request_id = 0
@@ -107,7 +107,7 @@ def spawn_proc():
     """Spawn a fresh khive-mcp process with kg + schedule packs."""
     return subprocess.Popen(
         [
-            BINARY, "--db", ":memory:", "--no-embed", "--log", "error",
+            BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
             "--pack", "kg", "--pack", "schedule",
         ],
         stdin=subprocess.PIPE,

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -23,8 +23,8 @@ import sys
 import os
 
 BINARY = os.environ.get(
-    "KHIVE_MCP_BINARY",
-    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "khive-mcp"),
+    "KKERNEL_BINARY",
+    os.path.join(os.path.dirname(__file__), "..", "crates", "target", "release", "kkernel"),
 )
 
 request_id = 0
@@ -94,7 +94,7 @@ def main():
 
     env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
     proc = subprocess.Popen(
-        [BINARY, "--db", ":memory:", "--no-embed", "--log", "error"],
+        [BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -382,7 +382,7 @@ def gtd_smoke():
     env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
     proc = subprocess.Popen(
         [
-            BINARY, "--db", ":memory:", "--no-embed", "--log", "error",
+            BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
             "--pack", "kg", "--pack", "gtd",
         ],
         stdin=subprocess.PIPE,
@@ -477,7 +477,7 @@ def memory_smoke():
     env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
     proc = subprocess.Popen(
         [
-            BINARY, "--db", ":memory:", "--no-embed", "--log", "error",
+            BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error",
             "--pack", "kg", "--pack", "memory",
         ],
         stdin=subprocess.PIPE,


### PR DESCRIPTION
This pull request introduces a major refactor of how the MCP server is distributed and invoked, consolidating the previous `khive-mcp` binary into a new `kkernel` binary with an `mcp` subcommand. It also establishes a new approach for managing schema DDL by introducing a consolidated SQL schema file, and adds SQL linting to CI and pre-commit hooks. Documentation and build scripts are updated to reflect these changes.

**Binary consolidation and invocation changes:**

* The MCP server is now invoked as a subcommand of the new `kkernel` binary (`kkernel mcp`), replacing the previous standalone `khive-mcp` binary. All build, release, and local development scripts, as well as the CLI, have been updated to use `kkernel` instead of `khive-mcp`. (`.github/workflows/release.yml`, `Makefile`, `cli/main.ts`, `cli/tests/golden/help_toplevel.txt`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L100-R100) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L112-R112) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L123-R125) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L13-R13) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L45-R60) [[6]](diffhunk://#diff-ae2f7f6eb712b936d8b1b76603a6688905f68096e2c1e6617ede14309de5213aR28) [[7]](diffhunk://#diff-ae2f7f6eb712b936d8b1b76603a6688905f68096e2c1e6617ede14309de5213aL244-R255) [[8]](diffhunk://#diff-1ba411b96bf2304d530ed1eeadc2292726a02bcf5ce8a7e31aa4b23d5c090007L1-R1)

**Schema management improvements:**

* Introduces a single consolidated schema file (`crates/khive-db/sql/schema.sql`) as the authoritative DDL for fresh databases, following ADR-015. Documentation is updated to require all schema DDL to be authored in `.sql` files and loaded via `include_str!`, never as inline Rust strings. (`crates/khive-db/sql/schema.sql`, `CLAUDE.md`) [[1]](diffhunk://#diff-58d5ef55b56f3efcbaeddb81cf1c7db11624920bc00e45f41545b2e53a174c6eR1-R307) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R238-R249) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L349-R357)

**SQL linting and developer workflow:**

* Adds a pre-commit hook and CI step to lint all SQL files using `scripts/lint-sql.sh`, ensuring SQL hygiene before code is merged. (`.pre-commit-config.yaml`, `CLAUDE.md`) [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R51-R56) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R238-R249)

**Dependency and config updates:**

* Adds the `sha2` crate as a dependency in `crates/khive-db/Cargo.toml`.

**Documentation fixes:**

* Updates default database path in the README to match the new binary and schema naming.

These changes modernize the build and deployment workflow, enforce SQL best practices, and improve maintainability by consolidating binaries and schema management.