### PR TITLE
feat(kkernel): multi-engine reindex + fold knowledge into reindex

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -44,7 +44,54 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 
 /// Build a fully-configured server from parsed args (without serving).
 pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
-    let db_path = match args.db.as_deref() {
+    let (cli_namespace_explicit, cli_namespace) =
+        resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let config = resolve_runtime_config(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: args.config.as_deref(),
+        namespace: cli_namespace,
+        namespace_explicit: cli_namespace_explicit,
+        no_embed: args.no_embed,
+        packs: if args.pack.is_empty() {
+            None
+        } else {
+            Some(args.pack.clone())
+        },
+    })?;
+
+    let runtime = KhiveRuntime::new(config)?;
+    KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// Inputs for [`resolve_runtime_config`] — the subset of serve-time arguments
+/// that determine the resolved [`RuntimeConfig`]. Callers other than
+/// `kkernel mcp` (e.g. `kkernel reindex`) supply these directly so they resolve
+/// the SAME engines, db path, and actor namespace the MCP server would.
+pub struct RuntimeConfigInputs<'a> {
+    /// Raw `--db` / `KHIVE_DB` value (`:memory:` sentinel honored).
+    pub db: Option<&'a str>,
+    /// Explicit `--config` / `KHIVE_CONFIG` path (else home-fallback search).
+    pub config: Option<&'a std::path::Path>,
+    /// Pre-resolved default namespace.
+    pub namespace: khive_runtime::Namespace,
+    /// Whether the namespace came from an explicit CLI flag (skips config tier).
+    pub namespace_explicit: bool,
+    /// Disable embedding entirely (still resolves actor namespace from config).
+    pub no_embed: bool,
+    /// Packs to register. `None` falls back to `RuntimeConfig::default().packs`.
+    pub packs: Option<Vec<String>>,
+}
+
+/// Resolve a [`RuntimeConfig`] from serve-time inputs, applying the SAME
+/// config-file / env / actor-namespace precedence as `kkernel mcp`.
+///
+/// Extracted from `build_server` so `kkernel reindex` reuses the exact engine
+/// and db resolution — otherwise an admin reindex writes vectors for the
+/// default/env model set while the MCP server serves recall from the
+/// config-file `[[engines]]` set.
+pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result<RuntimeConfig> {
+    let db_path = match inputs.db {
         Some(":memory:") => None,
         Some(path) => Some(PathBuf::from(path)),
         None => {
@@ -53,39 +100,27 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
         }
     };
 
-    let (cli_namespace_explicit, cli_namespace) =
-        resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    let packs = if args.pack.is_empty() {
-        RuntimeConfig::default().packs
-    } else {
-        args.pack.clone()
-    };
+    let packs = inputs
+        .packs
+        .unwrap_or_else(|| RuntimeConfig::default().packs);
 
     let base_config = RuntimeConfig {
         db_path,
-        default_namespace: cli_namespace,
+        default_namespace: inputs.namespace,
         packs,
         ..RuntimeConfig::default()
     };
 
-    let config = if args.no_embed {
+    if inputs.no_embed {
         let no_embed_base = RuntimeConfig {
             embedding_model: None,
             additional_embedding_models: vec![],
             ..base_config
         };
-        resolve_actor_from_config(
-            args.config.as_deref(),
-            no_embed_base,
-            cli_namespace_explicit,
-        )?
+        resolve_actor_from_config(inputs.config, no_embed_base, inputs.namespace_explicit)
     } else {
-        resolve_config(args.config.as_deref(), base_config, cli_namespace_explicit)?
-    };
-
-    let runtime = KhiveRuntime::new(config)?;
-    KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))
+        resolve_config(inputs.config, base_config, inputs.namespace_explicit)
+    }
 }
 
 /// Resolve the full config (embedding engines + actor namespace) from file or env.
@@ -158,5 +193,78 @@ fn resolve_actor_from_config(
             })
         }
         None => Ok(base),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use khive_runtime::Namespace;
+    use serial_test::serial;
+    use std::io::Write;
+
+    fn write_config(dir: &std::path::Path, body: &str) -> PathBuf {
+        let path = dir.join("khive.toml");
+        let mut f = std::fs::File::create(&path).expect("create config file");
+        f.write_all(body.as_bytes()).expect("write config");
+        path
+    }
+
+    // The resolver MUST honor config-file `[[engines]]` over RuntimeConfig
+    // defaults — otherwise `kkernel reindex` embeds for the wrong model set
+    // versus what `kkernel mcp` serves recall from. Regression for PR #8
+    // blocker.
+    #[test]
+    #[serial]
+    fn resolver_uses_config_file_engines_over_defaults() {
+        // Ensure env vars cannot leak into either branch.
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+
+        let default_cfg = RuntimeConfig::default();
+        let default_primary = format!("{:?}", default_cfg.embedding_model);
+        // Default ships a non-empty additional-engine list (the multilingual
+        // model). The single-engine config file below must override it.
+        assert!(
+            !default_cfg.additional_embedding_models.is_empty(),
+            "precondition: default config has additional engines"
+        );
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        // A single non-default engine that differs from the default primary.
+        let path = write_config(
+            dir.path(),
+            r#"
+[[engines]]
+name = "primary"
+model = "bge-small-en-v1.5"
+default = true
+"#,
+        );
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+        })
+        .expect("resolve config");
+
+        let resolved_primary = format!("{:?}", resolved.embedding_model);
+        assert_ne!(
+            resolved_primary, default_primary,
+            "resolved primary engine must come from the config file, not the default"
+        );
+        assert!(
+            resolved.embedding_model.is_some(),
+            "config-file engine must resolve to a primary embedding model"
+        );
+        assert!(
+            resolved.additional_embedding_models.is_empty(),
+            "config file declares one engine; additional list must be empty (not the default's)"
+        );
+        assert_eq!(resolved.db_path, None, ":memory: must map to in-memory db");
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -24,7 +24,7 @@ impl KnowledgeHandlers {
 
         if runtime.default_embedder_name().is_empty() {
             return Ok(
-                json!({ "indexed": 0, "skipped": 0, "total": 0, "reason": "no embedding model configured" }),
+                json!({ "indexed": 0, "skipped": 0, "failed": 0, "total": 0, "reason": "no embedding model configured" }),
             );
         }
 
@@ -84,6 +84,7 @@ impl KnowledgeHandlers {
         let total = atoms.len();
         let mut indexed = 0usize;
         let mut skipped = 0usize;
+        let mut failed = 0usize;
 
         let mut ann_vectors: Vec<f32> = Vec::new();
         let mut ann_ids: Vec<uuid::Uuid> = Vec::new();
@@ -130,28 +131,50 @@ impl KnowledgeHandlers {
                 continue;
             }
 
-            if let Ok(vectors) = runtime.vectors(token) {
-                let ns_str = token.namespace().as_str();
-                if !insert_only {
-                    for (id, _) in &staged {
-                        let _ = vectors.delete(*id).await;
+            // Track which atoms in this chunk had their vector persisted, so a
+            // failed insert is reported as `failed` rather than silently counted
+            // as `indexed`. A failed vector write means recall cannot retrieve
+            // that atom — that is a failure, not a success.
+            let mut chunk_ok: Vec<bool> = vec![true; staged.len()];
+            match runtime.vectors(token) {
+                Ok(vectors) => {
+                    let ns_str = token.namespace().as_str();
+                    if !insert_only {
+                        for (id, _) in &staged {
+                            let _ = vectors.delete(*id).await;
+                        }
+                    }
+                    for (i, ((id, _), emb)) in staged.iter().zip(embeddings.iter()).enumerate() {
+                        if let Err(e) = vectors
+                            .insert(
+                                *id,
+                                SubstrateKind::Entity,
+                                ns_str,
+                                "knowledge.atom",
+                                vec![emb.clone()],
+                            )
+                            .await
+                        {
+                            tracing::warn!(id = %id, error = %e, "knowledge vector insert failed");
+                            chunk_ok[i] = false;
+                            failed += 1;
+                        }
                     }
                 }
-                for ((id, _), emb) in staged.iter().zip(embeddings.iter()) {
-                    let _ = vectors
-                        .insert(
-                            *id,
-                            SubstrateKind::Entity,
-                            ns_str,
-                            "knowledge.atom",
-                            vec![emb.clone()],
-                        )
-                        .await;
+                Err(e) => {
+                    tracing::warn!(error = %e, "knowledge vector store unavailable");
+                    for ok in chunk_ok.iter_mut() {
+                        *ok = false;
+                    }
+                    failed += staged.len();
                 }
             }
 
             if rebuild_ann {
-                for ((id, _), emb) in staged.iter().zip(embeddings.iter()) {
+                for (i, ((id, _), emb)) in staged.iter().zip(embeddings.iter()).enumerate() {
+                    if !chunk_ok[i] {
+                        continue;
+                    }
                     if ann_dim == 0 {
                         ann_dim = emb.len();
                     }
@@ -162,7 +185,7 @@ impl KnowledgeHandlers {
                 }
             }
 
-            indexed += staged.len();
+            indexed += chunk_ok.iter().filter(|ok| **ok).count();
         }
 
         // Any vector write invalidates the existing snapshot — the corpus has changed.
@@ -198,6 +221,7 @@ impl KnowledgeHandlers {
         Ok(json!({
             "indexed": indexed,
             "skipped": skipped,
+            "failed": failed,
             "total": total,
             "ann_vectors": ann_count,
         }))

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -121,13 +121,23 @@ impl KnowledgeHandlers {
 
             let embeddings = match runtime.embed_batch(&texts).await {
                 Ok(e) => e,
-                Err(_) => {
-                    skipped += staged.len();
+                Err(e) => {
+                    tracing::warn!(
+                        batch_size = staged.len(),
+                        error = %e,
+                        "embed_batch failed; atoms cannot be recalled until reindexed"
+                    );
+                    failed += staged.len();
                     continue;
                 }
             };
             if embeddings.len() != staged.len() {
-                skipped += staged.len();
+                tracing::warn!(
+                    expected = staged.len(),
+                    got = embeddings.len(),
+                    "embed_batch returned wrong number of vectors; atoms cannot be recalled until reindexed"
+                );
+                failed += staged.len();
                 continue;
             }
 

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -205,25 +205,36 @@ impl KnowledgeHandlers {
         }
 
         let mut ann_count: Option<usize> = None;
+        let mut ann_failed = false;
         let is_full_corpus = p.ids.is_none();
         if rebuild_ann && is_full_corpus && !ann_vectors.is_empty() && ann_dim > 0 {
             match vamana::AnnBridge::build(ann_vectors, ann_dim, ann_ids) {
                 Ok(bridge) => {
                     ann_count = Some(bridge.num_vectors());
                     let model_name = runtime.default_embedder_name();
-                    if let Some(fp) = vamana::compute_fingerprint(runtime, token, model_name).await
-                    {
-                        if let Err(e) =
-                            vamana::persist_snapshot(runtime, &ns, model_name, &bridge, fp).await
-                        {
-                            tracing::error!(error = %e, "failed to persist Vamana snapshot");
+                    match vamana::compute_fingerprint(runtime, token, model_name).await {
+                        Some(fp) => {
+                            if let Err(e) =
+                                vamana::persist_snapshot(runtime, &ns, model_name, &bridge, fp)
+                                    .await
+                            {
+                                tracing::error!(error = %e, "failed to persist Vamana snapshot");
+                                ann_failed = true;
+                            }
+                        }
+                        None => {
+                            tracing::warn!(
+                                "failed to compute corpus fingerprint; Vamana snapshot will not be persisted"
+                            );
+                            ann_failed = true;
                         }
                     }
                     let key = vamana::AnnKey::new(&ns, model_name);
                     vamana::insert_ann_if_absent(ann, key, bridge).await;
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "failed to build Vamana ANN index");
+                    tracing::error!(error = %e, "failed to build Vamana ANN index");
+                    ann_failed = true;
                 }
             }
         }
@@ -234,6 +245,7 @@ impl KnowledgeHandlers {
             "failed": failed,
             "total": total,
             "ann_vectors": ann_count,
+            "ann_failed": ann_failed,
         }))
     }
 }

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -6,3 +6,28 @@ mod pack;
 mod vocab;
 
 pub use pack::KnowledgePack;
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use serde_json::Value;
+
+/// Reindex the knowledge corpus for `token`'s namespace: embed atoms with the
+/// default embedder and (optionally) rebuild the Vamana ANN snapshot.
+///
+/// Library entry for `kkernel reindex` — equivalent to the `knowledge.index`
+/// verb over the full corpus, callable without an MCP server. Knowledge search
+/// is single-model (it retrieves via the default embedder's ANN), so this does
+/// not fan out across registered models the way entity/note reindex does.
+pub async fn reindex_knowledge(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    rebuild_ann: bool,
+    batch_size: Option<u32>,
+) -> Result<Value, RuntimeError> {
+    let ann = knowledge::vamana::new_shared();
+    let mut params = serde_json::Map::new();
+    params.insert("rebuild_ann".into(), Value::Bool(rebuild_ann));
+    if let Some(bs) = batch_size {
+        params.insert("batch_size".into(), Value::from(bs));
+    }
+    knowledge::KnowledgeHandlers::index(runtime, token, Value::Object(params), &ann).await
+}

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1628,3 +1628,203 @@ async fn search_default_rerank_decompose_guard_avoids_fts_no_such_column() {
         "expected results array, got: {resp:?}"
     );
 }
+
+// ── embed_batch failure / count-mismatch counted as `failed` ─────────────────
+//
+// Regression for codex round-2 HIGH finding: embed_batch Err and count-mismatch
+// were both mapped to `skipped` (exit 0); they must map to `failed` (exit non-0
+// without --best-effort).  The knowledge index handler cannot call embed_batch
+// without a non-empty default_embedder_name, so these tests use a fake provider
+// registered under the default model key.
+
+mod embed_failure_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
+    use khive_types::Namespace;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use std::sync::Arc;
+
+    const MODEL_KEY: &str = "all-minilm-l6-v2";
+
+    /// Returns exactly one vector regardless of how many texts are passed.
+    /// Triggers the count-mismatch branch in the index handler.
+    struct OneDimService;
+
+    #[async_trait]
+    impl EmbeddingService for OneDimService {
+        async fn embed(
+            &self,
+            _texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(vec![vec![1.0_f32; 4]])
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "one-dim"
+        }
+    }
+
+    struct OneDimProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for OneDimProvider {
+        fn name(&self) -> &str {
+            MODEL_KEY
+        }
+
+        fn dimensions(&self) -> usize {
+            4
+        }
+
+        async fn build(
+            &self,
+        ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(OneDimService))
+        }
+    }
+
+    /// Always returns Err(InferenceFailed) to trigger the Err branch.
+    struct AlwaysFailService;
+
+    #[async_trait]
+    impl EmbeddingService for AlwaysFailService {
+        async fn embed(
+            &self,
+            _texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            Err(EmbedError::InferenceFailed("synthetic test failure".into()))
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "always-fail"
+        }
+    }
+
+    struct AlwaysFailProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for AlwaysFailProvider {
+        fn name(&self) -> &str {
+            MODEL_KEY
+        }
+
+        fn dimensions(&self) -> usize {
+            4
+        }
+
+        async fn build(
+            &self,
+        ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(AlwaysFailService))
+        }
+    }
+
+    /// Build a runtime whose default_embedder_name is non-empty (required for
+    /// the index handler to attempt embedding) but whose provider is replaced
+    /// with the given fake.
+    fn rt_with_fake(fake: impl EmbedderProvider + 'static) -> KhiveRuntime {
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: BackendId::main(),
+        })
+        .expect("runtime");
+        // Override the lattice provider with our fake — same key, last-writer wins.
+        rt.register_embedder(fake);
+        rt
+    }
+
+    /// Seed two atoms and return the fixture.
+    async fn fixture_with_two_atoms(rt: KhiveRuntime) -> Fixture {
+        let f = pack(rt);
+        f.dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [
+                    {
+                        "slug": "embed-fail-a",
+                        "name": "Embed Fail A",
+                        "content": "first atom content for embed failure regression test dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector"
+                    },
+                    {
+                        "slug": "embed-fail-b",
+                        "name": "Embed Fail B",
+                        "content": "second atom content for embed failure regression test dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector"
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("upsert atoms");
+        f
+    }
+
+    /// count-mismatch branch: embed_batch returns 1 vector for a 2-atom batch.
+    /// Must count both atoms as `failed`, not `skipped`.
+    #[tokio::test]
+    async fn index_embed_count_mismatch_counts_as_failed() {
+        let f = fixture_with_two_atoms(rt_with_fake(OneDimProvider)).await;
+        let result = f
+            .dispatch("knowledge.index", json!({}))
+            .await
+            .expect("index ok");
+
+        assert_eq!(
+            result["failed"].as_u64().unwrap_or(0),
+            2,
+            "count-mismatch must report both atoms as failed: {result:?}"
+        );
+        assert_eq!(
+            result["indexed"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "no atoms must be indexed on count-mismatch: {result:?}"
+        );
+        assert_eq!(
+            result["skipped"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "count-mismatch must not appear in skipped: {result:?}"
+        );
+    }
+
+    /// Err branch: embed_batch returns Err for every batch.
+    /// Must count all atoms as `failed`, not `skipped`.
+    #[tokio::test]
+    async fn index_embed_error_counts_as_failed() {
+        let f = fixture_with_two_atoms(rt_with_fake(AlwaysFailProvider)).await;
+        let result = f
+            .dispatch("knowledge.index", json!({}))
+            .await
+            .expect("index ok");
+
+        assert_eq!(
+            result["failed"].as_u64().unwrap_or(0),
+            2,
+            "embed Err must report both atoms as failed: {result:?}"
+        );
+        assert_eq!(
+            result["indexed"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "no atoms must be indexed on embed error: {result:?}"
+        );
+        assert_eq!(
+            result["skipped"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "embed Err must not appear in skipped: {result:?}"
+        );
+    }
+}

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1827,4 +1827,28 @@ mod embed_failure_tests {
             "embed Err must not appear in skipped: {result:?}"
         );
     }
+
+    /// Result JSON always carries `ann_failed` key. When the ANN block does not
+    /// run (rebuild_ann=false, which is the default), `ann_failed` must be false.
+    /// Embed failures that prevent vector writes also must not set ann_failed —
+    /// atom-level and ANN-level failures are distinct failure dimensions.
+    #[tokio::test]
+    async fn index_result_carries_ann_failed_false_when_ann_block_skipped() {
+        // Use count-mismatch provider: embed fails, no vectors stored, ANN block
+        // never entered (ann_vectors stays empty), so ann_failed must be false.
+        let f = fixture_with_two_atoms(rt_with_fake(OneDimProvider)).await;
+        let result = f
+            .dispatch("knowledge.index", json!({}))
+            .await
+            .expect("index ok");
+
+        assert!(
+            result.get("ann_failed").is_some(),
+            "result JSON must carry ann_failed key: {result:?}"
+        );
+        assert!(
+            !result["ann_failed"].as_bool().unwrap_or(true),
+            "ann_failed must be false when ANN block did not run: {result:?}"
+        );
+    }
 }

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -117,12 +117,15 @@ serves recall from. `--namespace` is the explicit per-namespace target and
 always wins over any config `[actor] id`.
 
 **Fail-closed.** By default reindex returns a **non-zero exit** if any requested
-engine failed, the knowledge pass errored, or any knowledge atom vector insert
-failed — a partial rebuild leaves stale recall/search state, so automation must
-not see success. Pass `--best-effort` to downgrade failures to a warning and
-exit 0. The report (JSON and `--human`) always reports attempted/indexed/failed
-counts honestly (`errors_skipped`, `knowledge_atoms_failed`,
-`knowledge_pass_errored`).
+engine failed, the knowledge pass errored, any knowledge atom vector insert
+failed, or the Vamana ANN build/snapshot persist failed — a partial rebuild
+leaves stale recall/search state, so automation must not see success. Pass
+`--best-effort` to downgrade failures to a warning and exit 0. The report (JSON
+and `--human`) always reports attempted/indexed/failed counts honestly
+(`errors_skipped`, `knowledge_atoms_failed`, `knowledge_pass_errored`,
+`knowledge_ann_failed`). Note: `knowledge_ann_failed` is a distinct failure
+dimension from `knowledge_atoms_failed` — atom vectors may have persisted
+successfully while the ANN rebuild or snapshot persist failed.
 
 **Multi-engine semantics.** Entities and notes embed with **every registered
 engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -18,7 +18,7 @@ kkernel <command> [flags]
   db        Schema migration lifecycle (migrate, check)
   engine    Embedding model lifecycle (list, status, migrate, drift-check)
   vector    Vector store capabilities and orphan sweep
-  reindex   Re-embed all entities and notes
+  reindex   Re-embed entities, notes, and the knowledge corpus (multi-engine)
   exec      Run a verb DSL expression through the pack registry
   mcp       Serve the MCP `request` surface (stdio / daemon / transports)
   backend   Inspect registered backends (list, info <name>)
@@ -96,14 +96,33 @@ kkernel reindex --db ~/.khive/khive.db --namespace local   # entities + notes + 
 kkernel reindex --db ~/.khive/khive.db --namespace khive
 ```
 
-| Flag               | Effect                                                                         |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                |
-| `--no-knowledge`   | only entities/notes (skip knowledge)                                           |
-| `--model <name>`   | entities/notes use this single engine instead of fanning out                   |
-| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild |
-| `--batch-size <n>` | records per embedding batch (default 100, max 500)                             |
-| `--human`          | readable report instead of JSON                                                |
+| Flag               | Effect                                                                          |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `--db <path>`      | database (env `KHIVE_DB`; `:memory:` for ephemeral) — parity with `mcp`/`exec`  |
+| `--config <path>`  | khive TOML config (env `KHIVE_CONFIG`) — resolves engines like `kkernel mcp`    |
+| `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                 |
+| `--no-knowledge`   | only entities/notes (skip knowledge)                                            |
+| `--model <name>`   | entities/notes use this single engine instead of fanning out                    |
+| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild  |
+| `--batch-size <n>` | records per embedding batch (default 100, max 500)                              |
+| `--best-effort`    | downgrade partial failures to a warning and still exit 0 (default fails closed) |
+| `--human`          | readable report instead of JSON                                                 |
+
+**Config resolution.** Engines, db path, and config file are resolved with the
+**same precedence as `kkernel mcp`** — config-file `[[engines]]` (via `--config`
+/ `KHIVE_CONFIG` / `./khive.toml` / `./.khive/config.toml` / `~/.khive/config.toml`)
+win over the `KHIVE_EMBEDDING_MODEL` env vars and over `RuntimeConfig` defaults.
+This guarantees reindex writes vectors for the SAME engine set the MCP server
+serves recall from. `--namespace` is the explicit per-namespace target and
+always wins over any config `[actor] id`.
+
+**Fail-closed.** By default reindex returns a **non-zero exit** if any requested
+engine failed, the knowledge pass errored, or any knowledge atom vector insert
+failed — a partial rebuild leaves stale recall/search state, so automation must
+not see success. Pass `--best-effort` to downgrade failures to a warning and
+exit 0. The report (JSON and `--human`) always reports attempted/indexed/failed
+counts honestly (`errors_skipped`, `knowledge_atoms_failed`,
+`knowledge_pass_errored`).
 
 **Multi-engine semantics.** Entities and notes embed with **every registered
 engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -85,44 +85,48 @@ Flags: `--db`, `--namespace`, `--presentation <agent|verbose|human>`.
 
 ---
 
-## Reindex workflows
+## Reindex — `kkernel reindex`
 
-Embeddings/FTS are rebuilt by two distinct paths, because entity/note vectors and
-knowledge atoms live in different stores:
-
-### Entities + notes — `kkernel reindex`
-
-Walks all entities and notes and (re-)embeds them. Namespace-scoped, so run once per
-namespace your data spans.
+`kkernel reindex` re-embeds **entities, notes, and the knowledge corpus** in one
+pass (namespace-scoped — run once per namespace your data spans). Progress prints
+to stderr; the JSON/`--human` report goes to stdout.
 
 ```bash
-kkernel reindex --db ~/.khive/khive.db --namespace local
+kkernel reindex --db ~/.khive/khive.db --namespace local   # entities + notes + knowledge
 kkernel reindex --db ~/.khive/khive.db --namespace khive
-# flags: --model, --batch-size (default 100), --keep-existing, --human
 ```
 
-`--keep-existing` skips records that already have a vector (incremental top-up).
-Omit it to drop-and-rebuild.
+| Flag               | Effect                                                                         |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                |
+| `--no-knowledge`   | only entities/notes (skip knowledge)                                           |
+| `--model <name>`   | entities/notes use this single engine instead of fanning out                   |
+| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild |
+| `--batch-size <n>` | records per embedding batch (default 100, max 500)                             |
+| `--human`          | readable report instead of JSON                                                |
 
-### Knowledge atoms — `kkernel exec 'knowledge.index(...)'`
+**Multi-engine semantics.** Entities and notes embed with **every registered
+engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),
+one vector record per engine — matching the runtime's create/update write path.
+`--model` narrows to a single engine. **Knowledge is single-model**: knowledge
+search retrieves via the default embedder's ANN, so the knowledge pass always
+uses the default embedder (fanning out would write vectors search never reads).
 
-The knowledge corpus is reindexed through its own handler. It embeds atoms and
-(optionally) rebuilds the Vamana ANN. Also namespace-scoped via `--namespace`.
+The knowledge pass calls the `khive_pack_knowledge::reindex_knowledge` library
+entry directly (the full-corpus `knowledge.index` handler) and rebuilds the
+Vamana ANN snapshot — no verb-DSL shell required.
 
 ```bash
-# embed all atoms in a namespace + rebuild the ANN snapshot
-kkernel exec 'knowledge.index(rebuild_ann=true)' --db ~/.khive/khive.db --namespace local
-
-# embed only specific atoms (by slug or id), no ANN rebuild
-kkernel exec 'knowledge.index(ids=["my-slug", "<uuid>"])' --db ~/.khive/khive.db
-
-# batch sizing (clamped 1..1000, default 500)
-kkernel exec 'knowledge.index(batch_size=1000, rebuild_ann=true)' --db ~/.khive/khive.db
+kkernel reindex --db ~/.khive/khive.db --knowledge-only      # just the corpus
+kkernel reindex --db ~/.khive/khive.db --no-knowledge        # just graph substrate
 ```
 
-`knowledge.index` indexes **atoms** (not sections) and reports
-`{indexed, skipped, total, ann_vectors}`. It is a no-op returning
-`"no embedding model configured"` when no embedder is set.
+For ad-hoc / scoped knowledge indexing (specific atoms, no ANN rebuild) the
+low-level verb is still available via `exec`:
+
+```bash
+kkernel exec 'knowledge.index(ids=["my-slug", "<uuid>"])' --db ~/.khive/khive.db
+```
 
 > Stop the MCP daemon before a large reindex to avoid SQLite write contention:
 > `pkill -f 'kkernel.*--daemon'` (or `KHIVE_NO_DAEMON=1`), then reindex, then let

--- a/crates/kkernel/src/dbpath.rs
+++ b/crates/kkernel/src/dbpath.rs
@@ -1,0 +1,42 @@
+//! Shared `--db` / `KHIVE_DB` resolution for `kkernel` subcommands.
+
+use std::path::PathBuf;
+
+/// Resolve the `--db`/`KHIVE_DB` value into a `db_path` override, mirroring
+/// `kkernel mcp`: an explicit `:memory:` means the ephemeral in-memory db
+/// (`None`), not a file literally named ":memory:" (which SQLite treats as a
+/// per-connection file → empty schema). `None` leaves the default in place.
+///
+/// Returns `Some(override)` when the caller supplied `--db`/`KHIVE_DB`, where
+/// the inner value is the `RuntimeConfig.db_path` to set; `None` means no
+/// override (keep `RuntimeConfig::default().db_path`).
+pub fn resolve_db_override(db: Option<&str>) -> Option<Option<PathBuf>> {
+    match db {
+        Some(":memory:") => Some(None),
+        Some(path) => Some(Some(PathBuf::from(path))),
+        None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_sentinel_maps_to_none() {
+        assert_eq!(resolve_db_override(Some(":memory:")), Some(None));
+    }
+
+    #[test]
+    fn explicit_path_maps_to_some() {
+        assert_eq!(
+            resolve_db_override(Some("/tmp/kkernel-test.db")),
+            Some(Some(PathBuf::from("/tmp/kkernel-test.db")))
+        );
+    }
+
+    #[test]
+    fn absent_db_leaves_default() {
+        assert_eq!(resolve_db_override(None), None);
+    }
+}

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1,13 +1,13 @@
 //! `kkernel exec` — run a verb DSL expression directly through the pack registry.
 
-use std::path::PathBuf;
-
 use anyhow::Result;
 use clap::Parser;
 
 use khive_mcp::server::KhiveMcpServer;
 use khive_mcp::tools::request::RequestParams;
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+
+use crate::dbpath::resolve_db_override;
 
 /// Arguments for `kkernel exec` — execute a verb DSL expression against a chosen
 /// database and namespace, the same syntax accepted by the MCP `request` tool.
@@ -36,18 +36,6 @@ pub struct ExecArgs {
 }
 
 /// Execute the DSL expression in-process and print the JSON result to stdout.
-/// Resolve the `--db`/`KHIVE_DB` value into a `db_path` override, mirroring
-/// `kkernel mcp`: an explicit `:memory:` means the ephemeral in-memory db
-/// (`None`), not a file literally named ":memory:" (which SQLite treats as a
-/// per-connection file → empty schema). `None` leaves the default in place.
-fn resolve_db_override(db: Option<&str>) -> Option<Option<PathBuf>> {
-    match db {
-        Some(":memory:") => Some(None),
-        Some(path) => Some(Some(PathBuf::from(path))),
-        None => None,
-    }
-}
-
 pub async fn run_exec(args: ExecArgs) -> Result<()> {
     let mut cfg = RuntimeConfig::default();
     if let Some(db_path) = resolve_db_override(args.db.as_deref()) {
@@ -78,26 +66,6 @@ mod tests {
     use super::*;
     use clap::Parser;
     use serial_test::serial;
-
-    #[test]
-    fn memory_sentinel_maps_to_none() {
-        // `:memory:` must become db_path=None (ephemeral), not a file path.
-        assert_eq!(resolve_db_override(Some(":memory:")), Some(None));
-    }
-
-    #[test]
-    fn explicit_path_maps_to_some() {
-        assert_eq!(
-            resolve_db_override(Some("/tmp/kkernel-exec-test.db")),
-            Some(Some(PathBuf::from("/tmp/kkernel-exec-test.db")))
-        );
-    }
-
-    #[test]
-    fn absent_db_leaves_default() {
-        // None → no override; run_exec keeps RuntimeConfig::default().db_path.
-        assert_eq!(resolve_db_override(None), None);
-    }
 
     #[test]
     #[serial]

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -1,6 +1,7 @@
 //! kkernel — khive admin/management library.
 
 pub mod coordinator;
+pub mod dbpath;
 pub mod engine;
 pub mod exec;
 pub mod kg;

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -10,7 +10,8 @@
 //! - `kg`      — KG validation, init, hook management
 //! - `engine`  — embedding model lifecycle: list/status/migrate/drift-check
 //! - `vector`  — vector store capabilities and orphan sweep
-//! - `reindex` — rebuild embedding vectors for entities and notes
+//! - `reindex` — rebuild embedding vectors for entities, notes, and the
+//!   knowledge corpus (fans out across every configured engine)
 //! - `exec`    — run a verb DSL expression through the pack registry
 //! - `mcp`     — serve the MCP `request` surface (stdio / daemon / transports)
 //! - `backend` — inspect registered backends (`list`, `info <name>`)
@@ -68,7 +69,8 @@ enum Command {
     #[command(subcommand)]
     Vector(vector::VectorCommand),
 
-    /// Re-embed all entities and notes using the configured embedding model.
+    /// Re-embed entities, notes, and the knowledge corpus, fanning out across
+    /// every configured embedding engine (resolved like `kkernel mcp`).
     Reindex(reindex::ReindexArgs),
 
     /// Execute a verb DSL expression (same syntax as MCP `request` tool).

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -342,10 +342,16 @@ async fn cmd_db_check(args: DbCheckArgs) -> Result<()> {
 }
 
 fn init_tracing(level: &str) {
-    // Tracing goes to stderr — stdout is reserved for JSON results.
+    // Tracing goes to stderr — stdout is reserved for JSON / MCP results.
+    //
+    // Silence the benign `lattice_inference` tokenizer warning ("tokenizer and
+    // model vocab sizes differ" — the multilingual paraphrase model carries a
+    // handful of extra reserved tokens) while honoring the caller's level for
+    // everything else.
+    let filter = format!("{level},lattice_inference=error");
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(level)
+        .with_env_filter(filter)
         .with_ansi(false)
         .init();
 }

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -53,9 +53,11 @@ pub struct ReindexArgs {
     #[arg(long)]
     pub keep_existing: bool,
 
-    /// Namespace to operate on.
-    #[arg(long, default_value = "local")]
-    pub namespace: String,
+    /// Namespace to operate on. When omitted, the config file `[actor] id` (if
+    /// any) is honored — matching the same precedence as `kkernel mcp`. An
+    /// explicit `--namespace` / `KHIVE_NAMESPACE` overrides the config tier.
+    #[arg(long, env = "KHIVE_NAMESPACE")]
+    pub namespace: Option<String>,
 
     /// Only reindex the knowledge corpus (skip entities and notes).
     #[arg(long, conflicts_with = "no_knowledge")]
@@ -207,23 +209,29 @@ async fn filter_unembedded(
 /// MCP server serves recall from. Fails closed on any partial failure unless
 /// `--best-effort` is set.
 pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
-    // `--namespace` is the operator's explicit per-namespace target (reindex is
-    // run once per namespace), so it always wins over any config `[actor] id`;
-    // the config tier still supplies engines + db path.
-    let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
+    // Namespace precedence mirrors `kkernel mcp`:
+    //   1. --namespace / KHIVE_NAMESPACE (explicit CLI/env) — skips config tier
+    //   2. [actor] id in the config file
+    //   3. Default "local"
+    let explicit = args.namespace.is_some();
+    let raw = args.namespace.as_deref().unwrap_or("local");
+    let ns = Namespace::parse(raw).map_err(|e| anyhow::anyhow!("{e}"))?;
     let cfg = resolve_runtime_config(RuntimeConfigInputs {
         db: args.db.as_deref(),
         config: args.config.as_deref(),
         namespace: ns,
-        namespace_explicit: true,
+        namespace_explicit: explicit,
         no_embed: false,
         packs: None,
     })?;
 
+    // Capture the resolved namespace BEFORE `new` consumes cfg — when
+    // `!explicit`, `resolve_runtime_config` may have applied `[actor] id` from
+    // the config file, making `cfg.default_namespace` differ from the CLI value.
+    let resolved_ns = cfg.default_namespace.clone();
     let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
-    let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
     let token = rt
-        .authorize(ns)
+        .authorize(resolved_ns)
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("failed to authorize namespace")?;
 
@@ -706,6 +714,82 @@ mod tests {
         assert_eq!(
             args.config.as_deref(),
             Some(std::path::Path::new("/tmp/kkernel-reindex.toml"))
+        );
+    }
+
+    // Namespace resolution parity with `kkernel mcp`: when --namespace is omitted,
+    // the config file `[actor] id` must set the effective namespace — same as the
+    // MCP path. When --namespace is explicit, it must override the config tier.
+    #[test]
+    #[serial]
+    fn namespace_absent_honors_config_actor_id() {
+        use std::io::Write;
+        std::env::remove_var("KHIVE_NAMESPACE");
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("khive.toml");
+        let mut f = std::fs::File::create(&config_path).expect("create config");
+        f.write_all(b"[actor]\nid = \"lambda:prod\"\n")
+            .expect("write config");
+
+        // No --namespace: must pick up [actor] id from config file.
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&config_path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+        })
+        .expect("resolve config");
+        assert_eq!(
+            resolved.default_namespace.as_str(),
+            "lambda:prod",
+            "omitted --namespace must defer to config [actor] id"
+        );
+
+        // Explicit --namespace must override [actor] id.
+        let resolved_explicit = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&config_path),
+            namespace: Namespace::parse("explicit-ns").expect("ns"),
+            namespace_explicit: true,
+            no_embed: false,
+            packs: None,
+        })
+        .expect("resolve config explicit");
+        assert_eq!(
+            resolved_explicit.default_namespace.as_str(),
+            "explicit-ns",
+            "explicit --namespace must override config [actor] id"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn namespace_env_var_sets_explicit_flag() {
+        std::env::set_var("KHIVE_NAMESPACE", "env-ns");
+        let args = ReindexArgs::parse_from(["reindex"]);
+        std::env::remove_var("KHIVE_NAMESPACE");
+        assert_eq!(
+            args.namespace.as_deref(),
+            Some("env-ns"),
+            "KHIVE_NAMESPACE env var must bind to --namespace"
+        );
+        assert!(
+            args.namespace.is_some(),
+            "env var binding must make namespace Some (explicit)"
+        );
+    }
+
+    #[test]
+    fn namespace_absent_defaults_to_none() {
+        let args = ReindexArgs::parse_from(["reindex"]);
+        assert!(
+            args.namespace.is_none(),
+            "omitted --namespace must be None (not a String default)"
         );
     }
 }

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -89,6 +89,10 @@ struct ReindexReport {
     knowledge_atoms_failed: u64,
     /// True when the knowledge pass itself errored (could not run to completion).
     knowledge_pass_errored: bool,
+    /// True when the Vamana ANN build or snapshot persist failed during the
+    /// knowledge pass. Distinct from atom-level failures: atom vectors DID
+    /// persist; the ANN snapshot is the failure dimension.
+    knowledge_ann_failed: bool,
     models_used: Vec<String>,
     elapsed_ms: u64,
     /// Entity/note vector inserts that failed across all engines.
@@ -98,7 +102,10 @@ struct ReindexReport {
 impl ReindexReport {
     /// Did any part of the run fail? Drives the fail-closed exit decision.
     fn has_failures(&self) -> bool {
-        self.errors_skipped > 0 || self.knowledge_atoms_failed > 0 || self.knowledge_pass_errored
+        self.errors_skipped > 0
+            || self.knowledge_atoms_failed > 0
+            || self.knowledge_pass_errored
+            || self.knowledge_ann_failed
     }
 }
 
@@ -256,6 +263,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                         knowledge_atoms_indexed: None,
                         knowledge_atoms_failed: 0,
                         knowledge_pass_errored: false,
+                        knowledge_ann_failed: false,
                         models_used: vec![],
                         elapsed_ms: 0,
                         errors_skipped: 0,
@@ -389,6 +397,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut knowledge_atoms_indexed: Option<u64> = None;
     let mut knowledge_atoms_failed: u64 = 0;
     let mut knowledge_pass_errored = false;
+    let mut knowledge_ann_failed = false;
     if do_knowledge {
         eprintln!("  indexing knowledge corpus (this can take a while)…");
         match khive_pack_knowledge::reindex_knowledge(&rt, &token, true, Some(batch_size)).await {
@@ -396,6 +405,10 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 knowledge_atoms_indexed =
                     Some(v.get("indexed").and_then(|n| n.as_u64()).unwrap_or(0));
                 knowledge_atoms_failed = v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
+                knowledge_ann_failed = v
+                    .get("ann_failed")
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
             }
             Err(e) => {
                 tracing::error!(error = %e, "knowledge reindex failed");
@@ -413,6 +426,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         knowledge_atoms_indexed,
         knowledge_atoms_failed,
         knowledge_pass_errored,
+        knowledge_ann_failed,
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
@@ -528,6 +542,9 @@ fn print_report(report: &ReindexReport, human: bool) {
                 report.knowledge_atoms_failed
             );
         }
+        if report.knowledge_ann_failed {
+            println!("Knowledge ANN: FAILED (snapshot not rebuilt/persisted)");
+        }
         if !report.models_used.is_empty() {
             println!("Models: {}", report.models_used.join(", "));
         }
@@ -634,6 +651,7 @@ mod tests {
             knowledge_atoms_indexed: Some(0),
             knowledge_atoms_failed: k_failed,
             knowledge_pass_errored: k_errored,
+            knowledge_ann_failed: false,
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: errors,
@@ -654,6 +672,33 @@ mod tests {
         assert!(
             report_with(0, 0, true).has_failures(),
             "knowledge pass error"
+        );
+    }
+
+    #[test]
+    fn has_failures_flags_knowledge_ann_failed() {
+        let report = ReindexReport {
+            entities_processed: 0,
+            notes_processed: 0,
+            knowledge_atoms_indexed: Some(10),
+            knowledge_atoms_failed: 0,
+            knowledge_pass_errored: false,
+            knowledge_ann_failed: true,
+            models_used: vec![],
+            elapsed_ms: 0,
+            errors_skipped: 0,
+        };
+        assert!(
+            report.has_failures(),
+            "knowledge_ann_failed alone must drive has_failures() = true"
+        );
+        assert!(
+            decide_result(report.has_failures(), false).is_err(),
+            "knowledge_ann_failed must fail closed (non-zero exit)"
+        );
+        assert!(
+            decide_result(report.has_failures(), true).is_ok(),
+            "best-effort downgrades knowledge_ann_failed to exit 0"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -20,14 +20,16 @@ use khive_types::SubstrateKind;
 
 const MAX_EMBED_BYTES: usize = 32_768;
 
-/// Arguments for `kkernel reindex` — rebuilds embedding vectors for all entities and notes.
+/// Arguments for `kkernel reindex` — rebuilds embedding vectors for entities,
+/// notes, and the knowledge corpus.
 #[derive(Parser, Debug)]
 pub struct ReindexArgs {
     /// Database path (defaults to `~/.khive/khive.db`).
     #[arg(long)]
     pub db: Option<PathBuf>,
 
-    /// Embedding model name (uses runtime default when omitted).
+    /// Embedding model for entities/notes. When omitted, fans out to ALL
+    /// registered models. (Knowledge always uses the default embedder.)
     #[arg(long)]
     pub model: Option<String>,
 
@@ -43,6 +45,14 @@ pub struct ReindexArgs {
     #[arg(long, default_value = "local")]
     pub namespace: String,
 
+    /// Only reindex the knowledge corpus (skip entities and notes).
+    #[arg(long, conflicts_with = "no_knowledge")]
+    pub knowledge_only: bool,
+
+    /// Skip the knowledge corpus (reindex only entities and notes).
+    #[arg(long)]
+    pub no_knowledge: bool,
+
     /// Print human-readable output instead of JSON.
     #[arg(long)]
     pub human: bool,
@@ -52,9 +62,93 @@ pub struct ReindexArgs {
 struct ReindexReport {
     entities_processed: u64,
     notes_processed: u64,
-    model_used: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    knowledge_atoms_indexed: Option<u64>,
+    models_used: Vec<String>,
     elapsed_ms: u64,
     errors_skipped: u64,
+}
+
+/// Embed `staged` with every model in `model_names` and store one vector record
+/// per model — mirroring the multi-model write path in the runtime. Returns the
+/// number of vector inserts that failed.
+///
+/// With `drop_existing`, each model's prior vector for an id is deleted before
+/// insert. Otherwise (`--keep-existing`), ids already embedded in a given model
+/// are skipped for that model only.
+// REASON: each argument is a distinct embed dimension (runtime, token, models,
+// namespace, batch, substrate kind, field, drop flag); a struct would add
+// indirection without grouping anything cohesive.
+#[allow(clippy::too_many_arguments)]
+async fn embed_and_store_batch(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    model_names: &[String],
+    namespace: &str,
+    staged: &[(Uuid, String)],
+    kind: SubstrateKind,
+    field: &str,
+    drop_existing: bool,
+) -> u64 {
+    let mut errors: u64 = 0;
+    for model_name in model_names {
+        let vectors = match rt.vectors_for_model(token, model_name) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(model = %model_name, error = %e, "vector store unavailable");
+                errors += staged.len() as u64;
+                continue;
+            }
+        };
+
+        // Narrow to the records this model still needs when keeping existing vectors.
+        let subset: Vec<&(Uuid, String)> = if drop_existing {
+            staged.iter().collect()
+        } else {
+            let ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
+            match filter_unembedded(vectors.as_ref(), &ids, namespace).await {
+                Ok(unembedded) => {
+                    let keep: HashSet<Uuid> = unembedded.into_iter().collect();
+                    staged.iter().filter(|(id, _)| keep.contains(id)).collect()
+                }
+                Err(e) => {
+                    tracing::error!(model = %model_name, error = %e, "filter_unembedded failed; skipping batch for this model");
+                    errors += staged.len() as u64;
+                    continue;
+                }
+            }
+        };
+        if subset.is_empty() {
+            continue;
+        }
+
+        let texts: Vec<String> = subset.iter().map(|(_, t)| truncate_text(t)).collect();
+        match rt.embed_batch_with_model(model_name, &texts).await {
+            Ok(embeddings) if embeddings.len() == subset.len() => {
+                for ((id, _), emb) in subset.iter().zip(embeddings.iter()) {
+                    if drop_existing {
+                        let _ = vectors.delete(*id).await;
+                    }
+                    if let Err(e) = vectors
+                        .insert(*id, kind, namespace, field, vec![emb.clone()])
+                        .await
+                    {
+                        tracing::warn!(id = %id, model = %model_name, error = %e, "vector insert failed");
+                        errors += 1;
+                    }
+                }
+            }
+            Ok(_) => {
+                tracing::warn!(model = %model_name, "embedding count mismatch for batch");
+                errors += subset.len() as u64;
+            }
+            Err(e) => {
+                tracing::warn!(model = %model_name, error = %e, "embed_batch failed");
+                errors += subset.len() as u64;
+            }
+        }
+    }
+    errors
 }
 
 /// Return the subset of `ids` that do NOT already have an embedding in `vectors`
@@ -90,23 +184,35 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("failed to authorize namespace")?;
 
-    let model_name: String = match args.model.as_deref().filter(|s| !s.is_empty()) {
-        Some(name) => name.to_string(),
-        None => {
-            let default = rt.default_embedder_name();
-            if default.is_empty() {
-                let report = ReindexReport {
-                    entities_processed: 0,
-                    notes_processed: 0,
-                    model_used: None,
-                    elapsed_ms: 0,
-                    errors_skipped: 0,
-                };
-                print_report(&report, args.human);
-                eprintln!("warning: no embedding model configured");
-                return Ok(());
+    let do_graph = !args.knowledge_only; // entities + notes
+    let do_knowledge = !args.no_knowledge; // knowledge corpus
+
+    // Explicit --model targets a single engine; otherwise fan out to ALL
+    // registered engines, matching the runtime's multi-model write path so a
+    // reindex reproduces exactly what create/update would have embedded.
+    // Only needed for the entity/note pass (knowledge uses the default embedder).
+    let model_names: Vec<String> = if !do_graph {
+        vec![]
+    } else {
+        match args.model.as_deref().filter(|s| !s.is_empty()) {
+            Some(name) => vec![name.to_string()],
+            None => {
+                let names = rt.registered_embedding_model_names();
+                if names.is_empty() {
+                    let report = ReindexReport {
+                        entities_processed: 0,
+                        notes_processed: 0,
+                        knowledge_atoms_indexed: None,
+                        models_used: vec![],
+                        elapsed_ms: 0,
+                        errors_skipped: 0,
+                    };
+                    print_report(&report, args.human);
+                    eprintln!("warning: no embedding model configured");
+                    return Ok(());
+                }
+                names
             }
-            default.to_string()
         }
     };
 
@@ -116,208 +222,139 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let start = std::time::Instant::now();
 
     let mut entities_processed: u64 = 0;
+    let mut notes_processed: u64 = 0;
     let mut errors_skipped: u64 = 0;
 
-    // ── entities ─────────────────────────────────────────────────────────────
-    let mut entity_offset: u32 = 0;
-    loop {
-        let batch = rt
-            .list_entities(&token, None, None, batch_size, entity_offset)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let n = batch.len();
-        if n == 0 {
-            break;
-        }
-
-        let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-        for entity in &batch {
-            let text = match &entity.description {
-                Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
-                _ => entity.name.clone(),
-            };
-            if !text.trim().is_empty() {
-                staged.push((entity.id, text));
+    // ── entities + notes (graph substrate) ────────────────────────────────────
+    if do_graph {
+        let mut entity_offset: u32 = 0;
+        loop {
+            let batch = rt
+                .list_entities(&token, None, None, batch_size, entity_offset)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let n = batch.len();
+            if n == 0 {
+                break;
             }
-        }
 
-        if !staged.is_empty() {
-            // When keeping existing vectors, skip IDs that already have embeddings.
-            if !drop_existing {
-                if let Ok(vectors) = rt.vectors_for_model(&token, &model_name) {
-                    let all_ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
-                    match filter_unembedded(vectors.as_ref(), &all_ids, &ns_str).await {
-                        Ok(unembedded) => {
-                            let keep: HashSet<Uuid> = unembedded.into_iter().collect();
-                            staged.retain(|(id, _)| keep.contains(id));
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "filter_unembedded failed; skipping entity batch to honour --keep-existing");
-                            errors_skipped += staged.len() as u64;
-                            staged.clear();
-                        }
-                    }
+            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
+            for entity in &batch {
+                let text = match &entity.description {
+                    Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
+                    _ => entity.name.clone(),
+                };
+                if !text.trim().is_empty() {
+                    staged.push((entity.id, text));
                 }
             }
 
             if !staged.is_empty() {
-                let texts: Vec<String> = staged.iter().map(|(_, t)| truncate_text(t)).collect();
-
-                match rt.embed_batch_with_model(&model_name, &texts).await {
-                    Ok(embeddings) if embeddings.len() == staged.len() => {
-                        match rt.vectors_for_model(&token, &model_name) {
-                            Ok(vectors) => {
-                                for ((id, _), emb) in staged.iter().zip(embeddings.iter()) {
-                                    if drop_existing {
-                                        let _ = vectors.delete(*id).await;
-                                    }
-                                    if let Err(e) = vectors
-                                        .insert(
-                                            *id,
-                                            SubstrateKind::Entity,
-                                            &ns_str,
-                                            "entity.body",
-                                            vec![emb.clone()],
-                                        )
-                                        .await
-                                    {
-                                        tracing::warn!(entity_id = %id, error = %e, "entity vector insert failed");
-                                        errors_skipped += 1;
-                                    }
-                                }
-                                entities_processed += staged.len() as u64;
-                            }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "failed to get vector store for model");
-                                errors_skipped += staged.len() as u64;
-                            }
-                        }
-                    }
-                    Ok(_) => {
-                        tracing::warn!("embedding count mismatch for entity batch");
-                        errors_skipped += staged.len() as u64;
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "entity embed_batch failed");
-                        errors_skipped += staged.len() as u64;
-                    }
-                }
+                errors_skipped += embed_and_store_batch(
+                    &rt,
+                    &token,
+                    &model_names,
+                    &ns_str,
+                    &staged,
+                    SubstrateKind::Entity,
+                    "entity.body",
+                    drop_existing,
+                )
+                .await;
+                entities_processed += staged.len() as u64;
             }
-        }
+            progress(&format!("  entities: {entities_processed} embedded"));
 
-        if n < batch_size as usize {
-            break;
-        }
-        entity_offset += n as u32;
-    }
-
-    // ── notes ─────────────────────────────────────────────────────────────────
-    let mut notes_processed: u64 = 0;
-    let mut note_offset: u32 = 0;
-
-    loop {
-        let batch = rt
-            .list_notes(&token, None, batch_size, note_offset)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let n = batch.len();
-        if n == 0 {
-            break;
-        }
-
-        let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
-        for note in &batch {
-            let text = match &note.name {
-                Some(name) if !name.is_empty() => format!("{name} {}", note.content),
-                _ => note.content.clone(),
-            };
-            if !text.trim().is_empty() {
-                staged.push((note.id, text));
+            if n < batch_size as usize {
+                break;
             }
+            entity_offset += n as u32;
+        }
+        if entities_processed > 0 {
+            eprintln!();
         }
 
-        if !staged.is_empty() {
-            // When keeping existing vectors, skip IDs that already have embeddings.
-            if !drop_existing {
-                if let Ok(vectors) = rt.vectors_for_model(&token, &model_name) {
-                    let all_ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
-                    match filter_unembedded(vectors.as_ref(), &all_ids, &ns_str).await {
-                        Ok(unembedded) => {
-                            let keep: HashSet<Uuid> = unembedded.into_iter().collect();
-                            staged.retain(|(id, _)| keep.contains(id));
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "filter_unembedded failed; skipping note batch to honour --keep-existing");
-                            errors_skipped += staged.len() as u64;
-                            staged.clear();
-                        }
-                    }
+        // ── notes ─────────────────────────────────────────────────────────────────
+        let mut note_offset: u32 = 0;
+
+        loop {
+            let batch = rt
+                .list_notes(&token, None, batch_size, note_offset)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let n = batch.len();
+            if n == 0 {
+                break;
+            }
+
+            let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
+            for note in &batch {
+                let text = match &note.name {
+                    Some(name) if !name.is_empty() => format!("{name} {}", note.content),
+                    _ => note.content.clone(),
+                };
+                if !text.trim().is_empty() {
+                    staged.push((note.id, text));
                 }
             }
 
             if !staged.is_empty() {
-                let texts: Vec<String> = staged.iter().map(|(_, t)| truncate_text(t)).collect();
+                errors_skipped += embed_and_store_batch(
+                    &rt,
+                    &token,
+                    &model_names,
+                    &ns_str,
+                    &staged,
+                    SubstrateKind::Note,
+                    "note.content",
+                    drop_existing,
+                )
+                .await;
+                notes_processed += staged.len() as u64;
+            }
+            progress(&format!("  notes: {notes_processed} embedded"));
 
-                match rt.embed_batch_with_model(&model_name, &texts).await {
-                    Ok(embeddings) if embeddings.len() == staged.len() => {
-                        match rt.vectors_for_model(&token, &model_name) {
-                            Ok(vectors) => {
-                                for ((id, _), emb) in staged.iter().zip(embeddings.iter()) {
-                                    if drop_existing {
-                                        let _ = vectors.delete(*id).await;
-                                    }
-                                    if let Err(e) = vectors
-                                        .insert(
-                                            *id,
-                                            SubstrateKind::Note,
-                                            &ns_str,
-                                            "note.content",
-                                            vec![emb.clone()],
-                                        )
-                                        .await
-                                    {
-                                        tracing::warn!(note_id = %id, error = %e, "note vector insert failed");
-                                        errors_skipped += 1;
-                                    }
-                                }
-                                notes_processed += staged.len() as u64;
-                            }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "failed to get vector store for model (notes)");
-                                errors_skipped += staged.len() as u64;
-                            }
-                        }
-                    }
-                    Ok(_) => {
-                        tracing::warn!("embedding count mismatch for note batch");
-                        errors_skipped += staged.len() as u64;
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "note embed_batch failed");
-                        errors_skipped += staged.len() as u64;
-                    }
-                }
+            if n < batch_size as usize {
+                break;
+            }
+            note_offset += n as u32;
+        }
+        if notes_processed > 0 {
+            eprintln!();
+        }
+
+        // Invalidate Vamana snapshots so the next warm-load triggers a rebuild
+        // against the freshly re-embedded entity/note vectors.
+        if let Err(e) = invalidate_vamana_snapshots(&rt, &ns_str).await {
+            tracing::warn!(error = %e, "failed to invalidate Vamana snapshots after reindex");
+        }
+    } // end if do_graph
+
+    // ── knowledge corpus ───────────────────────────────────────────────────────
+    // Reindex through the knowledge library directly (the `knowledge.index`
+    // handler over the full corpus), not the verb-DSL shell.
+    let mut knowledge_atoms_indexed: Option<u64> = None;
+    if do_knowledge {
+        eprintln!("  indexing knowledge corpus (this can take a while)…");
+        match khive_pack_knowledge::reindex_knowledge(&rt, &token, true, Some(batch_size)).await {
+            Ok(v) => {
+                knowledge_atoms_indexed =
+                    Some(v.get("indexed").and_then(|n| n.as_u64()).unwrap_or(0));
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "knowledge reindex failed");
+                eprintln!("warning: knowledge reindex failed: {e}");
             }
         }
-
-        if n < batch_size as usize {
-            break;
-        }
-        note_offset += n as u32;
     }
 
     let elapsed_ms = start.elapsed().as_millis() as u64;
 
-    // Invalidate Vamana snapshots so the next warm-load triggers a rebuild
-    // against the freshly re-embedded vectors.
-    if let Err(e) = invalidate_vamana_snapshots(&rt, &ns_str).await {
-        tracing::warn!(error = %e, "failed to invalidate Vamana snapshots after reindex");
-    }
-
     let report = ReindexReport {
         entities_processed,
         notes_processed,
-        model_used: Some(model_name),
+        knowledge_atoms_indexed,
+        models_used: model_names,
         elapsed_ms,
         errors_skipped,
     };
@@ -364,6 +401,13 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
     }
 }
 
+/// Emit an in-place progress line to stderr (stdout stays reserved for JSON).
+fn progress(msg: &str) {
+    use std::io::Write;
+    eprint!("\r{msg}");
+    let _ = std::io::stderr().flush();
+}
+
 fn truncate_text(t: &str) -> String {
     if t.len() <= MAX_EMBED_BYTES {
         t.to_string()
@@ -378,15 +422,20 @@ fn truncate_text(t: &str) -> String {
 
 fn print_report(report: &ReindexReport, human: bool) {
     if human {
+        let knowledge = report
+            .knowledge_atoms_indexed
+            .map(|n| format!(", {n} knowledge atoms"))
+            .unwrap_or_default();
         println!(
-            "Reindex complete: {} entities, {} notes ({} errors skipped) in {}ms",
+            "Reindex complete: {} entities, {} notes{} ({} errors skipped) in {}ms",
             report.entities_processed,
             report.notes_processed,
+            knowledge,
             report.errors_skipped,
             report.elapsed_ms
         );
-        if let Some(ref model) = report.model_used {
-            println!("Model: {model}");
+        if !report.models_used.is_empty() {
+            println!("Models: {}", report.models_used.join(", "));
         }
     } else {
         let json = serde_json::to_string(report).expect("serialize ReindexReport");

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -13,7 +13,8 @@ use clap::Parser;
 use serde::Serialize;
 use uuid::Uuid;
 
-use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
+use khive_runtime::{KhiveRuntime, Namespace};
 use khive_storage::error::StorageError;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
@@ -21,12 +22,23 @@ use khive_types::SubstrateKind;
 const MAX_EMBED_BYTES: usize = 32_768;
 
 /// Arguments for `kkernel reindex` — rebuilds embedding vectors for entities,
-/// notes, and the knowledge corpus.
+/// notes, and the knowledge corpus, fanning out across every configured
+/// embedding engine (resolved with the same config-file/env precedence as
+/// `kkernel mcp`).
 #[derive(Parser, Debug)]
 pub struct ReindexArgs {
-    /// Database path (defaults to `~/.khive/khive.db`).
-    #[arg(long)]
-    pub db: Option<PathBuf>,
+    /// Database path (defaults to `~/.khive/khive.db`). `:memory:` selects an
+    /// ephemeral in-memory database, matching `kkernel mcp`/`kkernel exec`.
+    #[arg(long, env = "KHIVE_DB")]
+    pub db: Option<String>,
+
+    /// Path to a khive TOML config file (env `KHIVE_CONFIG`). When provided,
+    /// embedding engines and actor namespace are resolved from it with the same
+    /// precedence as `kkernel mcp`, so reindex writes vectors for the SAME
+    /// engine set the MCP server serves recall from. Absent → home-fallback
+    /// search (./khive.toml, ./.khive/config.toml, ~/.khive/config.toml).
+    #[arg(long = "config", env = "KHIVE_CONFIG")]
+    pub config: Option<PathBuf>,
 
     /// Embedding model for entities/notes. When omitted, fans out to ALL
     /// registered models. (Knowledge always uses the default embedder.)
@@ -53,6 +65,13 @@ pub struct ReindexArgs {
     #[arg(long)]
     pub no_knowledge: bool,
 
+    /// Downgrade partial failures (failed model, failed vector insert, failed
+    /// knowledge pass) to a warning and still exit 0. Without this flag,
+    /// reindex FAILS CLOSED: any failure returns a non-zero exit so automation
+    /// does not treat a partial rebuild as a clean one.
+    #[arg(long)]
+    pub best_effort: bool,
+
     /// Print human-readable output instead of JSON.
     #[arg(long)]
     pub human: bool,
@@ -64,9 +83,21 @@ struct ReindexReport {
     notes_processed: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     knowledge_atoms_indexed: Option<u64>,
+    /// Atoms whose vector write failed during the knowledge pass.
+    knowledge_atoms_failed: u64,
+    /// True when the knowledge pass itself errored (could not run to completion).
+    knowledge_pass_errored: bool,
     models_used: Vec<String>,
     elapsed_ms: u64,
+    /// Entity/note vector inserts that failed across all engines.
     errors_skipped: u64,
+}
+
+impl ReindexReport {
+    /// Did any part of the run fail? Drives the fail-closed exit decision.
+    fn has_failures(&self) -> bool {
+        self.errors_skipped > 0 || self.knowledge_atoms_failed > 0 || self.knowledge_pass_errored
+    }
 }
 
 /// Embed `staged` with every model in `model_names` and store one vector record
@@ -170,12 +201,24 @@ async fn filter_unembedded(
     }
 }
 
-/// Re-embed all entities and notes using the configured or specified embedding model.
+/// Re-embed entities, notes, and the knowledge corpus, fanning out across every
+/// configured embedding engine. Engines, db path, and config are resolved with
+/// the same precedence as `kkernel mcp` so reindex writes the SAME vectors the
+/// MCP server serves recall from. Fails closed on any partial failure unless
+/// `--best-effort` is set.
 pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
-    let mut cfg = RuntimeConfig::default();
-    if let Some(ref db) = args.db {
-        cfg.db_path = Some(db.clone());
-    }
+    // `--namespace` is the operator's explicit per-namespace target (reindex is
+    // run once per namespace), so it always wins over any config `[actor] id`;
+    // the config tier still supplies engines + db path.
+    let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let cfg = resolve_runtime_config(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: args.config.as_deref(),
+        namespace: ns,
+        namespace_explicit: true,
+        no_embed: false,
+        packs: None,
+    })?;
 
     let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -203,6 +246,8 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                         entities_processed: 0,
                         notes_processed: 0,
                         knowledge_atoms_indexed: None,
+                        knowledge_atoms_failed: 0,
+                        knowledge_pass_errored: false,
                         models_used: vec![],
                         elapsed_ms: 0,
                         errors_skipped: 0,
@@ -289,10 +334,10 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
 
             let mut staged: Vec<(Uuid, String)> = Vec::with_capacity(n);
             for note in &batch {
-                let text = match &note.name {
-                    Some(name) if !name.is_empty() => format!("{name} {}", note.content),
-                    _ => note.content.clone(),
-                };
+                // Embed note.content ONLY — matching the create/update write path
+                // (operations.rs / curation.rs embed `note.content`, never the
+                // name). Reindex must reproduce exactly what those paths embedded.
+                let text = note.content.clone();
                 if !text.trim().is_empty() {
                     staged.push((note.id, text));
                 }
@@ -334,16 +379,20 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     // Reindex through the knowledge library directly (the `knowledge.index`
     // handler over the full corpus), not the verb-DSL shell.
     let mut knowledge_atoms_indexed: Option<u64> = None;
+    let mut knowledge_atoms_failed: u64 = 0;
+    let mut knowledge_pass_errored = false;
     if do_knowledge {
         eprintln!("  indexing knowledge corpus (this can take a while)…");
         match khive_pack_knowledge::reindex_knowledge(&rt, &token, true, Some(batch_size)).await {
             Ok(v) => {
                 knowledge_atoms_indexed =
                     Some(v.get("indexed").and_then(|n| n.as_u64()).unwrap_or(0));
+                knowledge_atoms_failed = v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
             }
             Err(e) => {
-                tracing::warn!(error = %e, "knowledge reindex failed");
-                eprintln!("warning: knowledge reindex failed: {e}");
+                tracing::error!(error = %e, "knowledge reindex failed");
+                eprintln!("error: knowledge reindex failed: {e}");
+                knowledge_pass_errored = true;
             }
         }
     }
@@ -354,13 +403,37 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         entities_processed,
         notes_processed,
         knowledge_atoms_indexed,
+        knowledge_atoms_failed,
+        knowledge_pass_errored,
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
     };
 
     print_report(&report, args.human);
+    finish(&report, args.best_effort)
+}
+
+/// Decide the process exit from a completed report: `Ok(())` when clean or in
+/// best-effort mode, `Err` (non-zero exit) when fail-closed and any part failed.
+/// Pure decision logic, unit-tested without running embedders.
+fn decide_result(has_failures: bool, best_effort: bool) -> Result<()> {
+    if has_failures && !best_effort {
+        anyhow::bail!(
+            "reindex completed with failures; recall/search state may be stale. \
+             Re-run, or pass --best-effort to accept a partial rebuild."
+        );
+    }
     Ok(())
+}
+
+/// Surface the fail-closed decision after printing the report.
+fn finish(report: &ReindexReport, best_effort: bool) -> Result<()> {
+    let result = decide_result(report.has_failures(), best_effort);
+    if report.has_failures() && best_effort {
+        eprintln!("warning: reindex completed with failures (best-effort mode; exiting 0)");
+    }
+    result
 }
 
 async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyhow::Result<()> {
@@ -426,14 +499,27 @@ fn print_report(report: &ReindexReport, human: bool) {
             .knowledge_atoms_indexed
             .map(|n| format!(", {n} knowledge atoms"))
             .unwrap_or_default();
+        let status = if report.has_failures() {
+            "Reindex completed WITH FAILURES"
+        } else {
+            "Reindex complete"
+        };
         println!(
-            "Reindex complete: {} entities, {} notes{} ({} errors skipped) in {}ms",
+            "{status}: {} entities, {} notes{} ({} entity/note errors) in {}ms",
             report.entities_processed,
             report.notes_processed,
             knowledge,
             report.errors_skipped,
             report.elapsed_ms
         );
+        if report.knowledge_pass_errored {
+            println!("Knowledge pass: FAILED (did not run to completion)");
+        } else if report.knowledge_atoms_failed > 0 {
+            println!(
+                "Knowledge pass: {} atom vector inserts FAILED",
+                report.knowledge_atoms_failed
+            );
+        }
         if !report.models_used.is_empty() {
             println!("Models: {}", report.models_used.join(", "));
         }
@@ -446,7 +532,10 @@ fn print_report(report: &ReindexReport, human: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dbpath::resolve_db_override;
+    use clap::Parser;
     use khive_storage::types::{SqlStatement, SqlValue};
+    use serial_test::serial;
 
     #[tokio::test]
     async fn test_reindex_invalidates_vamana_snapshots() {
@@ -527,6 +616,96 @@ mod tests {
         assert!(
             !remaining.contains(&"local::vamana::model-b".to_string()),
             "local vamana model-b must be deleted: {remaining:?}"
+        );
+    }
+
+    fn report_with(errors: u64, k_failed: u64, k_errored: bool) -> ReindexReport {
+        ReindexReport {
+            entities_processed: 0,
+            notes_processed: 0,
+            knowledge_atoms_indexed: Some(0),
+            knowledge_atoms_failed: k_failed,
+            knowledge_pass_errored: k_errored,
+            models_used: vec![],
+            elapsed_ms: 0,
+            errors_skipped: errors,
+        }
+    }
+
+    #[test]
+    fn has_failures_flags_each_failure_source() {
+        assert!(!report_with(0, 0, false).has_failures());
+        assert!(
+            report_with(1, 0, false).has_failures(),
+            "entity/note errors"
+        );
+        assert!(
+            report_with(0, 1, false).has_failures(),
+            "knowledge atom fails"
+        );
+        assert!(
+            report_with(0, 0, true).has_failures(),
+            "knowledge pass error"
+        );
+    }
+
+    #[test]
+    fn decide_result_fails_closed_by_default() {
+        assert!(decide_result(false, false).is_ok(), "clean run exits 0");
+        assert!(
+            decide_result(true, false).is_err(),
+            "failures fail closed (non-zero exit)"
+        );
+    }
+
+    #[test]
+    fn decide_result_best_effort_downgrades_to_ok() {
+        assert!(
+            decide_result(true, true).is_ok(),
+            "best-effort downgrades failures to exit 0"
+        );
+        assert!(decide_result(false, true).is_ok());
+    }
+
+    // DB resolution parity with `kkernel exec` / `kkernel mcp`. The shared
+    // helper is unit-tested in `dbpath`; here we assert reindex consumes it
+    // through clap (`--db` / `KHIVE_DB` / `:memory:`) the same way.
+    #[test]
+    fn db_memory_sentinel_resolves_to_none() {
+        assert_eq!(resolve_db_override(Some(":memory:")), Some(None));
+    }
+
+    #[test]
+    fn db_explicit_path_resolves_to_some() {
+        assert_eq!(
+            resolve_db_override(Some("/tmp/kkernel-reindex-test.db")),
+            Some(Some(PathBuf::from("/tmp/kkernel-reindex-test.db")))
+        );
+    }
+
+    #[test]
+    fn db_absent_leaves_default() {
+        assert_eq!(resolve_db_override(None), None);
+    }
+
+    #[test]
+    #[serial]
+    fn khive_db_env_binds_to_db_arg() {
+        std::env::set_var("KHIVE_DB", "/tmp/kkernel-reindex-env.db");
+        let args = ReindexArgs::parse_from(["reindex"]);
+        std::env::remove_var("KHIVE_DB");
+        assert_eq!(args.db.as_deref(), Some("/tmp/kkernel-reindex-env.db"));
+    }
+
+    #[test]
+    #[serial]
+    fn khive_config_env_binds_to_config_arg() {
+        std::env::set_var("KHIVE_CONFIG", "/tmp/kkernel-reindex.toml");
+        let args = ReindexArgs::parse_from(["reindex"]);
+        std::env::remove_var("KHIVE_CONFIG");
+        assert_eq!(
+            args.config.as_deref(),
+            Some(std::path::Path::new("/tmp/kkernel-reindex.toml"))
         );
     }
 }


### PR DESCRIPTION
**Stacked PR 2/3.** Base: `feat/kkernel-unify` (#7). Review/merge after #7.

## What's here
- **Multi-engine entity/note reindex**: entities and notes fan out to **every registered embedding model** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`), one vector record per engine — matching the runtime create/update write path. `--model` narrows to a single engine.
- **Knowledge folded into reindex**: `--knowledge-only` / `--no-knowledge` gate the knowledge pass; it embeds atoms (and rebuilds the atom Vamana ANN) via the library entry `khive_pack_knowledge::reindex_knowledge` instead of a separate ad-hoc command. Knowledge stays single-model (search retrieves via the default embedder's ANN).
- **Lattice tokenizer warning suppressed**: `init_tracing` appends `lattice_inference=error` so the benign multilingual-model vocab-size warning doesn't spam stderr; per-batch progress to stderr.
- Usage doc updated for the folded reindex surface.

## Verification
- `make ci` green; design review approved.
- Multi-engine fan-out confirmed: per-model vector tables created, both models in the report.