### PR TITLE
feat(pack-knowledge): section embeddings in reindex (ADR-051 phase 1)

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -9,5 +9,6 @@ mod fold_handler;
 mod index_handler;
 mod search;
 mod sections;
+pub(crate) mod sections_index;
 pub(super) mod util;
 pub(crate) struct KnowledgeHandlers;

--- a/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
@@ -41,15 +41,17 @@ fn truncate_bytes(t: &str) -> String {
 /// Embed sections in `token`'s namespace into `knowledge_sections.embedding`.
 ///
 /// With `drop_existing`, every section is re-embedded; otherwise only sections
-/// whose `embedding` is currently NULL are filled. Returns `(indexed, skipped)`.
+/// whose `embedding` is currently NULL are filled. Returns `(indexed, skipped,
+/// failed)`. Genuine skips (blank section text) go to `skipped`; embed errors
+/// and vector-count mismatches go to `failed` (fail-closed contract).
 pub(crate) async fn embed_sections(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     drop_existing: bool,
     batch_size: usize,
-) -> Result<(usize, usize), RuntimeError> {
+) -> Result<(usize, usize, usize), RuntimeError> {
     if runtime.default_embedder_name().is_empty() {
-        return Ok((0, 0));
+        return Ok((0, 0, 0));
     }
     let ns = token.namespace().as_str().to_owned();
     let sql = runtime.sql();
@@ -57,6 +59,7 @@ pub(crate) async fn embed_sections(
 
     let mut indexed = 0usize;
     let mut skipped = 0usize;
+    let mut failed = 0usize;
     let mut offset = 0i64;
 
     loop {
@@ -117,8 +120,17 @@ pub(crate) async fn embed_sections(
             let texts: Vec<String> = chunk.iter().map(|(_, t)| truncate_bytes(t)).collect();
             let embeddings = match runtime.embed_batch(&texts).await {
                 Ok(e) if e.len() == chunk.len() => e,
-                _ => {
-                    skipped += chunk.len();
+                Ok(_) => {
+                    tracing::warn!(
+                        batch = chunk.len(),
+                        "section embed_batch returned wrong vector count; counting as failed"
+                    );
+                    failed += chunk.len();
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, batch = chunk.len(), "section embed_batch failed; counting as failed");
+                    failed += chunk.len();
                     continue;
                 }
             };
@@ -129,7 +141,7 @@ pub(crate) async fn embed_sections(
             let now = now_us();
             for ((id, _), mut emb) in chunk.iter().zip(embeddings.into_iter()) {
                 unit_normalize(&mut emb);
-                writer
+                if let Err(e) = writer
                     .execute(SqlStatement {
                         sql: "UPDATE knowledge_sections SET embedding = ?1, updated_at = ?2 \
                               WHERE id = ?3"
@@ -142,8 +154,12 @@ pub(crate) async fn embed_sections(
                         label: None,
                     })
                     .await
-                    .map_err(|e| sql_err("section embedding update", e))?;
-                indexed += 1;
+                {
+                    tracing::warn!(id = %id, error = %e, "section embedding UPDATE failed; counting as failed");
+                    failed += 1;
+                } else {
+                    indexed += 1;
+                }
             }
         }
 
@@ -153,5 +169,5 @@ pub(crate) async fn embed_sections(
         offset += n as i64;
     }
 
-    Ok((indexed, skipped))
+    Ok((indexed, skipped, failed))
 }

--- a/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
@@ -1,0 +1,157 @@
+//! Section embedding pass (ADR-051).
+//!
+//! Embeds `knowledge_sections` into the inline `embedding` column with the
+//! default embedder. Vectors are unit-normalised little-endian `f32` so a stored
+//! dot product equals cosine similarity. Embed text is breadcrumb-enriched:
+//! `atom_name \n heading \n\n content`.
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_storage::types::{SqlStatement, SqlValue};
+
+use super::util::{now_us, row_str, sql_err, EMBED_BATCH, MAX_EMBED_BYTES};
+
+fn unit_normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 1e-12 {
+        for x in v.iter_mut() {
+            *x /= norm;
+        }
+    }
+}
+
+fn f32_to_le_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for x in v {
+        out.extend_from_slice(&x.to_le_bytes());
+    }
+    out
+}
+
+fn truncate_bytes(t: &str) -> String {
+    if t.len() <= MAX_EMBED_BYTES {
+        return t.to_string();
+    }
+    let mut end = MAX_EMBED_BYTES;
+    while !t.is_char_boundary(end) {
+        end -= 1;
+    }
+    t[..end].to_string()
+}
+
+/// Embed sections in `token`'s namespace into `knowledge_sections.embedding`.
+///
+/// With `drop_existing`, every section is re-embedded; otherwise only sections
+/// whose `embedding` is currently NULL are filled. Returns `(indexed, skipped)`.
+pub(crate) async fn embed_sections(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    drop_existing: bool,
+    batch_size: usize,
+) -> Result<(usize, usize), RuntimeError> {
+    if runtime.default_embedder_name().is_empty() {
+        return Ok((0, 0));
+    }
+    let ns = token.namespace().as_str().to_owned();
+    let sql = runtime.sql();
+    let page = batch_size.clamp(1, 1000) as i64;
+
+    let mut indexed = 0usize;
+    let mut skipped = 0usize;
+    let mut offset = 0i64;
+
+    loop {
+        // When keeping existing vectors we filter on `embedding IS NULL`; embedded
+        // rows leave the set, so the page offset stays 0. A full re-embed has a
+        // stable result set, so we paginate with a moving offset.
+        let (filter, query_offset) = if drop_existing {
+            ("", offset)
+        } else {
+            (" AND s.embedding IS NULL", 0)
+        };
+        let query = format!(
+            "SELECT s.id AS id, s.heading AS heading, s.content AS content, \
+                    a.name AS atom_name \
+             FROM knowledge_sections s \
+             JOIN knowledge_atoms a ON a.id = s.atom_id \
+             WHERE s.namespace = ?1{filter} \
+             ORDER BY s.id LIMIT ?2 OFFSET ?3"
+        );
+        let mut reader = sql
+            .reader()
+            .await
+            .map_err(|e| sql_err("section index reader", e))?;
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: query,
+                params: vec![
+                    SqlValue::Text(ns.clone()),
+                    SqlValue::Integer(page),
+                    SqlValue::Integer(query_offset),
+                ],
+                label: None,
+            })
+            .await
+            .map_err(|e| sql_err("section index page", e))?;
+        let n = rows.len();
+        if n == 0 {
+            break;
+        }
+
+        let mut staged: Vec<(String, String)> = Vec::with_capacity(n);
+        for r in &rows {
+            let Some(id) = row_str(r, "id") else {
+                continue;
+            };
+            let heading = row_str(r, "heading").unwrap_or_default();
+            let content = row_str(r, "content").unwrap_or_default();
+            let atom_name = row_str(r, "atom_name").unwrap_or_default();
+            let text = format!("{atom_name}\n{heading}\n\n{content}");
+            if text.trim().is_empty() {
+                skipped += 1;
+                continue;
+            }
+            staged.push((id, text));
+        }
+
+        for chunk in staged.chunks(EMBED_BATCH) {
+            let texts: Vec<String> = chunk.iter().map(|(_, t)| truncate_bytes(t)).collect();
+            let embeddings = match runtime.embed_batch(&texts).await {
+                Ok(e) if e.len() == chunk.len() => e,
+                _ => {
+                    skipped += chunk.len();
+                    continue;
+                }
+            };
+            let mut writer = sql
+                .writer()
+                .await
+                .map_err(|e| sql_err("section index writer", e))?;
+            let now = now_us();
+            for ((id, _), mut emb) in chunk.iter().zip(embeddings.into_iter()) {
+                unit_normalize(&mut emb);
+                writer
+                    .execute(SqlStatement {
+                        sql: "UPDATE knowledge_sections SET embedding = ?1, updated_at = ?2 \
+                              WHERE id = ?3"
+                            .into(),
+                        params: vec![
+                            SqlValue::Blob(f32_to_le_bytes(&emb)),
+                            SqlValue::Integer(now),
+                            SqlValue::Text(id.clone()),
+                        ],
+                        label: None,
+                    })
+                    .await
+                    .map_err(|e| sql_err("section embedding update", e))?;
+                indexed += 1;
+            }
+        }
+
+        if n < page as usize {
+            break;
+        }
+        offset += n as i64;
+    }
+
+    Ok((indexed, skipped))
+}

--- a/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
@@ -63,13 +63,17 @@ pub(crate) async fn embed_sections(
     let mut offset = 0i64;
 
     loop {
-        // When keeping existing vectors we filter on `embedding IS NULL`; embedded
-        // rows leave the set, so the page offset stays 0. A full re-embed has a
-        // stable result set, so we paginate with a moving offset.
+        let skipped_before = skipped;
+        let failed_before = failed;
+        // When keeping existing vectors we filter on `embedding IS NULL`. Embedded
+        // rows leave the set; rows that fail or are skipped stay NULL, so we must
+        // advance the offset past THEM each pass (see the offset update below) —
+        // otherwise a full page of persistent failures would re-select forever.
+        // A full re-embed has a stable result set, so we paginate by row count.
         let (filter, query_offset) = if drop_existing {
             ("", offset)
         } else {
-            (" AND s.embedding IS NULL", 0)
+            (" AND s.embedding IS NULL", offset)
         };
         let query = format!(
             "SELECT s.id AS id, s.heading AS heading, s.content AS content, \
@@ -166,7 +170,16 @@ pub(crate) async fn embed_sections(
         if n < page as usize {
             break;
         }
-        offset += n as i64;
+        // drop_existing: stable result set → paginate by full page.
+        // keep-existing: embedded rows leave the `embedding IS NULL` set, so only
+        // the rows still NULL after this pass (failed + skipped) need to be
+        // stepped over; advancing by exactly that count attempts each row once
+        // and guarantees termination.
+        offset += if drop_existing {
+            n as i64
+        } else {
+            (skipped - skipped_before + failed - failed_before) as i64
+        };
     }
 
     Ok((indexed, skipped, failed))

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -8,26 +8,73 @@ mod vocab;
 pub use pack::KnowledgePack;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
-use serde_json::Value;
+use serde_json::{json, Value};
 
-/// Reindex the knowledge corpus for `token`'s namespace: embed atoms with the
-/// default embedder and (optionally) rebuild the Vamana ANN snapshot.
+/// Options for [`reindex_knowledge`].
+#[derive(Debug, Clone, Copy)]
+pub struct KnowledgeReindexOptions {
+    /// Embed atoms (and rebuild the atom Vamana ANN).
+    pub atoms: bool,
+    /// Embed sections into `knowledge_sections.embedding` (ADR-051).
+    pub sections: bool,
+    /// Re-embed everything; when false, only fill missing vectors.
+    pub drop_existing: bool,
+    /// Rebuild the atom Vamana ANN snapshot (only meaningful with `atoms`).
+    pub rebuild_ann: bool,
+    /// Records per embedding batch.
+    pub batch_size: Option<u32>,
+}
+
+/// Reindex the knowledge corpus for `token`'s namespace: embed atoms and/or
+/// sections with the default embedder and (optionally) rebuild the atom Vamana
+/// ANN snapshot.
 ///
-/// Library entry for `kkernel reindex` — equivalent to the `knowledge.index`
-/// verb over the full corpus, callable without an MCP server. Knowledge search
-/// is single-model (it retrieves via the default embedder's ANN), so this does
-/// not fan out across registered models the way entity/note reindex does.
+/// Library entry for `kkernel reindex` — callable without an MCP server.
+/// Knowledge is single-model (search retrieves via the default embedder's ANN),
+/// so this does not fan out across registered models the way entity/note
+/// reindex does. Returns `{atoms_indexed, sections_indexed, failed, ann_failed}`.
 pub async fn reindex_knowledge(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
-    rebuild_ann: bool,
-    batch_size: Option<u32>,
+    opts: KnowledgeReindexOptions,
 ) -> Result<Value, RuntimeError> {
-    let ann = knowledge::vamana::new_shared();
-    let mut params = serde_json::Map::new();
-    params.insert("rebuild_ann".into(), Value::Bool(rebuild_ann));
-    if let Some(bs) = batch_size {
-        params.insert("batch_size".into(), Value::from(bs));
+    let mut atoms_indexed = 0u64;
+    let mut failed = 0u64;
+    let mut ann_failed = false;
+    if opts.atoms {
+        let ann = knowledge::vamana::new_shared();
+        let mut params = serde_json::Map::new();
+        params.insert("rebuild_ann".into(), Value::Bool(opts.rebuild_ann));
+        params.insert("insert_only".into(), Value::Bool(!opts.drop_existing));
+        if let Some(bs) = opts.batch_size {
+            params.insert("batch_size".into(), Value::from(bs));
+        }
+        let result =
+            knowledge::KnowledgeHandlers::index(runtime, token, Value::Object(params), &ann)
+                .await?;
+        atoms_indexed = result.get("indexed").and_then(|n| n.as_u64()).unwrap_or(0);
+        // Preserve the index handler's fail-closed accounting so the caller can
+        // exit non-zero on partial atom/ANN failure (kkernel reindex contract).
+        failed = result.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
+        ann_failed = result
+            .get("ann_failed")
+            .and_then(|b| b.as_bool())
+            .unwrap_or(false);
     }
-    knowledge::KnowledgeHandlers::index(runtime, token, Value::Object(params), &ann).await
+
+    let mut sections_indexed = 0u64;
+    if opts.sections {
+        let batch = opts.batch_size.unwrap_or(500) as usize;
+        let (indexed, _skipped) =
+            knowledge::sections_index::embed_sections(runtime, token, opts.drop_existing, batch)
+                .await?;
+        sections_indexed = indexed as u64;
+    }
+
+    Ok(json!({
+        "atoms_indexed": atoms_indexed,
+        "sections_indexed": sections_indexed,
+        "failed": failed,
+        "ann_failed": ann_failed,
+    }))
 }

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -32,7 +32,8 @@ pub struct KnowledgeReindexOptions {
 /// Library entry for `kkernel reindex` — callable without an MCP server.
 /// Knowledge is single-model (search retrieves via the default embedder's ANN),
 /// so this does not fan out across registered models the way entity/note
-/// reindex does. Returns `{atoms_indexed, sections_indexed, failed, ann_failed}`.
+/// reindex does. Returns `{atoms_indexed, sections_indexed, failed, ann_failed,
+/// sections_failed}`.
 pub async fn reindex_knowledge(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -63,12 +64,14 @@ pub async fn reindex_knowledge(
     }
 
     let mut sections_indexed = 0u64;
+    let mut sections_failed = 0u64;
     if opts.sections {
         let batch = opts.batch_size.unwrap_or(500) as usize;
-        let (indexed, _skipped) =
+        let (indexed, _skipped, sec_failed) =
             knowledge::sections_index::embed_sections(runtime, token, opts.drop_existing, batch)
                 .await?;
         sections_indexed = indexed as u64;
+        sections_failed = sec_failed as u64;
     }
 
     Ok(json!({
@@ -76,5 +79,6 @@ pub async fn reindex_knowledge(
         "sections_indexed": sections_indexed,
         "failed": failed,
         "ann_failed": ann_failed,
+        "sections_failed": sections_failed,
     }))
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1969,4 +1969,44 @@ mod embed_failure_tests {
             "no sections must be indexed on embed error: {result:?}"
         );
     }
+
+    /// Regression: `--keep-existing` (drop_existing=false) paginates the
+    /// `embedding IS NULL` set. A failed section stays NULL, so without advancing
+    /// the offset past stuck rows the loop re-selects the same page forever and
+    /// never returns a `sections_failed` report (fail-closed bypassed). With
+    /// batch_size=1 over two persistently-failing sections, the old code looped;
+    /// this test must TERMINATE and report both as sections_failed.
+    #[tokio::test]
+    async fn section_keep_existing_failures_terminate_and_report() {
+        let f = fixture_with_two_sections(rt_with_fake(AlwaysFailProvider)).await;
+        let rt = f.rt.clone();
+        let token = rt
+            .authorize(khive_types::Namespace::local())
+            .expect("authorize");
+
+        let result = khive_pack_knowledge::reindex_knowledge(
+            &rt,
+            &token,
+            khive_pack_knowledge::KnowledgeReindexOptions {
+                atoms: false,
+                sections: true,
+                drop_existing: false,
+                rebuild_ann: false,
+                batch_size: Some(1),
+            },
+        )
+        .await
+        .expect("reindex_knowledge must terminate, not loop");
+
+        assert_eq!(
+            result["sections_failed"].as_u64().unwrap_or(0),
+            2,
+            "keep-existing must attempt each section once and report both failed: {result:?}"
+        );
+        assert_eq!(
+            result["sections_indexed"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "no sections indexed when every embed fails: {result:?}"
+        );
+    }
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1851,4 +1851,122 @@ mod embed_failure_tests {
             "ann_failed must be false when ANN block did not run: {result:?}"
         );
     }
+
+    // ── Section embed failure regression (codex round-1 HIGH) ────────────────
+    //
+    // Mirrors the atom failure tests above but exercises the SECTION path via
+    // `reindex_knowledge(sections:true, atoms:false)`. Blank-text sections are
+    // genuine `skipped`; embed_batch Err and count-mismatch are `failed`.
+
+    /// Seed two sections via `knowledge.edit` and return the fixture. The atom
+    /// must exist before sections can be attached.
+    async fn fixture_with_two_sections(rt: KhiveRuntime) -> Fixture {
+        let f = pack(rt);
+        f.dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "sec-embed-fail",
+                    "name": "Section Embed Fail",
+                    "content": "atom content for section embed failure regression test dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+        // Two distinct sections so the batch has size 2.
+        f.dispatch(
+            "knowledge.edit",
+            json!({
+                "id": "sec-embed-fail",
+                "sections": [
+                    {
+                        "section_type": "overview",
+                        "content": "Overview content for section embed failure regression test. This text is long enough to satisfy the 80-character minimum section length requirement — dense sparse retrieval corpus benchmark search latency."
+                    },
+                    {
+                        "section_type": "formalism",
+                        "content": "Formalism content for section embed failure regression test. This text is long enough to satisfy the 80-character minimum section length requirement — gradient descent transformer attention vector index."
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("edit sections");
+        f
+    }
+
+    /// count-mismatch branch on the SECTION path: embed_batch returns 1 vector
+    /// for a 2-section batch. Must count both sections as `sections_failed`, not
+    /// `skipped`; `reindex_knowledge` must surface this in its result JSON.
+    #[tokio::test]
+    async fn section_embed_count_mismatch_counts_as_sections_failed() {
+        let f = fixture_with_two_sections(rt_with_fake(OneDimProvider)).await;
+        let rt = f.rt.clone();
+        let token = rt
+            .authorize(khive_types::Namespace::local())
+            .expect("authorize");
+
+        let result = khive_pack_knowledge::reindex_knowledge(
+            &rt,
+            &token,
+            khive_pack_knowledge::KnowledgeReindexOptions {
+                atoms: false,
+                sections: true,
+                drop_existing: true,
+                rebuild_ann: false,
+                batch_size: None,
+            },
+        )
+        .await
+        .expect("reindex_knowledge ok");
+
+        assert_eq!(
+            result["sections_failed"].as_u64().unwrap_or(0),
+            2,
+            "count-mismatch must report both sections as sections_failed: {result:?}"
+        );
+        assert_eq!(
+            result["sections_indexed"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "no sections must be indexed on count-mismatch: {result:?}"
+        );
+    }
+
+    /// Err branch on the SECTION path: embed_batch returns Err for every batch.
+    /// Must count all sections as `sections_failed`, not `skipped`.
+    #[tokio::test]
+    async fn section_embed_error_counts_as_sections_failed() {
+        let f = fixture_with_two_sections(rt_with_fake(AlwaysFailProvider)).await;
+        let rt = f.rt.clone();
+        let token = rt
+            .authorize(khive_types::Namespace::local())
+            .expect("authorize");
+
+        let result = khive_pack_knowledge::reindex_knowledge(
+            &rt,
+            &token,
+            khive_pack_knowledge::KnowledgeReindexOptions {
+                atoms: false,
+                sections: true,
+                drop_existing: true,
+                rebuild_ann: false,
+                batch_size: None,
+            },
+        )
+        .await
+        .expect("reindex_knowledge ok");
+
+        assert_eq!(
+            result["sections_failed"].as_u64().unwrap_or(0),
+            2,
+            "embed Err must report both sections as sections_failed: {result:?}"
+        );
+        assert_eq!(
+            result["sections_indexed"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "no sections must be indexed on embed error: {result:?}"
+        );
+    }
 }

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -129,18 +129,6 @@ and `--human`) always reports attempted/indexed/failed counts honestly
 `knowledge_ann_failed`). Note: `knowledge_ann_failed` is a distinct failure
 dimension from `knowledge_atoms_failed` — atom vectors may have persisted
 successfully while the ANN rebuild or snapshot persist failed.
-=======
-| Flag               | Effect                                                                         |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                |
-| `--no-knowledge`   | only entities/notes (skip knowledge)                                           |
-| `--no-sections`    | within the knowledge pass, embed atoms but skip section embeddings (ADR-051)   |
-| `--sections-only`  | embed only knowledge sections (skip entities/notes and atoms)                  |
-| `--model <name>`   | entities/notes use this single engine instead of fanning out                   |
-| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild |
-| `--batch-size <n>` | records per embedding batch (default 100, max 500)                             |
-| `--human`          | readable report instead of JSON                                                |
->>>>>>> b99b655 (docs(adr-051,kkernel): mark read-side deferred; document section flags)
 
 **Multi-engine semantics.** Entities and notes embed with **every registered
 engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -121,14 +121,16 @@ always wins over any config `[actor] id`.
 
 **Fail-closed.** By default reindex returns a **non-zero exit** if any requested
 engine failed, the knowledge pass errored, any knowledge atom vector insert
-failed, or the Vamana ANN build/snapshot persist failed — a partial rebuild
-leaves stale recall/search state, so automation must not see success. Pass
-`--best-effort` to downgrade failures to a warning and exit 0. The report (JSON
-and `--human`) always reports attempted/indexed/failed counts honestly
-(`errors_skipped`, `knowledge_atoms_failed`, `knowledge_pass_errored`,
-`knowledge_ann_failed`). Note: `knowledge_ann_failed` is a distinct failure
-dimension from `knowledge_atoms_failed` — atom vectors may have persisted
-successfully while the ANN rebuild or snapshot persist failed.
+failed, the Vamana ANN build/snapshot persist failed, or any knowledge section
+embed/write failed — a partial rebuild leaves stale recall/search state, so
+automation must not see success. Pass `--best-effort` to downgrade failures to a
+warning and exit 0. The report (JSON and `--human`) always reports
+attempted/indexed/failed counts honestly (`errors_skipped`,
+`knowledge_atoms_failed`, `knowledge_pass_errored`, `knowledge_ann_failed`,
+`knowledge_sections_failed`). Note: `knowledge_ann_failed` and
+`knowledge_sections_failed` are distinct failure dimensions from
+`knowledge_atoms_failed` — atom vectors may have persisted successfully while the
+ANN rebuild/snapshot persist or the section embed/write failed.
 
 **Multi-engine semantics.** Entities and notes embed with **every registered
 engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -94,6 +94,7 @@ to stderr; the JSON/`--human` report goes to stdout.
 ```bash
 kkernel reindex --db ~/.khive/khive.db --namespace local   # entities + notes + knowledge
 kkernel reindex --db ~/.khive/khive.db --namespace khive
+kkernel reindex --db ~/.khive/khive.db --sections-only      # backfill only section embeddings
 ```
 
 | Flag               | Effect                                                                          |
@@ -102,6 +103,8 @@ kkernel reindex --db ~/.khive/khive.db --namespace khive
 | `--config <path>`  | khive TOML config (env `KHIVE_CONFIG`) — resolves engines like `kkernel mcp`    |
 | `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                 |
 | `--no-knowledge`   | only entities/notes (skip knowledge)                                            |
+| `--no-sections`    | within the knowledge pass, embed atoms but skip section embeddings (ADR-051)    |
+| `--sections-only`  | embed only knowledge sections (skip entities/notes and atoms)                   |
 | `--model <name>`   | entities/notes use this single engine instead of fanning out                    |
 | `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild  |
 | `--batch-size <n>` | records per embedding batch (default 100, max 500)                              |
@@ -126,6 +129,18 @@ and `--human`) always reports attempted/indexed/failed counts honestly
 `knowledge_ann_failed`). Note: `knowledge_ann_failed` is a distinct failure
 dimension from `knowledge_atoms_failed` — atom vectors may have persisted
 successfully while the ANN rebuild or snapshot persist failed.
+=======
+| Flag               | Effect                                                                         |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `--knowledge-only` | only the knowledge corpus (skip entities/notes)                                |
+| `--no-knowledge`   | only entities/notes (skip knowledge)                                           |
+| `--no-sections`    | within the knowledge pass, embed atoms but skip section embeddings (ADR-051)   |
+| `--sections-only`  | embed only knowledge sections (skip entities/notes and atoms)                  |
+| `--model <name>`   | entities/notes use this single engine instead of fanning out                   |
+| `--keep-existing`  | skip records already embedded (incremental top-up) instead of drop-and-rebuild |
+| `--batch-size <n>` | records per embedding batch (default 100, max 500)                             |
+| `--human`          | readable report instead of JSON                                                |
+>>>>>>> b99b655 (docs(adr-051,kkernel): mark read-side deferred; document section flags)
 
 **Multi-engine semantics.** Entities and notes embed with **every registered
 engine** (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`),

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -103,6 +103,10 @@ struct ReindexReport {
     /// knowledge pass. Distinct from atom-level failures: atom vectors DID
     /// persist; the ANN snapshot is the failure dimension.
     knowledge_ann_failed: bool,
+    /// Section-level embed or SQL-write failures during the knowledge pass.
+    /// Distinct from atom-level failures; sections still index atoms even if
+    /// section embedding fails.
+    knowledge_sections_failed: u64,
     models_used: Vec<String>,
     elapsed_ms: u64,
     /// Entity/note vector inserts that failed across all engines.
@@ -116,6 +120,7 @@ impl ReindexReport {
             || self.knowledge_atoms_failed > 0
             || self.knowledge_pass_errored
             || self.knowledge_ann_failed
+            || self.knowledge_sections_failed > 0
     }
 }
 
@@ -278,6 +283,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                         knowledge_atoms_failed: 0,
                         knowledge_pass_errored: false,
                         knowledge_ann_failed: false,
+                        knowledge_sections_failed: 0,
                         models_used: vec![],
                         elapsed_ms: 0,
                         errors_skipped: 0,
@@ -413,6 +419,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut knowledge_atoms_failed: u64 = 0;
     let mut knowledge_pass_errored = false;
     let mut knowledge_ann_failed = false;
+    let mut knowledge_sections_failed: u64 = 0;
     if do_atoms || do_sections {
         eprintln!("  indexing knowledge corpus (this can take a while)…");
         let opts = khive_pack_knowledge::KnowledgeReindexOptions {
@@ -439,6 +446,10 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                             .and_then(|n| n.as_u64())
                             .unwrap_or(0),
                     );
+                    knowledge_sections_failed = v
+                        .get("sections_failed")
+                        .and_then(|n| n.as_u64())
+                        .unwrap_or(0);
                 }
             }
             Err(e) => {
@@ -459,6 +470,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         knowledge_atoms_failed,
         knowledge_pass_errored,
         knowledge_ann_failed,
+        knowledge_sections_failed,
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
@@ -579,6 +591,12 @@ fn print_report(report: &ReindexReport, human: bool) {
                 report.knowledge_atoms_failed
             );
         }
+        if report.knowledge_sections_failed > 0 {
+            println!(
+                "Knowledge sections: {} section embed/write failures",
+                report.knowledge_sections_failed
+            );
+        }
         if report.knowledge_ann_failed {
             println!("Knowledge ANN: FAILED (snapshot not rebuilt/persisted)");
         }
@@ -690,6 +708,7 @@ mod tests {
             knowledge_atoms_failed: k_failed,
             knowledge_pass_errored: k_errored,
             knowledge_ann_failed: false,
+            knowledge_sections_failed: 0,
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: errors,
@@ -723,6 +742,7 @@ mod tests {
             knowledge_atoms_failed: 0,
             knowledge_pass_errored: false,
             knowledge_ann_failed: true,
+            knowledge_sections_failed: 0,
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
@@ -738,6 +758,35 @@ mod tests {
         assert!(
             decide_result(report.has_failures(), true).is_ok(),
             "best-effort downgrades knowledge_ann_failed to exit 0"
+        );
+    }
+
+    #[test]
+    fn has_failures_flags_knowledge_sections_failed() {
+        let report = ReindexReport {
+            entities_processed: 0,
+            notes_processed: 0,
+            knowledge_atoms_indexed: None,
+            knowledge_sections_indexed: Some(0),
+            knowledge_atoms_failed: 0,
+            knowledge_pass_errored: false,
+            knowledge_ann_failed: false,
+            knowledge_sections_failed: 3,
+            models_used: vec![],
+            elapsed_ms: 0,
+            errors_skipped: 0,
+        };
+        assert!(
+            report.has_failures(),
+            "knowledge_sections_failed > 0 alone must drive has_failures() = true"
+        );
+        assert!(
+            decide_result(report.has_failures(), false).is_err(),
+            "knowledge_sections_failed must fail closed (non-zero exit)"
+        );
+        assert!(
+            decide_result(report.has_failures(), true).is_ok(),
+            "best-effort downgrades knowledge_sections_failed to exit 0"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -74,6 +74,14 @@ pub struct ReindexArgs {
     #[arg(long)]
     pub best_effort: bool,
 
+    /// Skip knowledge section embeddings (embed atoms but not sections).
+    #[arg(long, conflicts_with = "sections_only")]
+    pub no_sections: bool,
+
+    /// Only embed knowledge sections (skip entities, notes, and atoms).
+    #[arg(long, conflicts_with = "no_knowledge")]
+    pub sections_only: bool,
+
     /// Print human-readable output instead of JSON.
     #[arg(long)]
     pub human: bool,
@@ -85,6 +93,8 @@ struct ReindexReport {
     notes_processed: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     knowledge_atoms_indexed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    knowledge_sections_indexed: Option<u64>,
     /// Atoms whose vector write failed during the knowledge pass.
     knowledge_atoms_failed: u64,
     /// True when the knowledge pass itself errored (could not run to completion).
@@ -242,8 +252,11 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("failed to authorize namespace")?;
 
-    let do_graph = !args.knowledge_only; // entities + notes
+    // `--sections-only` is the narrowest scope: knowledge sections alone.
+    let do_graph = !args.knowledge_only && !args.sections_only; // entities + notes
     let do_knowledge = !args.no_knowledge; // knowledge corpus
+    let do_atoms = do_knowledge && !args.sections_only;
+    let do_sections = do_knowledge && !args.no_sections;
 
     // Explicit --model targets a single engine; otherwise fan out to ALL
     // registered engines, matching the runtime's multi-model write path so a
@@ -261,6 +274,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                         entities_processed: 0,
                         notes_processed: 0,
                         knowledge_atoms_indexed: None,
+                        knowledge_sections_indexed: None,
                         knowledge_atoms_failed: 0,
                         knowledge_pass_errored: false,
                         knowledge_ann_failed: false,
@@ -395,20 +409,39 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     // Reindex through the knowledge library directly (the `knowledge.index`
     // handler over the full corpus), not the verb-DSL shell.
     let mut knowledge_atoms_indexed: Option<u64> = None;
+    let mut knowledge_sections_indexed: Option<u64> = None;
     let mut knowledge_atoms_failed: u64 = 0;
     let mut knowledge_pass_errored = false;
     let mut knowledge_ann_failed = false;
-    if do_knowledge {
+    if do_atoms || do_sections {
         eprintln!("  indexing knowledge corpus (this can take a while)…");
-        match khive_pack_knowledge::reindex_knowledge(&rt, &token, true, Some(batch_size)).await {
+        let opts = khive_pack_knowledge::KnowledgeReindexOptions {
+            atoms: do_atoms,
+            sections: do_sections,
+            drop_existing,
+            rebuild_ann: true,
+            batch_size: Some(batch_size),
+        };
+        match khive_pack_knowledge::reindex_knowledge(&rt, &token, opts).await {
             Ok(v) => {
-                knowledge_atoms_indexed =
-                    Some(v.get("indexed").and_then(|n| n.as_u64()).unwrap_or(0));
-                knowledge_atoms_failed = v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
-                knowledge_ann_failed = v
-                    .get("ann_failed")
-                    .and_then(|b| b.as_bool())
-                    .unwrap_or(false);
+                if do_atoms {
+                    knowledge_atoms_indexed =
+                        Some(v.get("atoms_indexed").and_then(|n| n.as_u64()).unwrap_or(0));
+                    knowledge_atoms_failed =
+                        v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
+                    knowledge_ann_failed = v
+                        .get("ann_failed")
+                        .and_then(|b| b.as_bool())
+                        .unwrap_or(false);
+                }
+                if do_sections {
+                    knowledge_sections_indexed = Some(
+                        v.get("sections_indexed")
+                            .and_then(|n| n.as_u64())
+                            .unwrap_or(0),
+                    );
+                }
+
             }
             Err(e) => {
                 tracing::error!(error = %e, "knowledge reindex failed");
@@ -424,6 +457,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         entities_processed,
         notes_processed,
         knowledge_atoms_indexed,
+        knowledge_sections_indexed,
         knowledge_atoms_failed,
         knowledge_pass_errored,
         knowledge_ann_failed,
@@ -517,9 +551,13 @@ fn truncate_text(t: &str) -> String {
 
 fn print_report(report: &ReindexReport, human: bool) {
     if human {
-        let knowledge = report
+        let atoms = report
             .knowledge_atoms_indexed
             .map(|n| format!(", {n} knowledge atoms"))
+            .unwrap_or_default();
+        let sections = report
+            .knowledge_sections_indexed
+            .map(|n| format!(", {n} sections"))
             .unwrap_or_default();
         let status = if report.has_failures() {
             "Reindex completed WITH FAILURES"
@@ -527,10 +565,11 @@ fn print_report(report: &ReindexReport, human: bool) {
             "Reindex complete"
         };
         println!(
-            "{status}: {} entities, {} notes{} ({} entity/note errors) in {}ms",
+            "{status}: {} entities, {} notes{}{} ({} entity/note errors) in {}ms",
             report.entities_processed,
             report.notes_processed,
-            knowledge,
+            atoms,
+            sections,
             report.errors_skipped,
             report.elapsed_ms
         );

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -427,8 +427,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 if do_atoms {
                     knowledge_atoms_indexed =
                         Some(v.get("atoms_indexed").and_then(|n| n.as_u64()).unwrap_or(0));
-                    knowledge_atoms_failed =
-                        v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
+                    knowledge_atoms_failed = v.get("failed").and_then(|n| n.as_u64()).unwrap_or(0);
                     knowledge_ann_failed = v
                         .get("ann_failed")
                         .and_then(|b| b.as_bool())
@@ -441,7 +440,6 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                             .unwrap_or(0),
                     );
                 }
-
             }
             Err(e) => {
                 tracing::error!(error = %e, "knowledge reindex failed");
@@ -688,6 +686,7 @@ mod tests {
             entities_processed: 0,
             notes_processed: 0,
             knowledge_atoms_indexed: Some(0),
+            knowledge_sections_indexed: None,
             knowledge_atoms_failed: k_failed,
             knowledge_pass_errored: k_errored,
             knowledge_ann_failed: false,
@@ -720,6 +719,7 @@ mod tests {
             entities_processed: 0,
             notes_processed: 0,
             knowledge_atoms_indexed: Some(10),
+            knowledge_sections_indexed: None,
             knowledge_atoms_failed: 0,
             knowledge_pass_errored: false,
             knowledge_ann_failed: true,

--- a/docs/adr/ADR-048-knowledge-section-profiles.md
+++ b/docs/adr/ADR-048-knowledge-section-profiles.md
@@ -10,17 +10,18 @@ This ADR is accepted as the governing record for shipped knowledge sections and 
 profile primitives, while explicitly deferring broader resource dual-write, profile-weighted
 compose/suggest, hooks, lint, export, and observability phases.
 
-| Area                                                          | Status   | Shipped behavior                                                                                                                                                                                                        |
-| ------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `knowledge_sections`                                          | shipped  | Dedicated section rows with 10-value `SectionType`, `content_hash` + `UNIQUE(atom_id, content_hash)`, nullable `embedding`, section indexes, `fts_sections`, and FTS5 triggers. 80-char minimum content.                |
-| V22 lifecycle/source fields                                   | shipped  | Status/source columns on atoms, status columns on sections/domains, status indexes, and finalized atom backfill to `reviewed`.                                                                                          |
-| `knowledge.edit`                                              | shipped  | Upserts sections content-addressed by `content_hash`; identical content is idempotent, distinct content inserts a sibling row, and existing siblings (including verified ones) are left untouched.                      |
-| `knowledge.import`                                            | shipped  | Supports `atlas_md` files/directories with `chunk_strategy=section                                                                                                                                                      |
-| `knowledge.challenge` / `knowledge.adjudicate`                | shipped  | Challenge moves eligible sections to `disputed` and increments atom `dispute_count`; adjudicate requires disputed sections and resolves accept -> `verified`, reject -> `reviewed`.                                     |
-| Brain section posterior primitives                            | shipped  | Brain state, fold, feedback parsing, and `brain.create_profile(seed_priors.section_posteriors)` exist for section posteriors.                                                                                           |
-| `knowledge.suggest` / `knowledge.compose` profile weighting   | deferred | `suggest` is domain-oriented search with optional Vamana signal; `compose` uses explicit `domain_ids`/`atom_ids` and formats atom-body markdown. Neither resolves `brain` profiles or emits section-weighted manifests. |
-| Resource entity dual-write                                    | deferred | `knowledge.upsert_atoms` and `knowledge.upsert_domains` write corpus tables; domain mirror is into `knowledge_atoms` for FTS, not graph `entities`.                                                                     |
-| `knowledge.lint`, `knowledge.lint_config`, `knowledge.export` | deferred | These verbs are not registered in the shipped knowledge pack.                                                                                                                                                           |
+| Area                                                          | Status   | Shipped behavior                                                                                                                                                                                                          |
+| ------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge_sections`                                          | shipped  | Dedicated section rows with 10-value `SectionType`, `content_hash` + `UNIQUE(atom_id, content_hash)`, nullable `embedding`, section indexes, `fts_sections`, and FTS5 triggers. 80-char minimum content.                  |
+| Section write-side embedding backfill                         | shipped  | `kkernel reindex` populates `knowledge_sections.embedding` via breadcrumb-enriched embed text (ADR-051 phase 1). `knowledge.index` remains atom-only. Read-side section scoring in compose is deferred (ADR-051 phase 2). |
+| V22 lifecycle/source fields                                   | shipped  | Status/source columns on atoms, status columns on sections/domains, status indexes, and finalized atom backfill to `reviewed`.                                                                                            |
+| `knowledge.edit`                                              | shipped  | Upserts sections content-addressed by `content_hash`; identical content is idempotent, distinct content inserts a sibling row, and existing siblings (including verified ones) are left untouched.                        |
+| `knowledge.import`                                            | shipped  | Supports `atlas_md` files/directories with `chunk_strategy=section                                                                                                                                                        |
+| `knowledge.challenge` / `knowledge.adjudicate`                | shipped  | Challenge moves eligible sections to `disputed` and increments atom `dispute_count`; adjudicate requires disputed sections and resolves accept -> `verified`, reject -> `reviewed`.                                       |
+| Brain section posterior primitives                            | shipped  | Brain state, fold, feedback parsing, and `brain.create_profile(seed_priors.section_posteriors)` exist for section posteriors.                                                                                             |
+| `knowledge.suggest` / `knowledge.compose` profile weighting   | deferred | `suggest` is domain-oriented search with optional Vamana signal; `compose` uses explicit `domain_ids`/`atom_ids` and formats atom-body markdown. Neither resolves `brain` profiles or emits section-weighted manifests.   |
+| Resource entity dual-write                                    | deferred | `knowledge.upsert_atoms` and `knowledge.upsert_domains` write corpus tables; domain mirror is into `knowledge_atoms` for FTS, not graph `entities`.                                                                       |
+| `knowledge.lint`, `knowledge.lint_config`, `knowledge.export` | deferred | These verbs are not registered in the shipped knowledge pack.                                                                                                                                                             |
 
 ## Governance for Shipped Knowledge Sections and Profiles
 
@@ -153,8 +154,9 @@ Section_type is a closed enum matching the atlas schema v1: `overview`, `core_mo
 
 **Editing a section does not touch other sections.** `knowledge.edit(slug, sections=[...])`
 updates only the named section rows. Each section has a nullable `embedding` column. Shipped `knowledge.edit` clears
-`embedding=NULL` on section updates; `knowledge.index` currently indexes atoms, not
-sections. Section embedding backfill remains deferred.
+`embedding=NULL` on section updates; `knowledge.index` indexes atoms only. Section
+write-side embedding backfill is shipped via `kkernel reindex` (ADR-051 phase 1);
+section-aware compose and read-side scoring remain deferred.
 
 **Sections link to atoms structurally (FK), not via graph edges.** The section→atom
 relationship is always 1:N containment — there's no semantic edge type needed. All

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -1,0 +1,113 @@
+# ADR-051: Section-level embeddings and hybrid compose scoring
+
+## Status
+
+Accepted (2026-06-07)
+
+## Context
+
+The knowledge corpus stores atoms (`knowledge_atoms`) and their parsed sections
+(`knowledge_sections`). Today only **atoms** are embedded: `knowledge.index`
+writes one vector per atom into the default embedder's vector store, and search
+ranks atoms by TF-IDF with an atom-level embedding rerank.
+
+`knowledge_sections` has carried an unused `embedding BLOB` column since its
+introduction. The pre-OSS engine (`engine_v1`) had a real section-level vector
+path — `EmbeddedEngine::search_sections` (per-section cosine with fusion-strategy
+dispatch) consumed by compose for token-budget section selection. That path was
+**not ported** to the OSS pack: the column is never populated and never read, and
+compose scores sections by static weights only (`section_type + edge + quality`).
+The `retrieval` objective weight that was meant to carry section similarity is
+defined but unapplied. This is a regression, not merely an un-run backfill.
+
+An archived implementation spec (`.khive/archive/.../section_embeddings/
+khive_section_embeddings_spec/`) defines the intended design: breadcrumb-enriched
+section embedding text, hash-incremental backfill, and a hybrid compose score.
+
+## Decision
+
+Restore section-level embeddings and hybrid compose, adapted to the OSS schema.
+
+### Storage — reuse the existing column, single-model
+
+The spec proposed a **separate** `section_embeddings` table (its engine_v1 target
+lacked a per-section table and wanted multi-model rows). The OSS schema already
+makes that choice differently: `knowledge_sections` **is** the per-section table,
+with a built-in `embedding BLOB` column, `content_hash`, `sort_order` (the section
+index), `heading`, `section_type`, and `tokens`. We therefore populate the
+**existing `knowledge_sections.embedding` column** rather than add a redundant
+table.
+
+Section embeddings are **single-model** (the default embedder), consistent with
+knowledge search, which retrieves via the default embedder's ANN. (Entity/note
+vectors fan out across all registered engines; knowledge does not — see
+[ADR-021] and the reindex contract.) The blob is little-endian `f32`,
+**unit-normalised** so dot product equals cosine.
+
+### Write — section embedding pass in `kkernel reindex`
+
+Section embedding is folded into `kkernel reindex` alongside atoms:
+
+- default: embed entities + notes + knowledge **atoms + sections**
+- `--no-sections`: embed atoms but not sections
+- `--sections-only`: embed only sections (skip graph + atoms)
+- `--no-knowledge` / `--knowledge-only`: gate the whole knowledge pass (existing)
+
+Embed text is **breadcrumb-enriched** so a section carries its context:
+`atom_name \n heading \n\n content`, truncated to the model budget while
+preserving the breadcrumb prefix. (The spec's `domain_title` breadcrumb is
+omitted in v1 — domain membership is an edge lookup the pass does not yet join;
+it can be added when section retrieval is wired to domain scoping.)
+
+Re-embed is keyed on `content_hash`: with `--keep-existing`, sections whose
+`embedding` is already present are skipped; otherwise all in-scope sections are
+re-embedded. Hash-incremental **dirty tracking** (the spec's `atom_section_state`)
+is an optimisation deferred to a follow-up; a full re-embed is correct, just less
+incremental.
+
+### Read — hybrid compose scoring
+
+Compose scores each candidate section with the spec's hybrid formula:
+
+```
+0.55 · cosine(query, section)
+0.20 · bm25(query, heading + content)
+0.10 · cosine(query, atom)
+0.10 · domain_score
+0.05 · type_prior
+```
+
+- Section and atom cosines use the default embedder; the query is embedded once.
+- BM25 is normalised over the compose candidate set.
+- **Fallback:** a section with no stored embedding scores via the existing
+  keyword-only formula — compose works with zero, partial, or full section
+  embeddings, and never blocks on the backfill.
+- Section vectors are **lazily batch-loaded for the shortlisted atoms** with an
+  atom-level LRU; we do **not** load all section vectors at startup and do **not**
+  add a section ANN index until the query-time access pattern is proven (spec Q4).
+
+### Cross-encoder rerank (deferred, optional)
+
+The spec's Phase 3 cross-encoder rerank (`ms-marco-MiniLM-L6-v2`, top-20, off the
+critical path) is **out of scope** for this ADR and gated behind a future
+feature flag.
+
+## Consequences
+
+- `knowledge_sections.embedding` becomes load-bearing; `knowledge.stats`
+  embedding coverage gains a section dimension.
+- Compose gains a semantic signal (synonym/paraphrase recall) over keyword-only.
+- No schema migration is required for v1 (the column exists); adding
+  `atom_section_state` later is additive.
+- Reindex cost grows: sections outnumber atoms ~5× (358k vs 68k locally), all
+  embedded with the default model. The `--no-sections` flag bounds this when only
+  atom/graph vectors are needed.
+- Knowledge stays single-model; if section-level multi-model fusion is ever
+  wanted, that is a separate ADR (and likely the spec's separate-table design).
+
+## References
+
+- Archived spec: `.khive/archive/khive-internal/.khive/workspaces/20260401/
+  skills-engine-research/responses_2/section_embeddings/khive_section_embeddings_spec/`
+- `engine_v1/src/engine/sections.rs` (archived `search_sections`)
+- [ADR-021](ADR-021-memory-pack.md), [ADR-048](ADR-048-knowledge-section-profiles.md)

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -20,9 +20,9 @@ compose scores sections by static weights only (`section_type + edge + quality`)
 The `retrieval` objective weight that was meant to carry section similarity is
 defined but unapplied. This is a regression, not merely an un-run backfill.
 
-An archived implementation spec (`.khive/archive/.../section_embeddings/
-khive_section_embeddings_spec/`) defines the intended design: breadcrumb-enriched
-section embedding text, hash-incremental backfill, and a hybrid compose score.
+A pre-OSS implementation spec defines the intended design — breadcrumb-enriched
+section embedding text, hash-incremental backfill, and a hybrid compose score —
+tracked for the read side in issue #6.
 
 ## Decision
 

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -67,6 +67,13 @@ incremental.
 
 ### Read — hybrid compose scoring
 
+> **Status: deferred to Phase 2 (issue #6).** Phase 1 ships the **write** side only —
+> section embeddings populated by `kkernel reindex`. The read-side scoring described
+> below is the accepted design, not yet implemented; `knowledge.compose` remains
+> atom-level until #6 lands. The `type_prior` term is served by brain profile section
+> posteriors (ADR-048 §4), which requires the brain primitives to move into a shared
+> crate first (issue #5) — `knowledge` cannot depend on the `brain` pack.
+
 Compose scores each candidate section with the spec's hybrid formula:
 
 ```
@@ -94,9 +101,11 @@ feature flag.
 
 ## Consequences
 
-- `knowledge_sections.embedding` becomes load-bearing; `knowledge.stats`
-  embedding coverage gains a section dimension.
-- Compose gains a semantic signal (synonym/paraphrase recall) over keyword-only.
+- `knowledge_sections.embedding` becomes load-bearing once the read side lands.
+  Surfacing section coverage in `knowledge.stats` is part of the deferred read-side
+  work (issue #6); Phase 1 reports atom coverage only.
+- Compose gains a semantic signal (synonym/paraphrase recall) over keyword-only
+  — delivered by the deferred read side (issue #6).
 - No schema migration is required for v1 (the column exists); adding
   `atom_section_state` later is additive.
 - Reindex cost grows: sections outnumber atoms ~5× (358k vs 68k locally), all
@@ -107,7 +116,6 @@ feature flag.
 
 ## References
 
-- Archived spec: `.khive/archive/khive-internal/.khive/workspaces/20260401/
-  skills-engine-research/responses_2/section_embeddings/khive_section_embeddings_spec/`
-- `engine_v1/src/engine/sections.rs` (archived `search_sections`)
+- Issue #6 — hybrid section scoring + compose pipeline (the read-side work this ADR specifies)
+- Issue #5 — extract brain posterior/profile primitives into a shared crate (unblocks the `type_prior` term)
 - [ADR-021](ADR-021-memory-pack.md), [ADR-048](ADR-048-knowledge-section-profiles.md)


### PR DESCRIPTION
**Stacked PR 3/3.** Base: `feat/kkernel-reindex` (#8). Review/merge after #8.

ADR-051 **Phase 1 (write side only)**. Populates the long-unused `knowledge_sections.embedding` column so the read-side hybrid compose (issue #6) has vectors to consume.

## What's here
- **Section embedding pass** in `kkernel reindex`: embeds each section with the default embedder into `knowledge_sections.embedding` — unit-normalised little-endian `f32` (stored dot product = cosine), breadcrumb-enriched text `atom_name \n heading \n\n content`, char-boundary truncation to the model budget.
- **Flags**: `--no-sections` (atoms only), `--sections-only` (sections only). Default embeds entities + notes + atoms + sections.
- `khive_pack_knowledge::reindex_knowledge` gains `sections` option; `sections_index::embed_sections` paginates by `embedding IS NULL` (keep-existing) or moving offset (full re-embed).
- **ADR-051** documents the design; the **read side (hybrid compose scoring) is explicitly deferred to #6**, and the brain-served section-type weighting to #5 (knowledge can't depend on the brain pack). Phase 1 reports atom coverage only.

## Verification
- `make ci` green; design review approved.
- Verified: sections embed to 1536 bytes (384×4), sum-of-squares = 1.0000; `--keep-existing` re-embeds 0; `--no-sections` leaves embeddings NULL.

## Follow-ups
- #6 — hybrid section scoring + compose pipeline (read side)
- #5 — extract brain posterior/profile primitives into a shared crate (unblocks the section-type weight term)