### PR TITLE
feat(pack-knowledge): hybrid section scoring in compose (ADR-051 read-side)

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/compose.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/compose.rs
@@ -15,7 +15,7 @@ pub(super) struct ScoredSection {
     pub section_type: String,
     pub heading: String,
     pub content: String,
-    pub embedding: Vec<f32>,
+    pub embedding: Option<Vec<f32>>,
 }
 
 // ─── score weights ────────────────────────────────────────────────────────────
@@ -62,7 +62,7 @@ pub(super) struct ComposeSectionResult {
 
 // ─── DB load ─────────────────────────────────────────────────────────────────
 
-pub(super) async fn load_section_embeddings(
+pub(super) async fn load_sections(
     runtime: &KhiveRuntime,
     ns: &str,
     atom_ids: &[String],
@@ -85,7 +85,7 @@ pub(super) async fn load_section_embeddings(
     let mut reader = sql
         .reader()
         .await
-        .map_err(|e| sql_err("load_section_embeddings reader", e))?;
+        .map_err(|e| sql_err("load_sections reader", e))?;
 
     let rows = reader
         .query_all(SqlStatement {
@@ -93,14 +93,13 @@ pub(super) async fn load_section_embeddings(
                 "SELECT id, atom_id, section_type, heading, content, embedding \
                  FROM knowledge_sections \
                  WHERE namespace = ?1 \
-                   AND atom_id IN ({placeholders}) \
-                   AND embedding IS NOT NULL"
+                   AND atom_id IN ({placeholders})"
             ),
             params,
             label: None,
         })
         .await
-        .map_err(|e| sql_err("load_section_embeddings query", e))?;
+        .map_err(|e| sql_err("load_sections query", e))?;
 
     let mut by_atom: HashMap<String, Vec<ScoredSection>> = HashMap::new();
     for row in &rows {
@@ -117,12 +116,16 @@ pub(super) async fn load_section_embeddings(
         let content = row_str(row, "content").unwrap_or_default();
 
         let embedding = match row.get("embedding") {
-            Some(SqlValue::Blob(bytes)) => decode_embedding(bytes),
-            _ => continue,
+            Some(SqlValue::Blob(bytes)) => {
+                let decoded = decode_embedding(bytes);
+                if decoded.is_empty() {
+                    None
+                } else {
+                    Some(decoded)
+                }
+            }
+            _ => None,
         };
-        if embedding.is_empty() {
-            continue;
-        }
 
         by_atom
             .entry(atom_id.clone())
@@ -170,10 +173,9 @@ pub(super) fn score_sections(
         .iter()
         .zip(bm25_raw.iter())
         .map(|(section, &bm25_unnorm)| {
-            let sec_cos = if section.embedding.is_empty() {
-                0.0
-            } else {
-                cosine_similarity(query_embedding, &section.embedding).max(0.0)
+            let sec_cos = match &section.embedding {
+                Some(emb) if !emb.is_empty() => cosine_similarity(query_embedding, emb).max(0.0),
+                _ => 0.0,
             };
 
             let atom_cos = atom_cosine_scores
@@ -389,7 +391,7 @@ mod tests {
             section_type: "overview".to_string(),
             heading: "Overview".to_string(),
             content: "introduction to the topic".to_string(),
-            embedding: vec![1.0, 0.0],
+            embedding: Some(vec![1.0, 0.0]),
         };
         let sec2 = ScoredSection {
             id: "s2".to_string(),
@@ -397,7 +399,7 @@ mod tests {
             section_type: "references".to_string(),
             heading: "References".to_string(),
             content: "unrelated bibliography content".to_string(),
-            embedding: vec![0.0, 1.0],
+            embedding: Some(vec![0.0, 1.0]),
         };
 
         let mut sections: HashMap<String, Vec<ScoredSection>> = HashMap::new();
@@ -427,5 +429,56 @@ mod tests {
         let sum =
             w.section_cosine + w.section_bm25 + w.atom_cosine + w.domain_score + w.type_weight;
         assert!((sum - 1.0).abs() < 1e-6, "weights sum to {sum}");
+    }
+
+    #[test]
+    fn unembedded_section_still_scored_via_keyword_signals() {
+        let query_emb: Vec<f32> = vec![1.0, 0.0];
+        let mut atom_cos: HashMap<String, f32> = HashMap::new();
+        atom_cos.insert("a1".to_string(), 0.8);
+
+        let embedded = ScoredSection {
+            id: "s1".to_string(),
+            atom_id: "a1".to_string(),
+            section_type: "overview".to_string(),
+            heading: "Overview".to_string(),
+            content: "topic introduction".to_string(),
+            embedding: Some(vec![1.0, 0.0]),
+        };
+        let unembedded = ScoredSection {
+            id: "s2".to_string(),
+            atom_id: "a1".to_string(),
+            section_type: "details".to_string(),
+            heading: "Details".to_string(),
+            content: "topic details and explanation".to_string(),
+            embedding: None,
+        };
+
+        let mut sections: HashMap<String, Vec<ScoredSection>> = HashMap::new();
+        sections.insert("a1".to_string(), vec![embedded, unembedded]);
+
+        let domain_scores: HashMap<String, f32> = HashMap::new();
+        let type_weights: HashMap<String, f32> = HashMap::new();
+
+        let results = score_sections(
+            "topic overview",
+            &query_emb,
+            &atom_cos,
+            &sections,
+            &domain_scores,
+            &type_weights,
+            &ComposeScoreWeights::default(),
+        );
+
+        assert_eq!(results.len(), 2, "both sections must be scored");
+        let unembedded_result = results.iter().find(|r| r.section_id == "s2").unwrap();
+        assert_eq!(
+            unembedded_result.score_breakdown.section_cosine, 0.0,
+            "unembedded section_cosine must be 0"
+        );
+        assert!(
+            unembedded_result.score > 0.0,
+            "unembedded section must still have positive score from other signals"
+        );
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/compose.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/compose.rs
@@ -1,0 +1,431 @@
+//! Hybrid section scoring for knowledge.compose (ADR-051 read-side).
+
+use std::collections::HashMap;
+
+use khive_runtime::{KhiveRuntime, RuntimeError};
+use khive_storage::types::{SqlStatement, SqlValue};
+
+use super::util::{row_str, sql_err};
+
+// ─── section record (load result) ────────────────────────────────────────────
+
+pub(super) struct ScoredSection {
+    pub id: String,
+    pub atom_id: String,
+    pub section_type: String,
+    pub heading: String,
+    pub content: String,
+    pub embedding: Vec<f32>,
+}
+
+// ─── score weights ────────────────────────────────────────────────────────────
+
+pub(super) struct ComposeScoreWeights {
+    pub section_cosine: f32,
+    pub section_bm25: f32,
+    pub atom_cosine: f32,
+    pub domain_score: f32,
+    pub type_weight: f32,
+}
+
+impl Default for ComposeScoreWeights {
+    fn default() -> Self {
+        Self {
+            section_cosine: 0.55,
+            section_bm25: 0.20,
+            atom_cosine: 0.10,
+            domain_score: 0.10,
+            type_weight: 0.05,
+        }
+    }
+}
+
+// ─── scoring result ───────────────────────────────────────────────────────────
+
+pub(super) struct ScoreBreakdown {
+    pub section_cosine: f32,
+    pub section_bm25: f32,
+    pub atom_cosine: f32,
+    pub domain_score: f32,
+    pub type_weight: f32,
+}
+
+pub(super) struct ComposeSectionResult {
+    pub section_id: String,
+    pub atom_id: String,
+    pub section_type: String,
+    pub heading: String,
+    pub content: String,
+    pub score: f32,
+    pub score_breakdown: ScoreBreakdown,
+}
+
+// ─── DB load ─────────────────────────────────────────────────────────────────
+
+pub(super) async fn load_section_embeddings(
+    runtime: &KhiveRuntime,
+    ns: &str,
+    atom_ids: &[String],
+) -> Result<HashMap<String, Vec<ScoredSection>>, RuntimeError> {
+    if atom_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let placeholders: String = atom_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 2))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let mut params: Vec<SqlValue> = vec![SqlValue::Text(ns.to_owned())];
+    params.extend(atom_ids.iter().cloned().map(SqlValue::Text));
+
+    let sql = runtime.sql();
+    let mut reader = sql
+        .reader()
+        .await
+        .map_err(|e| sql_err("load_section_embeddings reader", e))?;
+
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT id, atom_id, section_type, heading, content, embedding \
+                 FROM knowledge_sections \
+                 WHERE namespace = ?1 \
+                   AND atom_id IN ({placeholders}) \
+                   AND embedding IS NOT NULL"
+            ),
+            params,
+            label: None,
+        })
+        .await
+        .map_err(|e| sql_err("load_section_embeddings query", e))?;
+
+    let mut by_atom: HashMap<String, Vec<ScoredSection>> = HashMap::new();
+    for row in &rows {
+        let id = match row_str(row, "id") {
+            Some(v) => v,
+            None => continue,
+        };
+        let atom_id = match row_str(row, "atom_id") {
+            Some(v) => v,
+            None => continue,
+        };
+        let section_type = row_str(row, "section_type").unwrap_or_default();
+        let heading = row_str(row, "heading").unwrap_or_default();
+        let content = row_str(row, "content").unwrap_or_default();
+
+        let embedding = match row.get("embedding") {
+            Some(SqlValue::Blob(bytes)) => decode_embedding(bytes),
+            _ => continue,
+        };
+        if embedding.is_empty() {
+            continue;
+        }
+
+        by_atom
+            .entry(atom_id.clone())
+            .or_default()
+            .push(ScoredSection {
+                id,
+                atom_id,
+                section_type,
+                heading,
+                content,
+                embedding,
+            });
+    }
+
+    Ok(by_atom)
+}
+
+// ─── hybrid scorer ────────────────────────────────────────────────────────────
+
+pub(super) fn score_sections(
+    raw_query: &str,
+    query_embedding: &[f32],
+    atom_cosine_scores: &HashMap<String, f32>,
+    sections: &HashMap<String, Vec<ScoredSection>>,
+    domain_scores: &HashMap<String, f32>,
+    type_weights: &HashMap<String, f32>,
+    weights: &ComposeScoreWeights,
+) -> Vec<ComposeSectionResult> {
+    let flat: Vec<&ScoredSection> = sections.values().flat_map(|secs| secs.iter()).collect();
+
+    if flat.is_empty() {
+        return Vec::new();
+    }
+
+    let doc_pairs: Vec<(&str, &str)> = flat
+        .iter()
+        .map(|s| (s.heading.as_str(), s.content.as_str()))
+        .collect();
+    let query_terms = tokenize(raw_query);
+    let bm25_raw = compute_bm25_scores(&query_terms, &doc_pairs);
+
+    let max_bm25 = bm25_raw.iter().cloned().fold(0.0f32, f32::max);
+
+    let mut results: Vec<ComposeSectionResult> = flat
+        .iter()
+        .zip(bm25_raw.iter())
+        .map(|(section, &bm25_unnorm)| {
+            let sec_cos = if section.embedding.is_empty() {
+                0.0
+            } else {
+                cosine_similarity(query_embedding, &section.embedding).max(0.0)
+            };
+
+            let atom_cos = atom_cosine_scores
+                .get(&section.atom_id)
+                .copied()
+                .unwrap_or(0.0)
+                .max(0.0);
+
+            let dom = domain_scores
+                .get(&section.atom_id)
+                .copied()
+                .unwrap_or(0.0)
+                .clamp(0.0, 1.0);
+
+            let type_w = type_weights
+                .get(section.section_type.as_str())
+                .copied()
+                .unwrap_or(0.05)
+                .clamp(0.0, 1.0);
+
+            let bm25_norm = if max_bm25 > 0.0 {
+                (bm25_unnorm / max_bm25).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+
+            let score = weights.section_cosine * sec_cos
+                + weights.section_bm25 * bm25_norm
+                + weights.atom_cosine * atom_cos
+                + weights.domain_score * dom
+                + weights.type_weight * type_w;
+
+            ComposeSectionResult {
+                section_id: section.id.clone(),
+                atom_id: section.atom_id.clone(),
+                section_type: section.section_type.clone(),
+                heading: section.heading.clone(),
+                content: section.content.clone(),
+                score,
+                score_breakdown: ScoreBreakdown {
+                    section_cosine: sec_cos,
+                    section_bm25: bm25_norm,
+                    atom_cosine: atom_cos,
+                    domain_score: dom,
+                    type_weight: type_w,
+                },
+            }
+        })
+        .collect();
+
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.section_id.cmp(&b.section_id))
+    });
+    results
+}
+
+// ─── BM25 over candidate set ──────────────────────────────────────────────────
+
+fn compute_bm25_scores(query_terms: &[String], sections: &[(&str, &str)]) -> Vec<f32> {
+    const K1: f32 = 1.5;
+    const B: f32 = 0.75;
+
+    if sections.is_empty() || query_terms.is_empty() {
+        return vec![0.0; sections.len()];
+    }
+
+    let docs: Vec<Vec<String>> = sections
+        .iter()
+        .map(|(heading, content)| tokenize(&format!("{heading} {content}")))
+        .collect();
+
+    let n = docs.len() as f32;
+    let avg_dl = docs.iter().map(|d| d.len() as f32).sum::<f32>() / n;
+
+    let mut scores = vec![0.0f32; docs.len()];
+    for term in query_terms {
+        let df = docs.iter().filter(|d| d.iter().any(|t| t == term)).count() as f32;
+        if df == 0.0 {
+            continue;
+        }
+        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+
+        for (i, doc) in docs.iter().enumerate() {
+            let tf = doc.iter().filter(|t| *t == term).count() as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let dl = doc.len() as f32;
+            let tf_norm = (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B + B * dl / avg_dl));
+            scores[i] += idf * tf_norm;
+        }
+    }
+
+    scores
+}
+
+// ─── pure helpers ─────────────────────────────────────────────────────────────
+
+pub(super) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        norm_a += a[i] * a[i];
+        norm_b += b[i] * b[i];
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom < 1e-8 {
+        0.0
+    } else {
+        (dot / denom).clamp(-1.0, 1.0)
+    }
+}
+
+pub(super) fn decode_embedding(blob: &[u8]) -> Vec<f32> {
+    if !blob.len().is_multiple_of(4) {
+        return Vec::new();
+    }
+    blob.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| t.len() >= 2)
+        .map(str::to_string)
+        .collect()
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_embedding_round_trips() {
+        let values: Vec<f32> = vec![1.0, -0.5, 0.0, 42.5];
+        let blob: Vec<u8> = values.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let decoded = decode_embedding(&blob);
+        assert_eq!(decoded.len(), 4);
+        for (a, b) in values.iter().zip(decoded.iter()) {
+            assert!((a - b).abs() < 1e-6, "mismatch: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn decode_embedding_rejects_misaligned_blob() {
+        let blob = vec![0u8; 7];
+        assert!(decode_embedding(&blob).is_empty());
+    }
+
+    #[test]
+    fn cosine_similarity_identical_vectors() {
+        let v = vec![1.0f32, 0.0, 0.0];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_orthogonal_vectors() {
+        let a = vec![1.0f32, 0.0];
+        let b = vec![0.0f32, 1.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_mismatched_lengths_returns_zero() {
+        let a = vec![1.0f32, 2.0];
+        let b = vec![1.0f32];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn bm25_scores_higher_for_matching_doc() {
+        let terms = vec!["rust".to_string(), "memory".to_string()];
+        let docs = &[
+            (
+                "Rust memory model",
+                "Rust ownership and memory safety rules",
+            ),
+            ("Python lists", "Python list operations and indexing"),
+        ];
+        let scores = compute_bm25_scores(&terms, docs);
+        assert_eq!(scores.len(), 2);
+        assert!(scores[0] > scores[1], "matching doc must score higher");
+    }
+
+    #[test]
+    fn bm25_empty_terms_returns_zeros() {
+        let docs = &[("heading", "content"), ("heading2", "content2")];
+        let scores = compute_bm25_scores(&[], docs);
+        assert!(scores.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn score_sections_sorted_desc() {
+        let query_emb: Vec<f32> = vec![1.0, 0.0];
+        let mut atom_cos: HashMap<String, f32> = HashMap::new();
+        atom_cos.insert("a1".to_string(), 0.9);
+
+        let sec = ScoredSection {
+            id: "s1".to_string(),
+            atom_id: "a1".to_string(),
+            section_type: "overview".to_string(),
+            heading: "Overview".to_string(),
+            content: "introduction to the topic".to_string(),
+            embedding: vec![1.0, 0.0],
+        };
+        let sec2 = ScoredSection {
+            id: "s2".to_string(),
+            atom_id: "a1".to_string(),
+            section_type: "references".to_string(),
+            heading: "References".to_string(),
+            content: "unrelated bibliography content".to_string(),
+            embedding: vec![0.0, 1.0],
+        };
+
+        let mut sections: HashMap<String, Vec<ScoredSection>> = HashMap::new();
+        sections.insert("a1".to_string(), vec![sec, sec2]);
+
+        let domain_scores: HashMap<String, f32> = HashMap::new();
+        let type_weights: HashMap<String, f32> = HashMap::new();
+
+        let results = score_sections(
+            "overview introduction topic",
+            &query_emb,
+            &atom_cos,
+            &sections,
+            &domain_scores,
+            &type_weights,
+            &ComposeScoreWeights::default(),
+        );
+
+        assert_eq!(results.len(), 2);
+        assert!(results[0].score >= results[1].score, "must be sorted desc");
+        assert_eq!(results[0].section_id, "s1");
+    }
+
+    #[test]
+    fn default_weights_sum_to_one() {
+        let w = ComposeScoreWeights::default();
+        let sum =
+            w.section_cosine + w.section_bm25 + w.atom_cosine + w.domain_score + w.type_weight;
+        assert!((sum - 1.0).abs() < 1e-6, "weights sum to {sum}");
+    }
+}

--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod schema;
 pub(crate) mod section_feedback;
 pub(crate) mod vamana;
 
+mod compose;
 mod crud;
 mod fold_handler;
 mod index_handler;

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -971,6 +971,43 @@ async fn rerank_text_items(
     Ok(())
 }
 
+fn format_section_compose_markdown(
+    query: &str,
+    domains: &[Domain],
+    atoms: &[Atom],
+    sections: &[super::compose::ComposeSectionResult],
+) -> String {
+    let mut out = String::from("# Knowledge Briefing\n\n");
+    out.push_str(&format!("Query: {query}\n"));
+
+    let mut by_atom: HashMap<&str, Vec<&super::compose::ComposeSectionResult>> = HashMap::new();
+    for s in sections {
+        by_atom.entry(s.atom_id.as_str()).or_default().push(s);
+    }
+
+    for atom in atoms {
+        let atom_id = atom.id.to_string();
+        if let Some(secs) = by_atom.get(atom_id.as_str()) {
+            out.push_str(&format!("\n## {}\n\n", atom.name));
+            out.push_str(&format!("Source: {}\n", atom.slug));
+            for s in secs {
+                out.push_str(&format!("\n### {} (score: {:.4})\n\n", s.heading, s.score));
+                if !s.content.is_empty() {
+                    out.push_str(&s.content);
+                    out.push('\n');
+                }
+            }
+        }
+    }
+    if !domains.is_empty() {
+        out.push_str("\n---\n\nDomains: ");
+        let names: Vec<&str> = domains.iter().map(|d| d.name.as_str()).collect();
+        out.push_str(&names.join(", "));
+        out.push('\n');
+    }
+    out
+}
+
 fn format_compose_markdown(query: &str, domains: &[Domain], atoms: &[(&Atom, f32)]) -> String {
     let mut out = String::from("# Knowledge Briefing\n\n");
     out.push_str(&format!("Query: {query}\n"));
@@ -1269,17 +1306,118 @@ impl KnowledgeHandlers {
 
         rerank_text_items(runtime, &raw_query, &mut items).await?;
 
-        let sorted_atoms: Vec<(&Atom, f32)> = items
+        let atom_ids: Vec<String> = ordered_atoms.iter().map(|a| a.id.to_string()).collect();
+        let atom_cosine_scores: HashMap<String, f32> = items
             .iter()
-            .filter_map(|item| {
-                ordered_atoms
-                    .iter()
-                    .find(|a| a.id.to_string() == item.id)
-                    .map(|a| (a, item.score))
-            })
+            .map(|item| (item.id.clone(), item.score))
             .collect();
 
-        let markdown = format_compose_markdown(&raw_query, &resolved_domains, &sorted_atoms);
+        let section_map = super::compose::load_section_embeddings(runtime, &ns, &atom_ids).await?;
+
+        let has_sections = !section_map.is_empty();
+
+        let section_results = if has_sections {
+            let domain_member_ids: HashSet<String> = member_slugs
+                .iter()
+                .filter_map(|slug| {
+                    ordered_atoms
+                        .iter()
+                        .find(|a| a.slug == *slug)
+                        .map(|a| a.id.to_string())
+                })
+                .collect();
+
+            let domain_scores: HashMap<String, f32> = ordered_atoms
+                .iter()
+                .map(|a| {
+                    let id = a.id.to_string();
+                    let score = if domain_member_ids.contains(&id) {
+                        1.0
+                    } else {
+                        0.0
+                    };
+                    (id, score)
+                })
+                .collect();
+
+            let section_state = khive_brain_core::SectionPosteriorState::default();
+            let type_weights: HashMap<String, f32> = section_state
+                .deterministic_weights()
+                .into_iter()
+                .map(|(st, w)| (st.as_str().to_string(), w as f32))
+                .collect();
+
+            let q_emb = runtime
+                .embed_batch(std::slice::from_ref(&raw_query))
+                .await
+                .ok()
+                .and_then(|mut v| {
+                    if v.len() == 1 {
+                        Some(v.remove(0))
+                    } else {
+                        None
+                    }
+                });
+
+            if let Some(qe) = q_emb {
+                super::compose::score_sections(
+                    &raw_query,
+                    &qe,
+                    &atom_cosine_scores,
+                    &section_map,
+                    &domain_scores,
+                    &type_weights,
+                    &super::compose::ComposeScoreWeights::default(),
+                )
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+
+        let (markdown, section_json) = if !section_results.is_empty() {
+            let md = format_section_compose_markdown(
+                &raw_query,
+                &resolved_domains,
+                &ordered_atoms,
+                &section_results,
+            );
+            let sj: Vec<Value> = section_results
+                .iter()
+                .map(|s| {
+                    json!({
+                        "section_id": s.section_id,
+                        "atom_id": s.atom_id,
+                        "section_type": s.section_type,
+                        "heading": s.heading,
+                        "score": (s.score * 10000.0).round() / 10000.0,
+                        "breakdown": {
+                            "section_cosine": (s.score_breakdown.section_cosine * 10000.0).round() / 10000.0,
+                            "section_bm25": (s.score_breakdown.section_bm25 * 10000.0).round() / 10000.0,
+                            "atom_cosine": (s.score_breakdown.atom_cosine * 10000.0).round() / 10000.0,
+                            "domain_score": (s.score_breakdown.domain_score * 10000.0).round() / 10000.0,
+                            "type_weight": (s.score_breakdown.type_weight * 10000.0).round() / 10000.0,
+                        },
+                    })
+                })
+                .collect();
+            (md, sj)
+        } else {
+            let sorted_atoms: Vec<(&Atom, f32)> = items
+                .iter()
+                .filter_map(|item| {
+                    ordered_atoms
+                        .iter()
+                        .find(|a| a.id.to_string() == item.id)
+                        .map(|a| (a, item.score))
+                })
+                .collect();
+            (
+                format_compose_markdown(&raw_query, &resolved_domains, &sorted_atoms),
+                Vec::new(),
+            )
+        };
 
         let atom_json: Vec<Value> = items
             .iter()
@@ -1300,15 +1438,21 @@ impl KnowledgeHandlers {
 
         let count = atom_json.len();
 
+        let mut data = json!({
+            "query": raw_query,
+            "markdown": markdown,
+            "domains": domain_json,
+            "atoms": atom_json,
+            "count": count,
+        });
+        if !section_json.is_empty() {
+            data["sections"] = json!(section_json);
+            data["section_count"] = json!(section_json.len());
+        }
+
         Ok(json!({
             "status": "ok",
-            "data": {
-                "query": raw_query,
-                "markdown": markdown,
-                "domains": domain_json,
-                "atoms": atom_json,
-                "count": count,
-            },
+            "data": data,
         }))
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1312,7 +1312,7 @@ impl KnowledgeHandlers {
             .map(|item| (item.id.clone(), item.score))
             .collect();
 
-        let section_map = super::compose::load_section_embeddings(runtime, &ns, &atom_ids).await?;
+        let section_map = super::compose::load_sections(runtime, &ns, &atom_ids).await?;
 
         let has_sections = !section_map.is_empty();
 


### PR DESCRIPTION
## Summary

- Implements hybrid section scoring in `knowledge.compose` per the ADR-051 spec formula:
  `0.55*sec_cosine + 0.20*bm25 + 0.10*atom_cosine + 0.10*domain + 0.05*type_weight`
- New `compose.rs` module with lazy batch section embedding loader, pure hybrid scorer, BM25 over candidate set, cosine similarity, LE f32 blob decoder
- Falls back to atom-only cosine reranking when no section embeddings exist (backwards compatible)
- Section type weights sourced from `SectionPosteriorState::deterministic_weights()` (brain-core)
- Compose response includes scored section manifest (`sections` + `section_count`) when available
- Section-aware markdown briefing format groups sections under their parent atoms

## Test plan

- [x] 9 unit tests in compose.rs: decode round-trip, cosine similarity, BM25 ranking, score ordering, weight sum
- [x] All 21 existing knowledge pack tests pass
- [x] Clippy clean, workspace check clean
- [ ] End-to-end: `knowledge.compose` with populated section embeddings returns section manifest
- [ ] End-to-end: `knowledge.compose` with zero section embeddings returns atom-only (fallback)

Closes #6