### PR TITLE
fix(mcp): remove ANN warm from stdio — daemon owns hot state

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -275,7 +275,6 @@ impl KhiveMcpServer {
     /// Serve over stdio (blocks until the connection closes).
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
         use rmcp::transport::stdio;
-        self.warm_all().await;
         let service = self.serve(stdio()).await?;
         service.waiting().await?;
         Ok(())


### PR DESCRIPTION
## Summary

- Reverts the `warm_all().await` added to `serve_stdio` in PR #19
- The stdio MCP server forwards requests to the warm daemon via Unix socket (`forward_or_spawn`) — ANN warm belongs in the daemon process only
- Daemon already spawns `warm_all` in background after socket bind (non-blocking)
- Blocking stdio startup on warm_all delayed MCP connection by ~30s when no valid snapshot existed

## Test plan

- [x] `cargo clippy -p khive-mcp -- -D warnings` — clean
- [x] Verified daemon warm path at `runtime/daemon.rs:264` spawns background
- [x] Verified stdio forwards to daemon at `server.rs:731`