### PR TITLE
fix(merge): restore compilation + harden khive-merge (issue #21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ docs-check:
 	deno fmt --check docs/
 
 check-fwd:
-	cargo check --manifest-path crates/khive-merge/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path crates/khive-merge/Cargo.toml --all-targets
+	cargo clippy --manifest-path crates/khive-merge/Cargo.toml --all-targets -- -D warnings
+	cargo test --manifest-path crates/khive-merge/Cargo.toml
 
 ci:
 	./scripts/ci.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check clippy test contract-test fmt fmt-check build clean ci docs-check publish publish-dry local proof-check
+.PHONY: check clippy test contract-test fmt fmt-check build clean ci docs-check publish publish-dry local proof-check check-fwd
 
 check:
 	cd crates && cargo check --workspace
@@ -31,6 +31,9 @@ clean:
 
 docs-check:
 	deno fmt --check docs/
+
+check-fwd:
+	cargo check --manifest-path crates/khive-merge/Cargo.toml
 
 ci:
 	./scripts/ci.sh

--- a/crates/khive-merge/docs/design.md
+++ b/crates/khive-merge/docs/design.md
@@ -23,7 +23,7 @@ integration layer is extended to expose snapshot ancestry for LCA walks.
 
 ### ADR-043: Three-Way Merge Conflict Taxonomy
 
-- The `MergeConflict` enum (in `merge_types.rs`) enumerates the six conflict kinds defined for
+- The `MergeConflict` enum (in `types.rs`) enumerates the six conflict kinds defined for
   the three-way merge: `NameConflict`, `KindConflict`, `ModifyDelete`, `PropertyMismatch`,
   `EdgeModifyDelete`, `DanglingEdge`.
 - Property merge rules (per-key, both-set-same → keep, both-set-different → conflict, one-side →
@@ -49,7 +49,7 @@ entity identity, field-level conflicts, edge weights, and dangling-edge semantic
 
 | Module | Role |
 |--------|------|
-| `merge_types` | Public types: `MergeStrategy`, `MergeConflict`, `MergeResult`, `MergeEngine` trait |
+| `types` | Public types: `SnapshotMergeStrategy`, `MergeConflict`, `MergeResult`, `MergeEngine` trait |
 | `merge` | Top-level `three_way_merge()` + `ThreeWayMergeEngine` impl |
 | `lca` | Lowest-common-ancestor walk over a `SnapshotReader` |
 | `diff_local` | Private: entity and edge diff between base and branch |

--- a/crates/khive-merge/src/diff_local.rs
+++ b/crates/khive-merge/src/diff_local.rs
@@ -171,7 +171,8 @@ fn entities_equal(a: &ExportedEntity, b: &ExportedEntity) -> bool {
         && properties_equal(&a.properties, &b.properties)
 }
 
-fn properties_equal(a: &Option<serde_json::Value>, b: &Option<serde_json::Value>) -> bool {
+/// Property equality check; shared with entity.rs for duplicate-addition detection.
+pub(crate) fn properties_equal(a: &Option<serde_json::Value>, b: &Option<serde_json::Value>) -> bool {
     match (a, b) {
         (None, None) => true,
         (Some(av), Some(bv)) => av == bv,

--- a/crates/khive-merge/src/entity.rs
+++ b/crates/khive-merge/src/entity.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use khive_runtime::portability::{ExportedEntity, KgArchive};
 use uuid::Uuid;
 
-use crate::diff_local::{diff_entities, EntityChange};
+use crate::diff_local::{diff_entities, properties_equal, EntityChange};
 use crate::types::{BranchSide, MergeConflict};
 
 /// Categorize all entity UUIDs across base, ours, theirs and produce:

--- a/crates/khive-merge/src/lca.rs
+++ b/crates/khive-merge/src/lca.rs
@@ -22,6 +22,7 @@ pub trait SnapshotReader: Send + Sync {
 ///
 /// Returns `None` if the two histories are disjoint (no common ancestor).
 /// In that case the merge uses an empty `KgArchive` as the base.
+/// Cycle-safe: both the `ours` and `theirs` parent chains are guarded by visited sets.
 pub fn find_lca(reader: &dyn SnapshotReader, ours_id: &str, theirs_id: &str) -> Option<String> {
     if ours_id == theirs_id {
         return Some(ours_id.to_string());
@@ -29,12 +30,19 @@ pub fn find_lca(reader: &dyn SnapshotReader, ours_id: &str, theirs_id: &str) -> 
 
     let ours_ancestors = collect_ancestors(reader, ours_id);
 
+    // Guard against cycles in the theirs parent chain.
+    let mut visited_theirs: HashSet<String> = HashSet::new();
+    visited_theirs.insert(theirs_id.to_string());
     let mut current = Some(theirs_id.to_string());
     while let Some(id) = current {
         if ours_ancestors.contains(&id) {
             return Some(id);
         }
-        current = reader.parent_of(&id);
+        let next = reader.parent_of(&id);
+        current = match next {
+            Some(ref nid) if !visited_theirs.insert(nid.clone()) => None,
+            other => other,
+        };
     }
 
     None
@@ -104,5 +112,29 @@ mod tests {
         parents.insert("c".into(), "base".into());
         let reader = MockReader { parents };
         assert_eq!(find_lca(&reader, "d", "e"), Some("c".into()));
+    }
+
+    #[test]
+    fn lca_cycle_in_theirs_terminates() {
+        // Cycle in theirs chain: f -> g -> f (infinite without guard).
+        // ours is linear with no common node.
+        let mut parents = HashMap::new();
+        parents.insert("a".into(), "root_a".into());
+        parents.insert("f".into(), "g".into());
+        parents.insert("g".into(), "f".into()); // cycle
+        let reader = MockReader { parents };
+        assert_eq!(find_lca(&reader, "a", "f"), None);
+    }
+
+    #[test]
+    fn lca_cycle_in_ours_terminates() {
+        // Cycle in ours chain: h -> i -> h.
+        // collect_ancestors must not loop; theirs is linear with no shared node.
+        let mut parents = HashMap::new();
+        parents.insert("h".into(), "i".into());
+        parents.insert("i".into(), "h".into()); // cycle
+        parents.insert("b".into(), "root_b".into());
+        let reader = MockReader { parents };
+        assert_eq!(find_lca(&reader, "h", "b"), None);
     }
 }

--- a/crates/khive-merge/src/lib.rs
+++ b/crates/khive-merge/src/lib.rs
@@ -13,4 +13,6 @@ pub mod strategy;
 pub mod types;
 
 pub use merge::ThreeWayMergeEngine;
-pub use types::{BranchSide, MergeConflict, MergeEngine, MergeError, MergeResult, MergeStrategy};
+pub use types::{
+    BranchSide, MergeConflict, MergeEngine, MergeError, MergeResult, SnapshotMergeStrategy,
+};

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -11,7 +11,7 @@ use crate::diff_local::EdgeKey;
 use crate::edge::{merge_edges, validate_dangling_edges};
 use crate::entity::merge_entities;
 use crate::strategy::{apply_ours, apply_theirs};
-use crate::types::{MergeConflict, MergeEngine, MergeError, MergeResult, MergeStrategy};
+use crate::types::{MergeConflict, MergeEngine, MergeError, MergeResult, SnapshotMergeStrategy};
 
 /// Validate archive invariants before merge.
 ///
@@ -106,26 +106,26 @@ pub fn three_way_merge(
     base: &KgArchive,
     ours: &KgArchive,
     theirs: &KgArchive,
-    strategy: MergeStrategy,
+    strategy: SnapshotMergeStrategy,
 ) -> Result<MergeResult, MergeError> {
     validate_inputs(base, ours, theirs)?;
 
     match strategy {
-        MergeStrategy::Ours => {
+        SnapshotMergeStrategy::Ours => {
             let mut merged = apply_ours(base, ours, theirs);
             sort_entities(&mut merged);
             sort_edges(&mut merged.edges);
             merged.exported_at = deterministic_timestamp(ours, theirs);
             Ok(MergeResult::Clean { merged })
         }
-        MergeStrategy::Theirs => {
+        SnapshotMergeStrategy::Theirs => {
             let mut merged = apply_theirs(base, ours, theirs);
             sort_entities(&mut merged);
             sort_edges(&mut merged.edges);
             merged.exported_at = deterministic_timestamp(ours, theirs);
             Ok(MergeResult::Clean { merged })
         }
-        MergeStrategy::Auto => three_way_merge_auto(base, ours, theirs),
+        SnapshotMergeStrategy::Auto => three_way_merge_auto(base, ours, theirs),
     }
 }
 
@@ -176,7 +176,7 @@ impl MergeEngine for ThreeWayMergeEngine {
         base: &KgArchive,
         ours: &KgArchive,
         theirs: &KgArchive,
-        strategy: MergeStrategy,
+        strategy: SnapshotMergeStrategy,
     ) -> Result<MergeResult, MergeError> {
         three_way_merge(base, ours, theirs, strategy)
     }

--- a/crates/khive-merge/src/types.rs
+++ b/crates/khive-merge/src/types.rs
@@ -6,9 +6,12 @@ use khive_runtime::portability::KgArchive;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Merge strategy selector.
+/// Snapshot merge strategy selector (ADR-010).
+///
+/// Renamed from `MergeStrategy` to avoid collision with `ContentMergeStrategy` in
+/// the note-curation layer (ADR-014).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MergeStrategy {
+pub enum SnapshotMergeStrategy {
     /// Three-way merge with conflict detection.
     Auto,
     /// Last-write-wins: ours fields prevail on conflict.
@@ -79,7 +82,9 @@ pub enum MergeConflict {
 /// Identifies which side of the merge a change originates from.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BranchSide {
+    /// The local branch being merged into the common base.
     Ours,
+    /// The remote branch being merged in.
     Theirs,
 }
 
@@ -88,12 +93,13 @@ pub enum BranchSide {
 /// Register an implementation of this trait in `khive-vcs` at startup to
 /// replace the default no-op merge engine.
 pub trait MergeEngine {
+    /// Run a three-way merge of `ours` and `theirs` against their common `base`.
     fn merge_branch(
         &self,
         base: &KgArchive,
         ours: &KgArchive,
         theirs: &KgArchive,
-        strategy: MergeStrategy,
+        strategy: SnapshotMergeStrategy,
     ) -> Result<MergeResult, MergeError>;
 }
 

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -7,7 +7,9 @@ use khive_runtime::portability::{ExportedEdge, ExportedEntity, KgArchive};
 use khive_storage::EdgeRelation;
 use uuid::Uuid;
 
-use khive_merge::types::{MergeConflict, MergeEngine, MergeError, MergeResult, MergeStrategy};
+use khive_merge::types::{
+    MergeConflict, MergeEngine, MergeError, MergeResult, SnapshotMergeStrategy,
+};
 use khive_merge::{merge::three_way_merge, ThreeWayMergeEngine};
 
 fn empty(ns: &str) -> KgArchive {
@@ -67,7 +69,7 @@ fn clean_merge_no_overlap() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id2, "B")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 2);
@@ -93,7 +95,7 @@ fn conflicts_on_name_mismatch() {
         a
     };
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
 }
 
@@ -116,7 +118,7 @@ fn ours_strategy_always_clean() {
         a
     };
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Ours).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities[0].name, "NameA");
@@ -142,7 +144,7 @@ fn theirs_strategy_always_clean() {
         a
     };
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Theirs).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities[0].name, "NameB");
@@ -171,7 +173,7 @@ fn dangling_edge_in_auto_merge() {
         a
     };
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
 }
 
@@ -182,7 +184,7 @@ fn three_way_merge_engine_impl() {
     let ours = empty("test");
     let theirs = empty("test");
     let result = engine
-        .merge_branch(&base, &ours, &theirs, MergeStrategy::Auto)
+        .merge_branch(&base, &ours, &theirs, SnapshotMergeStrategy::Auto)
         .unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
 }
@@ -210,7 +212,7 @@ fn kind_conflict_detected() {
         a
     };
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
     if let MergeResult::Conflicts { conflicts } = result {
         assert!(
@@ -233,7 +235,7 @@ fn duplicate_uuid_same_content_auto_resolves() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id, "Same")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Clean { .. }));
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 1);
@@ -250,7 +252,7 @@ fn duplicate_uuid_different_content_is_conflict() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id, "NameB")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(
         matches!(result, MergeResult::Conflicts { .. }),
         "duplicate UUID with different content must be a conflict"
@@ -277,8 +279,8 @@ fn repeated_auto_merge_produces_equal_output() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id2, "B")];
 
-    let r1 = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
-    let r2 = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let r1 = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+    let r2 = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
 
     if let (MergeResult::Clean { merged: m1 }, MergeResult::Clean { merged: m2 }) = (&r1, &r2) {
         assert_eq!(m1.exported_at, m2.exported_at, "timestamps must be equal");
@@ -301,7 +303,7 @@ fn entities_sorted_by_uuid() {
     }
     let theirs = empty("test");
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         ids.sort();
         let merged_ids: Vec<Uuid> = merged.entities.iter().map(|e| e.id).collect();
@@ -324,7 +326,7 @@ fn edges_sorted_by_source_target_relation() {
     ours.edges = vec![edge(c, a), edge(b, c), edge(a, b)];
     let theirs = empty("test");
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         for i in 1..merged.edges.len() {
             let prev = &merged.edges[i - 1];
@@ -355,7 +357,7 @@ fn ours_strategy_output_is_sorted() {
     }
     let theirs = empty("test");
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Ours).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert!(merged.entities.len() >= 2);
         assert!(
@@ -380,7 +382,7 @@ fn theirs_strategy_output_is_sorted() {
         theirs.entities = vec![entity(id2, "B"), entity(id1, "A")];
     }
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Theirs).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert!(merged.entities.len() >= 2);
         assert!(
@@ -400,7 +402,7 @@ fn rejects_namespace_mismatch() {
     let ours = empty("ns2");
     let theirs = empty("ns1");
 
-    let err = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap_err();
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
     assert!(
         matches!(err, MergeError::NamespaceMismatch { .. }),
         "expected NamespaceMismatch, got: {err:?}"
@@ -416,7 +418,7 @@ fn rejects_non_finite_edge_weight_nan() {
     ours.edges = vec![edge_weighted(a, b, f64::NAN)];
     let theirs = empty("test");
 
-    let err = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap_err();
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
     assert!(matches!(err, MergeError::InvalidEdgeWeight(_)));
 }
 
@@ -429,7 +431,7 @@ fn rejects_non_finite_edge_weight_inf() {
     ours.edges = vec![edge_weighted(a, b, f64::INFINITY)];
     let theirs = empty("test");
 
-    let err = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap_err();
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
     assert!(matches!(err, MergeError::InvalidEdgeWeight(_)));
 }
 
@@ -441,7 +443,7 @@ fn rejects_duplicate_entity_ids_in_archive() {
     ours.entities = vec![entity(id, "First"), entity(id, "Second")];
     let theirs = empty("test");
 
-    let err = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap_err();
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
     assert!(
         matches!(err, MergeError::DuplicateEntityId { .. }),
         "expected DuplicateEntityId, got: {err:?}"
@@ -457,7 +459,7 @@ fn rejects_duplicate_edge_keys_in_archive() {
     ours.edges = vec![edge(a, b), edge(a, b)];
     let theirs = empty("test");
 
-    let err = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap_err();
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
     assert!(
         matches!(err, MergeError::DuplicateEdgeKey { .. }),
         "expected DuplicateEdgeKey, got: {err:?}"
@@ -473,7 +475,7 @@ fn unchanged_entity_passes_through() {
     let base = archive_with_entities(vec![e.clone()]);
     let ours = archive_with_entities(vec![e.clone()]);
     let theirs = archive_with_entities(vec![e]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 1);
         assert_eq!(merged.entities[0].name, "A");
@@ -488,7 +490,7 @@ fn added_in_ours_included() {
     let base = archive_with_entities(vec![]);
     let ours = archive_with_entities(vec![entity(id, "New")]);
     let theirs = archive_with_entities(vec![]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 1);
     } else {
@@ -502,7 +504,7 @@ fn deleted_in_both_excluded() {
     let base = archive_with_entities(vec![entity(id, "Old")]);
     let ours = archive_with_entities(vec![]);
     let theirs = archive_with_entities(vec![]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 0);
     } else {
@@ -519,7 +521,7 @@ fn modify_delete_conflict() {
     let ours = archive_with_entities(vec![modified]);
     let theirs = archive_with_entities(vec![]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
     if let MergeResult::Conflicts { conflicts } = result {
         assert_eq!(conflicts.len(), 1);
@@ -539,7 +541,7 @@ fn property_mismatch_conflict() {
     let ours = archive_with_entities(vec![e_ours]);
     let theirs = archive_with_entities(vec![e_theirs]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
     if let MergeResult::Conflicts { conflicts } = result {
         assert!(conflicts
@@ -560,7 +562,7 @@ fn name_conflict_reported() {
     let ours = archive_with_entities(vec![e_ours]);
     let theirs = archive_with_entities(vec![e_theirs]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
     if let MergeResult::Conflicts { conflicts } = result {
         assert!(conflicts
@@ -581,7 +583,7 @@ fn tags_are_unioned() {
     let ours = archive_with_entities(vec![e_ours]);
     let theirs = archive_with_entities(vec![e_theirs]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         let tags = &merged.entities[0].tags;
         assert!(tags.contains(&"a".to_string()));
@@ -604,7 +606,7 @@ fn theirs_only_property_keys_preserved() {
     let ours = archive_with_entities(vec![e_ours]);
     let theirs = archive_with_entities(vec![e_theirs]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         let props = merged.entities[0]
             .properties
@@ -631,7 +633,7 @@ fn edge_added_in_ours_included() {
     let base = archive_full(entities.clone(), vec![]);
     let ours = archive_full(entities.clone(), vec![edge(a, b)]);
     let theirs = archive_full(entities, vec![]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.edges.len(), 1);
     } else {
@@ -647,7 +649,7 @@ fn edge_deleted_in_both_excluded() {
     let base = archive_full(entities.clone(), vec![edge(a, b)]);
     let ours = archive_full(entities.clone(), vec![]);
     let theirs = archive_full(entities, vec![]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.edges.len(), 0);
     } else {
@@ -663,7 +665,7 @@ fn max_weight_on_both_added() {
     let base = archive_full(entities.clone(), vec![]);
     let ours = archive_full(entities.clone(), vec![edge_weighted(a, b, 0.6)]);
     let theirs = archive_full(entities, vec![edge_weighted(a, b, 0.9)]);
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.edges.len(), 1);
         assert!((merged.edges[0].weight - 0.9).abs() < f64::EPSILON);
@@ -695,7 +697,7 @@ fn edge_modify_delete_conflict() {
     let ours = archive_full(entities.clone(), vec![]);
     let theirs = archive_full(entities, vec![edge_weighted(a, b, 1.0)]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     assert!(matches!(result, MergeResult::Conflicts { .. }));
     if let MergeResult::Conflicts { conflicts } = result {
         assert!(
@@ -719,7 +721,7 @@ fn merge_preserves_added_edge_id() {
     let ours = archive_full(entities.clone(), vec![branch_edge]);
     let theirs = archive_full(entities, vec![]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.edges.len(), 1);
         assert_eq!(
@@ -757,7 +759,7 @@ fn merge_preserves_weight_modified_edge_id() {
     let ours = archive_full(entities.clone(), vec![ours_edge]);
     let theirs = archive_full(entities, vec![base_edge]);
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Auto).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.edges.len(), 1);
         assert_eq!(merged.edges[0].weight, 0.9);
@@ -782,7 +784,7 @@ fn apply_ours_uses_ours_version() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id, "TheirsName")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Ours).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 1);
         assert_eq!(merged.entities[0].name, "OursName");
@@ -801,7 +803,7 @@ fn apply_theirs_uses_theirs_version() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id, "TheirsName")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Theirs).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 1);
         assert_eq!(merged.entities[0].name, "TheirsName");
@@ -820,7 +822,7 @@ fn apply_ours_includes_theirs_only_additions() {
     let mut theirs = empty("test");
     theirs.entities = vec![entity(id_theirs, "B")];
 
-    let result = three_way_merge(&base, &ours, &theirs, MergeStrategy::Ours).unwrap();
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
     if let MergeResult::Clean { merged } = result {
         assert_eq!(merged.entities.len(), 2);
     } else {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,6 +4,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/../crates"
 
+echo "=== Forward-Deployed Crates Check ==="
+# Excluded workspace crates (forward-deployed infrastructure) must still compile.
+cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml"
+
 echo "=== Format Check ==="
 cargo fmt --all -- --check
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,8 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/../crates"
 
 echo "=== Forward-Deployed Crates Check ==="
-# Excluded workspace crates (forward-deployed infrastructure) must still compile.
-cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml"
+# Excluded workspace crates (forward-deployed infrastructure) must still compile,
+# pass clippy under -D warnings across all targets, and pass their test suite.
+RUSTFLAGS="-D warnings" cargo check --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets
+cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --all-targets -- -D warnings
+cargo test --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml"
 
 echo "=== Format Check ==="
 cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- **Compile blocker (KMSTD-001)**: `properties_equal` was private in `diff_local.rs` but called from `entity.rs`. Made it `pub(crate)` and added the import — fixes E0425.
- **Rename drift (KMSTD-003)**: Renamed `MergeStrategy` → `SnapshotMergeStrategy` per ADR-010/014, which requires this name to avoid collision with `ContentMergeStrategy` in the note-curation layer. All call-sites updated (types.rs, merge.rs, lib.rs, test file).
- **Cycle-safety (KMSTD-005)**: `find_lca` only guarded the `ours` parent chain against cycles; the `theirs` walk could loop forever on a cyclic history. Added a `visited_theirs: HashSet<String>` guard matching the `collect_ancestors` pattern. Added two regression tests (`lca_cycle_in_theirs_terminates`, `lca_cycle_in_ours_terminates`).
- **Rustdoc (KMSTD-006)**: Added doc comments to `BranchSide` variants and `MergeEngine::merge_branch`.
- **CI guard**: Added `check-fwd` Make target (`cargo check --manifest-path crates/khive-merge/Cargo.toml`) and wired it into `scripts/ci.sh` as the first step, so excluded forward-deployed crates can't silently break again.

## Verification

```
cd crates/khive-merge

cargo check
→ Finished `dev` profile in 0.73s ✓

cargo clippy --all-targets -- -D warnings
→ Finished `dev` profile in 1.27s ✓

cargo test
→ test result: ok. 31 passed (unit) + 44 passed (integration) ✓

make check-fwd
→ Finished `dev` profile in 0.17s ✓
```

Closes #21