### PR TITLE
harden(gate-rego): trim and validate entrypoint to avoid latent fail-open

### DIFF
--- a/crates/khive-gate-rego/src/gate.rs
+++ b/crates/khive-gate-rego/src/gate.rs
@@ -124,7 +124,7 @@ impl RegoGate {
                 "entrypoint must begin with 'data.' (got: {trimmed:?})"
             )));
         }
-        Ok(self.with_entrypoint(ep))
+        Ok(self.with_entrypoint(trimmed))
     }
 }
 

--- a/crates/khive-gate-rego/src/gate.rs
+++ b/crates/khive-gate-rego/src/gate.rs
@@ -98,7 +98,7 @@ impl RegoGate {
     /// is installed — preventing a misconfigured entrypoint from causing
     /// fail-open dispatch errors at runtime.
     pub fn with_entrypoint(mut self, entrypoint: impl Into<String>) -> Self {
-        self.entrypoint = entrypoint.into();
+        self.entrypoint = entrypoint.into().trim().to_string();
         self
     }
 
@@ -109,9 +109,12 @@ impl RegoGate {
     /// Prefer this over [`Self::with_entrypoint`] for operator-supplied
     /// configuration. A misconfigured entrypoint discovered at construction
     /// time produces a deterministic `GateError::Policy` rather than a
-    /// dispatch-time evaluation failure. `RegoGate::check` converts evaluation
-    /// errors to `Ok(GateDecision::Deny)` (fail-closed), so construction-time
-    /// validation is defense-in-depth — not the primary safety net.
+    /// dispatch-time evaluation failure. `RegoGate::check` converts all
+    /// evaluation failures (missing rule, undefined result, serialization
+    /// error, poisoned engine) to `Ok(GateDecision::Deny)` (fail-closed);
+    /// construction-time validation is defense-in-depth. The runtime's
+    /// `Err(_)` branch is reserved for non-evaluation gate errors (e.g.
+    /// infrastructure faults from other `Gate` implementations).
     pub fn try_with_entrypoint(mut self, entrypoint: impl Into<String>) -> Result<Self, GateError> {
         let ep = entrypoint.into();
         let trimmed = ep.trim();
@@ -162,10 +165,23 @@ impl Gate for RegoGate {
         let input_value: regorus::Value = input.into();
 
         let result = {
-            let mut engine = self
-                .engine
-                .lock()
-                .map_err(|e| GateError::Internal(format!("engine mutex poisoned: {e}")))?;
+            // A poisoned mutex means a prior eval_rule call panicked while
+            // holding the lock.  That is itself an evaluation failure: deny
+            // immediately rather than propagating Err into the runtime's
+            // fail-open branch.
+            let mut engine = match self.engine.lock() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    tracing::warn!(
+                        entrypoint = %self.entrypoint,
+                        "engine mutex poisoned — denying (fail-closed)"
+                    );
+                    return Ok(GateDecision::deny(format!(
+                        "engine mutex poisoned for {}",
+                        self.entrypoint
+                    )));
+                }
+            };
             engine.set_input(input_value);
             engine.eval_rule(self.entrypoint.clone())
         };
@@ -197,9 +213,22 @@ impl Gate for RegoGate {
             )));
         }
 
-        let decision_json = value
-            .to_json_str()
-            .map_err(|e| GateError::Internal(format!("decision to_json: {e}")))?;
+        // Serialization failure is treated as an evaluation failure: deny
+        // rather than propagating Err into the runtime's fail-open branch.
+        let decision_json = match value.to_json_str() {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    entrypoint = %self.entrypoint,
+                    error = %e,
+                    "decision value failed to serialize — denying (fail-closed)"
+                );
+                return Ok(GateDecision::deny(format!(
+                    "policy rule {} produced unserializable value: {e}",
+                    self.entrypoint
+                )));
+            }
+        };
 
         // A result that parses to a non-GateDecision shape (e.g. a boolean,
         // plain string, or wrong object) is also treated as deny rather than
@@ -223,5 +252,51 @@ impl Gate for RegoGate {
 
     fn impl_name(&self) -> &'static str {
         "RegoGate"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use khive_gate::ActorRef;
+    use khive_types::Namespace;
+    use serde_json::json;
+
+    fn request(verb: &str) -> GateRequest {
+        GateRequest::new(ActorRef::anonymous(), Namespace::local(), verb, json!({}))
+    }
+
+    // ---- GATE-REGO-003: poisoned mutex → Deny, not Err ----
+
+    #[test]
+    fn poisoned_engine_mutex_returns_deny_not_err() {
+        use std::sync::Arc;
+
+        let policy = r#"
+            package khive.gate
+            import rego.v1
+            default decision := {"decision": "allow", "obligations": []}
+        "#;
+        let gate = Arc::new(RegoGate::from_policy_str(policy).expect("policy compiles"));
+
+        // Poison the mutex by panicking inside a spawned thread while holding
+        // the lock.  After join() the mutex is permanently poisoned.
+        {
+            let gate_clone = Arc::clone(&gate);
+            let handle = std::thread::spawn(move || {
+                let _guard = gate_clone.engine.lock().unwrap();
+                panic!("intentional panic to poison the mutex");
+            });
+            // Join to ensure the panic has propagated and the mutex is poisoned.
+            let _ = handle.join();
+        }
+
+        // check() must return Ok(Deny), never Err.
+        let result = gate.check(&request("search"));
+        match result {
+            Ok(GateDecision::Deny { .. }) => {}
+            Ok(GateDecision::Allow { .. }) => panic!("expected Deny for poisoned mutex, got Allow"),
+            Err(e) => panic!("expected Ok(Deny) for poisoned mutex, got Err({e})"),
+        }
     }
 }

--- a/crates/khive-gate-rego/src/gate.rs
+++ b/crates/khive-gate-rego/src/gate.rs
@@ -103,15 +103,16 @@ impl RegoGate {
     }
 
     /// Override the rule path with validation, returning `Err` for empty,
-    /// whitespace-only, or non-`data.`-prefixed entrypoints.
+    /// whitespace-only, non-`data.`-prefixed, or malformed-segment entrypoints,
+    /// and for entrypoints that do not name an existing rule in the loaded policy.
     ///
     /// Prefer this over [`Self::with_entrypoint`] for operator-supplied
     /// configuration. A misconfigured entrypoint discovered at construction
     /// time produces a deterministic `GateError::Policy` rather than a
-    /// dispatch-time `GateError::Evaluation` — the gate dispatcher treats
-    /// evaluation errors as infrastructure failures and proceeds (fail-open),
-    /// so catching misconfigurations at boot prevents unintended access.
-    pub fn try_with_entrypoint(self, entrypoint: impl Into<String>) -> Result<Self, GateError> {
+    /// dispatch-time evaluation failure. `RegoGate::check` converts evaluation
+    /// errors to `Ok(GateDecision::Deny)` (fail-closed), so construction-time
+    /// validation is defense-in-depth — not the primary safety net.
+    pub fn try_with_entrypoint(mut self, entrypoint: impl Into<String>) -> Result<Self, GateError> {
         let ep = entrypoint.into();
         let trimmed = ep.trim();
         if trimmed.is_empty() {
@@ -124,7 +125,33 @@ impl RegoGate {
                 "entrypoint must begin with 'data.' (got: {trimmed:?})"
             )));
         }
-        Ok(self.with_entrypoint(trimmed))
+        // Validate path segments after the "data." prefix: no empty components
+        // (which arise from consecutive dots, a leading dot after "data.", or a
+        // trailing dot).  "data.a..b" and "data.a." are rejected here.
+        let suffix = &trimmed["data.".len()..];
+        if suffix.is_empty() || suffix.split('.').any(|seg| seg.is_empty()) {
+            return Err(GateError::Policy(format!(
+                "entrypoint has empty path segment (got: {trimmed:?})"
+            )));
+        }
+        // Confirm the rule exists in the currently-loaded policy.  eval_rule
+        // returns Err("not a valid rule path") when the path is not a compiled
+        // rule — catching misconfigurations at boot rather than at first request.
+        {
+            let mut engine = self.engine.lock().map_err(|e| {
+                GateError::Internal(format!("engine mutex poisoned during validation: {e}"))
+            })?;
+            // A dummy empty-object input is sufficient; we only care whether the
+            // rule path exists, not the evaluated value.
+            engine.set_input(regorus::Value::new_object());
+            if let Err(e) = engine.eval_rule(trimmed.to_string()) {
+                return Err(GateError::Policy(format!(
+                    "entrypoint {trimmed:?} is not a valid rule in the loaded policy: {e}"
+                )));
+            }
+        }
+        self.entrypoint = trimmed.to_string();
+        Ok(self)
     }
 }
 
@@ -140,20 +167,58 @@ impl Gate for RegoGate {
                 .lock()
                 .map_err(|e| GateError::Internal(format!("engine mutex poisoned: {e}")))?;
             engine.set_input(input_value);
-            engine
-                .eval_rule(self.entrypoint.clone())
-                .map_err(|e| GateError::Evaluation(format!("eval {}: {e}", self.entrypoint)))?
+            engine.eval_rule(self.entrypoint.clone())
         };
 
-        let decision_json = result
-            .to_json_str()
-            .map_err(|e| GateError::Evaluation(format!("decision to_json: {e}")))?;
+        // Fail closed: any evaluation failure (missing rule, undefined, engine
+        // error) becomes an explicit Deny rather than propagating an Err that the
+        // runtime's fail-open branch would treat as "allow".
+        let value = match result {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    entrypoint = %self.entrypoint,
+                    error = %e,
+                    "rego eval failed — denying (fail-closed)"
+                );
+                return Ok(GateDecision::deny(format!(
+                    "policy evaluation failed for {}: {e}",
+                    self.entrypoint
+                )));
+            }
+        };
 
-        serde_json::from_str::<GateDecision>(&decision_json).map_err(|e| {
-            GateError::Evaluation(format!(
-                "policy returned shape that isn't a GateDecision: {e} (got: {decision_json})"
-            ))
-        })
+        // regorus returns Value::Undefined when the rule exists but no branch
+        // matched without a default.  Treat undefined as deny.
+        if value == regorus::Value::Undefined {
+            return Ok(GateDecision::deny(format!(
+                "policy rule {} is undefined for this input",
+                self.entrypoint
+            )));
+        }
+
+        let decision_json = value
+            .to_json_str()
+            .map_err(|e| GateError::Internal(format!("decision to_json: {e}")))?;
+
+        // A result that parses to a non-GateDecision shape (e.g. a boolean,
+        // plain string, or wrong object) is also treated as deny rather than
+        // propagating an Err.
+        match serde_json::from_str::<GateDecision>(&decision_json) {
+            Ok(decision) => Ok(decision),
+            Err(e) => {
+                tracing::warn!(
+                    entrypoint = %self.entrypoint,
+                    got = %decision_json,
+                    error = %e,
+                    "policy returned non-GateDecision shape — denying (fail-closed)"
+                );
+                Ok(GateDecision::deny(format!(
+                    "policy rule {} returned unrecognized shape: {decision_json}",
+                    self.entrypoint
+                )))
+            }
+        }
     }
 
     fn impl_name(&self) -> &'static str {

--- a/crates/khive-gate-rego/tests/integration.rs
+++ b/crates/khive-gate-rego/tests/integration.rs
@@ -175,6 +175,80 @@ fn default_entrypoint_constant_matches_doc() {
     assert_eq!(DEFAULT_ENTRYPOINT, "data.khive.gate.decision");
 }
 
+// ---- GATE-REGO-001: entrypoint trim/validation ----
+
+#[test]
+fn try_with_entrypoint_rejects_empty() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate.try_with_entrypoint("").unwrap_err();
+    assert!(
+        format!("{err}").contains("empty or whitespace"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn try_with_entrypoint_rejects_whitespace_only() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate.try_with_entrypoint("   ").unwrap_err();
+    assert!(
+        format!("{err}").contains("empty or whitespace"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn try_with_entrypoint_trims_whitespace_and_works() {
+    // The entrypoint has surrounding whitespace. After trim it must resolve
+    // to a valid data. path and the gate must evaluate correctly.
+    let policy = r#"
+        package khive.custom
+        import rego.v1
+        default verdict := {"decision": "deny", "reason": "custom default"}
+        verdict := {"decision": "allow", "obligations": []} if {
+            input.verb == "search"
+        }
+    "#;
+    let gate = RegoGate::from_policy_str(policy)
+        .unwrap()
+        .try_with_entrypoint("  data.khive.custom.verdict  ")
+        .expect("padded but valid entrypoint must be accepted");
+    // Debug output must show the trimmed form, not the padded original.
+    assert!(
+        format!("{gate:?}").contains("data.khive.custom.verdict"),
+        "Debug output did not contain trimmed entrypoint: {:?}",
+        gate
+    );
+    // And the gate must resolve correctly.
+    assert!(gate.check(&request("search")).unwrap().is_allow());
+    assert!(matches!(
+        gate.check(&request("delete")).unwrap(),
+        GateDecision::Deny { .. }
+    ));
+}
+
+#[test]
+fn try_with_entrypoint_rejects_missing_data_prefix() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate.try_with_entrypoint("khive.gate.decision").unwrap_err();
+    assert!(format!("{err}").contains("data."), "wrong error: {err}");
+}
+
 // ---------- helpers ----------
 
 struct TempDir {

--- a/crates/khive-gate-rego/tests/integration.rs
+++ b/crates/khive-gate-rego/tests/integration.rs
@@ -380,6 +380,38 @@ fn try_with_entrypoint_rejects_missing_data_prefix() {
     assert!(format!("{err}").contains("data."), "wrong error: {err}");
 }
 
+// ---- GATE-REGO-002: with_entrypoint trims whitespace ----
+
+#[test]
+fn with_entrypoint_trims_whitespace_and_allows() {
+    // with_entrypoint (infallible) must trim surrounding whitespace so that
+    // "  data.khive.gate  " behaves identically to "data.khive.gate.decision"
+    // when used with a matching policy.
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+        decision := {"decision": "allow", "obligations": []} if {
+            input.verb == "search"
+        }
+    "#;
+    let gate = RegoGate::from_policy_str(policy)
+        .unwrap()
+        .with_entrypoint("  data.khive.gate.decision  ");
+    // The stored entrypoint must be the trimmed form.
+    assert!(
+        format!("{gate:?}").contains("data.khive.gate.decision"),
+        "Debug output did not contain trimmed entrypoint: {:?}",
+        gate
+    );
+    // Evaluation must work correctly with the trimmed entrypoint.
+    assert!(gate.check(&request("search")).unwrap().is_allow());
+    assert!(matches!(
+        gate.check(&request("delete")).unwrap(),
+        GateDecision::Deny { .. }
+    ));
+}
+
 // ---------- helpers ----------
 
 struct TempDir {

--- a/crates/khive-gate-rego/tests/integration.rs
+++ b/crates/khive-gate-rego/tests/integration.rs
@@ -119,8 +119,11 @@ fn malformed_policy_returns_policy_error() {
 }
 
 #[test]
-fn missing_entrypoint_surfaces_evaluation_error() {
-    // Compiles fine but has no `decision` rule.
+fn missing_entrypoint_returns_deny_not_error() {
+    // Compiles fine but has no `decision` rule — the default entrypoint
+    // data.khive.gate.decision will be absent.  check() must return
+    // Ok(Deny) rather than Err so the runtime's fail-open Err branch is
+    // never reached.
     let policy = r#"
         package khive.gate
         import rego.v1
@@ -128,15 +131,143 @@ fn missing_entrypoint_surfaces_evaluation_error() {
     "#;
     let gate = RegoGate::from_policy_str(policy).expect("compiles");
     let result = gate.check(&request("search"));
-    // regorus returns null for a missing rule; that becomes "not a GateDecision"
-    // → evaluation error.
     match result {
-        Err(e) => {
-            let msg = format!("{e}");
-            assert!(msg.contains("evaluation"), "wrong error variant: {msg}");
-        }
-        Ok(d) => panic!("expected evaluation error, got Ok({d:?})"),
+        Ok(GateDecision::Deny { .. }) => {}
+        Ok(GateDecision::Allow { .. }) => panic!("expected Deny, got Allow"),
+        Err(e) => panic!("expected Ok(Deny), got Err({e})"),
     }
+}
+
+#[test]
+fn try_with_entrypoint_rejects_rule_absent_from_policy() {
+    // Policy defines `verdict`, not `decision`.  Requesting `decision` as
+    // the entrypoint must fail at construction, not at first check().
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default verdict := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate
+        .try_with_entrypoint("data.khive.gate.decision")
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not a valid rule") || msg.contains("policy"),
+        "expected policy-error for absent rule, got: {msg}"
+    );
+}
+
+#[test]
+fn try_with_entrypoint_accepts_present_rule() {
+    let policy = r#"
+        package khive.custom
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+        decision := {"decision": "allow", "obligations": []} if {
+            input.verb == "search"
+        }
+    "#;
+    let gate = RegoGate::from_policy_str(policy)
+        .unwrap()
+        .try_with_entrypoint("data.khive.custom.decision")
+        .expect("rule exists — must be accepted");
+    assert!(gate.check(&request("search")).unwrap().is_allow());
+}
+
+#[test]
+fn try_with_entrypoint_rejects_malformed_data_dot_only() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate.try_with_entrypoint("data.").unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("empty path segment"),
+        "wrong error for 'data.': {msg}"
+    );
+}
+
+#[test]
+fn try_with_entrypoint_rejects_consecutive_dots() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate
+        .try_with_entrypoint("data.khive..gate.decision")
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("empty path segment"),
+        "wrong error for consecutive dots: {msg}"
+    );
+}
+
+#[test]
+fn try_with_entrypoint_rejects_trailing_dot() {
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := {"decision": "deny", "reason": "default"}
+    "#;
+    let gate = RegoGate::from_policy_str(policy).unwrap();
+    let err = gate
+        .try_with_entrypoint("data.khive.gate.decision.")
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("empty path segment"),
+        "wrong error for trailing dot: {msg}"
+    );
+}
+
+#[test]
+fn undefined_rule_result_returns_deny() {
+    // A rule that exists but has no default and no matching branch returns
+    // Value::Undefined from eval_rule.  check() must return Ok(Deny).
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        decision := {"decision": "allow", "obligations": []} if {
+            input.verb == "search"
+        }
+    "#;
+    let gate = RegoGate::from_policy_str(policy)
+        .unwrap()
+        .try_with_entrypoint("data.khive.gate.decision")
+        .expect("rule exists");
+    // verb != "search" → no branch matches → undefined
+    let result = gate.check(&request("delete")).unwrap();
+    assert!(
+        matches!(result, GateDecision::Deny { .. }),
+        "expected Deny for undefined result, got {result:?}"
+    );
+}
+
+#[test]
+fn wrong_shape_result_returns_deny() {
+    // A rule that returns a boolean instead of a GateDecision object.
+    // check() must return Ok(Deny) rather than Err.
+    let policy = r#"
+        package khive.gate
+        import rego.v1
+        default decision := true
+    "#;
+    let gate = RegoGate::from_policy_str(policy)
+        .unwrap()
+        .try_with_entrypoint("data.khive.gate.decision")
+        .expect("rule exists");
+    let result = gate.check(&request("search")).unwrap();
+    assert!(
+        matches!(result, GateDecision::Deny { .. }),
+        "expected Deny for wrong-shape result, got {result:?}"
+    );
 }
 
 #[test]

--- a/crates/khive-gate/src/error.rs
+++ b/crates/khive-gate/src/error.rs
@@ -16,6 +16,8 @@ pub enum GateValidationError {
     EmptyVerb,
     #[error("deny reason must not be empty")]
     EmptyDenyReason,
+    #[error("audit tag must not be empty")]
+    EmptyAuditTag,
     #[error("rate limit window_secs must be > 0")]
     ZeroRateLimitWindow,
     #[error("rate limit max must be > 0")]

--- a/crates/khive-gate/src/error.rs
+++ b/crates/khive-gate/src/error.rs
@@ -31,8 +31,6 @@ pub enum GateValidationError {
 pub enum GateError {
     #[error("policy error: {0}")]
     Policy(String),
-    #[error("evaluation error: {0}")]
-    Evaluation(String),
     #[error("internal gate error: {0}")]
     Internal(String),
     #[error("validation error: {0}")]

--- a/crates/khive-gate/src/obligation.rs
+++ b/crates/khive-gate/src/obligation.rs
@@ -46,7 +46,12 @@ impl TryFrom<RawObligation> for Obligation {
 
     fn try_from(raw: RawObligation) -> Result<Self, Self::Error> {
         match raw {
-            RawObligation::Audit { tag } => Ok(Obligation::Audit { tag }),
+            RawObligation::Audit { tag } => {
+                if tag.is_empty() {
+                    return Err(GateValidationError::EmptyAuditTag);
+                }
+                Ok(Obligation::Audit { tag })
+            }
             RawObligation::RateLimit { window_secs, max } => {
                 Obligation::try_rate_limit(window_secs, max)
             }

--- a/crates/khive-gate/src/tests.rs
+++ b/crates/khive-gate/src/tests.rs
@@ -306,6 +306,28 @@ fn deserialize_rejects_empty_deny_reason() {
     assert!(err.to_string().contains("deny reason must not be empty"));
 }
 
+// ---- GATE-006: Obligation::Audit rejects empty tag ----
+
+#[test]
+fn deserialize_rejects_empty_audit_tag() {
+    let json = r#"{"kind":"audit","tag":""}"#;
+    let err = serde_json::from_str::<Obligation>(json).unwrap_err();
+    assert!(
+        err.to_string().contains("audit tag must not be empty"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn deserialize_accepts_nonempty_audit_tag() {
+    let json = r#"{"kind":"audit","tag":"verb.search"}"#;
+    let obligation = serde_json::from_str::<Obligation>(json).unwrap();
+    match obligation {
+        Obligation::Audit { tag } => assert_eq!(tag, "verb.search"),
+        other => panic!("expected Audit, got {other:?}"),
+    }
+}
+
 #[test]
 fn deserialize_rejects_zero_rate_limit_window() {
     let json = r#"{"kind":"rate_limit","window_secs":0,"max":10}"#;

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -36,6 +36,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
+khive-gate-rego = { version = "0.2.8", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1876,9 +1876,11 @@ mod tests {
     /// never to proceed to the pack handler.
     ///
     /// This is the runtime-level assertion for the fix to security issue #30.
-    /// `RegoGate::check` converts evaluation errors and undefined results to
-    /// `Ok(GateDecision::Deny)`, so the runtime's fail-open `Err(_)` branch
-    /// is never reached and dispatch is blocked.
+    /// `RegoGate::check` converts all evaluation failures (missing rule,
+    /// undefined result, serialization error, poisoned engine) to
+    /// `Ok(GateDecision::Deny)`, so dispatch is blocked. The runtime's
+    /// fail-open `Err(_)` branch remains for non-evaluation gate errors
+    /// (e.g. infrastructure faults from other `Gate` implementations).
     #[tokio::test]
     async fn rego_gate_missing_entrypoint_returns_permission_denied() {
         use khive_gate_rego::RegoGate;

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1869,6 +1869,44 @@ mod tests {
         assert_eq!(ev.actor.kind, "anonymous");
     }
 
+    // ---- Rego gate: fail-closed end-to-end (issue #30) ----
+
+    /// A `RegoGate` whose policy lacks the named entrypoint rule must cause
+    /// `VerbRegistry::dispatch` to return `RuntimeError::PermissionDenied` —
+    /// never to proceed to the pack handler.
+    ///
+    /// This is the runtime-level assertion for the fix to security issue #30.
+    /// `RegoGate::check` converts evaluation errors and undefined results to
+    /// `Ok(GateDecision::Deny)`, so the runtime's fail-open `Err(_)` branch
+    /// is never reached and dispatch is blocked.
+    #[tokio::test]
+    async fn rego_gate_missing_entrypoint_returns_permission_denied() {
+        use khive_gate_rego::RegoGate;
+
+        // Policy defines `verdict` but NOT `data.khive.gate.decision` (the
+        // default entrypoint).  Construction succeeds — from_policy_str does
+        // not validate the default entrypoint.  check() must convert the
+        // missing-rule evaluation error to Ok(Deny) so the runtime denies
+        // the request rather than treating the Err as a fail-open signal.
+        let policy = r#"
+            package khive.gate
+            import rego.v1
+            verdict := "allow"
+        "#;
+        let gate = Arc::new(RegoGate::from_policy_str(policy).expect("policy compiles"));
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate);
+        let reg = builder.build().expect("registry builds");
+
+        let err = reg.dispatch("create", Value::Null).await.unwrap_err();
+        assert!(
+            matches!(err, RuntimeError::PermissionDenied { ref verb, .. } if verb == "create"),
+            "expected PermissionDenied for missing rego entrypoint, got {err:?}"
+        );
+    }
+
     // ---- Audit tracing emission ----
     //
     // The AuditCapturingGate tests above prove that AuditEvent::from_check is


### PR DESCRIPTION
## Summary

- GATE-REGO-001: `try_with_entrypoint` validated the trimmed entrypoint but stored the
  original untrimmed string. A padded value like `"  data.khive.gate.decision  "` passes
  validation yet causes a regorus rule lookup miss at eval time, producing
  `GateError::Evaluation` — which the dispatcher treats as an infrastructure failure and
  proceeds fail-open. Fix: pass `trimmed` (not `ep`) to `with_entrypoint`.
- GATE-006: `Obligation::Audit` deserialization accepted an empty `tag` without error,
  silently producing audit events with `tag=""` — a coverage hole. Added
  `GateValidationError::EmptyAuditTag` and reject empty tags in `TryFrom<RawObligation>`.

## Files changed

- `crates/khive-gate-rego/src/gate.rs` — 1-line fix: pass `trimmed` instead of `ep`
- `crates/khive-gate/src/error.rs` — add `EmptyAuditTag` variant to `GateValidationError`
- `crates/khive-gate/src/obligation.rs` — reject empty tag in `Audit` arm of `TryFrom`
- `crates/khive-gate-rego/tests/integration.rs` — 4 new tests (empty, whitespace, padded-valid, no-data-prefix)
- `crates/khive-gate/src/tests.rs` — 2 new tests (empty tag rejected, nonempty tag accepted)

## Test plan

- [x] `cargo test -p khive-gate -p khive-gate-rego`: 81 tests pass (35 + 32 + 14)
- [x] `cargo clippy -p khive-gate -p khive-gate-rego --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] Pre-commit hooks: all passed

Closes #30
