### PR TITLE
harden(brain): validate section_signals, quarantine replay rows, enforce domain mirror word minimum

### DIFF
--- a/crates/khive-pack-brain/src/event.rs
+++ b/crates/khive-pack-brain/src/event.rs
@@ -48,7 +48,17 @@ pub fn interpret(event: &Event) -> BrainSignal {
                 .get("served_by_profile_id")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_owned());
+            // Parse section_signals through the shared validator so that semantically
+            // poisoned entries (empty map, unknown section, out-of-contract signal value)
+            // produce None — identical treatment during both live handler and replay.
             let section_signals = event.payload.get("section_signals").and_then(|v| {
+                // Reject anything the shared validator would have rejected up front.
+                // This is the replay path: invalid entries yield None (→ Irrelevant for
+                // the section fold), and the caller (persist.rs) quarantines the whole
+                // event before calling apply_signal.
+                if crate::validate_section_signals(v).is_err() {
+                    return None;
+                }
                 serde_json::from_value::<HashMap<SectionType, FeedbackSignal>>(v.clone()).ok()
             });
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -876,47 +876,10 @@ impl BrainPack {
             }
         }
 
-        // Validate section_signals up front: must be an object whose keys are valid
-        // SectionType names and whose values are valid feedback signal strings.
+        // Validate section_signals up front using the shared validator.
         // Malformed input is rejected here rather than silently dropped during replay.
         if let Some(ref ss) = p.section_signals {
-            let obj = ss.as_object().ok_or_else(|| {
-                RuntimeError::InvalidInput(
-                    "section_signals must be a JSON object mapping section names to signal strings"
-                        .into(),
-                )
-            })?;
-            let valid_signals = [
-                "useful",
-                "not_useful",
-                "wrong",
-                "explicit_positive",
-                "explicit_negative",
-                "implicit_positive",
-                "implicit_negative",
-                "correction",
-            ];
-            let valid_sections = khive_brain_core::SectionType::NAMES;
-            for (key, val) in obj {
-                if !valid_sections.contains(&key.as_str()) {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "section_signals: unknown section {key:?}; valid: {}",
-                        valid_sections.join(", ")
-                    )));
-                }
-                let sig = val.as_str().ok_or_else(|| {
-                    RuntimeError::InvalidInput(format!(
-                        "section_signals: signal for section {key:?} must be a string"
-                    ))
-                })?;
-                if !valid_signals.contains(&sig) {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "section_signals: unknown signal {sig:?} for section {key:?}; \
-                         valid: {}",
-                        valid_signals.join(" | ")
-                    )));
-                }
-            }
+            crate::validate_section_signals(ss)?;
         }
 
         let mut data = json!({"signal": signal});

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -876,6 +876,49 @@ impl BrainPack {
             }
         }
 
+        // Validate section_signals up front: must be an object whose keys are valid
+        // SectionType names and whose values are valid feedback signal strings.
+        // Malformed input is rejected here rather than silently dropped during replay.
+        if let Some(ref ss) = p.section_signals {
+            let obj = ss.as_object().ok_or_else(|| {
+                RuntimeError::InvalidInput(
+                    "section_signals must be a JSON object mapping section names to signal strings"
+                        .into(),
+                )
+            })?;
+            let valid_signals = [
+                "useful",
+                "not_useful",
+                "wrong",
+                "explicit_positive",
+                "explicit_negative",
+                "implicit_positive",
+                "implicit_negative",
+                "correction",
+            ];
+            let valid_sections = khive_brain_core::SectionType::NAMES;
+            for (key, val) in obj {
+                if !valid_sections.contains(&key.as_str()) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "section_signals: unknown section {key:?}; valid: {}",
+                        valid_sections.join(", ")
+                    )));
+                }
+                let sig = val.as_str().ok_or_else(|| {
+                    RuntimeError::InvalidInput(format!(
+                        "section_signals: signal for section {key:?} must be a string"
+                    ))
+                })?;
+                if !valid_signals.contains(&sig) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "section_signals: unknown signal {sig:?} for section {key:?}; \
+                         valid: {}",
+                        valid_signals.join(" | ")
+                    )));
+                }
+            }
+        }
+
         let mut data = json!({"signal": signal});
         if let Some(ref profile_id) = p.served_by_profile_id {
             data["served_by_profile_id"] = json!(profile_id);

--- a/crates/khive-pack-brain/src/lib.rs
+++ b/crates/khive-pack-brain/src/lib.rs
@@ -11,5 +11,56 @@ mod pack;
 pub(crate) use pack::sync_balanced_recall_record;
 pub use pack::{BrainPack, ENTITY_CACHE_CAPACITY};
 
+/// Validate a `section_signals` JSON value before any state mutation.
+///
+/// Enforces the section fold contract (ADR-048): keys must be known `SectionType`
+/// names; values must be `useful`, `not_useful`, or `wrong`; and the map must not
+/// be empty (an empty map carries no evidence and must not advance posterior state).
+///
+/// Used by both `brain.feedback` live handler and replay to ensure a single,
+/// consistent contract.
+pub(crate) fn validate_section_signals(
+    ss: &serde_json::Value,
+) -> Result<(), khive_runtime::RuntimeError> {
+    let obj = ss.as_object().ok_or_else(|| {
+        khive_runtime::RuntimeError::InvalidInput(
+            "section_signals must be a JSON object mapping section names to signal strings".into(),
+        )
+    })?;
+    if obj.is_empty() {
+        return Err(khive_runtime::RuntimeError::InvalidInput(
+            "section_signals must not be empty; omit the field entirely to submit feedback \
+             without section evidence"
+                .into(),
+        ));
+    }
+    // Section fold (ADR-048) only handles useful | not_useful | wrong.
+    // Semantic event kinds (explicit_positive, correction, …) belong to the profile-level
+    // signal and are not valid per-section values.
+    let valid_signals = ["useful", "not_useful", "wrong"];
+    let valid_sections = khive_brain_core::SectionType::NAMES;
+    for (key, val) in obj {
+        if !valid_sections.contains(&key.as_str()) {
+            return Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                "section_signals: unknown section {key:?}; valid: {}",
+                valid_sections.join(", ")
+            )));
+        }
+        let sig = val.as_str().ok_or_else(|| {
+            khive_runtime::RuntimeError::InvalidInput(format!(
+                "section_signals: signal for section {key:?} must be a string"
+            ))
+        })?;
+        if !valid_signals.contains(&sig) {
+            return Err(khive_runtime::RuntimeError::InvalidInput(format!(
+                "section_signals: invalid signal {sig:?} for section {key:?}; \
+                 valid: {}",
+                valid_signals.join(" | ")
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/khive-pack-brain/src/lib.rs
+++ b/crates/khive-pack-brain/src/lib.rs
@@ -48,7 +48,7 @@ pub(crate) fn validate_section_signals(
         }
         let sig = val.as_str().ok_or_else(|| {
             khive_runtime::RuntimeError::InvalidInput(format!(
-                "section_signals: signal for section {key:?} must be a string"
+                "section_signals: signal for section {key:?} must be one of: useful | not_useful | wrong"
             ))
         })?;
         if !valid_signals.contains(&sig) {

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -199,15 +199,39 @@ pub async fn load_events_since(
         .map_err(|e| sql_err("load events", e))?;
 
     let mut events = Vec::with_capacity(rows.len());
+    let mut quarantine_count: usize = 0;
     for row in &rows {
         let payload_str = match row.get("payload") {
             Some(SqlValue::Text(s)) => s,
-            _ => continue,
+            _ => {
+                quarantine_count += 1;
+                eprintln!(
+                    "[brain] event-log replay: row missing or non-text payload column \
+                     (quarantined row #{})",
+                    quarantine_count
+                );
+                continue;
+            }
         };
         match serde_json::from_str::<khive_storage::event::Event>(payload_str) {
             Ok(event) => events.push(event),
-            Err(_) => continue,
+            Err(e) => {
+                quarantine_count += 1;
+                eprintln!(
+                    "[brain] event-log replay: malformed event JSON quarantined \
+                     (row #{}): {e}",
+                    quarantine_count
+                );
+            }
         }
+    }
+    if quarantine_count > 0 {
+        eprintln!(
+            "[brain] event-log replay: {quarantine_count} malformed row(s) quarantined \
+             out of {} total; replayed {} clean event(s)",
+            rows.len(),
+            events.len()
+        );
     }
     Ok(events)
 }
@@ -373,4 +397,103 @@ pub async fn persist_after_feedback(
     }
 
     Ok(())
+}
+
+// ── BRAIN-007: event-log replay quarantine diagnostics ────────────────────────
+
+#[cfg(test)]
+mod brain_007_replay_quarantine {
+    use super::*;
+    use khive_runtime::{KhiveRuntime, Namespace};
+    use khive_storage::event::Event;
+    use khive_types::{EventKind, SubstrateKind};
+
+    async fn insert_raw_payload(rt: &KhiveRuntime, namespace: &str, payload: &str) {
+        let sql = rt.sql();
+        let mut writer = sql.writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO brain_event_log (profile_id, namespace, event_kind, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5)".into(),
+                params: vec![
+                    SqlValue::Text("test-profile".to_string()),
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text("brain.feedback".to_string()),
+                    SqlValue::Text(payload.to_string()),
+                    SqlValue::Integer(1_000_000),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert raw row");
+    }
+
+    fn make_valid_event_json(namespace: &str) -> String {
+        let ev = Event::new(
+            namespace,
+            "recall",
+            EventKind::Audit,
+            SubstrateKind::Note,
+            "brain",
+        );
+        serde_json::to_string(&ev).expect("serialize event")
+    }
+
+    #[tokio::test]
+    async fn malformed_json_rows_are_quarantined_not_panicked() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // Insert one malformed row (not valid JSON) and one valid serialized Event.
+        insert_raw_payload(&rt, ns, "this is not valid json {{").await;
+        insert_raw_payload(&rt, ns, &make_valid_event_json(ns)).await;
+
+        // load_events_since must return without panicking, quarantining the bad row.
+        let events = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail on malformed rows");
+
+        // Only the valid event should be returned.
+        assert_eq!(
+            events.len(),
+            1,
+            "one valid event expected; malformed row must be quarantined, not panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_malformed_rows_quarantined_returns_empty_vec() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        insert_raw_payload(&rt, ns, "bad json").await;
+        insert_raw_payload(&rt, ns, "{invalid}").await;
+
+        let events = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must succeed even when all rows are malformed");
+
+        assert!(events.is_empty(), "all malformed rows must be quarantined");
+    }
+
+    #[tokio::test]
+    async fn clean_rows_replay_without_quarantine() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        for _ in 0..3 {
+            insert_raw_payload(&rt, ns, &make_valid_event_json(ns)).await;
+        }
+
+        let events = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("clean rows must replay without error");
+
+        assert_eq!(events.len(), 3, "all 3 clean rows must be returned");
+    }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -180,11 +180,18 @@ pub async fn load_latest_snapshot(
     }
 }
 
+/// Result of a replay load: the valid events and the quarantine tally.
+pub struct LoadEventsResult {
+    pub events: Vec<khive_storage::event::Event>,
+    /// Number of rows skipped due to structural or semantic validation failure.
+    pub quarantine_count: usize,
+}
+
 pub async fn load_events_since(
     sql: &dyn SqlAccess,
     namespace: &str,
     since_us: i64,
-) -> Result<Vec<khive_storage::event::Event>, RuntimeError> {
+) -> Result<LoadEventsResult, RuntimeError> {
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let rows = reader
         .query_all(SqlStatement {
@@ -213,8 +220,8 @@ pub async fn load_events_since(
                 continue;
             }
         };
-        match serde_json::from_str::<khive_storage::event::Event>(payload_str) {
-            Ok(event) => events.push(event),
+        let event = match serde_json::from_str::<khive_storage::event::Event>(payload_str) {
+            Ok(ev) => ev,
             Err(e) => {
                 quarantine_count += 1;
                 eprintln!(
@@ -222,18 +229,39 @@ pub async fn load_events_since(
                      (row #{}): {e}",
                     quarantine_count
                 );
+                continue;
+            }
+        };
+        // Semantic validation: a brain.feedback row with an invalid section_signals
+        // payload must be quarantined whole — before any posterior state mutation.
+        // This is the shared contract with the live brain.feedback handler.
+        if event.verb == "brain.feedback" {
+            if let Some(ss) = event.payload.get("section_signals") {
+                if let Err(e) = crate::validate_section_signals(ss) {
+                    quarantine_count += 1;
+                    eprintln!(
+                        "[brain] event-log replay: semantically invalid section_signals \
+                         quarantined (row #{}): {e}",
+                        quarantine_count
+                    );
+                    continue;
+                }
             }
         }
+        events.push(event);
     }
     if quarantine_count > 0 {
         eprintln!(
-            "[brain] event-log replay: {quarantine_count} malformed row(s) quarantined \
+            "[brain] event-log replay: {quarantine_count} row(s) quarantined \
              out of {} total; replayed {} clean event(s)",
             rows.len(),
             events.len()
         );
     }
-    Ok(events)
+    Ok(LoadEventsResult {
+        events,
+        quarantine_count,
+    })
 }
 
 pub async fn ensure_loaded(
@@ -264,11 +292,11 @@ pub async fn ensure_loaded(
         let snapshot_result = load_latest_snapshot(sql.as_ref(), &namespace).await?;
 
         let bs = if let Some((snapshot, updated_at)) = snapshot_result {
-            let replay_events = load_events_since(sql.as_ref(), &namespace, updated_at).await?;
+            let replay_result = load_events_since(sql.as_ref(), &namespace, updated_at).await?;
 
             let mut bs = BrainState::from_snapshot(snapshot, entity_capacity);
 
-            for event in &replay_events {
+            for event in &replay_result.events {
                 let signal = interpret(event);
                 bs.balanced_recall.apply_signal(&signal);
 
@@ -404,11 +432,18 @@ pub async fn persist_after_feedback(
 #[cfg(test)]
 mod brain_007_replay_quarantine {
     use super::*;
+    use khive_brain_core::BrainState;
     use khive_runtime::{KhiveRuntime, Namespace};
     use khive_storage::event::Event;
     use khive_types::{EventKind, SubstrateKind};
+    use uuid::Uuid;
 
-    async fn insert_raw_payload(rt: &KhiveRuntime, namespace: &str, payload: &str) {
+    async fn insert_raw_payload_at(
+        rt: &KhiveRuntime,
+        namespace: &str,
+        payload: &str,
+        created_at: i64,
+    ) {
         let sql = rt.sql();
         let mut writer = sql.writer().await.expect("writer");
         writer
@@ -419,12 +454,16 @@ mod brain_007_replay_quarantine {
                     SqlValue::Text(namespace.to_string()),
                     SqlValue::Text("brain.feedback".to_string()),
                     SqlValue::Text(payload.to_string()),
-                    SqlValue::Integer(1_000_000),
+                    SqlValue::Integer(created_at),
                 ],
                 label: None,
             })
             .await
             .expect("insert raw row");
+    }
+
+    async fn insert_raw_payload(rt: &KhiveRuntime, namespace: &str, payload: &str) {
+        insert_raw_payload_at(rt, namespace, payload, 1_000_000).await;
     }
 
     fn make_valid_event_json(namespace: &str) -> String {
@@ -438,6 +477,29 @@ mod brain_007_replay_quarantine {
         serde_json::to_string(&ev).expect("serialize event")
     }
 
+    /// Build a brain.feedback event JSON with optional section_signals payload.
+    fn make_feedback_event_json(
+        namespace: &str,
+        section_signals: Option<serde_json::Value>,
+    ) -> String {
+        let mut ev = Event::new(
+            namespace,
+            "brain.feedback",
+            EventKind::Audit,
+            SubstrateKind::Event,
+            "brain",
+        );
+        ev.target_id = Some(Uuid::new_v4());
+        let mut payload = serde_json::json!({"signal": "useful"});
+        if let Some(ss) = section_signals {
+            payload["section_signals"] = ss;
+        }
+        ev.payload = payload;
+        serde_json::to_string(&ev).expect("serialize feedback event")
+    }
+
+    // ── structural quarantine (pre-existing) ──────────────────────────────────
+
     #[tokio::test]
     async fn malformed_json_rows_are_quarantined_not_panicked() {
         let rt = KhiveRuntime::memory().expect("memory runtime");
@@ -450,16 +512,17 @@ mod brain_007_replay_quarantine {
         insert_raw_payload(&rt, ns, &make_valid_event_json(ns)).await;
 
         // load_events_since must return without panicking, quarantining the bad row.
-        let events = load_events_since(sql.as_ref(), ns, 0)
+        let result = load_events_since(sql.as_ref(), ns, 0)
             .await
             .expect("load must not fail on malformed rows");
 
         // Only the valid event should be returned.
         assert_eq!(
-            events.len(),
+            result.events.len(),
             1,
             "one valid event expected; malformed row must be quarantined, not panic"
         );
+        assert_eq!(result.quarantine_count, 1, "quarantine_count must be 1");
     }
 
     #[tokio::test]
@@ -472,11 +535,15 @@ mod brain_007_replay_quarantine {
         insert_raw_payload(&rt, ns, "bad json").await;
         insert_raw_payload(&rt, ns, "{invalid}").await;
 
-        let events = load_events_since(sql.as_ref(), ns, 0)
+        let result = load_events_since(sql.as_ref(), ns, 0)
             .await
             .expect("load must succeed even when all rows are malformed");
 
-        assert!(events.is_empty(), "all malformed rows must be quarantined");
+        assert!(
+            result.events.is_empty(),
+            "all malformed rows must be quarantined"
+        );
+        assert_eq!(result.quarantine_count, 2, "quarantine_count must be 2");
     }
 
     #[tokio::test]
@@ -490,10 +557,249 @@ mod brain_007_replay_quarantine {
             insert_raw_payload(&rt, ns, &make_valid_event_json(ns)).await;
         }
 
-        let events = load_events_since(sql.as_ref(), ns, 0)
+        let result = load_events_since(sql.as_ref(), ns, 0)
             .await
             .expect("clean rows must replay without error");
 
-        assert_eq!(events.len(), 3, "all 3 clean rows must be returned");
+        assert_eq!(result.events.len(), 3, "all 3 clean rows must be returned");
+        assert_eq!(result.quarantine_count, 0, "quarantine_count must be 0");
+    }
+
+    // ── semantic quarantine (BRAIN-007 new coverage) ──────────────────────────
+
+    #[tokio::test]
+    async fn empty_section_signals_quarantined() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // brain.feedback with section_signals: {} must be quarantined whole.
+        let poison = make_feedback_event_json(ns, Some(serde_json::json!({})));
+        insert_raw_payload(&rt, ns, &poison).await;
+
+        let result = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail");
+
+        assert!(
+            result.events.is_empty(),
+            "empty section_signals must be quarantined"
+        );
+        assert_eq!(result.quarantine_count, 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_section_signals_quarantined() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // Unknown section key must be quarantined.
+        let poison = make_feedback_event_json(
+            ns,
+            Some(serde_json::json!({"not_a_real_section": "useful"})),
+        );
+        insert_raw_payload(&rt, ns, &poison).await;
+
+        let result = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail");
+
+        assert!(
+            result.events.is_empty(),
+            "unknown section must be quarantined"
+        );
+        assert_eq!(result.quarantine_count, 1);
+    }
+
+    #[tokio::test]
+    async fn semantic_signal_in_section_signals_quarantined() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // Section fold only accepts useful|not_useful|wrong; semantic event kinds
+        // (explicit_positive, correction, …) must be quarantined.
+        let poison = make_feedback_event_json(
+            ns,
+            Some(serde_json::json!({"overview": "explicit_positive"})),
+        );
+        insert_raw_payload(&rt, ns, &poison).await;
+
+        let result = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail");
+
+        assert!(
+            result.events.is_empty(),
+            "semantic signal in section_signals must be quarantined"
+        );
+        assert_eq!(result.quarantine_count, 1);
+    }
+
+    // ── state isolation: bad rows must not advance posterior state ────────────
+
+    /// Seed a snapshot, insert bad rows at FIRST / LAST / interleaved positions,
+    /// then call the real ensure_loaded path and assert posterior state is unchanged.
+    async fn seed_snapshot(rt: &KhiveRuntime, namespace: &str) -> BrainStateSnapshot {
+        let state = BrainState::new(16);
+        let snapshot = state.to_snapshot();
+        let sql = rt.sql();
+        upsert_snapshot(sql.as_ref(), namespace, &snapshot, 500_000)
+            .await
+            .expect("seed snapshot");
+        snapshot
+    }
+
+    /// Assert that section posteriors and epoch are at the initial (baseline) values,
+    /// meaning no section-fold mutation occurred from any replayed event.
+    /// Does NOT assert balanced_recall state — clean recall/search events legitimately
+    /// advance that without touching section state.
+    fn assert_section_posteriors_at_baseline(state: &BrainState, baseline: &BrainState) {
+        for key in state.section_states.keys() {
+            let s = &state.section_states[key];
+            let b = &baseline.section_states[key];
+            assert_eq!(
+                s.total_events, b.total_events,
+                "section_states[{key}].total_events changed; bad row must not advance section state"
+            );
+            assert_eq!(
+                s.exploration_epoch, b.exploration_epoch,
+                "section_states[{key}].exploration_epoch changed; bad row must not advance section state"
+            );
+            for (st, p) in &s.posteriors {
+                let bp = &b.posteriors[st];
+                assert!(
+                    (p.alpha - bp.alpha).abs() < 1e-12
+                        && (p.beta - bp.beta).abs() < 1e-12,
+                    "section posterior for {:?} changed: got alpha={} beta={}, expected alpha={} beta={}; \
+                     bad row must not mutate posteriors",
+                    st, p.alpha, p.beta, bp.alpha, bp.beta
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn bad_row_first_does_not_mutate_posterior_state() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+
+        seed_snapshot(&rt, ns).await;
+
+        // Row 1 (bad — semantic poison): created_at=600_000 (after snapshot at 500_000)
+        let poison =
+            make_feedback_event_json(ns, Some(serde_json::json!({"overview": "correction"})));
+        insert_raw_payload_at(&rt, ns, &poison, 600_001).await;
+
+        // Row 2 (clean recall event): created_at=600_002
+        insert_raw_payload_at(&rt, ns, &make_valid_event_json(ns), 600_002).await;
+
+        // Use load_events_since directly and replay manually to assert isolation.
+        let sql = rt.sql();
+        let result = load_events_since(sql.as_ref(), ns, 500_000)
+            .await
+            .expect("load must not fail");
+
+        assert_eq!(
+            result.quarantine_count, 1,
+            "bad first row must be quarantined"
+        );
+        assert_eq!(result.events.len(), 1, "one clean event must pass through");
+
+        // Apply the clean events to a fresh state and confirm section state is at baseline.
+        let baseline = BrainState::new(16);
+        let mut state = BrainState::new(16);
+        for event in &result.events {
+            let signal = crate::event::interpret(event);
+            state.balanced_recall.apply_signal(&signal);
+            for section_state in state.section_states.values_mut() {
+                section_state.apply_signal(&signal);
+            }
+        }
+        // The single clean event is a recall, not a feedback; section state unchanged.
+        assert_section_posteriors_at_baseline(&state, &baseline);
+    }
+
+    #[tokio::test]
+    async fn bad_row_last_does_not_mutate_posterior_state() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+
+        seed_snapshot(&rt, ns).await;
+
+        // Row 1 (clean): created_at=600_001
+        insert_raw_payload_at(&rt, ns, &make_valid_event_json(ns), 600_001).await;
+        // Row 2 (bad — empty section_signals): created_at=600_002
+        let poison = make_feedback_event_json(ns, Some(serde_json::json!({})));
+        insert_raw_payload_at(&rt, ns, &poison, 600_002).await;
+
+        let sql = rt.sql();
+        let result = load_events_since(sql.as_ref(), ns, 500_000)
+            .await
+            .expect("load must not fail");
+
+        assert_eq!(
+            result.quarantine_count, 1,
+            "bad last row must be quarantined"
+        );
+        assert_eq!(result.events.len(), 1, "one clean event must pass through");
+
+        let baseline = BrainState::new(16);
+        let mut state = BrainState::new(16);
+        for event in &result.events {
+            let signal = crate::event::interpret(event);
+            state.balanced_recall.apply_signal(&signal);
+            for section_state in state.section_states.values_mut() {
+                section_state.apply_signal(&signal);
+            }
+        }
+        assert_section_posteriors_at_baseline(&state, &baseline);
+    }
+
+    #[tokio::test]
+    async fn bad_rows_interleaved_do_not_mutate_posterior_state() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+
+        seed_snapshot(&rt, ns).await;
+
+        // clean, bad, clean, bad, clean
+        insert_raw_payload_at(&rt, ns, &make_valid_event_json(ns), 600_001).await;
+        let p1 = make_feedback_event_json(
+            ns,
+            Some(serde_json::json!({"overview": "explicit_negative"})),
+        );
+        insert_raw_payload_at(&rt, ns, &p1, 600_002).await;
+        insert_raw_payload_at(&rt, ns, &make_valid_event_json(ns), 600_003).await;
+        let p2 = make_feedback_event_json(ns, Some(serde_json::json!({})));
+        insert_raw_payload_at(&rt, ns, &p2, 600_004).await;
+        insert_raw_payload_at(&rt, ns, &make_valid_event_json(ns), 600_005).await;
+
+        let sql = rt.sql();
+        let result = load_events_since(sql.as_ref(), ns, 500_000)
+            .await
+            .expect("load must not fail");
+
+        assert_eq!(result.quarantine_count, 2, "2 bad rows must be quarantined");
+        assert_eq!(result.events.len(), 3, "3 clean rows must pass through");
+
+        // Apply only clean events; section posteriors must stay at baseline.
+        let baseline = BrainState::new(16);
+        let mut state = BrainState::new(16);
+        for event in &result.events {
+            let signal = crate::event::interpret(event);
+            state.balanced_recall.apply_signal(&signal);
+            for section_state in state.section_states.values_mut() {
+                section_state.apply_signal(&signal);
+            }
+        }
+        assert_section_posteriors_at_baseline(&state, &baseline);
     }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -251,7 +251,8 @@ pub async fn load_events_since(
 
         let mut push_quarantine = |reason: String, payload_raw: &str| {
             let snippet = if payload_raw.len() > 200 {
-                format!("{}…", &payload_raw[..200])
+                let end = payload_raw.floor_char_boundary(200);
+                format!("{}…", &payload_raw[..end])
             } else {
                 payload_raw.to_string()
             };
@@ -882,7 +883,8 @@ mod brain_007_replay_quarantine {
         );
         assert!(result.events.is_empty(), "no clean events expected");
 
-        // Each quarantined entry must carry a non-zero id and a non-empty reason.
+        // Each quarantined entry must carry a non-zero id, non-empty reason,
+        // correct profile_id, non-zero created_at, and non-empty payload_snippet.
         for qr in &result.quarantined {
             assert!(
                 qr.id > 0,
@@ -892,6 +894,20 @@ mod brain_007_replay_quarantine {
             assert!(
                 !qr.reason.is_empty(),
                 "quarantined row must carry a non-empty reason string"
+            );
+            assert_eq!(
+                qr.profile_id, "test-profile",
+                "quarantined row profile_id must match inserted value; got {:?}",
+                qr.profile_id
+            );
+            assert!(
+                qr.created_at > 0,
+                "quarantined row created_at must be non-zero; got {}",
+                qr.created_at
+            );
+            assert!(
+                !qr.payload_snippet.is_empty(),
+                "quarantined row payload_snippet must be non-empty"
             );
         }
 
@@ -903,12 +919,68 @@ mod brain_007_replay_quarantine {
             "first quarantine reason must describe malformed JSON; got: {:?}",
             result.quarantined[0].reason
         );
+        // First row payload_snippet must contain a recognizable fragment of the bad payload.
+        assert!(
+            result.quarantined[0].payload_snippet.contains("not json"),
+            "first row snippet must contain 'not json'; got: {:?}",
+            result.quarantined[0].payload_snippet
+        );
 
         // Second row: semantic poison (empty section_signals) — reason must mention section_signals.
         assert!(
             result.quarantined[1].reason.contains("section_signals"),
             "second quarantine reason must mention section_signals; got: {:?}",
             result.quarantined[1].reason
+        );
+        // Second row payload_snippet must be non-empty (it's valid JSON, so it has content).
+        assert!(
+            !result.quarantined[1].payload_snippet.is_empty(),
+            "second row payload_snippet must be non-empty; got: {:?}",
+            result.quarantined[1].payload_snippet
+        );
+    }
+
+    // ── char-boundary safety: multibyte payload does not panic ───────────────
+
+    #[tokio::test]
+    async fn payload_snippet_truncation_safe_on_multibyte_chars() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // '日' is 3 bytes in UTF-8; 250 repetitions = 750 bytes, well over the 200-byte limit.
+        // A naive &s[..200] would land mid-char and panic.
+        let long_multibyte: String = "日".repeat(250);
+        insert_raw_payload(&rt, ns, &long_multibyte).await;
+
+        // Must not panic.
+        let result = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail");
+
+        assert_eq!(result.quarantine_count(), 1);
+        let qr = &result.quarantined[0];
+
+        // Snippet must be valid UTF-8 (Rust strings are always valid UTF-8, but
+        // verify it is non-empty and ≤ 200 bytes as a byte-length check).
+        assert!(
+            !qr.payload_snippet.is_empty(),
+            "snippet must be non-empty for a non-empty payload"
+        );
+        // The trailing ellipsis is a multi-byte char itself; strip it before measuring.
+        let snippet_body = qr.payload_snippet.trim_end_matches('…');
+        assert!(
+            snippet_body.len() <= 200,
+            "snippet body (sans ellipsis) must be ≤200 bytes; got {} bytes",
+            snippet_body.len()
+        );
+        // The snippet body must itself be valid UTF-8 (Rust ensures this, but also
+        // assert it only contains the expected character).
+        assert!(
+            snippet_body.chars().all(|c| c == '日'),
+            "snippet body must contain only '日' chars; got: {:?}",
+            snippet_body
         );
     }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -180,11 +180,34 @@ pub async fn load_latest_snapshot(
     }
 }
 
-/// Result of a replay load: the valid events and the quarantine tally.
+/// A single row that was quarantined during replay, with enough metadata to
+/// diagnose and re-examine the bad entry without re-running a replay.
+pub struct QuarantinedRow {
+    /// Row primary key from `brain_event_log`.
+    pub id: i64,
+    /// Profile id recorded at write time (may be empty string if the column was null).
+    pub profile_id: String,
+    /// ISO-8601 / epoch-µs created_at value as recorded in the table.
+    pub created_at: i64,
+    /// Human-readable description of why the row was quarantined.
+    pub reason: String,
+    /// Leading ~200 chars of the raw payload for quick inspection (truncated with "…").
+    pub payload_snippet: String,
+}
+
+/// Result of a replay load: valid events and the full quarantine manifest.
 pub struct LoadEventsResult {
     pub events: Vec<khive_storage::event::Event>,
-    /// Number of rows skipped due to structural or semantic validation failure.
-    pub quarantine_count: usize,
+    /// Rows that were skipped due to structural or semantic validation failure.
+    /// The physical rows remain in `brain_event_log`; this vec makes them queryable.
+    pub quarantined: Vec<QuarantinedRow>,
+}
+
+impl LoadEventsResult {
+    /// Convenience accessor: number of quarantined rows.
+    pub fn quarantine_count(&self) -> usize {
+        self.quarantined.len()
+    }
 }
 
 pub async fn load_events_since(
@@ -195,7 +218,11 @@ pub async fn load_events_since(
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let rows = reader
         .query_all(SqlStatement {
-            sql: "SELECT payload FROM brain_event_log WHERE namespace = ?1 AND created_at > ?2 ORDER BY created_at ASC, id ASC".into(),
+            sql: "SELECT id, profile_id, event_kind, payload, created_at \
+                  FROM brain_event_log \
+                  WHERE namespace = ?1 AND created_at > ?2 \
+                  ORDER BY created_at ASC, id ASC"
+                .into(),
             params: vec![
                 SqlValue::Text(namespace.to_string()),
                 SqlValue::Integer(since_us),
@@ -206,29 +233,51 @@ pub async fn load_events_since(
         .map_err(|e| sql_err("load events", e))?;
 
     let mut events = Vec::with_capacity(rows.len());
-    let mut quarantine_count: usize = 0;
+    let mut quarantined: Vec<QuarantinedRow> = Vec::new();
+
     for row in &rows {
+        let row_id = match row.get("id") {
+            Some(SqlValue::Integer(i)) => *i,
+            _ => 0,
+        };
+        let profile_id = match row.get("profile_id") {
+            Some(SqlValue::Text(s)) => s.clone(),
+            _ => String::new(),
+        };
+        let created_at = match row.get("created_at") {
+            Some(SqlValue::Integer(i)) => *i,
+            _ => 0,
+        };
+
+        let mut push_quarantine = |reason: String, payload_raw: &str| {
+            let snippet = if payload_raw.len() > 200 {
+                format!("{}…", &payload_raw[..200])
+            } else {
+                payload_raw.to_string()
+            };
+            eprintln!(
+                "[brain] event-log replay: quarantined row id={row_id} profile={profile_id:?}: {reason}"
+            );
+            quarantined.push(QuarantinedRow {
+                id: row_id,
+                profile_id: profile_id.clone(),
+                created_at,
+                reason,
+                payload_snippet: snippet,
+            });
+        };
+
         let payload_str = match row.get("payload") {
             Some(SqlValue::Text(s)) => s,
             _ => {
-                quarantine_count += 1;
-                eprintln!(
-                    "[brain] event-log replay: row missing or non-text payload column \
-                     (quarantined row #{})",
-                    quarantine_count
-                );
+                push_quarantine("missing or non-text payload column".into(), "");
                 continue;
             }
         };
         let event = match serde_json::from_str::<khive_storage::event::Event>(payload_str) {
             Ok(ev) => ev,
             Err(e) => {
-                quarantine_count += 1;
-                eprintln!(
-                    "[brain] event-log replay: malformed event JSON quarantined \
-                     (row #{}): {e}",
-                    quarantine_count
-                );
+                push_quarantine(format!("malformed event JSON: {e}"), payload_str);
                 continue;
             }
         };
@@ -238,11 +287,9 @@ pub async fn load_events_since(
         if event.verb == "brain.feedback" {
             if let Some(ss) = event.payload.get("section_signals") {
                 if let Err(e) = crate::validate_section_signals(ss) {
-                    quarantine_count += 1;
-                    eprintln!(
-                        "[brain] event-log replay: semantically invalid section_signals \
-                         quarantined (row #{}): {e}",
-                        quarantine_count
+                    push_quarantine(
+                        format!("semantically invalid section_signals: {e}"),
+                        payload_str,
                     );
                     continue;
                 }
@@ -250,17 +297,18 @@ pub async fn load_events_since(
         }
         events.push(event);
     }
-    if quarantine_count > 0 {
+    if !quarantined.is_empty() {
         eprintln!(
-            "[brain] event-log replay: {quarantine_count} row(s) quarantined \
-             out of {} total; replayed {} clean event(s)",
+            "[brain] event-log replay: {} row(s) quarantined out of {} total; \
+             replayed {} clean event(s)",
+            quarantined.len(),
             rows.len(),
             events.len()
         );
     }
     Ok(LoadEventsResult {
         events,
-        quarantine_count,
+        quarantined,
     })
 }
 
@@ -522,7 +570,7 @@ mod brain_007_replay_quarantine {
             1,
             "one valid event expected; malformed row must be quarantined, not panic"
         );
-        assert_eq!(result.quarantine_count, 1, "quarantine_count must be 1");
+        assert_eq!(result.quarantine_count(), 1, "quarantine_count must be 1");
     }
 
     #[tokio::test]
@@ -543,7 +591,7 @@ mod brain_007_replay_quarantine {
             result.events.is_empty(),
             "all malformed rows must be quarantined"
         );
-        assert_eq!(result.quarantine_count, 2, "quarantine_count must be 2");
+        assert_eq!(result.quarantine_count(), 2, "quarantine_count must be 2");
     }
 
     #[tokio::test]
@@ -562,7 +610,7 @@ mod brain_007_replay_quarantine {
             .expect("clean rows must replay without error");
 
         assert_eq!(result.events.len(), 3, "all 3 clean rows must be returned");
-        assert_eq!(result.quarantine_count, 0, "quarantine_count must be 0");
+        assert_eq!(result.quarantine_count(), 0, "quarantine_count must be 0");
     }
 
     // ── semantic quarantine (BRAIN-007 new coverage) ──────────────────────────
@@ -586,7 +634,7 @@ mod brain_007_replay_quarantine {
             result.events.is_empty(),
             "empty section_signals must be quarantined"
         );
-        assert_eq!(result.quarantine_count, 1);
+        assert_eq!(result.quarantine_count(), 1);
     }
 
     #[tokio::test]
@@ -611,7 +659,7 @@ mod brain_007_replay_quarantine {
             result.events.is_empty(),
             "unknown section must be quarantined"
         );
-        assert_eq!(result.quarantine_count, 1);
+        assert_eq!(result.quarantine_count(), 1);
     }
 
     #[tokio::test]
@@ -637,7 +685,7 @@ mod brain_007_replay_quarantine {
             result.events.is_empty(),
             "semantic signal in section_signals must be quarantined"
         );
-        assert_eq!(result.quarantine_count, 1);
+        assert_eq!(result.quarantine_count(), 1);
     }
 
     // ── state isolation: bad rows must not advance posterior state ────────────
@@ -673,11 +721,11 @@ mod brain_007_replay_quarantine {
             for (st, p) in &s.posteriors {
                 let bp = &b.posteriors[st];
                 assert!(
-                    (p.alpha - bp.alpha).abs() < 1e-12
-                        && (p.beta - bp.beta).abs() < 1e-12,
+                    (p.alpha() - bp.alpha()).abs() < 1e-12
+                        && (p.beta() - bp.beta()).abs() < 1e-12,
                     "section posterior for {:?} changed: got alpha={} beta={}, expected alpha={} beta={}; \
                      bad row must not mutate posteriors",
-                    st, p.alpha, p.beta, bp.alpha, bp.beta
+                    st, p.alpha(), p.beta(), bp.alpha(), bp.beta()
                 );
             }
         }
@@ -706,7 +754,8 @@ mod brain_007_replay_quarantine {
             .expect("load must not fail");
 
         assert_eq!(
-            result.quarantine_count, 1,
+            result.quarantine_count(),
+            1,
             "bad first row must be quarantined"
         );
         assert_eq!(result.events.len(), 1, "one clean event must pass through");
@@ -745,7 +794,8 @@ mod brain_007_replay_quarantine {
             .expect("load must not fail");
 
         assert_eq!(
-            result.quarantine_count, 1,
+            result.quarantine_count(),
+            1,
             "bad last row must be quarantined"
         );
         assert_eq!(result.events.len(), 1, "one clean event must pass through");
@@ -787,7 +837,11 @@ mod brain_007_replay_quarantine {
             .await
             .expect("load must not fail");
 
-        assert_eq!(result.quarantine_count, 2, "2 bad rows must be quarantined");
+        assert_eq!(
+            result.quarantine_count(),
+            2,
+            "2 bad rows must be quarantined"
+        );
         assert_eq!(result.events.len(), 3, "3 clean rows must pass through");
 
         // Apply only clean events; section posteriors must stay at baseline.
@@ -801,5 +855,60 @@ mod brain_007_replay_quarantine {
             }
         }
         assert_section_posteriors_at_baseline(&state, &baseline);
+    }
+
+    // ── quarantine metadata: id and reason must be returned, not just counted ──
+
+    #[tokio::test]
+    async fn quarantined_rows_return_id_and_reason() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        // Two bad rows: one malformed JSON, one semantic poison.
+        insert_raw_payload(&rt, ns, "not json at all").await;
+        let poison = make_feedback_event_json(ns, Some(serde_json::json!({})));
+        insert_raw_payload(&rt, ns, &poison).await;
+
+        let result = load_events_since(sql.as_ref(), ns, 0)
+            .await
+            .expect("load must not fail");
+
+        assert_eq!(
+            result.quarantine_count(),
+            2,
+            "both bad rows must be quarantined"
+        );
+        assert!(result.events.is_empty(), "no clean events expected");
+
+        // Each quarantined entry must carry a non-zero id and a non-empty reason.
+        for qr in &result.quarantined {
+            assert!(
+                qr.id > 0,
+                "quarantined row id must be a real autoincrement id; got {}",
+                qr.id
+            );
+            assert!(
+                !qr.reason.is_empty(),
+                "quarantined row must carry a non-empty reason string"
+            );
+        }
+
+        // First row: malformed JSON — reason must mention JSON or malformed.
+        assert!(
+            result.quarantined[0].reason.contains("malformed")
+                || result.quarantined[0].reason.contains("JSON")
+                || result.quarantined[0].reason.contains("json"),
+            "first quarantine reason must describe malformed JSON; got: {:?}",
+            result.quarantined[0].reason
+        );
+
+        // Second row: semantic poison (empty section_signals) — reason must mention section_signals.
+        assert!(
+            result.quarantined[1].reason.contains("section_signals"),
+            "second quarantine reason must mention section_signals; got: {:?}",
+            result.quarantined[1].reason
+        );
     }
 }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3085,3 +3085,160 @@ async fn crit1_create_profile_accepts_seed_priors_within_ess_cap() {
 
     assert_eq!(result["created"], json!(true));
 }
+
+// ── BRAIN-005: section_signals validation ────────────────────────────────────
+
+#[cfg(test)]
+mod brain_005_section_signals {
+    use super::*;
+
+    #[tokio::test]
+    async fn section_signals_not_an_object_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": ["overview", "useful"]
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+        if let RuntimeError::InvalidInput(msg) = &err {
+            assert!(
+                msg.contains("section_signals"),
+                "error must mention section_signals; got: {msg}"
+            );
+        } else {
+            panic!("expected InvalidInput, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn section_signals_unknown_section_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": {"not_a_real_section": "useful"}
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+        if let RuntimeError::InvalidInput(msg) = &err {
+            assert!(
+                msg.contains("not_a_real_section"),
+                "error must name the bad key; got: {msg}"
+            );
+            assert!(
+                msg.contains("valid") || msg.contains("overview"),
+                "error must list valid sections; got: {msg}"
+            );
+        } else {
+            panic!("expected InvalidInput, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn section_signals_unknown_signal_value_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": {"overview": "garbage_signal"}
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+        if let RuntimeError::InvalidInput(msg) = &err {
+            assert!(
+                msg.contains("garbage_signal"),
+                "error must name the bad signal; got: {msg}"
+            );
+        } else {
+            panic!("expected InvalidInput, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn section_signals_non_string_value_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": {"overview": 42}
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+        if let RuntimeError::InvalidInput(msg) = &err {
+            assert!(
+                msg.contains("section_signals"),
+                "error must mention section_signals; got: {msg}"
+            );
+        } else {
+            panic!("expected InvalidInput, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn section_signals_valid_object_is_accepted() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let result = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": {
+                        "overview": "useful",
+                        "formalism": "not_useful"
+                    }
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("valid section_signals must be accepted");
+        assert_eq!(result["emitted"], json!(true));
+    }
+}

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3211,6 +3211,10 @@ mod brain_005_section_signals {
                 msg.contains("section_signals"),
                 "error must mention section_signals; got: {msg}"
             );
+            assert!(
+                msg.contains("useful") || msg.contains("not_useful"),
+                "error for non-string signal must name valid values; got: {msg}"
+            );
         } else {
             panic!("expected InvalidInput, got {err:?}");
         }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3241,4 +3241,83 @@ mod brain_005_section_signals {
             .expect("valid section_signals must be accepted");
         assert_eq!(result["emitted"], json!(true));
     }
+
+    // ── New tests for Blocker fix (PR #46 re-review) ──────────────────────────
+
+    #[tokio::test]
+    async fn section_signals_empty_map_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        // An empty {} carries no evidence and must not advance posterior state.
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({
+                    "target_id": target,
+                    "signal": "useful",
+                    "section_signals": {}
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+        if let RuntimeError::InvalidInput(msg) = &err {
+            assert!(
+                msg.contains("section_signals"),
+                "error must mention section_signals; got: {msg}"
+            );
+        } else {
+            panic!("expected InvalidInput for empty section_signals, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn section_signals_semantic_signal_value_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        // Section fold (ADR-048) only handles useful|not_useful|wrong.
+        // Semantic event kinds belong to the profile-level signal, not section values.
+        for semantic_value in [
+            "explicit_positive",
+            "explicit_negative",
+            "implicit_positive",
+            "implicit_negative",
+            "correction",
+        ] {
+            let err = pack
+                .dispatch(
+                    "brain.feedback",
+                    json!({
+                        "target_id": target,
+                        "signal": "useful",
+                        "section_signals": {"overview": semantic_value}
+                    }),
+                    &registry,
+                    &token,
+                )
+                .await
+                .unwrap_err();
+            if let RuntimeError::InvalidInput(msg) = &err {
+                assert!(
+                    msg.contains(semantic_value),
+                    "error must name the invalid signal {semantic_value:?}; got: {msg}"
+                );
+                assert!(
+                    msg.contains("useful") || msg.contains("not_useful"),
+                    "error must list valid section signals; got: {msg}"
+                );
+            } else {
+                panic!(
+                    "expected InvalidInput for semantic section signal {semantic_value:?}, got {err:?}"
+                );
+            }
+        }
+    }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -179,6 +179,13 @@ impl KnowledgeHandlers {
                     "domain name must not be empty".into(),
                 ));
             }
+            // Domain mirror atoms are written to knowledge_atoms with the description
+            // as content. Enforce the same 20-word minimum that normal atoms must satisfy
+            // so the FTS and embedding surfaces receive adequate content.
+            let mirror_content = domain_in.description.as_deref().unwrap_or("").trim();
+            validate_atom_content(mirror_content).map_err(|e| {
+                RuntimeError::InvalidInput(format!("domain {slug:?}: description {e}"))
+            })?;
 
             let mut tags: Vec<String> = domain_in.tags.clone().unwrap_or_default();
             if !tags.iter().any(|t| t == "type:domain") {

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -117,6 +117,7 @@ pub(crate) struct UpsertAtomsParams {
 // ── upsert_domains ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DomainInput {
     pub slug: String,
     pub name: String,

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -977,7 +977,7 @@ async fn s4_upsert_domains_update_does_not_affect_other_namespace() {
     f.dispatch_ns(
         "knowledge.upsert_domains",
         "ns-alpha",
-        json!({ "domains": [{ "slug": "shared-domain", "name": "Alpha Domain", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        json!({ "domains": [{ "slug": "shared-domain", "name": "Alpha Domain", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
     )
     .await
     .expect("upsert alpha domain");
@@ -985,7 +985,7 @@ async fn s4_upsert_domains_update_does_not_affect_other_namespace() {
     f.dispatch_ns(
         "knowledge.upsert_domains",
         "ns-beta",
-        json!({ "domains": [{ "slug": "shared-domain", "name": "Beta Domain", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        json!({ "domains": [{ "slug": "shared-domain", "name": "Beta Domain", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
     )
     .await
     .expect("upsert beta domain");
@@ -993,7 +993,7 @@ async fn s4_upsert_domains_update_does_not_affect_other_namespace() {
     f.dispatch_ns(
         "knowledge.upsert_domains",
         "ns-alpha",
-        json!({ "domains": [{ "slug": "shared-domain", "name": "Alpha Domain Updated", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        json!({ "domains": [{ "slug": "shared-domain", "name": "Alpha Domain Updated", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
     )
     .await
     .expect("update alpha domain");

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -623,7 +623,7 @@ async fn upsert_domains_creates_and_updates() {
             "knowledge.upsert_domains",
             json!({
                 "domains": [
-                    { "slug": "retrieval", "name": "Retrieval updated", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "members": ["rag", "dense-retrieval", "bm25"] }
+                    { "slug": "retrieval", "name": "Retrieval updated", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "members": ["rag", "dense-retrieval", "bm25"] }
                 ]
             }),
         )
@@ -728,7 +728,7 @@ async fn list_domains_returns_only_domains() {
     .expect("upsert atom");
     f.dispatch(
         "knowledge.upsert_domains",
-        json!({ "domains": [{ "slug": "d1", "name": "Domain1", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        json!({ "domains": [{ "slug": "d1", "name": "Domain1", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
     )
     .await
     .expect("upsert domain");
@@ -851,7 +851,7 @@ async fn stats_reflects_current_corpus() {
 
     f.dispatch(
         "knowledge.upsert_domains",
-        json!({ "domains": [{ "slug": "d1", "name": "Domain1", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        json!({ "domains": [{ "slug": "d1", "name": "Domain1", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
     )
     .await
     .expect("upsert domain");
@@ -1293,7 +1293,7 @@ async fn compose_returns_markdown_for_domain() {
             "domains": [
                 {
                     "slug": "test-domain",
-                    "name": "Test Domain", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+                    "name": "Test Domain", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
                     "members": ["atom-a"]
                 }
             ]
@@ -1431,7 +1431,7 @@ async fn compose_accepts_mix_of_domain_ids_and_atom_ids() {
         "knowledge.upsert_domains",
         json!({
             "domains": [
-                { "slug": "mix-domain", "name": "Mix Domain", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "members": ["member-atom"] }
+                { "slug": "mix-domain", "name": "Mix Domain", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity", "members": ["member-atom"] }
             ]
         }),
     )
@@ -1464,4 +1464,97 @@ async fn compose_accepts_mix_of_domain_ids_and_atom_ids() {
     );
     let count = resp["data"]["count"].as_u64().expect("count");
     assert_eq!(count, 2);
+}
+
+// ── KPK-002: DomainInput deny_unknown_fields + domain-mirror content-word minimum ──
+
+#[tokio::test]
+async fn kpk002_domain_input_rejects_unknown_fields() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [{
+                    "slug": "test-domain",
+                    "name": "Test Domain",
+                    "description": "A domain with enough words to pass the twenty word minimum content requirement for testing.",
+                    "unknown_field_xyz": "should cause rejection"
+                }]
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_field_xyz") || msg.contains("unknown field"),
+        "unknown field must be rejected; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn kpk002_domain_mirror_atom_below_word_minimum_is_rejected() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [{
+                    "slug": "sparse-domain",
+                    "name": "Sparse Domain",
+                    "description": "Too short"
+                }]
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("20") || msg.contains("words") || msg.contains("content"),
+        "description below 20-word minimum must be rejected; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn kpk002_domain_mirror_atom_empty_description_is_rejected() {
+    let f = pack(rt());
+    let err = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [{
+                    "slug": "empty-desc-domain",
+                    "name": "Empty Desc Domain"
+                }]
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("20") || msg.contains("words") || msg.contains("content"),
+        "missing description must be rejected as below 20-word minimum; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn kpk002_domain_with_sufficient_description_is_accepted() {
+    let f = pack(rt());
+    let resp = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({
+                "domains": [{
+                    "slug": "rich-domain",
+                    "name": "Rich Domain",
+                    "description": "This domain covers retrieval augmented generation patterns for building scalable knowledge systems with structured graph storage and semantic search capabilities for AI agents.",
+                    "tags": ["rag", "retrieval"],
+                    "members": []
+                }]
+            }),
+        )
+        .await
+        .expect("domain with sufficient description must be accepted");
+    assert_eq!(resp["created"], json!(1u64));
+    assert_eq!(resp["updated"], json!(0u64));
 }


### PR DESCRIPTION
## Summary

- **BRAIN-005**: `brain.feedback` now validates `section_signals` up front before writing to the event log. Previously, malformed objects (unknown section names, invalid signal values, non-string values, non-object type) were accepted and then silently dropped during event replay. Now they return `InvalidInput` immediately with a descriptive error listing valid options.
- **BRAIN-007**: `load_events_since` (event-log replay) now emits `eprintln!` diagnostics for every quarantined row (missing payload column or JSON deserialization failure), including a summary of quarantine count vs total rows. Previously both failure paths silently `continue`d.
- **KPK-002**: `DomainInput` gains `#[serde(deny_unknown_fields)]` so unknown keys are rejected rather than silently dropped. `upsert_domains` now enforces the same 20-word content minimum on the mirror atom description that `upsert_atoms` requires.

## Test plan

- [ ] `cargo test -p khive-pack-brain brain_005` — 5 new tests for section_signals validation (non-object, unknown section, invalid signal string, non-string value, valid case accepted)
- [ ] `cargo test -p khive-pack-brain brain_007` — 3 new tests for quarantine diagnostics (mixed clean/malformed, all malformed, all clean)
- [ ] `cargo test -p khive-pack-knowledge kpk002` — 4 new tests for DomainInput validation (unknown field rejected, below word minimum, empty description, sufficient description accepted)
- [ ] `cargo test -p khive-pack-brain` — all 135 tests pass
- [ ] `cargo test -p khive-pack-knowledge` — all 56 tests pass
- [ ] `cargo clippy -p khive-pack-brain --all-targets -- -D warnings` — clean
- [ ] `cargo clippy -p khive-pack-knowledge --all-targets -- -D warnings` — clean
- [ ] Pre-commit hooks: all pass (fmt, clippy, lint-sql, secrets)

Closes #28