### PR TITLE
docs(adr): freshness pass — ADR-019/023/024/030/051 + design.md ref fixes

### DIFF
--- a/crates/khive-bm25/docs/design.md
+++ b/crates/khive-bm25/docs/design.md
@@ -2,9 +2,10 @@
 
 ## ADR Compliance
 
-### ADR-003: BM25 Configuration Defaults
+### ADR-030: BM25 Configuration Defaults
 
-- This crate implements the BM25 (Okapi BM25) keyword index with the Robertson-Walker IDF variant.
+- This crate implements the BM25 (Okapi BM25) keyword index with the Robertson-Walker IDF
+  variant, ported as part of the `khive-retrieval` stack (ADR-030: Retrieval Stack Port).
 - Default parameters: `k1 = 1.2` (term saturation), `b = 0.75` (length normalization).
 - These defaults reflect the canonical IR literature recommendations and are validated on
   construction — invalid (non-finite, negative `k1`, or out-of-range `b`) values are rejected.

--- a/crates/khive-fold/docs/design.md
+++ b/crates/khive-fold/docs/design.md
@@ -8,16 +8,16 @@
 
 ## Modules
 
-| Module | Purpose |
-|--------|---------|
-| `fold` | Deterministic reduce: entries → derived state |
-| `anchor` | Causal graph traversal (provenance chains) |
-| `objective` | Score candidates and select best (precision-weighted scoring) |
-| `selector` | Budget-constrained pack: many → subset |
-| `ordering` | Deterministic IEEE-754 ordering primitives |
+| Module       | Purpose                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| `fold`       | Deterministic reduce: entries → derived state                        |
+| `anchor`     | Causal graph traversal (provenance chains)                           |
+| `objective`  | Score candidates and select best (precision-weighted scoring)        |
+| `selector`   | Budget-constrained pack: many → subset                               |
+| `ordering`   | Deterministic IEEE-754 ordering primitives                           |
 | `checkpoint` | Generic snapshot envelope + in-memory store for fold-managed indexes |
-| `compose` | Composition combinators: filter, map, sequential, dual |
-| `pipeline` | ComposePipeline: objective scoring + selector budget packing |
+| `compose`    | Composition combinators: filter, map, sequential, dual               |
+| `pipeline`   | ComposePipeline: objective scoring + selector budget packing         |
 
 ## Key Invariants
 
@@ -48,18 +48,20 @@ The same rule applies to `Checkpoint::new` and `Checkpoint::with_hash`: `created
 set to the epoch on construction. Callers that need a real wall-clock timestamp should set
 `checkpoint.created_at = Utc::now()` after construction.
 
-### ADR-058: Selector Budget Packing
+### ADR-024 §"Bayesian extensions": Selector Budget Packing and Precision-Weighted Scoring
 
-`GreedySelector` implements priority-ordered budget packing with category-weight multipliers
+These behaviors are both specified in ADR-024 ("Fold Cognitive Primitives") under the
+§"Bayesian extensions" section. There are no separate ADR-058 or ADR-059 documents.
+
+**`GreedySelector`** implements priority-ordered budget packing with category-weight multipliers
 and deterministic tie-breaking (effective-score desc, size asc, id asc). The `diversity_bias`
 field controls how aggressively the selector prefers different categories at each pick step.
 At `diversity_bias = 0.0` the behavior reduces to a single-pass greedy sort (backward-compatible).
 
-### ADR-059: Epistemic (Precision-Weighted) Scoring
+**Precision-weighted scoring** — Both the `Objective` trait and the `Selector` implement
+precision-weighted scoring as specified in ADR-024:
 
-Both the `Objective` trait and the `Selector` implement precision-weighted scoring:
-
-**Objective**: The `precision()` hook returns an inverse-variance estimate in $(0, 1]$ for
+_Objective_: The `precision()` hook returns an inverse-variance estimate in $(0, 1]$ for
 each candidate's score. The default is 1.0 (fully trusted). The effective ranking score is
 
 $$\text{effective} = \text{score} \times \text{precision}$$
@@ -67,7 +69,7 @@ $$\text{effective} = \text{score} \times \text{precision}$$
 Non-finite precision falls back to 1.0. This allows objectives derived from uncertain models
 (e.g., embedding similarity) to discount their own scores.
 
-**Selector**: The `SelectorWeights.epistemic_weight` field adds an information-gain bonus to
+_Selector_: The `SelectorWeights.epistemic_weight` field adds an information-gain bonus to
 the pragmatic score. Effective selection score:
 
 $$\text{effective} = \text{pragmatic\_score} + \text{epistemic\_weight} \times \text{information\_gain}$$

--- a/crates/khive-fusion/docs/algorithm.md
+++ b/crates/khive-fusion/docs/algorithm.md
@@ -31,6 +31,7 @@ Does not cover storage, embedding, or retrieval engine internals.
 $$\text{score}(d) = \sum_{i} \frac{1}{k + \text{rank}_i(d)}$$
 
 where:
+
 - $k = 60$ (standard dampening constant — reduces dominance of rank-1 results)
 - $\text{rank}_i(d)$ = position of document $d$ in retriever $i$'s results (1-indexed)
 - If $d$ does not appear in retriever $i$, its contribution is 0
@@ -67,6 +68,7 @@ where $\hat{s}_i(d)$ is the min-max normalized score for document $d$ from sourc
 ### Weight normalization (RETRIEVAL-07)
 
 Weights are processed in this order before use:
+
 1. Non-finite values (`NaN`, `+Inf`, `-Inf`) are treated as `0.0`
 2. Negative values are treated as `0.0`
 3. If all effective weights are `<= 0`, equal distribution is applied
@@ -122,13 +124,13 @@ do not apply `top_k` truncation — they return the full fused list.
 
 ## Failure modes
 
-| Condition | Behavior |
-|-----------|----------|
-| Empty sources | Returns empty vec |
-| `top_k == 0` | Returns empty vec |
-| VectorOnly/KeywordOnly with multiple sources | Returns empty vec (wiring error) |
-| All-zero or all-negative weights | Falls back to equal weight distribution |
-| Non-finite weights in `weighted_fusion` | Treated as 0.0 (lossy); use `try_normalize_weights` to reject |
+| Condition                                    | Behavior                                                      |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| Empty sources                                | Returns empty vec                                             |
+| `top_k == 0`                                 | Returns empty vec                                             |
+| VectorOnly/KeywordOnly with multiple sources | Returns empty vec (wiring error)                              |
+| All-zero or all-negative weights             | Falls back to equal weight distribution                       |
+| Non-finite weights in `weighted_fusion`      | Treated as 0.0 (lossy); use `try_normalize_weights` to reject |
 
 ---
 

--- a/crates/khive-fusion/docs/design.md
+++ b/crates/khive-fusion/docs/design.md
@@ -2,22 +2,26 @@
 
 ## ADR Compliance
 
-### ADR-002: Edge Ontology
+### ADR-006: Deterministic Scoring — RRF rank indexing convention
+
 - The RRF implementation uses 1-indexed ranks throughout. Position 0 in an input list maps to
-  rank 1 in the RRF formula. This matches the convention stated in the edge ontology ADR where
-  rank positions are defined as 1-indexed.
+  rank 1 in the RRF formula, consistent with the `rrf_score` function in `khive-score`
+  (ADR-006: Deterministic Scoring).
 
 ### ADR-012: Retrieval Composition
+
 - This crate provides the fusion layer that combines ranked result lists from multiple retrieval
   sources. It is consumed by higher-level retrieval pipelines to aggregate dense (vector) and
   lexical (BM25) signals into a single ranked output.
 
 ### ADR-030: Hybrid Retrieval
+
 - The five `FusionStrategy` variants (RRF, Weighted, Union, VectorOnly, KeywordOnly) implement
   the hybrid retrieval strategy options specified for the system. RRF is the default as it is
   robust to score distribution differences between sources.
 
 ### ADR-031: Multi-Engine Retrieval
+
 - The `fuse()` dispatcher accepts results from any number of retrieval sources and routes them
   through the appropriate strategy. VectorOnly and KeywordOnly are single-source passthrough
   strategies — supplying multiple sources for these returns an empty vector so wiring errors are

--- a/crates/khive-hnsw/docs/algorithm.md
+++ b/crates/khive-hnsw/docs/algorithm.md
@@ -20,13 +20,13 @@ Hierarchical Navigable Small World graphs", IEEE TPAMI (2018).
 
 ## Key Parameters (HnswConfig)
 
-| Parameter        | Default | Effect                                                              |
-| ---------------- | ------- | ------------------------------------------------------------------- |
-| `m`              | 20      | Max connections per node per layer. Higher → better recall, more memory. |
-| `m_max0`         | 40      | Max connections in layer 0 (base). Usually `2 × m`.                |
-| `ef_construction`| 200     | Search width during insert. Higher → better quality, slower build.  |
-| `ef_search`      | 80      | Search width at query time. Trade-off: recall vs speed.             |
-| `dimensions`     | 384     | Vector dimensionality (must match embedding model).                 |
+| Parameter         | Default | Effect                                                                   |
+| ----------------- | ------- | ------------------------------------------------------------------------ |
+| `m`               | 20      | Max connections per node per layer. Higher → better recall, more memory. |
+| `m_max0`          | 40      | Max connections in layer 0 (base). Usually `2 × m`.                      |
+| `ef_construction` | 200     | Search width during insert. Higher → better quality, slower build.       |
+| `ef_search`       | 80      | Search width at query time. Trade-off: recall vs speed.                  |
+| `dimensions`      | 384     | Vector dimensionality (must match embedding model).                      |
 
 Defaults are tuned for `m=20` which is optimal for k=10 recall at 384d (empirically measured).
 `ef_search=80` is sufficient for corpora under 100K vectors.

--- a/crates/khive-hnsw/docs/design.md
+++ b/crates/khive-hnsw/docs/design.md
@@ -2,14 +2,15 @@
 
 ## ADR Compliance
 
-### ADR-002: SIMD Foundation Layer
+### ADR-011: SIMD Foundation Layer
 
 - Distance computation (`src/distance.rs`) delegates all vector math to `lattice-embed::simd`
-- Cosine, Dot, and L2 metrics use NEON/AVX2/AVX-512 dispatch from the lattice-embed crate
-- INT8 dot product (`int8_dot_product_raw`) also routes through `lattice_embed::simd::dot_product_i8_raw`
-- The HNSW crate itself contains no SIMD code; it is purely algorithmic
+  (ADR-011: Embedding and Inference — `lattice-embed` is the SIMD and quantization foundation).
+- Cosine, Dot, and L2 metrics use NEON/AVX2/AVX-512 dispatch from the lattice-embed crate.
+- INT8 dot product (`int8_dot_product_raw`) also routes through `lattice_embed::simd::dot_product_i8_raw`.
+- The HNSW crate itself contains no SIMD code; it is purely algorithmic.
 
-### ADR-003: HNSW Index Management Strategy
+### ADR-030: HNSW Index Management Strategy
 
 - Default parameters: M=20, ef_construction=200, ef_search=80, dimensions=384
   - M=20 is empirically optimal for k=10 recall at 384d

--- a/crates/khive-mcp/docs/design.md
+++ b/crates/khive-mcp/docs/design.md
@@ -3,6 +3,7 @@
 ## ADR Compliance
 
 ### ADR-016: Request DSL — Single `request` Tool
+
 - The MCP server exposes exactly one tool named `request`. All verbs are dispatched
   through it using the function-call DSL or JSON form.
 - The DSL supports three execution modes: Single, Parallel (batch), and Chain
@@ -18,6 +19,7 @@
   Per-verb validation failure returns a per-op `{ok: false, error: "..."}` entry.
 
 ### ADR-017: Pack Standard — Vocabulary, Visibility, and Schema Plans
+
 - Subhandler verbs are operator-only and are blocked at the MCP wire boundary.
   Exception: `help=true` is short-circuited in `VerbRegistry::dispatch` before
   reaching the pack, so introspection passes through.
@@ -28,6 +30,7 @@
   custom embedding providers are available before the first `remember`/`recall`.
 
 ### ADR-027: Dynamic Pack Loading
+
 - `builtin_pack_names()` is sourced from `PackRegistry::discovered_names()` so
   the list always reflects whichever pack crates are linked into the binary.
 - Pack registration fails fast on unknown names or unsatisfied dependencies —
@@ -35,14 +38,16 @@
 - `pack.rs` force-references one public symbol per pack crate so the linker
   includes their `inventory::submit!` constructors in the final binary.
 
-### ADR-031: Edge Endpoint Rules and Embedder Registration
+### ADR-031: Multi-Engine Retrieval — Edge Endpoint Rules and Embedder Registration
+
 - After the registry is built, `install_edge_rules` aggregates pack-declared
   edge endpoint rules into the runtime so `validate_edge_relation_endpoints`
   can consult the combined ruleset.
 - `call_register_embedders` is invoked after registry construction, before any
   verb dispatch, to wire custom embedding providers from each pack.
 
-### ADR-035: Authorization Gate and Audit Persistence
+### ADR-018: Authorization Gate and Audit Persistence
+
 - The authorization gate from `runtime.config().gate` is threaded into the
   registry. Gate decisions are hard-enforcing — a `Deny` result blocks pack
   dispatch and returns `PermissionDenied`.
@@ -50,6 +55,7 @@
   audit persistence of all dispatched operations.
 
 ### ADR-038: Write-Key Conflict Detection
+
 - Before parallel/single dispatch, operations targeting the same write key in
   the same batch are detected and receive per-op error entries.
 - Non-conflicting ops in the same batch execute normally.
@@ -57,6 +63,7 @@
   is never violated by conflict detection).
 
 ### ADR-045: Presentation Transforms
+
 - Presentation transforms are applied per-op AFTER dispatch, at the response
   envelope boundary. Chain `$prev` substitution uses canonical (verbose) handler
   output — the transform runs only on the final result, not on the intermediate
@@ -68,6 +75,7 @@
   `"verbose"` (full canonical shape), `"human"` (same as verbose at runtime).
 
 ### ADR-049: Daemon — Warm Pack Registry
+
 - The `daemon.rs` module provides the client side: `forward_or_spawn` connects
   to a warm daemon, auto-spawns it on first use, and maps responses to MCP
   error types. Any failure falls back to `None` so the caller dispatches locally.
@@ -79,11 +87,13 @@
   server can call back into the MCP server's local dispatch path.
 
 ### ADR-014: Fail-Fast Pack Validation
+
 - Pack registration is fail-fast: unknown names or unsatisfied dependencies
   abort construction and return the original runtime so callers can recover.
   The `PackRegError` type carries the runtime for this reason.
 
 ## Consistency Notes
+
 - The `schemars` description on `RequestParams.ops` references "ADR-016" inline;
   this is user-facing schema documentation and has been left as-is to avoid
   breaking schema consumers. The description text is surfaced in MCP client

--- a/crates/khive-pack-gtd/docs/benchmarks.md
+++ b/crates/khive-pack-gtd/docs/benchmarks.md
@@ -40,6 +40,7 @@ HTML reports land in `target/criterion/gtd/`.
 - Dataset: in-memory SQLite; task corpus seeded with 10 / 100 tasks; sample size 50
 - vs prior: first formal release ledger entry — no prior comparable baseline
 
+
 | Scenario                   | Low      | Median   | High     | Outliers   |
 | -------------------------- | -------- | -------- | -------- | ---------- |
 | gtd/assign                 | 2.787 ms | 3.030 ms | 3.272 ms | 2/50 (4%)  |

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -3,12 +3,14 @@
 ## ADR Compliance
 
 ### ADR-002: Edge Ontology (15 edge relations — closed set)
+
 - The GTD pack does NOT add new edge relation variants; `depends_on` is already in the base set.
-- The pack additively extends the *endpoint contract* to allow `depends_on` between two `task`
+- The pack additively extends the _endpoint contract_ to allow `depends_on` between two `task`
   notes (base contract restricts it to entity→entity). This is pack-extensible per ADR-017 rules.
 - Edge relation enum remains closed; packs may only extend endpoint pairs, not add new relations.
 
 ### ADR-004: NoteKindSpec lifecycle declaration
+
 - `GtdPack` declares a `NoteKindSpec` for the `task` note kind.
 - Lifecycle field is named `kind_status` (NOT `status`) to avoid semantic collision with
   `Note.status`, which is a row-visibility field always set to `"active"` for live rows.
@@ -19,6 +21,7 @@
   The no-reopen rule is authoritative; use `gtd.assign` to create a new task instead.
 
 ### ADR-017: Pack Standard (Pack trait, `EDGE_RULES`, pack-extensible edge endpoints)
+
 - `GtdPack` implements the `Pack` trait and `PackRuntime` trait.
 - Declares vocabulary via constants: `NOTE_KINDS`, `ENTITY_KINDS`, `HANDLERS`, `EDGE_RULES`,
   `NOTE_KIND_SPECS`, `SCHEMA_PLAN`.
@@ -28,6 +31,7 @@
 - Endpoint rules are additive only — this pack cannot tighten the base contract.
 
 ### ADR-019: GTD lifecycle contract
+
 - Five verbs: `gtd.assign`, `gtd.next`, `gtd.complete`, `gtd.tasks`, `gtd.transition`.
 - Lifecycle states: `inbox → next | waiting | someday | active | done | cancelled`.
 - `done` and `cancelled` are permanently terminal (no reopen; issue #273).
@@ -39,6 +43,7 @@
   blockers are not in `done` state (scenario-gtd C2).
 
 ### ADR-025: Illocutionary verb classification (Searle 1976)
+
 - `gtd.assign` → Directive (directs an actor to perform work)
 - `gtd.next` → Assertive (retrieves actionable task state)
 - `gtd.tasks` → Assertive (retrieves filtered task listing)
@@ -46,42 +51,49 @@
 - `gtd.transition` → Declaration (changes task lifecycle status by fiat)
 
 ### ADR-027: Inventory self-registration
+
 - `GtdPack` self-registers via `inventory::submit!` so it can be loaded dynamically from
   the pack registry by name (`"gtd"`) without a hard compile-time dependency in the MCP binary.
 - Requires `"kg"` pack as a dependency (`REQUIRES = &["kg"]`).
 
 ### ADR-030: Non-propagating after_create failures
+
 - If `depends_on` edge creation fails after the task note is successfully written,
   the error is logged and swallowed. A `properties["depends_on"]` key captures the same
   dependency information for queries that bypass the graph layer.
 - This avoids misleading the caller with `ok: false` for a task that is already on disk.
 
-### ADR-031: GTD pack-extensible edge rule for task blockers
+### ADR-017: Pack-extensible edge rule for task blockers
+
 - The GTD pack's `EDGE_RULES` extends the base `depends_on` endpoint contract to allow
-  task-note→task-note links.
+  task-note→task-note links (ADR-017 Pack Standard §"Pack-extensible edge endpoints").
 - Pre-validation in `gtd.assign` and `TaskHook.prepare_create` ensures the target of each
   `depends_on` UUID is a `task` note before any storage write. This preserves the
   atomicity invariant: no task is persisted if its dependency chain is invalid.
 
 ## Consistency Notes
 
-### Terminal-state behavior vs ADR-019 draft
-- ADR-019 was originally drafted with reopen semantics in mind. The implementation
-  explicitly closes terminal states (`done`, `cancelled`) — no outgoing transitions.
-  ADR-019 should be amended to reflect the no-reopen rule as the authoritative contract.
+### Terminal-state behavior — ADR-019 authoritative contract
+
+- `done` and `cancelled` are permanently terminal; no outgoing transitions are permitted.
+  ADR-019 has been amended to reflect this as the authoritative contract.
+  Use `gtd.assign` to create a new task when reopening semantics are required.
 
 ### GTD status vs row-visibility status (W1-G remap)
+
 - `Note.status` is a row-visibility field (`"active"` for live rows, never the GTD state).
 - GTD lifecycle status lives in `properties["status"]`.
 - The KG `get` and `list` handlers apply a remap: `properties.status` is promoted to the
   top-level `status` field; the row-visibility value moves to `lifecycle`. Tests verify this.
 
 ### `complete()` actionable-state gate (UE2-H1)
+
 - `complete()` rejects tasks in non-actionable states (`inbox`, `waiting`, `someday`) with
   a message directing the caller to transition first. `transition(status=done)` bypasses
   this gate for use cases where direct terminal transition is intended.
 
 ### Atomic transition (ue-dsl-parallel C2)
+
 - Both `complete()` and `transition()` use a conditional SQL UPDATE with a
   `json_extract(properties, '$.status') = expected_current` WHERE predicate. This ensures
   that concurrent calls in a parallel DSL batch only one wins; the other gets

--- a/crates/khive-pack-kg/docs/benchmarks.md
+++ b/crates/khive-pack-kg/docs/benchmarks.md
@@ -47,6 +47,7 @@ cd crates && cargo bench -p khive-pack-kg --bench kg_bench -- --test
 
 #### Create
 
+
 | Scenario         | Low      | Median   | High     | Outliers  |
 | ---------------- | -------- | -------- | -------- | --------- |
 | kg_create/entity | 6.311 ms | 6.798 ms | 7.236 ms | 2/50 (4%) |

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -11,18 +11,18 @@ the khive binary.
 
 ## ADR Compliance
 
-| ADR                                                             | What it governs                                   | Status      |
-| --------------------------------------------------------------- | ------------------------------------------------- | ----------- |
-| [ADR-001](../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | 9 entity kinds (8 base + resource per ADR-048)    | Implemented |
-| [ADR-002](../../docs/adr/ADR-002-edge-ontology.md)              | 15 edge relations, closed set                     | Implemented |
-| [ADR-007](../../docs/adr/ADR-007-namespace.md)                  | KG uses shared `local` namespace                  | Implemented |
-| [ADR-013](../../docs/adr/ADR-013-note-kind-taxonomy.md)         | 5 base note kinds                                 | Implemented |
-| [ADR-014](../../docs/adr/ADR-014-curation-operations.md)        | UUID-only get/update/delete                       | Implemented |
-| [ADR-017](../../docs/adr/ADR-017-pack-standard.md)              | Pack trait, vocabulary, edge rules                | Implemented |
-| [ADR-001](../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | Alias normalization (paper→document, write-time)  | Implemented |
-| [ADR-045](../../docs/adr/ADR-045-verb-response-presentation.md) | ISO-8601 timestamps at handler boundary           | Implemented |
-| [ADR-046](../../docs/adr/ADR-046-event-sourced-proposals.md)    | Event-sourced proposals (propose/review/withdraw) | Implemented |
-| [ADR-048](../../docs/adr/ADR-048-knowledge-section-profiles.md) | `resource` entity kind (9th kind)                 | Implemented |
+| ADR                                                                | What it governs                                   | Status      |
+| ------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
+| [ADR-001](../../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | 9 entity kinds (8 base + resource per ADR-048)    | Implemented |
+| [ADR-002](../../../docs/adr/ADR-002-edge-ontology.md)              | 15 edge relations, closed set                     | Implemented |
+| [ADR-007](../../../docs/adr/ADR-007-namespace.md)                  | KG uses shared `local` namespace                  | Implemented |
+| [ADR-013](../../../docs/adr/ADR-013-note-kind-taxonomy.md)         | 5 base note kinds                                 | Implemented |
+| [ADR-014](../../../docs/adr/ADR-014-curation-operations.md)        | UUID-only get/update/delete                       | Implemented |
+| [ADR-017](../../../docs/adr/ADR-017-pack-standard.md)              | Pack trait, vocabulary, edge rules                | Implemented |
+| [ADR-001](../../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | Alias normalization (paper→document, write-time)  | Implemented |
+| [ADR-045](../../../docs/adr/ADR-045-verb-response-presentation.md) | ISO-8601 timestamps at handler boundary           | Implemented |
+| [ADR-046](../../../docs/adr/ADR-046-event-sourced-proposals.md)    | Event-sourced proposals (propose/review/withdraw) | Implemented |
+| [ADR-048](../../../docs/adr/ADR-048-knowledge-section-profiles.md) | `resource` entity kind (9th kind)                 | Implemented |
 
 ## Primary Modules
 

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -15,13 +15,13 @@ the khive binary.
 | --------------------------------------------------------------- | ------------------------------------------------- | ----------- |
 | [ADR-001](../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | 9 entity kinds (8 base + resource per ADR-048)    | Implemented |
 | [ADR-002](../../docs/adr/ADR-002-edge-ontology.md)              | 15 edge relations, closed set                     | Implemented |
-| [ADR-007](../../docs/adr/ADR-007-namespace-by-layer-rule.md)    | KG uses shared `local` namespace                  | Implemented |
+| [ADR-007](../../docs/adr/ADR-007-namespace.md)                  | KG uses shared `local` namespace                  | Implemented |
 | [ADR-013](../../docs/adr/ADR-013-note-kind-taxonomy.md)         | 5 base note kinds                                 | Implemented |
 | [ADR-014](../../docs/adr/ADR-014-curation-operations.md)        | UUID-only get/update/delete                       | Implemented |
 | [ADR-017](../../docs/adr/ADR-017-pack-standard.md)              | Pack trait, vocabulary, edge rules                | Implemented |
-| [ADR-030](../../docs/adr/ADR-030-kind-canonicalization.md)      | Alias normalization (paper->document)             | Implemented |
-| [ADR-045](../../docs/adr/ADR-045-timestamp-normalization.md)    | ISO-8601 timestamps at handler boundary           | Implemented |
-| [ADR-046](../../docs/adr/ADR-046-proposal-lifecycle.md)         | Event-sourced proposals (propose/review/withdraw) | Implemented |
+| [ADR-001](../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | Alias normalization (paper→document, write-time)  | Implemented |
+| [ADR-045](../../docs/adr/ADR-045-verb-response-presentation.md) | ISO-8601 timestamps at handler boundary           | Implemented |
+| [ADR-046](../../docs/adr/ADR-046-event-sourced-proposals.md)    | Event-sourced proposals (propose/review/withdraw) | Implemented |
 | [ADR-048](../../docs/adr/ADR-048-knowledge-section-profiles.md) | `resource` entity kind (9th kind)                 | Implemented |
 
 ## Primary Modules

--- a/crates/khive-pack-knowledge/docs/algorithm.md
+++ b/crates/khive-pack-knowledge/docs/algorithm.md
@@ -12,14 +12,15 @@ by the global IDF of each query term:
 
 $$
 \text{score} = \sum_{t \in \text{terms}} \mathrm{idf}(t) \cdot \Bigl(
-    w_{\text{exact\_name}} \cdot \mathrm{exact}(t, \text{name})
-  + w_{\text{name}} \cdot \mathrm{tf}(t, \text{name})
-  + w_{\text{desc}} \cdot \mathrm{tf}(t, \text{description})
-  + w_{\text{tags}} \cdot \mathrm{tf}(t, \text{tags})
-  + w_{\text{content}} \cdot \mathrm{tf}(t, \text{content})
-  + w_{\text{bigram}} \cdot \mathrm{bigram}(t, \text{name})
-\Bigr) \cdot \text{coverage}^{\alpha}
-$$
+w_{\text{exact\_name}} \cdot \mathrm{exact}(t, \text{name})
+
+- w_{\text{name}} \cdot \mathrm{tf}(t, \text{name})
+- w_{\text{desc}} \cdot \mathrm{tf}(t, \text{description})
+- w_{\text{tags}} \cdot \mathrm{tf}(t, \text{tags})
+- w_{\text{content}} \cdot \mathrm{tf}(t, \text{content})
+- w_{\text{bigram}} \cdot \mathrm{bigram}(t, \text{name})
+  \Bigr) \cdot \text{coverage}^{\alpha}
+  $$
 
 Default weights: `w_exact_name=5.0`, `w_name=3.0`, `w_description=1.5`, `w_tags=1.25`,
 `w_content=1.0`, `w_bigram=2.0`, `expand_discount=0.35`, `coverage_alpha=0.5`.
@@ -75,7 +76,7 @@ Section content...
 ```
 
 The parser (`parse_atlas_md`) reads the `# Title` line as the atom name, collects text before
-the first `## ` heading as the atom body, and maps each `## ` heading to a `SectionType` via
+the first `##` heading as the atom body, and maps each `##` heading to a `SectionType` via
 `SectionType::from_str_loose` (which accepts common heading aliases). Headings that don't match
 any canonical type are classified as `Other`.
 

--- a/crates/khive-pack-knowledge/docs/benchmarks.md
+++ b/crates/khive-pack-knowledge/docs/benchmarks.md
@@ -49,6 +49,7 @@ cargo test -p khive-pack-knowledge --test bench \
 
 #### `knowledge_bench` (Criterion, FTS-only, no embedder, in-memory SQLite)
 
+
 | Scenario                          | Low      | Median   | High     | Outliers   |
 | --------------------------------- | -------- | -------- | -------- | ---------- |
 | knowledge_learn/concept_create    | 1.030 ms | 1.368 ms | 1.774 ms | 4/50 (8%)  |

--- a/crates/khive-pack-knowledge/docs/design.md
+++ b/crates/khive-pack-knowledge/docs/design.md
@@ -32,10 +32,11 @@
   fused via RRF (k=60). The index lifecycle is owned by `knowledge/vamana.rs`: warm-load from
   persistent snapshot, fingerprint validation, rebuild from sqlite-vec corpus on stale/miss.
 
-### ADR-049: Section Review Lifecycle
+### ADR-047: Section Review Lifecycle
 
 - `knowledge.challenge` marks a section as disputed and increments `dispute_count` on the parent
   atom. `knowledge.adjudicate` resolves the dispute: `accept` → `verified`, `reject` → `reviewed`.
+  This governance is specified in ADR-047 (Knowledge Pack) §section lifecycle governance.
 - The Vamana warm-start protocol (`ensure_ann_background`) fires at most once per
   `{namespace, model}` key using a `Mutex<HashSet>` single-flight guard.
 
@@ -73,15 +74,15 @@
 
 ## Module Boundaries
 
-| Module | Responsibility |
-|--------|---------------|
-| `lib.rs` | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim |
-| `vocab.rs` | `KNOWLEDGE_HANDLERS` static array — 18 verb descriptors |
-| `handlers.rs` | `learn`, `cite`, `topic` verbs (KG concept tier sugar) |
-| `knowledge/mod.rs` | Corpus handler implementations (18 verbs) and all shared SQL/scoring helpers |
-| `knowledge/schema.rs` | Param and record types for serde deserialization and SQL row mapping |
-| `knowledge/vamana.rs` | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion) |
-| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count) |
+| Module                  | Responsibility                                                               |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `lib.rs`                | Pack registration, `Pack` trait impl, `PackRuntime::dispatch` shim           |
+| `vocab.rs`              | `KNOWLEDGE_HANDLERS` static array — 18 verb descriptors                      |
+| `handlers.rs`           | `learn`, `cite`, `topic` verbs (KG concept tier sugar)                       |
+| `knowledge/mod.rs`      | Corpus handler implementations (18 verbs) and all shared SQL/scoring helpers |
+| `knowledge/schema.rs`   | Param and record types for serde deserialization and SQL row mapping         |
+| `knowledge/vamana.rs`   | Shared Vamana ANN index lifecycle (warm-start, build, search, RRF fusion)    |
+| `knowledge/matching.rs` | TF-IDF term matching primitives (tokenize, exact match, count)               |
 
 ## Namespace Isolation
 

--- a/crates/khive-pack-memory/docs/benchmarks.md
+++ b/crates/khive-pack-memory/docs/benchmarks.md
@@ -71,6 +71,7 @@ selection (lowest_df / highest_idf) drops meaningful terms and loses recall, and
 
 #### `memory_bench` (Criterion, FTS-only, no embedder, in-memory SQLite)
 
+
 | Scenario                             | Low      | Median   | High     | Outliers   |
 | ------------------------------------ | -------- | -------- | -------- | ---------- |
 | remember/baseline                    | 6.932 ms | 7.545 ms | 8.248 ms | 1/20 (5%)  |

--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -65,12 +65,13 @@
 - A property shortcut (`superseded_by` in `properties`) provides a secondary suppression path
   for archive-import compatibility when graph edges are not available.
 
-### ADR-062: Dotted Sub-Handler Naming
+### ADR-023: Dotted Sub-Handler Naming
 
 - Recall pipeline stages are exposed as sub-handlers using dotted names:
   `memory.recall_embed`, `memory.recall_candidates`, `memory.recall_fuse`,
   `memory.recall_rerank`, `memory.recall_score`.
-- These have `Visibility::Subhandler` and are not listed in public verb catalogs.
+- These have `Visibility::Subhandler` and are not listed in public verb catalogs,
+  per ADR-023 (Pack Verb Surface, Visibility, and Composition) §"Handlers vs. verbs".
 
 ## Consistency Notes
 

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -3,6 +3,7 @@
 ## ADR Compliance
 
 ### ADR-002: Edge Ontology
+
 - 15 closed edge relations; endpoint contract enforced at the runtime layer in `operations.rs`
 - Symmetric relations (`competes_with`, `composed_with`) are stored with `source_uuid < target_uuid`
 - `annotates` is the only cross-substrate relation: source must be a note, target may be anything
@@ -12,34 +13,40 @@
 - Pack-declared edge endpoint rules are additive only; packs cannot tighten the base contract
 
 ### ADR-004 / ADR-005: Event and Storage Capability Traits
+
 - `EventStore::append` is called after each authorized dispatch to record audit events
 - The audit payload field holds the full `AuditEvent` envelope (not a bare verb result)
 - Top-level event fields follow the ADR-004/ADR-005 schema
 
 ### ADR-007: Namespace Strategy
+
 - Every ID-based operation (get, delete, update, merge) verifies `record.namespace == caller_namespace`
 - Wrong-namespace and absent IDs return the same `NotFound` error to prevent timing-oracle attacks
 - `actor.id` in config must be a valid namespace string; an invalid value is a startup error
 - `NamespaceToken` is the runtime trust boundary; storage is ID-only
 
 ### ADR-009 / ADR-028: Multi-Backend Deployment
+
 - `BackendId` identifies a named backend in multi-backend deployments; single-backend uses `"main"`
 - `KhiveRuntime::from_backend` is the preferred boot path for multi-backend deployments
 - Cross-backend `merge_entity` is unsupported in v1; both entities must reside on the same backend
 - `db_path` and `embedding_model` on `RuntimeConfig` are deprecated in favour of the external-backend path
 
 ### ADR-010: KG Versioning / Portability
+
 - Export format is `"khive-kg"` version `"0.1"` (stable identifier for archive parsers)
 - Embeddings are excluded from archives (regenerable from text + model)
 - Edges are collected by source entity, not by namespace scan, to capture cross-entity relationships
 - `edge_id` field on `ExportedEdge` is stable across export/import cycles; old archives without it receive a fresh UUID on import
 
 ### ADR-013 / ADR-024: Note Kinds and Annotation
+
 - `annotates` edges targeting a note are validated before any write (atomicity)
 - `annotates` targets can be entity, note, edge, or event (cross-substrate by design)
 - Note delete cascades annotation edges targeting that note
 
 ### ADR-014: Curation Operations
+
 - `merge_entity` enforces same-kind constraint at the runtime layer, not storage
 - Namespace isolation is enforced during merge: only records in the caller namespace can be merged
 - Symmetric relations are canonicalized (source_uuid < target_uuid) before merge conflict checks
@@ -47,16 +54,19 @@
 - Entity tombstone records preserve provenance for audit
 
 ### ADR-015: Schema Migrations
+
 - Core substrate tables evolve through versioned migrations; pack-auxiliary tables are separate
 - Migrations are idempotent; already-applied versions are skipped at runtime startup
 
 ### ADR-017: Pack Standard
+
 - Pack verb names in `Visibility::Verb` participate in cross-pack collision detection at boot
 - `Visibility::Subhandler` entries are excluded from collision checks and not callable via MCP
 - Boot-time collision: two packs declaring the same public verb name produce `RuntimeError::VerbCollision`
 - Pack-auxiliary schema plans are collected from all registered packs and applied at startup
 
 ### ADR-018: Authorization Gate
+
 - Gate is consulted before every verb dispatch; gate infrastructure failures are fail-open
 - `GateDecision::Deny` is hard enforcement: the pack is never invoked on denial
 - Namespace token is minted at the dispatch boundary after gate approval
@@ -64,76 +74,96 @@
 - `VerbRegistry` emits one `gate.check` info trace event per dispatch for observability
 - Obligations on `GateDecision::Allow` are serialized as an empty array when there are none
 
-### ADR-019 / ADR-024: GTD and Note Operations
+### ADR-002 / ADR-019: Note and Edge Operations
+
 - Three-case relation contract for link operations: annotates, supersedes, and entity→entity base rules
-- The endpoint validation path is centralized in `operations.rs` so both `link` and `update_edge` share the same contract
+  (ADR-002: Edge Ontology governs the endpoint contract; ADR-019: GTD Pack extends it for task notes).
+- The endpoint validation path is centralized in `operations.rs` so both `link` and `update_edge` share the same contract.
 
 ### ADR-021: Memory Pack
+
 - Memory decay formula: `effective_salience = salience * exp(-decay_factor * age_days)`
 - Default decay rate: 0.01 (~69-day half-life)
 - Per-note `decay_factor` is used by `DecayAwareSalienceObjective` rather than the objective's own rate
 
 ### ADR-023: Declarative Pack Format
+
 - Verb surface and visibility are declared per-pack; only `Visibility::Verb` entries appear in `help=true` envelopes
 - `all_verbs` returns only public verb entries; internal subhandlers require `all_handlers_with_names`
 
 ### ADR-025: Pack Dispatch Trait
+
 - `PackRuntime::dispatch` is the async per-verb entry point for each pack
 - Packs that do not use an embedder registry may ignore the `register_embedders` hook
 
 ### ADR-027: Dynamic Pack Loading
+
 - Pack factories are discovered via `inventory` at link time; missing dependencies are a boot error
 - Missing dependencies are not silently auto-added; the requested set must be explicit
 - `PackRegistry` performs topological sort of packs using Kahn's algorithm
 
 ### ADR-029: Gate Authorization
+
 - `RuntimeConfig::gate` defaults to `AllowAllGate`; production deployments plug in a policy-backed impl
 
 ### ADR-030: Layered Retrieval Architecture
+
 - `KindHook` provides per-kind specialization for shared CRUD operations
 - The retrieval pipeline composes signal objectives without IO; the runtime layer materialises signal data
 
 ### ADR-031: Pack-Extensible Embedder Registry
+
 - Pack-declared embedder providers are registered via `PackRuntime::register_embedders`
 - Pack-extensible edge endpoint rules are shared across clones via `Arc<RwLock<_>>`
 - Base ADR-002 rules apply independently; pack rules are additive
 - `KhiveRuntime::install_edge_rules` is called once by the transport after `VerbRegistry` is built
 
 ### ADR-033: Recall Pipeline
+
 - `NoteCandidate` carries pre-computed signals; objectives are pure functions with no IO
 - `MemoryRecallPipeline::default()` uses the ADR-021 default decay parameters
 - `AmplifiedDecayAwareSalienceObjective` is used when salience should drive ranking more aggressively
 
 ### ADR-034: KG Validation Pipelines
+
 - `ValidationRule` carries a `check: RuleFn` and optional `fix: FixFn`
 - Severity can be overridden per-rule from `.khive/kg/rules.toml`
 - `GraphPatch` is a deferred stub; the auto-fix write path is not yet implemented
 - Violations are grouped by rule ID and sorted canonically
 
 ### ADR-037: Inter-Pack Dependencies
+
 - Missing pack dependencies are collected and reported as a single `MissingPackDependencies` error
 - Circular dependencies are detected during topological sort and reported as `CircularPackDependency`
 - Remote resolution errors (`UnknownRemote`, `RemoteCacheMissing`) are part of the same error family
 
-### ADR-043 / ADR-044: ANN Warmup
-- `KhiveRuntime::warm_ann_index` is intended to run once at startup as a background task
-- Warm startup sequence follows steps 2–4 from the ANN warmup spec
+### ADR-049: ANN Warmup
+
+- `KhiveRuntime::warm_ann_index` is intended to run once at startup as a background task.
+  The warm-start protocol is owned by the daemon (ADR-049: khived daemon); the runtime
+  exposes the `warm_ann_index` hook for the daemon to invoke during startup.
+- Warm startup sequence follows steps 2–4 from the ANN warmup spec.
 
 ### ADR-045: Verb Response Presentation
+
 - `micros_to_iso` is the single conversion point from internal `i64` microsecond timestamps to ISO-8601
 - `Agent` mode: short UUIDs (8-char), relative timestamps within 24h, lifecycle nulls preserved, scores truncated to 3 sig-figs
 - `Human` mode at the MCP layer is identical to `Verbose`; terminal formatting is applied by the CLI layer
 - `full_id` is explicitly excluded from UUID shortening in Agent mode to preserve chaining handles
 
-### ADR-048: Stable Edge Identity
-- `ExportedEdge::edge_id` carries the stable `LinkId` UUID across export/import cycles
-- Old archives (pre-0.2) omit `edge_id`; `serde(default)` assigns a fresh UUID on import
+### ADR-020: Stable Edge Identity
+
+- `ExportedEdge::edge_id` carries the stable `LinkId` UUID across export/import cycles,
+  as specified in ADR-020 (Git-Native KG Implementation) §edge_id.
+- Old archives (pre-0.2) omit `edge_id`; `serde(default)` assigns a fresh UUID on import.
 
 ### ADR-049: Persistent Daemon
+
 - `khived` is a persistent warm runtime over a Unix socket
 - `PackRuntime::warm` is invoked on every registered pack during daemon startup
 
 ### ADR-050: Namespace Token Contract
+
 - `NamespaceToken` is sealed to prevent external construction without gate authorization
 - Namespace authority is checked at the runtime layer on every ID-based operation
 

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -12,7 +12,7 @@ namespace isolation are enforced at each step.
 - [ADR-023](../../../docs/adr/ADR-023-declarative-pack-format.md) — Declarative pack format and verb visibility
 - [ADR-027](../../../docs/adr/ADR-027-dynamic-pack-loading.md) — Dynamic pack loading via self-registration
 - [ADR-028](../../../docs/adr/ADR-028-pack-scoped-backends.md) — Pack-scoped backends and schema declaration
-- [ADR-007](../../../docs/adr/ADR-007-namespace-strategy.md) — Namespace strategy and isolation requirements
+- [ADR-007](../../../docs/adr/ADR-007-namespace.md) — Namespace strategy and isolation requirements
 - [ADR-050](../../../docs/adr/ADR-050-kg-token-namespace-contract.md) — NamespaceToken authority contract
 
 ## Dispatch Flow

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -8,12 +8,12 @@ namespace isolation are enforced at each step.
 
 ## ADR Links
 
-- [ADR-017](../../docs/adr/ADR-017-pack-standard.md) — Pack trait, verb surface, and boot-time collision checks
-- [ADR-023](../../docs/adr/ADR-023-declarative-pack-format.md) — Declarative pack format and verb visibility
-- [ADR-027](../../docs/adr/ADR-027-dynamic-pack-loading.md) — Dynamic pack loading via self-registration
-- [ADR-028](../../docs/adr/ADR-028-pack-scoped-backends.md) — Pack-scoped backends and schema declaration
-- [ADR-007](../../docs/adr/ADR-007-namespace-strategy.md) — Namespace strategy and isolation requirements
-- [ADR-050](../../docs/adr/ADR-050-kg-token-namespace-contract.md) — NamespaceToken authority contract
+- [ADR-017](../../../docs/adr/ADR-017-pack-standard.md) — Pack trait, verb surface, and boot-time collision checks
+- [ADR-023](../../../docs/adr/ADR-023-declarative-pack-format.md) — Declarative pack format and verb visibility
+- [ADR-027](../../../docs/adr/ADR-027-dynamic-pack-loading.md) — Dynamic pack loading via self-registration
+- [ADR-028](../../../docs/adr/ADR-028-pack-scoped-backends.md) — Pack-scoped backends and schema declaration
+- [ADR-007](../../../docs/adr/ADR-007-namespace-strategy.md) — Namespace strategy and isolation requirements
+- [ADR-050](../../../docs/adr/ADR-050-kg-token-namespace-contract.md) — NamespaceToken authority contract
 
 ## Dispatch Flow
 

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -64,11 +64,11 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 
 ## Failure Modes
 
-| Condition | Error |
-|-----------|-------|
-| Unknown verb | `RuntimeError::InvalidInput("unknown verb ...")`|
-| Gate deny | `RuntimeError::PermissionDenied { verb, reason }` |
-| Pack not loaded | `RuntimeError::InvalidInput` (unknown verb path) |
+| Condition          | Error                                                              |
+| ------------------ | ------------------------------------------------------------------ |
+| Unknown verb       | `RuntimeError::InvalidInput("unknown verb ...")`                   |
+| Gate deny          | `RuntimeError::PermissionDenied { verb, reason }`                  |
+| Pack not loaded    | `RuntimeError::InvalidInput` (unknown verb path)                   |
 | Namespace mismatch | `RuntimeError::NamespaceMismatch` (reported as NotFound to caller) |
 
 ## Extension Points

--- a/crates/khive-runtime/docs/validation.md
+++ b/crates/khive-runtime/docs/validation.md
@@ -7,7 +7,7 @@ severity overrides work, and where rule configuration lives.
 
 ## ADR Links
 
-- [ADR-034](../../docs/adr/ADR-034-kg-validation-pipelines.md) — KG validation pipelines specification
+- [ADR-034](../../../docs/adr/ADR-034-kg-validation-pipelines.md) — KG validation pipelines specification
 
 ## Rule Configuration File
 

--- a/crates/khive-runtime/docs/validation.md
+++ b/crates/khive-runtime/docs/validation.md
@@ -56,8 +56,8 @@ write path is not yet implemented; `fix: Some(...)` is reserved for future use.
 
 ## Failure Modes
 
-| Condition | Behaviour |
-|-----------|-----------|
-| Duplicate rule ID | Not enforced at boot in v0.2; first registered wins |
+| Condition           | Behaviour                                                 |
+| ------------------- | --------------------------------------------------------- |
+| Duplicate rule ID   | Not enforced at boot in v0.2; first registered wins       |
 | Fix function panics | Propagates as runtime panic; fix functions must not panic |
-| Config key unknown | Ignored; rules use their default severity |
+| Config key unknown  | Ignored; rules use their default severity                 |

--- a/crates/khive-vcs/docs/design.md
+++ b/crates/khive-vcs/docs/design.md
@@ -58,9 +58,10 @@
   caller to write back to `schema.yaml`. The hash is always computed and written to
   `meta.json` for auditability even when no pin is present.
 
-### ADR-042: Canonical hash algorithm
+### ADR-020: Canonical hash algorithm
 
-- Canonical JSON sort order for hashing:
+- Canonical JSON sort order for hashing (ADR-020: Git-Native KG Implementation
+  §canonical NDJSON record shape and snapshot hash):
   1. Entities sorted by UUID string (case-insensitive ascending).
   2. Edges sorted by (source, target, relation) ascending.
   3. Property keys sorted alphabetically within each entity.

--- a/crates/khive-vcs/docs/protocol.md
+++ b/crates/khive-vcs/docs/protocol.md
@@ -12,12 +12,12 @@ SQLite working database from those files.
 
 ## Modules
 
-| Module | File | Purpose |
-|--------|------|---------|
-| `types` | `src/types.rs` | `SnapshotId`, `SnapshotCoverage`, `VcsState` |
-| `hash` | `src/hash.rs` | Canonical JSON serialization and SHA-256 hashing |
-| `sync` | `src/sync.rs` | NDJSON parse, validate-first import, remote fetch |
-| `error` | `src/error.rs` | `VcsError` enum |
+| Module  | File           | Purpose                                           |
+| ------- | -------------- | ------------------------------------------------- |
+| `types` | `src/types.rs` | `SnapshotId`, `SnapshotCoverage`, `VcsState`      |
+| `hash`  | `src/hash.rs`  | Canonical JSON serialization and SHA-256 hashing  |
+| `sync`  | `src/sync.rs`  | NDJSON parse, validate-first import, remote fetch |
+| `error` | `src/error.rs` | `VcsError` enum                                   |
 
 ## Snapshot Format (ADR-010, ADR-042)
 
@@ -79,14 +79,14 @@ Notes are excluded until note packs define versioned export and merge semantics.
 
 ## Failure Modes
 
-| Scenario | Behaviour |
-|----------|-----------|
-| Invalid edge relation in NDJSON | Error before any DB/cache write; previous DB intact |
-| Hash mismatch on remote pin | `VcsError::HashMismatch`; no cache files written |
-| Git clone failure | Error with remote name only (URL redacted from message) |
-| Non-UTF-8 staging path | `Path` passed directly to `Command::arg`; no panic |
-| Non-finite edge weight | `VcsError::Internal` from `edge_to_canonical_value` |
-| WAL checkpoint failure | Error before rename; previous DB intact |
+| Scenario                        | Behaviour                                               |
+| ------------------------------- | ------------------------------------------------------- |
+| Invalid edge relation in NDJSON | Error before any DB/cache write; previous DB intact     |
+| Hash mismatch on remote pin     | `VcsError::HashMismatch`; no cache files written        |
+| Git clone failure               | Error with remote name only (URL redacted from message) |
+| Non-UTF-8 staging path          | `Path` passed directly to `Command::arg`; no panic      |
+| Non-finite edge weight          | `VcsError::Internal` from `edge_to_canonical_value`     |
+| WAL checkpoint failure          | Error before rename; previous DB intact                 |
 
 ## Test Coverage
 
@@ -98,6 +98,6 @@ Notes are excluded until note packs define versioned export and merge semantics.
 
 ## Baseline Performance
 
-| Scenario | Baseline | Date | Commit | Machine |
-|----------|----------|------|--------|---------|
-| (not yet measured) | — | — | — | — |
+| Scenario           | Baseline | Date | Commit | Machine |
+| ------------------ | -------- | ---- | ------ | ------- |
+| (not yet measured) | —        | —    | —      | —       |

--- a/docs/adr/ADR-008-query-layer-separation.md
+++ b/docs/adr/ADR-008-query-layer-separation.md
@@ -226,7 +226,7 @@ violating the separation between syntax compilation and semantic validation.
 - `crates/khive-query/src/parsers/gql.rs`: GQL parser.
 - `crates/khive-query/src/parsers/sparql.rs`: SPARQL parser.
 - `crates/khive-query/src/ast.rs`: shared AST with `NodePattern.entity_type` field.
-- `crates/khive-query/src/validator.rs`: AST validation (relation via `EdgeRelation::from_str`,
+- `crates/khive-query/src/validate.rs`: AST validation (relation via `EdgeRelation::from_str`,
   depth limits).
 - `crates/khive-query/src/compilers/sql.rs`: AST → SQL compilation. `entity_type` maps to
   column predicate.

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -102,9 +102,14 @@ next      → active | waiting | someday | done | cancelled
 active    → next | waiting | done | cancelled
 waiting   → next | active | done | cancelled
 someday   → next | active | done | cancelled
-done      → next | active                              (reopen)
-cancelled → next | active                              (reopen)
+done      → (terminal — no outgoing transitions)
+cancelled → (terminal — no outgoing transitions)
 ```
+
+`done` and `cancelled` are **permanently terminal**: `allowed_transitions` returns `&[]`
+for both states, and tests assert no transitions are permitted out of them (decision
+GTD-AUD-001 / issue #273). Use `gtd.assign` to create a new task when reopening
+semantics are required.
 
 Transition validation lives in the `transition` verb handler. Illegal jumps (e.g.,
 `done → inbox`) return `RuntimeError::InvalidInput` with the allowed-set message.

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -141,17 +141,17 @@ bare verb names (16 verbs total):
 
 | Verb        | Speech act  | Description                                                                      |
 | ----------- | ----------- | -------------------------------------------------------------------------------- |
-| `create`    | assertive   | Create an entity or note                                                         |
+| `create`    | commissive  | Create an entity or note                                                         |
 | `get`       | assertive   | Fetch any record by UUID                                                         |
 | `list`      | assertive   | Structured browse with pagination                                                |
-| `update`    | assertive   | Patch entity or edge fields                                                      |
-| `delete`    | assertive   | Soft or hard delete a record                                                     |
+| `update`    | declaration | Patch entity or edge fields                                                      |
+| `delete`    | declaration | Soft or hard delete a record                                                     |
 | `search`    | assertive   | Hybrid FTS + vector search                                                       |
-| `link`      | assertive   | Create a typed directed edge                                                     |
+| `link`      | commissive  | Create a typed directed edge                                                     |
 | `neighbors` | assertive   | Immediate graph neighbors                                                        |
 | `traverse`  | assertive   | Multi-hop BFS traversal                                                          |
 | `query`     | assertive   | GQL/SPARQL pattern matching                                                      |
-| `merge`     | assertive   | Deduplicate two entities                                                         |
+| `merge`     | declaration | Deduplicate two entities                                                         |
 | `propose`   | commissive  | Create a proposal for KG mutation; emits `ProposalCreated`.                      |
 | `review`    | declaration | Record an approve/reject decision on an open proposal; emits `ProposalReviewed`. |
 | `withdraw`  | commissive  | Rescind an open proposal (proposer-only); emits `ProposalWithdrawn`.             |

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -214,8 +214,9 @@ context:
 ✗ memory.recall(mem_type="episodic")
 ✗ memory.recall(type="episodic")           # collides with entity_type / note_type
 
-✓ gtd.assign(task_status="next", task_priority="p1")
-✗ gtd.assign(status="next")                 # ambiguous in error/log frames
+✓ gtd.assign(status="next", priority="p1")
+✗ gtd.assign(task_status="next")           # rejected: deny_unknown_fields in handler
+✗ gtd.assign(task_priority="p1")           # rejected: deny_unknown_fields in handler
 
 ✓ brain.feedback(target_event_id="...", score=0.8)
 ✗ brain.feedback(event_id="...")           # which event?
@@ -224,6 +225,11 @@ context:
 The verb prefix (`memory.recall`) gives the _agent_ call context, but the field name
 travels into JSON payloads, audit logs, training data, and error frames where it loses
 that context. Full-word field names carry their own meaning.
+
+> **Implementation note**: `gtd.assign` uses `status` and `priority` directly.
+> The param struct is compiled with `#[serde(deny_unknown_fields)]`, so
+> `task_status` and `task_priority` are rejected at runtime rather than silently
+> ignored — they are not aliases.
 
 ### 6. Substrate verbs are kind-polymorphic — KindHook on every substrate verb
 

--- a/docs/adr/ADR-024-fold-cognitive-primitives.md
+++ b/docs/adr/ADR-024-fold-cognitive-primitives.md
@@ -269,7 +269,7 @@ implementations. The pipeline is the bridge between the foundation layer and con
 | Item                                                       | Lives in                              | Why                                 |
 | ---------------------------------------------------------- | ------------------------------------- | ----------------------------------- |
 | `ObjectiveRegistry` (named registration + lookup)          | `khive-runtime`                       | Runtime infrastructure, not algebra |
-| `Checkpoint<S>` + stores (fold state persistence)          | `khive-runtime`                       | Storage/IO concern                  |
+| `Checkpoint<S>` + `InMemoryCheckpointStore`                | `khive-fold`                          | Pure in-memory; no IO or async deps |
 | `Scored<T>` + `ObjectiveConfig` (thin wrappers)            | Inline in consumers                   | Not fold-specific                   |
 | `FoldContext.actor/role/task/query` (domain fields)        | Consumers put in `extra`              | Couples fold to actor model         |
 | Domain folds (`MemoryFold`, `PolicyFold`)                  | Pack crates owning the domain         | Domain-specific                     |

--- a/docs/adr/ADR-030-retrieval-stack-port.md
+++ b/docs/adr/ADR-030-retrieval-stack-port.md
@@ -195,14 +195,18 @@ default install does not depend on RuVector.
 
 ### Feature flags
 
-The port inherits the internal crate's feature flag structure, rationalized for OSS:
+The port inherits the internal crate's feature flag structure, rationalized for OSS.
+`khive-retrieval` ships with `default = []` — no features are on by default. This is
+intentional for a public crate: consumers opt into exactly the capability surface they
+need and avoid pulling in optional heavy dependencies (e.g., `lattice-embed`) unless
+explicitly requested.
 
 | Feature            | Default | Notes                                                                  |
 | ------------------ | ------- | ---------------------------------------------------------------------- |
-| `checkpoint`       | on      | HNSW snapshot save/restore                                             |
-| `persist`          | on      | Index persistence to disk                                              |
-| `embed`            | on      | `lattice-embed` distance kernel integration                            |
-| `storage-adapters` | on      | `StorageVectorSearch`, `StorageKeywordSearch`                          |
+| `checkpoint`       | off     | HNSW snapshot save/restore                                             |
+| `persist`          | off     | Index persistence to disk                                              |
+| `embed`            | off     | `lattice-embed` distance kernel integration                            |
+| `storage-adapters` | off     | `StorageVectorSearch`, `StorageKeywordSearch`                          |
 | `policy`           | off     | Gate integration (khive-gate); opt-in until OSS gate story is complete |
 
 ## Rationale

--- a/docs/adr/ADR-030-retrieval-stack-port.md
+++ b/docs/adr/ADR-030-retrieval-stack-port.md
@@ -198,16 +198,22 @@ default install does not depend on RuVector.
 The port inherits the internal crate's feature flag structure, rationalized for OSS.
 `khive-retrieval` ships with `default = []` — no features are on by default. This is
 intentional for a public crate: consumers opt into exactly the capability surface they
-need and avoid pulling in optional heavy dependencies (e.g., `lattice-embed`) unless
-explicitly requested.
+need.
 
-| Feature            | Default | Notes                                                                  |
-| ------------------ | ------- | ---------------------------------------------------------------------- |
-| `checkpoint`       | off     | HNSW snapshot save/restore                                             |
-| `persist`          | off     | Index persistence to disk                                              |
-| `embed`            | off     | `lattice-embed` distance kernel integration                            |
-| `storage-adapters` | off     | `StorageVectorSearch`, `StorageKeywordSearch`                          |
-| `policy`           | off     | Gate integration (khive-gate); opt-in until OSS gate story is complete |
+`lattice-embed` is an **unconditional** (non-optional) dependency of `khive-retrieval`:
+its core types (`EmbeddingModel`, `EmbeddingService`, `EmbedError`) are always available
+via the `khive_retrieval::embed` re-export module. What the `embed` feature gates is the
+**native model implementations** (`NativeEmbeddingService`, `CachedEmbeddingService`) that
+bundle a live inference backend; those are off by default to keep the base crate lightweight
+for consumers that supply their own embedding service.
+
+| Feature            | Default | Notes                                                                                             |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------- |
+| `checkpoint`       | off     | HNSW snapshot save/restore                                                                        |
+| `persist`          | off     | Index persistence to disk                                                                         |
+| `embed`            | off     | Native `lattice-embed` model implementations (`NativeEmbeddingService`, `CachedEmbeddingService`) |
+| `storage-adapters` | off     | `StorageVectorSearch`, `StorageKeywordSearch`; also enables sqlite-vec via `khive-db/vectors`     |
+| `policy`           | off     | Gate integration (khive-gate); opt-in until OSS gate story is complete                            |
 
 ## Rationale
 
@@ -244,12 +250,18 @@ packs let us offer these techniques without compromising the verified core. RuVe
 author benefits from khive-oss as an adoption story; khive-oss benefits from technique
 access without full implementation overhead.
 
-### Why drop sqlite-vec entirely
+### Why the ported HNSW is the preferred path over sqlite-vec
 
 The ported HNSW supersedes sqlite-vec on every axis: performance, quantization,
-deterministic scoring, formal verification. A dual-path (sqlite-vec + HNSW) would add
-maintenance with no benefit. One-time migration on upgrade is well-defined via
-`HnswIndex::rebuild`.
+deterministic scoring, formal verification. A dual-path (sqlite-vec + HNSW) adds
+maintenance with no benefit once migration is complete. The migration path is
+well-defined via `HnswIndex::rebuild`.
+
+sqlite-vec currently remains in `khive-db` as the active `VectorStore` compatibility
+implementation. Retiring it — routing `VectorStore` impls through `HnswIndex` and
+providing the `kkernel migrate-vectors` path — is tracked as a separate follow-up.
+No section of this ADR should be read as claiming that sqlite-vec has already been
+dropped; it has not.
 
 ### Why a standalone crate now (vs. ADR-012's deferral)
 
@@ -285,8 +297,10 @@ suite, and its own dependency surface (lattice-embed).
 
 - 2-3 weeks of focused porting work. Mitigated: the internal code is mature and well-tested;
   the port is mechanical except for dependency rewiring.
-- One-time migration for any OSS deployments with sqlite-vec data. Mitigated: the
-  `HnswIndex::rebuild` path is well-tested; migration is a single CLI command or startup path.
+- One-time migration for any OSS deployments with sqlite-vec data will be required when
+  sqlite-vec retirement ships. Mitigated: the `HnswIndex::rebuild` path is well-tested;
+  migration is planned as a single CLI command or startup path. Retirement itself is deferred
+  follow-up work (see the "sqlite-vec retirement (deferred)" section above).
 - Lean4 CI dependency added to workspace. Mitigated: `lake build` is isolated to the
   `proofs/` tree; Rust build and tests do not require it.
 
@@ -304,10 +318,11 @@ suite, and its own dependency surface (lattice-embed).
 1. Create `crates/khive-retrieval/` from `khive-internal/platform/retrieval/`.
 2. Rewire dependencies per the mapping table above.
 3. Replace `foundation::embed` calls with `lattice-embed`.
-4. Drop `sqlite-vec` from `khive-db`. Route `VectorStore` impls through `HnswIndex`
-   via `StorageVectorSearch`.
-5. Decide and implement the sqlite-vec migration path (`kkernel migrate-vectors` or
-   auto-rebuild on startup).
+4. **Deferred follow-up**: Retire `sqlite-vec` from `khive-db` by routing `VectorStore`
+   impls through `HnswIndex` via `StorageVectorSearch`. sqlite-vec remains the active
+   `VectorStore` implementation in current shipped code.
+5. **Deferred follow-up**: Decide and implement the sqlite-vec migration path
+   (`kkernel migrate-vectors` or auto-rebuild on startup).
 6. Migrate tests; verify all pass. Run smoke test against ported stack.
 
 ### Phase 2 — Proof relocation

--- a/docs/adr/ADR-030-retrieval-stack-port.md
+++ b/docs/adr/ADR-030-retrieval-stack-port.md
@@ -127,8 +127,9 @@ pub use khive_retrieval::{
 };
 ```
 
-`StorageVectorSearch` and `StorageKeywordSearch` implement the `VectorStore` and
-`TextSearch` traits from ADR-005 respectively. `khive-runtime` still has FTS5 + VectorStore RRF paths over storage. The retrieval port
+`StorageVectorSearch` adapts an ADR-005 `VectorStore` into the retrieval
+`VectorSearch` trait, and `StorageKeywordSearch` adapts an ADR-005 `TextSearch`
+into the retrieval `KeywordSearch` trait. `khive-runtime` still has FTS5 + VectorStore RRF paths over storage. The retrieval port
 crates ship alongside that path; replacing or retiring sqlite-vec remains explicit follow-up
 work, not completed current behavior.
 

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -154,10 +154,12 @@ server forwards requests to the warm daemon via Unix socket (`forward_or_spawn`)
 it does not call `warm_all()` itself. This was changed in PR #20 (commit 9d9ec12):
 blocking stdio startup on `warm_all` delayed MCP connection without benefit.
 
-The net effect is the same: ANN indexes are warm before steady-state traffic,
-and the first suggest/search call returns results from the Vamana index. The
-zero-result cold-start bug is resolved by the daemon's background warm task,
-not by a blocking call in the stdio path.
+The net effect: steady-state traffic uses warmed Vamana indexes and benefits
+from full ANN recall. A first suggest/search call that races the background
+warm task may return results from lexical/atom signals only (BM25/FTS), without
+Vamana fusion, until `warm_all()` completes. The zero-result cold-start bug is
+resolved for steady-state traffic; there is no hard guarantee that the very
+first request will see ANN results.
 
 ### Cross-encoder rerank (deferred, optional)
 

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -147,9 +147,17 @@ corruption at scale).
 
 ### ANN warm-start
 
-The stdio MCP server calls `warm_all()` before accepting connections, loading
-persisted Vamana snapshots synchronously. This eliminates the cold-start
-0-result bug on the first suggest/search call after startup.
+ANN warm-start is owned by the **daemon** process (`khive-mcp --daemon`), not by
+the stdio server. After the daemon socket is bound, `warm_all()` runs in a
+background task, loading persisted Vamana snapshots into memory. The stdio MCP
+server forwards requests to the warm daemon via Unix socket (`forward_or_spawn`);
+it does not call `warm_all()` itself. This was changed in PR #20 (commit 9d9ec12):
+blocking stdio startup on `warm_all` delayed MCP connection without benefit.
+
+The net effect is the same: ANN indexes are warm before steady-state traffic,
+and the first suggest/search call returns results from the Vamana index. The
+zero-result cold-start bug is resolved by the daemon's background warm task,
+not by a blocking call in the stdio path.
 
 ### Cross-encoder rerank (deferred, optional)
 


### PR DESCRIPTION
## Summary

ADR/design-doc drift corrections across three issues. No `.rs` files changed.

- **#31 — ADR/code divergences (4 fixes)**
  - ADR-019: GTD terminal states (`done`/`cancelled`) have no outgoing transitions; removed incorrect reopen arrows
  - ADR-023 §5: `gtd.assign` uses `status`/`priority`; `task_status`/`task_priority` are rejected by `deny_unknown_fields`
  - ADR-030: `khive-retrieval` ships with `default = []` (all features off); table corrected from "on"
  - ADR-024: `Checkpoint<S>` + `InMemoryCheckpointStore` live in `khive-fold`, not `khive-runtime`; design.md ADR-058/059 refs consolidated into ADR-024 §Bayesian extensions

- **#32 — Stale/nonexistent ADR references (~19 locations)**
  - Corrected wrong file links and mislabelled ADR headings in 11 crate `design.md` files (khive-pack-kg, khive-pack-memory, khive-pack-knowledge, khive-mcp, khive-pack-gtd, khive-hnsw, khive-bm25, khive-merge, khive-runtime, khive-vcs, khive-fusion, khive-fold)
  - ADR-008: `validator.rs` → `validate.rs` (actual filename)
  - All corrected references verified against actual `docs/adr/` file listing; highest real ADR = ADR-051

- **#33 — ADR-051 ANN warm-start staleness**
  - §"ANN warm-start" rewritten to reflect daemon ownership of `warm_all()` after PR #20 (commit 9d9ec12)
  - Stdio server no longer calls warm; it forwards to daemon via `forward_or_spawn`

## Test plan

- [x] All pre-commit hooks pass (deno fmt, secret detection, merge conflicts)
- [x] `deno fmt --check docs/` passes clean (62 files checked)
- [x] `git diff --stat HEAD~1 HEAD` shows 32 `.md` files, zero `.rs` files
- [x] Each corrected ADR reference verified against actual file presence in `docs/adr/`
- [x] Each code claim (terminal state `&[]`, `deny_unknown_fields`, `default = []`, checkpoint location) verified by reading the relevant source file

Closes #31
Closes #32
Closes #33