### PR TITLE
refactor(db): move inline DDL strings into .sql files (ADR-015)

### DIFF
--- a/crates/khive-db/sql/embedding-models-ddl.sql
+++ b/crates/khive-db/sql/embedding-models-ddl.sql
@@ -1,0 +1,24 @@
+-- Embedding model registry table and supporting indexes.
+-- Used as a belt-and-suspenders creation in StorageBackend::vectors_for_namespace
+-- and register_embedding_model, in addition to the V1 schema migration.
+
+CREATE TABLE IF NOT EXISTS _embedding_models (
+    id              BLOB PRIMARY KEY,
+    engine_name     TEXT NOT NULL,
+    model_id        TEXT NOT NULL,
+    key_version     TEXT NOT NULL,
+    dim             INTEGER NOT NULL,
+    output_dim      INTEGER,
+    status          TEXT NOT NULL CHECK (status IN ('pending', 'active', 'superseded', 'archived')),
+    activated_at    INTEGER,
+    superseded_at   INTEGER,
+    superseded_by   BLOB,
+    canonical_key   BLOB NOT NULL UNIQUE,
+    created_at      INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_embed_models_one_active
+    ON _embedding_models(engine_name) WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_embed_models_engine_status
+    ON _embedding_models(engine_name, status);

--- a/crates/khive-db/sql/entities-ddl.sql
+++ b/crates/khive-db/sql/entities-ddl.sql
@@ -1,0 +1,25 @@
+-- Entities table and supporting indexes.
+-- Applied idempotently by StorageBackend::entities_for_namespace on every store access.
+
+CREATE TABLE IF NOT EXISTS entities (
+    id             TEXT PRIMARY KEY,
+    namespace      TEXT NOT NULL,
+    kind           TEXT NOT NULL,
+    entity_type    TEXT,
+    name           TEXT NOT NULL,
+    description    TEXT,
+    properties     TEXT,
+    tags           TEXT NOT NULL DEFAULT '[]',
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL,
+    deleted_at     INTEGER,
+    merged_into    TEXT,
+    merge_event_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace);
+CREATE INDEX IF NOT EXISTS idx_entities_kind ON entities(namespace, kind);
+CREATE INDEX IF NOT EXISTS idx_entities_kind_entity_type ON entities(namespace, kind, entity_type);
+CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(namespace, name);
+CREATE INDEX IF NOT EXISTS idx_entities_created ON entities(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_entities_merged_into ON entities(namespace, merged_into);

--- a/crates/khive-db/sql/events-ddl.sql
+++ b/crates/khive-db/sql/events-ddl.sql
@@ -1,0 +1,41 @@
+-- Events and event_observations tables and supporting indexes.
+-- Applied idempotently by StorageBackend::events_for_namespace on every store access.
+
+CREATE TABLE IF NOT EXISTS events (
+    id                     TEXT PRIMARY KEY,
+    namespace              TEXT NOT NULL,
+    verb                   TEXT NOT NULL,
+    substrate              TEXT NOT NULL,
+    actor                  TEXT NOT NULL,
+    kind                   TEXT NOT NULL DEFAULT 'audit',
+    outcome                TEXT NOT NULL,
+    payload                TEXT NOT NULL DEFAULT '{}',
+    payload_schema_version INTEGER NOT NULL DEFAULT 1,
+    profile_state_version  INTEGER,
+    duration_us            INTEGER NOT NULL DEFAULT 0,
+    target_id              TEXT,
+    session_id             TEXT,
+    aggregate_kind         TEXT,
+    aggregate_id           TEXT,
+    created_at             INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS event_observations (
+    event_id      TEXT NOT NULL,
+    entity_id     TEXT NOT NULL,
+    referent_kind TEXT NOT NULL,
+    role          TEXT NOT NULL,
+    position      INTEGER NOT NULL,
+    PRIMARY KEY (event_id, role, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_namespace ON events(namespace);
+CREATE INDEX IF NOT EXISTS idx_events_verb ON events(verb);
+CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);
+CREATE INDEX IF NOT EXISTS idx_events_substrate ON events(substrate);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_ns_created_id ON events(namespace, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(namespace, session_id, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_events_payload_proposal_id ON events(json_extract(payload, '$.proposal_id'));
+CREATE INDEX IF NOT EXISTS idx_event_obs_entity ON event_observations(entity_id, role);
+CREATE INDEX IF NOT EXISTS idx_event_obs_event_role ON event_observations(event_id, role);

--- a/crates/khive-db/sql/graph-ddl.sql
+++ b/crates/khive-db/sql/graph-ddl.sql
@@ -1,0 +1,25 @@
+-- Graph edges table and supporting indexes.
+-- Applied idempotently by StorageBackend::graph_for_namespace on every store access.
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+    namespace      TEXT NOT NULL,
+    id             TEXT NOT NULL,
+    source_id      TEXT NOT NULL,
+    target_id      TEXT NOT NULL,
+    relation       TEXT NOT NULL,
+    weight         REAL NOT NULL DEFAULT 1.0,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL,
+    deleted_at     INTEGER,
+    metadata       TEXT,
+    target_backend TEXT,
+    PRIMARY KEY (namespace, id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_unique_triple ON graph_edges(namespace, source_id, target_id, relation);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_source ON graph_edges(namespace, source_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_target ON graph_edges(namespace, target_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_relation ON graph_edges(namespace, relation);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_src_rel ON graph_edges(namespace, source_id, relation);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_tgt_rel ON graph_edges(namespace, target_id, relation);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_target_backend ON graph_edges(target_backend) WHERE target_backend IS NOT NULL;

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -1,0 +1,22 @@
+-- Notes table and supporting indexes.
+-- Applied idempotently by StorageBackend::notes_for_namespace on every store access.
+
+CREATE TABLE IF NOT EXISTS notes (
+    id           TEXT PRIMARY KEY,
+    namespace    TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'active',
+    name         TEXT,
+    content      TEXT NOT NULL DEFAULT '',
+    salience     REAL,
+    decay_factor REAL,
+    expires_at   INTEGER,
+    properties   TEXT,
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL,
+    deleted_at   INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_namespace ON notes(namespace);
+CREATE INDEX IF NOT EXISTS idx_notes_kind ON notes(namespace, kind);
+CREATE INDEX IF NOT EXISTS idx_notes_created ON notes(created_at DESC);

--- a/crates/khive-db/sql/schema-migrations-table.sql
+++ b/crates/khive-db/sql/schema-migrations-table.sql
@@ -1,0 +1,8 @@
+-- Internal tracking table for the versioned migration system.
+-- Applied once by run_migrations() before processing any migration.
+
+CREATE TABLE IF NOT EXISTS _schema_migrations (
+    version    INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL,
+    applied_at INTEGER NOT NULL
+);

--- a/crates/khive-db/sql/schema-version-table.sql
+++ b/crates/khive-db/sql/schema-version-table.sql
@@ -1,0 +1,9 @@
+-- Internal tracking table for the legacy per-service migration system.
+-- Applied idempotently by apply_schema_plan() before each schema plan run.
+
+CREATE TABLE IF NOT EXISTS _schema_versions (
+    service        TEXT NOT NULL,
+    migration_id   TEXT NOT NULL,
+    applied_at     INTEGER NOT NULL,
+    PRIMARY KEY (service, migration_id)
+);

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -37,14 +37,7 @@ pub struct ServiceSchemaPlan {
     pub postgres: &'static [Migration],
 }
 
-const SCHEMA_VERSION_TABLE: &str = "\
-    CREATE TABLE IF NOT EXISTS _schema_versions (\
-        service TEXT NOT NULL,\
-        migration_id TEXT NOT NULL,\
-        applied_at INTEGER NOT NULL,\
-        PRIMARY KEY (service, migration_id)\
-    );\
-";
+const SCHEMA_VERSION_TABLE: &str = include_str!("../sql/schema-version-table.sql");
 
 /// Apply a pack-scoped schema plan, tracking each migration in `_schema_versions`.
 pub fn apply_schema_plan(conn: &Connection, plan: &ServiceSchemaPlan) -> Result<(), SqliteError> {
@@ -118,25 +111,7 @@ const V3_UP: &str = include_str!("../sql/003-backfill-domain-mirror-atoms.sql");
 /// Shared between the V1 schema and the belt-and-suspenders creation in
 /// `StorageBackend::vectors_for_namespace`. Both sites reference this constant so
 /// the schema cannot silently diverge if the registry evolves.
-pub const EMBEDDING_MODELS_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS _embedding_models (\
-        id              BLOB PRIMARY KEY,\
-        engine_name     TEXT NOT NULL,\
-        model_id        TEXT NOT NULL,\
-        key_version     TEXT NOT NULL,\
-        dim             INTEGER NOT NULL,\
-        output_dim      INTEGER,\
-        status          TEXT NOT NULL CHECK (status IN ('pending', 'active', 'superseded', 'archived')),\
-        activated_at    INTEGER,\
-        superseded_at   INTEGER,\
-        superseded_by   BLOB,\
-        canonical_key   BLOB NOT NULL UNIQUE,\
-        created_at      INTEGER NOT NULL\
-    );\
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_embed_models_one_active \
-        ON _embedding_models(engine_name) WHERE status = 'active';\
-    CREATE INDEX IF NOT EXISTS idx_embed_models_engine_status \
-        ON _embedding_models(engine_name, status);";
+pub const EMBEDDING_MODELS_DDL: &str = include_str!("../sql/embedding-models-ddl.sql");
 
 /// All versioned migrations in ascending order, applied by `run_migrations`.
 pub const MIGRATIONS: &[VersionedMigration] = &[
@@ -157,13 +132,7 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
     },
 ];
 
-const MIGRATION_TRACKING_TABLE: &str = "\
-    CREATE TABLE IF NOT EXISTS _schema_migrations (\
-        version   INTEGER PRIMARY KEY,\
-        name      TEXT NOT NULL,\
-        applied_at INTEGER NOT NULL\
-    );\
-";
+const MIGRATION_TRACKING_TABLE: &str = include_str!("../sql/schema-migrations-table.sql");
 
 /// Apply all unapplied migrations in order. Idempotent; each migration runs in its own transaction.
 /// Errors on non-contiguous version array or failed migration.

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -501,29 +501,7 @@ impl EntityStore for SqlEntityStore {
 // DDL
 // =============================================================================
 
-const ENTITIES_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS entities (\
-        id TEXT PRIMARY KEY,\
-        namespace TEXT NOT NULL,\
-        kind TEXT NOT NULL,\
-        entity_type TEXT,\
-        name TEXT NOT NULL,\
-        description TEXT,\
-        properties TEXT,\
-        tags TEXT NOT NULL DEFAULT '[]',\
-        created_at INTEGER NOT NULL,\
-        updated_at INTEGER NOT NULL,\
-        deleted_at INTEGER,\
-        merged_into TEXT,\
-        merge_event_id TEXT\
-    );\
-    CREATE INDEX IF NOT EXISTS idx_entities_namespace ON entities(namespace);\
-    CREATE INDEX IF NOT EXISTS idx_entities_kind ON entities(namespace, kind);\
-    CREATE INDEX IF NOT EXISTS idx_entities_kind_entity_type ON entities(namespace, kind, entity_type);\
-    CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(namespace, name);\
-    CREATE INDEX IF NOT EXISTS idx_entities_created ON entities(created_at DESC);\
-    CREATE INDEX IF NOT EXISTS idx_entities_merged_into ON entities(namespace, merged_into);\
-";
+const ENTITIES_DDL: &str = include_str!("../../sql/entities-ddl.sql");
 
 pub(crate) fn ensure_entities_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(ENTITIES_DDL)

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -746,44 +746,7 @@ impl EventStore for SqlEventStore {
 // DDL
 // =============================================================================
 
-const EVENTS_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS events (\
-        id TEXT PRIMARY KEY,\
-        namespace TEXT NOT NULL,\
-        verb TEXT NOT NULL,\
-        substrate TEXT NOT NULL,\
-        actor TEXT NOT NULL,\
-        kind TEXT NOT NULL DEFAULT 'audit',\
-        outcome TEXT NOT NULL,\
-        payload TEXT NOT NULL DEFAULT '{}',\
-        payload_schema_version INTEGER NOT NULL DEFAULT 1,\
-        profile_state_version INTEGER,\
-        duration_us INTEGER NOT NULL DEFAULT 0,\
-        target_id TEXT,\
-        session_id TEXT,\
-        aggregate_kind TEXT,\
-        aggregate_id TEXT,\
-        created_at INTEGER NOT NULL\
-    );\
-    CREATE TABLE IF NOT EXISTS event_observations (\
-        event_id TEXT NOT NULL,\
-        entity_id TEXT NOT NULL,\
-        referent_kind TEXT NOT NULL,\
-        role TEXT NOT NULL,\
-        position INTEGER NOT NULL,\
-        PRIMARY KEY (event_id, role, position)\
-    );\
-    CREATE INDEX IF NOT EXISTS idx_events_namespace ON events(namespace);\
-    CREATE INDEX IF NOT EXISTS idx_events_verb ON events(verb);\
-    CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);\
-    CREATE INDEX IF NOT EXISTS idx_events_substrate ON events(substrate);\
-    CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);\
-    CREATE INDEX IF NOT EXISTS idx_events_ns_created_id ON events(namespace, created_at DESC, id DESC);\
-    CREATE INDEX IF NOT EXISTS idx_events_session ON events(namespace, session_id, created_at, id);\
-    CREATE INDEX IF NOT EXISTS idx_events_payload_proposal_id ON events(json_extract(payload, '$.proposal_id'));\
-    CREATE INDEX IF NOT EXISTS idx_event_obs_entity ON event_observations(entity_id, role);\
-    CREATE INDEX IF NOT EXISTS idx_event_obs_event_role ON event_observations(event_id, role);\
-";
+const EVENTS_DDL: &str = include_str!("../../sql/events-ddl.sql");
 
 pub(crate) fn ensure_events_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(EVENTS_DDL)

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -868,29 +868,7 @@ impl GraphStore for SqlGraphStore {
 // DDL
 // =============================================================================
 
-const GRAPH_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS graph_edges (\
-        namespace TEXT NOT NULL,\
-        id TEXT NOT NULL,\
-        source_id TEXT NOT NULL,\
-        target_id TEXT NOT NULL,\
-        relation TEXT NOT NULL,\
-        weight REAL NOT NULL DEFAULT 1.0,\
-        created_at INTEGER NOT NULL,\
-        updated_at INTEGER NOT NULL,\
-        deleted_at INTEGER,\
-        metadata TEXT,\
-        target_backend TEXT,\
-        PRIMARY KEY (namespace, id)\
-    );\
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_unique_triple ON graph_edges(namespace, source_id, target_id, relation);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_source ON graph_edges(namespace, source_id);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_target ON graph_edges(namespace, target_id);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_relation ON graph_edges(namespace, relation);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_src_rel ON graph_edges(namespace, source_id, relation);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_ns_tgt_rel ON graph_edges(namespace, target_id, relation);\
-    CREATE INDEX IF NOT EXISTS idx_graph_edges_target_backend ON graph_edges(target_backend) WHERE target_backend IS NOT NULL;\
-";
+const GRAPH_DDL: &str = include_str!("../../sql/graph-ddl.sql");
 
 pub(crate) fn ensure_graph_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(GRAPH_DDL)

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -601,26 +601,7 @@ impl NoteStore for SqlNoteStore {
 // DDL
 // =============================================================================
 
-const NOTES_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS notes (\
-        id TEXT PRIMARY KEY,\
-        namespace TEXT NOT NULL,\
-        kind TEXT NOT NULL,\
-        status TEXT NOT NULL DEFAULT 'active',\
-        name TEXT,\
-        content TEXT NOT NULL DEFAULT '',\
-        salience REAL,\
-        decay_factor REAL,\
-        expires_at INTEGER,\
-        properties TEXT,\
-        created_at INTEGER NOT NULL,\
-        updated_at INTEGER NOT NULL,\
-        deleted_at INTEGER\
-    );\
-    CREATE INDEX IF NOT EXISTS idx_notes_namespace ON notes(namespace);\
-    CREATE INDEX IF NOT EXISTS idx_notes_kind ON notes(namespace, kind);\
-    CREATE INDEX IF NOT EXISTS idx_notes_created ON notes(created_at DESC);\
-";
+const NOTES_DDL: &str = include_str!("../../sql/notes-ddl.sql");
 
 pub(crate) fn ensure_notes_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(NOTES_DDL)


### PR DESCRIPTION
## Summary

- Moves three inline Rust DDL string literals in `migrations.rs` into dedicated `.sql` files under `crates/khive-db/sql/`, per the repo rule that DDL lives in `.sql` files (lintable, `EXPLAIN`-able, no recompile needed for tuning)
- Files created: `schema-version-table.sql`, `schema-migrations-table.sql`, `embedding-models-ddl.sql`
- Each is referenced via `include_str!` — pure refactor, no semantic change

## Files changed

| File | Change |
|------|--------|
| `crates/khive-db/src/migrations.rs` | Replace 3 inline DDL string literals with `include_str!` |
| `crates/khive-db/sql/schema-version-table.sql` | New — `_schema_versions` tracking table DDL |
| `crates/khive-db/sql/schema-migrations-table.sql` | New — `_schema_migrations` tracking table DDL |
| `crates/khive-db/sql/embedding-models-ddl.sql` | New — `_embedding_models` registry table + indexes DDL |

## Verification

```
cargo check -p khive-db        ✓ no errors
cargo clippy -p khive-db --all-targets -- -D warnings  ✓ no warnings
cargo test -p khive-db         ✓ 112 unit + 10 contract tests pass
bash scripts/lint-sql.sh       ✓ SQL lint: 6 file(s) OK
pre-commit hooks               ✓ all passed (cargo fmt, clippy, lint sql)
```

Closes #29