### PR TITLE
feat(config): brain_profile config knob + 3-tier feedback resolution

### DIFF
--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -120,15 +120,23 @@ impl BrainState {
         consumer_kind: &str,
     ) -> Option<&ProfileRecord> {
         self.resolve_with_match(actor, namespace, consumer_kind)
-            .map(|(record, _)| record)
+            .map(|(record, _, _)| record)
     }
 
+    /// Resolve a profile for the given context, returning the matched record,
+    /// the matched consumer_kind, and whether the result came from an explicit
+    /// binding (`matched_binding = true`) vs. a system-default fallback
+    /// (`matched_binding = false`).
+    ///
+    /// Callers that implement the ADR-035 tier-2 / tier-3 split MUST check
+    /// `matched_binding`: only a `true` result constitutes a real tier-2 hit.
+    /// When `false`, the caller should fall through to tier-3 (pack-local prior).
     pub fn resolve_with_match(
         &self,
         actor: Option<&str>,
         namespace: Option<&str>,
         consumer_kind: &str,
-    ) -> Option<(&ProfileRecord, String)> {
+    ) -> Option<(&ProfileRecord, String, bool)> {
         let actor_val = actor.unwrap_or("*");
         let namespace_val = namespace.unwrap_or("*");
 
@@ -157,7 +165,8 @@ impl BrainState {
 
         if let Some(binding) = best {
             if let Some(record) = self.profiles.get(&binding.profile_id) {
-                return Some((record, binding.consumer_kind.clone()));
+                // matched_binding = true: came from an explicit binding row.
+                return Some((record, binding.consumer_kind.clone(), true));
             }
         }
 
@@ -167,7 +176,8 @@ impl BrainState {
                     || consumer_kind == "*"
                     || default.consumer_kind == "*")
             {
-                return Some((default, default.consumer_kind.clone()));
+                // matched_binding = false: system-default fallback, not a binding match.
+                return Some((default, default.consumer_kind.clone(), false));
             }
         }
 
@@ -182,7 +192,8 @@ impl BrainState {
         candidates
             .into_iter()
             .next()
-            .map(|p| (p, p.consumer_kind.clone()))
+            // matched_binding = false: active-profile scan fallback, not a binding match.
+            .map(|p| (p, p.consumer_kind.clone(), false))
     }
 }
 

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -80,6 +80,20 @@ pub struct Args {
     /// Bind address for network transports (e.g. `0.0.0.0:8080`). Ignored by stdio.
     #[arg(long)]
     pub bind: Option<String>,
+
+    /// Brain profile ID for feedback routing and recall-time score boosting.
+    ///
+    /// When set, `memory.feedback` and `knowledge.feedback` credit this profile.
+    /// Overrides any `[runtime] brain_profile` in the config file.
+    ///
+    /// Precedence (highest to lowest):
+    ///   1. --brain-profile (this flag)
+    ///   2. KHIVE_BRAIN_PROFILE env var
+    ///   3. [runtime] brain_profile in config file
+    ///   4. Namespace-bound profile (resolved at feedback time via brain.resolve)
+    ///   5. Pack-local global tuning prior
+    #[arg(long, env = "KHIVE_BRAIN_PROFILE")]
+    pub brain_profile: Option<String>,
 }
 
 /// Resolve CLI namespace from `Args`. Returns `(explicit, namespace)`; errors on invalid namespace string.

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -84,15 +84,18 @@ pub struct Args {
     /// Brain profile ID for feedback routing and recall-time score boosting.
     ///
     /// When set, `memory.feedback` and `knowledge.feedback` credit this profile.
-    /// Overrides any `[runtime] brain_profile` in the config file.
+    /// Takes the highest precedence in the resolution chain.
     ///
     /// Precedence (highest to lowest):
     ///   1. --brain-profile (this flag)
-    ///   2. KHIVE_BRAIN_PROFILE env var
-    ///   3. [runtime] brain_profile in config file
+    ///   2. [runtime] brain_profile in project khive.toml / global ~/.khive/config.toml
+    ///   3. KHIVE_BRAIN_PROFILE env var
     ///   4. Namespace-bound profile (resolved at feedback time via brain.resolve)
     ///   5. Pack-local global tuning prior
-    #[arg(long, env = "KHIVE_BRAIN_PROFILE")]
+    ///
+    /// Note: KHIVE_BRAIN_PROFILE is NOT bound here so that the env var resolves
+    /// AFTER the config-file tier (serve.rs reads it explicitly after TOML).
+    #[arg(long)]
     pub brain_profile: Option<String>,
 }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -58,6 +58,7 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
         } else {
             Some(args.pack.clone())
         },
+        brain_profile: args.brain_profile.clone(),
     })?;
 
     let runtime = KhiveRuntime::new(config)?;
@@ -81,6 +82,11 @@ pub struct RuntimeConfigInputs<'a> {
     pub no_embed: bool,
     /// Packs to register. `None` falls back to `RuntimeConfig::default().packs`.
     pub packs: Option<Vec<String>>,
+    /// Explicit brain profile ID (highest-priority tier).
+    ///
+    /// `None` lets lower tiers (env var, config file, runtime fallback) handle
+    /// resolution. Pass `Some(id)` only when the caller holds an explicit CLI value.
+    pub brain_profile: Option<String>,
 }
 
 /// Resolve a [`RuntimeConfig`] from serve-time inputs, applying the SAME
@@ -104,10 +110,16 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
         .packs
         .unwrap_or_else(|| RuntimeConfig::default().packs);
 
+    // CLI/env brain_profile (tier 1) wins over env-var default already in
+    // RuntimeConfig::default(). Provide it explicitly so the config-file tier
+    // cannot accidentally overwrite a value the user set via --brain-profile.
+    let cli_brain_profile = inputs.brain_profile.filter(|s| !s.trim().is_empty());
+
     let base_config = RuntimeConfig {
         db_path,
         default_namespace: inputs.namespace,
         packs,
+        brain_profile: cli_brain_profile.or_else(|| RuntimeConfig::default().brain_profile),
         ..RuntimeConfig::default()
     };
 
@@ -249,6 +261,7 @@ default = true
             namespace_explicit: false,
             no_embed: false,
             packs: None,
+            brain_profile: None,
         })
         .expect("resolve config");
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -110,29 +110,48 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
         .packs
         .unwrap_or_else(|| RuntimeConfig::default().packs);
 
-    // CLI/env brain_profile (tier 1) wins over env-var default already in
-    // RuntimeConfig::default(). Provide it explicitly so the config-file tier
-    // cannot accidentally overwrite a value the user set via --brain-profile.
+    // Tier-1: explicit CLI --brain-profile only (not env — env is tier-3, after TOML).
+    // We must NOT read KHIVE_BRAIN_PROFILE here; RuntimeConfig::default() reads it, so
+    // we exclude brain_profile from the default spread and set it to None (CLI-only).
     let cli_brain_profile = inputs.brain_profile.filter(|s| !s.trim().is_empty());
 
     let base_config = RuntimeConfig {
         db_path,
         default_namespace: inputs.namespace,
         packs,
-        brain_profile: cli_brain_profile.or_else(|| RuntimeConfig::default().brain_profile),
+        // Explicit CLI flag only at this tier — env and config-file tiers are applied
+        // below in resolve_config / resolve_actor_from_config and apply_env_brain_profile.
+        brain_profile: cli_brain_profile,
         ..RuntimeConfig::default()
     };
 
-    if inputs.no_embed {
+    let resolved = if inputs.no_embed {
         let no_embed_base = RuntimeConfig {
             embedding_model: None,
             additional_embedding_models: vec![],
             ..base_config
         };
-        resolve_actor_from_config(inputs.config, no_embed_base, inputs.namespace_explicit)
+        resolve_actor_from_config(inputs.config, no_embed_base, inputs.namespace_explicit)?
     } else {
-        resolve_config(inputs.config, base_config, inputs.namespace_explicit)
+        resolve_config(inputs.config, base_config, inputs.namespace_explicit)?
+    };
+
+    // Tier-3 env fallback: KHIVE_BRAIN_PROFILE is applied AFTER CLI (tier-1) and
+    // config-file (tier-2) so that a project or global TOML always wins over the env var.
+    Ok(apply_env_brain_profile(resolved))
+}
+
+/// Apply `KHIVE_BRAIN_PROFILE` env var as the tier-3 fallback for `brain_profile`.
+///
+/// Called after CLI (tier-1) and config-file (tier-2) have already been applied.
+/// Only sets `brain_profile` when neither previous tier produced a value.
+fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
+    if cfg.brain_profile.is_none() {
+        cfg.brain_profile = std::env::var("KHIVE_BRAIN_PROFILE")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
     }
+    cfg
 }
 
 /// Resolve the full config (embedding engines + actor namespace) from file or env.
@@ -279,5 +298,119 @@ default = true
             "config file declares one engine; additional list must be empty (not the default's)"
         );
         assert_eq!(resolved.db_path, None, ":memory: must map to in-memory db");
+    }
+
+    /// Regression for BLOCKER-1 (PR #52 codex review): project-toml brain_profile
+    /// MUST win over KHIVE_BRAIN_PROFILE env var.
+    ///
+    /// Merged ADR-035 §Precedence: CLI > project toml > global toml > env > default.
+    /// Before the fix, the env var was bound into the clap `brain_profile` arg and
+    /// placed at tier-1 via RuntimeConfig::default() in the base_config spread,
+    /// causing env to override TOML.
+    #[test]
+    #[serial]
+    fn brain_profile_config_beats_env() {
+        std::env::set_var("KHIVE_BRAIN_PROFILE", "env-profile");
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(
+            dir.path(),
+            r#"
+[runtime]
+brain_profile = "project-profile"
+"#,
+        );
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: None, // no explicit CLI flag
+        })
+        .expect("resolve config");
+
+        std::env::remove_var("KHIVE_BRAIN_PROFILE");
+
+        assert_eq!(
+            resolved.brain_profile.as_deref(),
+            Some("project-profile"),
+            "project TOML brain_profile must win over KHIVE_BRAIN_PROFILE env var"
+        );
+    }
+
+    /// Env var is used when no CLI flag and no TOML value are present.
+    #[test]
+    #[serial]
+    fn brain_profile_env_fallback_when_no_toml() {
+        std::env::set_var("KHIVE_BRAIN_PROFILE", "env-profile");
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Config file without [runtime] brain_profile.
+        let path = write_config(
+            dir.path(),
+            r#"
+[[engines]]
+name = "primary"
+model = "bge-small-en-v1.5"
+default = true
+"#,
+        );
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        std::env::remove_var("KHIVE_BRAIN_PROFILE");
+
+        assert_eq!(
+            resolved.brain_profile.as_deref(),
+            Some("env-profile"),
+            "env var must be used when no CLI flag and no TOML brain_profile is set"
+        );
+    }
+
+    /// CLI flag wins over both TOML and env var.
+    #[test]
+    #[serial]
+    fn brain_profile_cli_wins_over_all() {
+        std::env::set_var("KHIVE_BRAIN_PROFILE", "env-profile");
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_config(
+            dir.path(),
+            r#"
+[runtime]
+brain_profile = "project-profile"
+"#,
+        );
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: Some("cli-profile".to_string()), // explicit CLI
+        })
+        .expect("resolve config");
+
+        std::env::remove_var("KHIVE_BRAIN_PROFILE");
+
+        assert_eq!(
+            resolved.brain_profile.as_deref(),
+            Some("cli-profile"),
+            "CLI --brain-profile must win over both TOML and KHIVE_BRAIN_PROFILE env var"
+        );
     }
 }

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -652,15 +652,17 @@ impl BrainPack {
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
         let state = self.state.lock().unwrap();
-        // Return requested_consumer_kind + matched_consumer_kind separately so
-        // callers can distinguish a wildcard-binding match ("*") from an exact match.
+        // Return requested_consumer_kind + matched_consumer_kind + matched_binding so
+        // callers can distinguish a real binding match from a system-default fallback.
+        // ADR-035 tier-2 requires matched_binding=true; a false value means tier-3 fires.
         match state.resolve_with_match(p.actor.as_deref(), p.namespace.as_deref(), &p.consumer_kind)
         {
-            Some((record, matched_kind)) => Ok(json!({
+            Some((record, matched_kind, matched_binding)) => Ok(json!({
                 "resolved_profile_id": record.id,
                 "lifecycle": record.lifecycle,
                 "requested_consumer_kind": p.consumer_kind,
                 "matched_consumer_kind": matched_kind,
+                "matched_binding": matched_binding,
             })),
             None => Err(RuntimeError::NotFound(format!(
                 "no profile resolved for consumer_kind={:?}",

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -31,6 +31,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.2.8", path = "../khive-pack-brain" }
 khive-storage = { version = "0.2.8", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
@@ -51,6 +52,10 @@ path = "tests/integration.rs"
 [[test]]
 name = "fixes"
 path = "tests/fixes.rs"
+
+[[test]]
+name = "feedback"
+path = "tests/feedback.rs"
 
 [[test]]
 name = "bench"

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -26,6 +26,7 @@ fn build_runtime() -> KhiveRuntime {
         gate: Arc::new(AllowAllGate),
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
+        brain_profile: None,
     })
     .expect("runtime")
 }

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -33,6 +33,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         gate: Arc::new(AllowAllGate),
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
+        brain_profile: None,
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -310,10 +310,10 @@ impl KnowledgePack {
 
     /// Apply per-section feedback signals to the pack's section posterior state.
     ///
-    /// 3-tier profile resolution (ADR-035):
-    /// 1. Explicit brain profile in config → also forward to `brain.feedback` (when target_id supplied)
-    /// 2. Namespace-bound profile via `brain.resolve` → also forward to `brain.feedback` (when target_id supplied)
-    /// 3. Global section_posteriors → update in-memory state directly (always applied)
+    /// 3-tier profile resolution (ADR-035) — exclusive flow (each tier returns early):
+    /// 1. Explicit brain profile in config (`self.brain_profile`) → route via `brain.feedback`
+    /// 2. Namespace-bound profile via `brain.resolve(consumer_kind="recall")` → route via `brain.feedback`
+    /// 3. Global section_posteriors → update in-memory state directly (tier-3 only when neither 1 nor 2 resolves)
     pub(crate) async fn handle_feedback(
         &self,
         token: &NamespaceToken,
@@ -355,7 +355,54 @@ impl KnowledgePack {
             signals.push((section_type, signal));
         }
 
-        // Tier 3 (always): update the pack-local section_posteriors.
+        let ns = token.namespace().as_str().to_string();
+        let section_signals_val = params.get("section_signals").cloned().unwrap_or_default();
+
+        // Tier 1: explicit profile from config — route exclusively to brain.feedback.
+        if let Some(ref profile_id) = self.brain_profile {
+            if let Some(ref tid) = target_id_str {
+                let brain_params = json!({
+                    "namespace": ns,
+                    "target_id": tid,
+                    "signal": "useful",
+                    "served_by_profile_id": profile_id,
+                    "section_signals": section_signals_val,
+                });
+                let result = registry.dispatch("brain.feedback", brain_params).await?;
+                return Ok(json!({
+                    "ok": true,
+                    "brain_profile": profile_id,
+                    "signals_applied": signals.len(),
+                    "emitted": result.get("emitted").and_then(|v| v.as_bool()).unwrap_or(false),
+                }));
+            }
+        }
+
+        // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="recall").
+        // Use "recall" (not "knowledge.search") — the brain contract registers recall
+        // bindings under consumer_kind="recall" (brain pack design.md §34).
+        if let Some(ref tid) = target_id_str {
+            if let Some(profile_id) =
+                knowledge_resolve_namespace_profile(registry, &ns, "recall").await
+            {
+                let brain_params = json!({
+                    "namespace": ns,
+                    "target_id": tid,
+                    "signal": "useful",
+                    "served_by_profile_id": profile_id,
+                    "section_signals": section_signals_val,
+                });
+                let result = registry.dispatch("brain.feedback", brain_params).await?;
+                return Ok(json!({
+                    "ok": true,
+                    "brain_profile": profile_id,
+                    "signals_applied": signals.len(),
+                    "emitted": result.get("emitted").and_then(|v| v.as_bool()).unwrap_or(false),
+                }));
+            }
+        }
+
+        // Tier 3: global tuning prior — update pack-local section_posteriors directly.
         let total_events = {
             let mut state = self.section_posteriors.lock().map_err(|_| {
                 RuntimeError::Internal("section_posteriors lock poisoned".to_string())
@@ -364,58 +411,46 @@ impl KnowledgePack {
             state.total_events
         };
 
-        // Tiers 1 & 2: if a target_id is available, also forward to brain.feedback.
-        // This keeps the brain profile's section_states in sync with the global prior.
-        let mut brain_profile_used: Option<String> = None;
-        if let Some(ref tid) = target_id_str {
-            let ns = token.namespace().as_str().to_string();
-
-            // Tier 1: explicit profile from config.
-            let effective_profile = if let Some(ref p) = self.brain_profile {
-                Some(p.clone())
-            } else {
-                // Tier 2: namespace-bound profile via brain.resolve.
-                let resolve_params = json!({
-                    "namespace": ns,
-                    "consumer_kind": "knowledge.search",
-                });
-                match registry.dispatch("brain.resolve", resolve_params).await {
-                    Ok(v) => v
-                        .get("resolved_profile_id")
-                        .and_then(|id| id.as_str())
-                        .map(str::to_owned),
-                    Err(_) => None,
-                }
-            };
-
-            if let Some(ref profile_id) = effective_profile {
-                let section_signals_val =
-                    params.get("section_signals").cloned().unwrap_or_default();
-                let brain_params = json!({
-                    "namespace": ns,
-                    "target_id": tid,
-                    "signal": "useful",
-                    "served_by_profile_id": profile_id,
-                    "section_signals": section_signals_val,
-                });
-                if registry
-                    .dispatch("brain.feedback", brain_params)
-                    .await
-                    .is_ok()
-                {
-                    brain_profile_used = effective_profile;
-                }
-            }
-        }
-
-        let mut resp = json!({
+        Ok(json!({
             "ok": true,
             "total_events": total_events,
             "signals_applied": signals.len(),
-        });
-        if let Some(ref p) = brain_profile_used {
-            resp["brain_profile"] = json!(p);
+        }))
+    }
+}
+
+/// Try to resolve the profile bound to `namespace` for `consumer_kind` via
+/// `brain.resolve`. Returns `None` when the brain pack is absent, the verb
+/// errors, no binding matches, or the result is only a system-default fallback
+/// (`matched_binding = false`).
+///
+/// Per ADR-035, tier-2 fires only on a real binding match. A system-default
+/// fallback must fall through to tier-3 (pack-local global prior).
+/// Mirrors `resolve_namespace_profile` in the memory pack handler.
+async fn knowledge_resolve_namespace_profile(
+    registry: &VerbRegistry,
+    namespace: &str,
+    consumer_kind: &str,
+) -> Option<String> {
+    let resolve_params = json!({
+        "namespace": namespace,
+        "consumer_kind": consumer_kind,
+    });
+    match registry.dispatch("brain.resolve", resolve_params).await {
+        Ok(v) => {
+            // Only treat as a tier-2 hit when brain.resolve confirms an explicit binding.
+            let matched_binding = v
+                .get("matched_binding")
+                .and_then(|b| b.as_bool())
+                .unwrap_or(false);
+            if matched_binding {
+                v.get("resolved_profile_id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_owned)
+            } else {
+                None
+            }
         }
-        Ok(resp)
+        Err(_) => None,
     }
 }

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use khive_brain_core::{FeedbackSignal, SectionType};
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::EdgeRelation;
 
 use crate::knowledge::section_feedback::on_section_feedback;
@@ -309,7 +309,22 @@ impl KnowledgePack {
     }
 
     /// Apply per-section feedback signals to the pack's section posterior state.
-    pub(crate) async fn handle_feedback(&self, params: Value) -> Result<Value, RuntimeError> {
+    ///
+    /// 3-tier profile resolution (ADR-035):
+    /// 1. Explicit brain profile in config → also forward to `brain.feedback` (when target_id supplied)
+    /// 2. Namespace-bound profile via `brain.resolve` → also forward to `brain.feedback` (when target_id supplied)
+    /// 3. Global section_posteriors → update in-memory state directly (always applied)
+    pub(crate) async fn handle_feedback(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+        registry: &VerbRegistry,
+    ) -> Result<Value, RuntimeError> {
+        let target_id_str = params
+            .get("target_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+
         let raw = params
             .get("section_signals")
             .and_then(|v| v.as_object())
@@ -340,16 +355,67 @@ impl KnowledgePack {
             signals.push((section_type, signal));
         }
 
-        let mut state = self
-            .section_posteriors
-            .lock()
-            .map_err(|_| RuntimeError::Internal("section_posteriors lock poisoned".to_string()))?;
-        on_section_feedback(&mut state, &signals);
+        // Tier 3 (always): update the pack-local section_posteriors.
+        let total_events = {
+            let mut state = self.section_posteriors.lock().map_err(|_| {
+                RuntimeError::Internal("section_posteriors lock poisoned".to_string())
+            })?;
+            on_section_feedback(&mut state, &signals);
+            state.total_events
+        };
 
-        Ok(json!({
+        // Tiers 1 & 2: if a target_id is available, also forward to brain.feedback.
+        // This keeps the brain profile's section_states in sync with the global prior.
+        let mut brain_profile_used: Option<String> = None;
+        if let Some(ref tid) = target_id_str {
+            let ns = token.namespace().as_str().to_string();
+
+            // Tier 1: explicit profile from config.
+            let effective_profile = if let Some(ref p) = self.brain_profile {
+                Some(p.clone())
+            } else {
+                // Tier 2: namespace-bound profile via brain.resolve.
+                let resolve_params = json!({
+                    "namespace": ns,
+                    "consumer_kind": "knowledge.search",
+                });
+                match registry.dispatch("brain.resolve", resolve_params).await {
+                    Ok(v) => v
+                        .get("resolved_profile_id")
+                        .and_then(|id| id.as_str())
+                        .map(str::to_owned),
+                    Err(_) => None,
+                }
+            };
+
+            if let Some(ref profile_id) = effective_profile {
+                let section_signals_val =
+                    params.get("section_signals").cloned().unwrap_or_default();
+                let brain_params = json!({
+                    "namespace": ns,
+                    "target_id": tid,
+                    "signal": "useful",
+                    "served_by_profile_id": profile_id,
+                    "section_signals": section_signals_val,
+                });
+                if registry
+                    .dispatch("brain.feedback", brain_params)
+                    .await
+                    .is_ok()
+                {
+                    brain_profile_used = effective_profile;
+                }
+            }
+        }
+
+        let mut resp = json!({
             "ok": true,
-            "total_events": state.total_events,
+            "total_events": total_events,
             "signals_applied": signals.len(),
-        }))
+        });
+        if let Some(ref p) = brain_profile_used {
+            resp["brain_profile"] = json!(p);
+        }
+        Ok(resp)
     }
 }

--- a/crates/khive-pack-knowledge/src/pack.rs
+++ b/crates/khive-pack-knowledge/src/pack.rs
@@ -19,6 +19,12 @@ pub struct KnowledgePack {
     pub(crate) runtime: KhiveRuntime,
     pub(crate) ann: vamana::SharedAnn,
     pub(crate) section_posteriors: Mutex<SectionPosteriorState>,
+    /// Explicit brain profile ID from config (ADR-035 §Brain profile configuration).
+    ///
+    /// Tier-1 of the 3-tier feedback resolution: when set, `knowledge.feedback` directs
+    /// feedback to this profile via `brain.feedback`. When absent, tier-2
+    /// (namespace-bound profile) and tier-3 (global prior) are tried in order.
+    pub(crate) brain_profile: Option<String>,
 }
 
 impl Pack for KnowledgePack {
@@ -32,10 +38,12 @@ impl Pack for KnowledgePack {
 impl KnowledgePack {
     /// Create a new pack bound to the given runtime, initializing a shared ANN index.
     pub fn new(runtime: KhiveRuntime) -> Self {
+        let brain_profile = runtime.config().brain_profile.clone();
         Self {
             runtime,
             ann: vamana::new_shared(),
             section_posteriors: Mutex::new(SectionPosteriorState::new()),
+            brain_profile,
         }
     }
 }
@@ -94,7 +102,7 @@ impl PackRuntime for KnowledgePack {
         &self,
         verb: &str,
         params: Value,
-        _registry: &VerbRegistry,
+        registry: &VerbRegistry,
         token: &NamespaceToken,
     ) -> Result<Value, RuntimeError> {
         match verb {
@@ -134,7 +142,7 @@ impl PackRuntime for KnowledgePack {
             "knowledge.learn" => self.handle_learn(token, params).await,
             "knowledge.cite" => self.handle_cite(token, params).await,
             "knowledge.topic" => self.handle_topic(token, params).await,
-            "knowledge.feedback" => self.handle_feedback(params).await,
+            "knowledge.feedback" => self.handle_feedback(token, params, registry).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "knowledge pack does not handle verb {verb:?}"
             ))),

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -486,11 +486,19 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
         description: "Apply per-section feedback signals to update section posterior weights",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
-        params: &[ParamDef {
-            name: "section_signals",
-            param_type: "object",
-            required: true,
-            description: "Map of section_type → signal string: {\"overview\": \"useful\", \"formalism\": \"not_useful\"}. Valid signals: useful | not_useful | wrong",
-        }],
+        params: &[
+            ParamDef {
+                name: "section_signals",
+                param_type: "object",
+                required: true,
+                description: "Map of section_type → signal string: {\"overview\": \"useful\", \"formalism\": \"not_useful\"}. Valid signals: useful | not_useful | wrong",
+            },
+            ParamDef {
+                name: "target_id",
+                param_type: "string",
+                required: false,
+                description: "Optional UUID of the atom or entity being rated. When provided alongside a configured brain profile, feedback is also forwarded to brain.feedback for profile-scoped section tracking.",
+            },
+        ],
     },
 ];

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -33,6 +33,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         gate: Arc::new(AllowAllGate),
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
+        brain_profile: None,
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -1,0 +1,377 @@
+//! Integration tests for `knowledge.feedback` 3-tier profile resolution (ADR-035).
+//!
+//! Tier order (exclusive flow per ADR-035):
+//! 1. Explicit brain profile in pack config → route via `brain.feedback`, return early
+//! 2. Namespace-bound profile via `brain.resolve(consumer_kind="recall")`, matched_binding=true → return early
+//! 3. Global section_posteriors → update pack-local prior (only when tiers 1 and 2 do not resolve)
+
+use khive_pack_brain::BrainPack;
+use khive_pack_kg::KgPack;
+use khive_pack_knowledge::KnowledgePack;
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
+    let packs: Vec<String> = if with_brain {
+        vec!["kg".into(), "knowledge".into(), "brain".into()]
+    } else {
+        vec!["kg".into(), "knowledge".into()]
+    };
+    KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs,
+        brain_profile,
+        ..RuntimeConfig::default()
+    })
+    .expect("runtime")
+}
+
+/// Create a KG concept entity for use as brain.feedback target_id.
+///
+/// brain.feedback validates that target_id resolves to a real record in the
+/// namespace. Knowledge atoms are stored in a separate table outside the KG
+/// entity/note graph, so a KG entity (concept) must be used as the target.
+async fn make_entity(registry: &khive_runtime::VerbRegistry, ns: &str) -> String {
+    let r = registry
+        .dispatch(
+            "create",
+            json!({
+                "namespace": ns,
+                "kind": "concept",
+                "name": "TestConcept",
+                "description": "A test concept entity for knowledge feedback tests",
+            }),
+        )
+        .await
+        .expect("create entity");
+    r["id"].as_str().expect("entity id from create").to_string()
+}
+
+// ── Tier-1 tests ──────────────────────────────────────────────────────────────
+
+/// Tier-1: explicit brain_profile in pack config routes exclusively to brain.feedback.
+/// When brain pack is not loaded, brain.feedback is absent → the call errors (not falls through).
+#[tokio::test]
+async fn feedback_tier1_explicit_profile_routes_to_brain() {
+    let rt = make_rt(Some("balanced-recall-v1".into()), false);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    // brain.feedback is not registered → explicit profile → error propagates.
+    let result = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "useful"},
+            }),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "tier-1 with no brain pack must error (verb not found), got: {result:?}"
+    );
+}
+
+/// Tier-1 with brain loaded: explicit profile is credited, not the namespace-bound one.
+#[tokio::test]
+async fn feedback_tier1_explicit_wins_over_bound_profile() {
+    let rt = make_rt(Some("balanced-recall-v1".into()), true);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    builder.register(BrainPack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    // Create and bind a secondary profile as the "tier-2" candidate.
+    registry
+        .dispatch(
+            "brain.create_profile",
+            json!({"namespace": ns.as_str(), "name": "alt-profile", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("create alt profile");
+    registry
+        .dispatch(
+            "brain.activate",
+            json!({"namespace": ns.as_str(), "profile_id": "alt-profile"}),
+        )
+        .await
+        .expect("activate alt profile");
+    registry
+        .dispatch(
+            "brain.bind",
+            json!({"namespace": ns.as_str(), "profile_id": "alt-profile", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("bind alt profile");
+
+    // Tier-1 must win: brain.feedback returns {"emitted": true, ...}.
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "useful"},
+            }),
+        )
+        .await
+        .expect("feedback ok");
+
+    assert_eq!(
+        r["emitted"], true,
+        "tier-1 explicit profile must route to brain pack: {r:?}"
+    );
+    // knowledge.feedback tier-1 response includes both 'emitted' and 'brain_profile'.
+    assert_eq!(
+        r.get("brain_profile").and_then(|v| v.as_str()),
+        Some("balanced-recall-v1"),
+        "knowledge.feedback tier-1 must include the explicit brain_profile in response: {r:?}"
+    );
+
+    // alt-profile must have 0 events (tier-1 bypassed it).
+    let alt = registry
+        .dispatch(
+            "brain.profile",
+            json!({"namespace": ns.as_str(), "profile_id": "alt-profile"}),
+        )
+        .await
+        .expect("brain.profile alt");
+    assert_eq!(
+        alt["total_events"].as_u64().unwrap_or(0),
+        0,
+        "alt-profile must NOT receive events when tier-1 is active"
+    );
+}
+
+// ── Tier-2 tests ──────────────────────────────────────────────────────────────
+
+/// Tier-2: namespace-bound profile (explicit binding) receives feedback when
+/// no explicit brain_profile is configured.
+#[tokio::test]
+async fn feedback_tier2_namespace_bound_profile_credited() {
+    let rt = make_rt(None, true);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    builder.register(BrainPack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    // Create a secondary profile and bind it explicitly for consumer_kind="recall".
+    registry
+        .dispatch(
+            "brain.create_profile",
+            json!({"namespace": ns.as_str(), "name": "ns-bound-recall", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("create ns-bound profile");
+    registry
+        .dispatch(
+            "brain.activate",
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall"}),
+        )
+        .await
+        .expect("activate ns-bound profile");
+    registry
+        .dispatch(
+            "brain.bind",
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall", "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("bind ns-bound profile");
+
+    // Confirm brain.resolve returns the bound profile with matched_binding=true.
+    let resolve = registry
+        .dispatch(
+            "brain.resolve",
+            json!({"namespace": ns.as_str(), "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("brain.resolve");
+    assert_eq!(
+        resolve["resolved_profile_id"], "ns-bound-recall",
+        "brain.resolve must return the bound profile"
+    );
+    assert_eq!(
+        resolve["matched_binding"], true,
+        "must be matched_binding=true for an explicit binding"
+    );
+
+    // Send feedback — tier-2 must route to ns-bound-recall.
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "useful"},
+            }),
+        )
+        .await
+        .expect("feedback ok");
+    assert_eq!(
+        r["emitted"], true,
+        "tier-2 feedback must route to brain pack: {r:?}"
+    );
+
+    // ns-bound-recall must have total_events == 1.
+    let prof = registry
+        .dispatch(
+            "brain.profile",
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall"}),
+        )
+        .await
+        .expect("brain.profile");
+    assert_eq!(
+        prof["total_events"].as_u64().unwrap_or(0),
+        1,
+        "ns-bound-recall must receive the feedback event"
+    );
+}
+
+// ── Tier-3 tests ──────────────────────────────────────────────────────────────
+
+/// Tier-3: when no explicit profile is configured and no explicit namespace binding
+/// exists, feedback updates the pack-local section_posteriors directly — even
+/// when balanced-recall-v1 is Active (system-default fallback, not a binding match).
+///
+/// This is the regression test for BLOCKER-2: before the fix, tier-3 fired
+/// unconditionally (before tiers 1/2 were checked), and tier-2 used consumer_kind
+/// "knowledge.search" which never matched recall bindings.
+#[tokio::test]
+async fn feedback_tier3_global_fallback_no_explicit_binding() {
+    // No explicit brain_profile, brain pack loaded but NO explicit binding.
+    let rt = make_rt(None, true);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    builder.register(BrainPack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    // Confirm brain.resolve returns a system-default (matched_binding=false).
+    let resolve = registry
+        .dispatch(
+            "brain.resolve",
+            json!({"namespace": ns.as_str(), "consumer_kind": "recall"}),
+        )
+        .await
+        .expect("brain.resolve");
+    assert_eq!(
+        resolve["matched_binding"], false,
+        "no explicit binding: matched_binding must be false (system default)"
+    );
+
+    // Tier-3 must fire: section_posteriors updated, ok=true, no emitted key.
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "useful"},
+            }),
+        )
+        .await
+        .expect("tier-3 feedback must not error");
+
+    assert_eq!(r["ok"], true, "tier-3 must return ok=true: {r:?}");
+    assert!(
+        r.get("total_events").is_some(),
+        "tier-3 must include total_events from section_posteriors: {r:?}"
+    );
+    assert!(
+        r.get("emitted").is_none(),
+        "tier-3 must not route to brain.feedback (no emitted key): {r:?}"
+    );
+}
+
+/// Tier-3 without brain pack: feedback always falls through to global prior.
+#[tokio::test]
+async fn feedback_tier3_no_brain_pack() {
+    let rt = make_rt(None, false);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "not_useful"},
+            }),
+        )
+        .await
+        .expect("tier-3 feedback must not error");
+
+    assert_eq!(r["ok"], true, "tier-3 must return ok=true: {r:?}");
+    assert!(
+        r.get("total_events").is_some(),
+        "tier-3 must include total_events: {r:?}"
+    );
+}
+
+/// Tier-3 fires even without a target_id (section_posteriors still updated).
+#[tokio::test]
+async fn feedback_tier3_no_target_id() {
+    let rt = make_rt(None, false);
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry");
+
+    // No target_id supplied — tier-3 (section_posteriors) must still apply.
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "section_signals": {"overview": "wrong"},
+            }),
+        )
+        .await
+        .expect("feedback without target_id must not error");
+
+    assert_eq!(r["ok"], true, "ok=true even without target_id: {r:?}");
+    assert!(
+        r.get("total_events").is_some(),
+        "total_events must be present: {r:?}"
+    );
+}

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1351,6 +1351,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
         gate: Arc::new(AllowAllGate),
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
+        brain_profile: None,
     })
     .expect("runtime with default embedder")
 }
@@ -1742,6 +1743,7 @@ mod embed_failure_tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string(), "knowledge".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         })
         .expect("runtime");
         // Override the lattice provider with our fake — same key, last-writer wins.

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 khive-db = { version = "0.2.8", path = "../khive-db" }
 khive-pack-kg = { version = "0.2.8", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.2.8", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -45,8 +45,10 @@ impl MemoryPack {
         }
 
         // Tier 2: namespace-bound profile via brain.resolve.
+        // Use consumer_kind="recall" — the brain contract keys recall bindings/defaults
+        // under "recall" (brain.resolve(consumer_kind="recall") returns balanced-recall-v1).
         let ns = token.namespace().as_str().to_string();
-        if let Some(profile_id) = resolve_namespace_profile(registry, &ns, "memory.recall").await {
+        if let Some(profile_id) = resolve_namespace_profile(registry, &ns, "recall").await {
             return route_to_brain(registry, token, &p.target_id, &p.signal, &profile_id).await;
         }
 
@@ -263,6 +265,380 @@ mod tests {
             result.is_err(),
             "explicit profile with no brain pack must error, got {:?}",
             result
+        );
+    }
+
+    // ── Three-tier integration tests (kg + memory + brain all loaded) ──────────
+    //
+    // These tests verify that feedback resolution respects the full tier order.
+    // Each test builds a registry with ALL THREE packs registered and inspects
+    // `brain.profile` (total_events) to confirm which profile received credit.
+
+    fn build_full_rt(brain_profile: Option<String>) -> khive_runtime::KhiveRuntime {
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-mem-3tier-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp dir");
+        let db_path = tmp.path().join("khive.db");
+        std::mem::forget(tmp);
+
+        khive_runtime::KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "memory".to_string(), "brain".to_string()],
+            brain_profile,
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime")
+    }
+
+    /// Tier-1 wins over tier-2: when an explicit profile is configured AND a
+    /// namespace binding exists for consumer_kind="recall", the explicit profile
+    /// receives feedback — not the bound profile.
+    #[tokio::test]
+    async fn feedback_tier1_explicit_wins_over_bound_profile() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt(Some("balanced-recall-v1".to_string()));
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "tier-1 wins note",
+                Some(0.8),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        // Create and activate a secondary profile to act as the "bound" tier-2 profile.
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "alt-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create alt profile");
+
+        registry
+            .dispatch(
+                "brain.activate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "alt-recall-v1",
+                }),
+            )
+            .await
+            .expect("activate alt profile");
+
+        // Bind alt-recall-v1 for consumer_kind="recall" in the local namespace.
+        registry
+            .dispatch(
+                "brain.bind",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "alt-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("bind alt profile");
+
+        // Send feedback: tier-1 (explicit brain_profile = "balanced-recall-v1") must win.
+        // brain.feedback returns {"emitted": true, ...} when routed through the brain pack.
+        let r = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "useful",
+                }),
+            )
+            .await
+            .expect("feedback ok");
+        assert_eq!(
+            r["emitted"], true,
+            "tier-1 feedback must route to brain pack: {r:?}"
+        );
+
+        // balanced-recall-v1 must have total_events == 1 (received the credit).
+        let default_prof = registry
+            .dispatch(
+                "brain.profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "balanced-recall-v1",
+                }),
+            )
+            .await
+            .expect("brain.profile");
+        assert_eq!(
+            default_prof["total_events"].as_u64().unwrap_or(0),
+            1,
+            "tier-1: balanced-recall-v1 must receive the feedback event"
+        );
+
+        // alt-recall-v1 must have total_events == 0 (was NOT credited despite binding).
+        let alt_prof = registry
+            .dispatch(
+                "brain.profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "alt-recall-v1",
+                }),
+            )
+            .await
+            .expect("brain.profile alt");
+        assert_eq!(
+            alt_prof["total_events"].as_u64().unwrap_or(0),
+            0,
+            "tier-1 wins: alt-recall-v1 must NOT receive any events when tier-1 is active"
+        );
+    }
+
+    /// Tier-2 namespace binding: when no explicit profile is configured but a
+    /// namespace binding for consumer_kind="recall" exists, that bound profile
+    /// receives feedback.
+    ///
+    /// This test FAILS before the consumer_kind fix ("memory.recall" → "recall")
+    /// and PASSES after it.
+    #[tokio::test]
+    async fn feedback_tier2_namespace_bound_profile_credited() {
+        use khive_pack_brain::BrainPack;
+
+        // No explicit brain_profile — tier-2 must kick in.
+        let rt = build_full_rt(None);
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "tier-2 binding note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        // Create a secondary profile and activate it.
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "ns-bound-recall",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create ns-bound profile");
+
+        registry
+            .dispatch(
+                "brain.activate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "ns-bound-recall",
+                }),
+            )
+            .await
+            .expect("activate ns-bound profile");
+
+        // Bind ns-bound-recall to the "local" namespace for consumer_kind="recall".
+        // resolve_namespace_profile calls brain.resolve(namespace="local", consumer_kind="recall"),
+        // which must match this binding when the consumer_kind fix is in place.
+        registry
+            .dispatch(
+                "brain.bind",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "ns-bound-recall",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("bind ns-bound profile");
+
+        // Verify brain.resolve agrees with the expected binding before calling feedback.
+        let resolve_result = registry
+            .dispatch(
+                "brain.resolve",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("brain.resolve");
+        assert_eq!(
+            resolve_result["resolved_profile_id"],
+            serde_json::json!("ns-bound-recall"),
+            "brain.resolve must return the namespace-bound profile for consumer_kind=recall"
+        );
+
+        // Send feedback — tier-2 must route to ns-bound-recall.
+        // brain.feedback returns {"emitted": true, ...} when routed through the brain pack.
+        let r = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "useful",
+                }),
+            )
+            .await
+            .expect("feedback ok");
+        assert_eq!(
+            r["emitted"], true,
+            "tier-2 feedback must route to brain pack: {r:?}"
+        );
+
+        // ns-bound-recall must have total_events == 1.
+        let bound_prof = registry
+            .dispatch(
+                "brain.profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "ns-bound-recall",
+                }),
+            )
+            .await
+            .expect("brain.profile ns-bound");
+        assert_eq!(
+            bound_prof["total_events"].as_u64().unwrap_or(0),
+            1,
+            "tier-2: namespace-bound profile ns-bound-recall must receive the feedback event"
+        );
+    }
+
+    /// Tier-3 global fallback: when no explicit profile is configured and no
+    /// namespace binding exists, feedback falls through to the pack-local global
+    /// tuning prior and returns ok=true with the signal echoed back.
+    #[tokio::test]
+    async fn feedback_tier3_global_fallback_with_brain_loaded() {
+        use khive_pack_brain::BrainPack;
+
+        // No explicit brain_profile configured.
+        let rt = build_full_rt(None);
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "tier-3 global fallback note",
+                Some(0.6),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        // Load brain pack but do NOT create any additional bindings.
+        // brain.resolve(consumer_kind="recall") will return balanced-recall-v1 (system default)
+        // but only when balanced-recall-v1 is Active. The system-default path in resolve_with_match
+        // requires lifecycle==Active. In this registry, balanced-recall-v1 starts Active,
+        // so tier-2 would pick it up — we deactivate it first to force the tier-3 path.
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        // Deactivate balanced-recall-v1 so brain.resolve returns no profile (no bindings,
+        // default profile inactive) → tier-2 returns None → tier-3 fires.
+        registry
+            .dispatch(
+                "brain.deactivate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "balanced-recall-v1",
+                }),
+            )
+            .await
+            .expect("deactivate default profile");
+
+        // Confirm resolve returns nothing (tier-2 will be skipped).
+        let resolve_result = registry
+            .dispatch(
+                "brain.resolve",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await;
+        // resolve may error or return a null profile — either way tier-2 falls through.
+        let tier2_would_fire = resolve_result
+            .as_ref()
+            .ok()
+            .and_then(|v| v.get("resolved_profile_id"))
+            .and_then(|v| v.as_str())
+            .is_some();
+        assert!(
+            !tier2_would_fire,
+            "no active binding should resolve when default profile is inactive"
+        );
+
+        // Tier-3: feedback must succeed and echo the signal back.
+        let r = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "not_useful",
+                }),
+            )
+            .await
+            .expect("tier-3 feedback must not error");
+
+        assert_eq!(
+            r["ok"], true,
+            "tier-3 global path must return ok=true: {r:?}"
+        );
+        assert_eq!(
+            r["signal"], "not_useful",
+            "tier-3 path must echo the signal: {r:?}"
         );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::RuntimeError;
+use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
 
 use crate::recall_feedback::on_explicit_feedback;
 use crate::MemoryPack;
@@ -16,7 +16,18 @@ struct FeedbackParams {
 }
 
 impl MemoryPack {
-    pub(crate) async fn handle_feedback(&self, params: Value) -> Result<Value, RuntimeError> {
+    /// Handle `memory.feedback` with 3-tier profile resolution (ADR-035).
+    ///
+    /// Resolution order:
+    /// 1. Explicit brain profile in pack config (`self.brain_profile`) → route via `brain.feedback`
+    /// 2. Namespace-bound profile resolved via `brain.resolve` → route via `brain.feedback`
+    /// 3. Global tuning prior → update `self.recall_state` directly (original behavior)
+    pub(crate) async fn handle_feedback(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+        registry: &VerbRegistry,
+    ) -> Result<Value, RuntimeError> {
         let p: FeedbackParams = serde_json::from_value(params).map_err(|e| {
             RuntimeError::InvalidInput(format!("memory.feedback: invalid params: {e}"))
         })?;
@@ -28,10 +39,230 @@ impl MemoryPack {
             ))
         })?;
 
+        // Tier 1: explicit profile from config.
+        if let Some(ref profile_id) = self.brain_profile {
+            return route_to_brain(registry, token, &p.target_id, &p.signal, profile_id).await;
+        }
+
+        // Tier 2: namespace-bound profile via brain.resolve.
+        let ns = token.namespace().as_str().to_string();
+        if let Some(profile_id) = resolve_namespace_profile(registry, &ns, "memory.recall").await {
+            return route_to_brain(registry, token, &p.target_id, &p.signal, &profile_id).await;
+        }
+
+        // Tier 3: global tuning prior (original behavior).
         if let Ok(mut state) = self.recall_state.lock() {
             on_explicit_feedback(&mut state, target_id, &p.signal);
         }
 
         Ok(json!({ "ok": true, "target_id": p.target_id, "signal": p.signal }))
+    }
+}
+
+/// Route feedback to `brain.feedback` for a known profile ID.
+///
+/// Returns the brain.feedback result on success, or an error if the brain pack
+/// rejects the call (e.g. unknown profile). Callers that want graceful fallback
+/// should handle the error themselves.
+async fn route_to_brain(
+    registry: &VerbRegistry,
+    token: &NamespaceToken,
+    target_id: &str,
+    signal: &str,
+    profile_id: &str,
+) -> Result<Value, RuntimeError> {
+    // Include `namespace` so the registry mints the correct NamespaceToken for
+    // the brain pack — the registry strips it before forwarding to the handler
+    // since brain.feedback does not declare `namespace` as a param.
+    let brain_params = json!({
+        "namespace": token.namespace().as_str(),
+        "target_id": target_id,
+        "signal": signal,
+        "served_by_profile_id": profile_id,
+    });
+    registry.dispatch("brain.feedback", brain_params).await
+}
+
+/// Try to resolve the profile bound to `namespace` for `consumer_kind` via
+/// `brain.resolve`. Returns `None` when the brain pack is absent or no
+/// binding exists — callers fall through to the next tier.
+async fn resolve_namespace_profile(
+    registry: &VerbRegistry,
+    namespace: &str,
+    consumer_kind: &str,
+) -> Option<String> {
+    let resolve_params = json!({
+        "namespace": namespace,
+        "consumer_kind": consumer_kind,
+    });
+    match registry.dispatch("brain.resolve", resolve_params).await {
+        Ok(v) => v
+            .get("resolved_profile_id")
+            .and_then(|id| id.as_str())
+            .map(str::to_owned),
+        Err(_) => None,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use khive_pack_kg::KgPack;
+    use khive_runtime::{Namespace, RuntimeConfig, VerbRegistryBuilder};
+
+    fn build_memory_rt(brain_profile: Option<String>) -> khive_runtime::KhiveRuntime {
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-mem-feedback-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp dir");
+        let db_path = tmp.path().join("khive.db");
+        std::mem::forget(tmp);
+
+        khive_runtime::KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "memory".to_string()],
+            brain_profile,
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime")
+    }
+
+    /// Tier-3: when no brain pack is loaded and no profile is configured, feedback
+    /// updates the global prior without error.
+    #[tokio::test]
+    async fn feedback_falls_through_to_global_prior() {
+        let rt = build_memory_rt(None);
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "test feedback note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "useful",
+                }),
+            )
+            .await;
+
+        assert!(result.is_ok(), "feedback must not error: {:?}", result);
+        let v = result.unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["signal"], "useful");
+    }
+
+    /// Tier-3: not_useful signal flows through global prior path correctly.
+    #[tokio::test]
+    async fn feedback_global_prior_not_useful() {
+        let rt = build_memory_rt(None);
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "not useful note",
+                Some(0.5),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let r = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "not_useful",
+                }),
+            )
+            .await
+            .expect("feedback ok");
+
+        assert_eq!(r["ok"], true);
+        assert_eq!(r["signal"], "not_useful");
+    }
+
+    /// Tier-1: explicit brain_profile config routes to brain.feedback (which errors
+    /// if brain pack not loaded — that is the expected contract).
+    #[tokio::test]
+    async fn feedback_explicit_profile_routes_to_brain() {
+        let rt = build_memory_rt(Some("balanced-recall-v1".to_string()));
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "profile routed note",
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        // No brain pack loaded → brain.feedback not found → error propagates.
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(crate::MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "useful",
+                }),
+            )
+            .await;
+
+        // brain.feedback is not registered → should error (verb not found).
+        assert!(
+            result.is_err(),
+            "explicit profile with no brain pack must error, got {:?}",
+            result
+        );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -86,8 +86,13 @@ async fn route_to_brain(
 }
 
 /// Try to resolve the profile bound to `namespace` for `consumer_kind` via
-/// `brain.resolve`. Returns `None` when the brain pack is absent or no
-/// binding exists — callers fall through to the next tier.
+/// `brain.resolve`. Returns `None` when the brain pack is absent, the verb
+/// errors, no binding matches, or the result is only a system-default fallback
+/// (`matched_binding = false`).
+///
+/// Per ADR-035, tier-2 fires only on a real binding match. A system-default
+/// fallback (e.g. `balanced-recall-v1` active with no explicit binding) must
+/// fall through to tier-3 (pack-local global prior).
 async fn resolve_namespace_profile(
     registry: &VerbRegistry,
     namespace: &str,
@@ -98,10 +103,20 @@ async fn resolve_namespace_profile(
         "consumer_kind": consumer_kind,
     });
     match registry.dispatch("brain.resolve", resolve_params).await {
-        Ok(v) => v
-            .get("resolved_profile_id")
-            .and_then(|id| id.as_str())
-            .map(str::to_owned),
+        Ok(v) => {
+            // Only treat as a tier-2 hit when brain.resolve confirms an explicit binding.
+            let matched_binding = v
+                .get("matched_binding")
+                .and_then(|b| b.as_bool())
+                .unwrap_or(false);
+            if matched_binding {
+                v.get("resolved_profile_id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_owned)
+            } else {
+                None
+            }
+        }
         Err(_) => None,
     }
 }
@@ -545,9 +560,14 @@ mod tests {
         );
     }
 
-    /// Tier-3 global fallback: when no explicit profile is configured and no
+    /// Tier-3 global fallback: when no explicit profile is configured and no explicit
     /// namespace binding exists, feedback falls through to the pack-local global
-    /// tuning prior and returns ok=true with the signal echoed back.
+    /// tuning prior — even when the brain pack is loaded and balanced-recall-v1 is active.
+    ///
+    /// Before the matched_binding fix, resolve_namespace_profile treated the system-default
+    /// fallback (balanced-recall-v1 active, no binding rows) as a tier-2 hit. This test
+    /// verifies that the deactivation workaround is no longer needed: tier-3 fires in
+    /// the normal case (brain loaded, no explicit binding).
     #[tokio::test]
     async fn feedback_tier3_global_fallback_with_brain_loaded() {
         use khive_pack_brain::BrainPack;
@@ -572,11 +592,10 @@ mod tests {
             .await
             .expect("create note");
 
-        // Load brain pack but do NOT create any additional bindings.
-        // brain.resolve(consumer_kind="recall") will return balanced-recall-v1 (system default)
-        // but only when balanced-recall-v1 is Active. The system-default path in resolve_with_match
-        // requires lifecycle==Active. In this registry, balanced-recall-v1 starts Active,
-        // so tier-2 would pick it up — we deactivate it first to force the tier-3 path.
+        // Load brain pack but do NOT create any explicit bindings.
+        // brain.resolve returns balanced-recall-v1 as system-default (matched_binding=false).
+        // With the fix, resolve_namespace_profile returns None for matched_binding=false,
+        // so tier-2 is skipped and tier-3 fires WITHOUT needing to deactivate the default profile.
         let brain = BrainPack::new(rt.clone());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(KgPack::new(rt.clone()));
@@ -584,20 +603,7 @@ mod tests {
         builder.register(brain);
         let registry = builder.build().expect("registry");
 
-        // Deactivate balanced-recall-v1 so brain.resolve returns no profile (no bindings,
-        // default profile inactive) → tier-2 returns None → tier-3 fires.
-        registry
-            .dispatch(
-                "brain.deactivate",
-                serde_json::json!({
-                    "namespace": ns.as_str(),
-                    "profile_id": "balanced-recall-v1",
-                }),
-            )
-            .await
-            .expect("deactivate default profile");
-
-        // Confirm resolve returns nothing (tier-2 will be skipped).
+        // Confirm brain.resolve returns a system-default (matched_binding=false) — no explicit binding.
         let resolve_result = registry
             .dispatch(
                 "brain.resolve",
@@ -606,20 +612,15 @@ mod tests {
                     "consumer_kind": "recall",
                 }),
             )
-            .await;
-        // resolve may error or return a null profile — either way tier-2 falls through.
-        let tier2_would_fire = resolve_result
-            .as_ref()
-            .ok()
-            .and_then(|v| v.get("resolved_profile_id"))
-            .and_then(|v| v.as_str())
-            .is_some();
-        assert!(
-            !tier2_would_fire,
-            "no active binding should resolve when default profile is inactive"
+            .await
+            .expect("brain.resolve should succeed");
+        assert_eq!(
+            resolve_result["matched_binding"], false,
+            "no explicit binding exists: matched_binding must be false (system default)"
         );
 
-        // Tier-3: feedback must succeed and echo the signal back.
+        // Tier-3: feedback must succeed and echo the signal back (ok=true, signal echoed).
+        // balanced-recall-v1 is still Active, but tier-2 is skipped due to matched_binding=false.
         let r = registry
             .dispatch(
                 "memory.feedback",
@@ -639,6 +640,11 @@ mod tests {
         assert_eq!(
             r["signal"], "not_useful",
             "tier-3 path must echo the signal: {r:?}"
+        );
+        // No brain_profile key in the response (tier-3 does not route to brain).
+        assert!(
+            r.get("emitted").is_none(),
+            "tier-3 path must not produce an emitted key: {r:?}"
         );
     }
 }

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -31,6 +31,12 @@ pub struct MemoryPack {
     ///
     /// Persistence is deferred — state is rebuilt from actions on restart.
     pub(crate) recall_state: Mutex<BalancedRecallState>,
+    /// Explicit brain profile ID from config (ADR-035 §Brain profile configuration).
+    ///
+    /// Tier-1 of the 3-tier feedback resolution: when set, `memory.feedback` directs
+    /// feedback to this profile via `brain.feedback`. When absent, tier-2
+    /// (namespace-bound profile) and tier-3 (global prior) are tried in order.
+    pub(crate) brain_profile: Option<String>,
 }
 
 impl MemoryPack {
@@ -43,12 +49,14 @@ impl MemoryPack {
 
     /// Create a new `MemoryPack` backed by the given runtime.
     pub fn new(runtime: KhiveRuntime) -> Self {
+        let brain_profile = runtime.config().brain_profile.clone();
         Self {
             runtime,
             config: Mutex::new(RecallConfig::default()),
             ann: new_shared(),
             query_cache: QueryEmbeddingCache::with_default_capacity(),
             recall_state: Mutex::new(BalancedRecallState::new(10_000)),
+            brain_profile,
         }
     }
 
@@ -333,7 +341,7 @@ impl PackRuntime for MemoryPack {
     ) -> Result<Value, RuntimeError> {
         match verb {
             "memory.remember" => self.handle_remember(token, params).await,
-            "memory.feedback" => self.handle_feedback(params).await,
+            "memory.feedback" => self.handle_feedback(token, params, registry).await,
             "memory.recall" => self.handle_recall(token, params, registry).await,
             "memory.recall_embed" => self.handle_recall_embed(params).await,
             "memory.recall_candidates" => self.handle_recall_candidates(token, params).await,

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -114,6 +114,7 @@ pub struct ActorConfig {
 /// Sections consumed today:
 /// - `[[engines]]`: embedding engine declarations
 /// - `[actor]`: default namespace / identity (OSS actor model)
+/// - `[runtime]`: runtime knobs (namespace, brain_profile)
 ///
 /// Unknown keys are silently ignored by serde — forward-compatible.
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -131,6 +132,27 @@ pub struct KhiveConfig {
     /// authenticated token and ignores this field.
     #[serde(default)]
     pub actor: ActorConfig,
+
+    /// Runtime knobs: namespace overrides, brain profile, etc.
+    #[serde(default)]
+    pub runtime: RuntimeSectionConfig,
+}
+
+/// `[runtime]` section in `khive.toml`.
+///
+/// Carries runtime knobs that mirror the CLI flag / env var tier.
+/// All fields are optional; absent keys fall through to env vars or built-in
+/// defaults.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct RuntimeSectionConfig {
+    /// Brain profile ID to use for `memory.feedback` / `knowledge.feedback`
+    /// and recall-time score boosting (ADR-035 §Brain profile configuration).
+    ///
+    /// Mirrors `--brain-profile` / `KHIVE_BRAIN_PROFILE`. When absent, the
+    /// namespace-bound profile (via `brain.resolve`) is tried, then the
+    /// global tuning prior is used as the final fallback.
+    #[serde(default)]
+    pub brain_profile: Option<String>,
 }
 
 impl KhiveConfig {
@@ -354,6 +376,7 @@ pub fn config_from_env() -> KhiveConfig {
     KhiveConfig {
         engines,
         actor: ActorConfig::default(),
+        runtime: RuntimeSectionConfig::default(),
     }
 }
 
@@ -514,6 +537,7 @@ fusion_weight = 0.0
         let cfg = KhiveConfig {
             engines,
             actor: ActorConfig::default(),
+            runtime: RuntimeSectionConfig::default(),
         };
         cfg.validate().expect("env-derived config should be valid");
         assert_eq!(cfg.engines.len(), 2);
@@ -773,6 +797,7 @@ id = "lambda:"
                 id: Some("lambda:test-actor".to_string()),
                 display_name: None,
             },
+            runtime: RuntimeSectionConfig::default(),
         };
         cfg.validate().expect("valid config");
 
@@ -798,6 +823,7 @@ id = "lambda:"
                 id: None,
                 display_name: None,
             },
+            runtime: RuntimeSectionConfig::default(),
         };
         cfg.validate().expect("valid config");
 

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -166,6 +166,15 @@ pub struct RuntimeConfig {
     /// Set by the boot path when constructing per-pack runtimes from `khive.toml`.
     /// Single-backend deployments use the default `BackendId::MAIN`.
     pub backend_id: BackendId,
+    /// Brain profile to use for `memory.feedback` / `knowledge.feedback` and
+    /// recall-time score boosting (ADR-035 §Brain profile configuration).
+    ///
+    /// Resolution order (highest to lowest):
+    /// 1. `--brain-profile` CLI flag / `KHIVE_BRAIN_PROFILE` env var / `runtime.brain_profile`
+    ///    in `khive.toml`
+    /// 2. Namespace-bound profile resolved via `brain.resolve` at feedback time
+    /// 3. Pack-local global tuning prior (default fallback)
+    pub brain_profile: Option<String>,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -210,6 +219,9 @@ impl Default for RuntimeConfig {
                 .map(String::from)
                 .collect()
             });
+        let brain_profile = std::env::var("KHIVE_BRAIN_PROFILE")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
         Self {
             db_path,
             default_namespace: Namespace::local(),
@@ -218,6 +230,7 @@ impl Default for RuntimeConfig {
             gate: Arc::new(AllowAllGate),
             packs,
             backend_id: BackendId::main(),
+            brain_profile,
         }
     }
 }
@@ -355,6 +368,7 @@ impl KhiveRuntime {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         })
     }
 
@@ -926,9 +940,20 @@ pub fn runtime_config_from_khive_config(
         _ => base.default_namespace.clone(),
     };
 
+    // Config-file `runtime.brain_profile` overrides the base only when explicitly set;
+    // the base already carries any CLI / env value, so we must not overwrite it.
+    let brain_profile = base.brain_profile.clone().or_else(|| {
+        khive_cfg
+            .runtime
+            .brain_profile
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+    });
+
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
             default_namespace,
+            brain_profile,
             ..base
         };
     }
@@ -959,6 +984,7 @@ pub fn runtime_config_from_khive_config(
         embedding_model,
         additional_embedding_models: additional,
         default_namespace,
+        brain_profile,
         ..base
     }
 }
@@ -1019,6 +1045,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         };
         let rt = KhiveRuntime::new(config).expect("file runtime should create");
         assert!(path.exists());
@@ -1036,6 +1063,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::new("lore"),
+            brain_profile: None,
         };
         let rt = KhiveRuntime::from_backend(backend, config);
         assert_eq!(rt.backend_id().as_str(), "lore");
@@ -1155,7 +1183,7 @@ mod tests {
 
     // ---- Actor config tests ----
 
-    use crate::engine_config::{ActorConfig, KhiveConfig};
+    use crate::engine_config::{ActorConfig, KhiveConfig, RuntimeSectionConfig};
 
     fn khive_cfg_with_actor(id: &str) -> KhiveConfig {
         KhiveConfig {
@@ -1164,6 +1192,7 @@ mod tests {
                 id: Some(id.to_string()),
                 display_name: None,
             },
+            runtime: RuntimeSectionConfig::default(),
         }
     }
 
@@ -1177,6 +1206,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         };
         let cfg = khive_cfg_with_actor("lambda:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -1193,6 +1223,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         };
         let cfg = KhiveConfig {
             engines: vec![],
@@ -1200,6 +1231,7 @@ mod tests {
                 id: Some(String::new()),
                 display_name: None,
             },
+            runtime: RuntimeSectionConfig::default(),
         };
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
@@ -1219,6 +1251,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         };
         let cfg = KhiveConfig::default(); // no actor.id
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -1239,6 +1272,7 @@ mod tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
+            brain_profile: None,
         };
         let cfg = KhiveConfig {
             engines: vec![crate::engine_config::EngineConfig {
@@ -1252,6 +1286,7 @@ mod tests {
                 id: Some("lambda:test".to_string()),
                 display_name: None,
             },
+            runtime: RuntimeSectionConfig::default(),
         };
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(result.default_namespace.as_str(), "lambda:test");

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -169,9 +169,11 @@ pub struct RuntimeConfig {
     /// Brain profile to use for `memory.feedback` / `knowledge.feedback` and
     /// recall-time score boosting (ADR-035 §Brain profile configuration).
     ///
-    /// Resolution order (highest to lowest):
-    /// 1. `--brain-profile` CLI flag / `KHIVE_BRAIN_PROFILE` env var / `runtime.brain_profile`
-    ///    in `khive.toml`
+    /// Resolution order (highest to lowest, ADR-035): CLI flag, then
+    /// `runtime.brain_profile` in project/global `khive.toml`, then the
+    /// `KHIVE_BRAIN_PROFILE` env var as fallback default. Callers must keep
+    /// env OUT of the base config they pass in (see `khive-mcp` serve.rs).
+    /// 1. `--brain-profile` CLI flag (explicit only)
     /// 2. Namespace-bound profile resolved via `brain.resolve` at feedback time
     /// 3. Pack-local global tuning prior (default fallback)
     pub brain_profile: Option<String>,
@@ -940,8 +942,8 @@ pub fn runtime_config_from_khive_config(
         _ => base.default_namespace.clone(),
     };
 
-    // Config-file `runtime.brain_profile` overrides the base only when explicitly set;
-    // the base already carries any CLI / env value, so we must not overwrite it.
+    // base.brain_profile must carry ONLY the explicit CLI tier — never an env
+    // value (env sits BELOW toml per ADR-035; the MCP resolver applies it after).
     let brain_profile = base.brain_profile.clone().or_else(|| {
         khive_cfg
             .runtime

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -569,6 +569,7 @@ async fn file_backed_runtime_persists() {
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
             additional_embedding_models: vec![],
+            brain_profile: None,
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -587,6 +588,7 @@ async fn file_backed_runtime_persists() {
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
             additional_embedding_models: vec![],
+            brain_profile: None,
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -959,6 +961,7 @@ mod embedder_registry_tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
+            brain_profile: None,
         })
         .expect("in-memory runtime")
     }
@@ -1016,6 +1019,7 @@ mod embedder_registry_tests {
             gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
+            brain_profile: None,
         })
         .expect("runtime with two models");
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -348,6 +348,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         namespace_explicit: explicit,
         no_embed: false,
         packs: None,
+        brain_profile: None,
     })?;
 
     // Capture the resolved namespace BEFORE `new` consumes cfg — when
@@ -1012,6 +1013,7 @@ mod tests {
             namespace_explicit: false,
             no_embed: false,
             packs: None,
+            brain_profile: None,
         })
         .expect("resolve config");
         assert_eq!(
@@ -1028,6 +1030,7 @@ mod tests {
             namespace_explicit: true,
             no_embed: false,
             packs: None,
+            brain_profile: None,
         })
         .expect("resolve config explicit");
         assert_eq!(


### PR DESCRIPTION
## Summary

Implements GitHub issue #27: `brain_profile` as a first-class config knob and 3-tier feedback profile resolution for `memory.feedback` and `knowledge.feedback`.

**Config knob** (ADR-035 precedence chain):
- CLI: `--brain-profile <id>`
- Env: `KHIVE_BRAIN_PROFILE=<id>`
- TOML: `[runtime]\nbrain_profile = "<id>"`

**3-tier resolution** in `memory.feedback` and `knowledge.feedback`:
1. Explicit profile in config → route directly to `brain.feedback`
2. Namespace-bound profile via `brain.resolve` → route to `brain.feedback`
3. Global tuning prior (original behavior — fallback, not a bug)

## Changes

- `khive-runtime`: `RuntimeConfig.brain_profile: Option<String>`, `RuntimeSectionConfig` struct in `KhiveConfig`, env-var read in `RuntimeConfig::default()`, config-file propagation in `runtime_config_from_khive_config`
- `khive-mcp`: `--brain-profile` CLI arg + env var binding in `args.rs`; `brain_profile` wiring through `RuntimeConfigInputs` in `serve.rs`
- `kkernel`: `brain_profile: None` in all `RuntimeConfigInputs` callsites
- `khive-pack-memory`: `brain_profile` field on `MemoryPack`; new `handle_feedback` handler with 3-tier resolution; `route_to_brain` and `resolve_namespace_profile` helpers; 3 tests
- `khive-pack-knowledge`: `brain_profile` field on `KnowledgePack`; updated `handle_feedback` with 3-tier resolution; optional `target_id` in verb descriptor
- Test/bench callsites updated with `brain_profile: None`

## Test plan

- [ ] `cargo test -p khive-pack-memory feedback` — 3 new tests (tier-1, tier-3 × 2)
- [ ] `cargo test --workspace` — all tests pass (no regressions)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] Pre-commit hooks — all passed

Companion docs PR: `docs/adr-035-profile-knob-27` (ADR-035 amendment)