### PR TITLE
chore(deps): remove unused deps, workspace-dep discipline, #[allow] REASON form

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -85,6 +85,9 @@ rmcp = "1.7"
 futures = "0.3"
 serial_test = "3"
 libc = "0.2"
+proptest = "1"
+crossbeam-queue = "0.3"
+sqlite-vec = { version = "0.1.9" }
 
 [profile.release]
 opt-level = 3

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-crossbeam-queue = "0.3"
+crossbeam-queue = { workspace = true }
 parking_lot = { workspace = true }
 sha2 = { workspace = true }
-sqlite-vec = { version = "0.1.9", optional = true }
+sqlite-vec = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 [dependencies]
 khive-gate = { version = "0.2.8", path = "../khive-gate" }
 serde_json = { workspace = true }
-tracing = { workspace = true }
 
 regorus = { workspace = true }
 

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -24,8 +24,8 @@ rand = { workspace = true }
 rayon = { workspace = true }
 
 [dev-dependencies]
-blake3 = "1"
-proptest = "1"
+blake3 = { workspace = true }
+proptest = { workspace = true }
 uuid = { workspace = true }
 criterion = { workspace = true }
 lattice-embed = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -24,7 +24,6 @@ rand = { workspace = true }
 rayon = { workspace = true }
 
 [dev-dependencies]
-blake3 = { workspace = true }
 proptest = { workspace = true }
 uuid = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -22,8 +22,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-rand = { workspace = true }
-rand_distr = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -686,6 +686,9 @@ fn read_merge_entity(
 /// provenance.  Returns the updated `into` entity so the caller can do the async vec re-insert.
 ///
 /// When `dry_run` is true, all reads and computations are performed but no writes are issued.
+// REASON: merge requires both entity IDs, the namespace, FTS and vec table names, merge
+// policy, and dry-run flag — all are load-bearing; reducing to a struct would obscure
+// the sync/async boundary split that keeps this function off the async runtime.
 #[allow(clippy::too_many_arguments)]
 fn merge_entity_sql(
     conn: &rusqlite::Connection,
@@ -701,6 +704,9 @@ fn merge_entity_sql(
     let from_entity = read_merge_entity(conn, from_id, &namespace)?;
 
     // --- Collect edges incident to from_id ---
+    // REASON: EdgeRow fields are populated via rusqlite row mapping; the struct is fully
+    // constructed even though not all fields are read back after construction — the
+    // complete mapping guards against column-order bugs when the schema changes.
     #[allow(dead_code)]
     struct EdgeRow {
         id: Uuid,
@@ -1118,6 +1124,8 @@ fn append_merge_history(props: Option<Value>, entry: Value) -> Result<Option<Val
 /// re-embedding.
 ///
 /// When `dry_run` is true, all reads and computations are performed but no writes are issued.
+// REASON: note merge additionally requires a content_strategy parameter versus entity merge;
+// same sync/async boundary rationale as merge_entity_sql applies here.
 #[allow(clippy::too_many_arguments)]
 fn merge_note_sql(
     conn: &rusqlite::Connection,
@@ -1145,6 +1153,7 @@ fn merge_note_sql(
     let from_str = from_id.to_string();
 
     // Collect edges incident to from_id.
+    // REASON: same as merge_entity_sql — full field mapping prevents column-order bugs.
     #[allow(dead_code)]
     struct EdgeRow {
         id: Uuid,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -319,6 +319,9 @@ impl KhiveRuntime {
     // ---- Entity operations ----
 
     /// Create and persist a new entity.
+    // REASON: entity creation requires kind, type, name, description, properties, tags, and
+    // namespace token — refactoring into a builder would add indirection without reducing
+    // caller complexity; this signature mirrors the MCP verb surface directly.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_entity(
         &self,
@@ -1069,6 +1072,9 @@ impl KhiveRuntime {
     ///   `SubstrateKind::Note`.
     /// - For each UUID in `annotates`, creates an `EdgeRelation::Annotates` edge from
     ///   the note to that target.
+    // REASON: note creation requires kind, name, content, salience, properties, annotates,
+    // and namespace token — mirrors the MCP verb surface; a builder would not reduce
+    // caller complexity for pack handler callers.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_note(
         &self,
@@ -1087,6 +1093,8 @@ impl KhiveRuntime {
     }
 
     /// Like [`create_note`] but also sets a non-zero decay factor on the note.
+    // REASON: extends create_note with an additional decay_factor parameter; same
+    // rationale — mirrors the MCP surface and reduces an extra builder layer.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_note_with_decay(
         &self,
@@ -1114,6 +1122,9 @@ impl KhiveRuntime {
     }
 
     /// Like [`create_note_with_decay`] but targets a specific embedding model.
+    // REASON: adds an embedding_model parameter to the decay variant; the full parameter
+    // set is required for correct MCP verb routing and cannot be collapsed without
+    // introducing a separate config struct that would obscure call sites.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_note_with_decay_for_embedding_model(
         &self,
@@ -1141,6 +1152,9 @@ impl KhiveRuntime {
         .await
     }
 
+    // REASON: private inner function unifies all create_note variants; it receives every
+    // optional parameter individually so that public variants can pass None without
+    // requiring callers to construct an intermediate struct.
     #[allow(clippy::too_many_arguments)]
     async fn create_note_inner(
         &self,


### PR DESCRIPTION
## Summary

Closes #38

Addresses all five items from the P3 dependency + lint-justification audit:

- **BRAIN-009**: Removed `rand` and `rand_distr` from `khive-pack-brain` — confirmed zero usage via grep. The crate delegates sampling to `khive-brain-core`, which carries these deps legitimately.
- **GATE-REGO-005**: Removed `tracing` from `khive-gate-rego` — confirmed zero usage via grep. The crate uses only `regorus` and `serde_json`.
- **HNSW-011**: Switched `blake3` and `proptest` dev-deps in `khive-hnsw` to `{ workspace = true }`. `blake3` was already in `[workspace.dependencies]`; `proptest = "1"` was added to workspace to canonicalise.
- **KDB-007**: Switched `crossbeam-queue` and `sqlite-vec` in `khive-db` to `{ workspace = true }`. Both added to `[workspace.dependencies]` at their existing locked versions (`0.3` / `0.1.9`). `sqlite-vec` retains `optional = true` on the consumer side per the `vectors` feature gate.
- **CORE-007 / RUNTIME-006**: Added `// REASON:` justification comments to all `#[allow(clippy::too_many_arguments)]` and `#[allow(dead_code)]` attributes in `operations.rs` and `curation.rs` that previously had none.

## Verification

- `cargo check --workspace` — clean (0 errors, 0 warnings)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace` — clean
- All pre-commit hooks passed (cargo fmt, cargo clippy, secret detection)
- Usage verified by grep before each removal: `rand`/`rand_distr` → 0 hits in `khive-pack-brain/src/`; `tracing` → 0 hits in `khive-gate-rego/src/`; `blake3` → 0 hits in `khive-hnsw/src/`, `tests/`, `benches/`
- `proptest`, `crossbeam-queue`, `sqlite-vec` confirmed in use — not removed, only promoted to workspace

## Test plan

- [ ] CI passes (cargo check + clippy + test)
- [ ] `khive-hnsw` proptest suite still runs (proptest used in `tests/hnsw_tests.rs:672`)
- [ ] `khive-db` vectors feature compiles with `sqlite-vec` optional feature intact