### PR TITLE
docs(kg): queue-time re-verification + cross-batch dedup guidance

### DIFF
--- a/marketplace/kg/agents/digester.md
+++ b/marketplace/kg/agents/digester.md
@@ -58,9 +58,16 @@ Before processing any source:
    numbers → `properties`. "Introduced by", "competes with", "depends on" → `link`. Do not encode
    relationships as property strings.
 
-5. **Anti-dupe via search before every create.** If `search(query=<name>)` returns a match with the
-   same kind, link to it. If a similar name returns a _different_ kind (e.g., "LoRA" the
-   paper-document vs "LoRA" the concept), they are intentionally separate — do not merge.
+5. **Anti-dupe via search before every create — across ALL prior batch tags, not just this run.**
+   If `search(query=<name>)` returns a match with the same kind, link to it. Different batch tags
+   do not make the same entity distinct: a class ingested under `batch:source-2026-05-21` and
+   again under `batch:module-2026-05-27` is one entity with one duplicate to merge.
+   Search by class/module name regardless of what batch tag the existing entity carries.
+   If a similar name returns a _different_ kind (e.g., "LoRA" the paper-document vs "LoRA" the
+   concept), they are intentionally separate — do not merge.
+
+   **Lesson (2026-06-09)**: 6 lionagi classes were double-ingested across two batch waves
+   ("source" 5/21 and "module" 5/27) and required manual merges by Leo.
 
 6. **Note salience honestly.** 0.85+ for cross-cutting insights, 0.5-0.75 for normal observations,
    <0.5 for context that doesn't matter long-term. Inflated salience poisons future recall.
@@ -162,3 +169,4 @@ gtd.complete(id="<your-task-id>", result="Ingested N entities, M edges, K notes.
 - Inflating note salience to make findings stand out
 - Storing relationships as property strings ("authored_by_paper" = property name)
 - Finishing without queueing the polish handoff — a digest with no follow-up is debt
+- Scoping dedup search to the current batch only — prior batch tags hide real duplicates

--- a/marketplace/kg/agents/expander.md
+++ b/marketplace/kg/agents/expander.md
@@ -55,7 +55,9 @@ drifts when context blurs across targets.
 
 2. **Citation discipline.** Every new entity needs a description sentence sourced from either (a)
    the parent concept's description, (b) a paper in the graph, (c) an existing project/code
-   reference. If you cannot quote a source, the entity becomes a `question` note.
+   reference. If you cannot quote a source, the entity becomes a `question` note. Before
+   creating any entity, search by name across all prior batch tags — different batch tags do
+   not make the same concept distinct; search first, create only on confirmed absence.
 
 3. **Hard ceilings**:
    - **Extend mode**: max 5 new entities per invocation

--- a/marketplace/kg/agents/gap-analyst.md
+++ b/marketplace/kg/agents/gap-analyst.md
@@ -80,6 +80,10 @@ A single artifact: `gap_inventory.md`. Structure:
 ```markdown
 # Gap Inventory — <date>
 
+> **Snapshot notice**: this inventory reflects graph state at generation time. Any agent
+> queueing tasks from this file MUST re-verify each claim against the live graph at queue
+> time before acting — subsequent digest or polish waves may have resolved listed gaps.
+
 **Graph snapshot**: N concepts, M projects, K documents. Density: D edges/entity. **Polish health**:
 <last polish run date, residual orphan count, residual dupe count>
 

--- a/marketplace/kg/agents/librarian.md
+++ b/marketplace/kg/agents/librarian.md
@@ -49,6 +49,29 @@ Run these in parallel:
  gtd.tasks(assignee="expander", status="next", limit=20)]
 ```
 
+### Re-verify queued tasks against the live graph
+
+Before acting on any task that was created from a gap inventory, triage report, or survey
+document, verify the claim is still true in the **live graph** — inventories are snapshots;
+the graph is truth.
+
+For each queued task whose title references a specific entity or gap, spot-check:
+
+```
+get(id="<entity-uuid>")                      # still exists?
+neighbors(node_id="<id>", direction="both")  # still missing the claimed edge?
+```
+
+If the condition no longer holds, cancel the task and record why:
+
+```
+gtd.transition(id="<task-id>", status="cancelled",
+               note="Re-verified: condition resolved since task was queued. <evidence>")
+```
+
+**Lesson (2026-06-09)**: 5 of 24 queued kg tasks were stale at librarian triage — the entities
+or edges they referenced had been created in a subsequent digest wave.
+
 For each agent's queue:
 
 1. **Aging**: any task in `next` longer than 24h is stale. Likely cause: assignee is silent /


### PR DESCRIPTION
## Summary

Two production incidents from 2026-06-09 KG maintenance, codified as mandatory KG-maintenance rules.

**Rule 1 — Queue-time re-verification** (inventories are snapshots; the graph is truth)

Any maintenance workflow that queues tasks from a gap inventory, triage report, or survey document must
re-verify each claim against the live graph at queue time before acting. A subsequent digest
or polish wave may have already resolved the gap.

Evidence: 5 of 24 queued kg tasks were stale at librarian triage (2026-06-09).

**Rule 2 — Cross-batch dedup before create** (different batch tags hide duplicates)

Before creating any entity, search by class/module/concept name across ALL prior digest
batches — not just the current run. Different `batch:` tags do not make the same concept
distinct.

Evidence: 6 lionagi classes were double-ingested across "source" 5/21 and "module" 5/27
batch waves and required manual merges by a maintainer (2026-06-09).

## Files touched

| File | Change |
|------|--------|
| `marketplace/kg/agents/librarian.md` | Added "Re-verify queued tasks against the live graph" subsection in Queue health audit with spot-check protocol and cancellation pattern |
| `marketplace/kg/agents/gap-analyst.md` | Added snapshot notice in the `gap_inventory.md` template header so the producer-side is explicit |
| `marketplace/kg/agents/digester.md` | Extended Operating rule 5 (anti-dupe) with cross-batch scope; added one anti-pattern line |
| `marketplace/kg/agents/expander.md` | Added one sentence to Operating rule 2 (citation discipline) aligning it with cross-batch search |

Diff stat: 4 files, 41 insertions, 4 deletions.

## Assignment

Maintainer follow-up (p1)