### PR TITLE
feat(guard): vendor JSON/JSONL data-leak pre-commit + CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
           deno-version: v2.x
       - run: ../scripts/ci.sh
 
+  data-leak-guard:
+    name: JSON/JSONL data-leak guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan whole tree for corpus files
+        run: bash scripts/check-json-data.sh --all
+
   docs:
     name: Docs lint
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,18 @@ repos:
         files: ^(docs/.*\.md|README\.md|CLAUDE\.md|AGENTS\.md)$
         pass_filenames: false
 
+  # JSON/JSONL data-leak guard
+  # Catches corpus files that check-added-large-files (<512KB) and gitleaks both miss:
+  # any .jsonl/.ndjson outside bench paths, and .json > 256KB that isn't a lockfile.
+  - repo: local
+    hooks:
+      - id: check-json-data
+        name: JSON/JSONL data-leak guard
+        entry: bash scripts/check-json-data.sh
+        language: system
+        files: '\.(json|jsonl|ndjson)$'
+        pass_filenames: false
+
   # Secrets scanning
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/scripts/check-json-data.sh
+++ b/scripts/check-json-data.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-json-data.sh — block JSON/JSONL corpus files from being committed.
+#
+# Based on the machine-wide guard born 2026-06-10 after an agent session pushed
+# an entire memory corpus as JSONL onto a public PR.
+#
+# Modes:
+#   default (no args)    — inspect staged files (git diff --cached); use in pre-commit
+#   --all                — scan entire working tree; use in CI
+#
+# Rules:
+#   .jsonl / .ndjson     — ALWAYS blocked unless path looks like benchmark
+#                          results (bench/, benchmark/, criterion/, *bench*result*)
+#   .json                — blocked if larger than MAX_JSON_KB (default 256 KB),
+#                          unless a known lockfile or benchmark-results path
+#
+# Bypass (deliberate, auditable): KHIVE_ALLOW_DATA=1 git commit ...
+# Tune:    KHIVE_MAX_JSON_KB=512 git commit ...
+
+set -uo pipefail
+
+[ "${KHIVE_ALLOW_DATA:-0}" = "1" ] && exit 0
+
+MAX_JSON_KB="${KHIVE_MAX_JSON_KB:-256}"
+LOCKFILES='package-lock.json|deno.lock|flake.lock|composer.lock|bun.lock|.package.resolved'
+BENCH_RE='(^|/)(bench|benches|benchmark|benchmarks|criterion)(/|$)|bench.*result|result.*bench'
+
+fail=0
+
+check_file() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local base lower size_kb
+  base="$(basename "$f")"
+  lower="$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')"
+
+  case "$base" in
+    *.jsonl|*.ndjson)
+      if ! printf '%s' "$lower" | grep -qE "$BENCH_RE"; then
+        echo "BLOCKED: $f — JSONL/NDJSON staged outside a benchmark-results path." >&2
+        fail=1
+      fi
+      ;;
+    *.json)
+      printf '%s' "$base" | grep -qE "^(${LOCKFILES})$" && return 0
+      printf '%s' "$lower" | grep -qE "$BENCH_RE" && return 0
+      size_kb=$(( ($(wc -c < "$f") + 1023) / 1024 ))
+      if [ "$size_kb" -gt "$MAX_JSON_KB" ]; then
+        echo "BLOCKED: $f — ${size_kb}KB JSON exceeds ${MAX_JSON_KB}KB config-file ceiling." >&2
+        fail=1
+      fi
+      ;;
+  esac
+}
+
+if [ "${1:-}" = "--all" ]; then
+  # CI mode: scan every tracked + untracked (non-ignored) file in the tree
+  while IFS= read -r f; do
+    check_file "$f"
+  done < <(git ls-files && git ls-files --others --exclude-standard)
+else
+  # Pre-commit mode: staged files only
+  while IFS= read -r f; do
+    check_file "$f"
+  done < <(git diff --cached --name-only --diff-filter=ACMR)
+fi
+
+if [ "$fail" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+Large JSON / any JSONL outside benchmark paths is treated as a data-corpus
+leak risk (see the khive-used-to-be-oss incident, 2026-06).
+  - Data exports belong in .khive/, data/, or object storage — not git.
+  - Benchmark results: keep them under a bench*/criterion path.
+  - Genuinely intentional? Re-run with: KHIVE_ALLOW_DATA=1 git commit ...
+EOF
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Gap closed**: `check-added-large-files` (512KB cap) and `gitleaks` (secrets only) both miss corpus JSONL files under 512KB — the class of file that caused a prior data-leak incident.
- **Critical context**: this repo overrides `core.hooksPath` for the pre-commit framework, which means outside-repo git hooks can be bypassed here. This vendor is therefore mandatory, not optional.

## Rules

| File type | Condition | Decision |
|-----------|-----------|----------|
| `.jsonl` / `.ndjson` | path outside `bench*/criterion` | BLOCK |
| `.json` | > 256 KB AND not a lockfile | BLOCK |
| `.json` lockfile (`package-lock.json`, `deno.lock`, etc.) | any size | pass |
| Any file in `bench*/criterion` path | any size | pass |
| Bypass | `KHIVE_ALLOW_DATA=1 git commit` | pass (auditable) |

## Files changed

- `scripts/check-json-data.sh` — portable script; staged-file mode (pre-commit) and `--all` mode (CI full-tree scan)
- `.pre-commit-config.yaml` — new `check-json-data` local hook entry (placed before `gitleaks`); `pass_filenames: false`, `language: system`
- `.github/workflows/ci.yml` — new `data-leak-guard` job (plain ubuntu runner, no Rust toolchain); runs `--all` scan on every push/PR

## Test matrix

| Case | Input | Expected RC | Actual RC |
|------|-------|-------------|-----------|
| 1 | `test.jsonl` staged at root | BLOCK (RC=1) | 1 |
| 2 | same file + `KHIVE_ALLOW_DATA=1` | pass (RC=0) | 0 |
| 3 | `benches/results.jsonl` staged | pass (RC=0) | 0 |
| 4 | `big.json` 305KB at root staged | BLOCK (RC=1) | 1 |

All 4 cases verified locally. The pre-commit framework confirmed the new hook registered correctly (shown as "JSON/JSONL data-leak guard ... Skipped" on commit — correct, no .json/.jsonl staged).

**Held pending maintainer review before merge.**