### PR TITLE
test(vcs): hermetic git hooks in fixture commits

### DIFF
--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -773,7 +773,10 @@ mod tests {
     }
 
     fn run_git(dir: &Path, args: &[&str]) {
+        // Hermetic: user-level core.hooksPath (e.g. the machine-wide JSON/JSONL
+        // data-leak guard) must not run against fixture commits in temp repos.
         let status = Command::new("git")
+            .args(["-c", "core.hooksPath=/dev/null"])
             .args(args)
             .current_dir(dir)
             .status()


### PR DESCRIPTION
Local verification caught 4 khive-vcs failures: an outside-repo JSON/JSONL leak guard blocks the tests' entities.ndjson fixture commits in temp repos, while CI does not have that hook. Fix: tests pin core.hooksPath=/dev/null (hermetic against user hooks). Runtime khive-vcs is read-side only (clone/rev-parse) — no product change needed today; the future kg git-sync WRITE path will need KHIVE_ALLOW_DATA on its own commits (noted for ADR-028 work).