### PR TITLE
fix(gate-rego): restore tracing dep — #53/#43 stale-green interaction

### DIFF
--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 [dependencies]
 khive-gate = { version = "0.2.8", path = "../khive-gate" }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 regorus = { workspace = true }
 


### PR DESCRIPTION
Main red since 7e81b7d: #53 removed tracing from khive-gate-rego Cargo.toml (unused on 06-08), #43 added tracing::warn calls in gate.rs (written 06-08, branch still had the dep). Squash of #43 didn't touch Cargo.toml → main has the calls without the dep. Verified locally: workspace check RC=0, gate-rego tests 23/0, full clippy RC=0. Verification note: remaining stale PRs (#41/#45/#46/#47/#52/#54/#56) should get full local verification after each merge.