### PR TITLE
test(kkernel): hermetic git hooks in fetch test repos

### DIFF
--- a/crates/kkernel/src/kg/fetch.rs
+++ b/crates/kkernel/src/kg/fetch.rs
@@ -50,7 +50,10 @@ mod tests {
     use super::*;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
+        // Hermetic: machine-wide hooks (e.g. leak-guard via core.hooksPath)
+        // must not block commits inside throwaway test repos.
         let status = std::process::Command::new("git")
+            .args(["-c", "core.hooksPath=/dev/null"])
             .args(args)
             .current_dir(dir)
             .status()


### PR DESCRIPTION
4-line test-hygiene fix: `-c core.hooksPath=/dev/null` in the fetch test's `run_git` helper, same hermetic pattern as khive-vcs #65. Found by local verification; CI did not reproduce because it lacks the external leak-guard hook.