### PR TITLE
fix(runtime): hard delete purges soft-deleted records

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -492,6 +492,25 @@ impl GraphStore for SqlGraphStore {
         .await
     }
 
+    async fn get_edge_including_deleted(&self, id: LinkId) -> Result<Option<Edge>, StorageError> {
+        let namespace = self.namespace.clone();
+        let id_str = Uuid::from(id).to_string();
+
+        self.with_reader("get_edge_including_deleted", move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT namespace, id, source_id, target_id, relation, weight, \
+                        created_at, updated_at, deleted_at, metadata, target_backend \
+                 FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+            )?;
+            let mut rows = stmt.query(rusqlite::params![namespace, id_str])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_edge(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> Result<bool, StorageError> {
         let namespace = self.namespace.clone();
         let id_str = Uuid::from(id).to_string();

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -862,6 +862,20 @@ impl GraphStore for SqlGraphStore {
         })
         .await
     }
+
+    async fn purge_incident_edges(&self, node_id: Uuid) -> Result<u64, StorageError> {
+        let namespace = self.namespace.clone();
+        let id_str = node_id.to_string();
+        self.with_writer("purge_incident_edges", move |conn| {
+            let affected = conn.execute(
+                "DELETE FROM graph_edges \
+                 WHERE namespace = ?1 AND (source_id = ?2 OR target_id = ?2)",
+                rusqlite::params![namespace, id_str],
+            )?;
+            Ok(affected as u64)
+        })
+        .await
+    }
 }
 
 // =============================================================================

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -402,6 +402,24 @@ impl NoteStore for SqlNoteStore {
         .await
     }
 
+    async fn get_note_including_deleted(&self, id: Uuid) -> Result<Option<Note>, StorageError> {
+        let id_str = id.to_string();
+
+        self.with_reader("get_note_including_deleted", move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+                 properties, created_at, updated_at, deleted_at \
+                 FROM notes WHERE id = ?1",
+            )?;
+            let mut rows = stmt.query(rusqlite::params![id_str])?;
+            match rows.next()? {
+                Some(row) => Ok(Some(read_note(row)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
     async fn get_notes_batch(&self, ids: &[Uuid]) -> Result<Vec<Note>, StorageError> {
         if ids.is_empty() {
             return Ok(vec![]);

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -89,7 +89,7 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "UUID of the entity, note, or edge to fetch.",
+                description: "UUID of the entity, note, edge, event, or proposal to fetch.",
             },
             ParamDef {
                 name: "include_deleted",

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -260,6 +260,28 @@ pub(crate) async fn resolve_uuid_async(
     resolve_name_async(s, runtime, token).await
 }
 
+pub(crate) async fn resolve_uuid_including_deleted(
+    s: &str,
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+) -> Result<Uuid, RuntimeError> {
+    if let Ok(uuid) = Uuid::from_str(s) {
+        return Ok(uuid);
+    }
+    if s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        match runtime.resolve_prefix_including_deleted(token, s).await {
+            Ok(Some(uuid)) => return Ok(uuid),
+            Ok(None) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "no record matches prefix: {s:?}"
+                )))
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    resolve_name_async(s, runtime, token).await
+}
+
 // ---- Output formatting helpers ----
 
 pub(crate) fn format_edge_output(v: Value, _verbose: bool) -> Value {

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -46,7 +46,12 @@ impl KgPack {
             Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
             Some(Resolved::Note(_)) => Ok(KindSpec::Note { specific: None }),
             _ => {
-                if self.runtime.get_edge(token, id).await?.is_some() {
+                if self
+                    .runtime
+                    .get_edge_including_deleted(token, id)
+                    .await?
+                    .is_some()
+                {
                     Ok(KindSpec::Edge)
                 } else {
                     Err(RuntimeError::NotFound(format!("not found: {id_str}")))

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -9,8 +9,8 @@ use khive_runtime::{
 
 use super::common::{
     description_patch, deser, immutable_event_error, normalize_entity_timestamps,
-    optional_string_patch, parse_relation, resolve_kind_spec, resolve_uuid_async, string_value,
-    to_json, DeleteParams, KindSpec, UpdateParams,
+    optional_string_patch, parse_relation, resolve_kind_spec, resolve_uuid_async,
+    resolve_uuid_including_deleted, string_value, to_json, DeleteParams, KindSpec, UpdateParams,
 };
 use crate::KgPack;
 
@@ -23,6 +23,26 @@ impl KgPack {
     ) -> Result<KindSpec, RuntimeError> {
         use khive_runtime::Resolved;
         match self.runtime.resolve(token, id).await? {
+            Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
+            Some(Resolved::Note(_)) => Ok(KindSpec::Note { specific: None }),
+            _ => {
+                if self.runtime.get_edge(token, id).await?.is_some() {
+                    Ok(KindSpec::Edge)
+                } else {
+                    Err(RuntimeError::NotFound(format!("not found: {id_str}")))
+                }
+            }
+        }
+    }
+
+    async fn infer_kind_from_uuid_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        id_str: &str,
+    ) -> Result<KindSpec, RuntimeError> {
+        use khive_runtime::Resolved;
+        match self.runtime.resolve_including_deleted(token, id).await? {
             Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
             Some(Resolved::Note(_)) => Ok(KindSpec::Note { specific: None }),
             _ => {
@@ -121,29 +141,47 @@ impl KgPack {
         registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
         let p: DeleteParams = deser(params)?;
+        let hard = p.hard.unwrap_or(false);
         let explicit_spec: Option<KindSpec> = if let Some(k) = p.kind.as_deref() {
             Some(resolve_kind_spec(k, registry)?)
         } else {
             None
         };
-        let id = resolve_uuid_async(&p.id, &self.runtime, token).await?;
+        let id = if hard {
+            resolve_uuid_including_deleted(&p.id, &self.runtime, token).await?
+        } else {
+            resolve_uuid_async(&p.id, &self.runtime, token).await?
+        };
         let spec: KindSpec = match explicit_spec {
             Some(s) => s,
-            None => self.infer_kind_from_uuid(token, id, &p.id).await?,
+            None => {
+                if hard {
+                    self.infer_kind_from_uuid_including_deleted(token, id, &p.id)
+                        .await?
+                } else {
+                    self.infer_kind_from_uuid(token, id, &p.id).await?
+                }
+            }
         };
 
         match spec {
             KindSpec::Entity { specific } => {
                 if let Some(ref expected) = specific {
-                    let entity = self.runtime.get_entity(token, id).await?;
+                    let entity = if hard {
+                        self.runtime
+                            .get_entity_including_deleted(token, id)
+                            .await?
+                            .ok_or_else(|| {
+                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
+                            })?
+                    } else {
+                        self.runtime.get_entity(token, id).await?
+                    };
                     if entity.kind != *expected {
                         return Err(RuntimeError::NotFound(format!("{} {}", expected, p.id)));
                     }
                 }
-                let deleted = self
-                    .runtime
-                    .delete_entity(token, id, p.hard.unwrap_or(false))
-                    .await?;
+                let deleted = self.runtime.delete_entity(token, id, hard).await?;
                 if !deleted {
                     return Err(RuntimeError::NotFound(format!("entity {}", p.id)));
                 }
@@ -151,30 +189,35 @@ impl KgPack {
             }
             KindSpec::Note { specific } => {
                 if let Some(ref expected) = specific {
-                    let note = self
-                        .runtime
-                        .notes(token)?
-                        .get_note(id)
-                        .await
-                        .map_err(RuntimeError::Storage)?;
-                    if note.as_ref().is_none_or(|n| n.kind != *expected) {
+                    let note = if hard {
+                        self.runtime
+                            .get_note_including_deleted(token, id)
+                            .await?
+                            .ok_or_else(|| {
+                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
+                            })?
+                    } else {
+                        self.runtime
+                            .notes(token)?
+                            .get_note(id)
+                            .await
+                            .map_err(RuntimeError::Storage)?
+                            .ok_or_else(|| {
+                                RuntimeError::NotFound(format!("{} {}", expected, p.id))
+                            })?
+                    };
+                    if note.kind != *expected {
                         return Err(RuntimeError::NotFound(format!("{} {}", expected, p.id)));
                     }
                 }
-                let deleted = self
-                    .runtime
-                    .delete_note(token, id, p.hard.unwrap_or(false))
-                    .await?;
+                let deleted = self.runtime.delete_note(token, id, hard).await?;
                 if !deleted {
                     return Err(RuntimeError::NotFound(format!("note {}", p.id)));
                 }
                 to_json(&serde_json::json!({ "deleted": deleted, "id": p.id, "kind": p.kind }))
             }
             KindSpec::Edge => {
-                let deleted = self
-                    .runtime
-                    .delete_edge(token, id, p.hard.unwrap_or(false))
-                    .await?;
+                let deleted = self.runtime.delete_edge(token, id, hard).await?;
                 to_json(&serde_json::json!({ "deleted": deleted, "id": p.id, "kind": "edge" }))
             }
             KindSpec::Event => Err(immutable_event_error()),

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -5277,3 +5277,227 @@ async fn link_concept_to_concept_extends_still_works() {
     let edge = result.unwrap();
     assert_eq!(edge["relation"], "extends");
 }
+
+// ---- #71 regression: hard delete must purge soft-deleted records ----
+
+/// Soft-delete an entity, then hard-delete it — must succeed and leave the row gone.
+#[tokio::test]
+async fn hard_delete_purges_soft_deleted_entity() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "PurgeMeEntity"}),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    f.dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete must succeed");
+
+    let purge = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        purge.is_ok(),
+        "hard delete of a soft-deleted entity must succeed (issue #71); got: {purge:?}"
+    );
+    assert_eq!(
+        purge.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let second = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        second.is_err(),
+        "second hard delete must return not-found (row is physically gone); got: {second:?}"
+    );
+}
+
+/// Hard-delete a soft-deleted entity resolved via short prefix must succeed.
+#[tokio::test]
+async fn hard_delete_soft_deleted_entity_by_prefix() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "PurgeMeByPrefix"}),
+        )
+        .await
+        .expect("create must succeed");
+    let full_id = created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+    let prefix = &full_id[..8];
+
+    f.dispatch("delete", json!({"id": full_id}))
+        .await
+        .expect("soft delete must succeed");
+
+    let purge = f
+        .dispatch("delete", json!({"id": prefix, "hard": true}))
+        .await;
+    assert!(
+        purge.is_ok(),
+        "hard delete by short prefix of a soft-deleted entity must succeed (issue #71); got: {purge:?}"
+    );
+    assert_eq!(
+        purge.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
+/// Hard-delete a soft-deleted entity cascades its incident edges.
+#[tokio::test]
+async fn hard_delete_soft_deleted_entity_cascades_edges() {
+    let (f, _rt) = pack_with_edge_rules();
+
+    let source = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CascadeSource"}),
+        )
+        .await
+        .expect("create source must succeed");
+    let target = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CascadeTarget"}),
+        )
+        .await
+        .expect("create target must succeed");
+    let source_id = source["id"].as_str().unwrap().to_string();
+    let target_id = target["id"].as_str().unwrap().to_string();
+
+    f.dispatch(
+        "link",
+        json!({"source_id": source_id, "target_id": target_id, "relation": "extends"}),
+    )
+    .await
+    .expect("link must succeed");
+
+    f.dispatch("delete", json!({"id": source_id}))
+        .await
+        .expect("soft delete must succeed");
+
+    f.dispatch("delete", json!({"id": source_id, "hard": true}))
+        .await
+        .expect("hard delete of soft-deleted entity must succeed (issue #71)");
+
+    let neighbors = f
+        .dispatch(
+            "neighbors",
+            json!({"node_id": target_id, "direction": "in"}),
+        )
+        .await
+        .expect("neighbors query must succeed");
+    let arr = neighbors.as_array().expect("neighbors must return array");
+    assert!(
+        arr.is_empty(),
+        "hard delete must cascade and remove incident edges; got: {arr:?}"
+    );
+}
+
+/// Hard-delete a soft-deleted entity from a different namespace must be denied.
+#[tokio::test]
+async fn hard_delete_soft_deleted_entity_cross_namespace_denied() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CrossNsConcept"}),
+        )
+        .await
+        .expect("create must succeed");
+    let id = created["id"].as_str().unwrap().to_string();
+
+    f.dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete must succeed");
+
+    let result = f
+        .dispatch(
+            "delete",
+            json!({"id": id, "hard": true, "namespace": "ns-attacker"}),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "cross-namespace hard delete of a soft-deleted entity must be denied; got: {result:?}"
+    );
+}
+
+/// Soft-delete a note, then hard-delete it — must succeed and leave the row gone.
+#[tokio::test]
+async fn hard_delete_purges_soft_deleted_note() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "purge me note content"}),
+        )
+        .await
+        .expect("create note must succeed");
+    let id = created["id"]
+        .as_str()
+        .expect("create must return id")
+        .to_string();
+
+    f.dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete must succeed");
+
+    let purge = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        purge.is_ok(),
+        "hard delete of a soft-deleted note must succeed (issue #71); got: {purge:?}"
+    );
+    assert_eq!(
+        purge.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let second = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        second.is_err(),
+        "second hard delete must return not-found (note row is physically gone); got: {second:?}"
+    );
+}
+
+/// Hard-delete a soft-deleted note from a different namespace must be denied.
+#[tokio::test]
+async fn hard_delete_soft_deleted_note_cross_namespace_denied() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "cross-ns note purge target"}),
+        )
+        .await
+        .expect("create note must succeed");
+    let id = created["id"].as_str().unwrap().to_string();
+
+    f.dispatch("delete", json!({"id": id}))
+        .await
+        .expect("soft delete must succeed");
+
+    let result = f
+        .dispatch(
+            "delete",
+            json!({"id": id, "hard": true, "namespace": "ns-attacker"}),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "cross-namespace hard delete of a soft-deleted note must be denied; got: {result:?}"
+    );
+}

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -5501,3 +5501,76 @@ async fn hard_delete_soft_deleted_note_cross_namespace_denied() {
         "cross-namespace hard delete of a soft-deleted note must be denied; got: {result:?}"
     );
 }
+
+/// Soft-delete an edge, then hard-delete it WITHOUT supplying explicit kind — must
+/// succeed and leave the row physically gone (ADR-002: public delete auto-detects).
+#[tokio::test]
+async fn hard_delete_soft_deleted_edge_without_kind_purges_row() {
+    use khive_storage::{SqlStatement, SqlValue};
+    use uuid::Uuid;
+
+    let (f, rt) = pack_with_edge_rules();
+
+    let source = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "EdgePurgeSource"}),
+        )
+        .await
+        .expect("create source must succeed");
+    let target = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "EdgePurgeTarget"}),
+        )
+        .await
+        .expect("create target must succeed");
+    let source_id = source["id"].as_str().unwrap().to_string();
+    let target_id = target["id"].as_str().unwrap().to_string();
+
+    let linked = f
+        .dispatch(
+            "link",
+            json!({"source_id": source_id, "target_id": target_id, "relation": "extends"}),
+        )
+        .await
+        .expect("link must succeed");
+    let edge_id = linked["id"]
+        .as_str()
+        .expect("link must return id")
+        .to_string();
+    let edge_uuid = Uuid::parse_str(&edge_id).expect("edge id must be valid UUID");
+
+    // Soft-delete the edge.
+    f.dispatch("delete", json!({"id": edge_id}))
+        .await
+        .expect("soft delete must succeed");
+
+    // Hard-delete WITHOUT explicit kind — exercises infer_kind_from_uuid_including_deleted.
+    let purge = f
+        .dispatch("delete", json!({"id": edge_id, "hard": true}))
+        .await;
+    assert!(
+        purge.is_ok(),
+        "hard delete of a soft-deleted edge without kind must succeed (ADR-002); got: {purge:?}"
+    );
+
+    // Verify the row is physically gone via raw SQL (no deleted_at filter).
+    let mut reader = rt.sql().reader().await.expect("sql reader must open");
+    let count = reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT COUNT(*) FROM graph_edges WHERE id = ?1".into(),
+            params: vec![SqlValue::Text(edge_uuid.to_string())],
+            label: Some("count_edge_row_by_id".into()),
+        })
+        .await
+        .expect("count query must succeed");
+    let row_count = match count {
+        Some(SqlValue::Integer(n)) => n as u64,
+        _ => 0,
+    };
+    assert_eq!(
+        row_count, 0,
+        "hard delete must physically remove the edge row from graph_edges"
+    );
+}

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1779,27 +1779,12 @@ impl KhiveRuntime {
             DeleteMode::Soft
         };
 
-        // On hard delete, cascade-remove incident edges and clean up indexes.
+        // On hard delete, cascade-remove all incident edges (including soft-deleted) and clean up
+        // indexes. Uses purge_incident_edges so that already-soft-deleted edges are also removed,
+        // preventing dangling graph_edges rows (ADR-002 no-dangling-references).
         if hard {
             let graph = self.graph(token)?;
-            for direction in [Direction::Out, Direction::In] {
-                let hits = graph
-                    .neighbors(
-                        id,
-                        NeighborQuery {
-                            direction,
-                            relations: None,
-                            limit: None,
-                            min_weight: None,
-                        },
-                    )
-                    .await?;
-                for hit in hits {
-                    graph
-                        .delete_edge(LinkId::from(hit.edge_id), DeleteMode::Hard)
-                        .await?;
-                }
-            }
+            graph.purge_incident_edges(id).await?;
             let ns_str = ns.to_string();
             self.text_for_notes(token)?
                 .delete_document(&ns_str, id)
@@ -1945,27 +1930,12 @@ impl KhiveRuntime {
             DeleteMode::Soft
         };
 
-        // On hard delete, cascade-remove incident edges to prevent dangling refs.
+        // On hard delete, cascade-remove all incident edges (including soft-deleted) to prevent
+        // dangling refs. Uses purge_incident_edges so that already-soft-deleted edges are also
+        // removed (ADR-002 no-dangling-references).
         if hard {
             let graph = self.graph(token)?;
-            for direction in [Direction::Out, Direction::In] {
-                let hits = graph
-                    .neighbors(
-                        id,
-                        NeighborQuery {
-                            direction,
-                            relations: None,
-                            limit: None,
-                            min_weight: None,
-                        },
-                    )
-                    .await?;
-                for hit in hits {
-                    graph
-                        .delete_edge(LinkId::from(hit.edge_id), DeleteMode::Hard)
-                        .await?;
-                }
-            }
+            graph.purge_incident_edges(id).await?;
             self.remove_from_indexes(token, id).await?;
         }
 
@@ -5887,6 +5857,147 @@ mod tests {
         assert!(
             paths.is_empty(),
             "foreign traversal root must be filtered before expansion, got {paths:?}"
+        );
+    }
+
+    // ---- PR #82 regression: purge cascade must include already-soft-deleted edges ----
+    //
+    // ADR-002 requires hard delete to cascade ALL incident edges synchronously. The old
+    // implementation drove the cascade through `neighbors()`, which filters `deleted_at IS NULL`,
+    // so incident edges that were already soft-deleted survived endpoint purge as dangling rows.
+    // `purge_incident_edges` issues a single DELETE without a `deleted_at` guard.
+
+    /// Count ALL `graph_edges` rows for a given UUID (source OR target), including soft-deleted.
+    async fn count_all_incident_edges(rt: &KhiveRuntime, node_id: Uuid, ns: &str) -> u64 {
+        let mut reader = rt.sql().reader().await.expect("sql reader must open");
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM graph_edges \
+                      WHERE namespace = ?1 AND (source_id = ?2 OR target_id = ?2)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(node_id.to_string()),
+                ],
+                label: Some("count_all_incident_edges".into()),
+            })
+            .await
+            .expect("count query must succeed");
+        match row {
+            Some(SqlValue::Integer(n)) => n as u64,
+            _ => panic!("count must return an integer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hard_delete_entity_purges_already_soft_deleted_incident_edge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ns = tok.namespace().to_string();
+
+        let a = rt
+            .create_entity(&tok, "concept", None, "SrcA", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "TgtB", None, None, vec![])
+            .await
+            .unwrap();
+
+        rt.link(&tok, a.id, b.id, EdgeRelation::Extends, 1.0, None)
+            .await
+            .unwrap();
+
+        // Soft-delete the edge — it is now invisible to `neighbors` but still in storage.
+        let edge_hit = rt
+            .neighbors(&tok, a.id, Direction::Out, None, None)
+            .await
+            .unwrap();
+        assert_eq!(edge_hit.len(), 1, "edge must exist before soft-delete");
+        let edge_uuid = edge_hit[0].edge_id;
+        rt.delete_edge(&tok, edge_uuid, false).await.unwrap();
+
+        // Confirm the edge is invisible to normal read paths but present in raw storage.
+        let visible = rt
+            .neighbors(&tok, a.id, Direction::Out, None, None)
+            .await
+            .unwrap();
+        assert!(visible.is_empty(), "soft-deleted edge must be invisible");
+        let raw_before = count_all_incident_edges(&rt, a.id, &ns).await;
+        assert_eq!(
+            raw_before, 1,
+            "soft-deleted edge must still be a physical row"
+        );
+
+        // Hard-delete (purge) the source entity — cascade must also remove the soft-deleted edge.
+        rt.delete_entity(&tok, a.id, true).await.unwrap();
+
+        let raw_after = count_all_incident_edges(&rt, a.id, &ns).await;
+        assert_eq!(
+            raw_after, 0,
+            "purge_incident_edges must physically remove soft-deleted edge rows (ADR-002)"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_delete_note_purges_already_soft_deleted_incident_edge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ns = tok.namespace().to_string();
+
+        let target = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "purge-cascade target note",
+                Some(0.5),
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let annotating = rt
+            .create_note(
+                &tok,
+                "insight",
+                None,
+                "annotator note",
+                Some(0.5),
+                None,
+                vec![target.id],
+            )
+            .await
+            .unwrap();
+
+        // Soft-delete the annotates edge.
+        let edge_hit = rt
+            .neighbors(
+                &tok,
+                annotating.id,
+                Direction::Out,
+                None,
+                Some(vec![EdgeRelation::Annotates]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(edge_hit.len(), 1, "annotates edge must exist");
+        let edge_uuid = edge_hit[0].edge_id;
+        rt.delete_edge(&tok, edge_uuid, false).await.unwrap();
+
+        let raw_before = count_all_incident_edges(&rt, target.id, &ns).await;
+        assert_eq!(
+            raw_before, 1,
+            "soft-deleted edge must still be a physical row before note purge"
+        );
+
+        // Hard-delete the target note — cascade must remove the soft-deleted edge row.
+        rt.delete_note(&tok, target.id, true).await.unwrap();
+
+        let raw_after = count_all_incident_edges(&rt, target.id, &ns).await;
+        assert_eq!(
+            raw_after, 0,
+            "purge_incident_edges must physically remove soft-deleted edge rows on note purge (ADR-002)"
         );
     }
 }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -419,6 +419,26 @@ impl KhiveRuntime {
         Ok(Some(entity))
     }
 
+    /// Retrieve a note by ID including soft-deleted rows, enforcing namespace isolation.
+    ///
+    /// Returns `Ok(Some(note))` when the note exists in the caller's namespace regardless
+    /// of `deleted_at`. Returns `Ok(None)` when the UUID was never created or belongs to
+    /// a different namespace.
+    pub async fn get_note_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<khive_storage::note::Note>> {
+        let note = match self.notes(token)?.get_note_including_deleted(id).await? {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+        if note.namespace != token.namespace().as_str() {
+            return Ok(None);
+        }
+        Ok(Some(note))
+    }
+
     /// Fetch multiple entities by ID, returning only those that exist in the
     /// caller's namespace.  Missing or namespace-mismatched IDs are silently
     /// omitted so that batch lookups don't abort on a single stale reference.
@@ -1560,6 +1580,23 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         prefix: &str,
     ) -> RuntimeResult<Option<Uuid>> {
+        self.resolve_prefix_inner(token, prefix, false).await
+    }
+
+    pub async fn resolve_prefix_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        prefix: &str,
+    ) -> RuntimeResult<Option<Uuid>> {
+        self.resolve_prefix_inner(token, prefix, true).await
+    }
+
+    async fn resolve_prefix_inner(
+        &self,
+        token: &NamespaceToken,
+        prefix: &str,
+        include_deleted: bool,
+    ) -> RuntimeResult<Option<Uuid>> {
         use khive_storage::types::{SqlStatement, SqlValue};
 
         let ns = token.namespace().as_str().to_owned();
@@ -1576,7 +1613,7 @@ impl KhiveRuntime {
         let mut reader = self.sql().reader().await.map_err(RuntimeError::Storage)?;
 
         for (table, has_deleted_at) in tables {
-            let deleted_filter = if has_deleted_at {
+            let deleted_filter = if has_deleted_at && !include_deleted {
                 " AND deleted_at IS NULL"
             } else {
                 ""
@@ -1669,6 +1706,42 @@ impl KhiveRuntime {
         Ok(None)
     }
 
+    /// Resolve a UUID to its substrate kind, including soft-deleted rows.
+    ///
+    /// Used exclusively by the hard-delete path to locate records that have
+    /// already been soft-deleted. Namespace isolation is still enforced.
+    pub async fn resolve_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<Resolved>> {
+        let ns = token.namespace().as_str();
+
+        if let Some(entity) = self
+            .entities(token)?
+            .get_entity_including_deleted(id)
+            .await?
+        {
+            if Self::ensure_namespace(&entity.namespace, ns).is_ok() {
+                return Ok(Some(Resolved::Entity(entity)));
+            }
+        }
+
+        if let Some(note) = self.notes(token)?.get_note_including_deleted(id).await? {
+            if Self::ensure_namespace(&note.namespace, ns).is_ok() {
+                return Ok(Some(Resolved::Note(note)));
+            }
+        }
+
+        if let Some(event) = self.events(token)?.get_event(id).await? {
+            if Self::ensure_namespace(&event.namespace, ns).is_ok() {
+                return Ok(Some(Resolved::Event(event)));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Delete a note by ID, enforcing namespace isolation.
     ///
     /// On hard delete, cascades to remove all incident edges (both inbound and
@@ -1686,9 +1759,16 @@ impl KhiveRuntime {
     ) -> RuntimeResult<bool> {
         let ns = token.namespace().as_str();
         let note_store = self.notes(token)?;
-        let note = match note_store.get_note(id).await? {
-            Some(n) => n,
-            None => return Ok(false),
+        let note = if hard {
+            match note_store.get_note_including_deleted(id).await? {
+                Some(n) => n,
+                None => return Ok(false),
+            }
+        } else {
+            match note_store.get_note(id).await? {
+                Some(n) => n,
+                None => return Ok(false),
+            }
         };
         if Self::ensure_namespace(&note.namespace, ns).is_err() {
             return Ok(false);
@@ -1843,9 +1923,20 @@ impl KhiveRuntime {
         id: Uuid,
         hard: bool,
     ) -> RuntimeResult<bool> {
-        let entity = match self.entities(token)?.get_entity(id).await? {
-            Some(e) => e,
-            None => return Ok(false),
+        let entity = if hard {
+            match self
+                .entities(token)?
+                .get_entity_including_deleted(id)
+                .await?
+            {
+                Some(e) => e,
+                None => return Ok(false),
+            }
+        } else {
+            match self.entities(token)?.get_entity(id).await? {
+                Some(e) => e,
+                None => return Ok(false),
+            }
         };
         Self::ensure_namespace(&entity.namespace, token.namespace().as_str())?;
         let mode = if hard {

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2014,6 +2014,36 @@ impl KhiveRuntime {
         Ok(self.graph(token)?.get_edge(LinkId::from(edge_id)).await?)
     }
 
+    /// Fetch an edge by UUID including soft-deleted rows, returning `None` if absent or if the
+    /// record belongs to a different namespace. Used by the hard-delete path so that a
+    /// soft-deleted primary edge can still be purged via its edge ID.
+    pub async fn get_edge_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        edge_id: Uuid,
+    ) -> RuntimeResult<Option<Edge>> {
+        let mut reader = self.sql().reader().await?;
+        let record_ns = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT namespace FROM graph_edges WHERE id = ?1 LIMIT 1".into(),
+                params: vec![SqlValue::Text(edge_id.to_string())],
+                label: Some("get_edge_including_deleted_namespace".into()),
+            })
+            .await?;
+
+        let Some(SqlValue::Text(record_ns)) = record_ns else {
+            return Ok(None);
+        };
+        if Self::ensure_namespace(&record_ns, token.namespace().as_str()).is_err() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .graph(token)?
+            .get_edge_including_deleted(LinkId::from(edge_id))
+            .await?)
+    }
+
     /// List edges matching `filter`. `limit` is capped at 1000; defaults to 100.
     pub async fn list_edges(
         &self,
@@ -2259,30 +2289,28 @@ impl KhiveRuntime {
             DeleteMode::Soft
         };
 
-        // Guard: verify `edge_id` is actually an edge before touching anything.
-        // Without this check, passing an entity/note UUID would delete all inbound
-        // annotates edges targeting that record and then return false — a destructive
-        // side effect on an invalid call.
-        if graph.get_edge(LinkId::from(edge_id)).await?.is_none() {
+        // Guard: verify `edge_id` is actually an edge (not an entity/note UUID) before touching
+        // anything. For soft delete, the live-only check is correct — there is nothing to do if
+        // the row is already soft-deleted. For hard delete, also check soft-deleted rows so that
+        // a soft-deleted edge can still be purged via its edge ID (namespace check is preserved:
+        // get_edge_including_deleted returns None for foreign-namespace IDs).
+        let edge_exists = if hard {
+            self.get_edge_including_deleted(token, edge_id)
+                .await?
+                .is_some()
+        } else {
+            graph.get_edge(LinkId::from(edge_id)).await?.is_some()
+        };
+        if !edge_exists {
             return Ok(false);
         }
 
-        // Cascade: remove annotate edges that target this edge (inbound from note sources).
-        let inbound = graph
-            .neighbors(
-                edge_id,
-                NeighborQuery {
-                    direction: Direction::In,
-                    relations: None,
-                    limit: None,
-                    min_weight: None,
-                },
-            )
-            .await?;
-        for hit in inbound {
-            graph
-                .delete_edge(LinkId::from(hit.edge_id), DeleteMode::Hard)
-                .await?;
+        // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
+        // already-soft-deleted ones — to prevent dangling graph_edges rows (ADR-002).
+        // On soft delete the cascade is skipped (data-vs-view principle: soft-deleting the base
+        // edge does not cascade to annotation edges; only a hard purge cleans up incident rows).
+        if hard {
+            graph.purge_incident_edges(edge_id).await?;
         }
 
         let deleted = graph.delete_edge(LinkId::from(edge_id), mode).await?;
@@ -5998,6 +6026,158 @@ mod tests {
         assert_eq!(
             raw_after, 0,
             "purge_incident_edges must physically remove soft-deleted edge rows on note purge (ADR-002)"
+        );
+    }
+
+    // ---- PR #82 round-2 regression: edge-ID hard-delete path ----
+    //
+    // Bug class (codex R2): delete_edge drove the primary-edge guard through get_edge()
+    // (live-only) and the cascade through neighbors() (live-only). Two reachable holes:
+    // (a) soft-deleted primary edge cannot be hard-purged via its own ID;
+    // (b) an already-soft-deleted annotates edge targeting a base edge survives that
+    //     edge's hard delete as a dangling row with target_id = physically-gone edge id.
+
+    /// Count graph_edges rows matching the given edge ID, including soft-deleted rows.
+    async fn count_edge_rows_by_id(rt: &KhiveRuntime, edge_id: Uuid, ns: &str) -> u64 {
+        let mut reader = rt.sql().reader().await.expect("sql reader must open");
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM graph_edges WHERE namespace = ?1 AND id = ?2".into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(edge_id.to_string()),
+                ],
+                label: Some("count_edge_rows_by_id".into()),
+            })
+            .await
+            .expect("count query must succeed");
+        match row {
+            Some(SqlValue::Integer(n)) => n as u64,
+            _ => panic!("count must return an integer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hard_delete_edge_purges_already_soft_deleted_primary_edge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ns = tok.namespace().to_string();
+
+        let a = rt
+            .create_entity(&tok, "concept", None, "EA", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "EB", None, None, vec![])
+            .await
+            .unwrap();
+
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 1.0, None)
+            .await
+            .unwrap();
+        let edge_uuid: Uuid = edge.id.into();
+
+        // Soft-delete the edge first.
+        let soft = rt.delete_edge(&tok, edge_uuid, false).await.unwrap();
+        assert!(soft, "soft delete must succeed");
+
+        // Edge is now invisible to normal reads but still a physical row.
+        assert!(
+            rt.get_edge(&tok, edge_uuid).await.unwrap().is_none(),
+            "soft-deleted edge must be invisible to get_edge"
+        );
+        assert_eq!(
+            count_edge_rows_by_id(&rt, edge_uuid, &ns).await,
+            1,
+            "soft-deleted edge must still be a physical row"
+        );
+
+        // Hard-delete (purge) via the edge ID — must succeed and remove the row.
+        let purged = rt.delete_edge(&tok, edge_uuid, true).await.unwrap();
+        assert!(
+            purged,
+            "hard delete of a soft-deleted edge must return true"
+        );
+
+        assert_eq!(
+            count_edge_rows_by_id(&rt, edge_uuid, &ns).await,
+            0,
+            "hard-delete must physically remove the soft-deleted edge row (ADR-002)"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_delete_base_edge_purges_already_soft_deleted_annotates_edge() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let ns = tok.namespace().to_string();
+
+        let a = rt
+            .create_entity(&tok, "concept", None, "CA", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "CB", None, None, vec![])
+            .await
+            .unwrap();
+
+        // Create the base edge to be annotated.
+        let base_edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 1.0, None)
+            .await
+            .unwrap();
+        let base_edge_uuid: Uuid = base_edge.id.into();
+
+        // Create a note that annotates the base edge.
+        let note = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "note about base edge",
+                Some(0.5),
+                None,
+                vec![base_edge_uuid],
+            )
+            .await
+            .unwrap();
+
+        // Find the annotates edge.
+        let ann_hits = rt
+            .neighbors(
+                &tok,
+                note.id,
+                Direction::Out,
+                None,
+                Some(vec![EdgeRelation::Annotates]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ann_hits.len(), 1, "annotates edge must exist");
+        let ann_edge_uuid = ann_hits[0].edge_id;
+
+        // Soft-delete the annotates edge — now invisible but still a physical row.
+        rt.delete_edge(&tok, ann_edge_uuid, false).await.unwrap();
+        assert_eq!(
+            count_edge_rows_by_id(&rt, ann_edge_uuid, &ns).await,
+            1,
+            "soft-deleted annotates edge must still be a physical row"
+        );
+
+        // Hard-delete the base edge — cascade must also remove the soft-deleted annotates row.
+        let purged = rt.delete_edge(&tok, base_edge_uuid, true).await.unwrap();
+        assert!(purged, "hard delete of base edge must return true");
+
+        assert_eq!(
+            count_edge_rows_by_id(&rt, ann_edge_uuid, &ns).await,
+            0,
+            "hard-delete of base edge must purge already-soft-deleted annotates edge row (ADR-002)"
+        );
+        assert_eq!(
+            count_edge_rows_by_id(&rt, base_edge_uuid, &ns).await,
+            0,
+            "hard-delete must physically remove the base edge row"
         );
     }
 }

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -15,8 +15,11 @@ pub trait GraphStore: Send + Sync + 'static {
     async fn upsert_edge(&self, edge: Edge) -> StorageResult<()>;
     /// Insert or update a batch of edges.
     async fn upsert_edges(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
-    /// Fetch an edge by link ID, returning `None` if absent.
+    /// Fetch an edge by link ID, returning `None` if absent. Filters soft-deleted rows.
     async fn get_edge(&self, id: LinkId) -> StorageResult<Option<Edge>>;
+    /// Fetch an edge by link ID including soft-deleted rows. Used by the runtime hard-delete path
+    /// to locate and namespace-check an already-soft-deleted edge before purging it.
+    async fn get_edge_including_deleted(&self, id: LinkId) -> StorageResult<Option<Edge>>;
     /// Delete an edge by link ID using the specified delete mode.
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> StorageResult<bool>;
     /// Query edges with filter, sort, and pagination.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -36,4 +36,8 @@ pub trait GraphStore: Send + Sync + 'static {
     ) -> StorageResult<Vec<NeighborHit>>;
     /// Multi-hop BFS traversal from the given roots.
     async fn traverse(&self, request: TraversalRequest) -> StorageResult<Vec<GraphPath>>;
+    /// Hard-delete every incident edge (source or target) for `node_id`, regardless of soft-delete
+    /// state. Used during endpoint hard-delete to prevent dangling `graph_edges` rows (ADR-002
+    /// no-dangling-references contract).
+    async fn purge_incident_edges(&self, node_id: Uuid) -> StorageResult<u64>;
 }

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -280,6 +280,11 @@ pub trait NoteStore: Send + Sync + 'static {
     async fn upsert_notes(&self, notes: Vec<Note>) -> StorageResult<BatchWriteSummary>;
     /// Fetch a note by UUID, returning `None` if absent.
     async fn get_note(&self, id: Uuid) -> StorageResult<Option<Note>>;
+    /// Fetch a note by UUID regardless of soft-deletion state.
+    ///
+    /// Returns the note row even when `deleted_at` is set. Callers use this
+    /// to distinguish "soft-deleted" from "never existed".
+    async fn get_note_including_deleted(&self, id: Uuid) -> StorageResult<Option<Note>>;
     /// Delete a note by UUID using the specified delete mode.
     async fn delete_note(&self, id: Uuid, mode: DeleteMode) -> StorageResult<bool>;
     /// Query notes by namespace and optional kind with pagination.


### PR DESCRIPTION
Root cause: fetch-before-delete applied `deleted_at IS NULL` filters at four interacting layers, making soft-deleted rows invisible before the physical DELETE ran.

Added `get_note_including_deleted` to `NoteStore` (mirrors the existing entity variant), `resolve_including_deleted` and `resolve_prefix_including_deleted` at the runtime layer, and routed all hard-delete code paths through `_including_deleted` variants. Namespace isolation still enforced at every fetch. Six regression tests added.

Closes #71