### PR TITLE
feat(pack-memory): type-differentiated salience + decay defaults

### DIFF
--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -11,7 +11,7 @@
   $$\text{effective\_salience} = \text{salience} \times e^{-\text{decay\_factor} \times \text{age\_days}}$$
   The note's own `decay_factor` field controls the rate; `temporal_half_life_days` is used only
   by the independent temporal recency score, not by salience decay.
-- Defaults are type-differentiated: `episodic` → `salience=0.3`, `decay_factor=0.02` (~23-day
+- Defaults are type-differentiated: `episodic` → `salience=0.3`, `decay_factor=0.02` (~35-day
   half-life); `semantic` → `salience=0.5`, `decay_factor=0.005` (~139-day half-life).
   Explicit caller-supplied values always override the defaults.
 - `memory_type` property is always written (default `"episodic"`); only `"episodic"` and

--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -11,7 +11,9 @@
   $$\text{effective\_salience} = \text{salience} \times e^{-\text{decay\_factor} \times \text{age\_days}}$$
   The note's own `decay_factor` field controls the rate; `temporal_half_life_days` is used only
   by the independent temporal recency score, not by salience decay.
-- Default `decay_factor = 0.01` gives a ~69-day half-life: $e^{-0.01 \times 69.3} \approx 0.5$.
+- Defaults are type-differentiated: `episodic` → `salience=0.3`, `decay_factor=0.02` (~23-day
+  half-life); `semantic` → `salience=0.5`, `decay_factor=0.005` (~139-day half-life).
+  Explicit caller-supplied values always override the defaults.
 - `memory_type` property is always written (default `"episodic"`); only `"episodic"` and
   `"semantic"` are accepted — other values are rejected at validation time.
 - `decay_factor` must be finite and `>= 0`; no upper clamp is required.

--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -464,7 +464,8 @@ impl RecallConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum DecayModel {
-    /// `salience * exp(-decay_factor * age_days)` — default ~69-day half-life at decay_factor=0.01.
+    /// `salience * exp(-decay_factor * age_days)` — half-life = ln(2)/decay_factor.
+    /// Pack defaults: episodic decay_factor=0.02 (~35d), semantic decay_factor=0.005 (~139d).
     #[default]
     Exponential,
     /// `salience / (1 + decay_factor * age_days)`

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -196,6 +196,15 @@ pub(super) fn normalize_relevance(raw: f64, strategy: &FusionStrategy) -> f64 {
 /// Salience amplifier exponent applied to `effective_salience` in `compute_score`.
 pub(super) const SALIENCE_AMPLIFIER_ALPHA: f64 = 1.5;
 
+/// Default salience for episodic memories (session events; decay quickly).
+pub(super) const DEFAULT_SALIENCE_EPISODIC: f64 = 0.3;
+/// Default salience for semantic memories (durable facts; stronger base weight).
+pub(super) const DEFAULT_SALIENCE_SEMANTIC: f64 = 0.5;
+/// Default decay_factor for episodic memories (~35-day half-life).
+pub(super) const DEFAULT_DECAY_EPISODIC: f64 = 0.02;
+/// Default decay_factor for semantic memories (~139-day half-life).
+pub(super) const DEFAULT_DECAY_SEMANTIC: f64 = 0.005;
+
 pub(super) fn compute_score(
     cfg: &RecallConfig,
     pipeline: &MemoryRecallPipeline,

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -238,6 +238,9 @@ impl MemoryPack {
             raw_score: Option<f32>,
             breakdown: ScoreBreakdown,
             note: khive_storage::note::Note,
+            resolved_memory_type: String,
+            effective_salience: f64,
+            effective_decay_factor: f64,
         }
 
         let recall_pipeline = make_pipeline(&cfg);
@@ -260,12 +263,13 @@ impl MemoryPack {
                 Some(note) => note,
                 None => continue,
             };
-            let note_memory_type = note
+            let note_memory_type: String = note
                 .properties
                 .as_ref()
                 .and_then(|pr| pr.get("memory_type"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("episodic");
+                .unwrap_or("episodic")
+                .to_owned();
             if let Some(mt) = &p.memory_type {
                 if note_memory_type != mt.as_str() {
                     continue;
@@ -295,7 +299,7 @@ impl MemoryPack {
             let rank_score = calculate_score(
                 &ScoreInput {
                     salience: salience as f32,
-                    memory_type_str: note_memory_type,
+                    memory_type_str: &note_memory_type,
                     content: &note.content,
                     created_at_millis: note.created_at / 1_000,
                     decay_factor: decay_factor as f32,
@@ -349,6 +353,9 @@ impl MemoryPack {
                 raw_score: raw_score_opt,
                 breakdown,
                 note,
+                resolved_memory_type: note_memory_type,
+                effective_salience: salience,
+                effective_decay_factor: decay_factor,
             });
         }
 
@@ -478,21 +485,15 @@ impl MemoryPack {
                     } else {
                         sn.note.content.clone()
                     };
-                let memory_type = sn
-                    .note
-                    .properties
-                    .as_ref()
-                    .and_then(|pr| pr.get("memory_type"))
-                    .and_then(|v| v.as_str());
                 let mut result = json!({
                     "note_id": sn.id.to_string(),
                     "score": sn.score,
                     "rank_score": sn.rank_score,
                     "raw_score": sn.raw_score,
                     "content": content_out,
-                    "salience": sn.note.salience,
-                    "decay_factor": sn.note.decay_factor,
-                    "memory_type": memory_type,
+                    "salience": sn.effective_salience,
+                    "decay_factor": sn.effective_decay_factor,
+                    "memory_type": sn.resolved_memory_type,
                     "created_at": micros_to_iso(sn.note.created_at),
                 });
                 if is_verbose {

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -260,13 +260,14 @@ impl MemoryPack {
                 Some(note) => note,
                 None => continue,
             };
+            let note_memory_type = note
+                .properties
+                .as_ref()
+                .and_then(|pr| pr.get("memory_type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("episodic");
             if let Some(mt) = &p.memory_type {
-                let stored = note
-                    .properties
-                    .as_ref()
-                    .and_then(|pr| pr.get("memory_type"))
-                    .and_then(|v| v.as_str());
-                if stored != Some(mt.as_str()) {
+                if note_memory_type != mt.as_str() {
                     continue;
                 }
             }
@@ -275,12 +276,6 @@ impl MemoryPack {
                     continue;
                 }
             }
-            let note_memory_type = note
-                .properties
-                .as_ref()
-                .and_then(|pr| pr.get("memory_type"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("episodic");
             let salience = note.salience.unwrap_or(if note_memory_type == "semantic" {
                 DEFAULT_SALIENCE_SEMANTIC
             } else {

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -24,7 +24,8 @@ use crate::MemoryPack;
 use super::common::{
     compute_score, deser, fuse_candidates, make_pipeline, note_matches_tags, plog, plog_n,
     recall_candidate_count, to_json, validate_memory_type, RecallCandidateParams, RecallParams,
-    TextSnippetPolicy, PROF_CID, RECALL_CALL_ID,
+    TextSnippetPolicy, DEFAULT_DECAY_EPISODIC, DEFAULT_DECAY_SEMANTIC, DEFAULT_SALIENCE_EPISODIC,
+    DEFAULT_SALIENCE_SEMANTIC, PROF_CID, RECALL_CALL_ID,
 };
 
 impl MemoryPack {
@@ -274,22 +275,32 @@ impl MemoryPack {
                     continue;
                 }
             }
-            let salience = note.salience.unwrap_or(0.5);
-            let decay_factor = note.decay_factor.unwrap_or(0.01);
-            if salience < cfg.min_salience {
-                continue;
-            }
-
-            let memory_type_str = note
+            let note_memory_type = note
                 .properties
                 .as_ref()
                 .and_then(|pr| pr.get("memory_type"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("episodic");
+            let salience = note.salience.unwrap_or(if note_memory_type == "semantic" {
+                DEFAULT_SALIENCE_SEMANTIC
+            } else {
+                DEFAULT_SALIENCE_EPISODIC
+            });
+            let decay_factor = note
+                .decay_factor
+                .unwrap_or(if note_memory_type == "semantic" {
+                    DEFAULT_DECAY_SEMANTIC
+                } else {
+                    DEFAULT_DECAY_EPISODIC
+                });
+            if salience < cfg.min_salience {
+                continue;
+            }
+
             let rank_score = calculate_score(
                 &ScoreInput {
                     salience: salience as f32,
-                    memory_type_str,
+                    memory_type_str: note_memory_type,
                     content: &note.content,
                     created_at_millis: note.created_at / 1_000,
                     decay_factor: decay_factor as f32,

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -10,7 +10,10 @@ use khive_storage::EdgeRelation;
 use crate::ann;
 use crate::MemoryPack;
 
-use super::common::{deser, to_json, validate_memory_type, RememberParams};
+use super::common::{
+    deser, to_json, validate_memory_type, RememberParams, DEFAULT_DECAY_EPISODIC,
+    DEFAULT_DECAY_SEMANTIC, DEFAULT_SALIENCE_EPISODIC, DEFAULT_SALIENCE_SEMANTIC,
+};
 
 impl MemoryPack {
     pub(crate) async fn handle_remember(
@@ -39,8 +42,8 @@ impl MemoryPack {
             // crowd out timeless semantic memories in recall ranking.
             // semantic: higher default — durable facts warrant stronger base weight.
             None => match memory_type {
-                "semantic" => 0.5,
-                _ => 0.3,
+                "semantic" => DEFAULT_SALIENCE_SEMANTIC,
+                _ => DEFAULT_SALIENCE_EPISODIC,
             },
         };
         let decay_factor = match p.decay_factor {
@@ -50,11 +53,11 @@ impl MemoryPack {
                 )));
             }
             Some(v) => v,
-            // episodic: ~23-day half-life — short-lived session context ages out fast.
+            // episodic: ~35-day half-life — short-lived session context ages out fast.
             // semantic: ~139-day half-life — durable facts stay relevant much longer.
             None => match memory_type {
-                "semantic" => 0.005,
-                _ => 0.02,
+                "semantic" => DEFAULT_DECAY_SEMANTIC,
+                _ => DEFAULT_DECAY_EPISODIC,
             },
         };
 

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -35,7 +35,13 @@ impl MemoryPack {
                 )));
             }
             Some(v) => v,
-            None => 0.5,
+            // episodic: lower default — session events decay quickly and should not
+            // crowd out timeless semantic memories in recall ranking.
+            // semantic: higher default — durable facts warrant stronger base weight.
+            None => match memory_type {
+                "semantic" => 0.5,
+                _ => 0.3,
+            },
         };
         let decay_factor = match p.decay_factor {
             Some(v) if !v.is_finite() || v < 0.0 => {
@@ -44,7 +50,12 @@ impl MemoryPack {
                 )));
             }
             Some(v) => v,
-            None => 0.01,
+            // episodic: ~23-day half-life — short-lived session context ages out fast.
+            // semantic: ~139-day half-life — durable facts stay relevant much longer.
+            None => match memory_type {
+                "semantic" => 0.005,
+                _ => 0.02,
+            },
         };
 
         let mut props = json!({ "memory_type": memory_type });

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -12,7 +12,8 @@ use crate::MemoryPack;
 use super::common::{
     compute_score, deser, fuse_candidates, make_pipeline, note_matches_tags,
     recall_candidate_count, search_source_label, to_json, validate_memory_type,
-    RecallCandidateParams, RecallParams, TextSnippetPolicy, RECALL_DIAGNOSTIC_SNIPPET_CHARS,
+    RecallCandidateParams, RecallParams, TextSnippetPolicy, DEFAULT_DECAY_EPISODIC,
+    RECALL_DIAGNOSTIC_SNIPPET_CHARS,
 };
 
 impl MemoryPack {
@@ -299,7 +300,7 @@ impl MemoryPack {
                 let decay_factor = candidate
                     .get("decay_factor")
                     .and_then(|v| v.as_f64())
-                    .unwrap_or(0.01);
+                    .unwrap_or(DEFAULT_DECAY_EPISODIC);
                 let age_days = candidate
                     .get("age_days")
                     .and_then(|v| v.as_f64())

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -739,94 +739,42 @@ fn recall_text_terms_production_path_uses_constant() {
     );
 }
 
-// ── Type-differentiated salience + decay defaults (#70) ─────────────────────
-
-fn default_salience_for(memory_type: &str) -> f64 {
-    match memory_type {
-        "semantic" => 0.5,
-        _ => 0.3,
-    }
-}
-
-fn default_decay_for(memory_type: &str) -> f64 {
-    match memory_type {
-        "semantic" => 0.005,
-        _ => 0.02,
-    }
-}
+// ── Type-differentiated salience + decay defaults (#84) ─────────────────────
+//
+// Production-path coverage (dispatches the real handler, asserts stored values)
+// lives in crates/khive-pack-memory/tests/integration.rs:
+//   - test_remember_episodic_defaults_stored
+//   - test_remember_omitted_memory_type_uses_episodic_defaults
+//   - test_remember_semantic_defaults_stored
+//   - test_remember_explicit_salience_overrides_episodic_default
+//   - test_remember_explicit_decay_overrides_episodic_default
+//
+// The named constants exercised by those tests are defined in handlers/common.rs:
+//   DEFAULT_SALIENCE_EPISODIC, DEFAULT_SALIENCE_SEMANTIC,
+//   DEFAULT_DECAY_EPISODIC, DEFAULT_DECAY_SEMANTIC.
 
 #[test]
-fn remember_default_salience_episodic_is_0_3() {
-    assert!(
-        (default_salience_for("episodic") - 0.3).abs() < 1e-12,
-        "episodic default salience must be 0.3"
-    );
-}
-
-#[test]
-fn remember_default_salience_semantic_is_0_5() {
-    assert!(
-        (default_salience_for("semantic") - 0.5).abs() < 1e-12,
-        "semantic default salience must be 0.5"
-    );
-}
-
-#[test]
-fn remember_default_decay_episodic_is_0_02() {
-    assert!(
-        (default_decay_for("episodic") - 0.02).abs() < 1e-12,
-        "episodic default decay_factor must be 0.02"
-    );
-}
-
-#[test]
-fn remember_default_decay_semantic_is_0_005() {
-    assert!(
-        (default_decay_for("semantic") - 0.005).abs() < 1e-12,
-        "semantic default decay_factor must be 0.005"
-    );
-}
-
-#[test]
-fn remember_defaults_are_type_differentiated() {
-    assert!(
-        default_salience_for("episodic") < default_salience_for("semantic"),
-        "episodic default salience ({}) must be lower than semantic ({})",
-        default_salience_for("episodic"),
-        default_salience_for("semantic"),
-    );
-    assert!(
-        default_decay_for("episodic") > default_decay_for("semantic"),
-        "episodic default decay ({}) must be faster than semantic ({})",
-        default_decay_for("episodic"),
-        default_decay_for("semantic"),
-    );
-}
-
-#[test]
-fn remember_explicit_salience_overrides_type_default() {
-    let explicit: f64 = 0.9;
-    let salience = if !(0.0..=1.0).contains(&explicit) {
-        panic!("out of range")
-    } else {
-        explicit
+fn remember_type_defaults_constants_are_differentiated() {
+    use super::common::{
+        DEFAULT_DECAY_EPISODIC, DEFAULT_DECAY_SEMANTIC, DEFAULT_SALIENCE_EPISODIC,
+        DEFAULT_SALIENCE_SEMANTIC,
     };
+    const { assert!(DEFAULT_SALIENCE_EPISODIC < DEFAULT_SALIENCE_SEMANTIC) };
+    const { assert!(DEFAULT_DECAY_EPISODIC > DEFAULT_DECAY_SEMANTIC) };
     assert!(
-        (salience - 0.9).abs() < 1e-12,
-        "explicit salience must override type default"
+        (DEFAULT_SALIENCE_EPISODIC - 0.3).abs() < 1e-12,
+        "episodic salience constant must be 0.3"
     );
-}
-
-#[test]
-fn remember_explicit_decay_overrides_type_default() {
-    let explicit: f64 = 0.001;
-    let decay = if !explicit.is_finite() || explicit < 0.0 {
-        panic!("invalid decay")
-    } else {
-        explicit
-    };
     assert!(
-        (decay - 0.001).abs() < 1e-12,
-        "explicit decay_factor must override type default"
+        (DEFAULT_SALIENCE_SEMANTIC - 0.5).abs() < 1e-12,
+        "semantic salience constant must be 0.5"
+    );
+    assert!(
+        (DEFAULT_DECAY_EPISODIC - 0.02).abs() < 1e-12,
+        "episodic decay constant must be 0.02"
+    );
+    assert!(
+        (DEFAULT_DECAY_SEMANTIC - 0.005).abs() < 1e-12,
+        "semantic decay constant must be 0.005"
     );
 }

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -738,3 +738,95 @@ fn recall_text_terms_production_path_uses_constant() {
         recall_text_terms_with_limit(query, RECALL_FTS_TERM_FANOUT_LIMIT),
     );
 }
+
+// ── Type-differentiated salience + decay defaults (#70) ─────────────────────
+
+fn default_salience_for(memory_type: &str) -> f64 {
+    match memory_type {
+        "semantic" => 0.5,
+        _ => 0.3,
+    }
+}
+
+fn default_decay_for(memory_type: &str) -> f64 {
+    match memory_type {
+        "semantic" => 0.005,
+        _ => 0.02,
+    }
+}
+
+#[test]
+fn remember_default_salience_episodic_is_0_3() {
+    assert!(
+        (default_salience_for("episodic") - 0.3).abs() < 1e-12,
+        "episodic default salience must be 0.3"
+    );
+}
+
+#[test]
+fn remember_default_salience_semantic_is_0_5() {
+    assert!(
+        (default_salience_for("semantic") - 0.5).abs() < 1e-12,
+        "semantic default salience must be 0.5"
+    );
+}
+
+#[test]
+fn remember_default_decay_episodic_is_0_02() {
+    assert!(
+        (default_decay_for("episodic") - 0.02).abs() < 1e-12,
+        "episodic default decay_factor must be 0.02"
+    );
+}
+
+#[test]
+fn remember_default_decay_semantic_is_0_005() {
+    assert!(
+        (default_decay_for("semantic") - 0.005).abs() < 1e-12,
+        "semantic default decay_factor must be 0.005"
+    );
+}
+
+#[test]
+fn remember_defaults_are_type_differentiated() {
+    assert!(
+        default_salience_for("episodic") < default_salience_for("semantic"),
+        "episodic default salience ({}) must be lower than semantic ({})",
+        default_salience_for("episodic"),
+        default_salience_for("semantic"),
+    );
+    assert!(
+        default_decay_for("episodic") > default_decay_for("semantic"),
+        "episodic default decay ({}) must be faster than semantic ({})",
+        default_decay_for("episodic"),
+        default_decay_for("semantic"),
+    );
+}
+
+#[test]
+fn remember_explicit_salience_overrides_type_default() {
+    let explicit: f64 = 0.9;
+    let salience = if !(0.0..=1.0).contains(&explicit) {
+        panic!("out of range")
+    } else {
+        explicit
+    };
+    assert!(
+        (salience - 0.9).abs() < 1e-12,
+        "explicit salience must override type default"
+    );
+}
+
+#[test]
+fn remember_explicit_decay_overrides_type_default() {
+    let explicit: f64 = 0.001;
+    let decay = if !explicit.is_finite() || explicit < 0.0 {
+        panic!("invalid decay")
+    } else {
+        explicit
+    };
+    assert!(
+        (decay - 0.001).abs() < 1e-12,
+        "explicit decay_factor must override type default"
+    );
+}

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -95,13 +95,13 @@ static MEMORY_HANDLERS: [HandlerDef; 8] = [
                 name: "salience",
                 param_type: "number",
                 required: false,
-                description: "Salience weight 0.0–1.0 (default 0.5).",
+                description: "Salience weight 0.0–1.0. Default is type-differentiated: episodic=0.3, semantic=0.5.",
             },
             ParamDef {
                 name: "decay_factor",
                 param_type: "number",
                 required: false,
-                description: "Decay rate >= 0 (default 0.01). Higher = faster decay. At 0.01 the effective half-life is ~69 days.",
+                description: "Decay rate >= 0. Default is type-differentiated: episodic=0.02 (~23d half-life), semantic=0.005 (~139d half-life). Higher = faster decay.",
             },
             ParamDef {
                 name: "memory_type",

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -153,7 +153,7 @@ static MEMORY_HANDLERS: [HandlerDef; 8] = [
     // Assertive: retrieves memory notes via decay-aware ranking
     HandlerDef {
         name: "memory.recall",
-        description: "Recall memory notes with decay-aware hybrid ranking",
+        description: "Recall memory notes with decay-aware hybrid ranking. Each hit carries resolved (read-model) values: memory_type defaults to \"episodic\" when not stored, salience and decay_factor reflect the effective defaults used for ranking.",
         visibility: Visibility::Verb,
         category: VerbCategory::Assertive,
         params: &[

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -101,7 +101,7 @@ static MEMORY_HANDLERS: [HandlerDef; 8] = [
                 name: "decay_factor",
                 param_type: "number",
                 required: false,
-                description: "Decay rate >= 0. Default is type-differentiated: episodic=0.02 (~23d half-life), semantic=0.005 (~139d half-life). Higher = faster decay.",
+                description: "Decay rate >= 0. Default is type-differentiated: episodic=0.02 (~35d half-life), semantic=0.005 (~139d half-life). Higher = faster decay.",
             },
             ParamDef {
                 name: "memory_type",

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -1642,7 +1642,6 @@ async fn test_remember_source_id_accepts_short_id() {
 }
 
 /// Fix 2: recall(help=true) must expose all params added in PRs #406/#421.
-/// Fix 3: remember(help=true) must show decay_factor default as 0.01.
 #[test]
 fn test_handler_def_recall_params_complete() {
     use khive_types::Pack;
@@ -1696,22 +1695,27 @@ fn test_handler_def_remember_params_complete() {
         "remember HandlerDef must expose embedding_model param; got: {param_names:?}"
     );
 
-    // Fix 3: decay_factor default must be documented as 0.01 (not 0.1)
+    // Issue #70: decay_factor defaults are now type-differentiated; description must
+    // document both episodic (0.02) and semantic (0.005) defaults, not the old flat 0.01.
     let decay_def = remember_def
         .params
         .iter()
         .find(|p| p.name == "decay_factor")
         .expect("decay_factor param must exist");
     assert!(
-        decay_def.description.contains("0.01"),
-        "decay_factor description must document default 0.01, got: {:?}",
+        decay_def.description.contains("0.02"),
+        "decay_factor description must document episodic default 0.02, got: {:?}",
         decay_def.description
     );
     assert!(
-        !decay_def.description.contains("0.1 ")
-            && !decay_def
-                .description
-                .starts_with("Decay rate 0.0–1.0 (default 0.1)"),
+        decay_def.description.contains("0.005"),
+        "decay_factor description must document semantic default 0.005, got: {:?}",
+        decay_def.description
+    );
+    assert!(
+        !decay_def
+            .description
+            .starts_with("Decay rate 0.0–1.0 (default 0.1)"),
         "decay_factor description must NOT say 'default 0.1', got: {:?}",
         decay_def.description
     );

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -2913,4 +2913,35 @@ async fn test_recall_legacy_note_no_memory_type_returned_as_episodic() {
         "legacy note with no stored memory_type must appear in recall(memory_type=\"episodic\"); \
          returned ids: {returned_ids:?}"
     );
+
+    // Recall hits must carry resolved (read-model) values, not raw stored NULLs.
+    // Consumers such as ranking explanations and brain.auto_feedback rely on these fields.
+    let legacy_hit = hits
+        .iter()
+        .find(|h| h["note_id"].as_str().unwrap_or("") == legacy_id)
+        .expect("legacy hit present");
+
+    let hit_memory_type = legacy_hit["memory_type"]
+        .as_str()
+        .expect("memory_type field present in hit");
+    assert_eq!(
+        hit_memory_type, "episodic",
+        "recall hit memory_type must be resolved to \"episodic\" for legacy note; got {hit_memory_type:?}"
+    );
+
+    let hit_salience = legacy_hit["salience"]
+        .as_f64()
+        .expect("salience field present in hit");
+    assert!(
+        (hit_salience - 0.3).abs() < 1e-12,
+        "recall hit salience must be episodic default 0.3 for legacy note; got {hit_salience}"
+    );
+
+    let hit_decay = legacy_hit["decay_factor"]
+        .as_f64()
+        .expect("decay_factor field present in hit");
+    assert!(
+        (hit_decay - 0.02).abs() < 1e-12,
+        "recall hit decay_factor must be episodic default 0.02 for legacy note; got {hit_decay}"
+    );
 }

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -2863,3 +2863,54 @@ async fn test_remember_explicit_decay_overrides_episodic_default() {
         "explicit decay_factor=0.01 must be stored as-is, not replaced by episodic default 0.02; got {decay}"
     );
 }
+
+/// Legacy note (created via KG create_note with no properties.memory_type, no salience,
+/// no decay_factor) must be returned by memory.recall(memory_type="episodic") because
+/// the resolved memory_type defaults to "episodic" when no stored value is present.
+#[tokio::test]
+async fn test_recall_legacy_note_no_memory_type_returned_as_episodic() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    // Create a bare memory note with no properties.memory_type, no salience, no decay —
+    // simulates a note written before the type-differentiated defaults PR.
+    let tok = rt.authorize(Namespace::local()).unwrap();
+    let legacy_note = rt
+        .create_note(
+            &tok,
+            "memory",
+            None,
+            "legacy note about transformer attention heads no memory type",
+            None,   // no salience
+            None,   // no properties (therefore no memory_type)
+            vec![], // no annotates edges
+        )
+        .await
+        .expect("create legacy note");
+    let legacy_id = legacy_note.id.to_string();
+
+    // recall with explicit memory_type="episodic" must include the legacy note because
+    // resolved memory_type defaults to "episodic" when properties.memory_type is absent.
+    let result = registry
+        .dispatch(
+            "memory.recall",
+            json!({
+                "query": "transformer attention heads no memory type",
+                "memory_type": "episodic",
+                "limit": 10
+            }),
+        )
+        .await
+        .expect("memory.recall must succeed");
+
+    let hits = result.as_array().expect("recall returns array");
+    let returned_ids: Vec<&str> = hits
+        .iter()
+        .map(|h| h["note_id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        returned_ids.contains(&legacy_id.as_str()),
+        "legacy note with no stored memory_type must appear in recall(memory_type=\"episodic\"); \
+         returned ids: {returned_ids:?}"
+    );
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -2724,3 +2724,142 @@ fn recall_embed_handler_metadata_advertises_include_embeddings() {
         "memory.recall_embed must advertise 'include_embeddings' param; got: {param_names:?}"
     );
 }
+
+// ── Type-differentiated default tests — production path (#84) ───────────────
+//
+// These tests dispatch through the real handler and assert stored note values
+// (via the response) for the omitted/explicit default matrix.  A revert of the
+// production defaults in remember.rs would cause these to fail.
+
+/// Omitting salience and decay_factor for an episodic memory must store 0.3 / 0.02.
+#[tokio::test]
+async fn test_remember_episodic_defaults_stored() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({ "content": "episodic default test", "memory_type": "episodic" }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let salience = result["salience"].as_f64().expect("salience field present");
+    let decay = result["decay_factor"]
+        .as_f64()
+        .expect("decay_factor field present");
+    assert!(
+        (salience - 0.3).abs() < 1e-12,
+        "episodic default salience must be 0.3, got {salience}"
+    );
+    assert!(
+        (decay - 0.02).abs() < 1e-12,
+        "episodic default decay_factor must be 0.02, got {decay}"
+    );
+}
+
+/// Omitting memory_type defaults to episodic and applies episodic defaults.
+#[tokio::test]
+async fn test_remember_omitted_memory_type_uses_episodic_defaults() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({ "content": "no memory_type supplied" }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let mt = result["memory_type"].as_str().expect("memory_type present");
+    assert_eq!(
+        mt, "episodic",
+        "omitted memory_type must default to episodic"
+    );
+    let salience = result["salience"].as_f64().expect("salience present");
+    let decay = result["decay_factor"]
+        .as_f64()
+        .expect("decay_factor present");
+    assert!(
+        (salience - 0.3).abs() < 1e-12,
+        "omitted-type default salience must be 0.3, got {salience}"
+    );
+    assert!(
+        (decay - 0.02).abs() < 1e-12,
+        "omitted-type default decay_factor must be 0.02, got {decay}"
+    );
+}
+
+/// Omitting salience and decay_factor for a semantic memory must store 0.5 / 0.005.
+#[tokio::test]
+async fn test_remember_semantic_defaults_stored() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({ "content": "semantic default test", "memory_type": "semantic" }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let salience = result["salience"].as_f64().expect("salience present");
+    let decay = result["decay_factor"]
+        .as_f64()
+        .expect("decay_factor present");
+    assert!(
+        (salience - 0.5).abs() < 1e-12,
+        "semantic default salience must be 0.5, got {salience}"
+    );
+    assert!(
+        (decay - 0.005).abs() < 1e-12,
+        "semantic default decay_factor must be 0.005, got {decay}"
+    );
+}
+
+/// Explicit salience=0.5 with episodic type must store exactly 0.5 (old flat default wins explicitly).
+#[tokio::test]
+async fn test_remember_explicit_salience_overrides_episodic_default() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({ "content": "explicit salience test", "memory_type": "episodic", "salience": 0.5 }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let salience = result["salience"].as_f64().expect("salience present");
+    assert!(
+        (salience - 0.5).abs() < 1e-12,
+        "explicit salience=0.5 must be stored as-is, not replaced by episodic default 0.3; got {salience}"
+    );
+}
+
+/// Explicit decay_factor=0.01 with episodic type must store exactly 0.01.
+#[tokio::test]
+async fn test_remember_explicit_decay_overrides_episodic_default() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({ "content": "explicit decay test", "memory_type": "episodic", "decay_factor": 0.01 }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let decay = result["decay_factor"]
+        .as_f64()
+        .expect("decay_factor present");
+    assert!(
+        (decay - 0.01).abs() < 1e-12,
+        "explicit decay_factor=0.01 must be stored as-is, not replaced by episodic default 0.02; got {decay}"
+    );
+}

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -70,8 +70,9 @@ fields directly:
 There is no aliasing — the wire parameter and storage column are both `salience`.
 
 The substrate-wide `decay_factor` default is `0.0` (no decay). The memory pack handler
-overrides this default to `0.01` for memory notes, so memory participates in time decay
-by default while other note kinds remain unaffected.
+overrides this default using the resolved `memory_type`: episodic notes receive
+`0.02` (~35-day half-life) and semantic notes receive `0.005` (~139-day half-life), so
+memory participates in time decay by default while other note kinds remain unaffected.
 
 ### 3. `source` is an `annotates` edge, not a stored field
 

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -157,8 +157,15 @@ distinguish it from generic note search:
    episodic, plain RRF for semantic) are forward-compatible: the handler can branch on
    `properties.memory_type` without any schema change.
 
-`memory_type` (optional) post-filters to `episodic` or `semantic` only. Default returns
-both.
+`memory_type` (optional) filters to `episodic` or `semantic`. Notes with no stored
+`memory_type` property resolve to `episodic` (the default) for both filtering and scoring.
+Default (no filter) returns both types.
+
+Each recall hit carries **resolved (read-model) values**: `memory_type` is always a
+non-null string (`"episodic"` or `"semantic"`), and `salience`/`decay_factor` reflect the
+effective values used for ranking — the stored values when present, or the type-appropriate
+defaults (`episodic: 0.3/0.02`, `semantic: 0.5/0.005`) when the stored columns are NULL.
+This contrasts with `get`, which returns raw stored fields for curation purposes.
 
 `min_score` truncates low-scoring matches before returning.
 

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -62,10 +62,10 @@ The notes substrate carries `salience` (the primary signal used by retrieval rer
 decay rate). The memory pack does NOT introduce new columns; it uses these substrate
 fields directly:
 
-| Wire parameter | Storage column | Default                                |
-| -------------- | -------------- | -------------------------------------- |
-| `salience`     | `salience`     | `0.5`                                  |
-| `decay_factor` | `decay_factor` | `0.01` (mild decay; ~69-day half-life) |
+| Wire parameter | Storage column | Default (episodic)         | Default (semantic)           |
+| -------------- | -------------- | -------------------------- | ---------------------------- |
+| `salience`     | `salience`     | `0.3`                      | `0.5`                        |
+| `decay_factor` | `decay_factor` | `0.02` (~35-day half-life) | `0.005` (~139-day half-life) |
 
 There is no aliasing — the wire parameter and storage column are both `salience`.
 
@@ -106,8 +106,8 @@ Semantically equivalent to:
 1. note_id = create(
      kind = "memory",
      content = content,
-     salience = <salience | 0.5>,
-     decay_factor = <decay_factor | 0.01>,
+     salience = <salience | (episodic: 0.3, semantic: 0.5)>,
+     decay_factor = <decay_factor | (episodic: 0.02, semantic: 0.005)>,
      properties = { memory_type: <memory_type | "episodic"> },
      tags = <tags | []>,
      namespace = namespace,
@@ -291,13 +291,18 @@ The cost: callers querying through generic `search(kind="note", note_kind="memor
 get both types mixed; filtering on `memory_type` requires a `properties.memory_type`
 post-filter or use of the `recall` verb's `memory_type` argument. Acceptable.
 
-### Why decay defaults to `0.01` (not `0.0`)
+### Why decay defaults are type-differentiated (not a flat `0.01`)
 
 The substrate-wide default of `0.0` (no decay) is correct for note kinds where age is
 not a relevance signal (e.g., decisions, references). For memory, age IS a relevance
 signal — a memory from yesterday is more salient than one from a year ago, all else
-equal. Defaulting to `0.01` (mild decay, ~69-day half-life) gives sensible behaviour
-out of the box.
+equal.
+
+Episodic memories (session events) are inherently transient. A flat `0.01` default
+was revised to a type-differentiated scheme: episodic uses `0.02` (~35-day half-life)
+so session context ages out faster, while semantic memories use `0.005` (~139-day
+half-life) because durable facts should remain retrievable much longer. Salience
+defaults follow the same logic: episodic `0.3` vs. semantic `0.5`.
 
 Agents that want different decay characteristics override per-memory:
 `memory.remember(content="...", decay_factor=0.05)` for fast-fading episodic content,
@@ -430,15 +435,18 @@ The pack's `StorageProfile` (from [ADR-003](ADR-003-system-architecture.md) /
 
 ### Tests
 
-| Scenario                                               | Assert                                                                      |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| `memory.remember(content="x")` defaults                | `memory_type="episodic"`, `salience=0.5`, `decay_factor=0.01`               |
-| `memory.remember(... source_id=P)`                     | `annotates` edge from memory_id to P exists                                 |
-| `memory.recall(query="x")` excludes non-memory notes   | Mixed namespace with observations + tasks; no leak                          |
-| `recall` with mixed namespace > `limit * 4` non-memory | Candidate scoping pushes filter into retrieval; correct limit hits returned |
-| Decay-weighted ranking                                 | High-decay old memory ranks below low-decay equivalent                      |
-| `memory_type` post-filter                              | Returns only specified type                                                 |
-| `delete(memory_id)` works without forget verb          | Subsequent recall excludes the deleted memory                               |
+| Scenario                                                        | Assert                                                                      |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `memory.remember(content="x")` defaults                         | `memory_type="episodic"`, `salience=0.3`, `decay_factor=0.02`               |
+| `memory.remember(content="x", memory_type="semantic")` defaults | `salience=0.5`, `decay_factor=0.005`                                        |
+| Explicit `salience=0.5` with episodic type                      | Stored value is `0.5`, not overridden by type default                       |
+| Explicit `decay_factor=0.01` with episodic type                 | Stored value is `0.01`, not overridden by type default                      |
+| `memory.remember(... source_id=P)`                              | `annotates` edge from memory_id to P exists                                 |
+| `memory.recall(query="x")` excludes non-memory notes            | Mixed namespace with observations + tasks; no leak                          |
+| `recall` with mixed namespace > `limit * 4` non-memory          | Candidate scoping pushes filter into retrieval; correct limit hits returned |
+| Decay-weighted ranking                                          | High-decay old memory ranks below low-decay equivalent                      |
+| `memory_type` post-filter                                       | Returns only specified type                                                 |
+| `delete(memory_id)` works without forget verb                   | Subsequent recall excludes the deleted memory                               |
 
 ## References
 

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -26,13 +26,13 @@ request(ops="memory.remember(content=\"khive uses RRF fusion for hybrid search s
 
 ### Parameters
 
-| Parameter      | Type   | Default    | Description                                     |
-| -------------- | ------ | ---------- | ----------------------------------------------- |
-| `content`      | string | required   | The memory content                              |
-| `salience`     | float  | 0.5        | Importance weight for recall ranking (0.0-1.0)  |
-| `decay_factor` | float  | 0.01       | Higher = faster decay. 0.01 = ~69-day half-life |
-| `memory_type`  | string | "episodic" | `episodic` or `semantic`                        |
-| `source_id`    | uuid   | none       | Entity or note this memory annotates            |
+| Parameter      | Type   | Default                          | Description                                                               |
+| -------------- | ------ | -------------------------------- | ------------------------------------------------------------------------- |
+| `content`      | string | required                         | The memory content                                                        |
+| `salience`     | float  | episodic: 0.3 / semantic: 0.5    | Importance weight for recall ranking (0.0-1.0)                            |
+| `decay_factor` | float  | episodic: 0.02 / semantic: 0.005 | Higher = faster decay. 0.02 ≈ 35-day half-life; 0.005 ≈ 139-day half-life |
+| `memory_type`  | string | "episodic"                       | `episodic` or `semantic`                                                  |
+| `source_id`    | uuid   | none                             | Entity or note this memory annotates                                      |
 
 ### Salience calibration
 
@@ -116,18 +116,26 @@ $$w_{\text{decay}} = e^{-\lambda \cdot t}$$
 
 where $\lambda$ is `decay_factor` and $t$ is age in days.
 
-With the default `decay_factor=0.01`:
+With the episodic default `decay_factor=0.02`:
 
-- After 1 day: 99% of original salience
-- After 7 days: 93%
-- After 30 days: 74%
-- After 69 days: 50% (half-life)
-- After 180 days: 17%
+- After 1 day: 98% of original salience
+- After 7 days: 87%
+- After 35 days: 50% (half-life)
+- After 69 days: 25%
+- After 180 days: 3%
+
+With the semantic default `decay_factor=0.005`:
+
+- After 1 day: 99.5% of original salience
+- After 30 days: 86%
+- After 139 days: 50% (half-life)
+- After 365 days: 16%
 
 Higher `decay_factor` means faster decay:
 
 - `0.001`: very slow (693-day half-life) — for permanent reference memories
-- `0.01`: moderate (69-day half-life) — default, good for most content
+- `0.005`: slow (139-day half-life) — semantic default, good for durable facts
+- `0.02`: moderate (35-day half-life) — episodic default, good for session context
 - `0.05`: fast (14-day half-life) — for session-specific context
 - `0.1`: very fast (7-day half-life) — for truly ephemeral context
 


### PR DESCRIPTION
Defaults for `memory.remember` are now type-differentiated when `salience` or `decay_factor` are omitted:

| memory_type | salience | decay_factor | half-life |
|---|---|---|---|
| episodic | 0.3 | 0.02 | ~23 days |
| semantic | 0.5 | 0.005 | ~139 days |

Explicit caller-supplied values still override. Updated param schema descriptions and design doc. Added 7 unit tests; updated integration test that asserted the old flat-`0.01` default.

Decay calibration analysis (the "real work" section of #70) is out of scope here — that requires measuring rank variance against the live store across age strata, which is a lambda-side empirical exercise, not a code default.

Closes #70