### PR TITLE
fix(db): backfill FTS on reindex — close coverage gap for pre-existing notes

### DIFF
--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -629,6 +629,42 @@ pub fn note_fts_document(note: &Note) -> TextDocument {
     }
 }
 
+/// SQL-bind–ready scalars derived from [`note_fts_document`].
+///
+/// Used by `merge_note_sql` to guarantee that the raw SQL FTS INSERT stores
+/// exactly what [`Fts5TextSearch::upsert_document`] would write, preventing
+/// null/empty-string divergence on the `title` column for nameless notes.
+pub(crate) struct NoteFtsScalars {
+    /// Empty string when `note.name` is `None` — matches the `unwrap_or("")` in
+    /// `Fts5TextSearch::upsert_document`.
+    pub title: String,
+    pub body: String,
+    /// Always the JSON array `"[]"`.
+    pub tags: String,
+    /// Serialised `note.properties`, or `None` when properties are absent.
+    pub metadata: Option<String>,
+    /// `note.updated_at` converted to `DateTime<Utc>` timestamp_micros.
+    pub updated_at_micros: i64,
+}
+
+/// Derive [`NoteFtsScalars`] from a [`Note`].
+///
+/// All values match the encoding that [`Fts5TextSearch::upsert_document`]
+/// applies when given the output of [`note_fts_document`].
+pub(crate) fn note_fts_scalars(note: &Note) -> NoteFtsScalars {
+    let doc = note_fts_document(note);
+    NoteFtsScalars {
+        title: doc.title.unwrap_or_default(),
+        body: doc.body,
+        tags: "[]".to_string(),
+        metadata: doc
+            .metadata
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default()),
+        updated_at_micros: doc.updated_at.timestamp_micros(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Transactional merge SQL helpers
 // ---------------------------------------------------------------------------
@@ -1412,10 +1448,18 @@ fn merge_note_sql(
             ),
             rusqlite::params![&namespace, &into_str],
         )?;
-        // Body parity with note_fts_document: prepend name when present.
-        let merged_fts_body = match &merged_name {
-            Some(n) => format!("{n} {merged_content}"),
-            None => merged_content.clone(),
+        // Derive FTS scalars through the shared constructor so this raw SQL
+        // path is field-identical to TextSearch::upsert_document.  Critically,
+        // `title` is an empty string (not SQL NULL) for nameless notes —
+        // matching the unwrap_or("") in Fts5TextSearch::upsert_document and
+        // allowing get_document to round-trip None ↔ "" correctly.
+        let fts_merged = {
+            let mut merged_note = Note::new(&namespace, &*into_note.kind, &*merged_content);
+            merged_note.id = into_id;
+            merged_note.name = merged_name.clone();
+            merged_note.properties = merged_props.clone();
+            merged_note.updated_at = now;
+            note_fts_scalars(&merged_note)
         };
         conn.execute(
             &format!(
@@ -1427,12 +1471,12 @@ fn merge_note_sql(
             rusqlite::params![
                 &into_str,
                 SubstrateKind::Note.to_string(),
-                &merged_name,
-                &merged_fts_body,
-                "[]",
+                &fts_merged.title,
+                &fts_merged.body,
+                &fts_merged.tags,
                 &namespace,
-                &props_str,
-                now,
+                &fts_merged.metadata,
+                fts_merged.updated_at_micros,
             ],
         )?;
 
@@ -2346,6 +2390,110 @@ mod tests {
         assert_eq!(
             from_after.content, "From content",
             "dry_run must not mutate from-note"
+        );
+    }
+
+    // Regression: merge two NAMELESS notes with no embedding model configured.
+    // Before this fix, the raw SQL FTS INSERT bound &merged_name directly — for a
+    // nameless note that is SQL NULL, while Fts5TextSearch::upsert_document stores
+    // an empty string.  The mismatch caused get_document to diverge (or fail) for
+    // nameless merged notes.  After the fix, note_fts_scalars drives every scalar
+    // and the round-trip is field-identical.
+    #[tokio::test]
+    async fn merge_nameless_notes_fts_document_is_parity_correct() {
+        use khive_storage::types::TextSearchRequest;
+
+        let rt = rt(); // in-memory runtime — no embedding model configured
+        let tok = NamespaceToken::local();
+
+        let into = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "intosentinelzxq body",
+                None,
+                Some(serde_json::json!({"src": "into"})),
+                vec![],
+            )
+            .await
+            .expect("create into-note");
+        let from = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "fromsentinelzxq body",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create from-note");
+
+        let into_id = into.id;
+        let from_id = from.id;
+
+        rt.merge_note(
+            &tok,
+            into_id,
+            from_id,
+            EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
+            false,
+        )
+        .await
+        .expect("merge_note must succeed");
+
+        // Fetch the merged note from the note store to get its current state.
+        let note_store = rt.notes(&tok).expect("note store");
+        let merged_note = note_store
+            .get_note(into_id)
+            .await
+            .expect("get_note")
+            .expect("merged note must exist");
+
+        // Compute the expected FTS document via the shared constructor.
+        let expected = note_fts_document(&merged_note);
+
+        // Fetch the stored FTS document and verify field parity.
+        let fts = rt.text_for_notes(&tok).expect("FTS store");
+        let stored = fts
+            .get_document("local", into_id)
+            .await
+            .expect("get_document must not error")
+            .expect("FTS document must exist after merge");
+
+        // Core parity: subject_id, title (must be None, not Some("")), body.
+        assert_eq!(stored.subject_id, expected.subject_id, "subject_id");
+        assert_eq!(
+            stored.title, expected.title,
+            "title (None for nameless note)"
+        );
+        assert_eq!(stored.body, expected.body, "body");
+        assert_eq!(stored.namespace, expected.namespace, "namespace");
+        assert_eq!(stored.kind, expected.kind, "kind");
+
+        // The merged note is nameless — title must be None, matching the shared path.
+        assert!(
+            stored.title.is_none(),
+            "nameless merged note must have title=None in FTS (was NULL before fix)"
+        );
+
+        // The merged note must be searchable by a unique token from the into-note body.
+        let hits = fts
+            .search(TextSearchRequest {
+                query: "intosentinelzxq".to_string(),
+                mode: khive_storage::types::TextQueryMode::Plain,
+                filter: None,
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+            .expect("search");
+        assert!(
+            hits.iter().any(|h| h.subject_id == into_id),
+            "merged note must be searchable by into-note content"
         );
     }
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use khive_db::SqliteError;
+use khive_storage::note::Note;
 use khive_storage::types::{EdgeFilter, TextDocument};
 use khive_storage::{EdgeRelation, Entity, SubstrateKind};
 use khive_types::EventKind;
@@ -420,21 +421,12 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         note: &khive_storage::note::Note,
     ) -> RuntimeResult<()> {
-        let ns = note.namespace.clone();
         self.text_for_notes(token)?
-            .upsert_document(TextDocument {
-                subject_id: note.id,
-                kind: SubstrateKind::Note,
-                title: note.name.clone(),
-                body: note.content.clone(),
-                tags: Vec::new(),
-                namespace: ns.clone(),
-                metadata: note.properties.clone(),
-                updated_at: chrono::Utc::now(),
-            })
+            .upsert_document(note_fts_document(note))
             .await?;
 
         if self.config().embedding_model.is_some() {
+            let ns = note.namespace.clone();
             let vector = self.embed(&note.content).await?;
             self.vectors(token)?
                 .insert(
@@ -599,6 +591,41 @@ impl KhiveRuntime {
             self.reindex_note(token, &updated_note).await?;
         }
         Ok(summary)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FTS document construction
+// ---------------------------------------------------------------------------
+
+/// Build the `TextDocument` for a note. This is the single source of truth for
+/// note FTS document shape; all write paths (create, update, reindex) must go
+/// through this function so recall parity is guaranteed. Changes here apply to
+/// every caller automatically.
+///
+/// Body rule: when the note has a `name`, prepend it to the content
+/// (`"<name> <content>"`). This matches the FTS index contract: title and body
+/// both contribute to ranking, and the name is the most salient signal.
+///
+/// `updated_at` is taken from the note's own timestamp (not `Utc::now()`) so
+/// that backfill and reindex runs record the note's actual mutation time rather
+/// than the reindex execution time.
+pub fn note_fts_document(note: &Note) -> TextDocument {
+    let body = match &note.name {
+        Some(n) => format!("{n} {}", note.content),
+        None => note.content.clone(),
+    };
+    let updated_at =
+        chrono::DateTime::from_timestamp_micros(note.updated_at).unwrap_or_else(chrono::Utc::now);
+    TextDocument {
+        subject_id: note.id,
+        kind: SubstrateKind::Note,
+        title: note.name.clone(),
+        body,
+        tags: vec![],
+        namespace: note.namespace.clone(),
+        metadata: note.properties.clone(),
+        updated_at,
     }
 }
 
@@ -1385,6 +1412,11 @@ fn merge_note_sql(
             ),
             rusqlite::params![&namespace, &into_str],
         )?;
+        // Body parity with note_fts_document: prepend name when present.
+        let merged_fts_body = match &merged_name {
+            Some(n) => format!("{n} {merged_content}"),
+            None => merged_content.clone(),
+        };
         conn.execute(
             &format!(
                 "INSERT INTO {} \
@@ -1396,7 +1428,7 @@ fn merge_note_sql(
                 &into_str,
                 SubstrateKind::Note.to_string(),
                 &merged_name,
-                &merged_content,
+                &merged_fts_body,
                 "[]",
                 &namespace,
                 &props_str,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -22,8 +22,8 @@ pub mod runtime;
 pub mod validation;
 
 pub use curation::{
-    ContentMergeStrategy, EdgeListFilter, EdgePatch, EntityDedupMergePolicy, EntityPatch,
-    MergeSummary, NotePatch,
+    note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch, EntityDedupMergePolicy,
+    EntityPatch, MergeSummary, NotePatch,
 };
 #[cfg(unix)]
 pub use daemon::{

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -27,6 +27,7 @@ use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
 use khive_db::SqliteError;
 use rusqlite::OptionalExtension;
 
+use crate::curation::note_fts_document;
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
@@ -1220,22 +1221,8 @@ impl KhiveRuntime {
         }
         self.notes(token)?.upsert_note(note.clone()).await?;
 
-        let body = match &note.name {
-            Some(n) => format!("{n} {}", note.content),
-            None => note.content.clone(),
-        };
-
         self.text_for_notes(token)?
-            .upsert_document(TextDocument {
-                subject_id: note.id,
-                kind: SubstrateKind::Note,
-                title: note.name.clone(),
-                body,
-                tags: vec![],
-                namespace: ns.to_string(),
-                metadata: note.properties.clone(),
-                updated_at: chrono::Utc::now(),
-            })
+            .upsert_document(note_fts_document(&note))
             .await?;
 
         // Multi-model vector embedding:

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::config::{parse_embedding_model_alias, sanitize_key};
+use crate::curation::note_fts_document;
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 use khive_score::{rrf_score, DeterministicScore};
@@ -340,7 +341,7 @@ impl KhiveRuntime {
     ///
     /// Returns the total number of records backfilled across all models.
     pub async fn backfill_missing_embeddings(&self, token: &NamespaceToken) -> RuntimeResult<u64> {
-        use khive_storage::types::{SqlRow, SqlStatement, SqlValue, TextDocument};
+        use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
 
         let model_names = self.registered_embedding_model_names();
         if model_names.is_empty() {
@@ -462,11 +463,15 @@ impl KhiveRuntime {
 
             // --- Notes: embed content where no vector entry exists ---
             let text_store = self.text_for_notes(token).ok();
+            let note_store = self.notes(token).ok();
             let mut note_total = 0usize;
             loop {
+                // Select only the id here; the full Note is fetched below so that
+                // note_fts_document receives all fields (name, properties, updated_at)
+                // and produces a parity-correct document rather than a stripped one.
                 let note_sql = SqlStatement {
                     sql: format!(
-                        "SELECT id, content FROM notes \
+                        "SELECT id FROM notes \
                          WHERE namespace = ?1 AND deleted_at IS NULL \
                          AND id NOT IN (\
                              SELECT subject_id FROM {vec_table} \
@@ -499,42 +504,38 @@ impl KhiveRuntime {
                             None
                         }
                     });
-                    let content = row.columns.get(1).and_then(|c| {
-                        if let SqlValue::Text(s) = &c.value {
-                            Some(s.clone())
-                        } else {
-                            None
-                        }
-                    });
 
-                    let (Some(id_str), Some(content)) = (id_str, content) else {
+                    let Some(id_str) = id_str else {
                         continue;
                     };
                     let Ok(id) = id_str.parse::<Uuid>() else {
                         continue;
                     };
-                    if content.trim().is_empty() {
+
+                    // Fetch the full Note so that note_fts_document has all fields
+                    // (name, properties, updated_at) — prevents overwriting a correct
+                    // FTS row with a stripped content-only document.
+                    let note = match &note_store {
+                        Some(store) => match store.get_note(id).await {
+                            Ok(Some(n)) => n,
+                            _ => continue,
+                        },
+                        None => continue,
+                    };
+
+                    if note.content.trim().is_empty() {
                         continue;
                     }
 
-                    // Repopulate FTS entry if missing (best-effort, first model only to avoid N duplicates).
+                    // Repopulate FTS entry using the shared constructor (first model only
+                    // to avoid N identical overwrites per note).
                     if model_names.first().map(|n| n.as_str()) == Some(model_name.as_str()) {
                         if let Some(ref ts) = text_store {
-                            let _ = ts
-                                .upsert_document(TextDocument {
-                                    subject_id: id,
-                                    namespace: ns.clone(),
-                                    kind: SubstrateKind::Note,
-                                    title: None,
-                                    body: content.clone(),
-                                    tags: vec![],
-                                    metadata: None,
-                                    updated_at: chrono::Utc::now(),
-                                })
-                                .await;
+                            let _ = ts.upsert_document(note_fts_document(&note)).await;
                         }
                     }
 
+                    let content = note.content.clone();
                     match self.embed_with_model(model_name, &content).await {
                         Ok(vector) => {
                             if let Ok(vs) = self.vectors_for_model(token, model_name) {

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1231,13 +1231,16 @@ mod tests {
     // must produce a stored FTS document that is field-identical to calling
     // note_fts_document() on the same Note. Catches drift between the shared
     // constructor and any caller that previously built documents inline.
+    // Properties are included so that metadata and updated_at are also under test.
     #[tokio::test]
     async fn note_fts_document_matches_runtime_create_path() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let ns = Namespace::parse("local").expect("ns");
         let token = rt.authorize(ns).expect("authorize");
 
-        // Create with a name so the title+body composition is exercised.
+        // Create with a name AND properties so metadata, title+body composition,
+        // and updated_at derivation are all exercised.
+        let props = serde_json::json!({"key": "value", "score": 42});
         let note = rt
             .create_note(
                 &token,
@@ -1245,7 +1248,7 @@ mod tests {
                 Some("cross path title"),
                 "cross path content body",
                 None,
-                None,
+                Some(props),
                 vec![],
             )
             .await
@@ -1267,6 +1270,103 @@ mod tests {
         assert_eq!(stored.title, expected.title, "title");
         assert_eq!(stored.body, expected.body, "body");
         assert_eq!(stored.namespace, expected.namespace, "namespace");
+        assert_eq!(stored.tags, expected.tags, "tags");
+        assert_eq!(stored.metadata, expected.metadata, "metadata");
+        // Compare at microsecond resolution — DateTime<Utc> round-trips through i64.
+        assert_eq!(
+            stored.updated_at.timestamp_micros(),
+            note.updated_at,
+            "updated_at must be derived from the note, not Utc::now()"
+        );
+    }
+
+    // Regression: run_reindex with no embedding model must still populate FTS for
+    // pre-existing notes. Guards against reintroduction of the early-return that
+    // skipped the FTS pass when model_names was empty (round-1 fix).
+    #[tokio::test]
+    async fn run_reindex_populates_fts_without_embedding_model() {
+        use khive_storage::types::TextFilter;
+        use khive_types::SubstrateKind;
+
+        // Use a temp-file db so run_reindex (which builds its own runtime) and our
+        // verification pass share the same on-disk state.
+        let db_file = tempfile::NamedTempFile::new().expect("temp db file");
+        let db_path = db_file.path().to_str().expect("utf8 path").to_string();
+
+        // Seed notes via a runtime opened on the same file BEFORE calling run_reindex.
+        {
+            let cfg = resolve_runtime_config(RuntimeConfigInputs {
+                db: Some(&db_path),
+                config: None,
+                namespace: Namespace::parse("local").expect("ns"),
+                namespace_explicit: true,
+                no_embed: true,
+                packs: None,
+                brain_profile: None,
+            })
+            .expect("resolve config for seed");
+            let rt = KhiveRuntime::new(cfg).expect("seed runtime");
+            let token = rt
+                .authorize(Namespace::parse("local").expect("ns"))
+                .expect("authorize");
+            let note_store = rt.notes(&token).expect("note store");
+            for i in 0..3usize {
+                note_store
+                    .upsert_note(Note::new(
+                        "local",
+                        "observation",
+                        format!("run-reindex-sentinel{i} body"),
+                    ))
+                    .await
+                    .expect("upsert seed note");
+            }
+        }
+
+        // run_reindex with no embedding model and --no-knowledge.
+        let args = ReindexArgs {
+            db: Some(db_path.clone()),
+            config: None,
+            model: None,
+            batch_size: 100,
+            keep_existing: false,
+            namespace: Some("local".to_string()),
+            knowledge_only: false,
+            no_knowledge: true,
+            best_effort: true,
+            no_sections: false,
+            sections_only: false,
+            human: false,
+        };
+        run_reindex(args).await.expect("run_reindex must succeed");
+
+        // Verify FTS was populated by re-opening the db.
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(&db_path),
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: true,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config for verify");
+        let rt = KhiveRuntime::new(cfg).expect("verify runtime");
+        let token = rt
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let fts = rt.text_for_notes(&token).expect("FTS store");
+        let count = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Note],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("fts count");
+        assert_eq!(
+            count, 3,
+            "run_reindex must populate FTS even when no embedding model is configured"
+        );
     }
 
     // No-embedding-model FTS: when no embedding model is registered, the note

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -16,10 +16,9 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
-use khive_runtime::{KhiveRuntime, Namespace};
+use khive_runtime::{note_fts_document, KhiveRuntime, Namespace};
 use khive_storage::error::StorageError;
 use khive_storage::note::Note;
-use khive_storage::types::TextDocument;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
 
@@ -217,14 +216,14 @@ struct ReindexReport {
     /// Entity/note vector inserts that failed across all engines.
     errors_skipped: u64,
     /// Note FTS upserts that failed during the backfill pass.
-    fts_notes_failed: u64,
+    notes_fts_failed: u64,
 }
 
 impl ReindexReport {
     /// Did any part of the run fail? Drives the fail-closed exit decision.
     fn has_failures(&self) -> bool {
         self.errors_skipped > 0
-            || self.fts_notes_failed > 0
+            || self.notes_fts_failed > 0
             || self.knowledge_atoms_failed > 0
             || self.knowledge_pass_errored
             || self.knowledge_ann_failed
@@ -312,28 +311,6 @@ async fn embed_and_store_batch(
         }
     }
     errors
-}
-
-/// Build the `TextDocument` for a note, mirroring the document-construction logic in
-/// `operations.rs` (`upsert_note` / FTS write path). Both callers — the create/update
-/// MCP path and this reindex path — must produce byte-identical documents for a given
-/// note; any divergence would cause a recall parity bug. Changes here require the
-/// same change in operations.rs and vice versa.
-fn note_fts_document(note: &Note) -> TextDocument {
-    let body = match &note.name {
-        Some(n) => format!("{n} {}", note.content),
-        None => note.content.clone(),
-    };
-    TextDocument {
-        subject_id: note.id,
-        kind: SubstrateKind::Note,
-        title: note.name.clone(),
-        body,
-        tags: vec![],
-        namespace: note.namespace.clone(),
-        metadata: note.properties.clone(),
-        updated_at: chrono::Utc::now(),
-    }
 }
 
 /// Upsert FTS documents for a batch of notes into the namespace text index. Returns the
@@ -424,6 +401,10 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     // registered engines, matching the runtime's multi-model write path so a
     // reindex reproduces exactly what create/update would have embedded.
     // Only needed for the entity/note pass (knowledge uses the default embedder).
+    //
+    // When no embedding model is configured, model_names is empty: the embedding
+    // loop is a no-op but the note loop still runs for FTS backfill, which needs
+    // no embedder and must never be skipped due to a missing embedding config.
     let model_names: Vec<String> = if !do_graph {
         vec![]
     } else {
@@ -432,23 +413,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
             None => {
                 let names = rt.registered_embedding_model_names();
                 if names.is_empty() {
-                    let report = ReindexReport {
-                        entities_processed: 0,
-                        notes_processed: 0,
-                        knowledge_atoms_indexed: None,
-                        knowledge_sections_indexed: None,
-                        knowledge_atoms_failed: 0,
-                        knowledge_pass_errored: false,
-                        knowledge_ann_failed: false,
-                        knowledge_sections_failed: 0,
-                        models_used: vec![],
-                        elapsed_ms: 0,
-                        errors_skipped: 0,
-                        fts_notes_failed: 0,
-                    };
-                    print_report(&report, args.human);
-                    eprintln!("warning: no embedding model configured");
-                    return Ok(());
+                    eprintln!("warning: no embedding model configured — skipping vector embedding; FTS backfill will still run");
                 }
                 names
             }
@@ -463,7 +428,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut entities_processed: u64 = 0;
     let mut notes_processed: u64 = 0;
     let mut errors_skipped: u64 = 0;
-    let mut fts_notes_failed: u64 = 0;
+    let mut notes_fts_failed: u64 = 0;
 
     // ── entities + notes (graph substrate) ────────────────────────────────────
     if do_graph {
@@ -558,7 +523,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
             // FTS backfill: index every note in this batch regardless of whether
             // it had content to embed. Mirrors the upsert_document call in
             // operations.rs — see note_fts_document for the parity contract.
-            fts_notes_failed += fts_backfill_notes_batch(&rt, &token, &batch).await;
+            notes_fts_failed += fts_backfill_notes_batch(&rt, &token, &batch).await;
 
             note_bar.update(notes_processed, note_total);
 
@@ -657,7 +622,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
-        fts_notes_failed,
+        notes_fts_failed,
     };
 
     print_report(&report, args.human);
@@ -781,13 +746,13 @@ fn print_report(report: &ReindexReport, human: bool) {
             atoms,
             sections,
             report.errors_skipped,
-            report.fts_notes_failed,
+            report.notes_fts_failed,
             report.elapsed_ms
         );
-        if report.fts_notes_failed > 0 {
+        if report.notes_fts_failed > 0 {
             println!(
                 "FTS backfill: {} note upserts FAILED",
-                report.fts_notes_failed
+                report.notes_fts_failed
             );
         }
         if report.knowledge_pass_errored {
@@ -919,7 +884,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: errors,
-            fts_notes_failed: 0,
+            notes_fts_failed: 0,
         }
     }
 
@@ -954,7 +919,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
-            fts_notes_failed: 0,
+            notes_fts_failed: 0,
         };
         assert!(
             report.has_failures(),
@@ -984,7 +949,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
-            fts_notes_failed: 0,
+            notes_fts_failed: 0,
         };
         assert!(
             report.has_failures(),
@@ -1139,7 +1104,7 @@ mod tests {
     }
 
     #[test]
-    fn has_failures_flags_fts_notes_failed() {
+    fn has_failures_flags_notes_fts_failed() {
         let report = ReindexReport {
             entities_processed: 0,
             notes_processed: 0,
@@ -1152,19 +1117,19 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
-            fts_notes_failed: 1,
+            notes_fts_failed: 1,
         };
         assert!(
             report.has_failures(),
-            "fts_notes_failed > 0 alone must drive has_failures() = true"
+            "notes_fts_failed > 0 alone must drive has_failures() = true"
         );
         assert!(
             decide_result(report.has_failures(), false).is_err(),
-            "fts_notes_failed must fail closed (non-zero exit)"
+            "notes_fts_failed must fail closed (non-zero exit)"
         );
         assert!(
             decide_result(report.has_failures(), true).is_ok(),
-            "best-effort downgrades fts_notes_failed to exit 0"
+            "best-effort downgrades notes_fts_failed to exit 0"
         );
     }
 
@@ -1259,6 +1224,98 @@ mod tests {
         assert!(
             hits.iter().any(|h| h.subject_id == notes[0].id),
             "pre-existing note must be findable by FTS after backfill"
+        );
+    }
+
+    // Cross-path equality: a note created through the runtime (operations.rs path)
+    // must produce a stored FTS document that is field-identical to calling
+    // note_fts_document() on the same Note. Catches drift between the shared
+    // constructor and any caller that previously built documents inline.
+    #[tokio::test]
+    async fn note_fts_document_matches_runtime_create_path() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        // Create with a name so the title+body composition is exercised.
+        let note = rt
+            .create_note(
+                &token,
+                "observation",
+                Some("cross path title"),
+                "cross path content body",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create_note");
+
+        // Retrieve the stored FTS document written by the create path.
+        let fts = rt.text_for_notes(&token).expect("FTS store");
+        let stored = fts
+            .get_document("local", note.id)
+            .await
+            .expect("get_document")
+            .expect("document must exist after create");
+
+        // Build the expected document using the shared constructor on the same note.
+        let expected = note_fts_document(&note);
+
+        assert_eq!(stored.subject_id, expected.subject_id, "subject_id");
+        assert_eq!(stored.kind, expected.kind, "kind");
+        assert_eq!(stored.title, expected.title, "title");
+        assert_eq!(stored.body, expected.body, "body");
+        assert_eq!(stored.namespace, expected.namespace, "namespace");
+    }
+
+    // No-embedding-model FTS: when no embedding model is registered, the note
+    // loop and FTS backfill must still execute — FTS needs no embedder.
+    #[tokio::test]
+    async fn fts_backfill_runs_without_embedding_model() {
+        use khive_storage::types::TextFilter;
+        use khive_types::SubstrateKind;
+
+        // KhiveRuntime::memory() has no embedding model configured.
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        let notes: Vec<Note> = (0..3)
+            .map(|i| {
+                Note::new(
+                    "local",
+                    "observation",
+                    format!("nomodel-sentinel{i} content"),
+                )
+            })
+            .collect();
+
+        let note_store = rt.notes(&token).expect("note store");
+        for note in &notes {
+            note_store.upsert_note(note.clone()).await.expect("upsert");
+        }
+
+        // With no embedding model, embed_and_store_batch is a no-op but
+        // fts_backfill_notes_batch must still populate the FTS index.
+        let errors = fts_backfill_notes_batch(&rt, &token, &notes).await;
+        assert_eq!(
+            errors, 0,
+            "FTS backfill must succeed with no embedding model"
+        );
+
+        let fts = rt.text_for_notes(&token).expect("FTS store");
+        let count = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Note],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count");
+        assert_eq!(
+            count, 3,
+            "FTS must be populated even when no embedding model is configured"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1,9 +1,9 @@
-//! `kkernel reindex` — rebuild embedding vectors for entities and notes.
+//! `kkernel reindex` — rebuild embedding vectors and FTS documents for entities and notes.
 //!
 //! This is an infrastructure-level operation that walks all entities and notes
-//! in a database and (re-)embeds them using the specified model. It is NOT a
-//! pack verb — it operates on the raw runtime stores regardless of which packs
-//! are loaded.
+//! in a database and (re-)embeds them using the specified model and backfills the
+//! FTS index. It is NOT a pack verb — it operates on the raw runtime stores
+//! regardless of which packs are loaded.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -18,6 +18,8 @@ use uuid::Uuid;
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
 use khive_runtime::{KhiveRuntime, Namespace};
 use khive_storage::error::StorageError;
+use khive_storage::note::Note;
+use khive_storage::types::TextDocument;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
 
@@ -214,12 +216,15 @@ struct ReindexReport {
     elapsed_ms: u64,
     /// Entity/note vector inserts that failed across all engines.
     errors_skipped: u64,
+    /// Note FTS upserts that failed during the backfill pass.
+    fts_notes_failed: u64,
 }
 
 impl ReindexReport {
     /// Did any part of the run fail? Drives the fail-closed exit decision.
     fn has_failures(&self) -> bool {
         self.errors_skipped > 0
+            || self.fts_notes_failed > 0
             || self.knowledge_atoms_failed > 0
             || self.knowledge_pass_errored
             || self.knowledge_ann_failed
@@ -309,6 +314,54 @@ async fn embed_and_store_batch(
     errors
 }
 
+/// Build the `TextDocument` for a note, mirroring the document-construction logic in
+/// `operations.rs` (`upsert_note` / FTS write path). Both callers — the create/update
+/// MCP path and this reindex path — must produce byte-identical documents for a given
+/// note; any divergence would cause a recall parity bug. Changes here require the
+/// same change in operations.rs and vice versa.
+fn note_fts_document(note: &Note) -> TextDocument {
+    let body = match &note.name {
+        Some(n) => format!("{n} {}", note.content),
+        None => note.content.clone(),
+    };
+    TextDocument {
+        subject_id: note.id,
+        kind: SubstrateKind::Note,
+        title: note.name.clone(),
+        body,
+        tags: vec![],
+        namespace: note.namespace.clone(),
+        metadata: note.properties.clone(),
+        updated_at: chrono::Utc::now(),
+    }
+}
+
+/// Upsert FTS documents for a batch of notes into the namespace text index. Returns the
+/// number of per-note upsert failures. Idempotent: calling again for an already-indexed
+/// note replaces the existing row (FTS upsert semantics). Fails per-note, never panics.
+async fn fts_backfill_notes_batch(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    batch: &[Note],
+) -> u64 {
+    let fts = match rt.text_for_notes(token) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!(error = %e, "FTS store unavailable; counting whole batch as failed");
+            return batch.len() as u64;
+        }
+    };
+    let mut errors: u64 = 0;
+    for note in batch {
+        let doc = note_fts_document(note);
+        if let Err(e) = fts.upsert_document(doc).await {
+            tracing::warn!(id = %note.id, error = %e, "FTS upsert failed for note");
+            errors += 1;
+        }
+    }
+    errors
+}
+
 /// Return the subset of `ids` that do NOT already have an embedding in `vectors`
 /// for the given `namespace`. When `batch_exists` is unsupported (e.g. a custom
 /// backend), conservatively returns all IDs so every record gets embedded.
@@ -391,6 +444,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                         models_used: vec![],
                         elapsed_ms: 0,
                         errors_skipped: 0,
+                        fts_notes_failed: 0,
                     };
                     print_report(&report, args.human);
                     eprintln!("warning: no embedding model configured");
@@ -409,6 +463,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut entities_processed: u64 = 0;
     let mut notes_processed: u64 = 0;
     let mut errors_skipped: u64 = 0;
+    let mut fts_notes_failed: u64 = 0;
 
     // ── entities + notes (graph substrate) ────────────────────────────────────
     if do_graph {
@@ -499,6 +554,12 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 .await;
                 notes_processed += staged.len() as u64;
             }
+
+            // FTS backfill: index every note in this batch regardless of whether
+            // it had content to embed. Mirrors the upsert_document call in
+            // operations.rs — see note_fts_document for the parity contract.
+            fts_notes_failed += fts_backfill_notes_batch(&rt, &token, &batch).await;
+
             note_bar.update(notes_processed, note_total);
 
             if n < batch_size as usize {
@@ -596,6 +657,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
+        fts_notes_failed,
     };
 
     print_report(&report, args.human);
@@ -713,14 +775,21 @@ fn print_report(report: &ReindexReport, human: bool) {
             "Reindex complete"
         };
         println!(
-            "{status}: {} entities, {} notes{}{} ({} entity/note errors) in {}ms",
+            "{status}: {} entities, {} notes{}{} ({} vector errors, {} FTS errors) in {}ms",
             report.entities_processed,
             report.notes_processed,
             atoms,
             sections,
             report.errors_skipped,
+            report.fts_notes_failed,
             report.elapsed_ms
         );
+        if report.fts_notes_failed > 0 {
+            println!(
+                "FTS backfill: {} note upserts FAILED",
+                report.fts_notes_failed
+            );
+        }
         if report.knowledge_pass_errored {
             println!("Knowledge pass: FAILED (did not run to completion)");
         } else if report.knowledge_atoms_failed > 0 {
@@ -850,6 +919,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: errors,
+            fts_notes_failed: 0,
         }
     }
 
@@ -884,6 +954,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
+            fts_notes_failed: 0,
         };
         assert!(
             report.has_failures(),
@@ -913,6 +984,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
+            fts_notes_failed: 0,
         };
         assert!(
             report.has_failures(),
@@ -1064,5 +1136,168 @@ mod tests {
             args.namespace.is_none(),
             "omitted --namespace must be None (not a String default)"
         );
+    }
+
+    #[test]
+    fn has_failures_flags_fts_notes_failed() {
+        let report = ReindexReport {
+            entities_processed: 0,
+            notes_processed: 0,
+            knowledge_atoms_indexed: None,
+            knowledge_sections_indexed: None,
+            knowledge_atoms_failed: 0,
+            knowledge_pass_errored: false,
+            knowledge_ann_failed: false,
+            knowledge_sections_failed: 0,
+            models_used: vec![],
+            elapsed_ms: 0,
+            errors_skipped: 0,
+            fts_notes_failed: 1,
+        };
+        assert!(
+            report.has_failures(),
+            "fts_notes_failed > 0 alone must drive has_failures() = true"
+        );
+        assert!(
+            decide_result(report.has_failures(), false).is_err(),
+            "fts_notes_failed must fail closed (non-zero exit)"
+        );
+        assert!(
+            decide_result(report.has_failures(), true).is_ok(),
+            "best-effort downgrades fts_notes_failed to exit 0"
+        );
+    }
+
+    // Parity: note_fts_document must produce the same body/title as operations.rs.
+    #[test]
+    fn note_fts_document_parity_with_name() {
+        let mut note = Note::new("local", "memory", "the content body");
+        note.name = Some("my title".to_string());
+        let doc = note_fts_document(&note);
+        assert_eq!(doc.subject_id, note.id);
+        assert_eq!(doc.namespace, "local");
+        assert_eq!(doc.title.as_deref(), Some("my title"));
+        assert_eq!(doc.body, "my title the content body");
+        assert_eq!(doc.kind, SubstrateKind::Note);
+    }
+
+    #[test]
+    fn note_fts_document_parity_without_name() {
+        let note = Note::new("local", "memory", "body only content");
+        let doc = note_fts_document(&note);
+        assert!(doc.title.is_none());
+        assert_eq!(doc.body, "body only content");
+    }
+
+    // Regression: insert N notes via NoteStore (bypassing FTS), run
+    // fts_backfill_notes_batch, assert FTS count == N and a keyword hit works.
+    #[tokio::test]
+    async fn fts_backfill_populates_pre_existing_notes() {
+        use khive_storage::types::TextFilter;
+        use khive_types::SubstrateKind;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        let notes: Vec<Note> = (0..5)
+            .map(|i| {
+                Note::new(
+                    "local",
+                    "memory",
+                    format!("zxqsentinel{i} backfill content"),
+                )
+            })
+            .collect();
+
+        let note_store = rt.notes(&token).expect("note store");
+        for note in &notes {
+            note_store
+                .upsert_note(note.clone())
+                .await
+                .expect("upsert note");
+        }
+
+        // FTS should be empty before backfill (notes inserted via store, not runtime).
+        let fts = rt.text_for_notes(&token).expect("FTS store");
+        let before = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Note],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count before");
+        assert_eq!(before, 0, "FTS must be empty before backfill");
+
+        // Run the backfill.
+        let errors = fts_backfill_notes_batch(&rt, &token, &notes).await;
+        assert_eq!(errors, 0, "backfill must produce zero errors");
+
+        // FTS must now contain one row per note.
+        let after = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Note],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count after");
+        assert_eq!(after, 5, "FTS must contain exactly N docs after backfill");
+
+        // A keyword from the first note must be retrievable.
+        let hits = fts
+            .search(khive_storage::types::TextSearchRequest {
+                query: "zxqsentinel0".to_string(),
+                mode: khive_storage::types::TextQueryMode::Plain,
+                filter: None,
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+            .expect("FTS search");
+        assert!(
+            hits.iter().any(|h| h.subject_id == notes[0].id),
+            "pre-existing note must be findable by FTS after backfill"
+        );
+    }
+
+    // Idempotency: running backfill twice must not duplicate rows.
+    #[tokio::test]
+    async fn fts_backfill_is_idempotent() {
+        use khive_storage::types::TextFilter;
+        use khive_types::SubstrateKind;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        let notes: Vec<Note> = (0..3)
+            .map(|i| Note::new("local", "memory", format!("idemnote{i} content")))
+            .collect();
+
+        let note_store = rt.notes(&token).expect("note store");
+        for note in &notes {
+            note_store
+                .upsert_note(note.clone())
+                .await
+                .expect("upsert note");
+        }
+
+        let errors1 = fts_backfill_notes_batch(&rt, &token, &notes).await;
+        let errors2 = fts_backfill_notes_batch(&rt, &token, &notes).await;
+        assert_eq!(errors1, 0);
+        assert_eq!(errors2, 0);
+
+        let fts = rt.text_for_notes(&token).expect("FTS store");
+        let count = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Note],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count");
+        assert_eq!(count, 3, "second backfill pass must not duplicate rows");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #86. `fts_notes_local` was created in schema V1 without bulk backfill. Notes written before the FTS virtual table existed — 98.3% of production memories — receive zero FTS signal in RRF fusion permanently, causing a structural recency bias in recall independent of scoring constants.

- **`note_fts_document()`**: single source of truth for FTS document construction, mirroring `operations.rs` exactly (reindex-parity contract). Both the MCP create/update path and reindex now call the same field-mapping logic.
- **`fts_backfill_notes_batch()`**: upserts FTS docs for a batch of notes. Idempotent (FTS upsert replaces on `subject_id`). Per-note errors are counted and surfaced; wholesale store unavailability counts the full batch as failed. Never raw SQL into the virtual table — uses the `TextSearch::upsert_document` API exclusively.
- **Wired into notes loop**: runs immediately after the vector pass for each batch in `run_reindex`, covering all non-deleted notes regardless of whether they had embeddable content.
- **`fts_notes_failed` in `ReindexReport`**: counted in `has_failures()` — any FTS failure triggers the fail-closed exit unless `--best-effort`. Human-readable output reports FTS errors separately from vector errors.
- **No triggers added**: scope stays within the reindex admin lane per coordinator note. Notes FTS remains runtime-upsert by design.

## Validation (DB copy `/tmp/recall-calib/fts-fix-validate.db`)

| | FTS rows | Eligible notes | Coverage |
|---|---|---|---|
| Before | 341 | 12,464 | 2.7% |
| After | 12,464 | 12,464 | **100%** |

`kkernel reindex --namespace local --no-knowledge --human` exit 0, 0 vector errors, 0 FTS errors.

## Test plan

- [x] `has_failures_flags_fts_notes_failed` — `fts_notes_failed > 0` alone drives fail-closed exit
- [x] `note_fts_document_parity_with_name` — body = `"{name} {content}"`, title set
- [x] `note_fts_document_parity_without_name` — body = content, title `None`
- [x] `fts_backfill_populates_pre_existing_notes` — insert 5 notes via `NoteStore` (bypassing FTS), run backfill, assert count == 5 and keyword hit on first note returns its ID
- [x] `fts_backfill_is_idempotent` — two backfill passes on same 3 notes = count stays 3
- [x] All existing tests pass: `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — RC=0
- [x] `cargo fmt --all -- --check` — RC=0