### PR TITLE
fix(reindex): entity FTS backfill and entity_fts_document constructor

### DIFF
--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -379,27 +379,14 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         entity: &Entity,
     ) -> RuntimeResult<()> {
-        let body = match &entity.description {
-            Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
-            _ => entity.name.clone(),
-        };
         // Use entity.namespace (authoritative) rather than token.namespace().as_str() (caller claim).
         let ns = entity.namespace.clone();
-        self.text(token)?
-            .upsert_document(TextDocument {
-                subject_id: entity.id,
-                kind: SubstrateKind::Entity,
-                title: Some(entity.name.clone()),
-                body: body.clone(),
-                tags: entity.tags.clone(),
-                namespace: ns.clone(),
-                metadata: entity.properties.clone(),
-                updated_at: chrono::Utc::now(),
-            })
-            .await?;
+        let doc = entity_fts_document(entity);
+        let embed_body = doc.body.clone();
+        self.text(token)?.upsert_document(doc).await?;
 
         if self.config().embedding_model.is_some() {
-            let vector = self.embed_document(&body).await?;
+            let vector = self.embed_document(&embed_body).await?;
             self.vectors(token)?
                 .insert(
                     entity.id,
@@ -620,6 +607,37 @@ impl KhiveRuntime {
 // ---------------------------------------------------------------------------
 // FTS document construction
 // ---------------------------------------------------------------------------
+
+/// Build the `TextDocument` for an entity. This is the single source of truth for
+/// entity FTS document shape; all write paths (create, update, merge, reindex, backfill)
+/// must go through this function so search parity is guaranteed.
+///
+/// Body rule: when the entity has a non-empty description, prepend the name
+/// (`"<name> <description>"`). Otherwise the body is just the name. This
+/// matches the FTS index contract: `title` and `body` are the ranked columns;
+/// `tags`, `metadata`, and `namespace` are UNINDEXED.
+///
+/// `updated_at` is taken from the entity's own timestamp so that backfill and
+/// reindex runs record the entity's actual mutation time rather than the
+/// reindex execution time.
+pub fn entity_fts_document(entity: &Entity) -> TextDocument {
+    let body = match &entity.description {
+        Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
+        _ => entity.name.clone(),
+    };
+    let updated_at =
+        chrono::DateTime::from_timestamp_micros(entity.updated_at).unwrap_or_else(chrono::Utc::now);
+    TextDocument {
+        subject_id: entity.id,
+        kind: SubstrateKind::Entity,
+        title: Some(entity.name.clone()),
+        body,
+        tags: entity.tags.clone(),
+        namespace: entity.namespace.clone(),
+        metadata: entity.properties.clone(),
+        updated_at,
+    }
+}
 
 /// Build the `TextDocument` for a note. This is the single source of truth for
 /// note FTS document shape; all write paths (create, update, reindex) must go
@@ -1012,6 +1030,9 @@ fn merge_entity_sql(
         )?;
 
         // --- Reindex into_id in FTS (delete existing, insert updated) ---
+        // Body formula mirrors entity_fts_document (the canonical constructor) —
+        // this path is sync/spawn_blocking so it cannot call entity_fts_document
+        // directly, but must stay field-identical.
         let fts_body = match &merged_description {
             Some(d) if !d.is_empty() => format!("{} {}", merged_name, d),
             _ => merged_name.clone(),
@@ -2880,5 +2901,182 @@ mod tests {
         assert!(rt.get_entity(&ns_a, into_a.id).await.is_ok());
         assert!(rt.get_entity(&ns_a, from_a.id).await.is_ok());
         assert!(rt.get_entity(&ns_b, foreign_b.id).await.is_ok());
+    }
+
+    // Parity: entity_fts_document must produce the same body/title as the
+    // create_entity and update_entity FTS write paths.
+    #[test]
+    fn entity_fts_document_with_description() {
+        let mut entity = Entity::new("local", "concept", "MyEntity");
+        entity = entity.with_description("some description text");
+        let doc = entity_fts_document(&entity);
+        assert_eq!(doc.subject_id, entity.id);
+        assert_eq!(doc.namespace, "local");
+        assert_eq!(doc.title.as_deref(), Some("MyEntity"));
+        assert_eq!(doc.body, "MyEntity some description text");
+        assert_eq!(doc.kind, khive_types::SubstrateKind::Entity);
+    }
+
+    #[test]
+    fn entity_fts_document_without_description() {
+        let entity = Entity::new("local", "concept", "NameOnly");
+        let doc = entity_fts_document(&entity);
+        assert_eq!(doc.title.as_deref(), Some("NameOnly"));
+        assert_eq!(doc.body, "NameOnly");
+    }
+
+    #[test]
+    fn entity_fts_document_empty_description_uses_name_only() {
+        let mut entity = Entity::new("local", "concept", "TitleOnly");
+        entity = entity.with_description("");
+        let doc = entity_fts_document(&entity);
+        assert_eq!(
+            doc.body, "TitleOnly",
+            "empty description must not be appended"
+        );
+    }
+
+    // Cross-path equality: an entity created through the runtime (operations.rs
+    // create_entity path) must produce a stored FTS document field-identical to
+    // entity_fts_document() called on the same Entity.
+    #[tokio::test]
+    async fn entity_fts_document_matches_runtime_create_path() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "CrossPathTitle",
+                Some("cross path description body"),
+                Some(serde_json::json!({"key": "val"})),
+                vec!["tag1".to_string()],
+            )
+            .await
+            .expect("create_entity");
+
+        let fts = rt.text(&tok).expect("FTS store");
+        let stored = fts
+            .get_document("local", entity.id)
+            .await
+            .expect("get_document")
+            .expect("document must exist after create_entity");
+
+        let expected = entity_fts_document(&entity);
+
+        assert_eq!(stored.subject_id, expected.subject_id, "subject_id");
+        assert_eq!(stored.kind, expected.kind, "kind");
+        assert_eq!(stored.title, expected.title, "title");
+        assert_eq!(stored.body, expected.body, "body");
+        assert_eq!(stored.namespace, expected.namespace, "namespace");
+    }
+
+    // Cross-path equality: update_entity must produce a stored FTS document
+    // field-identical to entity_fts_document() on the updated Entity.
+    #[tokio::test]
+    async fn entity_fts_document_matches_runtime_update_path() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "OldName",
+                Some("old desc"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create_entity");
+
+        let updated = rt
+            .update_entity(
+                &tok,
+                entity.id,
+                EntityPatch {
+                    name: Some("NewName".to_string()),
+                    description: Some(Some("new desc".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update_entity");
+
+        let fts = rt.text(&tok).expect("FTS store");
+        let stored = fts
+            .get_document("local", updated.id)
+            .await
+            .expect("get_document")
+            .expect("document must exist after update_entity");
+
+        let expected = entity_fts_document(&updated);
+
+        assert_eq!(stored.title, expected.title, "title after update");
+        assert_eq!(stored.body, expected.body, "body after update");
+    }
+
+    // Cross-path equality: merge_entity must produce a stored FTS document for
+    // the kept entity that is field-identical to entity_fts_document().
+    #[tokio::test]
+    async fn entity_fts_document_matches_runtime_merge_path() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let into_e = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "IntoEntity",
+                Some("into desc"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create into");
+        let from_e = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "FromEntity",
+                Some("from desc"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create from");
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into_e.id,
+                from_e.id,
+                EntityDedupMergePolicy::PreferInto,
+                false,
+            )
+            .await
+            .expect("merge_entity");
+
+        let kept = rt
+            .get_entity(&tok, summary.kept_id)
+            .await
+            .expect("get kept");
+
+        let fts = rt.text(&tok).expect("FTS store");
+        let stored = fts
+            .get_document("local", kept.id)
+            .await
+            .expect("get_document")
+            .expect("FTS document must exist for kept entity after merge");
+
+        let expected = entity_fts_document(&kept);
+
+        assert_eq!(stored.title, expected.title, "title after merge");
+        assert_eq!(stored.body, expected.body, "body after merge");
     }
 }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -23,8 +23,8 @@ pub mod secret_gate;
 pub mod validation;
 
 pub use curation::{
-    note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch, EntityDedupMergePolicy,
-    EntityPatch, MergeSummary, NotePatch,
+    entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
+    EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,
 };
 #[cfg(unix)]
 pub use daemon::{

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -18,8 +18,8 @@ use khive_score::DeterministicScore;
 use khive_storage::note::Note;
 use khive_storage::types::{
     DeleteMode, Direction, EdgeSortField, GraphPath, LinkId, NeighborHit, NeighborQuery, Page,
-    PageRequest, SortOrder, SqlRow, SqlStatement, SqlValue, TextDocument, TextFilter,
-    TextQueryMode, TextSearchRequest, TraversalRequest,
+    PageRequest, SortOrder, SqlRow, SqlStatement, SqlValue, TextFilter, TextQueryMode,
+    TextSearchRequest, TraversalRequest,
 };
 use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
@@ -27,7 +27,7 @@ use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
 use khive_db::SqliteError;
 use rusqlite::OptionalExtension;
 
-use crate::curation::note_fts_document;
+use crate::curation::{entity_fts_document, note_fts_document};
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
@@ -357,25 +357,12 @@ impl KhiveRuntime {
         }
         self.entities(token)?.upsert_entity(entity.clone()).await?;
 
-        let body = match &entity.description {
-            Some(d) if !d.is_empty() => format!("{} {}", entity.name, d),
-            _ => entity.name.clone(),
-        };
-        self.text(token)?
-            .upsert_document(TextDocument {
-                subject_id: entity.id,
-                kind: SubstrateKind::Entity,
-                title: Some(entity.name.clone()),
-                body: body.clone(),
-                tags: entity.tags.clone(),
-                namespace: ns.to_string(),
-                metadata: entity.properties.clone(),
-                updated_at: chrono::Utc::now(),
-            })
-            .await?;
+        let doc = entity_fts_document(&entity);
+        let embed_body = doc.body.clone();
+        self.text(token)?.upsert_document(doc).await?;
 
         if self.config().embedding_model.is_some() {
-            let vector = self.embed_document(&body).await?;
+            let vector = self.embed_document(&embed_body).await?;
             self.vectors(token)?
                 .insert(
                     entity.id,

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -10,9 +10,9 @@ use std::process::Command;
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use khive_runtime::portability::{ExportedEdge, ExportedEntity, KgArchive};
-use khive_runtime::{KhiveRuntime, RuntimeConfig};
-use khive_storage::types::{Edge, TextDocument};
-use khive_storage::{LinkId, SubstrateKind};
+use khive_runtime::{entity_fts_document, KhiveRuntime, RuntimeConfig};
+use khive_storage::types::Edge;
+use khive_storage::LinkId;
 use khive_types::EdgeRelation;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -656,11 +656,6 @@ async fn upsert_entities(
     for r in records {
         let created_at = parse_ts_micros(r.created_at.as_deref());
         let updated_at = parse_ts_micros(r.updated_at.as_deref());
-        // Build the FTS body from name + description (same as create_entity in operations.rs).
-        let body = match &r.description {
-            Some(d) if !d.is_empty() => format!("{} {}", r.name, d),
-            _ => r.name.clone(),
-        };
         let entity = khive_storage::entity::Entity {
             id: r.id,
             namespace: namespace.to_string(),
@@ -676,6 +671,9 @@ async fn upsert_entities(
             merge_event_id: None,
             merged_into: None,
         };
+        // Use the canonical FTS document constructor so sync, create, update,
+        // merge, and reindex all produce identical document shapes.
+        let fts_doc = entity_fts_document(&entity);
         store
             .upsert_entity(entity)
             .await
@@ -683,19 +681,9 @@ async fn upsert_entities(
         // Populate FTS5 index so text search works after sync.
         // Vectors are intentionally skipped: they are local-only derived state
         // and will be computed by `kkernel kg embed` when needed.
-        text.upsert_document(TextDocument {
-            subject_id: r.id,
-            kind: SubstrateKind::Entity,
-            title: Some(r.name.clone()),
-            body,
-            tags: r.tags.clone(),
-            namespace: namespace.to_string(),
-            metadata: r.properties.clone(),
-            updated_at: chrono::DateTime::from_timestamp_micros(updated_at)
-                .unwrap_or_else(chrono::Utc::now),
-        })
-        .await
-        .with_context(|| format!("fts index entity {}", r.id))?;
+        text.upsert_document(fts_doc)
+            .await
+            .with_context(|| format!("fts index entity {}", r.id))?;
         count += 1;
     }
     Ok(count)
@@ -1387,6 +1375,54 @@ mod tests {
         assert!(
             err_str.contains("scp-test") || err_chain.contains("scp-test"),
             "remote name must be present for diagnostics: {err_str} | {err_chain}"
+        );
+    }
+
+    /// Regression: VCS sync FTS document must be field-identical to
+    /// `entity_fts_document` output for the same entity.  Before this fix,
+    /// `upsert_entities` built a `TextDocument` inline with slightly different
+    /// field mapping than the canonical helper, which could produce divergent
+    /// FTS shapes when the helper is updated.
+    #[test]
+    fn sync_fts_document_matches_entity_fts_document() {
+        use khive_runtime::entity_fts_document;
+        use khive_storage::SubstrateKind;
+
+        let id = uuid::Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+        let props: Option<serde_json::Value> =
+            Some(serde_json::json!({"domain": "attention", "status": "researched"}));
+
+        let entity = khive_storage::entity::Entity {
+            id,
+            namespace: "test-ns".to_string(),
+            kind: "concept".to_string(),
+            entity_type: None,
+            name: "FlashAttention".to_string(),
+            description: Some("Fast attention algorithm".to_string()),
+            properties: props.clone(),
+            tags: vec!["attention".to_string(), "inference".to_string()],
+            created_at: 1_000_000,
+            updated_at: 2_000_000,
+            deleted_at: None,
+            merge_event_id: None,
+            merged_into: None,
+        };
+
+        let doc = entity_fts_document(&entity);
+
+        assert_eq!(doc.subject_id, id);
+        assert_eq!(doc.kind, SubstrateKind::Entity);
+        assert_eq!(doc.namespace, "test-ns");
+        assert_eq!(doc.title.as_deref(), Some("FlashAttention"));
+        assert_eq!(doc.body, "FlashAttention Fast attention algorithm");
+        assert_eq!(
+            doc.tags,
+            vec!["attention".to_string(), "inference".to_string()]
+        );
+        assert_eq!(doc.metadata, props);
+        assert_eq!(
+            doc.updated_at,
+            chrono::DateTime::from_timestamp_micros(2_000_000).unwrap()
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -16,7 +16,8 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
-use khive_runtime::{note_fts_document, KhiveRuntime, Namespace};
+use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
+use khive_storage::entity::Entity;
 use khive_storage::error::StorageError;
 use khive_storage::note::Note;
 use khive_storage::VectorStore;
@@ -215,6 +216,8 @@ struct ReindexReport {
     elapsed_ms: u64,
     /// Entity/note vector inserts that failed across all engines.
     errors_skipped: u64,
+    /// Entity FTS upserts that failed during the backfill pass.
+    entities_fts_failed: u64,
     /// Note FTS upserts that failed during the backfill pass.
     notes_fts_failed: u64,
 }
@@ -223,6 +226,7 @@ impl ReindexReport {
     /// Did any part of the run fail? Drives the fail-closed exit decision.
     fn has_failures(&self) -> bool {
         self.errors_skipped > 0
+            || self.entities_fts_failed > 0
             || self.notes_fts_failed > 0
             || self.knowledge_atoms_failed > 0
             || self.knowledge_pass_errored
@@ -339,6 +343,32 @@ async fn fts_backfill_notes_batch(
     errors
 }
 
+/// Upsert FTS documents for a batch of entities into the namespace text index. Returns the
+/// number of per-entity upsert failures. Idempotent: calling again for an already-indexed
+/// entity replaces the existing row (FTS upsert semantics). Fails per-entity, never panics.
+async fn fts_backfill_entities_batch(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    batch: &[Entity],
+) -> u64 {
+    let fts = match rt.text(token) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!(error = %e, "FTS store unavailable; counting whole batch as failed");
+            return batch.len() as u64;
+        }
+    };
+    let mut errors: u64 = 0;
+    for entity in batch {
+        let doc = entity_fts_document(entity);
+        if let Err(e) = fts.upsert_document(doc).await {
+            tracing::warn!(id = %entity.id, error = %e, "FTS upsert failed for entity");
+            errors += 1;
+        }
+    }
+    errors
+}
+
 /// Return the subset of `ids` that do NOT already have an embedding in `vectors`
 /// for the given `namespace`. When `batch_exists` is unsupported (e.g. a custom
 /// backend), conservatively returns all IDs so every record gets embedded.
@@ -428,6 +458,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut entities_processed: u64 = 0;
     let mut notes_processed: u64 = 0;
     let mut errors_skipped: u64 = 0;
+    let mut entities_fts_failed: u64 = 0;
     let mut notes_fts_failed: u64 = 0;
 
     // ── entities + notes (graph substrate) ────────────────────────────────────
@@ -472,6 +503,12 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
                 .await;
                 entities_processed += staged.len() as u64;
             }
+
+            // FTS backfill: index every entity in this batch regardless of whether
+            // it had content to embed. Mirrors the upsert_document call in
+            // operations.rs — see entity_fts_document for the parity contract.
+            entities_fts_failed += fts_backfill_entities_batch(&rt, &token, &batch).await;
+
             entity_bar.update(entities_processed, entity_total);
 
             if n < batch_size as usize {
@@ -622,6 +659,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         models_used: model_names,
         elapsed_ms,
         errors_skipped,
+        entities_fts_failed,
         notes_fts_failed,
     };
 
@@ -739,6 +777,7 @@ fn print_report(report: &ReindexReport, human: bool) {
         } else {
             "Reindex complete"
         };
+        let fts_errors = report.entities_fts_failed + report.notes_fts_failed;
         println!(
             "{status}: {} entities, {} notes{}{} ({} vector errors, {} FTS errors) in {}ms",
             report.entities_processed,
@@ -746,9 +785,15 @@ fn print_report(report: &ReindexReport, human: bool) {
             atoms,
             sections,
             report.errors_skipped,
-            report.notes_fts_failed,
+            fts_errors,
             report.elapsed_ms
         );
+        if report.entities_fts_failed > 0 {
+            println!(
+                "FTS backfill: {} entity upserts FAILED",
+                report.entities_fts_failed
+            );
+        }
         if report.notes_fts_failed > 0 {
             println!(
                 "FTS backfill: {} note upserts FAILED",
@@ -884,6 +929,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: errors,
+            entities_fts_failed: 0,
             notes_fts_failed: 0,
         }
     }
@@ -919,6 +965,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
+            entities_fts_failed: 0,
             notes_fts_failed: 0,
         };
         assert!(
@@ -949,6 +996,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
+            entities_fts_failed: 0,
             notes_fts_failed: 0,
         };
         assert!(
@@ -1117,6 +1165,7 @@ mod tests {
             models_used: vec![],
             elapsed_ms: 0,
             errors_skipped: 0,
+            entities_fts_failed: 0,
             notes_fts_failed: 1,
         };
         assert!(
@@ -1456,5 +1505,258 @@ mod tests {
             .await
             .expect("count");
         assert_eq!(count, 3, "second backfill pass must not duplicate rows");
+    }
+
+    // Parity: entity_fts_document must produce the same body/title as
+    // operations.rs create_entity.
+    #[test]
+    fn entity_fts_document_parity_with_description() {
+        use khive_storage::entity::Entity;
+        let mut entity = Entity::new("local", "concept", "TestEntity");
+        entity = entity.with_description("detail text");
+        let doc = entity_fts_document(&entity);
+        assert_eq!(doc.subject_id, entity.id);
+        assert_eq!(doc.namespace, "local");
+        assert_eq!(doc.title.as_deref(), Some("TestEntity"));
+        assert_eq!(doc.body, "TestEntity detail text");
+        assert_eq!(doc.kind, SubstrateKind::Entity);
+    }
+
+    #[test]
+    fn entity_fts_document_parity_without_description() {
+        use khive_storage::entity::Entity;
+        let entity = Entity::new("local", "concept", "NameOnly");
+        let doc = entity_fts_document(&entity);
+        assert_eq!(doc.title.as_deref(), Some("NameOnly"));
+        assert_eq!(doc.body, "NameOnly");
+    }
+
+    // Regression: insert N entities via EntityStore (bypassing FTS), run
+    // fts_backfill_entities_batch, assert FTS count == N and a keyword hit works.
+    #[tokio::test]
+    async fn fts_backfill_populates_pre_existing_entities() {
+        use khive_storage::entity::Entity;
+        use khive_storage::types::TextFilter;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        let entities: Vec<Entity> = (0..5)
+            .map(|i| {
+                Entity::new("local", "concept", format!("zxqentitysentinel{i}"))
+                    .with_description(format!("backfill entity description {i}"))
+            })
+            .collect();
+
+        let entity_store = rt.entities(&token).expect("entity store");
+        for entity in &entities {
+            entity_store
+                .upsert_entity(entity.clone())
+                .await
+                .expect("upsert entity");
+        }
+
+        // FTS should be empty before backfill (entities inserted via store, not runtime).
+        let fts = rt.text(&token).expect("FTS store");
+        let before = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Entity],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count before");
+        assert_eq!(before, 0, "FTS must be empty before backfill");
+
+        // Run the backfill.
+        let errors = fts_backfill_entities_batch(&rt, &token, &entities).await;
+        assert_eq!(errors, 0, "backfill must produce zero errors");
+
+        // FTS must now contain one row per entity.
+        let after = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Entity],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count after");
+        assert_eq!(after, 5, "FTS must contain exactly N docs after backfill");
+
+        // A keyword from the first entity must be retrievable.
+        let hits = fts
+            .search(khive_storage::types::TextSearchRequest {
+                query: "zxqentitysentinel0".to_string(),
+                mode: khive_storage::types::TextQueryMode::Plain,
+                filter: None,
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+            .expect("FTS search");
+        assert!(
+            hits.iter().any(|h| h.subject_id == entities[0].id),
+            "pre-existing entity must be findable by FTS after backfill"
+        );
+    }
+
+    // run_reindex with no embedding model must populate entity FTS for pre-existing
+    // entities. Guards the entity FTS path running independently of embedding.
+    #[tokio::test]
+    async fn run_reindex_populates_entity_fts_without_embedding_model() {
+        use khive_storage::entity::Entity;
+        use khive_storage::types::TextFilter;
+
+        let db_file = tempfile::NamedTempFile::new().expect("temp db file");
+        let db_path = db_file.path().to_str().expect("utf8 path").to_string();
+
+        // Seed entities via EntityStore (bypassing runtime FTS write).
+        {
+            let cfg = resolve_runtime_config(RuntimeConfigInputs {
+                db: Some(&db_path),
+                config: None,
+                namespace: Namespace::parse("local").expect("ns"),
+                namespace_explicit: true,
+                no_embed: true,
+                packs: None,
+                brain_profile: None,
+            })
+            .expect("resolve config for seed");
+            let rt = KhiveRuntime::new(cfg).expect("seed runtime");
+            let token = rt
+                .authorize(Namespace::parse("local").expect("ns"))
+                .expect("authorize");
+            let entity_store = rt.entities(&token).expect("entity store");
+            for i in 0..3usize {
+                entity_store
+                    .upsert_entity(Entity::new(
+                        "local",
+                        "concept",
+                        format!("reindex-entity-sentinel{i}"),
+                    ))
+                    .await
+                    .expect("upsert seed entity");
+            }
+        }
+
+        let args = ReindexArgs {
+            db: Some(db_path.clone()),
+            config: None,
+            model: None,
+            batch_size: 100,
+            keep_existing: false,
+            namespace: Some("local".to_string()),
+            knowledge_only: false,
+            no_knowledge: true,
+            best_effort: true,
+            no_sections: false,
+            sections_only: false,
+            human: false,
+        };
+        run_reindex(args).await.expect("run_reindex must succeed");
+
+        // Verify entity FTS was populated.
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(&db_path),
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: true,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config for verify");
+        let rt = KhiveRuntime::new(cfg).expect("verify runtime");
+        let token = rt
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let fts = rt.text(&token).expect("entity FTS store");
+        let count = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Entity],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("fts count");
+        assert_eq!(
+            count, 3,
+            "run_reindex must populate entity FTS even when no embedding model is configured"
+        );
+    }
+
+    // Idempotency: running entity FTS backfill twice must not duplicate rows.
+    #[tokio::test]
+    async fn fts_backfill_entities_is_idempotent() {
+        use khive_storage::entity::Entity;
+        use khive_storage::types::TextFilter;
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        let entities: Vec<Entity> = (0..3)
+            .map(|i| Entity::new("local", "concept", format!("idem-entity{i}")))
+            .collect();
+
+        let entity_store = rt.entities(&token).expect("entity store");
+        for entity in &entities {
+            entity_store
+                .upsert_entity(entity.clone())
+                .await
+                .expect("upsert entity");
+        }
+
+        let errors1 = fts_backfill_entities_batch(&rt, &token, &entities).await;
+        let errors2 = fts_backfill_entities_batch(&rt, &token, &entities).await;
+        assert_eq!(errors1, 0);
+        assert_eq!(errors2, 0);
+
+        let fts = rt.text(&token).expect("FTS store");
+        let count = fts
+            .count(TextFilter {
+                kinds: vec![SubstrateKind::Entity],
+                namespaces: vec!["local".to_string()],
+                ids: vec![],
+            })
+            .await
+            .expect("count");
+        assert_eq!(
+            count, 3,
+            "second backfill pass must not duplicate entity rows"
+        );
+    }
+
+    // has_failures must flag entities_fts_failed alone.
+    #[test]
+    fn has_failures_flags_entities_fts_failed() {
+        let report = ReindexReport {
+            entities_processed: 0,
+            notes_processed: 0,
+            knowledge_atoms_indexed: None,
+            knowledge_sections_indexed: None,
+            knowledge_atoms_failed: 0,
+            knowledge_pass_errored: false,
+            knowledge_ann_failed: false,
+            knowledge_sections_failed: 0,
+            models_used: vec![],
+            elapsed_ms: 0,
+            errors_skipped: 0,
+            entities_fts_failed: 1,
+            notes_fts_failed: 0,
+        };
+        assert!(
+            report.has_failures(),
+            "entities_fts_failed > 0 alone must drive has_failures() = true"
+        );
+        assert!(
+            decide_result(report.has_failures(), false).is_err(),
+            "entities_fts_failed must fail closed (non-zero exit)"
+        );
+        assert!(
+            decide_result(report.has_failures(), true).is_ok(),
+            "best-effort downgrades entities_fts_failed to exit 0"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Mirrors PR #88's note-FTS architecture for entities. The live DB shows 33/2,599 rows in `fts_entities_local` (~1.3%) because entity writes historically missed FTS indexing and `kkernel reindex` had no entity-FTS backfill pass. This PR closes that gap.

## What mirrors #88 (file:line)

| #88 piece | Entity mirror |
|-----------|--------------|
| `note_fts_document` constructor — `curation.rs:620` | `entity_fts_document` — `crates/khive-runtime/src/curation.rs` (before `note_fts_document`); body = `"name description"` when description non-empty, else `"name"` |
| `create_note` routed through `note_fts_document` — `operations.rs` | `create_entity` routed through `entity_fts_document` — `crates/khive-runtime/src/operations.rs` |
| `reindex_note` routed through `note_fts_document` — `curation.rs` | `reindex_entity` routed through `entity_fts_document` — `crates/khive-runtime/src/curation.rs` |
| `fts_backfill_notes_batch` — `crates/kkernel/src/reindex.rs` | `fts_backfill_entities_batch` — `crates/kkernel/src/reindex.rs`; fail-closed (FTS store unavailable = whole batch counted as failed) |
| `notes_fts_failed: u64` in `ReindexReport` | `entities_fts_failed: u64` in `ReindexReport` |
| `has_failures()` gates on `notes_fts_failed` | `has_failures()` now also gates on `entities_fts_failed` |

`merge_entity_sql` runs in `spawn_blocking` (sync context) so it cannot call `entity_fts_document` directly; that path was already field-identical and is annotated with a parity comment.

`entity_fts_document` is exported from `khive-runtime/src/lib.rs`.

## Trigger-narrowing status

No action needed. Entities have **no SQL FTS triggers** — FTS indexing is entirely managed through Rust code paths (`create_entity`, `update_entity`, `reindex_entity`, `merge_entity_sql`). The V2 migration (`002-narrow-fts-sections-update-trigger.sql`) that narrowed `fts_sections_au` to text-column changes only has no equivalent needed for entities. Confirmed by reading `crates/khive-db/sql/entities-ddl.sql` and `crates/khive-db/sql/schema.sql`.

## Tests added

**`crates/khive-runtime/src/curation.rs`** (6 tests):
- `entity_fts_document_with_description` — unit: body = "name description"
- `entity_fts_document_without_description` — unit: body = "name"
- `entity_fts_document_empty_description_uses_name_only` — unit: empty string treated as absent
- `entity_fts_document_matches_runtime_create_path` — async: create via runtime, FTS body matches constructor
- `entity_fts_document_matches_runtime_update_path` — async: update via runtime, FTS body matches constructor
- `entity_fts_document_matches_runtime_merge_path` — async: merge via runtime, winner's FTS body matches constructor

**`crates/kkernel/src/reindex.rs`** (6 tests):
- `entity_fts_document_parity_with_description` — unit: reindex-local constructor matches curation output
- `entity_fts_document_parity_without_description` — unit: same, no description
- `fts_backfill_populates_pre_existing_entities` — async: inserts via EntityStore (bypassing FTS), runs backfill, asserts count==N and keyword search hits
- `run_reindex_populates_entity_fts_without_embedding_model` — async: seeds 3 entities via EntityStore, runs `run_reindex`, verifies FTS count==3
- `fts_backfill_entities_is_idempotent` — async: two backfill passes, count stays 3 not 6
- `has_failures_flags_entities_fts_failed` — unit: `entities_fts_failed: 1` drives `has_failures()`=true; best-effort flag downgrades exit

## Local verification RCs

```
cargo test --workspace:                          RC=0 (all suites pass)
cargo clippy --workspace --all-targets -- -D warnings:  RC=0 (0 warnings)
cargo fmt --all -- --check:                      RC=0 (no diff)
pre-commit hooks (on commit):                    all Passed
```

Local verification output above is the evidence.

## Expected FTS coverage after live reindex

Run `kkernel reindex` against the live DB after deploying. With all 2,599 entities processed through `fts_backfill_entities_batch`, `fts_entities_local` should go from 33 rows to 2,599 rows (100% coverage), assuming no FTS store errors on any entity.

Closes #92