### PR TITLE
chore(release): v0.2.9 — version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-11
+
+GitHub release only — crates.io remains at 0.2.8.
+
+### Added
+
+- Write-time secret detection gate — credential plaintext is hard-blocked from
+  content-bearing verbs with a masked reason (#76, #83)
+- Type-differentiated salience + decay defaults for memory writes: episodic
+  0.3/0.02, semantic 0.5/0.005 (#70, #84)
+- `knowledge.get` `include_sections` param (#89); draft atoms excluded from
+  knowledge search by default with `include_drafts` opt-in (#78, #90)
+- `brain_profile` config knob with 3-tier feedback resolution: explicit →
+  namespace-bound → global (#52, ADR-035)
+- Vendored JSON/JSONL data-leak pre-commit + CI check (#61)
+- Reindex progress bars and domain mirror backfill (#19)
+
+### Fixed
+
+- FTS coverage gap: reindex now backfills pre-existing notes (#88) and entities
+  (#96) into FTS; new canonical `entity_fts_document` constructor shared by all
+  entity FTS write paths
+- Embed-intent prefixes wired across all call sites — instruction-tuned
+  embedding models receive `query:`/`passage:` correctly (#95)
+- Hard delete purges soft-deleted records (#82)
+- `kkernel kg validate` enforces closed-taxonomy schema checks (#41)
+- khive-merge compiles again and is hardened (#21, #42)
+- `kkernel exec` routes through the warm daemon when available (#63, #64);
+  ANN warm removed from stdio — daemon owns hot state (#20)
+- Nondeterministic HashMap ordering + startup robustness (#45)
+- FTS UPDATE triggers narrowed to indexed columns — stops WAL bloat from
+  embedding updates (#19)
+
+### Security
+
+- serde boundaries reject non-finite/NaN and invalid values (#49)
+- gate-rego: entrypoint trimmed and validated to avoid latent fail-open (#43);
+  tracing dependency restored (#66)
+- Remote URLs redacted from git clone error messages (#40)
+- brain `section_signals` validated; replay rows quarantined (#46)
+
+### Changed
+
+- Schema DDL moved from inline Rust strings to `.sql` files per ADR-015 (#51)
+- Workspace dependency discipline; unused deps removed; `#[allow]` REASON form (#53)
+- Oversized production files split; long functions extracted (#35, #56)
+- Crate-doc shape + rustdoc hygiene pass (#36, #55)
+- ADR freshness pass: ADR-019/023/024/030/051 (#48)
+
 ## [0.2.0] - 2026-05-22
 
 ### Added

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -40,7 +40,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Release prep for v0.2.9 — workspace version bump + CHANGELOG entry covering the 43 commits since v0.2.8 (security hardening sweep, FTS coverage fixes from the recall calibration loop, embed-intent prefixes, salience/decay defaults, audit-20260608 burn-down).

Distribution decision (2026-06-11): **GitHub release only — no crates.io publish.** Repo went private 2026-06-09; publishing tarballs would re-expose source. crates.io stays at 0.2.8.

Gates at 5c97d2c (local CI substitute): `cargo test --workspace` RC=0 · `cargo clippy --workspace --all-targets -- -D warnings` RC=0 · `cargo fmt --all -- --check` RC=0 (pipefail-captured).