### PR TITLE
fix(ci): lint-sql.sh skips build-artifact SQL under target dirs

### DIFF
--- a/scripts/lint-sql.sh
+++ b/scripts/lint-sql.sh
@@ -18,7 +18,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$SCRIPT_DIR/.."
 
-SQL_FILES=$(find "$ROOT/crates" -name '*.sql' -type f | sort)
+SQL_FILES=$(find "$ROOT/crates" \
+    \( -name 'target' -o -name 'target-wt' \) -type d -prune \
+    -o -name '*.sql' -type f -print \
+    | sort)
 
 if [ -z "$SQL_FILES" ]; then
     echo "no SQL files found"


### PR DESCRIPTION
## Summary

- `cargo build` populates `crates/target/` and `crates/*/target-wt/` with build artifacts that may include `.sql` files; the previous `find` glob matched them, polluting the SQL lint with non-authored content.
- Changed the `find` command to prune any directory named `target` or `target-wt` before collecting `.sql` files.
- All 10 authored `.sql` files continue to be linted; build-artifact dirs are silently skipped.

## Verification (empirical, three cases)

| Case | What | RC | Proves |
|------|------|-----|--------|
| (a) Malformed SQL under `crates/khive-db/target/__lintcheck_junk.sql` | run lint | **0** | `target/` is excluded |
| (b) Malformed SQL under `crates/khive-db/sql/__lintcheck_junk.sql` | run lint | **1** | Authored SQL is still linted |
| (c) Clean tree (no temp files) | run lint | **0** | No regression on real files |

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Optionally: create a dummy `.sql` file under `crates/target/` in the CI environment and re-run `make ci` to validate the prune path