### PR TITLE
fix(memory): return id (not note_id) for note identity on the wire

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,15 +160,65 @@ request(ops="[{\"tool\":\"create\",\"args\":{\"kind\":\"entity\",\"entity_kind\"
 ```
 
 Ops in a batch run in parallel and have no ordering guarantee. If op B depends on op A's output
-(e.g. create-then-link), use two `request` calls.
+(e.g. create-then-link), chain them with `|` instead (see _Efficient batching and round-trip reduction_ below).
 
 **Deferred (not yet available):**
 
 - `create(supersedes=<old-id>)` parameter shortcut — this convenience form (which would atomically
   create a new record and add a `supersedes` edge to the old one) is not yet in the wire surface.
-  Use the two-step approach: `create(...)` then `link(..., relation="supersedes")`.
+  Use two ops, which you can run as one chained call: `create(...) | link(..., relation="supersedes")`.
 - Note merge — only entity merge is implemented (`merge(into_id=..., from_id=...)`).
   Deduplicating two notes is not yet supported; add a `supersedes` edge manually.
+
+### Efficient batching and round-trip reduction
+
+Every `request` call is one round trip, and the server keeps a warm daemon between calls (see
+_Daemon and warm startup_). Folding work into fewer calls cuts both the per-call round trip and
+repeated access to that warm state. Two forms do this: a parallel batch for independent ops, and a
+sequential chain for dependent ops.
+
+Batch independent ops with `[ … ]`. They run in parallel, each returns its own `ok`/`error` so one
+failure does not abort the rest, and the limit is 100 ops per batch. Orient at session start in one
+call instead of three:
+
+```text
+request(ops="[gtd.next(limit=10), gtd.tasks(status=\"active\"), comm.inbox(limit=10)]")
+```
+
+The response carries each op's result alongside a `summary` with `total`, `succeeded`, and `failed`.
+
+Chain dependent ops with `|` and `$prev`. When one op needs the previous op's output, separate them
+with `|` and reference the prior result with `$prev`. A chain runs sequentially and skips the
+remaining ops if a step fails. This collapses create-then-link into a single call:
+
+```text
+request(ops="create(kind=\"concept\", name=\"LoRA\") | link(source_id=$prev.id, target_id=\"<uuid>\", relation=\"extends\")")
+```
+
+`$prev` reads fields by dotted path and arrays by index, such as `$prev.id` or `$prev[0].id`.
+Reference the field the previous verb actually returns; create, remember, and the other write verbs
+return the new record's `id`. Recording a corrected memory and marking the old one superseded is then
+one call:
+
+```text
+request(ops="memory.remember(content=\"corrected fact\", salience=0.8) | link(source_id=$prev.id, target_id=\"<old-uuid>\", relation=\"supersedes\")")
+```
+
+`$prev` refers to the immediately preceding op only. In a three-op chain `A | B | C`, the `$prev` in
+`C` is `B`'s result, not `A`'s; there is no multi-step back-reference. If `C` needs a value from `A`,
+split the work into two `request` calls.
+
+The two forms cannot be combined in one `request`, and the JSON op form does not support `$prev`:
+
+| Situation                       | Use                        | Note                                         |
+| ------------------------------- | -------------------------- | -------------------------------------------- |
+| Ops are independent             | batch `[a(), b()]`         | parallel, up to 100 ops                      |
+| Op B needs op A's result        | chain `a() \| b(…=$prev…)` | sequential, aborts on failure                |
+| Two writes to the same record   | chain, not batch           | a parallel batch rejects same-record writes  |
+| Discovering a verb's parameters | `verb(help=true)`          | returns the parameter schema without running |
+
+Mixing `,` and `|` at the top level of one `request` is rejected, as is `$prev` inside the JSON op
+form. Use the function-call form shown above for chaining.
 
 ### Notes vs entities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,12 +210,12 @@ split the work into two `request` calls.
 
 The two forms cannot be combined in one `request`, and the JSON op form does not support `$prev`:
 
-| Situation                       | Use                        | Note                                         |
-| ------------------------------- | -------------------------- | -------------------------------------------- |
-| Ops are independent             | batch `[a(), b()]`         | parallel, up to 100 ops                      |
-| Op B needs op A's result        | chain `a() \| b(…=$prev…)` | sequential, aborts on failure                |
-| Two writes to the same record   | chain, not batch           | a parallel batch rejects same-record writes  |
-| Discovering a verb's parameters | `verb(help=true)`          | returns the parameter schema without running |
+| Situation                       | Use                        | Note                                                                                  |
+| ------------------------------- | -------------------------- | ------------------------------------------------------------------------------------- |
+| Ops are independent             | batch `[a(), b()]`         | parallel, up to 100 ops                                                               |
+| Op B needs op A's result        | chain `a() \| b(…=$prev…)` | sequential, aborts on failure                                                         |
+| Two writes to the same record   | chain, not batch           | conflicting same-record writes get per-op errors and are skipped; other ops still run |
+| Discovering a verb's parameters | `verb(help=true)`          | returns the parameter schema without running                                          |
 
 Mixing `,` and `|` at the top level of one `request` is rejected, as is `$prev` inside the JSON op
 form. Use the function-call form shown above for chaining.

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -209,7 +209,7 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 name: "results",
                 param_type: "array",
                 required: true,
-                description: "Recall result objects; the first object's note_id is credited.",
+                description: "Recall result objects; the first object's id is credited.",
             },
             khive_types::ParamDef {
                 name: "signal",
@@ -988,7 +988,7 @@ impl BrainPack {
 
         #[derive(Deserialize)]
         struct AutoFeedbackResult {
-            note_id: String,
+            id: String,
         }
 
         let p: AutoFeedbackParams = serde_json::from_value(params)
@@ -1007,7 +1007,7 @@ impl BrainPack {
             }));
         };
 
-        let target = resolve_auto_feedback_target(&self.runtime, token, &first.note_id).await?;
+        let target = resolve_auto_feedback_target(&self.runtime, token, &first.id).await?;
 
         let mut feedback_params = json!({
             "target_id": target.to_string(),
@@ -1352,7 +1352,7 @@ impl BrainPack {
 
 // ── brain.auto_feedback helpers ───────────────────────────────────────────────
 
-/// Resolve a `note_id` from `memory.recall` output to a full UUID.
+/// Resolve an `id` from `memory.recall` output to a full UUID.
 ///
 /// Accepts a 36-char UUID directly, or an 8-char hex prefix (Agent-mode short
 /// form). Returns `InvalidInput` if neither form matches or the prefix is
@@ -1372,12 +1372,12 @@ pub(crate) async fn resolve_auto_feedback_target(
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
             .ok_or_else(|| {
                 RuntimeError::InvalidInput(format!(
-                    "auto_feedback: no record matches note_id prefix: {raw:?}"
+                    "auto_feedback: no record matches id prefix: {raw:?}"
                 ))
             });
     }
     Err(RuntimeError::InvalidInput(format!(
-        "auto_feedback: invalid note_id {raw:?}; expected full UUID or 8-char hex prefix"
+        "auto_feedback: invalid id {raw:?}; expected full UUID or 8-char hex prefix"
     )))
 }
 

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2413,7 +2413,7 @@ async fn brain_auto_feedback_emits_implicit_positive_for_first_result() {
             "brain.auto_feedback",
             json!({
                 "query": "recall calibration target",
-                "results": [{ "note_id": target }]
+                "results": [{ "id": target }]
             }),
             &registry,
             &token,
@@ -2481,7 +2481,7 @@ async fn brain_auto_feedback_accepts_short_note_id_prefix() {
             "brain.auto_feedback",
             json!({
                 "query": "prefix resolution test",
-                "results": [{ "note_id": prefix }]
+                "results": [{ "id": prefix }]
             }),
             &registry,
             &token,

--- a/crates/khive-pack-memory/benches/e2e_recall.rs
+++ b/crates/khive-pack-memory/benches/e2e_recall.rs
@@ -160,7 +160,7 @@ async fn run_recall_inner(
     };
     let ids: Vec<String> = arr
         .iter()
-        .filter_map(|m| m["note_id"].as_str().map(|s| s.to_string()))
+        .filter_map(|m| m["id"].as_str().map(|s| s.to_string()))
         .collect();
     Ok((elapsed, ids))
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -492,7 +492,7 @@ impl MemoryPack {
                         sn.note.content.clone()
                     };
                 let mut result = json!({
-                    "note_id": sn.id.to_string(),
+                    "id": sn.id.to_string(),
                     "score": sn.score,
                     "rank_score": sn.rank_score,
                     "raw_score": sn.raw_score,
@@ -516,7 +516,7 @@ impl MemoryPack {
         {
             let latency_us = recall_start.elapsed().as_micros() as i64;
             let top_id = results.first().and_then(|r| {
-                r.get("note_id")
+                r.get("id")
                     .and_then(|v| v.as_str())
                     .and_then(|s| s.parse::<Uuid>().ok())
             });
@@ -538,7 +538,7 @@ impl MemoryPack {
                         .iter()
                         .map(|h| {
                             json!({
-                                "note_id": h.subject_id.to_string(),
+                                "id": h.subject_id.to_string(),
                                 "score": h.score.to_f64(),
                                 "rank": h.rank,
                             })

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -143,7 +143,7 @@ impl MemoryPack {
         };
 
         let mut response = json!({
-            "note_id": note.id.to_string(),
+            "id": note.id.to_string(),
             "kind": note.kind,
             "salience": note.salience,
             "decay_factor": note.decay_factor,

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -129,7 +129,7 @@ impl MemoryPack {
             .filter(|hit| memory_ids.contains(&hit.subject_id))
             .map(|hit| {
                 json!({
-                    "note_id": hit.subject_id.to_string(),
+                    "id": hit.subject_id.to_string(),
                     "score": hit.score.to_f64(),
                     "rank": hit.rank,
                     "title": hit.title.as_deref(),
@@ -143,7 +143,7 @@ impl MemoryPack {
             .iter()
             .map(|hit| {
                 json!({
-                    "note_id": hit.subject_id.to_string(),
+                    "id": hit.subject_id.to_string(),
                     "score": hit.score.to_f64(),
                     "rank": hit.rank,
                 })
@@ -166,7 +166,7 @@ impl MemoryPack {
                         .iter()
                         .map(|h| {
                             json!({
-                                "note_id": h.subject_id.to_string(),
+                                "id": h.subject_id.to_string(),
                                 "score": h.score.to_f64(),
                                 "rank": h.rank,
                             })
@@ -244,7 +244,7 @@ impl MemoryPack {
                     }
                 }
                 Some(json!({
-                    "note_id": hit.entity_id.to_string(),
+                    "id": hit.entity_id.to_string(),
                     "fused_score": hit.score.to_f64(),
                     "source": search_source_label(hit.source),
                     "title": hit.title,
@@ -281,13 +281,13 @@ impl MemoryPack {
             .iter()
             .map(|candidate| {
                 let id = candidate
-                    .get("note_id")
+                    .get("id")
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
 
                 if cfg.reranker_weights.is_empty() {
                     return json!({
-                        "note_id": id,
+                        "id": id,
                         "rerank_scores": {},
                         "rerank_score": 0.0_f64,
                     });
@@ -355,7 +355,7 @@ impl MemoryPack {
                 }
 
                 json!({
-                    "note_id": id,
+                    "id": id,
                     "rerank_scores": rerank_scores,
                     "rerank_score": rerank_score,
                 })

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -588,7 +588,7 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
                 .iter()
                 .map(|h| {
                     serde_json::json!({
-                        "note_id": h.subject_id.to_string(),
+                        "id": h.subject_id.to_string(),
                         "score": h.score.to_f64(),
                         "rank": h.rank,
                     })
@@ -600,9 +600,9 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
 
     assert_eq!(per_model.len(), 2, "should have one entry per model");
     assert_eq!(per_model[0]["model"], "model-a");
-    assert_eq!(per_model[0]["hits"][0]["note_id"], id1.to_string());
+    assert_eq!(per_model[0]["hits"][0]["id"], id1.to_string());
     assert_eq!(per_model[1]["model"], "model-b");
-    assert_eq!(per_model[1]["hits"][0]["note_id"], id2.to_string());
+    assert_eq!(per_model[1]["hits"][0]["id"], id2.to_string());
 }
 
 #[test]

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -46,7 +46,7 @@ async fn test_remember_recall_smoke() {
         .await
         .expect("memory.remember succeeds");
 
-    let note_id = result["note_id"].as_str().expect("has note_id");
+    let note_id = result["id"].as_str().expect("has note_id");
     assert!(!note_id.is_empty());
 
     let recall_result = registry
@@ -59,7 +59,7 @@ async fn test_remember_recall_smoke() {
 
     let hits = recall_result.as_array().expect("array of hits");
     assert!(!hits.is_empty(), "recall returned at least one result");
-    let first_id = hits[0]["note_id"].as_str().unwrap();
+    let first_id = hits[0]["id"].as_str().unwrap();
     assert_eq!(first_id, note_id, "recalled the memory we just created");
 }
 
@@ -84,7 +84,7 @@ async fn test_recall_decay_ranking() {
         )
         .await
         .expect("fresh remember");
-    let fresh_id = fresh["note_id"].as_str().unwrap().to_string();
+    let fresh_id = fresh["id"].as_str().unwrap().to_string();
 
     // Create old memory (simulate 90 days ago) with high decay
     let old = registry
@@ -98,7 +98,7 @@ async fn test_recall_decay_ranking() {
         )
         .await
         .expect("old remember");
-    let old_id = old["note_id"].as_str().unwrap().to_string();
+    let old_id = old["id"].as_str().unwrap().to_string();
 
     // Manually backdate the old note to simulate age
     let old_uuid: uuid::Uuid = old_id.parse().unwrap();
@@ -132,7 +132,7 @@ async fn test_recall_decay_ranking() {
         .iter()
         .map(|h| {
             (
-                h["note_id"].as_str().unwrap(),
+                h["id"].as_str().unwrap(),
                 h["rank_score"].as_f64().unwrap_or(0.0),
             )
         })
@@ -173,7 +173,7 @@ async fn test_recall_salience_ranking() {
         )
         .await
         .expect("high salience remember");
-    let high_id = high["note_id"].as_str().unwrap().to_string();
+    let high_id = high["id"].as_str().unwrap().to_string();
 
     let low = registry
         .dispatch(
@@ -186,7 +186,7 @@ async fn test_recall_salience_ranking() {
         )
         .await
         .expect("low salience remember");
-    let low_id = low["note_id"].as_str().unwrap().to_string();
+    let low_id = low["id"].as_str().unwrap().to_string();
 
     let recall_result = registry
         .dispatch(
@@ -201,7 +201,7 @@ async fn test_recall_salience_ranking() {
         .iter()
         .map(|h| {
             (
-                h["note_id"].as_str().unwrap(),
+                h["id"].as_str().unwrap(),
                 h["rank_score"].as_f64().unwrap_or(0.0),
             )
         })
@@ -250,7 +250,7 @@ async fn test_recall_memory_type_filter() {
         )
         .await
         .expect("semantic remember");
-    let semantic_id = semantic["note_id"].as_str().unwrap().to_string();
+    let semantic_id = semantic["id"].as_str().unwrap().to_string();
 
     let filtered = registry
         .dispatch(
@@ -266,10 +266,7 @@ async fn test_recall_memory_type_filter() {
         let mt = hit["memory_type"].as_str().unwrap_or("");
         assert_eq!(mt, "semantic", "only semantic results returned");
     }
-    let ids: Vec<&str> = hits
-        .iter()
-        .map(|h| h["note_id"].as_str().unwrap())
-        .collect();
+    let ids: Vec<&str> = hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
     assert!(
         ids.contains(&semantic_id.as_str()),
         "semantic note is in results"
@@ -315,11 +312,7 @@ async fn test_remember_source_id_not_in_properties() {
         .await
         .expect("remember with source_id");
 
-    let note_id: Uuid = result["note_id"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .expect("valid uuid");
+    let note_id: Uuid = result["id"].as_str().unwrap().parse().expect("valid uuid");
 
     let note_store = rt
         .notes(&rt.authorize(Namespace::local()).unwrap())
@@ -358,11 +351,7 @@ async fn test_remember_decay_factor_no_upper_cap() {
         .await
         .expect("remember with decay_factor > 1.0 should succeed");
 
-    let note_id: Uuid = result["note_id"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .expect("valid uuid");
+    let note_id: Uuid = result["id"].as_str().unwrap().parse().expect("valid uuid");
 
     let note_store = rt
         .notes(&rt.authorize(Namespace::local()).unwrap())
@@ -415,11 +404,7 @@ async fn test_remember_default_memory_type_written_to_properties() {
         .await
         .expect("remember without memory_type");
 
-    let note_id: Uuid = result["note_id"]
-        .as_str()
-        .unwrap()
-        .parse()
-        .expect("valid uuid");
+    let note_id: Uuid = result["id"].as_str().unwrap().parse().expect("valid uuid");
 
     // The response must carry memory_type
     assert_eq!(
@@ -503,8 +488,8 @@ async fn test_recall_rerank_passthrough_with_no_active_rerankers() {
     let registry = make_registry(rt);
 
     let candidates = json!([
-        { "note_id": "00000000-0000-0000-0000-000000000001", "fused_score": 0.8 },
-        { "note_id": "00000000-0000-0000-0000-000000000002", "fused_score": 0.6 },
+        { "id": "00000000-0000-0000-0000-000000000001", "fused_score": 0.8 },
+        { "id": "00000000-0000-0000-0000-000000000002", "fused_score": 0.6 },
     ]);
 
     let result = registry
@@ -566,7 +551,7 @@ async fn test_recall_candidates_returns_arrays() {
 
     let text = result["text_candidates"].as_array().expect("text array");
     assert!(!text.is_empty());
-    assert!(text[0]["note_id"].as_str().is_some());
+    assert!(text[0]["id"].as_str().is_some());
     assert!(text[0]["score"].as_f64().is_some());
     assert!(text[0]["rank"].as_u64().is_some());
     assert!(result["candidate_limit"].as_u64().is_some());
@@ -808,10 +793,7 @@ async fn test_recall_fuse_shape_preserved_after_retrieval_wiring() {
     assert!(!fused.is_empty(), "fused_candidates must be non-empty");
 
     let c = &fused[0];
-    assert!(
-        c["note_id"].as_str().is_some(),
-        "note_id must be a string UUID"
-    );
+    assert!(c["id"].as_str().is_some(), "note_id must be a string UUID");
     assert!(
         c["fused_score"].as_f64().is_some(),
         "fused_score must be a float"
@@ -928,8 +910,8 @@ async fn test_recall_excludes_non_memory_notes() {
         )
         .await
         .expect("remember 2");
-    let mem1_id = mem1["note_id"].as_str().unwrap().to_string();
-    let mem2_id = mem2["note_id"].as_str().unwrap().to_string();
+    let mem1_id = mem1["id"].as_str().unwrap().to_string();
+    let mem2_id = mem2["id"].as_str().unwrap().to_string();
 
     let result = registry
         .dispatch(
@@ -944,10 +926,7 @@ async fn test_recall_excludes_non_memory_notes() {
         !hits.is_empty(),
         "recall should return memory notes even when non-memory notes dominate the index"
     );
-    let ids: Vec<&str> = hits
-        .iter()
-        .map(|h| h["note_id"].as_str().unwrap())
-        .collect();
+    let ids: Vec<&str> = hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
     assert!(
         ids.contains(&mem1_id.as_str()) || ids.contains(&mem2_id.as_str()),
         "at least one memory note must appear in recall results"
@@ -955,7 +934,7 @@ async fn test_recall_excludes_non_memory_notes() {
     for hit in hits {
         // recall must never surface observation or other non-memory kinds
         assert!(
-            hit.get("note_id").is_some(),
+            hit.get("id").is_some(),
             "hit has note_id field (memory pack shape)"
         );
         assert!(
@@ -1138,8 +1117,8 @@ async fn test_recall_default_identity() {
     // shifts the ranking or rescaling.
     for (i, (b, k)) in base_hits.iter().zip(knobless_hits.iter()).enumerate() {
         assert_eq!(
-            b["note_id"].as_str(),
-            k["note_id"].as_str(),
+            b["id"].as_str(),
+            k["id"].as_str(),
             "null knobs altered note_id at position {i}"
         );
         // Scores must round-trip; allow tiny float jitter
@@ -1360,7 +1339,7 @@ async fn test_recall_with_empty_reranker_weights_is_passthrough() {
         .as_array()
         .expect("array")
         .iter()
-        .map(|h| h["note_id"].as_str().unwrap().to_string())
+        .map(|h| h["id"].as_str().unwrap().to_string())
         .collect();
 
     let with_empty_reranker = registry
@@ -1377,7 +1356,7 @@ async fn test_recall_with_empty_reranker_weights_is_passthrough() {
         .as_array()
         .expect("array")
         .iter()
-        .map(|h| h["note_id"].as_str().unwrap().to_string())
+        .map(|h| h["id"].as_str().unwrap().to_string())
         .collect();
 
     assert_eq!(
@@ -1431,7 +1410,7 @@ async fn test_recall_with_reranker_weights_changes_ordering() {
         )
         .await
         .expect("high salience remember");
-    let high_id = high_salience["note_id"].as_str().unwrap().to_string();
+    let high_id = high_salience["id"].as_str().unwrap().to_string();
 
     // Step 1: baseline recall — pure relevance scoring (salience_weight=0) so
     // BM25-heavy low-salience notes rank first.
@@ -1457,7 +1436,7 @@ async fn test_recall_with_reranker_weights_changes_ordering() {
     );
     let baseline_ids: Vec<String> = baseline_hits
         .iter()
-        .map(|h| h["note_id"].as_str().unwrap().to_string())
+        .map(|h| h["id"].as_str().unwrap().to_string())
         .collect();
     let baseline_top = &baseline_ids[0];
 
@@ -1486,7 +1465,7 @@ async fn test_recall_with_reranker_weights_changes_ordering() {
     assert!(!reranked_hits.is_empty(), "must get results");
     let reranked_ids: Vec<String> = reranked_hits
         .iter()
-        .map(|h| h["note_id"].as_str().unwrap().to_string())
+        .map(|h| h["id"].as_str().unwrap().to_string())
         .collect();
     let top_id = &reranked_ids[0];
 
@@ -1516,12 +1495,12 @@ async fn test_rerank_subhandler_uses_request_weights() {
     // when relevance weight = 1.0.
     let candidates = json!([
         {
-            "note_id": "00000000-0000-0000-0000-000000000001",
+            "id": "00000000-0000-0000-0000-000000000001",
             "fused_score": 0.9,
             "source": "both"
         },
         {
-            "note_id": "00000000-0000-0000-0000-000000000002",
+            "id": "00000000-0000-0000-0000-000000000002",
             "fused_score": 0.3,
             "source": "text"
         }
@@ -1547,7 +1526,7 @@ async fn test_rerank_subhandler_uses_request_weights() {
     let score_for = |id: &str| -> f64 {
         reranked
             .iter()
-            .find(|c| c["note_id"].as_str() == Some(id))
+            .find(|c| c["id"].as_str() == Some(id))
             .and_then(|c| c["rerank_score"].as_f64())
             .unwrap_or(f64::NAN)
     };
@@ -1616,7 +1595,7 @@ async fn test_remember_source_id_accepts_short_id() {
         .await
         .expect("remember with 8-char short source_id must succeed");
 
-    let note_id_str = result["note_id"].as_str().expect("has note_id");
+    let note_id_str = result["id"].as_str().expect("has note_id");
 
     // Verify the annotates edge was created: neighbors(note, direction=out) returns
     // an array of NeighborHit; each hit carries "id" (the neighbor's UUID) and "relation".
@@ -1986,7 +1965,7 @@ async fn test_custom_embedder_only_runtime_fanout_remember_recall() {
         .await
         .expect("remember with custom-only embedder must succeed");
 
-    let note_id = result["note_id"].as_str().expect("note_id present");
+    let note_id = result["id"].as_str().expect("note_id present");
     assert!(!note_id.is_empty());
 
     // recall — custom embedder must have participated: at least the text path
@@ -2000,10 +1979,7 @@ async fn test_custom_embedder_only_runtime_fanout_remember_recall() {
         .expect("recall after custom-embedder remember");
 
     let hits = recall_result.as_array().expect("array");
-    let ids: Vec<&str> = hits
-        .iter()
-        .map(|h| h["note_id"].as_str().unwrap())
-        .collect();
+    let ids: Vec<&str> = hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
     assert!(
         ids.contains(&note_id),
         "recall must find the note created via custom embedder; got: {ids:?}"
@@ -2055,7 +2031,7 @@ async fn test_weighted_fusion_multi_model_text_not_zeroed() {
         .await
         .expect("remember with two custom embedders");
 
-    let note_id = result["note_id"].as_str().expect("note_id");
+    let note_id = result["id"].as_str().expect("note_id");
 
     // Recall with explicit Weighted strategy — text must not be zeroed.
     let recall = registry
@@ -2071,10 +2047,7 @@ async fn test_weighted_fusion_multi_model_text_not_zeroed() {
         .expect("recall with weighted fusion and 2 vector models");
 
     let hits = recall.as_array().expect("array");
-    let ids: Vec<&str> = hits
-        .iter()
-        .map(|h| h["note_id"].as_str().unwrap())
-        .collect();
+    let ids: Vec<&str> = hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
     assert!(
         ids.contains(&note_id),
         "weighted fusion with N>1 vector models must not zero-weight text — \
@@ -2287,7 +2260,7 @@ async fn recall_candidates_text_candidates_non_empty_for_partial_match() {
 
     // All returned text candidates must be memory-kind notes.
     for tc in text_candidates {
-        let note_id = tc["note_id"].as_str().expect("note_id present");
+        let note_id = tc["id"].as_str().expect("note_id present");
         assert!(
             !note_id.is_empty(),
             "text_candidate note_id must be non-empty"
@@ -2427,7 +2400,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         )
         .await
         .expect("remember impl khive");
-    let impl_khive_id = impl_khive["note_id"].as_str().unwrap().to_owned();
+    let impl_khive_id = impl_khive["id"].as_str().unwrap().to_owned();
 
     let critic_khive = registry
         .dispatch(
@@ -2440,7 +2413,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         )
         .await
         .expect("remember critic khive");
-    let critic_khive_id = critic_khive["note_id"].as_str().unwrap().to_owned();
+    let critic_khive_id = critic_khive["id"].as_str().unwrap().to_owned();
 
     let impl_rust = registry
         .dispatch(
@@ -2453,7 +2426,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         )
         .await
         .expect("remember impl rust");
-    let impl_rust_id = impl_rust["note_id"].as_str().unwrap().to_owned();
+    let impl_rust_id = impl_rust["id"].as_str().unwrap().to_owned();
 
     // no-filter: all three should appear.
     let no_filter = registry
@@ -2467,7 +2440,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         .as_array()
         .unwrap()
         .iter()
-        .filter_map(|h| h["note_id"].as_str())
+        .filter_map(|h| h["id"].as_str())
         .collect();
     assert!(
         no_filter_ids.contains(&impl_khive_id.as_str()),
@@ -2499,7 +2472,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         .as_array()
         .unwrap()
         .iter()
-        .filter_map(|h| h["note_id"].as_str())
+        .filter_map(|h| h["id"].as_str())
         .collect();
     assert!(
         any_ids.contains(&critic_khive_id.as_str()),
@@ -2531,7 +2504,7 @@ async fn recall_tags_filter_any_all_and_no_filter() {
         .as_array()
         .unwrap()
         .iter()
-        .filter_map(|h| h["note_id"].as_str())
+        .filter_map(|h| h["id"].as_str())
         .collect();
     assert!(
         all_ids.contains(&impl_khive_id.as_str()),
@@ -2906,7 +2879,7 @@ async fn test_recall_legacy_note_no_memory_type_returned_as_episodic() {
     let hits = result.as_array().expect("recall returns array");
     let returned_ids: Vec<&str> = hits
         .iter()
-        .map(|h| h["note_id"].as_str().unwrap_or(""))
+        .map(|h| h["id"].as_str().unwrap_or(""))
         .collect();
     assert!(
         returned_ids.contains(&legacy_id.as_str()),
@@ -2918,7 +2891,7 @@ async fn test_recall_legacy_note_no_memory_type_returned_as_episodic() {
     // Consumers such as ranking explanations and brain.auto_feedback rely on these fields.
     let legacy_hit = hits
         .iter()
-        .find(|h| h["note_id"].as_str().unwrap_or("") == legacy_id)
+        .find(|h| h["id"].as_str().unwrap_or("") == legacy_id)
         .expect("legacy hit present");
 
     let hit_memory_type = legacy_hit["memory_type"]
@@ -3089,7 +3062,7 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
             )
             .await
             .expect("remember");
-        stored_ids.push(res["note_id"].as_str().unwrap().to_owned());
+        stored_ids.push(res["id"].as_str().unwrap().to_owned());
     }
     let id_rank1 = &stored_ids[0];
     let id_rank3 = &stored_ids[2];
@@ -3130,16 +3103,14 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
         returned.len()
     );
 
-    let returned_id = returned[0]["note_id"].as_str().expect("note_id present");
+    let returned_id = returned[0]["id"].as_str().expect("note_id present");
     assert_eq!(
         returned_id, id_rank1,
         "#94 rank-order: the single returned note must be rank #1 ({id_rank1}), got {returned_id}"
     );
 
     // rank #3 must not appear — its presence is the rank-skip signature.
-    let has_rank3 = returned
-        .iter()
-        .any(|r| r["note_id"].as_str() == Some(id_rank3));
+    let has_rank3 = returned.iter().any(|r| r["id"].as_str() == Some(id_rank3));
     assert!(
         !has_rank3,
         "#94 rank-order: rank #3 ({id_rank3}) must NOT be in results — \

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -792,14 +792,14 @@ impl VerbRegistry {
                     .with_outcome(EventOutcome::Success)
                     .with_duration_us(dispatch_us);
 
-                    // For recall verbs: extract the first result's note_id as
+                    // For recall verbs: extract the first result's id as
                     // target_id so the brain temporal posterior can observe
                     // real hit/miss and latency (fix for codex P12 Major).
                     if verb == "memory.recall" {
                         let first_note_id = ok_val
                             .as_array()
                             .and_then(|arr| arr.first())
-                            .and_then(|v| v.get("note_id"))
+                            .and_then(|v| v.get("id"))
                             .and_then(|v| v.as_str())
                             .and_then(|s| s.parse::<uuid::Uuid>().ok());
                         if let Some(note_id) = first_note_id {

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -104,7 +104,7 @@ memory.remember(content, memory_type?, salience?, decay_factor?, source_id?, tag
 Semantically equivalent to:
 
 ```
-1. note_id = create(
+1. id = create(
      kind = "memory",
      content = content,
      salience = <salience | (episodic: 0.3, semantic: 0.5)>,
@@ -115,7 +115,7 @@ Semantically equivalent to:
    )
 
 2. if source_id is provided:
-     link(source_id = note_id, target_id = source_id, relation = "annotates")
+     link(source_id = id, target_id = source_id, relation = "annotates")
 ```
 
 The handler validates: (a) `content` non-empty, (b) `memory_type ∈ {episodic, semantic}`

--- a/docs/adr/ADR-031-multi-engine-retrieval.md
+++ b/docs/adr/ADR-031-multi-engine-retrieval.md
@@ -450,11 +450,11 @@ async fn handle_recall(args):
 ```text
 async fn handle_remember(args):
     registry = self.runtime.embedders()
-    note_id  = self.runtime.create_note(args.content, ...)
+    id = self.runtime.create_note(args.content, ...)
 
     embeddings = registry.embed_document_all(args.content)  # document_prefix applied per D1
     for (cfg, vector) in embeddings:
-        self.runtime.upsert_vector(args.namespace, cfg.name, note_id, vector)
+        self.runtime.upsert_vector(args.namespace, cfg.name, id, vector)
 ```
 
 **Per-engine normalization** (`noise_floor`, `max_similarity`, `threshold` from `EngineConfig`):

--- a/docs/adr/ADR-033-recall-pipeline.md
+++ b/docs/adr/ADR-033-recall-pipeline.md
@@ -98,14 +98,14 @@ The recall pipeline decomposes into shipped subhandlers. `memory.recall` is the 
 The debug/calibration handlers are registered as `Visibility::Subhandler`; MCP blocks normal
 calls to subhandlers and exposes help only.
 
-| Handler                    | Visibility | Input                                  | Output                                                                   |
-| -------------------------- | ---------- | -------------------------------------- | ------------------------------------------------------------------------ |
-| `memory.recall_embed`      | Subhandler | `{query: str}`                         | `{embeddings: [{engine_id, model_id, vector: [f32]}]}`                   |
-| `memory.recall_candidates` | Subhandler | `{query, namespace, limit}`            | `{text_hits, vector_hits_by_engine}`                                     |
-| `memory.recall_fuse`       | Subhandler | `{text_hits, vector_hits, strategy}`   | `{fused_hits}`                                                           |
-| `memory.recall_rerank`     | Subhandler | `{candidates, config?}`                | `{reranked: [{note_id, rerank_scores, rerank_score}], active_rerankers}` |
-| `memory.recall_score`      | Subhandler | `{fused_hits, reranked?, config}`      | `{scored: [{id, score, breakdown}]}`                                     |
-| `memory.recall`            | **Verb**   | `{query, namespace?, limit?, config?}` | `{results}`                                                              |
+| Handler                    | Visibility | Input                                  | Output                                                              |
+| -------------------------- | ---------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `memory.recall_embed`      | Subhandler | `{query: str}`                         | `{embeddings: [{engine_id, model_id, vector: [f32]}]}`              |
+| `memory.recall_candidates` | Subhandler | `{query, namespace, limit}`            | `{text_hits, vector_hits_by_engine}`                                |
+| `memory.recall_fuse`       | Subhandler | `{text_hits, vector_hits, strategy}`   | `{fused_hits}`                                                      |
+| `memory.recall_rerank`     | Subhandler | `{candidates, config?}`                | `{reranked: [{id, rerank_scores, rerank_score}], active_rerankers}` |
+| `memory.recall_score`      | Subhandler | `{fused_hits, reranked?, config}`      | `{scored: [{id, score, breakdown}]}`                                |
+| `memory.recall`            | **Verb**   | `{query, namespace?, limit?, config?}` | `{results}`                                                         |
 
 `memory.recall_embed` generates one embedding **per active engine** — the multi-engine
 fan-out from ADR-031. The output is a list of `{engine_id, model_id, vector}` triples,
@@ -119,7 +119,7 @@ The `memory.recall_score` handler returns a score breakdown per result:
 
 ```json
 {
-  "note_id": "abc...",
+  "id": "abc...",
   "score": 0.42,
   "breakdown": {
     "relevance": 0.35,
@@ -302,7 +302,11 @@ _model class_ (e.g., cross-encoder, graph-proximate) would require a new ADR.
 
 **`recall.rerank` subhandler:** Accepts fused candidates (with optional `fused_score`,
 `salience`, `age_days`, `decay_factor`, `temporal`, `source` fields) plus a `config`
-override. Returns `{reranked: [{note_id, rerank_scores, rerank_score}], active_rerankers}`.
+override. Returns `{reranked: [{id, rerank_scores, rerank_score}], active_rerankers}`.
+
+Amendment (2026-06-14): the recall/rerank hit identity field was renamed `note_id` → `id` for
+cross-verb coherence — `create`, `remember`, and `recall` all return `id` for the record. No
+field collision (annotation-edge ids remain `edge_id`). Clean break, no dual-emit.
 When weights are empty, returns candidates with empty `rerank_scores` (pass-through).
 
 ### 6.3 Multi-model vector fusion (v024/multi-vector-fusion)
@@ -336,7 +340,7 @@ When `recall` is called without an explicit `embedding_model` parameter:
    strategy behavior (RRF and Weighted do not apply their full algorithm to a single-source
    input — `fuse_search_results` returns raw scores when `sources.len() == 1`).
 
-**Wire shape is unchanged:** `recall` always returns `[{note_id, score, ...}]`. The
+**Wire shape:** `recall` always returns `[{id, score, ...}]`. The
 per-model vector breakdown is only exposed via the `recall.candidates` sub-handler's
 `vector_candidates_per_model` field, which appears only when two or more models are active.
 

--- a/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
+++ b/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
@@ -82,9 +82,9 @@ the final `rank_score` directly. It is not further blended with RRF/salience/tem
 
 The shipped memory-pack subhandler is:
 
-| Handler                | Visibility | Input                   | Output                                                                   |
-| ---------------------- | ---------- | ----------------------- | ------------------------------------------------------------------------ |
-| `memory.recall_rerank` | Subhandler | `{candidates, config?}` | `{reranked: [{note_id, rerank_scores, rerank_score}], active_rerankers}` |
+| Handler                | Visibility | Input                   | Output                                                              |
+| ---------------------- | ---------- | ----------------------- | ------------------------------------------------------------------- |
+| `memory.recall_rerank` | Subhandler | `{candidates, config?}` | `{reranked: [{id, rerank_scores, rerank_score}], active_rerankers}` |
 
 It is an internal feature-weight subhandler. It does not accept `hook`, `profile_id`, or
 `model_id`, and it does not return `hook_applied`.

--- a/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
+++ b/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
@@ -86,6 +86,10 @@ The shipped memory-pack subhandler is:
 | ---------------------- | ---------- | ----------------------- | ------------------------------------------------------------------- |
 | `memory.recall_rerank` | Subhandler | `{candidates, config?}` | `{reranked: [{id, rerank_scores, rerank_score}], active_rerankers}` |
 
+Amendment (2026-06-14): the recall/rerank hit identity field was renamed `note_id` → `id` for
+cross-verb coherence — `create`, `remember`, and `recall` all return `id` for the record. Clean
+break, no dual-emit. No collision — annotation-edge ids remain `edge_id`.
+
 It is an internal feature-weight subhandler. It does not accept `hook`, `profile_id`, or
 `model_id`, and it does not return `hook_applied`.
 

--- a/marketplace/brain/skills/tune/SKILL.md
+++ b/marketplace/brain/skills/tune/SKILL.md
@@ -12,19 +12,19 @@ drifted and you want to return to the prior.
 
 ### 1. Emit explicit feedback on a recalled memory
 
-After a `recall` call returns a memory, note its `note_id` from the result. Emit feedback with one
+After a `recall` call returns a memory, note its `id` from the result. Emit feedback with one
 of eight signals:
 
-| Signal | Meaning |
-| --- | --- |
-| `useful` | Memory was relevant and helpful |
-| `not_useful` | Memory was returned but unhelpful |
-| `wrong` | Memory content was incorrect (strongest negative) |
-| `explicit_positive` | Strong positive signal (equivalent to `useful`) |
+| Signal              | Meaning                                             |
+| ------------------- | --------------------------------------------------- |
+| `useful`            | Memory was relevant and helpful                     |
+| `not_useful`        | Memory was returned but unhelpful                   |
+| `wrong`             | Memory content was incorrect (strongest negative)   |
+| `explicit_positive` | Strong positive signal (equivalent to `useful`)     |
 | `explicit_negative` | Strong negative signal (equivalent to `not_useful`) |
-| `implicit_positive` | Weak positive signal inferred from agent behavior |
-| `implicit_negative` | Weak negative signal inferred from agent behavior |
-| `correction` | Memory was returned with errors that were corrected |
+| `implicit_positive` | Weak positive signal inferred from agent behavior   |
+| `implicit_negative` | Weak negative signal inferred from agent behavior   |
+| `correction`        | Memory was returned with errors that were corrected |
 
 `target_id` must be the **full UUID** of the memory note — short prefix IDs are not accepted.
 
@@ -112,7 +112,7 @@ prior (~0.7 for relevance, ~0.2 for salience, ~0.1 for temporal with the default
 ## Anti-patterns
 
 - **Using a short UUID prefix for `target_id`.** `brain.feedback` requires the full UUID — short
-  prefix IDs are rejected. Use the complete `note_id` from the recall response.
+  prefix IDs are rejected. Use the complete `id` from the recall response.
 - **Resetting during an active session.** Reset discards posteriors accumulated during the current
   session. Use it between sessions or after deliberate behavioral experiments.
 - **Over-emitting wrong signal.** A single `wrong` event is sufficient; duplicate signals on the

--- a/marketplace/memory/skills/recall/SKILL.md
+++ b/marketplace/memory/skills/recall/SKILL.md
@@ -49,7 +49,7 @@ All three score fields are bounded to `[0.0, 1.0]`. Pass `include_breakdown=true
 per-component `breakdown` field (relevance, salience contributions, temporal).
 
 Treat higher-ranked hits as more relevant, not automatically true. When a hit matters, carry forward
-its `note_id` in your notes or response so it can be inspected later.
+its `id` in your notes or response so it can be inspected later.
 
 ### 4. Adjust thresholds only after the first pass
 

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -548,7 +548,7 @@ def test_note_supersession(proc: subprocess.Popen) -> None:
         "query": "unique_token_abc",
         "limit": 20,
     })
-    hit_note_ids = [h.get("id", h.get("note_id", "")) for h in hits]
+    hit_note_ids = [h.get("id", "") for h in hits]
 
     assert old_id not in hit_note_ids, (
         f"Superseded note (old_id={old_id}) should be excluded from search, "

--- a/tests/khive-contract/tests/test_adr_019_note_kind.py
+++ b/tests/khive-contract/tests/test_adr_019_note_kind.py
@@ -155,7 +155,7 @@ def test_note_supersession_search_excludes_old_but_get_keeps_both(
         "limit": 20,
         "namespace": temp_namespace,
     })
-    hit_ids = [h.get("id", h.get("note_id", "")) for h in hits]
+    hit_ids = [h.get("id", "") for h in hits]
 
     assert old_id not in hit_ids, (
         f"Superseded note (old_id={old_id}) should be excluded from search, "

--- a/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
+++ b/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
@@ -174,7 +174,7 @@ def test_pack_product_verbs_are_reachable_when_loaded(
         "namespace": ns,
     })
     assert mem is not None, "memory.remember must return a result"
-    mem_id = mem.get("id") or mem.get("note_id")
+    mem_id = mem["id"]
     assert mem_id, f"memory.remember must return an id: {mem}"
 
     # memory.recall

--- a/tests/khive-contract/tests/test_smoke.py
+++ b/tests/khive-contract/tests/test_smoke.py
@@ -382,7 +382,7 @@ def test_memory_smoke(
         "namespace": ns,
     })
     assert mem is not None, "memory.remember must return a result"
-    mem_id = mem.get("id") or mem.get("note_id")
+    mem_id = mem["id"]
     assert mem_id, f"memory.remember must return an id: {mem}"
 
     # remember second memory

--- a/tests/khive-contract/tune/grid_search.py
+++ b/tests/khive-contract/tune/grid_search.py
@@ -120,9 +120,9 @@ def setup_session(
             args["tags"] = mem["tags"]
 
         result = session.verb("remember", args)
-        note_id = result.get("note_id") or result.get("id") if result else None
+        note_id = result["id"] if result else None
         if not note_id:
-            raise RuntimeError(f"remember() returned no note_id for memory {i}: {result!r}")
+            raise RuntimeError(f"remember() returned no id for memory {i}: {result!r}")
 
         if version == "v2":
             corpus_key = mem.get("id", str(i))
@@ -223,7 +223,7 @@ def evaluate_config(
         retrieved_ids: list[str] = []
         if isinstance(hits, list):
             for h in hits:
-                nid = h.get("note_id") or h.get("id") if isinstance(h, dict) else None
+                nid = h.get("id") if isinstance(h, dict) else None
                 if nid:
                     retrieved_ids.append(str(nid))
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -503,7 +503,7 @@ def memory_smoke():
             "memory_type": "semantic",
         })
         assert mem is not None, "memory.remember must return a result"
-        mem_id = mem.get("id") or mem.get("note_id")
+        mem_id = mem["id"]
         assert mem_id, f"memory.remember must return an id: {mem}"
         print(f"  [memory] memory.remember — id {str(mem_id)[:8]}...")
 


### PR DESCRIPTION
## Summary

- **Coherence fix**: `memory.remember` was returning `note_id` for the record identity while `create` and all other write verbs return `id`. This renames the JSON key `note_id` → `id` across all memory pack wire results: `memory.remember`, `memory.recall`, `recall.candidates`, `recall.fuse`, and `recall.rerank`.
- **No field collision**: `edge_id` (the annotates-edge returned by `remember` when `source_id` is given) is a distinct semantic field and is unchanged. There was no pre-existing `id` key in any of these responses.
- **Clean break**: no dual-emit, no backwards-compat shim. All readers (brain auto-feedback extraction in pack.rs, top-id extraction in recall.rs, rerank input reader in sub_handlers.rs, all tests) are updated in lockstep.
- **ADR contract update**: ADR-033 and ADR-042 wire shape tables updated; ADR-033 §6.2 receives a dated amendment note. ADR-021 pseudocode variable renamed. SKILL.md updated.
- **AGENTS.md**: adds "Efficient batching and round-trip reduction" section explaining `[…]` parallel batch and `|`/`$prev` sequential chain forms with decision table and examples.

## No-collision analysis

`NoteSearchHit` in `crates/khive-runtime/src/operations.rs` (line 47-53) has a `note_id: Uuid` field but only `#[derive(Clone, Debug)]` — no `Serialize`. It is internal only and is **not changed**.

`BrainSignal::RecallHit` in `khive-brain-core` uses `target_id`, not `note_id`, on the wire. Not changed.

`edge_id` in `memory.remember` response stays: it identifies the `annotates` edge, not the memory note.

## Gate results

All run with an isolated `CARGO_TARGET_DIR`:

- TEST_RC=0 (all tests pass — khive-pack-memory + khive-runtime)
- CLIPPY_RC=0 (`-D warnings`, no exceptions)
- FMT_RC=0 (cargo fmt --check)
- DENO_RC=0 (5 markdown files formatted)
- GREP_RC=1 (no `"note_id"` remains in `crates/khive-pack-memory/src` or `crates/khive-runtime/src/pack.rs`)

## Files changed (18 files, 2 commits)

**Commit 1** — Rust + ADR + marketplace + tests:
- `crates/khive-pack-memory/src/handlers/remember.rs` — wire output `note_id` → `id`
- `crates/khive-pack-memory/src/handlers/recall.rs` — wire output + top-id reader (2 sites)
- `crates/khive-pack-memory/src/handlers/sub_handlers.rs` — candidates (3 sites), fuse (1), rerank reader+output (2)
- `crates/khive-runtime/src/pack.rs` — brain auto-feedback extraction comment + `.get("id")`
- `crates/khive-pack-memory/src/handlers/tests.rs` — per-model verbose hit json + 2 assert accesses
- `crates/khive-pack-memory/tests/integration.rs` — ~48 JSON key accesses + 2 fixture objects
- `crates/khive-pack-memory/benches/e2e_recall.rs` — id extraction
- `docs/adr/ADR-033-recall-pipeline.md` — wire shape table, score breakdown example, §6.2 note, §6.3 sentence, amendment note
- `docs/adr/ADR-042-local-rerank-via-lattice-inference.md` — wire shape table
- `docs/adr/ADR-021-memory-pack.md` — pseudocode variable
- `marketplace/brain/skills/tune/SKILL.md` — two references
- `tests/smoke_test.py`, `tests/contract_test.py`, `tests/khive-contract/tests/test_adr_023_verb_taxonomy.py`, `tests/khive-contract/tests/test_smoke.py`, `tests/khive-contract/tests/test_adr_019_note_kind.py`, `tests/khive-contract/tune/grid_search.py` — strict on `id`

**Commit 2** — AGENTS.md: new "Efficient batching and round-trip reduction" section

Held pending maintainer review before merge.