### PR TITLE
docs(adr): amend 049/026/003 for single-binary kkernel topology (#12)

### DIFF
--- a/docs/adr/ADR-003-system-architecture.md
+++ b/docs/adr/ADR-003-system-architecture.md
@@ -480,3 +480,55 @@ boundary tight and avoids adding a public surface for internal plumbing.
   When they differ, ADR-003 wins and CLAUDE.md should be corrected.
 - MCP wire protocol is unchanged. Agents see the same `request` tool.
 - The `request` DSL syntax is unchanged.
+
+## Amendment (2026-06-14): single-binary kkernel topology
+
+The convergence path described in this ADR (Binary architecture section, "Convergence
+path") is now complete. The following topology statements are updated to reflect shipped
+reality.
+
+**`khive-mcp` is now a library**: The ADR's crate responsibility table (line 205) lists
+`khive-mcp` as "the agent binary" owning "MCP stdio transport, gate enforcement,
+request/response adaptation." In the shipped codebase `khive-mcp` is a library crate with
+no binary of its own. Its `Cargo.toml` carries no `[[bin]]` section and its description
+reads "khive MCP server library — served via the kkernel binary." Its `lib.rs` (line 4)
+documents: "The binary frontend is `kkernel mcp`; this crate ships no binary of its own."
+
+**Crate dependency diagram correction**: The "Binary architecture" dependency diagram
+(lines 88-98) shows `khive-mcp` as a peer binary with its own `main`. In the shipped
+layout `khive-mcp` is a library dependency of `kkernel`. The `kkernel` crate's
+`Cargo.toml` lists `khive-mcp = { path = "../khive-mcp" }` as a dependency, and
+`kkernel/src/main.rs` (line 211) delegates `Command::Mcp(a)` directly to
+`khive_mcp::serve::run(a, &khive_mcp::transport::TransportRegistry::with_builtins())`.
+
+**Single shipped binary**: The "End state" bullet in the Binary architecture section
+(line 63) describes the end state as "`kkernel` is the single Rust binary." That end
+state is now current. The binary is declared in `crates/kkernel/Cargo.toml`
+(`[[bin]] name = "kkernel"`, `path = "src/main.rs"`). The subcommand surface matches
+the end-state description: `kkernel mcp` (MCP stdio server), `kkernel sync`, `kkernel
+pack list`, `kkernel db migrate`, plus `kkernel exec` (verb DSL from CLI) and
+`kkernel reindex` (embedding rebuild).
+
+**Dispatch model diagram correction**: The Dispatch model diagram (line 113) lists
+"Binary (kkernel mcp / khive-mcp)" as the top-level dispatch entry. The current shipped
+entry point is `kkernel mcp` only; `khive-mcp` no longer acts as a standalone binary
+entry point.
+
+**Trust boundary table correction**: The Validation Boundary table (line 237) assigns
+"Gate enforcement" to "`khive-mcp` (agent binary)". Gate enforcement is still the
+responsibility of the MCP-serving mode; the correct owner is `kkernel mcp` (the `mcp`
+subcommand of `kkernel`), implemented in the `khive-mcp` library crate consumed by
+`kkernel`.
+
+**Negative consequence correction**: The Negative consequences note (line 467) states
+"Two binaries (three during convergence)." Convergence is complete: there is one shipped
+binary (`kkernel`). The remaining note that "convergence path reduces to one binary with
+multiple modes" describes the current state.
+
+**Future layer table correction**: The Future Layer Contract table (line 325) lists
+`khive-mcp` as "current (deprecating)." The deprecation is complete. `khive-mcp` is now
+a library; only `kkernel mcp` appears in user-facing documentation and MCP configurations.
+
+Rationale: the kkernel unification merged the agent-facing MCP transport into `kkernel`
+as a library-backed subcommand, completing the three-step convergence sequence described
+in this ADR and eliminating `khive-mcp` as a standalone binary.

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -290,3 +290,34 @@ users install once and run constantly, install size is a real friction point.
 - `cargo-zigbuild` — https://github.com/rust-cross/cargo-zigbuild
 - Apple notarization — `xcrun notarytool`
 - Windows Authenticode signing
+
+## Amendment (2026-06-14): single-binary kkernel topology
+
+The ADR-003 convergence path is now complete. The following corrections apply to the
+packaging description above.
+
+**Subpackage binary count**: The Decision section (line 62) states "Each subpackage ships
+exactly two binaries: `kkernel` and `khive-mcp` for the matching platform." This is no
+longer accurate. `khive-mcp` is now a library crate with no shipped binary. Its
+`Cargo.toml` declares no `[[bin]]` section; its description reads "khive MCP server
+library — served via the kkernel binary." Each platform subpackage ships one binary:
+`kkernel`.
+
+**Build pipeline step correction**: The "Build / release pipeline" table (line 115) lists
+step 1 as `cargo build --release --target <triple> -p kkernel -p khive-mcp`. The correct
+command builds only `-p kkernel`; building `-p khive-mcp` produces no binary artifact
+because the crate is library-only.
+
+**`khive-mcp` shim**: The sentence "After ADR-003's convergence to single-binary, each
+subpackage will ship one binary (`kkernel`) and the `khive-mcp` shim" (line 63) describes
+the now-complete state. The `khive-mcp` shim is not a separate file distributed in the
+subpackage; `khive-mcp` functionality is reached via the `kkernel mcp` subcommand. Any
+backward-compatibility shim (if shipped) is a thin wrapper that delegates to `kkernel mcp`.
+
+**Negative consequences correction**: The Negative section (line 253) states "Six native
+binaries built per release, two per binary set (`kkernel` + `khive-mcp`) pre-convergence."
+Convergence is complete: each release builds one binary per platform (`kkernel`), not two.
+
+Rationale: the kkernel unification absorbed `khive-mcp` as a library crate, reducing the
+shipped artifact to a single binary per platform. Build pipelines and subpackage manifests
+should reference `kkernel` only.

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -147,3 +147,44 @@ Warm becomes **non-blocking**, benefiting both modes:
 - [ADR-031](ADR-031-multi-engine-retrieval.md) — `PackRuntime::warm()` / `register_embedders` hooks
 - [ADR-047](ADR-047-knowledge-pack.md), ADR-033 family — knowledge search + Vamana ANN
 - Pre-OSS reference: `khive-internal/apps/cli/src/server/` (daemon loop), `src/daemon.rs` (client)
+
+## Amendment (2026-06-14): single-binary kkernel topology
+
+The convergence path described in ADR-003 is now complete. The shipped binary is `kkernel`,
+not `khive-mcp`. The following topology corrections apply to this ADR.
+
+**Binary name**: The ADR's Context section (line 9) refers to "the MCP surface ships as a
+single binary, `khive-mcp`" and describes `.mcp.json → command: khive-mcp`. The shipped
+configuration is `command: kkernel` with subcommand `mcp`. The `kkernel` binary is declared
+in `crates/kkernel/Cargo.toml` (`[[bin]] name = "kkernel"`, path = `src/main.rs`).
+
+**`khive-mcp` is a library**: `khive-mcp` ships no binary of its own. Its `Cargo.toml`
+carries no `[[bin]]` section and its description reads "khive MCP server library — served
+via the kkernel binary." Its `lib.rs` (line 4) documents: "The binary frontend is
+`kkernel mcp`; this crate ships no binary of its own."
+
+**Daemon spawn**: The Decision section (line 39) describes the daemon flag as
+`khive-mcp --daemon`. In the shipped code the daemon is spawned by `spawn_daemon()` in
+`crates/khive-mcp/src/daemon.rs` (lines 87-104). The function calls
+`std::env::current_exe()` to obtain the running binary path (which resolves to `kkernel`),
+then appends the subcommand arguments `["mcp", "--daemon"]`. The MCP entry point
+`crates/khive-mcp/src/serve.rs` (line 17) is driven by `kkernel mcp` as confirmed by the
+`run(args, registry)` function and the comment on line 3: "This is the bootstrap that the
+`kkernel mcp` subcommand drives."
+
+**Section 1 corrected description**: "One binary, two modes" remains accurate in intent,
+but the binary is `kkernel`, not `khive-mcp`. The two modes are `kkernel mcp` (stdio) and
+`kkernel mcp --daemon` (Unix socket server).
+
+**Diagram correction**: The ASCII diagram in Section 2 should read:
+
+```
+kkernel mcp (stdio, thin)              kkernel mcp --daemon (long-lived)
+  request(ops=...)  --frame-->  warm VerbRegistry.dispatch --> result
+                    <--frame---
+```
+
+Rationale: the kkernel unification (ADR-003 convergence path, now complete) absorbed
+`khive-mcp` as a library, making `kkernel` the sole shipped Rust binary. All MCP
+configurations, daemon-spawn logic, and user-facing documentation should reference
+`kkernel mcp` and `kkernel mcp --daemon` instead of `khive-mcp` and `khive-mcp --daemon`.


### PR DESCRIPTION
## Summary

- ADR-049: corrects binary name from `khive-mcp` to `kkernel`, updates daemon spawn description from `khive-mcp --daemon` to `kkernel mcp --daemon`, and fixes the thin-client ASCII diagram to show `kkernel mcp` as both the stdio and daemon mode
- ADR-026: corrects subpackage binary count (one binary per platform, not two), fixes the build pipeline `-p` flag, and updates the "pre-convergence / post-convergence" language to reflect the completed state
- ADR-003: corrects `khive-mcp` from "agent binary" to "library crate consumed by kkernel", updates the crate dependency diagram, dispatch model, trust boundary table, future layer table, and negative consequence note to match the shipped single-binary topology

All amendments are appended as dated `## Amendment` sections. No original ADR text was altered or deleted.

## Code evidence (file:line)

| Claim | Evidence |
| --- | --- |
| `kkernel` is the shipped binary | `crates/kkernel/Cargo.toml` `[[bin]] name = "kkernel"` |
| `khive-mcp` has no binary | `crates/khive-mcp/Cargo.toml` — no `[[bin]]` section; description "khive MCP server library" |
| `khive-mcp` lib.rs documents library-only role | `crates/khive-mcp/src/lib.rs:4` |
| `kkernel mcp` subcommand routes to `khive_mcp::serve::run` | `crates/kkernel/src/main.rs:211` |
| Daemon spawn uses `current_exe()` + `["mcp", "--daemon"]` | `crates/khive-mcp/src/daemon.rs:88-96` |
| `serve.rs` is driven by `kkernel mcp` | `crates/khive-mcp/src/serve.rs:3` |

## Test plan

- [ ] All three amended files pass `deno fmt` (FMT_RC=0, confirmed)
- [ ] No original ADR text was deleted (amendments are additive append-only sections)
- [ ] Pre-commit hooks passed (confirmed in commit output)