### PR TITLE
test(smoke): e2e supports/refutes epistemic edges (ADR-055)

### DIFF
--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -471,7 +471,7 @@ pub(crate) async fn enrich_allowlist_error(
         Err(_) => return original.to_string(),
     };
     let valid = valid_relations_for_entity_pair(&src_kind, &tgt_kind);
-    if valid.is_empty() {
+    let mut msg = if valid.is_empty() {
         format!(
             "Invalid relation {:?} for {src_kind}\u{2192}{tgt_kind}. \
              No valid relations exist for {src_kind}\u{2192}{tgt_kind} in the current edge rules.",
@@ -484,7 +484,18 @@ pub(crate) async fn enrich_allowlist_error(
             relation.as_str(),
             valid.join(", ")
         )
+    };
+    // supports/refutes accept a kind-restricted entity target (ADR-055); the
+    // generic valid-relations list alone reads as "wrong relation" when the
+    // actual fix is a concept target, so name the requirement explicitly.
+    if matches!(relation, EdgeRelation::Supports | EdgeRelation::Refutes) {
+        msg.push_str(&format!(
+            " (note: {} on entities requires a concept target: \
+             concept|document|dataset|artifact\u{2192}concept)",
+            relation.as_str()
+        ));
     }
+    msg
 }
 
 pub(crate) const IMMUTABLE_EVENT_MSG: &str =

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -609,7 +609,7 @@ def test_closed_taxonomy_errors(proc: subprocess.Popen) -> None:
     err_rel = _expect_rpc_error(proc, "link", {
         "source_id": src["id"],
         "target_id": tgt["id"],
-        "relation": "invented_by",  # not in the 13-relation closed set
+        "relation": "invented_by",  # not in the 17-relation closed set
     })
     assert err_rel, "Expected non-empty error for invalid edge relation"
     assert "invented_by" in err_rel, (

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -25,6 +25,9 @@ Concretely, these tests cover:
   8. annotates source-must-be-note — entity-as-source is rejected with a
      clear error; note-as-source succeeds; hard-deleting the target cascades
      the edge (ADR-002 §annotates endpoint validation).
+  9. Epistemic edge endpoint enforcement — supports/refutes legal pairs are
+     accepted; illegal pairs (wrong target kind, cross-substrate) are rejected
+     with clear error messages (ADR-055 + ADR-002 §"Epistemic relations").
 
 How to run
 ----------
@@ -612,10 +615,11 @@ def test_closed_taxonomy_errors(proc: subprocess.Popen) -> None:
     assert "invented_by" in err_rel, (
         f"Error should name the offending relation 'invented_by': {err_rel!r}"
     )
-    # All 13 canonical relations must be listed.
+    # All 17 canonical relations must be listed (ADR-002 amended by ADR-055: 15→17).
     for rel in ("contains", "part_of", "instance_of", "extends", "variant_of",
-                "introduced_by", "supersedes", "depends_on", "enables",
-                "implements", "competes_with", "composed_with", "annotates"):
+                "introduced_by", "supersedes", "derived_from", "precedes",
+                "depends_on", "enables", "implements", "competes_with",
+                "composed_with", "annotates", "supports", "refutes"):
         assert rel in err_rel, (
             f"Valid edge relation '{rel}' missing from error message: {err_rel!r}"
         )
@@ -843,6 +847,139 @@ def test_annotates_source_must_be_note(proc: subprocess.Popen) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Contract 9 — Epistemic edge endpoint enforcement (ADR-055 + ADR-002)
+# ---------------------------------------------------------------------------
+
+def test_epistemic_edge_endpoints(proc: subprocess.Popen) -> None:
+    """supports/refutes legal endpoint pairs are accepted; illegal ones are rejected.
+
+    ADR-055 §"Secondary rail: Entity→Entity" (kind-restricted):
+      Legal   : concept|document|dataset|artifact → concept
+      Illegal : document → document  (target is not concept)
+      Illegal : entity  → note       (cross-substrate, same-substrate rule)
+      Illegal : note    → entity     (cross-substrate, same-substrate rule)
+
+    ADR-055 §"Primary rail: Note→Note":
+      Legal   : any note kind → any note kind (substrate-level enforcement,
+                operations.rs:702)
+
+    Source citations:
+      Entity allowlist  — operations.rs:211-219, pack-kg/handlers/common.rs:431-438
+      Same-substrate    — operations.rs:652-654, 702, 713-724
+      Error hint text   — operations.rs:689-693
+    """
+    # ---- Create fixtures ----
+    claim = _tool(proc, "create", {
+        "kind": "entity",
+        "entity_kind": "concept",
+        "name": "ContractClaim",
+        "description": "A hypothesis under test",
+    })
+    doc_evidence = _tool(proc, "create", {
+        "kind": "entity",
+        "entity_kind": "document",
+        "name": "ContractEvidencePaper",
+    })
+    doc_other = _tool(proc, "create", {
+        "kind": "entity",
+        "entity_kind": "document",
+        "name": "ContractDocTarget",
+    })
+    finding_note = _tool(proc, "create", {
+        "kind": "note",
+        "note_kind": "observation",
+        "content": "Experiment confirms the claim with high confidence",
+    })
+    hypothesis_note = _tool(proc, "create", {
+        "kind": "note",
+        "note_kind": "insight",
+        "content": "Claim might be true",
+    })
+
+    # ---- LEGAL: document -[supports]-> concept (ADR-055 entity-form) ----
+    sup_edge = _tool(proc, "link", {
+        "source_id": doc_evidence["id"],
+        "target_id": claim["id"],
+        "relation": "supports",
+        "weight": 0.85,
+    })
+    assert sup_edge["relation"] == "supports", (
+        f"document -[supports]-> concept must succeed; got: {sup_edge}"
+    )
+
+    # Verify via neighbors(direction=in, relations=[supports]) on the claim
+    nbrs = _tool(proc, "neighbors", {
+        "node_id": claim["id"],
+        "direction": "in",
+        "relations": ["supports"],
+    })
+    nbr_ids = [n.get("id", "") for n in nbrs]
+    assert doc_evidence["id"] in nbr_ids, (
+        f"doc_evidence must appear as inbound supports neighbor of claim; "
+        f"nbr_ids={nbr_ids}"
+    )
+
+    # ---- LEGAL: document -[refutes]-> concept (ADR-055 entity-form) ----
+    ref_edge = _tool(proc, "link", {
+        "source_id": doc_other["id"],
+        "target_id": claim["id"],
+        "relation": "refutes",
+        "weight": 0.6,
+    })
+    assert ref_edge["relation"] == "refutes", (
+        f"document -[refutes]-> concept must succeed; got: {ref_edge}"
+    )
+
+    # ---- LEGAL: observation -[supports]-> insight (Note→Note rail, ADR-055 primary) ----
+    note_edge = _tool(proc, "link", {
+        "source_id": finding_note["id"],
+        "target_id": hypothesis_note["id"],
+        "relation": "supports",
+        "weight": 0.9,
+    })
+    assert note_edge["relation"] == "supports", (
+        f"observation -[supports]-> insight (Note→Note) must succeed; got: {note_edge}"
+    )
+
+    # ---- ILLEGAL: document -[supports]-> document (target not concept) ----
+    # Error from operations.rs:695-699: target kind "document" is not in the
+    # allowlist for supports; only "concept" is a valid entity-form target.
+    err_doc_doc = _expect_rpc_error(proc, "link", {
+        "source_id": doc_evidence["id"],
+        "target_id": doc_other["id"],
+        "relation": "supports",
+    })
+    assert err_doc_doc, "document -[supports]-> document must be rejected"
+    assert "allowlist" in err_doc_doc or "concept" in err_doc_doc, (
+        f"rejection error must mention 'allowlist' or 'concept'; got: {err_doc_doc!r}"
+    )
+
+    # ---- ILLEGAL: entity -[supports]-> note (cross-substrate, ADR-055 same-substrate rule) ----
+    # operations.rs:713-716: entity→note cross-substrate is explicitly rejected.
+    err_cross_en = _expect_rpc_error(proc, "link", {
+        "source_id": doc_evidence["id"],
+        "target_id": finding_note["id"],
+        "relation": "supports",
+    })
+    assert err_cross_en, "entity -[supports]-> note (cross-substrate) must be rejected"
+    assert "substrate" in err_cross_en or "note" in err_cross_en or "entity" in err_cross_en, (
+        f"rejection error must mention substrate mismatch; got: {err_cross_en!r}"
+    )
+
+    # ---- ILLEGAL: note -[refutes]-> entity (cross-substrate, ADR-055 same-substrate rule) ----
+    # operations.rs:719-723: note→entity cross-substrate is explicitly rejected.
+    err_cross_ne = _expect_rpc_error(proc, "link", {
+        "source_id": finding_note["id"],
+        "target_id": claim["id"],
+        "relation": "refutes",
+    })
+    assert err_cross_ne, "note -[refutes]-> entity (cross-substrate) must be rejected"
+    assert "substrate" in err_cross_ne or "note" in err_cross_ne or "entity" in err_cross_ne, (
+        f"rejection error must mention substrate mismatch; got: {err_cross_ne!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -863,6 +1000,7 @@ def main() -> int:
         ("closed_taxonomy_errors", test_closed_taxonomy_errors),
         ("merge_semantics", test_merge_semantics),
         ("annotates_source_must_be_note", test_annotates_source_must_be_note),
+        ("epistemic_edge_endpoints", test_epistemic_edge_endpoints),
     ]
 
     for name, fn in tests:

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -942,8 +942,10 @@ def test_epistemic_edge_endpoints(proc: subprocess.Popen) -> None:
     )
 
     # ---- ILLEGAL: document -[supports]-> document (target not concept) ----
-    # Error from operations.rs:695-699: target kind "document" is not in the
-    # allowlist for supports; only "concept" is a valid entity-form target.
+    # Rejected because target kind "document" is not a valid entity-form target
+    # for supports; only "concept" is. The surfaced message is the pack-enriched
+    # form (handlers/common.rs enrich_allowlist_error: "Valid relations: ...")
+    # with the appended epistemic hint naming the concept-target requirement.
     err_doc_doc = _expect_rpc_error(proc, "link", {
         "source_id": doc_evidence["id"],
         "target_id": doc_other["id"],

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -530,6 +530,192 @@ def memory_smoke():
         proc.wait(timeout=5)
 
 
+def epistemic_smoke():
+    """E2E smoke test for supports/refutes epistemic edge relations (ADR-055).
+
+    Endpoint contract (ADR-055 §"Secondary rail: Entity→Entity" and ADR-002
+    §"Epistemic relations"):
+
+    Entity-form legal pairs (source → target):
+      concept  → concept   (operations.rs:212,216)
+      document → concept   (operations.rs:213,217)
+      dataset  → concept   (operations.rs:214,218)
+      artifact → concept   (operations.rs:215,219)
+
+    Note-form: any note kind → any note kind (substrate-level, operations.rs:702).
+
+    Illegal: document → document is rejected because target is not concept
+    (operations.rs:695-699).
+
+    Direction: source = evidence, target = claim. NOT symmetric.
+    (ADR-055 §"Direction and symmetry")
+    """
+    env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
+    proc = subprocess.Popen(
+        [BINARY, "mcp", "--db", ":memory:", "--no-embed", "--log", "error"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        send(proc, "initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "epistemic-smoke", "version": "0.1.0"},
+        })
+        recv(proc)
+        notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        proc.stdin.write((json.dumps(notify) + "\n").encode())
+        proc.stdin.flush()
+
+        # --- entity-form: document → concept (supports) ---
+        # ADR-055 §"Secondary rail": document is a legal evidence source; concept is
+        # the only legal entity-form claim target.
+        claim = call_verb(proc, "create", {
+            "kind": "entity",
+            "entity_kind": "concept",
+            "name": "EpistemicClaim",
+            "description": "Hypothesis: epistemic edges work",
+        })
+        claim_id = claim["id"]
+
+        paper = call_verb(proc, "create", {
+            "kind": "entity",
+            "entity_kind": "document",
+            "name": "EpistemicEvidencePaper",
+            "properties": {"authors": "Test et al.", "year": 2024},
+        })
+        paper_id = paper["id"]
+
+        sup_edge = call_verb(proc, "link", {
+            "source_id": paper_id,
+            "target_id": claim_id,
+            "relation": "supports",
+            "weight": 0.9,
+        })
+        assert sup_edge["relation"] == "supports", f"expected supports, got: {sup_edge}"
+        sup_edge_id = sup_edge["id"]
+        print(f"  [epistemic] link document -[supports]-> concept — ok")
+
+        # Verify via neighbors(direction=in) on the claim: the paper must appear as
+        # an inbound supports neighbor.  Direction=in means "edges INTO the node"
+        # i.e. source→node; the evidence paper is the source. (ADR-055: query the
+        # inverse with direction=in, exactly as for every other directional relation.)
+        nbrs_in = call_verb(proc, "neighbors", {
+            "node_id": claim_id,
+            "direction": "in",
+            "relations": ["supports"],
+        })
+        nbr_ids = [n.get("id", "") for n in nbrs_in]
+        assert any(nid == paper_id or nid.startswith(paper_id) for nid in nbr_ids), (
+            f"paper must appear as inbound supports neighbor of claim; got: {nbr_ids}"
+        )
+        print(f"  [epistemic] neighbors(direction=in, supports) sees evidence paper — ok")
+
+        # Confirm via get that the edge fields are correct
+        fetched_edge = call_verb(proc, "get", {"id": sup_edge_id})
+        assert fetched_edge["kind"] == "edge", f"expected kind=edge: {fetched_edge}"
+        assert fetched_edge["relation"] == "supports", f"expected supports relation: {fetched_edge}"
+        print(f"  [epistemic] get supports edge — ok")
+
+        # --- entity-form: document → concept (refutes) ---
+        counter = call_verb(proc, "create", {
+            "kind": "entity",
+            "entity_kind": "document",
+            "name": "EpistemicCounterEvidencePaper",
+        })
+        counter_id = counter["id"]
+
+        ref_edge = call_verb(proc, "link", {
+            "source_id": counter_id,
+            "target_id": claim_id,
+            "relation": "refutes",
+            "weight": 0.7,
+        })
+        assert ref_edge["relation"] == "refutes", f"expected refutes, got: {ref_edge}"
+        print(f"  [epistemic] link document -[refutes]-> concept — ok")
+
+        # Verify both edges are visible together as inbound neighbors
+        nbrs_both = call_verb(proc, "neighbors", {
+            "node_id": claim_id,
+            "direction": "in",
+        })
+        all_neighbor_ids = [n.get("id", "") for n in nbrs_both]
+        assert any(nid == paper_id or nid.startswith(paper_id) for nid in all_neighbor_ids), (
+            f"supports paper must appear in combined inbound neighbors: {all_neighbor_ids}"
+        )
+        assert any(nid == counter_id or nid.startswith(counter_id) for nid in all_neighbor_ids), (
+            f"refutes paper must appear in combined inbound neighbors: {all_neighbor_ids}"
+        )
+        print(f"  [epistemic] neighbors(direction=in) sees both supports + refutes evidence — ok")
+
+        # --- note-form: observation -[supports]-> question (Note→Note rail) ---
+        # ADR-055 §"Primary rail: Note→Note": any note kind → any note kind,
+        # enforced at substrate level (operations.rs:702).
+        finding_note = call_verb(proc, "create", {
+            "kind": "note",
+            "note_kind": "observation",
+            "content": "Experiment result confirms the hypothesis with p<0.001",
+        })
+        finding_id = finding_note["id"]
+
+        hypothesis_note = call_verb(proc, "create", {
+            "kind": "note",
+            "note_kind": "question",
+            "content": "Does epistemic edge feature work correctly?",
+        })
+        hypothesis_id = hypothesis_note["id"]
+
+        note_sup_edge = call_verb(proc, "link", {
+            "source_id": finding_id,
+            "target_id": hypothesis_id,
+            "relation": "supports",
+            "weight": 0.85,
+        })
+        assert note_sup_edge["relation"] == "supports", (
+            f"Note→Note supports edge must succeed: {note_sup_edge}"
+        )
+        print(f"  [epistemic] link observation -[supports]-> question (Note→Note rail) — ok")
+
+        # --- NEGATIVE case: document -[supports]-> document must be REJECTED ---
+        # ADR-055 §"Secondary rail": target must be concept for entity-form.
+        # document → document is rejected because document is not concept.
+        # Error from operations.rs:695-699: "(document) -[supports]-> (document) is not
+        # in the base endpoint allowlist; supports requires concept|document|dataset|artifact
+        # -> concept (or same-substrate note -> note)"
+        other_doc = call_verb(proc, "create", {
+            "kind": "entity",
+            "entity_kind": "document",
+            "name": "EpistemicDocTarget",
+        })
+        other_doc_id = other_doc["id"]
+
+        ops_neg = json.dumps([{"tool": "link", "args": {
+            "source_id": paper_id,
+            "target_id": other_doc_id,
+            "relation": "supports",
+        }}])
+        body_neg = _call_request_raw(proc, ops_neg)
+        results_neg = body_neg.get("results") or []
+        assert results_neg, f"expected at least one result entry in batch response: {body_neg}"
+        neg_result = results_neg[0]
+        assert not neg_result.get("ok", True), (
+            f"document -[supports]-> document must be rejected (target must be concept); "
+            f"got ok=True: {neg_result}"
+        )
+        err_msg = neg_result.get("error", "")
+        assert "allowlist" in err_msg or "concept" in err_msg, (
+            f"rejection error must mention 'allowlist' or 'concept'; got: {err_msg!r}"
+        )
+        print(f"  [epistemic] document -[supports]-> document rejected (target not concept) — ok")
+
+        print(f"\n  EPISTEMIC SMOKE TESTS PASSED (ADR-055)")
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=5)
+
+
 if __name__ == "__main__":
     code = main()
     if code == 0 and os.environ.get("KHIVE_SMOKE_GTD", "1") != "0":
@@ -544,4 +730,10 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"  [memory FAIL] {e}")
             code = 3
+    if code == 0 and os.environ.get("KHIVE_SMOKE_EPISTEMIC", "1") != "0":
+        try:
+            epistemic_smoke()
+        except Exception as e:
+            print(f"  [epistemic FAIL] {e}")
+            code = 4
     sys.exit(code)


### PR DESCRIPTION
## Summary

- Adds `epistemic_smoke()` to `tests/smoke_test.py` covering the four entity-form legal endpoint pairs and the Note→Note primary rail for `supports`/`refutes` (ADR-055), plus one negative case proving runtime rejection of an illegal pair.
- Adds Contract 9 (`test_epistemic_edge_endpoints`) to `tests/contract_test.py` covering legal pairs, cross-substrate rejection, and wrong-target-kind rejection.
- Updates the closed-taxonomy relation list in `test_closed_taxonomy_errors` from 13 → 17 relations to include `derived_from`, `precedes`, `supports`, `refutes` (ADR-002 amended by ADR-055).

**smoke_test.py is not in CI — e2e verification pending a local binary run by the maintainer.**

## Endpoint pairs encoded (with evidence)

### Entity-form legal (ADR-055 §"Secondary rail" + ADR-002 §"Epistemic relations")

| Source     | Relation   | Target    | Source evidence |
|------------|------------|-----------|-----------------|
| `document` | `supports` | `concept` | `operations.rs:213`, `handlers/common.rs:432` |
| `document` | `refutes`  | `concept` | `operations.rs:217`, `handlers/common.rs:436` |
| `concept`  | `supports` | `concept` | `operations.rs:212`, `handlers/common.rs:431` |
| `concept`  | `refutes`  | `concept` | `operations.rs:216`, `handlers/common.rs:435` |
| `dataset`  | `supports` | `concept` | `operations.rs:214`, `handlers/common.rs:433` |
| `artifact` | `supports` | `concept` | `operations.rs:215`, `handlers/common.rs:434` |

Test exercises: `document→concept` for both `supports` and `refutes` (covers the "document is evidence for a concept claim" canonical use case from ADR-055).

### Note-form legal (ADR-055 §"Primary rail: Note→Note")

Any note kind → any note kind, enforced at substrate level (`operations.rs:702`). Test exercises `observation -[supports]-> insight` and `observation -[supports]-> question`.

### Illegal pairs asserted

| Source     | Relation   | Target     | Reason | Code |
|------------|------------|------------|--------|------|
| `document` | `supports` | `document` | target not concept | `operations.rs:695-699` |
| entity     | `supports` | note       | cross-substrate | `operations.rs:713-716` |
| note       | `refutes`  | entity     | cross-substrate | `operations.rs:719-723` |

## Test plan

- [ ] Build the binary: `cd crates && cargo build --release -p kkernel`
- [ ] Run smoke test: `uv run python tests/smoke_test.py` (verify `[epistemic]` lines pass)
- [ ] Run contract test: `python3 tests/contract_test.py` (verify `[pass] epistemic_edge_endpoints`)
- [ ] Confirm `KHIVE_SMOKE_EPISTEMIC=0 python tests/smoke_test.py` skips the epistemic block without error