### PR TITLE
fix(knowledge): report real total_events in stats (#80)

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -623,6 +623,16 @@ impl KnowledgeHandlers {
             .await
             .map_err(|e| sql_err("stats finalized", e))?;
 
+        let event_count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'"
+                    .into(),
+                params: vec![SqlValue::Text(ns.clone())],
+                label: None,
+            })
+            .await
+            .map_err(|e| sql_err("stats events", e))?;
+
         let total_atoms = match atom_count {
             Some(SqlValue::Integer(n)) => n,
             _ => 0,
@@ -632,6 +642,10 @@ impl KnowledgeHandlers {
             _ => 0,
         };
         let finalized = match finalized_count {
+            Some(SqlValue::Integer(n)) => n,
+            _ => 0,
+        };
+        let total_events = match event_count {
             Some(SqlValue::Integer(n)) => n,
             _ => 0,
         };
@@ -648,7 +662,7 @@ impl KnowledgeHandlers {
         Ok(json!({
             "total_atoms": total_atoms,
             "total_domains": total_domains,
-            "total_events": 0,
+            "total_events": total_events,
             "eval_coverage": eval_coverage,
             "embedding_coverage": embedding_coverage,
             "namespace": ns,

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -2930,6 +2930,15 @@ async fn stats_total_events_counts_knowledge_verbs() {
     .await
     .expect("upsert atoms second");
 
+    // Non-knowledge verbs in the SAME namespace must NOT be counted: this proves the
+    // `verb LIKE 'knowledge.%'` predicate actually filters, not merely that events
+    // exist. Two of them push a broken (unfiltered) count to >= 4, outside [2, 3].
+    for name in ["evt-entity-a", "evt-entity-b"] {
+        f.dispatch("create", json!({ "kind": "concept", "name": name }))
+            .await
+            .expect("create concept");
+    }
+
     let stats = f
         .dispatch("knowledge.stats", json!({}))
         .await
@@ -2939,8 +2948,12 @@ async fn stats_total_events_counts_knowledge_verbs() {
         .as_i64()
         .expect("total_events must be an integer");
 
+    // 2 = the knowledge.upsert_atoms dispatches; +1 if the knowledge.stats audit event
+    // is recorded before the handler's COUNT runs. The 2 non-knowledge `create` events
+    // must be excluded, so an unfiltered predicate would yield >= 4.
     assert!(
-        total_events >= 2,
-        "total_events must count at least the 2 knowledge.upsert_atoms dispatches; got {total_events}"
+        (2..=3).contains(&total_events),
+        "total_events must count the knowledge.* dispatches but EXCLUDE the 2 \
+         non-knowledge `create` events; expected 2 or 3, got {total_events}"
     );
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -11,7 +11,7 @@
 
 use khive_pack_kg::KgPack;
 use khive_pack_knowledge::KnowledgePack;
-use khive_runtime::{KhiveRuntime, RuntimeError, VerbRegistry, VerbRegistryBuilder};
+use khive_runtime::{KhiveRuntime, Namespace, RuntimeError, VerbRegistry, VerbRegistryBuilder};
 use khive_storage::{SqlStatement, SqlValue};
 use serde_json::{json, Value};
 
@@ -2879,5 +2879,68 @@ async fn explicit_domain_ids_compose_includes_draft_member_atoms() {
     assert!(
         atom_names.contains(&"compose-draft-member"),
         "explicit domain_ids compose must include draft member atoms (caller opted in): {atom_names:?}"
+    );
+}
+
+// ── #80: stats.total_events must count real knowledge events ─────────────────
+
+fn pack_with_events(rt: KhiveRuntime) -> Fixture {
+    let rt_clone = rt.clone();
+    let tok = rt.authorize(Namespace::local()).expect("local token");
+    let event_store = rt.events(&tok).expect("event store");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_event_store(event_store);
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    Fixture {
+        registry,
+        rt: rt_clone,
+    }
+}
+
+#[tokio::test]
+async fn stats_total_events_counts_knowledge_verbs() {
+    let f = pack_with_events(rt());
+
+    let long_content = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu \
+                        nu xi omicron pi rho sigma tau upsilon phi chi psi omega";
+
+    // Dispatch two knowledge verbs so their audit events land in the events table.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                { "slug": "evt-atom-a", "name": "Event Atom A", "content": long_content }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atoms");
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                { "slug": "evt-atom-b", "name": "Event Atom B", "content": long_content }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atoms second");
+
+    let stats = f
+        .dispatch("knowledge.stats", json!({}))
+        .await
+        .expect("stats ok");
+
+    let total_events = stats["total_events"]
+        .as_i64()
+        .expect("total_events must be an integer");
+
+    assert!(
+        total_events >= 2,
+        "total_events must count at least the 2 knowledge.upsert_atoms dispatches; got {total_events}"
     );
 }


### PR DESCRIPTION
## Root cause

`KnowledgeHandlers::stats` in `crates/khive-pack-knowledge/src/knowledge/crud.rs:651` returned a hardcoded literal `"total_events": 0` instead of querying the database. The `events` table (part of the V1 schema baseline — `crates/khive-db/sql/schema.sql:53`) stores one row per verb execution with `verb` and `namespace` columns. Every knowledge verb dispatched through a `VerbRegistry` with an `EventStore` wired in produces a row matching `verb LIKE 'knowledge.%'`.

## Fix

Added a `query_scalar` call in `stats()` immediately after the `finalized_count` query, following the identical pattern used for `atom_count`, `domain_count`, and `finalized_count`:

```rust
let event_count = reader
    .query_scalar(SqlStatement {
        sql: "SELECT COUNT(*) FROM events WHERE namespace = ?1 AND verb LIKE 'knowledge.%'"
            .into(),
        params: vec![SqlValue::Text(ns.clone())],
        label: None,
    })
    .await
    .map_err(|e| sql_err("stats events", e))?;
```

The matched value is extracted with the same `SqlValue::Integer` arm and stored in `total_events`, which replaces the literal `0` in the JSON output.

No schema migration is needed — the `events` table has existed since V1.

## Test

`stats_total_events_counts_knowledge_verbs` in `crates/khive-pack-knowledge/tests/fixes.rs`:

- Creates a `Fixture` with an `EventStore` wired into the `VerbRegistry` (mirrors `pack_with_events` pattern from `khive-pack-kg/tests/integration.rs:56`).
- Dispatches two `knowledge.upsert_atoms` calls, producing two events in the table.
- Asserts `stats["total_events"] >= 2`.

## Gate results

| Leg | RC |
|-----|----|
| `cargo test -p khive-pack-knowledge` | 0 (153 tests, 0 failures) |
| `cargo clippy -p khive-pack-knowledge --all-targets -- -D warnings` | 0 |
| `cargo fmt --all` | 0 |
| `cargo check --workspace` | 0 |