### PR TITLE
fix(recall): multilingual dense routing for non-ASCII queries, split from CJK FTS bypass

### DIFF
--- a/crates/khive-pack-memory/docs/design.md
+++ b/crates/khive-pack-memory/docs/design.md
@@ -55,8 +55,8 @@
   that model is preferred over other registered models.
 - CJK routing only activates when a multilingual model is actually present; detection falls
   back to all registered models when none is found, ensuring CJK queries still return results.
-- The model preference is configured via `ScoringConfig.cjk_model` or by matching registered
-  model names against known multilingual substrings.
+- The model preference is configured via `ScoringConfig.multilingual_model` or by matching
+  registered model names against known multilingual substrings.
 
 ### ADR-002: Edge Ontology — Supersedes Suppression
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -280,8 +280,8 @@ pub(super) struct RecallCandidateSet {
     pub(super) text_hits: Vec<TextSearchHit>,
     /// One entry per embedding model: (model_name, hits).
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
-    /// True when CJK routing was requested AND a multilingual model was found.
-    pub(super) cjk_routed: bool,
+    /// True when multilingual dense routing was requested AND a multilingual model was found.
+    pub(super) multilingual_routed: bool,
 }
 
 impl RecallCandidateSet {
@@ -336,7 +336,10 @@ pub(super) struct CandidateMeta {
 pub(super) struct RecallCandidateParams<'a> {
     pub(super) candidate_limit: u32,
     pub(super) embedding_model: Option<&'a str>,
-    pub(super) is_cjk: bool,
+    /// Route the FTS path through the CJK-bypass tokenizer. Keyed on `contains_cjk`.
+    pub(super) cjk_fts_bypass: bool,
+    /// Route the dense/vector path to the multilingual model. Keyed on `needs_multilingual`.
+    pub(super) use_multilingual: bool,
     pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
     pub(super) snippet_policy: TextSnippetPolicy,
     pub(super) fts_gather: &'a crate::config::RecallFtsGatherConfig,
@@ -345,13 +348,14 @@ pub(super) struct RecallCandidateParams<'a> {
 pub(super) struct RecallVectorCandidateParams<'a> {
     pub(super) candidate_limit: u32,
     pub(super) embedding_model: Option<&'a str>,
-    pub(super) is_cjk: bool,
+    /// Route the dense/vector path to the multilingual model. Keyed on `needs_multilingual`.
+    pub(super) use_multilingual: bool,
     pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
 }
 
 pub(super) struct RecallVectorCandidateResult {
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
-    pub(super) cjk_routed: bool,
+    pub(super) multilingual_routed: bool,
 }
 
 pub(super) fn retrieval_hybrid_config(strategy: &FusionStrategy, limit: usize) -> HybridConfig {
@@ -523,7 +527,7 @@ impl MemoryPack {
         ns: &str,
         candidate_limit: u32,
         snippet_policy: TextSnippetPolicy,
-        is_cjk: bool,
+        cjk_fts_bypass: bool,
         fts_gather: &crate::config::RecallFtsGatherConfig,
     ) -> Result<Vec<TextSearchHit>, RuntimeError> {
         let terms = recall_text_terms(query);
@@ -542,7 +546,7 @@ impl MemoryPack {
                 ns,
                 candidate_limit,
                 snippet_policy,
-                is_cjk,
+                cjk_fts_bypass,
                 fts_gather,
                 &terms,
             )
@@ -583,7 +587,8 @@ impl MemoryPack {
         let RecallCandidateParams {
             candidate_limit,
             embedding_model,
-            is_cjk,
+            cjk_fts_bypass,
+            use_multilingual,
             scoring_cfg,
             snippet_policy,
             fts_gather,
@@ -610,7 +615,7 @@ impl MemoryPack {
                 &primary_ns,
                 candidate_limit,
                 snippet_policy,
-                is_cjk,
+                cjk_fts_bypass,
                 fts_gather,
             );
             let vector_fut = self.collect_recall_vector_hits(
@@ -620,7 +625,7 @@ impl MemoryPack {
                 RecallVectorCandidateParams {
                     candidate_limit,
                     embedding_model,
-                    is_cjk,
+                    use_multilingual,
                     scoring_cfg,
                 },
             );
@@ -629,7 +634,7 @@ impl MemoryPack {
                 namespace: primary_ns,
                 text_hits,
                 vector_hits_per_model: vector_result.vector_hits_per_model,
-                cjk_routed: vector_result.cjk_routed,
+                multilingual_routed: vector_result.multilingual_routed,
             });
         }
 
@@ -653,7 +658,7 @@ impl MemoryPack {
                     ns_str,
                     candidate_limit,
                     snippet_policy,
-                    is_cjk,
+                    cjk_fts_bypass,
                     fts_gather,
                 )
                 .await?;
@@ -668,7 +673,7 @@ impl MemoryPack {
                 RecallVectorCandidateParams {
                     candidate_limit,
                     embedding_model,
-                    is_cjk,
+                    use_multilingual,
                     scoring_cfg,
                 },
             )
@@ -678,7 +683,7 @@ impl MemoryPack {
             namespace: primary_ns,
             text_hits: all_text_hits,
             vector_hits_per_model: vector_result.vector_hits_per_model,
-            cjk_routed: vector_result.cjk_routed,
+            multilingual_routed: vector_result.multilingual_routed,
         })
     }
 
@@ -693,22 +698,22 @@ impl MemoryPack {
         let RecallVectorCandidateParams {
             candidate_limit,
             embedding_model,
-            is_cjk,
+            use_multilingual,
             scoring_cfg,
         } = opts;
         let prof = recall_profile_enabled();
         let call_id = PROF_CID.with(|c| c.get());
 
-        let mut cjk_routed = false;
+        let mut multilingual_routed = false;
         let model_names: Vec<String> = if let Some(m) = embedding_model {
             vec![m.to_string()]
         } else {
             let names = self.runtime.registered_embedding_model_names();
             if names.is_empty() {
                 vec![]
-            } else if is_cjk {
+            } else if use_multilingual {
                 let multilingual_model = scoring_cfg
-                    .cjk_model
+                    .multilingual_model
                     .as_deref()
                     .and_then(|m| names.iter().find(|n| n.as_str() == m).cloned())
                     .or_else(|| {
@@ -719,7 +724,7 @@ impl MemoryPack {
                     });
                 match multilingual_model {
                     Some(model) => {
-                        cjk_routed = true;
+                        multilingual_routed = true;
                         vec![model]
                     }
                     None => names,
@@ -896,7 +901,7 @@ impl MemoryPack {
 
         Ok(RecallVectorCandidateResult {
             vector_hits_per_model,
-            cjk_routed,
+            multilingual_routed,
         })
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -16,8 +16,8 @@ use khive_storage::EdgeRelation;
 use crate::config::ScoreBreakdown;
 use crate::rerank::{weighted_rerank, RerankFeatures};
 use crate::scoring::{
-    calculate_score, needs_multilingual, normalize_min_score, normalize_rank_fusion_scores,
-    normalize_rrf_scores, ScoreInput,
+    calculate_score, contains_cjk, needs_multilingual, normalize_min_score,
+    normalize_rank_fusion_scores, normalize_rrf_scores, ScoreInput,
 };
 use crate::MemoryPack;
 
@@ -110,7 +110,9 @@ impl MemoryPack {
         let mut scoring_cfg = cfg.scoring.clone().unwrap_or_default();
         scoring_cfg.apply_dos_caps();
 
-        let is_cjk = scoring_cfg.enable_cjk_routing && needs_multilingual(query_trimmed);
+        let cjk_fts_bypass = scoring_cfg.enable_multilingual_routing && contains_cjk(query_trimmed);
+        let use_multilingual =
+            scoring_cfg.enable_multilingual_routing && needs_multilingual(query_trimmed);
 
         let candidate_limit =
             recall_candidate_count(&cfg, limit_u32).min(scoring_cfg.max_recall_candidates as u32);
@@ -132,7 +134,8 @@ impl MemoryPack {
                 RecallCandidateParams {
                     candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
-                    is_cjk,
+                    cjk_fts_bypass,
+                    use_multilingual,
                     scoring_cfg: &scoring_cfg,
                     snippet_policy: TextSnippetPolicy::Omit,
                     fts_gather: &effective_fts_gather,
@@ -157,7 +160,7 @@ impl MemoryPack {
             t_stage = Some(Instant::now());
         }
 
-        let actual_cjk_routed = candidates.cjk_routed;
+        let actual_multilingual_routed = candidates.multilingual_routed;
         let (memory_ids, mut notes_by_id) =
             self.load_memory_candidate_notes(token, &candidates).await?;
 
@@ -505,8 +508,8 @@ impl MemoryPack {
                 if is_verbose {
                     result["breakdown"] = json!(sn.breakdown);
                 }
-                if actual_cjk_routed {
-                    result["cjk_routed"] = json!(true);
+                if actual_multilingual_routed {
+                    result["multilingual_routed"] = json!(true);
                 }
                 result
             })

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -16,7 +16,7 @@ use khive_storage::EdgeRelation;
 use crate::config::ScoreBreakdown;
 use crate::rerank::{weighted_rerank, RerankFeatures};
 use crate::scoring::{
-    calculate_score, contains_cjk, normalize_min_score, normalize_rank_fusion_scores,
+    calculate_score, needs_multilingual, normalize_min_score, normalize_rank_fusion_scores,
     normalize_rrf_scores, ScoreInput,
 };
 use crate::MemoryPack;
@@ -110,7 +110,7 @@ impl MemoryPack {
         let mut scoring_cfg = cfg.scoring.clone().unwrap_or_default();
         scoring_cfg.apply_dos_caps();
 
-        let is_cjk = scoring_cfg.enable_cjk_routing && contains_cjk(query_trimmed);
+        let is_cjk = scoring_cfg.enable_cjk_routing && needs_multilingual(query_trimmed);
 
         let candidate_limit =
             recall_candidate_count(&cfg, limit_u32).min(scoring_cfg.max_recall_candidates as u32);

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -112,7 +112,8 @@ impl MemoryPack {
                 RecallCandidateParams {
                     candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
-                    is_cjk: false,
+                    cjk_fts_bypass: false,
+                    use_multilingual: false,
                     scoring_cfg: &scoring_cfg,
                     snippet_policy: TextSnippetPolicy::Include {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,
@@ -210,7 +211,8 @@ impl MemoryPack {
                 RecallCandidateParams {
                     candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
-                    is_cjk: false,
+                    cjk_fts_bypass: false,
+                    use_multilingual: false,
                     scoring_cfg: &scoring_cfg_fuse,
                     snippet_policy: TextSnippetPolicy::Include {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -224,7 +224,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         namespace: "local".to_string(),
         text_hits: text_hits.clone(),
         vector_hits_per_model: vec![("mock".to_string(), vector_hits.clone())],
-        cjk_routed: false,
+        multilingual_routed: false,
     };
     let cfg_rrf = RecallConfig {
         fuse_strategy: FusionStrategy::Rrf { k: 60 },
@@ -237,7 +237,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         namespace: "local".to_string(),
         text_hits,
         vector_hits_per_model: vec![("mock".to_string(), vector_hits)],
-        cjk_routed: false,
+        multilingual_routed: false,
     };
     let cfg_weighted = RecallConfig {
         fuse_strategy: FusionStrategy::Weighted {
@@ -577,7 +577,7 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
             ("model-a".to_string(), hits_a),
             ("model-b".to_string(), hits_b),
         ],
-        cjk_routed: false,
+        multilingual_routed: false,
     };
 
     let per_model: Vec<Value> = candidates

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -8,6 +8,7 @@
 //!   5. `normalize_min_score` — dual-scale input (0.0–1.0 fraction or 0–100 integer).
 //!   6. `is_meaningful_query` — noise gate before embedding compute.
 //!   7. `contains_cjk` — CJK routing decision.
+//!   8. `needs_multilingual` — broad multilingual routing gate (non-ASCII alphabetic script).
 // FILE SIZE JUSTIFICATION: scoring.rs bundles ScoringConfig, all normalization helpers,
 // CJK routing, and the full test suite for the scoring pipeline. The tests require access
 // to module-private helpers; splitting would require pub(crate) promotion of private fns.
@@ -353,6 +354,25 @@ pub fn contains_cjk(text: &str) -> bool {
     }
     let cjk = chars.iter().filter(|&&c| is_cjk_char(c)).count();
     (cjk as f32) / (chars.len() as f32) > 0.15
+}
+
+/// Returns `true` when `text` is not predominantly ASCII/Latin-English and should
+/// be routed to the multilingual embedding model.
+///
+/// Specifically: >15% of characters are alphabetic but not ASCII alphabetic.
+/// This covers CJK, Cyrillic, Arabic, Devanagari, Hebrew, Thai, accented-Latin
+/// (é, ü, ñ, …), and every other non-ASCII script recognised by Unicode's
+/// `is_alphabetic` without introducing new crate dependencies.
+pub fn needs_multilingual(text: &str) -> bool {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.is_empty() {
+        return false;
+    }
+    let non_ascii_alpha = chars
+        .iter()
+        .filter(|&&c| c.is_alphabetic() && !c.is_ascii_alphabetic())
+        .count();
+    (non_ascii_alpha as f32) / (chars.len() as f32) > 0.15
 }
 
 /// Normalize `min_score`: 0–1 passes through, 1–100 divides by 100, others return Err.
@@ -729,5 +749,65 @@ mod tests {
         let s2 = output[&ids[2]];
         assert!(s0 > s1 && s1 > s2, "ordering must be preserved");
         assert!(s0 <= 1.0 && s2 >= 0.0, "scores must be in [0,1]");
+    }
+
+    // ── needs_multilingual ────────────────────────────────────────────────────
+
+    #[test]
+    fn needs_multilingual_ascii_english_routes_primary() {
+        assert!(!needs_multilingual("hello world"));
+        assert!(!needs_multilingual("rust programming language"));
+        assert!(!needs_multilingual(""));
+        assert!(!needs_multilingual("42 items in the list"));
+    }
+
+    #[test]
+    fn needs_multilingual_cjk_routes_multilingual() {
+        // Pure CJK: 4/4 = 100% non-ASCII alpha → well above 15%.
+        assert!(needs_multilingual("你好世界"));
+        // Mixed: 2 CJK out of 5 chars = 40%.
+        assert!(needs_multilingual("abc你好"));
+    }
+
+    #[test]
+    fn needs_multilingual_cyrillic_routes_multilingual() {
+        // "Привет мир" (Hello world in Russian): all Cyrillic alphabetic.
+        assert!(needs_multilingual("Привет мир"));
+        // Single Cyrillic word mixed with Latin — Г alone is 1/7 ≈ 14% (below threshold).
+        // Verify with a word that has enough Cyrillic chars to cross 15%.
+        assert!(needs_multilingual("Привет hello")); // Привет = 6 non-ASCII alpha, total chars including space = 12 → 6/12 = 50%
+    }
+
+    #[test]
+    fn needs_multilingual_arabic_routes_multilingual() {
+        // "مرحبا" (Hello in Arabic): all Arabic alphabetic.
+        assert!(needs_multilingual("مرحبا بالعالم"));
+    }
+
+    #[test]
+    fn needs_multilingual_devanagari_routes_multilingual() {
+        // "नमस्ते" (Namaste in Hindi/Devanagari).
+        assert!(needs_multilingual("नमस्ते दुनिया"));
+    }
+
+    #[test]
+    fn needs_multilingual_accented_latin_routes_multilingual() {
+        // French: "café résumé" — é is alphabetic and non-ASCII.
+        // 2 accented chars out of 11 total = 18% > 15%.
+        assert!(needs_multilingual("café résumé"));
+        // German: "Müller" — ü is alphabetic and non-ASCII, 1/6 = 16.7% > 15%.
+        assert!(needs_multilingual("Müller"));
+        // Spanish: "niño" — ñ is 1/4 = 25% > 15%.
+        assert!(needs_multilingual("niño"));
+    }
+
+    #[test]
+    fn needs_multilingual_pure_ascii_accented_below_threshold_routes_primary() {
+        // "hello naïve" — ï is 1/11 ≈ 9% < 15% → stays on primary.
+        // (Deliberate design decision: a single diacritic in an otherwise English
+        // sentence does not warrant multilingual routing.)
+        assert!(!needs_multilingual("hello naive")); // no diacritics, definitely primary
+                                                     // "über" — ü is 1/4 = 25% → routes multilingual (German word).
+        assert!(needs_multilingual("über"));
     }
 }

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -266,13 +266,14 @@ pub struct ScoringConfig {
     /// When true, suppress memories whose `properties.supersedes` value matches
     /// the ID of another memory in the result set. Default: true.
     pub enable_supersedes_suppression: bool,
-    /// When true and a multilingual embedding model is registered, route CJK
-    /// queries to it as the primary model. Default: true.
-    pub enable_cjk_routing: bool,
-    /// Name of the multilingual embedding model to use for CJK routing.
+    /// When true and a multilingual embedding model is registered, route
+    /// non-ASCII-script queries (CJK, Cyrillic, Arabic, accented-Latin, …) to
+    /// it as the primary dense model. Default: true.
+    pub enable_multilingual_routing: bool,
+    /// Name of the multilingual embedding model to prefer for dense routing.
     /// When None, the handler checks registered model names for substrings
     /// "multilingual" or "paraphrase". Default: None.
-    pub cjk_model: Option<String>,
+    pub multilingual_model: Option<String>,
 
     // ── Conditional adjustments ────────────────────────────────────────────
     /// Score adjustments applied after the base formula. Default: episodic bonus,
@@ -300,8 +301,8 @@ impl Default for ScoringConfig {
             mmr_prefix_len: 100,
 
             enable_supersedes_suppression: true,
-            enable_cjk_routing: true,
-            cjk_model: None,
+            enable_multilingual_routing: true,
+            multilingual_model: None,
 
             adjustments: default_adjustments(),
         }
@@ -356,23 +357,32 @@ pub fn contains_cjk(text: &str) -> bool {
     (cjk as f32) / (chars.len() as f32) > 0.15
 }
 
-/// Returns `true` when `text` is not predominantly ASCII/Latin-English and should
-/// be routed to the multilingual embedding model.
+/// Returns `true` when `text` should be routed to the multilingual embedding model
+/// for dense retrieval.
 ///
-/// Specifically: >15% of characters are alphabetic but not ASCII alphabetic.
-/// This covers CJK, Cyrillic, Arabic, Devanagari, Hebrew, Thai, accented-Latin
-/// (é, ü, ñ, …), and every other non-ASCII script recognised by Unicode's
-/// `is_alphabetic` without introducing new crate dependencies.
+/// Triggers when >15% of **alphabetic** characters are non-ASCII-alphabetic.
+/// Denominator is alphabetic-character count (not total characters), so punctuation,
+/// digits, and whitespace do not dilute the signal. This means `Müller` and
+/// `Müller?` and `Müller!!!` all route identically.
+///
+/// Covers: CJK, Cyrillic, Arabic, Devanagari, Hebrew, Thai, accented-Latin
+/// (é, ü, ñ, …) and any other non-ASCII script Unicode recognises as alphabetic,
+/// without introducing new crate dependencies.
+///
+/// **Known limitation**: ASCII-only non-English Latin (`bonjour le monde`,
+/// `como estas`, `ich suche einen buchhalter`) is NOT detected and routes to the
+/// primary model. Real language detection for that case requires a dedicated crate
+/// and is tracked as a follow-up to issue #101.
 pub fn needs_multilingual(text: &str) -> bool {
-    let chars: Vec<char> = text.chars().collect();
-    if chars.is_empty() {
+    let alpha_chars: Vec<char> = text.chars().filter(|c| c.is_alphabetic()).collect();
+    if alpha_chars.is_empty() {
         return false;
     }
-    let non_ascii_alpha = chars
+    let non_ascii_alpha = alpha_chars
         .iter()
-        .filter(|&&c| c.is_alphabetic() && !c.is_ascii_alphabetic())
+        .filter(|&&c| !c.is_ascii_alphabetic())
         .count();
-    (non_ascii_alpha as f32) / (chars.len() as f32) > 0.15
+    (non_ascii_alpha as f32) / (alpha_chars.len() as f32) > 0.15
 }
 
 /// Normalize `min_score`: 0–1 passes through, 1–100 divides by 100, others return Err.
@@ -793,21 +803,46 @@ mod tests {
     #[test]
     fn needs_multilingual_accented_latin_routes_multilingual() {
         // French: "café résumé" — é is alphabetic and non-ASCII.
-        // 2 accented chars out of 11 total = 18% > 15%.
+        // Alphabetic chars: c,a,f,é,r,é,s,u,m,é = 10; non-ASCII alpha: 3; 3/10 = 30% > 15%.
         assert!(needs_multilingual("café résumé"));
-        // German: "Müller" — ü is alphabetic and non-ASCII, 1/6 = 16.7% > 15%.
+        // German: "Müller" — ü is 1/6 alpha = 16.7% > 15%.
         assert!(needs_multilingual("Müller"));
-        // Spanish: "niño" — ñ is 1/4 = 25% > 15%.
+        // Spanish: "niño" — ñ is 1/4 alpha = 25% > 15%.
         assert!(needs_multilingual("niño"));
     }
 
     #[test]
+    fn needs_multilingual_alphabetic_denominator_is_stable_under_punctuation() {
+        // INVARIANT 2: punctuation/digits must not change routing decision.
+        // "Müller" alpha: M,ü,l,l,e,r = 6; non-ASCII alpha: ü = 1; 1/6 = 16.7% > 15%.
+        assert!(needs_multilingual("Müller"));
+        // "Müller?" — same 6 alpha chars; ? is not alphabetic; 1/6 = 16.7% → still routes.
+        assert!(needs_multilingual("Müller?"));
+        // "Müller!!!" — same 6 alpha chars; 1/6 = 16.7% → still routes.
+        assert!(needs_multilingual("Müller!!!"));
+        // Digit-heavy short accented query: "42 Ü" — alpha: Ü = 1; non-ASCII: 1; 1/1 = 100%.
+        assert!(needs_multilingual("42 Ü"));
+        // Empty / no-alpha: must return false without divide-by-zero.
+        assert!(!needs_multilingual(""));
+        assert!(!needs_multilingual("42 100 ???"));
+    }
+
+    #[test]
     fn needs_multilingual_pure_ascii_accented_below_threshold_routes_primary() {
-        // "hello naïve" — ï is 1/11 ≈ 9% < 15% → stays on primary.
+        // "hello naïve" — ï is 1 non-ASCII alpha out of 10 alpha = 10% < 15% → primary.
         // (Deliberate design decision: a single diacritic in an otherwise English
         // sentence does not warrant multilingual routing.)
         assert!(!needs_multilingual("hello naive")); // no diacritics, definitely primary
-                                                     // "über" — ü is 1/4 = 25% → routes multilingual (German word).
+                                                     // "über" — ü is 1/4 alpha = 25% → routes multilingual (German word).
         assert!(needs_multilingual("über"));
+    }
+
+    #[test]
+    fn needs_multilingual_ascii_only_non_english_latin_routes_primary_known_limitation() {
+        // INVARIANT 4: ASCII-only non-English Latin is NOT detected here.
+        // Real language detection is tracked as a follow-up to issue #101.
+        assert!(!needs_multilingual("bonjour le monde"));
+        assert!(!needs_multilingual("como estas"));
+        assert!(!needs_multilingual("ich suche einen buchhalter"));
     }
 }

--- a/crates/khive-pack-memory/src/text_gather.rs
+++ b/crates/khive-pack-memory/src/text_gather.rs
@@ -87,7 +87,7 @@ pub async fn collect_text_hits(
     ns: &str,
     candidate_limit: u32,
     snippet_policy: TextSnippetPolicy,
-    is_cjk: bool,
+    cjk_fts_bypass: bool,
     cfg: &RecallFtsGatherConfig,
     all_terms: &[String],
 ) -> Result<Vec<TextSearchHit>, RuntimeError> {
@@ -100,7 +100,7 @@ pub async fn collect_text_hits(
     });
 
     // CJK bypass: skip term selection and use existing ranked path.
-    if is_cjk && cfg.cjk_bypass_ranked {
+    if cjk_fts_bypass && cfg.cjk_bypass_ranked {
         let selected_terms: Vec<String> = all_terms.iter().take(cfg.term_k).cloned().collect();
         let join_query = if selected_terms.is_empty() {
             return Ok(Vec::new());
@@ -539,7 +539,7 @@ mod collect_text_hits_tests {
     // ── CJK case: trigram path stays covered ──────────────────────────────────
 
     /// Insert a doc with Chinese text, query via trigram bypass path.
-    /// Verifies the CJK bypass (`is_cjk=true, cjk_bypass_ranked=true`) finds it.
+    /// Verifies the CJK bypass (`cjk_fts_bypass=true, cjk_bypass_ranked=true`) finds it.
     #[tokio::test]
     async fn gather_cjk_bypass_finds_cjk_document() {
         let searcher = backend_text("ctf_cjk");
@@ -577,7 +577,7 @@ mod collect_text_hits_tests {
             ns,
             10,
             TextSnippetPolicy::Omit,
-            true, // is_cjk=true
+            true, // cjk_fts_bypass=true
             &cfg,
             &terms,
         )


### PR DESCRIPTION
## Summary

Broadens `memory.recall` dense-embedding routing from CJK-only to all queries with non-ASCII
alphabetic content, and splits that decision from the (still CJK-only) FTS lexical bypass.

- Adds `needs_multilingual(text)` (`scoring.rs`): `true` when >15% of **alphabetic** characters
  are non-ASCII-alphabetic. Covers CJK, Cyrillic, Arabic, Devanagari, Hebrew, Thai, and
  accented-Latin (é, ü, ñ, …). Alphabetic-only denominator, so punctuation/digits do not flip
  routing (`Müller` and `Müller?` route identically). No new crate dependencies.
- **Splits the routing flag** so the two concerns are independent:
  - `cjk_fts_bypass = enable_multilingual_routing && contains_cjk(query)` drives the FTS lexical
    bypass (`text_gather.rs` `cjk_bypass_ranked`) and is **kept CJK-only** per #101.
  - `use_multilingual = enable_multilingual_routing && needs_multilingual(query)` drives the
    dense embedding model selection (`common.rs`).

  Before this PR a single shared flag drove both, which would have broadened the CJK FTS bypass
  to Cyrillic/Arabic/accented scripts.
- Renames the dense-routing plumbing `cjk_*` → `multilingual_*`: config `enable_multilingual_routing`,
  `multilingual_model`, and the consumer-visible response key `multilingual_routed`. `contains_cjk`
  and `cjk_bypass_ranked` are retained (genuinely CJK-specific).

## Scope — `Refs #101` (NOT `Fixes`)

This closes the **non-ASCII + accented-Latin** portion of #101. ASCII-only non-English
Latin-script queries (`bonjour le monde`, `como estas`, `ich suche einen buchhalter`) still
route to the primary model — detecting those needs a real language identifier and carries an
English-recall regression risk, so it is deferred to **#128**. The boundary is documented on
`needs_multilingual` and asserted by a known-limitation test. #101 stays open until #128 lands.

## Store-side parity

Safe to merge: the multilingual model is registered by default and `memory.remember` / note
creation fans out embeddings to all registered models, so multilingual queries hit a populated
vector space. Note UPDATE / entity reindex remain primary-only until #10.

## Gate RCs (commit `ee8be54`)

| Gate | RC |
|------|----|
| `cargo test -p khive-pack-memory -p khive-runtime` | 0 (memory 162 unit + 63 integration; runtime 409 unit + 55 integration) |
| `cargo clippy -p khive-pack-memory -p khive-runtime --all-targets -- -D warnings` | 0 |
| `cargo fmt --all -- --check` | 0 |

## Verification

Design review confirmed the store-parity improvement: all code findings were addressed, the two routing flags are never crossed, and the CJK FTS bypass remains CJK-only.

Refs #101. Refs #128.