### PR TITLE
feat(runtime): multi-namespace read visibility (visible-set tokens)

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -181,11 +181,32 @@ fn build_entity_where(
     namespace: &str,
     filter: &EntityFilter,
 ) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
-    let mut conditions: Vec<String> = vec![
-        "namespace = ?1".to_string(),
-        "deleted_at IS NULL".to_string(),
-    ];
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(namespace.to_string())];
+    // When filter.namespaces is non-empty use `namespace IN (...)` so that
+    // multi-namespace read visibility works.  Otherwise fall back to the
+    // single-namespace equality check for backward compatibility.
+    let (ns_condition, ns_params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) =
+        if !filter.namespaces.is_empty() {
+            let placeholders: Vec<String> = (1..=filter.namespaces.len())
+                .map(|i| format!("?{i}"))
+                .collect();
+            let params: Vec<Box<dyn rusqlite::types::ToSql>> = filter
+                .namespaces
+                .iter()
+                .map(|ns| -> Box<dyn rusqlite::types::ToSql> { Box::new(ns.clone()) })
+                .collect();
+            (
+                format!("namespace IN ({})", placeholders.join(", ")),
+                params,
+            )
+        } else {
+            (
+                "namespace = ?1".to_string(),
+                vec![Box::new(namespace.to_string())],
+            )
+        };
+
+    let mut conditions: Vec<String> = vec![ns_condition, "deleted_at IS NULL".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = ns_params;
 
     if !filter.ids.is_empty() {
         let placeholders: Vec<String> = filter

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -224,11 +224,31 @@ fn build_note_filter_where(
     namespace: &str,
     filter: &NoteFilter,
 ) -> Result<(String, Vec<Box<dyn rusqlite::types::ToSql>>), rusqlite::Error> {
-    let mut conditions = vec![
-        "namespace = ?1".to_string(),
-        "deleted_at IS NULL".to_string(),
-    ];
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(namespace.to_string())];
+    // When filter.namespaces is non-empty use `namespace IN (...)` for
+    // multi-namespace read visibility. Otherwise fall back to equality.
+    let (ns_condition, ns_params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) =
+        if !filter.namespaces.is_empty() {
+            let placeholders: Vec<String> = (1..=filter.namespaces.len())
+                .map(|i| format!("?{i}"))
+                .collect();
+            let params: Vec<Box<dyn rusqlite::types::ToSql>> = filter
+                .namespaces
+                .iter()
+                .map(|ns| -> Box<dyn rusqlite::types::ToSql> { Box::new(ns.clone()) })
+                .collect();
+            (
+                format!("namespace IN ({})", placeholders.join(", ")),
+                params,
+            )
+        } else {
+            (
+                "namespace = ?1".to_string(),
+                vec![Box::new(namespace.to_string())],
+            )
+        };
+
+    let mut conditions = vec![ns_condition, "deleted_at IS NULL".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = ns_params;
 
     if let Some(kind) = &filter.kind {
         params.push(Box::new(kind.clone()));

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -229,6 +229,7 @@ async fn test_filtered_namespace_and_kind_isolation() {
             value: SqlValue::Text("pending".to_string()),
         }],
         order_by: None,
+        ..Default::default()
     };
 
     let page = store
@@ -282,6 +283,7 @@ async fn test_filtered_order_by_json_path_asc() {
             value: SqlValue::Text("pending".to_string()),
         }],
         order_by: Some(("$.trigger_at".to_string(), SortDir::Asc)),
+        ..Default::default()
     };
 
     let page = store
@@ -319,6 +321,7 @@ async fn test_filtered_soft_deleted_excluded() {
             value: SqlValue::Text("pending".to_string()),
         }],
         order_by: None,
+        ..Default::default()
     };
 
     let page = store
@@ -343,6 +346,7 @@ async fn test_filtered_invalid_json_path_rejected() {
             value: SqlValue::Text("x".to_string()),
         }],
         order_by: None,
+        ..Default::default()
     };
 
     let result = store

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -198,9 +198,11 @@ impl KhiveMcpServer {
         let gate = runtime.config().gate.clone();
         let default_namespace = runtime.config().default_namespace.clone();
         let config_id = compute_config_id(runtime.config());
+        let visible_namespaces = runtime.config().visible_namespaces.clone();
         let mut builder = VerbRegistryBuilder::new();
         builder.with_gate(gate);
         builder.with_default_namespace(default_namespace.as_str());
+        builder.with_visible_namespaces(visible_namespaces);
         // Wire the EventStore into the registry for audit persistence.
         if let Ok(tok) = runtime.authorize(khive_runtime::Namespace::local()) {
             if let Ok(event_store) = runtime.events(&tok) {

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -52,13 +52,21 @@ pub fn compute_config_id(config: &RuntimeConfig) -> String {
         .map(|m| format!("{m:?}"))
         .collect();
     extra.sort();
+    let mut visible: Vec<String> = config
+        .visible_namespaces
+        .iter()
+        .map(|ns| ns.as_str().to_owned())
+        .collect();
+    visible.sort();
+    visible.dedup();
     format!(
-        "packs=[{}];db={};embed={};extra=[{}];backend={:?}",
+        "packs=[{}];db={};embed={};extra=[{}];backend={:?};visible=[{}]",
         packs.join(","),
         db,
         primary,
         extra.join(","),
         config.backend_id,
+        visible.join(","),
     )
 }
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3880,33 +3880,34 @@ fn compute_config_id_is_stable_under_visible_namespace_reorder() {
 // but mutations on visible-only records must return NotFound.
 // =============================================================================
 
-/// An actor configured with `visible_namespaces = ["vis-b"]` must be able to
-/// READ entities from `vis-b`, but a mutation that targets a `vis-b` entity
-/// by UUID must return NotFound (ADR-007:215-219 timing-oracle mitigation).
+/// Proves the full config→dispatch wiring: an actor configured with
+/// `visible_namespaces = ["vis-b"]` (in RuntimeConfig) has that visible set
+/// flow through `KhiveMcpServer::with_packs` → `VerbRegistryBuilder::with_visible_namespaces`
+/// → `VerbRegistry::dispatch` → `NamespaceToken::mint_with_visibility`.
 ///
-/// Test setup:
-/// - Builds a RuntimeConfig as if loaded from:
-///     [actor]
-///     id = "vis-a"
-///     visible_namespaces = ["vis-b"]
-/// - Creates an entity in `vis-b`.
-/// - With the vis-a visible-set token: `get` the entity (must succeed).
-/// - With the vis-a visible-set token: try to `link` with the vis-b entity
-///   as a target; the runtime's `resolve_primary` must return NotFound for
-///   vis-b entities, so the link must fail.
+/// Two assertions dispatched through the REAL registry boundary:
+///   (a) `get(id=<vis-b-entity>)` returns ok:true  — cross-namespace read works.
+///   (b) `link(source_id=<vis-a>, target_id=<vis-b>, ...)` returns ok:false
+///       with a "not found" error — visible-only record cannot be a mutation target
+///       (ADR-007:215-219 timing-oracle mitigation).
+///
+/// The test does NOT call rt.authorize_with_visibility / rt.get_entity / rt.link
+/// directly — all reads and mutations go through dispatch_request_local so a
+/// future regression in the with_packs / token-minting path would fail here.
 #[tokio::test]
-async fn visible_namespaces_config_read_allowed_mutation_rejected() {
-    use khive_mcp::server::compute_config_id;
+async fn visible_namespaces_config_wires_through_dispatch_boundary() {
+    use khive_mcp::{server::compute_config_id, tools::request::RequestParams};
     use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
-    use khive_types::EdgeRelation;
+
+    disable_daemon();
+
+    let ns_a = Namespace::parse("vcfg-a").unwrap();
+    let ns_b = Namespace::parse("vcfg-b").unwrap();
 
     // Build a RuntimeConfig equivalent to:
     //   [actor]
-    //   id = "vis-a"
-    //   visible_namespaces = ["vis-b"]
-    let ns_a = Namespace::parse("vis-a").unwrap();
-    let ns_b = Namespace::parse("vis-b").unwrap();
-
+    //   id = "vcfg-a"
+    //   visible_namespaces = ["vcfg-b"]
     let cfg = RuntimeConfig {
         db_path: None,
         default_namespace: ns_a.clone(),
@@ -3917,68 +3918,93 @@ async fn visible_namespaces_config_read_allowed_mutation_rejected() {
         ..RuntimeConfig::default()
     };
 
-    // Verify the config_id encodes vis-b (Finding 1 integration check).
+    // Verify the config_id encodes vcfg-b (Finding 1 integration check).
     let cid = compute_config_id(&cfg);
     assert!(
-        cid.contains("vis-b"),
-        "config_id must encode visible namespace vis-b; got: {cid}"
+        cid.contains("vcfg-b"),
+        "config_id must encode visible namespace vcfg-b; got: {cid}"
     );
 
     let rt = KhiveRuntime::new(cfg).expect("in-memory runtime");
 
-    // Create an entity in vis-b using vis-b's own token.
-    let tok_b = rt
-        .authorize(ns_b.clone())
-        .expect("authorize vis-b must succeed");
+    // Seed data: create an entity in vcfg-b and one in vcfg-a.
+    // These must go through direct runtime calls (not dispatch) because the
+    // server's default namespace is vcfg-a — we need to write into vcfg-b
+    // without overriding the server's namespace.
+    let tok_b = rt.authorize(ns_b.clone()).expect("authorize vcfg-b");
     let entity_in_b = rt
-        .create_entity(&tok_b, "concept", None, "Vis-B-Entity", None, None, vec![])
+        .create_entity(&tok_b, "concept", None, "VcfgB-Entity", None, None, vec![])
         .await
-        .expect("create entity in vis-b");
-
-    // Create an entity in vis-a (owned by the actor).
-    let tok_a = rt
-        .authorize(ns_a.clone())
-        .expect("authorize vis-a must succeed");
+        .expect("create entity in vcfg-b");
+    let tok_a = rt.authorize(ns_a.clone()).expect("authorize vcfg-a");
     let entity_in_a = rt
-        .create_entity(&tok_a, "concept", None, "Vis-A-Entity", None, None, vec![])
+        .create_entity(&tok_a, "concept", None, "VcfgA-Entity", None, None, vec![])
         .await
-        .expect("create entity in vis-a");
+        .expect("create entity in vcfg-a");
 
-    // Mint a visible-set token: primary = vis-a, also sees vis-b.
-    let tok_vis = rt
-        .authorize_with_visibility(ns_a.clone(), vec![ns_b.clone()])
-        .expect("authorize_with_visibility must succeed");
+    // Build the server through with_packs so the visible set flows through the
+    // full wiring chain: RuntimeConfig → with_packs → builder.with_visible_namespaces
+    // → VerbRegistry.visible_namespaces → dispatch → mint_with_visibility.
+    let server = KhiveMcpServer::with_packs(rt, &["kg".to_string()])
+        .expect("server builds with visible_namespaces set");
 
-    // READ: get vis-b entity via the visible-set token (must succeed).
-    let got = rt
-        .get_entity(&tok_vis, entity_in_b.id)
+    // ── (a) READ: get the vcfg-b entity via registry dispatch ────────────────
+    //
+    // dispatch_request_local mints a token with primary=vcfg-a + visible=[vcfg-b].
+    // The `get` handler calls resolve() (visible-aware) — must find the entity.
+    let get_out = server
+        .dispatch_request_local(RequestParams {
+            ops: format!(r#"get(id="{}")"#, entity_in_b.id),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+        })
         .await
-        .expect("get_entity must succeed for visible-namespace entity");
+        .expect("dispatch get must not error at the MCP level");
+
+    let get_body: Value = serde_json::from_str(&get_out).expect("get response must be valid JSON");
+    let get_result = &get_body["results"][0];
     assert_eq!(
-        got.id, entity_in_b.id,
-        "get_entity via visible-set token must return the vis-b entity"
+        get_result["ok"],
+        json!(true),
+        "get(id=<vcfg-b entity>) via config-derived dispatch token must return ok:true; \
+         visible_namespaces in RuntimeConfig must flow through with_packs to the dispatch token; \
+         got: {get_result}"
+    );
+    assert_eq!(
+        get_result["result"]["id"].as_str().unwrap_or(""),
+        entity_in_b.id.as_hyphenated().to_string(),
+        "returned entity id must match the vcfg-b entity"
     );
 
-    // MUTATION: link with vis-b entity as the *target* — resolve_primary must
-    // return None for vis-b entities (they are not in the primary namespace),
-    // and the link must fail.
+    // ── (b) MUTATION: link targeting vcfg-b entity must return NotFound ───────
     //
-    // Note: link validates both endpoints via resolve_primary (for entity-relation
-    // endpoint validation). A vis-b entity as target is NotFound in the primary.
-    let link_result = rt
-        .link(
-            &tok_vis,
-            entity_in_a.id, // source is primary — OK
-            entity_in_b.id, // target is visible-only — must be rejected
-            EdgeRelation::Extends,
-            1.0,
-            None,
-        )
-        .await;
+    // dispatch_request_local mints a token with primary=vcfg-a + visible=[vcfg-b].
+    // link calls resolve_primary() on both endpoints; vcfg-b entity is NotFound
+    // in the primary namespace → link must fail (ADR-007:215-219).
+    let link_out = server
+        .dispatch_request_local(RequestParams {
+            ops: format!(
+                r#"link(source_id="{}", target_id="{}", relation="extends")"#,
+                entity_in_a.id, entity_in_b.id,
+            ),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+        })
+        .await
+        .expect("dispatch link must not error at the MCP level");
 
+    let link_body: Value =
+        serde_json::from_str(&link_out).expect("link response must be valid JSON");
+    let link_result = &link_body["results"][0];
+    assert_eq!(
+        link_result["ok"],
+        json!(false),
+        "link(target_id=<vcfg-b entity>) via config-derived dispatch token must return ok:false; \
+         visible-only record must not be a mutation endpoint; got: {link_result}"
+    );
+    let err_msg = link_result["error"].to_string().to_lowercase();
     assert!(
-        link_result.is_err(),
-        "link with visible-only (vis-b) entity as target must fail; \
-         a visible-only record must not be a mutation endpoint"
+        err_msg.contains("not found") || err_msg.contains("notfound"),
+        "link error must be NotFound (not Forbidden, per ADR-007:215-219); got: {link_result}"
     );
 }

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3796,3 +3796,189 @@ async fn test_propose_pipe_withdraw_chain() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// =============================================================================
+// Finding 1: compute_config_id must include visible_namespaces so two configs
+// with different visible sets produce distinct fingerprints.
+// =============================================================================
+
+/// Two RuntimeConfigs that are identical except for their `visible_namespaces`
+/// must produce different `compute_config_id` fingerprints.
+///
+/// Without this, a daemon started for `primary=vis-a, visible=[]` could be
+/// reused for `primary=vis-a, visible=[vis-b]` — granting cross-namespace
+/// reads to a caller that should be namespace-isolated.
+#[test]
+fn compute_config_id_differs_when_visible_namespaces_differ() {
+    use khive_mcp::server::compute_config_id;
+    use khive_runtime::{Namespace, RuntimeConfig};
+
+    let base = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse("vis-a").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        visible_namespaces: vec![],
+        ..RuntimeConfig::default()
+    };
+    let with_visible = RuntimeConfig {
+        visible_namespaces: vec![Namespace::parse("vis-b").unwrap()],
+        ..base.clone()
+    };
+
+    let id_no_vis = compute_config_id(&base);
+    let id_with_vis = compute_config_id(&with_visible);
+
+    assert_ne!(
+        id_no_vis, id_with_vis,
+        "compute_config_id must differ when visible_namespaces differs; \
+         same id would allow wrong-visibility daemon reuse"
+    );
+    assert!(
+        id_with_vis.contains("vis-b"),
+        "visible namespace 'vis-b' must appear in config_id string; got: {id_with_vis}"
+    );
+}
+
+/// Order of entries in visible_namespaces must not change the fingerprint
+/// (the fingerprint sorts + deduplicates before hashing).
+#[test]
+fn compute_config_id_is_stable_under_visible_namespace_reorder() {
+    use khive_mcp::server::compute_config_id;
+    use khive_runtime::{Namespace, RuntimeConfig};
+
+    let cfg_ab = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse("vis-a").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        visible_namespaces: vec![
+            Namespace::parse("vis-b").unwrap(),
+            Namespace::parse("vis-c").unwrap(),
+        ],
+        ..RuntimeConfig::default()
+    };
+    let cfg_ba = RuntimeConfig {
+        visible_namespaces: vec![
+            Namespace::parse("vis-c").unwrap(),
+            Namespace::parse("vis-b").unwrap(),
+        ],
+        ..cfg_ab.clone()
+    };
+
+    assert_eq!(
+        compute_config_id(&cfg_ab),
+        compute_config_id(&cfg_ba),
+        "compute_config_id must be stable under reordering of visible_namespaces"
+    );
+}
+
+// =============================================================================
+// Finding 6: actor.visible_namespaces from config wires cross-namespace reads
+// but mutations on visible-only records must return NotFound.
+// =============================================================================
+
+/// An actor configured with `visible_namespaces = ["vis-b"]` must be able to
+/// READ entities from `vis-b`, but a mutation that targets a `vis-b` entity
+/// by UUID must return NotFound (ADR-007:215-219 timing-oracle mitigation).
+///
+/// Test setup:
+/// - Builds a RuntimeConfig as if loaded from:
+///     [actor]
+///     id = "vis-a"
+///     visible_namespaces = ["vis-b"]
+/// - Creates an entity in `vis-b`.
+/// - With the vis-a visible-set token: `get` the entity (must succeed).
+/// - With the vis-a visible-set token: try to `link` with the vis-b entity
+///   as a target; the runtime's `resolve_primary` must return NotFound for
+///   vis-b entities, so the link must fail.
+#[tokio::test]
+async fn visible_namespaces_config_read_allowed_mutation_rejected() {
+    use khive_mcp::server::compute_config_id;
+    use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+    use khive_types::EdgeRelation;
+
+    // Build a RuntimeConfig equivalent to:
+    //   [actor]
+    //   id = "vis-a"
+    //   visible_namespaces = ["vis-b"]
+    let ns_a = Namespace::parse("vis-a").unwrap();
+    let ns_b = Namespace::parse("vis-b").unwrap();
+
+    let cfg = RuntimeConfig {
+        db_path: None,
+        default_namespace: ns_a.clone(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        visible_namespaces: vec![ns_b.clone()],
+        ..RuntimeConfig::default()
+    };
+
+    // Verify the config_id encodes vis-b (Finding 1 integration check).
+    let cid = compute_config_id(&cfg);
+    assert!(
+        cid.contains("vis-b"),
+        "config_id must encode visible namespace vis-b; got: {cid}"
+    );
+
+    let rt = KhiveRuntime::new(cfg).expect("in-memory runtime");
+
+    // Create an entity in vis-b using vis-b's own token.
+    let tok_b = rt
+        .authorize(ns_b.clone())
+        .expect("authorize vis-b must succeed");
+    let entity_in_b = rt
+        .create_entity(&tok_b, "concept", None, "Vis-B-Entity", None, None, vec![])
+        .await
+        .expect("create entity in vis-b");
+
+    // Create an entity in vis-a (owned by the actor).
+    let tok_a = rt
+        .authorize(ns_a.clone())
+        .expect("authorize vis-a must succeed");
+    let entity_in_a = rt
+        .create_entity(&tok_a, "concept", None, "Vis-A-Entity", None, None, vec![])
+        .await
+        .expect("create entity in vis-a");
+
+    // Mint a visible-set token: primary = vis-a, also sees vis-b.
+    let tok_vis = rt
+        .authorize_with_visibility(ns_a.clone(), vec![ns_b.clone()])
+        .expect("authorize_with_visibility must succeed");
+
+    // READ: get vis-b entity via the visible-set token (must succeed).
+    let got = rt
+        .get_entity(&tok_vis, entity_in_b.id)
+        .await
+        .expect("get_entity must succeed for visible-namespace entity");
+    assert_eq!(
+        got.id, entity_in_b.id,
+        "get_entity via visible-set token must return the vis-b entity"
+    );
+
+    // MUTATION: link with vis-b entity as the *target* — resolve_primary must
+    // return None for vis-b entities (they are not in the primary namespace),
+    // and the link must fail.
+    //
+    // Note: link validates both endpoints via resolve_primary (for entity-relation
+    // endpoint validation). A vis-b entity as target is NotFound in the primary.
+    let link_result = rt
+        .link(
+            &tok_vis,
+            entity_in_a.id, // source is primary — OK
+            entity_in_b.id, // target is visible-only — must be rejected
+            EdgeRelation::Extends,
+            1.0,
+            None,
+        )
+        .await;
+
+    assert!(
+        link_result.is_err(),
+        "link with visible-only (vis-b) entity as target must fail; \
+         a visible-only record must not be a mutation endpoint"
+    );
+}

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -839,10 +839,12 @@ impl BrainPack {
             }
         };
 
-        // Validate target_id resolves to an existing record in this namespace.
+        // Validate target_id in the PRIMARY namespace only. A visible-only
+        // (foreign) record must not be targeted by a mutation (feedback event).
+        // NotFound (not Forbidden) per ADR-007:215-219.
         let resolved = self
             .runtime
-            .resolve(token, target)
+            .resolve_primary(token, target)
             .await
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
         if resolved.is_none() {

--- a/crates/khive-pack-brain/tests/dispatch_hook.rs
+++ b/crates/khive-pack-brain/tests/dispatch_hook.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use khive_pack_brain::BrainPack;
 use khive_pack_kg::KgPack;
-use khive_runtime::{DispatchHook, KhiveRuntime, PackRuntime, VerbRegistryBuilder};
+use khive_runtime::{DispatchHook, KhiveRuntime, Namespace, PackRuntime, VerbRegistryBuilder};
 use serde_json::json;
 
 /// Promote `namespace` on `brain` via the production dispatch path.
@@ -344,5 +344,74 @@ async fn cold_hook_signal_applies_on_top_of_persisted_snapshot() {
         "active snapshot for 'local' must equal persisted total ({persisted_total}) + \
          1 saved-state signal; got {}",
         snap.balanced_recall.total_events
+    );
+}
+
+// ---- Finding 3 regression: brain.feedback target_id must be primary-only ----
+
+/// `brain.feedback` must reject a `target_id` that lives in a visible (non-primary)
+/// namespace. A visible-only record must not be the target of a feedback mutation.
+///
+/// This tests that the fix from `resolve` to `resolve_primary` is in effect:
+/// a record the caller can READ but not MUTATE returns NotFound on feedback.
+#[tokio::test]
+async fn brain_feedback_rejects_visible_only_target_id() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+
+    let ns_primary = Namespace::parse("brain-primary-ns").unwrap();
+    let ns_foreign = Namespace::parse("brain-foreign-ns").unwrap();
+
+    // Create a KG entity in the foreign namespace.
+    let tok_foreign = rt.authorize(ns_foreign.clone()).unwrap();
+    let foreign_entity = rt
+        .create_entity(
+            &tok_foreign,
+            "concept",
+            None,
+            "ForeignTarget",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let foreign_id = foreign_entity.id.as_hyphenated().to_string();
+
+    // Build a visible-set token: primary-ns can read (but not mutate) foreign-ns.
+    let tok_vis = rt
+        .authorize_with_visibility(ns_primary.clone(), vec![ns_foreign.clone()])
+        .unwrap();
+
+    // Verify the visible-set token CAN read the foreign entity (control check).
+    let found = rt.get_entity(&tok_vis, foreign_entity.id).await;
+    assert!(
+        found.is_ok(),
+        "visible-set token must be able to read the foreign entity; got: {found:?}"
+    );
+
+    // brain.feedback with the foreign entity as target_id must fail NotFound.
+    let brain = BrainPack::new(rt.clone());
+    let empty_registry = VerbRegistryBuilder::new().build().unwrap();
+
+    // First promote the primary namespace.
+    brain
+        .dispatch("brain.profiles", json!({}), &empty_registry, &tok_vis)
+        .await
+        .expect("promote primary namespace");
+
+    let err = brain
+        .dispatch(
+            "brain.feedback",
+            json!({ "target_id": foreign_id, "signal": "useful" }),
+            &empty_registry,
+            &tok_vis,
+        )
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("not found"),
+        "brain.feedback with visible-only target_id must return NotFound; got: {msg}"
     );
 }

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -124,6 +124,7 @@ pub(crate) async fn handle_inbox(
         kind: Some("message".to_string()),
         property_filters,
         order_by: None, // preserves existing created_at DESC ordering
+        ..Default::default()
     };
     let page = runtime
         .notes(token)?
@@ -402,6 +403,7 @@ pub(crate) async fn handle_thread(
             value: SqlValue::Text(canonical_thread_id.clone()),
         }],
         order_by: None,
+        ..Default::default()
     };
     const PAGE_SIZE: u32 = 200;
     let mut messages: Vec<Value> = Vec::new();

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -2092,6 +2092,7 @@ async fn test_inbox_read_filter_json_type_truth_table() {
             },
         ],
         order_by: None,
+        ..Default::default()
     };
     let unread_page = store
         .query_notes_filtered("local", &unread_filter, PageRequest::default())
@@ -2140,6 +2141,7 @@ async fn test_inbox_read_filter_json_type_truth_table() {
             },
         ],
         order_by: None,
+        ..Default::default()
     };
     let read_page = store
         .query_notes_filtered("local", &read_filter, PageRequest::default())

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -240,7 +240,9 @@ async fn resolve_context_entity_id(
         ))
     })?;
 
-    match runtime.resolve(token, uuid).await? {
+    // Mutation rule: the annotated entity must live in the PRIMARY namespace.
+    // A visible-only (foreign) entity returns NotFound here per ADR-007:215-219.
+    match runtime.resolve_primary(token, uuid).await? {
         Some(Resolved::Entity(_)) => Ok(uuid),
         Some(Resolved::Note(n)) => Err(RuntimeError::InvalidInput(format!(
             "context_entity_id {uuid} must reference a KG entity; got note kind {:?}",
@@ -508,7 +510,10 @@ impl GtdPack {
         // from `create(note_kind="task")` and violate the "no failure after
         // successful write" rule).
         for dep_uuid in &resolved_deps {
-            match self.runtime().resolve(token, *dep_uuid).await? {
+            // Mutation rule: depends_on targets must be in the PRIMARY namespace.
+            // A visible-only (foreign) task is NotFound here — callers must own both
+            // sides of a dependency edge. NotFound (not Forbidden) per ADR-007:215-219.
+            match self.runtime().resolve_primary(token, *dep_uuid).await? {
                 Some(Resolved::Note(n)) if n.kind == "task" => {}
                 Some(Resolved::Note(n)) => {
                     return Err(RuntimeError::InvalidInput(format!(

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -408,3 +408,104 @@ async fn assign_rejects_malformed_context_entity_id() {
         "error must echo the malformed value; got: {msg}"
     );
 }
+
+// ---- Finding 2 regression: depends_on and context_entity_id must be primary-only ----
+
+/// A task in a visible (non-primary) namespace must be treated as NotFound
+/// when referenced as a `depends_on` target.
+///
+/// This is a direct runtime-layer test: `resolve_primary` must return None
+/// for a foreign-visible note, while `resolve` (visible-aware) returns Some.
+/// The distinction is what the fixed code path relies on.
+#[tokio::test]
+async fn resolve_primary_rejects_visible_only_task() {
+    use khive_runtime::{KhiveRuntime, Namespace};
+
+    let rt = KhiveRuntime::memory().unwrap();
+
+    let ns_primary = Namespace::parse("dep-primary-ns").unwrap();
+    let ns_foreign = Namespace::parse("dep-foreign-ns").unwrap();
+
+    // Create a task in the foreign namespace.
+    let tok_foreign = rt.authorize(ns_foreign.clone()).unwrap();
+    let foreign_task = rt
+        .create_note(
+            &tok_foreign,
+            "task",
+            Some("foreign blocker"),
+            "foreign blocker",
+            Some(0.5),
+            Some(serde_json::json!({"status": "inbox", "priority": "p2"})),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // Build a visible-set token: primary-ns can see foreign-ns.
+    let tok_vis = rt
+        .authorize_with_visibility(ns_primary.clone(), vec![ns_foreign.clone()])
+        .unwrap();
+
+    // resolve (visible-aware) finds the foreign task.
+    let resolved_visible = rt.resolve(&tok_vis, foreign_task.id).await.unwrap();
+    assert!(
+        resolved_visible.is_some(),
+        "visible-aware resolve must find the foreign task"
+    );
+
+    // resolve_primary must NOT find it (foreign namespace).
+    let resolved_primary = rt.resolve_primary(&tok_vis, foreign_task.id).await.unwrap();
+    assert!(
+        resolved_primary.is_none(),
+        "resolve_primary must return None for a visible-only task; \
+         the depends_on validator uses resolve_primary and must reject it as NotFound"
+    );
+}
+
+/// A KG entity in a visible (non-primary) namespace must be treated as NotFound
+/// by `resolve_primary`, which is what `context_entity_id` validation now uses.
+#[tokio::test]
+async fn resolve_primary_rejects_visible_only_entity() {
+    use khive_runtime::{KhiveRuntime, Namespace};
+
+    let rt = KhiveRuntime::memory().unwrap();
+
+    let ns_primary = Namespace::parse("ctx-dep-primary-ns").unwrap();
+    let ns_foreign = Namespace::parse("ctx-dep-foreign-ns").unwrap();
+
+    let tok_foreign = rt.authorize(ns_foreign.clone()).unwrap();
+    let foreign_entity = rt
+        .create_entity(
+            &tok_foreign,
+            "concept",
+            None,
+            "Foreign Concept",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    let tok_vis = rt
+        .authorize_with_visibility(ns_primary.clone(), vec![ns_foreign.clone()])
+        .unwrap();
+
+    // resolve (visible-aware) finds the foreign entity.
+    let resolved_visible = rt.resolve(&tok_vis, foreign_entity.id).await.unwrap();
+    assert!(
+        resolved_visible.is_some(),
+        "visible-aware resolve must find the foreign entity"
+    );
+
+    // resolve_primary must NOT find it — context_entity_id validation uses this.
+    let resolved_primary = rt
+        .resolve_primary(&tok_vis, foreign_entity.id)
+        .await
+        .unwrap();
+    assert!(
+        resolved_primary.is_none(),
+        "resolve_primary must return None for a visible-only entity; \
+         context_entity_id validation uses resolve_primary and must reject it as NotFound"
+    );
+}

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -68,14 +68,17 @@ impl KgPack {
             .await
             .map_err(RuntimeError::Storage)?
         {
-            if note.namespace == token.namespace().as_str() {
+            if token
+                .visible_namespace_strs()
+                .contains(&note.namespace.as_str())
+            {
                 let note_val = normalize_entity_timestamps(to_json(&note)?);
                 let remapped = remap_note_status(note_val);
                 return flatten_get_result("note", remapped);
             }
         }
 
-        if let Some(edge) = self.runtime.get_edge(graph_token, id).await? {
+        if let Some(edge) = self.runtime.get_edge_visible(token, id).await? {
             return flatten_get_result("edge", to_json(&edge)?);
         }
 
@@ -86,7 +89,10 @@ impl KgPack {
             .await
             .map_err(RuntimeError::Storage)?
         {
-            if event.namespace == token.namespace().as_str() {
+            if token
+                .visible_namespace_strs()
+                .contains(&event.namespace.as_str())
+            {
                 return flatten_get_result("event", normalize_event_timestamps(to_json(&event)?));
             }
         }

--- a/crates/khive-pack-kg/src/handlers/list.rs
+++ b/crates/khive-pack-kg/src/handlers/list.rs
@@ -82,6 +82,11 @@ impl KgPack {
                                 .map(|t| vec![t.to_string()])
                                 .unwrap_or_default(),
                             tags_any: tag_list.clone(),
+                            namespaces: token
+                                .visible_namespace_strs()
+                                .iter()
+                                .map(|s| s.to_string())
+                                .collect(),
                             ..Default::default()
                         };
                         let page = self

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -80,6 +80,11 @@ impl KgPack {
                                 token.namespace().as_str(),
                                 EntityFilter {
                                     ids: candidate_ids,
+                                    namespaces: token
+                                        .visible_namespace_strs()
+                                        .iter()
+                                        .map(|s| s.to_string())
+                                        .collect(),
                                     ..EntityFilter::default()
                                 },
                                 PageRequest {

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -27,6 +27,7 @@ fn build_runtime() -> KhiveRuntime {
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
         brain_profile: None,
+        visible_namespaces: vec![],
     })
     .expect("runtime")
 }

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -34,6 +34,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
         brain_profile: None,
+        visible_namespaces: vec![],
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -34,6 +34,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
         brain_profile: None,
+        visible_namespaces: vec![],
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1416,6 +1416,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
         packs: vec!["kg".to_string(), "knowledge".to_string()],
         backend_id: BackendId::main(),
         brain_profile: None,
+        visible_namespaces: vec![],
     })
     .expect("runtime with default embedder")
 }
@@ -2084,6 +2085,7 @@ mod embed_failure_tests {
             packs: vec!["kg".to_string(), "knowledge".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         })
         .expect("runtime");
         // Override the lattice provider with our fake — same key, last-writer wins.
@@ -2443,6 +2445,7 @@ mod ann_bypass_regression {
             packs: vec!["kg".to_string(), "knowledge".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         })
         .expect("runtime");
         rt.register_embedder(CorrectDimProvider);

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -589,13 +589,16 @@ impl MemoryPack {
             fts_gather,
         } = opts;
 
-        // FTS recall fans out across all visible namespaces (global table with
-        // namespace column, supports IN filter).
+        // FTS recall fans out across all visible namespaces by iterating each
+        // namespace's own FTS virtual table (fts_notes_{ns}) — there is NO global
+        // FTS table and TextFilter.namespaces does NOT yield cross-namespace hits.
+        // Each namespace is selected by minting a token via token.with_namespace(ns)
+        // (see multi-namespace fanout path below at line 633+).
         //
         // Phase-1.5 limitation: vector/ANN recall stays primary-namespace-only.
         // Each namespace owns a separate ANN index instance; cross-namespace
         // recall on the vector path requires fanout+fusion across index instances,
-        // which ships in a follow-up PR. FTS-path recall is cross-namespace today.
+        // which is deferred to a follow-up PR.
         let visible = token.visible_namespace_strs();
         let primary_ns = token.namespace().as_str().to_string();
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -588,34 +588,77 @@ impl MemoryPack {
             snippet_policy,
             fts_gather,
         } = opts;
-        let ns = token.namespace().as_str().to_string();
 
-        let text_fut = self.collect_recall_text_hits(
-            token,
-            query,
-            &ns,
-            candidate_limit,
-            snippet_policy,
-            is_cjk,
-            fts_gather,
-        );
-        let vector_fut = self.collect_recall_vector_hits(
-            token,
-            query,
-            &ns,
-            RecallVectorCandidateParams {
+        // Use all visible namespaces for FTS; fall back to primary for vector
+        // recall (vector index is per-namespace, primary is the write namespace).
+        let visible = token.visible_namespace_strs();
+        let primary_ns = token.namespace().as_str().to_string();
+
+        // For single-namespace (common case) take the fast path.
+        if visible.len() <= 1 {
+            let text_fut = self.collect_recall_text_hits(
+                token,
+                query,
+                &primary_ns,
                 candidate_limit,
-                embedding_model,
+                snippet_policy,
                 is_cjk,
-                scoring_cfg,
-            },
-        );
+                fts_gather,
+            );
+            let vector_fut = self.collect_recall_vector_hits(
+                token,
+                query,
+                &primary_ns,
+                RecallVectorCandidateParams {
+                    candidate_limit,
+                    embedding_model,
+                    is_cjk,
+                    scoring_cfg,
+                },
+            );
+            let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
+            return Ok(RecallCandidateSet {
+                namespace: primary_ns,
+                text_hits,
+                vector_hits_per_model: vector_result.vector_hits_per_model,
+                cjk_routed: vector_result.cjk_routed,
+            });
+        }
 
-        let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
+        // Multi-namespace: fanout FTS across all visible namespaces, aggregate.
+        let mut all_text_hits = Vec::new();
+        for ns_str in &visible {
+            let hits = self
+                .collect_recall_text_hits(
+                    token,
+                    query,
+                    ns_str,
+                    candidate_limit,
+                    snippet_policy,
+                    is_cjk,
+                    fts_gather,
+                )
+                .await?;
+            all_text_hits.extend(hits);
+        }
+        // Vector recall stays in primary namespace (single index).
+        let vector_result = self
+            .collect_recall_vector_hits(
+                token,
+                query,
+                &primary_ns,
+                RecallVectorCandidateParams {
+                    candidate_limit,
+                    embedding_model,
+                    is_cjk,
+                    scoring_cfg,
+                },
+            )
+            .await?;
 
         Ok(RecallCandidateSet {
-            namespace: ns,
-            text_hits,
+            namespace: primary_ns,
+            text_hits: all_text_hits,
             vector_hits_per_model: vector_result.vector_hits_per_model,
             cjk_routed: vector_result.cjk_routed,
         })

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -589,8 +589,13 @@ impl MemoryPack {
             fts_gather,
         } = opts;
 
-        // Use all visible namespaces for FTS; fall back to primary for vector
-        // recall (vector index is per-namespace, primary is the write namespace).
+        // FTS recall fans out across all visible namespaces (global table with
+        // namespace column, supports IN filter).
+        //
+        // Phase-1.5 limitation: vector/ANN recall stays primary-namespace-only.
+        // Each namespace owns a separate ANN index instance; cross-namespace
+        // recall on the vector path requires fanout+fusion across index instances,
+        // which ships in a follow-up PR. FTS-path recall is cross-namespace today.
         let visible = token.visible_namespace_strs();
         let primary_ns = token.namespace().as_str().to_string();
 
@@ -625,12 +630,22 @@ impl MemoryPack {
             });
         }
 
-        // Multi-namespace: fanout FTS across all visible namespaces, aggregate.
+        // Multi-namespace: fanout FTS across all visible namespaces.
+        //
+        // Each namespace has its own FTS virtual table (fts_notes_{ns}); we must
+        // select that table by minting a token whose primary namespace matches the
+        // target namespace. `token.with_namespace` creates such a token while
+        // preserving the actor context.
         let mut all_text_hits = Vec::new();
         for ns_str in &visible {
+            let ns_parsed = match khive_runtime::Namespace::parse(ns_str) {
+                Ok(ns) => ns,
+                Err(_) => continue,
+            };
+            let ns_token = token.with_namespace(ns_parsed);
             let hits = self
                 .collect_recall_text_hits(
-                    token,
+                    &ns_token,
                     query,
                     ns_str,
                     candidate_limit,

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -407,6 +407,7 @@ pub(crate) async fn handle_agenda(
             value: SqlValue::Text("pending".to_string()),
         }],
         order_by: Some(("$.trigger_at".to_string(), SortDir::Asc)),
+        ..Default::default()
     };
 
     const PAGE_SIZE: u32 = 200;

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -79,16 +79,23 @@ pub struct NamespaceToken {
 }
 
 impl NamespaceToken {
-    /// Mint an authorized token with an explicit visibility set.
+    /// Mint an authorized token with an extended visibility set.
     ///
-    /// `visible` MUST contain `namespace`; callers are responsible for this
-    /// invariant. The `mint_authorized` convenience form enforces it by
-    /// defaulting `visible` to `[namespace]`.
+    /// `extra_visible` lists namespaces beyond the primary that the token may
+    /// read. The primary namespace is always included in the visible set
+    /// regardless of what `extra_visible` contains. Duplicates are removed.
     pub(crate) fn mint_with_visibility(
         namespace: Namespace,
-        visible: Vec<Namespace>,
+        extra_visible: Vec<Namespace>,
         actor: ActorRef,
     ) -> Self {
+        let mut visible = vec![namespace.clone()];
+        for ns in extra_visible {
+            if !visible.contains(&ns) {
+                visible.push(ns);
+            }
+        }
+        debug_assert!(!visible.is_empty(), "visible set must be non-empty");
         Self {
             namespace,
             visible,
@@ -102,8 +109,7 @@ impl NamespaceToken {
     /// The visible set defaults to `[namespace]` — backward-compatible with
     /// single-namespace enforcement.
     pub(crate) fn mint_authorized(namespace: Namespace, actor: ActorRef) -> Self {
-        let visible = vec![namespace.clone()];
-        Self::mint_with_visibility(namespace, visible, actor)
+        Self::mint_with_visibility(namespace, vec![], actor)
     }
 
     /// Convenience constructor for the local namespace with an anonymous actor.
@@ -221,6 +227,12 @@ pub struct RuntimeConfig {
     /// 2. Namespace-bound profile resolved via `brain.resolve` at feedback time
     /// 3. Pack-local global tuning prior (default fallback)
     pub brain_profile: Option<String>,
+    /// Extra namespaces the pack-dispatch token may read (beyond the primary).
+    ///
+    /// Populated from `actor.visible_namespaces` in `khive.toml`. The primary
+    /// namespace (actor.id) is always implicitly readable and need not appear
+    /// here. Empty by default (single-namespace behaviour).
+    pub visible_namespaces: Vec<Namespace>,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -277,6 +289,7 @@ impl Default for RuntimeConfig {
             packs,
             backend_id: BackendId::main(),
             brain_profile,
+            visible_namespaces: vec![],
         }
     }
 }
@@ -387,10 +400,26 @@ pub fn runtime_config_from_khive_config(
             .filter(|s| !s.trim().is_empty())
     });
 
+    let visible_namespaces: Vec<Namespace> = khive_cfg
+        .actor
+        .visible_namespaces
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|s| match Namespace::parse(s) {
+            Ok(ns) => Some(ns),
+            Err(e) => {
+                tracing::warn!(ns = %s, error = %e, "actor.visible_namespaces: invalid namespace; skipped");
+                None
+            }
+        })
+        .collect();
+
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
             default_namespace,
             brain_profile,
+            visible_namespaces,
             ..base
         };
     }
@@ -422,6 +451,7 @@ pub fn runtime_config_from_khive_config(
         additional_embedding_models: additional,
         default_namespace,
         brain_profile,
+        visible_namespaces,
         ..base
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -62,21 +62,48 @@ mod private {
 /// Created by [`VerbRegistry::dispatch`] after the gate approves the request.
 /// The sealed inner field prevents external code from constructing a token
 /// without going through the authorization path.
+///
+/// The `namespace` field is the **write namespace**: all records created via
+/// this token land in that namespace. `visible` is the **read visibility set**:
+/// list/search/get operations will return records from any namespace in this
+/// set. The write namespace is always a member of the visible set.
+///
+/// Single-namespace behaviour (backward-compatible default): `visible` contains
+/// exactly `[namespace]` — identical to the old strict-equality checks.
 #[derive(Clone, Debug)]
 pub struct NamespaceToken {
     namespace: Namespace,
+    visible: Vec<Namespace>,
     actor: ActorRef,
     _sealed: private::Sealed,
 }
 
 impl NamespaceToken {
-    /// Mint an authorized token. Only callable from within `khive-runtime`.
-    pub(crate) fn mint_authorized(namespace: Namespace, actor: ActorRef) -> Self {
+    /// Mint an authorized token with an explicit visibility set.
+    ///
+    /// `visible` MUST contain `namespace`; callers are responsible for this
+    /// invariant. The `mint_authorized` convenience form enforces it by
+    /// defaulting `visible` to `[namespace]`.
+    pub(crate) fn mint_with_visibility(
+        namespace: Namespace,
+        visible: Vec<Namespace>,
+        actor: ActorRef,
+    ) -> Self {
         Self {
             namespace,
+            visible,
             actor,
             _sealed: private::Sealed,
         }
+    }
+
+    /// Mint an authorized token. Only callable from within `khive-runtime`.
+    ///
+    /// The visible set defaults to `[namespace]` — backward-compatible with
+    /// single-namespace enforcement.
+    pub(crate) fn mint_authorized(namespace: Namespace, actor: ActorRef) -> Self {
+        let visible = vec![namespace.clone()];
+        Self::mint_with_visibility(namespace, visible, actor)
     }
 
     /// Convenience constructor for the local namespace with an anonymous actor.
@@ -99,9 +126,26 @@ impl NamespaceToken {
         Self::mint_authorized(ns, ActorRef::anonymous())
     }
 
-    /// Return the namespace this token authorises access to.
+    /// Return the write namespace this token authorises.
+    ///
+    /// All records created via this token land in this namespace.
     pub fn namespace(&self) -> &Namespace {
         &self.namespace
+    }
+
+    /// Return the read-visibility set.
+    ///
+    /// List, search, and get operations must accept records whose namespace is
+    /// a member of this set. The write namespace is always included.
+    pub fn visible_namespaces(&self) -> &[Namespace] {
+        &self.visible
+    }
+
+    /// Return a deduplicated list of visible namespace strings (borrowed).
+    ///
+    /// Convenience for passing directly to storage layer filters.
+    pub fn visible_namespace_strs(&self) -> Vec<&str> {
+        self.visible.iter().map(|ns| ns.as_str()).collect()
     }
 
     /// Return the actor reference embedded in this token.
@@ -113,7 +157,8 @@ impl NamespaceToken {
     ///
     /// Used by packs that apply a namespace policy (e.g. the KG pack overrides the
     /// caller's namespace to `Namespace::local()` so that entity/edge/note records
-    /// always land in the shared graph).
+    /// always land in the shared graph). The visible set is also replaced with
+    /// `[ns]` so isolation is maintained for the overridden namespace.
     pub fn with_namespace(&self, ns: Namespace) -> Self {
         Self::mint_authorized(ns, self.actor.clone())
     }

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -90,9 +90,15 @@ pub struct EngineConfig {
 ///
 /// ```toml
 /// [actor]
-/// id = "lambda:khive"          # default namespace (required)
-/// display_name = "Ocean's khive lambda"  # human label (optional)
+/// id = "lambda:leo"                          # write namespace (required)
+/// display_name = "Leo global orchestrator"   # human label (optional)
+/// visible_namespaces = ["lambda:khive", "local"]  # additional readable namespaces
 /// ```
+///
+/// The `visible_namespaces` list extends the read visibility of the token
+/// minted for this actor. Records in any of those namespaces will appear in
+/// list / search / get results alongside records in the primary `id` namespace.
+/// The primary namespace is always visible regardless of this list.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ActorConfig {
     /// Namespace identifier used as the default actor for all operations.
@@ -107,6 +113,13 @@ pub struct ActorConfig {
     /// surfaced in introspection and log output only.
     #[serde(default)]
     pub display_name: Option<String>,
+
+    /// Additional namespaces this actor can read from (beyond its own write
+    /// namespace). Each string must be a valid `Namespace`. The primary `id`
+    /// namespace is always included in the visible set — no need to repeat it
+    /// here. When absent or empty, visibility defaults to `[id]` only.
+    #[serde(default)]
+    pub visible_namespaces: Option<Vec<String>>,
 }
 
 /// Top-level khive configuration loaded from `khive.toml` or `config.toml`.
@@ -269,6 +282,22 @@ impl KhiveConfig {
                 id: id.to_string(),
                 reason: e.to_string(),
             })?;
+        }
+
+        // Validate actor.visible_namespaces when present.
+        if let Some(ref vis) = self.actor.visible_namespaces {
+            for ns_str in vis {
+                if ns_str.is_empty() {
+                    return Err(ConfigError::InvalidActorId {
+                        id: ns_str.clone(),
+                        reason: "visible_namespaces entries must not be empty".to_string(),
+                    });
+                }
+                Namespace::parse(ns_str).map_err(|e| ConfigError::InvalidActorId {
+                    id: ns_str.clone(),
+                    reason: format!("invalid visible namespace: {e}"),
+                })?;
+            }
         }
 
         if self.engines.is_empty() {
@@ -796,6 +825,7 @@ id = "lambda:"
             actor: ActorConfig {
                 id: Some("lambda:test-actor".to_string()),
                 display_name: None,
+                ..Default::default()
             },
             runtime: RuntimeSectionConfig::default(),
         };
@@ -822,6 +852,7 @@ id = "lambda:"
             actor: ActorConfig {
                 id: None,
                 display_name: None,
+                ..Default::default()
             },
             runtime: RuntimeSectionConfig::default(),
         };

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -667,8 +667,8 @@ impl KhiveRuntime {
             ));
         }
         if relation == EdgeRelation::Annotates {
-            // Source must be a note in namespace.
-            match self.resolve(token, source_id).await? {
+            // Source must be a note in the primary namespace.
+            match self.resolve_primary(token, source_id).await? {
                 Some(Resolved::Note(_)) => {}
                 Some(_) => {
                     return Err(RuntimeError::InvalidInput(format!(
@@ -687,8 +687,8 @@ impl KhiveRuntime {
                     )));
                 }
             }
-            // Target may be any substrate (entity, note, event, or edge).
-            if !self.substrate_exists_in_ns(token, target_id).await? {
+            // Target may be any substrate (entity, note, event, or edge) — primary only.
+            if !self.substrate_exists_in_primary(token, target_id).await? {
                 return Err(RuntimeError::NotFound(format!(
                     "link target {target_id} not found in namespace"
                 )));
@@ -700,7 +700,7 @@ impl KhiveRuntime {
             // supersedes / supports / refutes: same-substrate only (note→note or entity→entity).
             // Event and edge endpoints are invalid regardless of the other endpoint.
             let rel_name = relation.as_str();
-            let src = match self.resolve(token, source_id).await? {
+            let src = match self.resolve_primary(token, source_id).await? {
                 Some(r) => r,
                 None => {
                     if self.get_edge(token, source_id).await?.is_some() {
@@ -713,7 +713,7 @@ impl KhiveRuntime {
                     )));
                 }
             };
-            let tgt = match self.resolve(token, target_id).await? {
+            let tgt = match self.resolve_primary(token, target_id).await? {
                 Some(r) => r,
                 None => {
                     if self.get_edge(token, target_id).await?.is_some() {
@@ -772,10 +772,10 @@ impl KhiveRuntime {
             // restrictions (see base allowlist). Packs may extend the allowlist
             // additively via EDGE_RULES.
             //
-            // Strategy: resolve both endpoints once, consult pack rules; on
+            // Strategy: resolve both endpoints once (primary-only), consult pack rules; on
             // miss, fall through to the original base-rule error messages.
-            let src_res = self.resolve(token, source_id).await?;
-            let tgt_res = self.resolve(token, target_id).await?;
+            let src_res = self.resolve_primary(token, source_id).await?;
+            let tgt_res = self.resolve_primary(token, target_id).await?;
 
             if pack_rule_allows(
                 &self.pack_edge_rules(),
@@ -946,6 +946,25 @@ impl KhiveRuntime {
         }
     }
 
+    /// Returns `true` if `id` resolves to a live substrate record in the PRIMARY namespace only.
+    ///
+    /// Used from mutation endpoint validation where visible-set membership is not
+    /// sufficient — the record must belong to the caller's write namespace.
+    pub(crate) async fn substrate_exists_in_primary(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<bool> {
+        if self.resolve_primary(token, id).await?.is_some() {
+            return Ok(true);
+        }
+        match self.get_edge(token, id).await {
+            Ok(Some(_)) => Ok(true),
+            Ok(None) | Err(RuntimeError::NotFound(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Get immediate neighbors of a node, optionally filtered by relation type.
     ///
     /// Pass `relations: Some(vec![EdgeRelation::Annotates])` to retrieve only
@@ -996,7 +1015,14 @@ impl KhiveRuntime {
 
         query.direction =
             normalize_symmetric_direction(query.direction, query.relations.as_deref());
-        let mut hits = self.graph(token)?.neighbors(node_id, query).await?;
+        let mut hits = Vec::new();
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            let mut ns_hits = self.graph(&temp)?.neighbors(node_id, query.clone()).await?;
+            hits.append(&mut ns_hits);
+        }
+        hits.sort_by_key(|h| (h.node_id, h.edge_id));
+        hits.dedup_by_key(|h| (h.node_id, h.edge_id));
         self.enrich_neighbor_hits(token, &mut hits).await;
         // Filter out soft-deleted entity nodes (Fix 2).
         let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.node_id).collect();
@@ -1028,7 +1054,12 @@ impl KhiveRuntime {
             return Ok(Vec::new());
         }
 
-        let mut paths = self.graph(token)?.traverse(request).await?;
+        let mut paths = Vec::new();
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            let mut ns_paths = self.graph(&temp)?.traverse(request.clone()).await?;
+            paths.append(&mut ns_paths);
+        }
         self.enrich_path_nodes(token, &mut paths).await;
         // Filter out soft-deleted entity nodes from all path nodes (Fix 2).
         let all_node_ids: Vec<Uuid> = paths
@@ -1260,8 +1291,10 @@ impl KhiveRuntime {
         let ns = token.namespace().as_str();
 
         // Validate all annotates targets before any write (atomicity: all-or-nothing).
+        // Targets must be in the primary namespace — visible-set membership is not
+        // sufficient for mutation endpoint validation.
         for &target_id in &annotates {
-            if !self.substrate_exists_in_ns(token, target_id).await? {
+            if !self.substrate_exists_in_primary(token, target_id).await? {
                 return Err(RuntimeError::NotFound(format!(
                     "create_note annotates target {target_id} not found in namespace"
                 )));
@@ -1768,8 +1801,6 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         id: Uuid,
     ) -> RuntimeResult<Option<Resolved>> {
-        let ns = token.namespace().as_str();
-
         // Entity: use the namespace-checked getter (errors on mismatch/absent).
         match self.get_entity(token, id).await {
             Ok(entity) => return Ok(Some(Resolved::Entity(entity))),
@@ -1777,14 +1808,49 @@ impl KhiveRuntime {
             Err(e) => return Err(e),
         }
 
-        // Note: storage get_note is ID-only — verify namespace after fetch.
+        // Note: storage get_note is ID-only — verify against visible set.
+        if let Some(note) = self.notes(token)?.get_note(id).await? {
+            if Self::ensure_namespace_visible(&note.namespace, token).is_ok() {
+                return Ok(Some(Resolved::Note(note)));
+            }
+        }
+
+        // Event: storage get_event is ID-only — verify against visible set.
+        if let Some(event) = self.events(token)?.get_event(id).await? {
+            if Self::ensure_namespace_visible(&event.namespace, token).is_ok() {
+                return Ok(Some(Resolved::Event(event)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Resolve a UUID to its substrate kind using primary-namespace-only enforcement.
+    ///
+    /// Unlike `resolve`, never consults the visible set. Use from mutation validation
+    /// paths (link, annotate, build_edge) where strict primary ownership is required.
+    pub async fn resolve_primary(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<Resolved>> {
+        let ns = token.namespace().as_str();
+
+        // Entity: primary-only check (exclude entities in visible-only namespaces).
+        if let Some(entity) = self.entities(token)?.get_entity(id).await? {
+            if Self::ensure_namespace(&entity.namespace, ns).is_ok() {
+                return Ok(Some(Resolved::Entity(entity)));
+            }
+        }
+
+        // Note: primary-only check.
         if let Some(note) = self.notes(token)?.get_note(id).await? {
             if Self::ensure_namespace(&note.namespace, ns).is_ok() {
                 return Ok(Some(Resolved::Note(note)));
             }
         }
 
-        // Event: storage get_event is ID-only — verify namespace after fetch.
+        // Event: primary-only check.
         if let Some(event) = self.events(token)?.get_event(id).await? {
             if Self::ensure_namespace(&event.namespace, ns).is_ok() {
                 return Ok(Some(Resolved::Event(event)));
@@ -2105,6 +2171,41 @@ impl KhiveRuntime {
         Ok(self.graph(token)?.get_edge(LinkId::from(edge_id)).await?)
     }
 
+    /// Fetch a single edge by id from any namespace in the token's visible set.
+    ///
+    /// Returns `Ok(None)` when the edge is absent or its namespace is not in the
+    /// visible set. Used by read paths (e.g. `get` verb) so that a caller with
+    /// cross-namespace visibility can retrieve edges from non-primary namespaces.
+    pub async fn get_edge_visible(
+        &self,
+        token: &NamespaceToken,
+        edge_id: Uuid,
+    ) -> RuntimeResult<Option<Edge>> {
+        let mut reader = self.sql().reader().await?;
+        let record_ns = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT namespace FROM graph_edges \
+                      WHERE id = ?1 AND deleted_at IS NULL LIMIT 1"
+                    .into(),
+                params: vec![SqlValue::Text(edge_id.to_string())],
+                label: Some("get_edge_visible_namespace".into()),
+            })
+            .await?;
+        let Some(SqlValue::Text(record_ns)) = record_ns else {
+            return Ok(None);
+        };
+        if Self::ensure_namespace_visible(&record_ns, token).is_err() {
+            return Ok(None);
+        }
+        // Re-use the primary-namespace graph store; the edge row is already confirmed
+        // visible so the namespace token is just used for backend routing here.
+        let temp = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&record_ns)
+                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+        );
+        Ok(self.graph(&temp)?.get_edge(LinkId::from(edge_id)).await?)
+    }
+
     /// Fetch an edge by UUID including soft-deleted rows, returning `None` if absent or if the
     /// record belongs to a different namespace. Used by the hard-delete path so that a
     /// soft-deleted primary edge can still be purged via its edge ID.
@@ -2143,18 +2244,26 @@ impl KhiveRuntime {
         limit: u32,
     ) -> RuntimeResult<Vec<Edge>> {
         let limit = limit.clamp(1, 1000);
-        let page = self
-            .graph(token)?
-            .query_edges(
-                filter.into(),
-                vec![SortOrder {
-                    field: EdgeSortField::CreatedAt,
-                    direction: khive_storage::types::SortDirection::Asc,
-                }],
-                PageRequest { offset: 0, limit },
-            )
-            .await?;
-        Ok(page.items)
+        let mut results = Vec::new();
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            let page = self
+                .graph(&temp)?
+                .query_edges(
+                    filter.clone().into(),
+                    vec![SortOrder {
+                        field: EdgeSortField::CreatedAt,
+                        direction: khive_storage::types::SortDirection::Asc,
+                    }],
+                    PageRequest { offset: 0, limit },
+                )
+                .await?;
+            results.extend(page.items);
+        }
+        results.sort_by_key(|e| Uuid::from(e.id));
+        results.dedup_by_key(|e| Uuid::from(e.id));
+        results.truncate(limit as usize);
+        Ok(results)
     }
 
     /// Patch-style edge update. Only `Some(_)` fields are applied.

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -927,10 +927,12 @@ impl KhiveRuntime {
         Ok(persisted)
     }
 
-    /// Returns `true` if `id` resolves to a live substrate record in `namespace`.
+    /// Returns `true` if `id` resolves to a live substrate record in the
+    /// caller's visible namespace set.
     ///
-    /// Covers entity, note, event (via `resolve`) and edge (via `get_edge`).
-    /// A record that exists in a different namespace returns `false` (fail-closed).
+    /// Covers entity, note, event (via `resolve`) and edge (via `get_edge_visible`).
+    /// Only records that are accessible to the caller (primary or configured visible
+    /// namespaces) return `true`; absent or foreign-invisible records return `false`.
     pub(crate) async fn substrate_exists_in_ns(
         &self,
         token: &NamespaceToken,
@@ -939,7 +941,7 @@ impl KhiveRuntime {
         if self.resolve(token, id).await?.is_some() {
             return Ok(true);
         }
-        match self.get_edge(token, id).await {
+        match self.get_edge_visible(token, id).await {
             Ok(Some(_)) => Ok(true),
             Ok(None) | Err(RuntimeError::NotFound(_)) => Ok(false),
             Err(err) => Err(err),
@@ -3257,6 +3259,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(just_extends, 1);
+    }
+
+    // ---- Finding 4 regression: substrate_exists_in_ns must use get_edge_visible ----
+
+    /// An edge owned by a visible (non-primary) namespace must be found by
+    /// `substrate_exists_in_ns` and therefore usable as a graph root in
+    /// `neighbors` and `traverse`.
+    #[tokio::test]
+    async fn edge_in_visible_namespace_reachable_as_graph_root() {
+        let rt = rt();
+        let ns_a = Namespace::parse("vis-edge-a").unwrap();
+        let ns_b = Namespace::parse("vis-edge-b").unwrap();
+
+        // Create two entities and an edge in namespace B.
+        let tok_b = NamespaceToken::for_namespace(ns_b.clone());
+        let src = rt
+            .create_entity(&tok_b, "concept", None, "SrcB", None, None, vec![])
+            .await
+            .unwrap();
+        let tgt = rt
+            .create_entity(&tok_b, "concept", None, "TgtB", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok_b, src.id, tgt.id, EdgeRelation::Extends, 1.0, None)
+            .await
+            .unwrap();
+
+        // Namespace A with B in its visible set should be able to get the
+        // edge and use it as a traverse root.
+        let tok_a_vis = rt
+            .authorize_with_visibility(ns_a.clone(), vec![ns_b.clone()])
+            .unwrap();
+
+        // Direct get of the edge must succeed (visible namespace).
+        let got = rt.get_edge_visible(&tok_a_vis, edge.id.0).await.unwrap();
+        assert!(
+            got.is_some(),
+            "edge in visible namespace must be retrievable via get_edge_visible"
+        );
+
+        // neighbors/traverse use substrate_exists_in_ns which now calls
+        // get_edge_visible — they must not return empty for a visible-ns edge root.
+        let neighbors = rt
+            .neighbors(&tok_a_vis, src.id, Direction::Out, Some(16), None)
+            .await
+            .unwrap();
+        assert!(
+            neighbors.iter().any(|h| h.node_id == tgt.id),
+            "neighbors of visible-ns node must include its visible-ns neighbor; got: {neighbors:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -386,26 +386,26 @@ impl KhiveRuntime {
         Ok(entity)
     }
 
-    /// Retrieve an entity by ID, enforcing namespace isolation.
+    /// Retrieve an entity by ID, enforcing namespace visibility.
     ///
-    /// Returns `Err(NotFound)` if the entity does not exist or belongs to a
-    /// different namespace (indistinguishable — no cross-namespace existence oracle).
+    /// Returns `Err(NotFound)` if the entity does not exist or its namespace is
+    /// not in the token's visible set (indistinguishable — no cross-namespace
+    /// existence oracle).
     pub async fn get_entity(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<Entity> {
         let entity = self
             .entities(token)?
             .get_entity(id)
             .await?
             .ok_or_else(|| RuntimeError::NotFound("not found in this namespace".into()))?;
-        Self::ensure_namespace(&entity.namespace, token.namespace().as_str())?;
+        Self::ensure_namespace_visible(&entity.namespace, token)?;
         Ok(entity)
     }
 
-    /// Retrieve an entity by ID including soft-deleted rows, enforcing namespace isolation.
+    /// Retrieve an entity by ID including soft-deleted rows, enforcing namespace visibility.
     ///
-    /// Returns `Ok(Some(entity))` when the entity exists in the caller's namespace
-    /// regardless of `deleted_at`. Returns `Ok(None)` when the UUID was never created
-    /// or belongs to a different namespace. Callers use this to distinguish
-    /// "soft-deleted" from "never existed".
+    /// Returns `Ok(Some(entity))` when the entity exists in a namespace visible
+    /// to the token regardless of `deleted_at`. Returns `Ok(None)` when the UUID
+    /// was never created or is not visible to the caller.
     pub async fn get_entity_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -419,17 +419,17 @@ impl KhiveRuntime {
             Some(e) => e,
             None => return Ok(None),
         };
-        if entity.namespace != token.namespace().as_str() {
+        if Self::ensure_namespace_visible(&entity.namespace, token).is_err() {
             return Ok(None);
         }
         Ok(Some(entity))
     }
 
-    /// Retrieve a note by ID including soft-deleted rows, enforcing namespace isolation.
+    /// Retrieve a note by ID including soft-deleted rows, enforcing namespace visibility.
     ///
-    /// Returns `Ok(Some(note))` when the note exists in the caller's namespace regardless
-    /// of `deleted_at`. Returns `Ok(None)` when the UUID was never created or belongs to
-    /// a different namespace.
+    /// Returns `Ok(Some(note))` when the note exists in a namespace visible to
+    /// the token regardless of `deleted_at`. Returns `Ok(None)` when the UUID
+    /// was never created or is not visible to the caller.
     pub async fn get_note_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -439,7 +439,7 @@ impl KhiveRuntime {
             Some(n) => n,
             None => return Ok(None),
         };
-        if note.namespace != token.namespace().as_str() {
+        if Self::ensure_namespace_visible(&note.namespace, token).is_err() {
             return Ok(None);
         }
         Ok(Some(note))
@@ -474,18 +474,43 @@ impl KhiveRuntime {
         Ok(page.items)
     }
 
-    /// Enforce that `record_ns` matches `caller_ns`.
+    /// Enforce that `record_ns` is within the caller's visible namespace set.
     ///
-    /// Returns `Err(NotFound)` when they differ — wrong-namespace
-    /// and absent UUIDs must be indistinguishable externally (no existence oracle).
-    pub(crate) fn ensure_namespace(record_ns: &str, caller_ns: &str) -> RuntimeResult<()> {
-        if record_ns == caller_ns {
+    /// Returns `Err(NotFound)` when the record namespace is not in the visible
+    /// set — wrong-namespace and absent UUIDs must be indistinguishable
+    /// externally (no existence oracle).
+    ///
+    /// When the visible set is a single entry equal to `caller_primary_ns`, this
+    /// is identical to the former strict-equality check (backward-compatible).
+    pub(crate) fn ensure_namespace(record_ns: &str, caller_primary_ns: &str) -> RuntimeResult<()> {
+        if record_ns == caller_primary_ns {
             return Ok(());
         }
         Err(RuntimeError::NotFound("not found in this namespace".into()))
     }
 
-    /// List entities in a namespace, optionally filtered by kind and entity_type.
+    /// Enforce that `record_ns` is a member of the token's visible namespace set.
+    ///
+    /// This is the multi-namespace-aware variant used when the token carries an
+    /// extended visibility set. For single-namespace tokens (visible == [primary])
+    /// this degenerates to the same strict-equality check as `ensure_namespace`.
+    pub(crate) fn ensure_namespace_visible(
+        record_ns: &str,
+        token: &NamespaceToken,
+    ) -> RuntimeResult<()> {
+        for ns in token.visible_namespaces() {
+            if record_ns == ns.as_str() {
+                return Ok(());
+            }
+        }
+        Err(RuntimeError::NotFound("not found in this namespace".into()))
+    }
+
+    /// List entities visible to the token, optionally filtered by kind and entity_type.
+    ///
+    /// When the token carries a multi-namespace visible set, entities from all
+    /// visible namespaces are returned. When the visible set is `[primary]`
+    /// (the default) this behaves identically to the pre-visibility behaviour.
     pub async fn list_entities(
         &self,
         token: &NamespaceToken,
@@ -494,6 +519,11 @@ impl KhiveRuntime {
         limit: u32,
         offset: u32,
     ) -> RuntimeResult<Vec<Entity>> {
+        let ns_strs: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
         let filter = EntityFilter {
             kinds: match kind {
                 Some(k) => vec![k.to_string()],
@@ -503,6 +533,7 @@ impl KhiveRuntime {
                 Some(t) => vec![t.to_string()],
                 None => vec![],
             },
+            namespaces: ns_strs,
             ..Default::default()
         };
         let page = self
@@ -524,7 +555,7 @@ impl KhiveRuntime {
     /// When `domain_tag` is Some, the query is restricted at the storage layer via
     /// `EntityFilter::tags_any` so the page result already reflects the domain
     /// constraint.  This avoids the silent truncation that occurs when filtering
-    /// post-page (K-3).
+    /// post-page (K-3). Multi-namespace visibility from the token is applied.
     pub async fn list_entities_tagged(
         &self,
         token: &NamespaceToken,
@@ -533,6 +564,11 @@ impl KhiveRuntime {
         limit: u32,
         offset: u32,
     ) -> RuntimeResult<Vec<Entity>> {
+        let ns_strs: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
         let filter = EntityFilter {
             kinds: match kind {
                 Some(k) => vec![k.to_string()],
@@ -542,6 +578,7 @@ impl KhiveRuntime {
                 Some(t) if !t.is_empty() => vec![t.to_string()],
                 _ => vec![],
             },
+            namespaces: ns_strs,
             ..Default::default()
         };
         let page = self
@@ -561,12 +598,18 @@ impl KhiveRuntime {
     /// Count entities filtered by kind and optional domain tag.
     ///
     /// Used to report a meaningful `total` alongside a paginated listing (K-6).
+    /// Multi-namespace visibility from the token is applied.
     pub async fn count_entities_tagged(
         &self,
         token: &NamespaceToken,
         kind: Option<&str>,
         domain_tag: Option<&str>,
     ) -> RuntimeResult<u64> {
+        let ns_strs: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
         let filter = EntityFilter {
             kinds: match kind {
                 Some(k) => vec![k.to_string()],
@@ -576,6 +619,7 @@ impl KhiveRuntime {
                 Some(t) if !t.is_empty() => vec![t.to_string()],
                 _ => vec![],
             },
+            namespaces: ns_strs,
             ..Default::default()
         };
         Ok(self
@@ -1429,7 +1473,11 @@ impl KhiveRuntime {
         Ok(note)
     }
 
-    /// List notes, optionally filtered by kind.
+    /// List notes visible to the token, optionally filtered by kind.
+    ///
+    /// When the token carries a multi-namespace visible set, notes from all
+    /// visible namespaces are returned. When the visible set is `[primary]`
+    /// (the default) this behaves identically to the pre-visibility behaviour.
     pub async fn list_notes(
         &self,
         token: &NamespaceToken,
@@ -1437,11 +1485,35 @@ impl KhiveRuntime {
         limit: u32,
         offset: u32,
     ) -> RuntimeResult<Vec<Note>> {
+        let visible = token.visible_namespaces();
+        if visible.len() == 1 {
+            // Fast path: single namespace — use the dedicated query_notes method.
+            let page = self
+                .notes(token)?
+                .query_notes(
+                    token.namespace().as_str(),
+                    kind,
+                    PageRequest {
+                        offset: offset.into(),
+                        limit,
+                    },
+                )
+                .await?;
+            return Ok(page.items);
+        }
+        // Multi-namespace path: use query_notes_filtered with the visible set.
+        use khive_storage::note::NoteFilter;
+        let ns_strs: Vec<String> = visible.iter().map(|ns| ns.as_str().to_owned()).collect();
+        let filter = NoteFilter {
+            kind: kind.map(|k| k.to_string()),
+            namespaces: ns_strs,
+            ..Default::default()
+        };
         let page = self
             .notes(token)?
-            .query_notes(
+            .query_notes_filtered(
                 token.namespace().as_str(),
-                kind,
+                &filter,
                 PageRequest {
                     offset: offset.into(),
                     limit,
@@ -1471,16 +1543,20 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Vec<NoteSearchHit>> {
         const RRF_K: usize = 60;
         let candidates = limit.saturating_mul(4).max(limit);
-        let ns = token.namespace().as_str().to_owned();
+        let visible_ns: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
 
-        // FTS5 over the notes index.
+        // FTS5 over the notes index — search all visible namespaces.
         let text_hits = self
             .text_for_notes(token)?
             .search(TextSearchRequest {
                 query: query_text.to_string(),
                 mode: TextQueryMode::Plain,
                 filter: Some(TextFilter {
-                    namespaces: vec![ns.clone()],
+                    namespaces: visible_ns.clone(),
                     ..TextFilter::default()
                 }),
                 top_k: candidates,
@@ -1876,9 +1952,12 @@ impl KhiveRuntime {
         use khive_query::QueryValue;
         use khive_storage::types::SqlValue;
 
-        let ns = token.namespace().as_str();
         let ast = khive_query::parse_auto(query)?;
-        opts.scopes = vec![ns.to_string()];
+        opts.scopes = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_string())
+            .collect();
         let compiled = khive_query::compile(&ast, &opts)?;
         let warnings = compiled.warnings;
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -267,6 +267,8 @@ pub struct VerbRegistryBuilder {
     packs: Vec<Box<dyn PackRuntime>>,
     gate: GateRef,
     default_namespace: String,
+    /// Extra readable namespaces threaded into dispatch tokens.
+    visible_namespaces: Vec<Namespace>,
     /// Optional audit event sink.
     ///
     /// When set, every gate check writes a storage `Event` in addition to the
@@ -289,9 +291,19 @@ impl VerbRegistryBuilder {
             packs: Vec::new(),
             gate: std::sync::Arc::new(AllowAllGate),
             default_namespace: Namespace::local().as_str().to_string(),
+            visible_namespaces: vec![],
             event_store: None,
             dispatch_hook: None,
         }
+    }
+
+    /// Set the extra readable namespaces threaded into dispatch tokens.
+    ///
+    /// These are the namespaces from `actor.visible_namespaces` in `khive.toml`.
+    /// The primary namespace is always readable and need not appear here.
+    pub fn with_visible_namespaces(&mut self, ns: Vec<Namespace>) -> &mut Self {
+        self.visible_namespaces = ns;
+        self
     }
 
     /// Register a pack. The bound `P: Pack + PackRuntime` ensures the pack
@@ -449,6 +461,7 @@ impl VerbRegistryBuilder {
             packs: Arc::new(ordered_packs),
             gate: self.gate,
             default_namespace: self.default_namespace,
+            visible_namespaces: self.visible_namespaces,
             event_store: self.event_store,
             dispatch_hook: self.dispatch_hook,
         })
@@ -576,6 +589,8 @@ pub struct VerbRegistry {
     packs: std::sync::Arc<Vec<Box<dyn PackRuntime>>>,
     gate: GateRef,
     default_namespace: String,
+    /// Extra readable namespaces for dispatch tokens (from `actor.visible_namespaces`).
+    visible_namespaces: Vec<Namespace>,
     /// Audit event sink — `None` means tracing-only (v0.2 default).
     event_store: Option<Arc<dyn EventStore>>,
     /// Post-dispatch hook — `None` means no real-time observation (Issue #158).
@@ -747,9 +762,11 @@ impl VerbRegistry {
 
         // Mint the authorized namespace token at the dispatch boundary.
         // ns_str was already validated above when building the gate request.
-        let token = NamespaceToken::mint_authorized(
-            Namespace::parse(&ns_str)
-                .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?,
+        let primary = Namespace::parse(&ns_str)
+            .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
+        let token = NamespaceToken::mint_with_visibility(
+            primary,
+            self.visible_namespaces.clone(),
             ActorRef::anonymous(),
         );
 

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -330,6 +330,25 @@ impl KhiveRuntime {
     /// The fused candidate set is kept untruncated until after the alive + kind filter so
     /// that right-kind hits ranked below `limit` in the raw fusion still surface when
     /// higher-ranked candidates are wrong-kind or soft-deleted.
+    ///
+    /// # Cross-namespace visibility (Phase 1.5 limitation — primary namespace only)
+    ///
+    /// Both the **FTS leg** and the **vector/ANN leg** are currently restricted to
+    /// the **primary namespace only** for search.
+    ///
+    /// Rationale: each namespace owns a separate FTS table (`fts_entities_{ns}`)
+    /// and a separate ANN index instance. Cross-namespace fanout requires iterating
+    /// over every visible namespace's store, issuing parallel search requests, and
+    /// fusing the results — this is deferred to Phase 1.5.
+    ///
+    /// The `visible_ns` list is forwarded in the `TextFilter.namespaces` field,
+    /// which limits results to those namespaces within the primary store. Because
+    /// entities from extra namespaces live in their own FTS tables, this filter has
+    /// no cross-namespace effect today.
+    ///
+    /// Callers with a multi-namespace visible set can READ cross-namespace entities
+    /// directly via `get_entity` / `resolve`, but `hybrid_search` returns only
+    /// primary-namespace hits until Phase 1.5 cross-namespace fanout ships.
     #[allow(clippy::too_many_arguments)]
     pub async fn hybrid_search(
         &self,

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -342,14 +342,18 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Vec<SearchHit>> {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
-        let ns = token.namespace().as_str().to_owned();
+        let visible_ns: Vec<String> = token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect();
         let text_hits = self
             .text(token)?
             .search(TextSearchRequest {
                 query: query_text.to_string(),
                 mode: TextQueryMode::Plain,
                 filter: Some(TextFilter {
-                    namespaces: vec![ns.clone()],
+                    namespaces: visible_ns.clone(),
                     ..TextFilter::default()
                 }),
                 top_k: candidates,
@@ -387,6 +391,7 @@ impl KhiveRuntime {
                         ids: candidate_ids,
                         kinds: entity_kind.map(|k| vec![k.to_string()]).unwrap_or_default(),
                         entity_types: entity_type.map(|t| vec![t.to_string()]).unwrap_or_default(),
+                        namespaces: visible_ns,
                         ..EntityFilter::default()
                     },
                     PageRequest {

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -305,6 +305,10 @@ impl KhiveRuntime {
     /// `AllowAllGate` this always succeeds. When a real policy-backed gate is
     /// installed, this method enforces it and returns `PermissionDenied` on
     /// denial.
+    ///
+    /// The returned token's read visibility set defaults to `[ns]` — identical
+    /// to the pre-visibility-set behaviour. Use [`authorize_with_visibility`]
+    /// to mint a token that can read additional namespaces.
     pub fn authorize(&self, ns: Namespace) -> RuntimeResult<NamespaceToken> {
         let actor = ActorRef::anonymous();
         let req = GateRequest::new(
@@ -325,6 +329,68 @@ impl KhiveRuntime {
                     }
                 }
                 Ok(NamespaceToken::mint_authorized(ns, actor))
+            }
+            Ok(khive_gate::GateDecision::Deny { reason }) => {
+                Err(crate::RuntimeError::PermissionDenied {
+                    verb: "authorize".to_string(),
+                    reason,
+                })
+            }
+            Ok(_) => Err(crate::RuntimeError::PermissionDenied {
+                verb: "authorize".to_string(),
+                reason: "gate denied".to_string(),
+            }),
+            Err(e) => Err(crate::RuntimeError::Internal(format!("gate error: {e}"))),
+        }
+    }
+
+    /// Mint an authorization token with an explicit read-visibility set.
+    ///
+    /// `primary` is the **write namespace** — all records created via the
+    /// returned token land there. `extra_visible` lists additional namespaces
+    /// the token may read. The primary is always included in the visible set
+    /// regardless of `extra_visible`.
+    ///
+    /// Usage (lambda:leo reading both leo and khive namespaces):
+    /// ```rust,ignore
+    /// let tok = rt.authorize_with_visibility(
+    ///     Namespace::parse("lambda:leo").unwrap(),
+    ///     vec![Namespace::parse("lambda:khive").unwrap()],
+    /// )?;
+    /// ```
+    pub fn authorize_with_visibility(
+        &self,
+        primary: Namespace,
+        extra_visible: Vec<Namespace>,
+    ) -> RuntimeResult<NamespaceToken> {
+        let actor = ActorRef::anonymous();
+        let req = GateRequest::new(
+            actor.clone(),
+            primary.clone(),
+            "authorize",
+            serde_json::Value::Null,
+        );
+        match self.config.gate.check(&req) {
+            Ok(ref decision) if decision.is_allow() => {
+                if let khive_gate::GateDecision::Allow { ref obligations } = decision {
+                    if !obligations.is_empty() {
+                        tracing::debug!(
+                            namespace = %primary.as_str(),
+                            "authorize_with_visibility: obligations={:?}",
+                            obligations
+                        );
+                    }
+                }
+                // Build the full visible set: primary + extras, deduplicated.
+                let mut visible = vec![primary.clone()];
+                for ns in extra_visible {
+                    if !visible.contains(&ns) {
+                        visible.push(ns);
+                    }
+                }
+                Ok(NamespaceToken::mint_with_visibility(
+                    primary, visible, actor,
+                ))
             }
             Ok(khive_gate::GateDecision::Deny { reason }) => {
                 Err(crate::RuntimeError::PermissionDenied {
@@ -804,6 +870,7 @@ mod tests {
             actor: ActorConfig {
                 id: Some(id.to_string()),
                 display_name: None,
+                ..Default::default()
             },
             runtime: RuntimeSectionConfig::default(),
         }
@@ -843,6 +910,7 @@ mod tests {
             actor: ActorConfig {
                 id: Some(String::new()),
                 display_name: None,
+                ..Default::default()
             },
             runtime: RuntimeSectionConfig::default(),
         };
@@ -898,6 +966,7 @@ mod tests {
             actor: ActorConfig {
                 id: Some("lambda:test".to_string()),
                 display_name: None,
+                ..Default::default()
             },
             runtime: RuntimeSectionConfig::default(),
         };

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -155,6 +155,7 @@ impl KhiveRuntime {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         })
     }
 
@@ -164,6 +165,14 @@ impl KhiveRuntime {
     /// to identify which backend owns a given node, and to detect cross-backend merges.
     pub fn backend_id(&self) -> &BackendId {
         &self.config.backend_id
+    }
+
+    /// Return the extra-visible namespaces from config (beyond the primary).
+    ///
+    /// Used by pack dispatch to mint tokens that can read across namespaces
+    /// configured in `actor.visible_namespaces` in `khive.toml`.
+    pub fn visible_namespaces(&self) -> &[Namespace] {
+        &self.config.visible_namespaces
     }
 
     /// Return a reference to the runtime config.
@@ -381,15 +390,10 @@ impl KhiveRuntime {
                         );
                     }
                 }
-                // Build the full visible set: primary + extras, deduplicated.
-                let mut visible = vec![primary.clone()];
-                for ns in extra_visible {
-                    if !visible.contains(&ns) {
-                        visible.push(ns);
-                    }
-                }
                 Ok(NamespaceToken::mint_with_visibility(
-                    primary, visible, actor,
+                    primary,
+                    extra_visible,
+                    actor,
                 ))
             }
             Ok(khive_gate::GateDecision::Deny { reason }) => {
@@ -725,6 +729,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).expect("file runtime should create");
         assert!(path.exists());
@@ -743,6 +748,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::new("lore"),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let rt = KhiveRuntime::from_backend(backend, config);
         assert_eq!(rt.backend_id().as_str(), "lore");
@@ -887,6 +893,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let cfg = khive_cfg_with_actor("lambda:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -904,6 +911,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let cfg = KhiveConfig {
             engines: vec![],
@@ -933,6 +941,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let cfg = KhiveConfig::default(); // no actor.id
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -954,6 +963,7 @@ mod tests {
             packs: vec!["kg".to_string()],
             backend_id: BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let cfg = KhiveConfig {
             engines: vec![crate::engine_config::EngineConfig {

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -2220,3 +2220,100 @@ async fn create_note_annotates_refuses_target_in_visible_only_namespace() {
         "annotates with target in visible-only namespace must be rejected"
     );
 }
+
+// =============================================================================
+// Finding 5: hybrid_search cross-namespace Option B limitation documented + tested
+// =============================================================================
+
+/// Documents the Phase 1.5 limitation: `hybrid_search` is primary-namespace-only
+/// for both the FTS and vector legs (each namespace owns its own FTS table and
+/// ANN index; cross-namespace fanout is deferred to Phase 1.5).
+///
+/// This test verifies the actual current behavior:
+/// - The primary-namespace entity appears in results.
+/// - The extra-namespace entity does NOT appear in results (its FTS data lives
+///   in `fts_entities_{extra-ns}`, a separate table not queried here).
+///
+/// A caller with a visible set can READ the extra-namespace entity directly via
+/// `get_entity`, but `hybrid_search` does not surface it today.
+#[tokio::test]
+async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
+    let rt = rt();
+
+    let ns_primary = Namespace::parse("hs-primary-ns").unwrap();
+    let ns_extra = Namespace::parse("hs-extra-ns").unwrap();
+
+    let tok_primary = rt.authorize(ns_primary.clone()).unwrap();
+    let tok_extra = rt.authorize(ns_extra.clone()).unwrap();
+
+    // Create an entity in primary namespace with a distinctive term.
+    let entity_in_primary = rt
+        .create_entity(
+            &tok_primary,
+            "concept",
+            None,
+            "StellarPrimary",
+            Some("unique stellar primary concept"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // Create an entity in the extra namespace with the same distinctive term.
+    let entity_in_extra = rt
+        .create_entity(
+            &tok_extra,
+            "concept",
+            None,
+            "StellarExtra",
+            Some("unique stellar extra concept"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // Visible-set token: primary = hs-primary-ns, also sees hs-extra-ns.
+    let vis_tok = rt
+        .authorize_with_visibility(ns_primary.clone(), vec![ns_extra.clone()])
+        .unwrap();
+
+    // Search: FTS-only (no embedding model in test runtime).
+    // Current behavior: only primary-namespace results surface.
+    let hits = rt
+        .hybrid_search(&vis_tok, "stellar", None, 20, None, None)
+        .await
+        .unwrap();
+
+    let hit_ids: Vec<Uuid> = hits.iter().map(|h| h.entity_id).collect();
+
+    // Primary entity must surface.
+    assert!(
+        hit_ids.contains(&entity_in_primary.id),
+        "hybrid_search must return entity from primary namespace; \
+         expected entity_id={}, got: {hit_ids:?}",
+        entity_in_primary.id,
+    );
+
+    // Extra-namespace entity does NOT surface — Phase 1.5 limitation.
+    // Each namespace has its own FTS table; cross-namespace FTS fanout is deferred.
+    assert!(
+        !hit_ids.contains(&entity_in_extra.id),
+        "hybrid_search must NOT return entity from extra (visible-only) namespace \
+         until Phase 1.5 cross-namespace fanout ships; \
+         entity_id={} unexpectedly appeared in: {hit_ids:?}",
+        entity_in_extra.id,
+    );
+
+    // Direct read of the extra-namespace entity via get_entity must still work
+    // (this proves the visible set wiring is correct — only search is primary-scoped).
+    let fetched = rt
+        .get_entity(&vis_tok, entity_in_extra.id)
+        .await
+        .expect("get_entity via visible-set token must return extra-namespace entity");
+    assert_eq!(
+        fetched.id, entity_in_extra.id,
+        "visible-set read of extra-namespace entity must succeed"
+    );
+}

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -570,6 +570,7 @@ async fn file_backed_runtime_persists() {
             backend_id: khive_runtime::BackendId::main(),
             additional_embedding_models: vec![],
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -589,6 +590,7 @@ async fn file_backed_runtime_persists() {
             backend_id: khive_runtime::BackendId::main(),
             additional_embedding_models: vec![],
             brain_profile: None,
+            visible_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -1076,6 +1078,7 @@ mod embedder_registry_tests {
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         })
         .expect("in-memory runtime")
     }
@@ -1134,6 +1137,7 @@ mod embedder_registry_tests {
             packs: vec!["kg".to_string()],
             backend_id: khive_runtime::BackendId::main(),
             brain_profile: None,
+            visible_namespaces: vec![],
         })
         .expect("runtime with two models");
 
@@ -2051,4 +2055,168 @@ async fn namespace_isolation_backward_compat() {
         .unwrap();
     assert_eq!(b_entities.len(), 1);
     assert_eq!(b_entities[0].name, "EntityB");
+}
+
+// =============================================================================
+// Fix 4: visible-set token invariants (primary always included, no duplicates)
+// =============================================================================
+
+/// No extra-visible namespaces → visible set contains only the primary.
+#[test]
+fn mint_with_visibility_empty_extra_yields_primary_only() {
+    let rt = rt();
+    let tok = rt
+        .authorize_with_visibility(Namespace::parse("ns-primary-only").unwrap(), vec![])
+        .unwrap();
+
+    let vis = tok.visible_namespaces();
+    assert_eq!(vis.len(), 1, "primary only when no extras given");
+    assert_eq!(vis[0].as_str(), "ns-primary-only");
+    assert_eq!(tok.namespace().as_str(), "ns-primary-only");
+}
+
+/// When the primary is repeated in the extra list it must not appear twice.
+#[test]
+fn mint_with_visibility_deduplicates_primary_in_extras() {
+    let rt = rt();
+    let tok = rt
+        .authorize_with_visibility(
+            Namespace::parse("ns-dedup").unwrap(),
+            vec![
+                Namespace::parse("ns-dedup").unwrap(),
+                Namespace::parse("ns-extra").unwrap(),
+            ],
+        )
+        .unwrap();
+
+    let vis = tok.visible_namespaces();
+    assert_eq!(vis.len(), 2, "primary counted once, one distinct extra");
+    assert_eq!(vis[0].as_str(), "ns-dedup");
+    assert_eq!(vis[1].as_str(), "ns-extra");
+}
+
+// =============================================================================
+// Fix 1: mutations confined to primary namespace; reads use visible set
+// =============================================================================
+
+/// A note written into an extra-visible namespace can be read back through
+/// the visible-set token (resolve uses the visible set for notes).
+#[tokio::test]
+async fn resolve_uses_visible_set_for_note_in_extra_namespace() {
+    let rt = rt();
+    let _tok_a = rt.authorize(Namespace::parse("res-a").unwrap()).unwrap();
+    let tok_b = rt.authorize(Namespace::parse("res-b").unwrap()).unwrap();
+
+    let note_b = rt
+        .create_note(&tok_b, "observation", None, "NoteInB", None, None, vec![])
+        .await
+        .unwrap();
+
+    // visible-set token: primary=res-a, sees res-b too.
+    let vis_tok = rt
+        .authorize_with_visibility(
+            Namespace::parse("res-a").unwrap(),
+            vec![Namespace::parse("res-b").unwrap()],
+        )
+        .unwrap();
+
+    // get_note_including_deleted uses resolve() which should honour visible set.
+    let fetched = rt
+        .get_note_including_deleted(&vis_tok, note_b.id)
+        .await
+        .expect("call must not error");
+    assert!(
+        fetched.is_some(),
+        "note in extra-visible namespace must be readable via visible-set token"
+    );
+    assert_eq!(fetched.unwrap().content, "NoteInB");
+}
+
+/// A link whose target lives in the extra-visible (but not primary) namespace
+/// must be rejected — mutation endpoints must both be in the primary namespace.
+#[tokio::test]
+async fn link_refuses_target_in_visible_but_not_primary_namespace() {
+    let rt = rt();
+    let tok_a = rt
+        .authorize(Namespace::parse("link-mut-a").unwrap())
+        .unwrap();
+    let tok_b = rt
+        .authorize(Namespace::parse("link-mut-b").unwrap())
+        .unwrap();
+
+    let entity_a = rt
+        .create_entity(&tok_a, "concept", None, "SrcEntity", None, None, vec![])
+        .await
+        .unwrap();
+    let entity_b = rt
+        .create_entity(&tok_b, "concept", None, "TgtEntity", None, None, vec![])
+        .await
+        .unwrap();
+
+    // primary=link-mut-a, visible=[link-mut-a, link-mut-b].
+    // entity_b lives in link-mut-b (visible, not primary).
+    let vis_tok = rt
+        .authorize_with_visibility(
+            Namespace::parse("link-mut-a").unwrap(),
+            vec![Namespace::parse("link-mut-b").unwrap()],
+        )
+        .unwrap();
+
+    let result = rt
+        .link(
+            &vis_tok,
+            entity_a.id,
+            entity_b.id,
+            EdgeRelation::Extends,
+            1.0,
+            None,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "link with target in visible-only namespace must be rejected by mutation endpoint validation"
+    );
+}
+
+/// An annotates note whose annotated target lives in the extra-visible (but not
+/// primary) namespace must be rejected by create_note's mutation gate.
+#[tokio::test]
+async fn create_note_annotates_refuses_target_in_visible_only_namespace() {
+    let rt = rt();
+    let _tok_a = rt
+        .authorize(Namespace::parse("ann-mut-a").unwrap())
+        .unwrap();
+    let tok_b = rt
+        .authorize(Namespace::parse("ann-mut-b").unwrap())
+        .unwrap();
+
+    let entity_b = rt
+        .create_entity(&tok_b, "concept", None, "AnnotTarget", None, None, vec![])
+        .await
+        .unwrap();
+
+    // primary=ann-mut-a, visible=[ann-mut-a, ann-mut-b].
+    // entity_b lives in ann-mut-b (visible, not primary).
+    let vis_tok = rt
+        .authorize_with_visibility(
+            Namespace::parse("ann-mut-a").unwrap(),
+            vec![Namespace::parse("ann-mut-b").unwrap()],
+        )
+        .unwrap();
+
+    let result = rt
+        .create_note(
+            &vis_tok,
+            "observation",
+            None,
+            "AnnotNote",
+            None,
+            None,
+            vec![entity_b.id],
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "annotates with target in visible-only namespace must be rejected"
+    );
 }

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1875,3 +1875,180 @@ async fn update_edge_note_note_to_refutes_accepted() {
         .expect("update_edge note→note supports → refutes must be accepted");
     assert_eq!(updated.relation, EdgeRelation::Refutes);
 }
+
+// =============================================================================
+// Multi-namespace read visibility (visible-set tokens)
+// =============================================================================
+
+/// A token with visible=[a,b] can list/get entities+notes in both namespaces,
+/// but not in a third namespace c. Writes land in the primary (a) only.
+#[tokio::test]
+async fn visible_set_reads_primary_and_extra_not_third() {
+    let rt = rt();
+
+    // Mint single-namespace write tokens for three isolated namespaces.
+    let tok_a = rt.authorize(Namespace::parse("vis-a").unwrap()).unwrap();
+    let tok_b = rt.authorize(Namespace::parse("vis-b").unwrap()).unwrap();
+    let tok_c = rt.authorize(Namespace::parse("vis-c").unwrap()).unwrap();
+
+    // Write one entity and one note in each namespace.
+    let entity_a = rt
+        .create_entity(&tok_a, "concept", None, "EntityA", None, None, vec![])
+        .await
+        .unwrap();
+    let entity_b = rt
+        .create_entity(&tok_b, "concept", None, "EntityB", None, None, vec![])
+        .await
+        .unwrap();
+    let entity_c = rt
+        .create_entity(&tok_c, "concept", None, "EntityC", None, None, vec![])
+        .await
+        .unwrap();
+
+    let note_a = rt
+        .create_note(&tok_a, "observation", None, "NoteA", None, None, vec![])
+        .await
+        .unwrap();
+    let note_b = rt
+        .create_note(&tok_b, "observation", None, "NoteB", None, None, vec![])
+        .await
+        .unwrap();
+    let note_c = rt
+        .create_note(&tok_c, "observation", None, "NoteC", None, None, vec![])
+        .await
+        .unwrap();
+
+    // Mint a visible-set token: primary=vis-a, visible=[vis-a, vis-b].
+    let vis_tok = rt
+        .authorize_with_visibility(
+            Namespace::parse("vis-a").unwrap(),
+            vec![Namespace::parse("vis-b").unwrap()],
+        )
+        .unwrap();
+
+    // --- list_entities sees a+b, not c ---
+    let visible_entities = rt.list_entities(&vis_tok, None, None, 50, 0).await.unwrap();
+    let entity_names: Vec<&str> = visible_entities.iter().map(|e| e.name.as_str()).collect();
+    assert!(entity_names.contains(&"EntityA"), "EntityA must be visible");
+    assert!(entity_names.contains(&"EntityB"), "EntityB must be visible");
+    assert!(
+        !entity_names.contains(&"EntityC"),
+        "EntityC must NOT be visible"
+    );
+
+    // --- list_notes sees a+b, not c ---
+    let visible_notes = rt.list_notes(&vis_tok, None, 50, 0).await.unwrap();
+    let note_contents: Vec<&str> = visible_notes.iter().map(|n| n.content.as_str()).collect();
+    assert!(note_contents.contains(&"NoteA"), "NoteA must be visible");
+    assert!(note_contents.contains(&"NoteB"), "NoteB must be visible");
+    assert!(
+        !note_contents.contains(&"NoteC"),
+        "NoteC must NOT be visible"
+    );
+
+    // --- get_entity: a and b succeed, c returns NotFound ---
+    rt.get_entity(&vis_tok, entity_a.id)
+        .await
+        .expect("get entity_a must succeed");
+    rt.get_entity(&vis_tok, entity_b.id)
+        .await
+        .expect("get entity_b (visible non-primary) must succeed");
+    let err_c = rt.get_entity(&vis_tok, entity_c.id).await;
+    assert!(
+        err_c.is_err(),
+        "get entity_c (non-visible) must return NotFound"
+    );
+
+    // --- get_note: a and b visible, c filtered out ---
+    // get_note_including_deleted returns Ok(None) when namespace not visible.
+    let fetched_note_a = rt
+        .get_note_including_deleted(&vis_tok, note_a.id)
+        .await
+        .expect("call must not error");
+    assert!(
+        fetched_note_a.is_some(),
+        "note_a (primary namespace) must be returned"
+    );
+
+    let fetched_note_b = rt
+        .get_note_including_deleted(&vis_tok, note_b.id)
+        .await
+        .expect("call must not error");
+    assert!(
+        fetched_note_b.is_some(),
+        "note_b (visible non-primary) must be returned"
+    );
+
+    let fetched_note_c = rt
+        .get_note_including_deleted(&vis_tok, note_c.id)
+        .await
+        .expect("call must not error");
+    assert!(
+        fetched_note_c.is_none(),
+        "note_c (non-visible namespace) must be filtered out"
+    );
+
+    // --- WRITE via vis_tok lands in primary (vis-a) only, not in vis-b ---
+    let written = rt
+        .create_entity(
+            &vis_tok,
+            "concept",
+            None,
+            "WrittenViaVisToken",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        written.namespace.as_str(),
+        "vis-a",
+        "write must stamp primary namespace, not any extra-visible one"
+    );
+
+    // Verify vis-b does not contain the newly written entity.
+    let b_entities = rt.list_entities(&tok_b, None, None, 50, 0).await.unwrap();
+    let b_names: Vec<&str> = b_entities.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        !b_names.contains(&"WrittenViaVisToken"),
+        "write must NOT appear in vis-b"
+    );
+
+    // Suppress unused-variable warnings for IDs we intentionally only inserted.
+    let _ = note_a;
+    let _ = note_c;
+    let _ = entity_c;
+}
+
+/// Backward compatibility: a token minted via `authorize()` (no visibility)
+/// behaves exactly as before — single namespace, strict equality on reads/writes.
+/// This is the original namespace_isolation test reproduced verbatim to confirm
+/// nothing regressed.
+#[tokio::test]
+async fn namespace_isolation_backward_compat() {
+    let rt = rt();
+    let ns_a_tok = rt.authorize(Namespace::parse("bc-a").unwrap()).unwrap();
+    let ns_b_tok = rt.authorize(Namespace::parse("bc-b").unwrap()).unwrap();
+
+    rt.create_entity(&ns_a_tok, "concept", None, "EntityA", None, None, vec![])
+        .await
+        .unwrap();
+    rt.create_entity(&ns_b_tok, "concept", None, "EntityB", None, None, vec![])
+        .await
+        .unwrap();
+
+    let a_entities = rt
+        .list_entities(&ns_a_tok, None, None, 50, 0)
+        .await
+        .unwrap();
+    assert_eq!(a_entities.len(), 1);
+    assert_eq!(a_entities[0].name, "EntityA");
+
+    let b_entities = rt
+        .list_entities(&ns_b_tok, None, None, 50, 0)
+        .await
+        .unwrap();
+    assert_eq!(b_entities.len(), 1);
+    assert_eq!(b_entities[0].name, "EntityB");
+}

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -88,6 +88,13 @@ pub struct EntityFilter {
     pub entity_types: Vec<String>,
     pub name_prefix: Option<String>,
     pub tags_any: Vec<String>,
+    /// When non-empty, restricts results to any of these namespaces using
+    /// `namespace IN (...)`. Takes precedence over the `namespace` string
+    /// parameter passed to `query_entities` / `count_entities`. When empty the
+    /// caller-supplied `namespace` parameter is used (single-namespace path,
+    /// backward-compatible default).
+    #[serde(default)]
+    pub namespaces: Vec<String>,
 }
 
 /// Entity CRUD operations over the entities substrate table.

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -269,6 +269,12 @@ pub struct NoteFilter {
     pub property_filters: Vec<PropertyFilter>,
     /// `(json_path, direction)` — `None` defaults to `created_at DESC`.
     pub order_by: Option<(String, SortDir)>,
+    /// When non-empty, restricts results to any of these namespaces using
+    /// `namespace IN (...)`. Takes precedence over the `namespace` string
+    /// parameter passed to `query_notes_filtered`. When empty the
+    /// caller-supplied `namespace` parameter is used (backward-compatible).
+    #[serde(default)]
+    pub namespaces: Vec<String>,
 }
 
 /// Temporal-referential note CRUD over the notes substrate table.


### PR DESCRIPTION
## Summary

- `NamespaceToken` gains a `visible: Vec<Namespace>` field. `authorize()` is unchanged (visible=[primary]). New `authorize_with_visibility(primary, extras)` mints a token that reads multiple namespaces while writing to exactly one.
- `EntityFilter` and `NoteFilter` gain a `namespaces: Vec<String>` field. SQL builders emit `namespace IN (...)` when non-empty, falling back to the existing `namespace = ?` single-equality path for backward compatibility.
- All read paths — `list_entities`, `list_notes`, `hybrid_search`, `search_notes`, `query_with_metadata`, `ensure_namespace_visible` — use the full visible set from the token.
- Writes are unaffected: records are always stamped with the primary namespace only.
- `ActorConfig` gains optional `visible_namespaces: Option<Vec<String>>` for TOML configuration.

## Test plan

- [x] `namespace_isolation` (existing test) passes unchanged — backward-compat proof
- [x] New `visible_set_reads_primary_and_extra_not_third`: three namespaces a/b/c, token primary=a visible=[a,b]; asserts list/get see a+b not c; asserts write via token lands in a only (not b)
- [x] `namespace_isolation_backward_compat`: duplicates the original isolation test under the new implementation
- [x] `cargo test -p khive-runtime`: 49 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean

## Scope

PHASE 1 mechanism only. No data migration, no schema change, no production DB access, no comm-pack change. Default namespace (`local`) unchanged.