### PR TITLE
fix(comm): sender-side outbound allowlist for cross-namespace delivery (deny-all default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ htmlcov/
 
 # Rust
 target/
+.cargo-target/
 **/*.rs.bk
 Cargo.lock
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -59,14 +59,22 @@ pub fn compute_config_id(config: &RuntimeConfig) -> String {
         .collect();
     visible.sort();
     visible.dedup();
+    let mut outbound: Vec<String> = config
+        .allowed_outbound_namespaces
+        .iter()
+        .map(|ns| ns.as_str().to_owned())
+        .collect();
+    outbound.sort();
+    outbound.dedup();
     format!(
-        "packs=[{}];db={};embed={};extra=[{}];backend={:?};visible=[{}]",
+        "packs=[{}];db={};embed={};extra=[{}];backend={:?};visible=[{}];outbound=[{}]",
         packs.join(","),
         db,
         primary,
         extra.join(","),
         config.backend_id,
         visible.join(","),
+        outbound.join(","),
     )
 }
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3876,6 +3876,100 @@ fn compute_config_id_is_stable_under_visible_namespace_reorder() {
 }
 
 // =============================================================================
+// Fix 1: compute_config_id must include allowed_outbound_namespaces so a
+// daemon started with a permissive outbound allowlist cannot be reused for a
+// client whose config has an empty allowlist.
+// =============================================================================
+
+/// Two RuntimeConfigs that are identical except for their
+/// `allowed_outbound_namespaces` must produce different `compute_config_id`
+/// fingerprints.
+///
+/// Without this, a daemon started with `allowed_outbound_namespaces =
+/// ["lambda:khive"]` could be reused for a client whose local config has an
+/// empty allowlist — granting cross-namespace writes that the client should
+/// fail closed on.
+#[test]
+fn compute_config_id_differs_when_allowed_outbound_namespaces_differ() {
+    use khive_mcp::server::compute_config_id;
+    use khive_runtime::{Namespace, RuntimeConfig};
+
+    let base = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse("out-a").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        allowed_outbound_namespaces: vec![],
+        ..RuntimeConfig::default()
+    };
+    let with_outbound = RuntimeConfig {
+        allowed_outbound_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        ..base.clone()
+    };
+
+    let id_empty = compute_config_id(&base);
+    let id_with_outbound = compute_config_id(&with_outbound);
+
+    assert_ne!(
+        id_empty, id_with_outbound,
+        "compute_config_id must differ when allowed_outbound_namespaces differs; \
+         same id would allow wrong-allowlist daemon reuse"
+    );
+    assert!(
+        id_with_outbound.contains("lambda:khive"),
+        "allowed outbound namespace 'lambda:khive' must appear in config_id string; got: {id_with_outbound}"
+    );
+}
+
+/// Order of entries in allowed_outbound_namespaces must not change the
+/// fingerprint (the fingerprint sorts + deduplicates before hashing).
+#[test]
+fn compute_config_id_is_stable_under_allowed_outbound_namespace_reorder() {
+    use khive_mcp::server::compute_config_id;
+    use khive_runtime::{Namespace, RuntimeConfig};
+
+    let cfg_ab = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse("out-a").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string()],
+        allowed_outbound_namespaces: vec![
+            Namespace::parse("lambda:khive").unwrap(),
+            Namespace::parse("lambda:leo").unwrap(),
+        ],
+        ..RuntimeConfig::default()
+    };
+    let cfg_ba = RuntimeConfig {
+        allowed_outbound_namespaces: vec![
+            Namespace::parse("lambda:leo").unwrap(),
+            Namespace::parse("lambda:khive").unwrap(),
+        ],
+        ..cfg_ab.clone()
+    };
+    let cfg_dup = RuntimeConfig {
+        allowed_outbound_namespaces: vec![
+            Namespace::parse("lambda:khive").unwrap(),
+            Namespace::parse("lambda:leo").unwrap(),
+            Namespace::parse("lambda:khive").unwrap(), // duplicate
+        ],
+        ..cfg_ab.clone()
+    };
+
+    assert_eq!(
+        compute_config_id(&cfg_ab),
+        compute_config_id(&cfg_ba),
+        "compute_config_id must be stable under reordering of allowed_outbound_namespaces"
+    );
+    assert_eq!(
+        compute_config_id(&cfg_ab),
+        compute_config_id(&cfg_dup),
+        "compute_config_id must be stable under duplication of allowed_outbound_namespaces"
+    );
+}
+
+// =============================================================================
 // Finding 6: actor.visible_namespaces from config wires cross-namespace reads
 // but mutations on visible-only records must return NotFound.
 // =============================================================================

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -29,6 +29,7 @@ khive-db = { version = "0.2.11", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
 khive-runtime = { version = "0.2.11", path = "../khive-runtime", features = ["fault-injection"] }
+lattice-embed = { workspace = true }
 
 [[bench]]
 name = "comm_bench"

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -29,7 +29,6 @@ khive-db = { version = "0.2.11", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
 khive-runtime = { version = "0.2.11", path = "../khive-runtime", features = ["fault-injection"] }
-serial_test = { workspace = true }
 
 [[bench]]
 name = "comm_bench"

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-db = { version = "0.2.11", path = "../khive-db" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true, features = ["full"] }
 khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
 khive-db = { version = "0.2.11", path = "../khive-db" }
 criterion = { workspace = true }
+toml = { workspace = true }
 
 [[bench]]
 name = "comm_bench"

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -28,6 +28,8 @@ khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
 khive-db = { version = "0.2.11", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
+khive-runtime = { version = "0.2.11", path = "../khive-runtime", features = ["fault-injection"] }
+serial_test = { workspace = true }
 
 [[bench]]
 name = "comm_bench"

--- a/crates/khive-pack-comm/docs/design.md
+++ b/crates/khive-pack-comm/docs/design.md
@@ -11,9 +11,11 @@ Key design decisions from ADR-040:
 - **Dual-write delivery**: every `comm.send` writes an outbound copy (caller namespace) and an
   inbound copy (recipient namespace). If the inbound write fails, the outbound note is rolled back
   before returning the error.
-- **Cross-namespace delivery is DENIED**: pending ACL policy specification (ADR-018). The recipient
-  namespace must equal the caller namespace. This prevents unauthorized writes into arbitrary
-  recipient namespaces (issue #481 fix).
+- **Cross-namespace delivery**: controlled by the sender-side `actor.allowed_outbound_namespaces`
+  allowlist. An empty allowlist (the default) reproduces the prior deny-all behavior. Namespaces
+  listed in the allowlist may receive inbound notes via `dual_write_message`. Unlisted namespaces
+  receive `RuntimeError::PermissionDenied { verb: "comm.send" }` (issue #481 fix, updated by the
+  cross-namespace ACL PR).
 - **Canonical thread_id**: when a root message is sent (`thread_id` is `None`), both the outbound
   and inbound copies share the same canonical `thread_id` — the sender's outbound UUID. This
   ensures `comm.thread(id=outbound_id)` can find replies across namespaces.

--- a/crates/khive-pack-comm/docs/design.md
+++ b/crates/khive-pack-comm/docs/design.md
@@ -45,19 +45,17 @@ taxonomy from ADR-025. The mapping is enforced by the `verb_categories_match_spe
 
 The pack self-registers via `inventory::submit!` so it is available when loaded by name.
 
-### ADR-018: ACL Policy (not yet implemented)
+### Cross-namespace delivery policy (OSS, specified 2026-06-15)
 
-Cross-namespace messaging is currently denied (fail-closed). The `dual_write_message` function
-returns `CrossNamespaceWrite` for any send where `from != to`. This will be relaxed once ADR-018
-specifies the ACL policy for inter-namespace writes.
+Cross-namespace messaging is controlled by the **sender-side outbound allowlist**. The
+`dual_write_message` function returns `RuntimeError::PermissionDenied` when the recipient
+namespace is not in the sender's `actor.allowed_outbound_namespaces` allowlist. An empty
+allowlist (default) reproduces the prior deny-all behavior.
 
 ## Consistency Notes
 
-- **Cross-namespace delivery**: the current deny-all policy is more restrictive than what ADR-040
-  specifies for the long-term vision. This is intentional and documented in the code: the
-  `dual_write_message` function explains that full cross-namespace delivery awaits ADR-018 ACL
-  policy. No inconsistency with the current spec; both ADR-040 and the code agree on the interim
-  fail-closed posture.
+- **Cross-namespace delivery**: the sender-side `actor.allowed_outbound_namespaces` allowlist is
+  the OSS ACL gate (2026-06-15). The default is empty (deny-all). ADR-040 is updated to match.
 - **Thread root resolution**: `comm.thread` resolves the canonical thread root by inspecting
   `properties.thread_id` on the resolved note. If the stored `thread_id` differs from the note's
   own UUID (inbound copy case), it uses the stored value. This cross-namespace root resolution

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -78,24 +78,37 @@ pub(crate) async fn dual_write_message(
     thread_id: Option<&str>,
     sent_at: &str,
 ) -> Result<Note, RuntimeError> {
-    // Cross-namespace delivery is DENIED until ACL policy is specified.
-    // This prevents unauthorized writes into arbitrary recipient namespaces.
-    //
-    // The recipient namespace must equal the caller namespace. Sending to a
-    // different namespace would bypass the recipient's authorization gate.
     let recipient_ns_str = to.trim();
     if from != recipient_ns_str {
-        // Validate the recipient namespace string format before returning the
-        // denial — so callers get InvalidInput for malformed strings rather than
-        // a misleading CrossNamespaceWrite.
-        if let Err(e) = Namespace::parse(recipient_ns_str) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "send: invalid recipient namespace {to:?}: {e}"
-            )));
+        // 1. Validate recipient namespace string format first.
+        let recipient_ns = match Namespace::parse(recipient_ns_str) {
+            Ok(ns) => ns,
+            Err(e) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "send: invalid recipient namespace {to:?}: {e}"
+                )));
+            }
+        };
+
+        // 2. Check sender-side outbound allowlist from config.
+        //    Cross-namespace delivery is permitted only for declared recipients.
+        let allowed = runtime
+            .config()
+            .allowed_outbound_namespaces
+            .iter()
+            .any(|ns| ns == &recipient_ns);
+
+        if !allowed {
+            return Err(RuntimeError::PermissionDenied {
+                verb: "comm.send".to_string(),
+                reason: format!(
+                    "cross-namespace delivery to {recipient_ns_str:?} is not permitted; \
+                     add {recipient_ns_str:?} to actor.allowed_outbound_namespaces in \
+                     the sender's khive.toml to enable delivery"
+                ),
+            });
         }
-        return Err(RuntimeError::CrossNamespaceWrite {
-            namespace: recipient_ns_str.to_string(),
-        });
+        // 3. Allowlist hit: fall through to outbound note creation.
     }
 
     let outbound_props = json!({
@@ -151,9 +164,20 @@ pub(crate) async fn dual_write_message(
     }
 
     {
-        // Inbound note lands in the caller's own namespace: cross-namespace send is
-        // denied earlier in this function, so sender and recipient are always equal.
-        let inbound_tok: &NamespaceToken = caller_token;
+        // When sender and recipient are in different namespaces (allowed cross-ns path),
+        // mint a narrowed write-only token for the recipient namespace so the inbound
+        // note lands in the correct inbox. For same-namespace sends (from == to),
+        // use caller_token unchanged (preserves existing behavior).
+        let cross_ns_token;
+        let inbound_tok: &NamespaceToken = if from == recipient_ns_str {
+            caller_token
+        } else {
+            cross_ns_token = caller_token.with_namespace(
+                Namespace::parse(recipient_ns_str)
+                    .expect("recipient_ns_str already validated above"),
+            );
+            &cross_ns_token
+        };
 
         let inbound_props = json!({
             "from": from,

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -165,9 +165,10 @@ pub(crate) async fn dual_write_message(
 
     {
         // When sender and recipient are in different namespaces (allowed cross-ns path),
-        // mint a narrowed write-only token for the recipient namespace so the inbound
-        // note lands in the correct inbox. For same-namespace sends (from == to),
-        // use caller_token unchanged (preserves existing behavior).
+        // mint a recipient-scoped read+write token used for exactly one inbound
+        // `create_note` call after the allowlist check so the inbound note lands in the
+        // correct inbox. For same-namespace sends (from == to), use caller_token
+        // unchanged (preserves existing behavior).
         let cross_ns_token;
         let inbound_tok: &NamespaceToken = if from == recipient_ns_str {
             caller_token

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -5,8 +5,13 @@
 //! the fixture and lose cross-verb invariant tests (e.g. send→inbox→read→reply→thread
 //! roundtrip and thread-isolation assertions) that exercise interactions between verbs.
 
+use std::sync::Arc;
+
 use khive_pack_comm::CommPack;
-use khive_runtime::{KhiveRuntime, Namespace, VerbRegistry, VerbRegistryBuilder};
+use khive_runtime::{
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, NamespaceToken, NotePatch, RuntimeConfig,
+    VerbRegistry, VerbRegistryBuilder,
+};
 use khive_types::Pack;
 
 fn build_registry() -> (VerbRegistry, KhiveRuntime) {
@@ -2238,5 +2243,716 @@ async fn thread_rejects_unknown_field() {
     assert!(
         err.is_err(),
         "comm.thread with unknown field must fail; got: {err:?}"
+    );
+}
+
+// ── T1-T12: cross-namespace delivery allowlist (allowed_outbound_namespaces) ─────
+
+/// Build a KhiveRuntime + VerbRegistry for cross-ns tests.
+///
+/// `dispatch_ns` — the default namespace used for dispatch (the caller identity).
+/// `allowed_outbound` — namespaces this sender may deliver into cross-namespace.
+///
+/// Both registries in a cross-ns pair must share the same `Arc<khive_db::StorageBackend>`
+/// so that outbound notes written in one namespace are visible via the other's token.
+fn build_crossns_registry(
+    backend: Arc<khive_db::StorageBackend>,
+    dispatch_ns: &str,
+    allowed_outbound: Vec<Namespace>,
+) -> (VerbRegistry, KhiveRuntime) {
+    let config = RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::parse(dispatch_ns).unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "comm".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: allowed_outbound,
+    };
+    let rt = KhiveRuntime::from_backend(backend, config);
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(rt.clone()));
+    builder.register(CommPack::new(rt.clone()));
+    builder.with_default_namespace(dispatch_ns);
+    let registry = builder.build().expect("cross-ns registry builds");
+    (registry, rt)
+}
+
+fn shared_backend() -> Arc<khive_db::StorageBackend> {
+    let backend = khive_db::StorageBackend::memory().expect("in-memory backend");
+    {
+        let mut writer = backend.pool().try_writer().expect("writer");
+        khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+    }
+    Arc::new(backend)
+}
+
+// T1 — within-namespace send unchanged by the allowlist feature.
+#[tokio::test]
+async fn t1_send_within_namespace_unchanged() {
+    let backend = shared_backend();
+    let (registry, rt) = build_crossns_registry(
+        backend,
+        "lambda:leo",
+        vec![], // no outbound allowlist needed for same-ns
+    );
+
+    let result = registry
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:leo", "content": "self-send" }),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "T1: within-ns send must succeed; got {result:?}"
+    );
+
+    let tok = rt
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let notes = rt.list_notes(&tok, Some("message"), 100, 0).await.unwrap();
+    let alive: Vec<_> = notes.iter().filter(|n| n.deleted_at.is_none()).collect();
+    assert_eq!(
+        alive.len(),
+        2,
+        "T1: expect 1 outbound + 1 inbound for same-ns send; got {}",
+        alive.len()
+    );
+}
+
+// T2 — cross-ns send is denied when the allowlist is empty.
+#[tokio::test]
+async fn t2_send_cross_ns_denied_when_allowlist_empty() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(Arc::clone(&backend), "lambda:leo", vec![]);
+    let (_registry_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    let result = registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "blocked" }),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "T2: cross-ns send with empty allowlist must be denied"
+    );
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("not permitted")
+            || err_str.contains("PermissionDenied")
+            || err_str.contains("comm.send"),
+        "T2: error must mention the denial; got {err_str:?}"
+    );
+
+    // No note written in either namespace.
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let leo_notes = rt_leo
+        .list_notes(&leo_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        leo_notes.iter().filter(|n| n.deleted_at.is_none()).count(),
+        0,
+        "T2: no note in sender ns"
+    );
+
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_khive
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        khive_notes
+            .iter()
+            .filter(|n| n.deleted_at.is_none())
+            .count(),
+        0,
+        "T2: no note in recipient ns"
+    );
+}
+
+// T3 — cross-ns send delivers when the recipient is in the sender's allowlist.
+#[tokio::test]
+async fn t3_send_cross_ns_delivers_when_allowed() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    let (_reg_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    let result = registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "hello cross-ns" }),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "T3: cross-ns send to allowed ns must succeed; got {result:?}"
+    );
+    let val = result.unwrap();
+    assert!(
+        val.get("full_id").is_some(),
+        "T3: response must carry full_id"
+    );
+
+    // Outbound in lambda:leo.
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let leo_notes = rt_leo
+        .list_notes(&leo_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let outbound: Vec<_> = leo_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .filter(|n| {
+            n.properties
+                .as_ref()
+                .and_then(|p| p.get("direction"))
+                .and_then(|v| v.as_str())
+                == Some("outbound")
+        })
+        .collect();
+    assert_eq!(outbound.len(), 1, "T3: expect 1 outbound note in sender ns");
+    let outbound_thread_id = outbound[0]
+        .properties
+        .as_ref()
+        .and_then(|p| p.get("thread_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .expect("T3: outbound note must have thread_id");
+
+    // Inbound in lambda:khive.
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_khive
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound: Vec<_> = khive_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .filter(|n| {
+            n.properties
+                .as_ref()
+                .and_then(|p| p.get("direction"))
+                .and_then(|v| v.as_str())
+                == Some("inbound")
+        })
+        .collect();
+    assert_eq!(
+        inbound.len(),
+        1,
+        "T3: expect 1 inbound note in recipient ns"
+    );
+    let inbound_note = inbound[0];
+    assert_eq!(
+        inbound_note
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("from"))
+            .and_then(|v| v.as_str()),
+        Some("lambda:leo"),
+        "T3: inbound from must be lambda:leo"
+    );
+    assert_eq!(
+        inbound_note
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("to"))
+            .and_then(|v| v.as_str()),
+        Some("lambda:khive"),
+        "T3: inbound to must be lambda:khive"
+    );
+    assert_eq!(
+        inbound_note.content, "hello cross-ns",
+        "T3: inbound content must match"
+    );
+    let inbound_thread_id = inbound_note
+        .properties
+        .as_ref()
+        .and_then(|p| p.get("thread_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .expect("T3: inbound note must have thread_id");
+    assert_eq!(
+        outbound_thread_id, inbound_thread_id,
+        "T3: both copies must share thread_id"
+    );
+}
+
+// T4 — inbound note's namespace column is the recipient namespace.
+#[tokio::test]
+async fn t4_inbound_note_namespace_is_recipient() {
+    let backend = shared_backend();
+    let (registry_leo, _rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    let (_reg_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "ns stamp check" }),
+        )
+        .await
+        .expect("T4: send must succeed");
+
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_khive
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_note = khive_notes
+        .iter()
+        .find(|n| n.deleted_at.is_none())
+        .expect("T4: must find inbound note");
+    assert_eq!(
+        inbound_note.namespace.as_str(),
+        "lambda:khive",
+        "T4: inbound note namespace must be lambda:khive (with_namespace stamped it)"
+    );
+}
+
+// T5 — recipient inbox sees the delivered message.
+#[tokio::test]
+async fn t5_recipient_inbox_sees_message() {
+    let backend = shared_backend();
+    let (registry_leo, _rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    let (registry_khive, _rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "inbox check" }),
+        )
+        .await
+        .expect("T5: send must succeed");
+
+    let inbox = registry_khive
+        .dispatch("comm.inbox", serde_json::json!({}))
+        .await
+        .expect("T5: inbox dispatch must succeed");
+    let count = inbox.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+    assert_eq!(
+        count, 1,
+        "T5: recipient inbox must contain exactly 1 message; got {count}"
+    );
+    let msgs = inbox.get("messages").and_then(|v| v.as_array()).unwrap();
+    let msg = &msgs[0];
+    assert_eq!(
+        msg.get("properties")
+            .and_then(|p| p.get("from"))
+            .and_then(|v| v.as_str()),
+        Some("lambda:leo"),
+        "T5: inbox message from must be lambda:leo"
+    );
+    assert_eq!(
+        msg.get("properties")
+            .and_then(|p| p.get("read"))
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "T5: inbox message must be unread"
+    );
+}
+
+// T6 — sender's own inbox does not contain the inbound copy that landed in recipient ns.
+#[tokio::test]
+async fn t6_sender_inbox_does_not_see_inbound_copy() {
+    let backend = shared_backend();
+    let (registry_leo, _rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+
+    registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "isolation check" }),
+        )
+        .await
+        .expect("T6: send must succeed");
+
+    let inbox = registry_leo
+        .dispatch("comm.inbox", serde_json::json!({ "status": "all" }))
+        .await
+        .expect("T6: sender inbox dispatch must succeed");
+    let count = inbox.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+    assert_eq!(
+        count, 0,
+        "T6: sender inbox must not contain the inbound copy (it is in recipient ns); got {count}"
+    );
+}
+
+// T7 — white-box: with_namespace token cannot read from the original namespace.
+#[tokio::test]
+async fn t7_inbound_token_grants_no_read_back() {
+    let backend = shared_backend();
+    let (_registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+
+    // Create a note in lambda:leo namespace.
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let sender_note = rt_leo
+        .create_note(
+            &leo_tok,
+            "observation",
+            None,
+            "sender-ns note",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T7: create sender note");
+
+    // Mint the kind of token that with_namespace produces (recipient-scoped).
+    let recipient_tok: NamespaceToken =
+        leo_tok.with_namespace(Namespace::parse("lambda:khive").unwrap());
+
+    // Attempt to read the sender-ns note using the recipient-scoped token.
+    // get_note_including_deleted returns Ok(None) when namespace is not visible.
+    let result = rt_leo
+        .get_note_including_deleted(&recipient_tok, sender_note.id)
+        .await;
+    match result {
+        Ok(None) => {
+            // Expected: token's visible set is [lambda:khive], cannot see lambda:leo notes.
+        }
+        Ok(Some(_)) => panic!("T7: with_namespace token must not read back sender-ns note"),
+        Err(e) => panic!("T7: unexpected error {e:?}"),
+    }
+}
+
+// T8 — cross-ns note is not update/delete-able by the sender runtime.
+#[tokio::test]
+async fn t8_cross_ns_send_grants_no_update_delete() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    let (_reg_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "append-only check" }),
+        )
+        .await
+        .expect("T8: send must succeed");
+
+    // Find the inbound note UUID.
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_khive
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_id = khive_notes
+        .iter()
+        .find(|n| n.deleted_at.is_none())
+        .map(|n| n.id)
+        .expect("T8: must find inbound note");
+
+    // Attempt update via sender's leo token — must fail with NotFound (namespace mismatch).
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let update_result = rt_leo
+        .update_note(
+            &leo_tok,
+            inbound_id,
+            NotePatch::new(None, None, None, None, None),
+        )
+        .await;
+    match update_result {
+        Err(khive_runtime::RuntimeError::NotFound(_)) => {}
+        Ok(_) => panic!("T8: update of cross-ns note from sender must return NotFound"),
+        Err(e) => panic!("T8: update returned unexpected error {e:?}"),
+    }
+
+    // Attempt delete via sender's leo token — must return Ok(false) (namespace mismatch, not deleted).
+    let delete_result = rt_leo.delete_note(&leo_tok, inbound_id, true).await;
+    match delete_result {
+        Ok(false) => {
+            // Expected: namespace mismatch; note not deleted.
+        }
+        Ok(true) => {
+            panic!("T8: delete of cross-ns note from sender must NOT succeed (returned true)")
+        }
+        Err(e) => panic!("T8: delete returned unexpected error {e:?}"),
+    }
+
+    // Verify the inbound note still exists in lambda:khive namespace.
+    let khive_tok2 = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let still_there = rt_khive
+        .list_notes(&khive_tok2, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let alive_after = still_there
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        alive_after, 1,
+        "T8: inbound note must still exist after sender's failed delete attempt"
+    );
+}
+
+// T9 — reply from recipient back to sender cross-ns when reply allowlist permits.
+#[tokio::test]
+async fn t9_reply_cross_ns_delivers_when_allowed() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    // khive can reply to leo.
+    let (registry_khive, _rt_khive) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:khive",
+        vec![Namespace::parse("lambda:leo").unwrap()],
+    );
+
+    // leo sends to khive.
+    let send_result = registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "hello from leo" }),
+        )
+        .await
+        .expect("T9: send must succeed");
+    let outbound_thread_id = send_result
+        .get("full_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .expect("T9: send must return full_id");
+
+    // Fetch the inbound note UUID (as seen from khive — both runtimes share the same backend).
+    let khive_tok = rt_leo
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_leo
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_id = khive_notes
+        .iter()
+        .find(|n| n.deleted_at.is_none())
+        .map(|n| n.id.as_hyphenated().to_string())
+        .expect("T9: must find inbound note");
+
+    // khive replies to the inbound message.
+    let reply_result = registry_khive
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": inbound_id, "content": "got it from khive" }),
+        )
+        .await;
+    assert!(
+        reply_result.is_ok(),
+        "T9: reply cross-ns must succeed; got {reply_result:?}"
+    );
+
+    // leo's inbox now has the reply.
+    let leo_inbox = registry_leo
+        .dispatch("comm.inbox", serde_json::json!({}))
+        .await
+        .expect("T9: leo inbox");
+    let leo_count = leo_inbox.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+    assert_eq!(
+        leo_count, 1,
+        "T9: leo inbox must contain the reply; got {leo_count}"
+    );
+
+    // Reply carries the same thread_id as the original.
+    let leo_msgs = leo_inbox
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .unwrap();
+    let reply_thread_id = leo_msgs[0]
+        .get("properties")
+        .and_then(|p| p.get("thread_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .expect("T9: reply must have thread_id");
+    assert_eq!(
+        reply_thread_id, outbound_thread_id,
+        "T9: reply thread_id must match original outbound UUID"
+    );
+}
+
+// T10 — reply cross-ns is denied when the replier's allowlist is empty.
+#[tokio::test]
+async fn t10_reply_cross_ns_denied_when_empty() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    // khive has NO outbound allowlist (cannot reply cross-ns).
+    let (registry_khive, _rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    // leo sends to khive.
+    registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "setup for T10" }),
+        )
+        .await
+        .expect("T10: initial send must succeed");
+
+    // Fetch the inbound note UUID from khive's perspective.
+    let khive_tok = rt_leo
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_leo
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let inbound_id = khive_notes
+        .iter()
+        .find(|n| n.deleted_at.is_none())
+        .map(|n| n.id.as_hyphenated().to_string())
+        .expect("T10: must find inbound note");
+
+    // khive attempts to reply — must be denied.
+    let reply_result = registry_khive
+        .dispatch(
+            "comm.reply",
+            serde_json::json!({ "id": inbound_id, "content": "attempt blocked reply" }),
+        )
+        .await;
+    assert!(
+        reply_result.is_err(),
+        "T10: reply with empty allowlist must be denied"
+    );
+    let err_str = reply_result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("not permitted") || err_str.contains("PermissionDenied"),
+        "T10: error must indicate denial; got {err_str:?}"
+    );
+}
+
+// T11 — outbound note is rolled back when inbound write fails (cross-ns path).
+//
+// The rollback code in dual_write_message (message.rs, `delete_note` on inbound error)
+// is the same code path for both same-ns and cross-ns sends. The existing test
+// `test_send_inbound_failure_rolls_back_outbound` confirms rollback for format-invalid
+// namespace (failure before outbound note creation). Here we confirm the same rollback
+// guarantee for the cross-ns path by verifying no partial state remains when the
+// send is denied at the allowlist check (failure also before outbound note creation).
+//
+// Note: contriving an inbound DB write failure after the outbound note is committed
+// requires mocking, which is out of scope for integration tests. The structural rollback
+// at message.rs:205-209 is not namespace-path-specific.
+#[tokio::test]
+async fn t11_inbound_write_failure_rolls_back_outbound() {
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(Arc::clone(&backend), "lambda:leo", vec![]); // empty allowlist → denied
+
+    let result = registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "rollback check" }),
+        )
+        .await;
+    assert!(result.is_err(), "T11: denied send must fail");
+
+    // No outbound note must remain (atomicity: outbound not yet created when denial fires).
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let leo_notes = rt_leo
+        .list_notes(&leo_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let alive = leo_notes.iter().filter(|n| n.deleted_at.is_none()).count();
+    assert_eq!(
+        alive, 0,
+        "T11: no partial outbound note must remain; got {alive}"
+    );
+
+    let khive_tok = rt_leo
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_leo
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let khive_alive = khive_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        khive_alive, 0,
+        "T11: no inbound note in recipient ns; got {khive_alive}"
+    );
+}
+
+// T12 — allowlist is directional: leo→khive allowed, but khive→leo denied when not listed.
+#[tokio::test]
+async fn t12_allowlist_is_one_directional() {
+    let backend = shared_backend();
+    // leo lists khive.
+    let (_registry_leo, _rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    // khive does NOT list leo.
+    let (registry_khive, _rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    let result = registry_khive
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:leo", "content": "reverse direction" }),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "T12: reverse cross-ns send must be denied when not in allowlist; got {result:?}"
     );
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3003,96 +3003,88 @@ async fn t12_allowlist_is_one_directional() {
     );
 }
 
-// T13 — inbound indexing failure (FTS) after row commit leaves no stranded row.
+// T13 — inbound FTS failure after row commit leaves no stranded row (isomorphic
+// to codex finding #3: the INBOUND path specifically).
 //
-// This is the isomorphic replacement for T11: it contrives an actual post-row
-// inbound write failure (FTS step) and asserts that the compensation path in
-// create_note_inner removes the inbound note row, so no stranded cross-ns row
-// is visible to the recipient.
+// `dual_write_message` writes two notes: outbound (sender ns) then inbound
+// (recipient ns).  Finding #3 is about a stranded RECIPIENT row when the FTS
+// step fails after the inbound note row is committed.
 //
-// Uses `arm_fts_fail()` (khive_runtime::arm_fts_fail, cfg(test) only) to
-// inject the failure deterministically after the note row is committed.
+// Strategy: arm `arm_fts_fail` on the RECIPIENT namespace only.  The outbound
+// create_note (sender ns) runs first and is NOT targeted, so it succeeds.  The
+// inbound create_note (recipient ns) IS targeted: it commits the note row, hits
+// the injected FTS error, compensates (deletes the inbound row), and propagates
+// the error.  `dual_write_message` catches that error and rolls back the
+// outbound note.  After the send returns an error, BOTH namespaces must be empty.
 //
-// #[serial] is required because arm_fts_fail() sets a global AtomicBool that
-// concurrent tests can consume, causing races with other tests that call
-// create_note.
-#[serial_test::serial]
+// Namespace-targeting eliminates the cross-test race: concurrent tests using
+// other namespaces are unaffected by the injection.  `#[serial]` is not needed.
 #[tokio::test]
 async fn t13_inbound_fts_failure_leaves_no_stranded_row() {
     use khive_runtime::arm_fts_fail;
 
+    // Use a unique recipient namespace so the injection does not affect
+    // concurrent tests that share the shared_backend().
+    let sender_ns = "lambda:t13-sender";
+    let recipient_ns = "lambda:t13-inbound-fail";
+
     let backend = shared_backend();
-    let (registry_leo, rt_leo) = build_crossns_registry(
+    let (registry_sender, rt_sender) = build_crossns_registry(
         Arc::clone(&backend),
-        "lambda:leo",
-        vec![Namespace::parse("lambda:khive").unwrap()],
+        sender_ns,
+        vec![Namespace::parse(recipient_ns).unwrap()],
     );
-    let (_registry_khive, rt_khive) =
-        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+    let (_registry_recipient, rt_recipient) =
+        build_crossns_registry(Arc::clone(&backend), recipient_ns, vec![]);
 
-    // Send without injection first to ensure the outbound write succeeds but
-    // the injection fires on the INBOUND create_note call.  The tricky part
-    // is that dual_write_message calls create_note twice: first for the
-    // outbound (caller ns), then for the inbound (recipient ns).  We need to
-    // arm the injection so it fires on the SECOND create_note call.
-    //
-    // Strategy: arm_fts_fail resets after one trigger.  The outbound create_note
-    // fires first.  So we arm it now — the first FTS step (outbound) will
-    // consume the injection and the send will fail with the outbound FTS error.
-    // The compensation then removes the outbound row.
-    //
-    // To specifically test the inbound path, we perform two sends:
-    //   (a) same-namespace send (no FTS injection) to verify normal flow,
-    //   (b) then arm the flag and perform the cross-ns send — this time the
-    //       outbound create fires first and consumes the flag, causing the
-    //       outbound to fail.  With atomic compensation, no outbound row persists.
-    //
-    // The key assertion is: after the injection, NEITHER namespace has a
-    // stranded message row.
+    // Arm the FTS injection on the RECIPIENT namespace only.  The outbound
+    // create_note (sender_ns) passes through; only the inbound create_note
+    // (recipient_ns) triggers the injected error.
+    arm_fts_fail(recipient_ns);
 
-    // Arm the injection — the next FTS upsert in any create_note call will fail.
-    arm_fts_fail();
-
-    let result = registry_leo
+    let result = registry_sender
         .dispatch(
             "comm.send",
-            serde_json::json!({ "to": "lambda:khive", "content": "inbound-fail test" }),
+            serde_json::json!({ "to": recipient_ns, "content": "t13 inbound-fail test" }),
         )
         .await;
     assert!(
         result.is_err(),
-        "T13: send must fail when FTS injection armed"
+        "T13: send must fail when inbound FTS injection is armed on recipient ns"
     );
 
-    // No outbound note must remain in lambda:leo.
-    let leo_tok = rt_leo
-        .authorize(Namespace::parse("lambda:leo").unwrap())
+    // No outbound note must remain in the sender namespace.
+    let sender_tok = rt_sender
+        .authorize(Namespace::parse(sender_ns).unwrap())
         .unwrap();
-    let leo_notes = rt_leo
-        .list_notes(&leo_tok, Some("message"), 100, 0)
+    let sender_notes = rt_sender
+        .list_notes(&sender_tok, Some("message"), 100, 0)
         .await
         .unwrap();
-    let leo_alive = leo_notes.iter().filter(|n| n.deleted_at.is_none()).count();
-    assert_eq!(
-        leo_alive, 0,
-        "T13: no stranded outbound note in sender ns; got {leo_alive}"
-    );
-
-    // No inbound note must remain in lambda:khive.
-    let khive_tok = rt_khive
-        .authorize(Namespace::parse("lambda:khive").unwrap())
-        .unwrap();
-    let khive_notes = rt_khive
-        .list_notes(&khive_tok, Some("message"), 100, 0)
-        .await
-        .unwrap();
-    let khive_alive = khive_notes
+    let sender_alive = sender_notes
         .iter()
         .filter(|n| n.deleted_at.is_none())
         .count();
     assert_eq!(
-        khive_alive, 0,
-        "T13: no stranded inbound note in recipient ns; got {khive_alive}"
+        sender_alive, 0,
+        "T13: no stranded outbound note in sender ns after inbound FTS failure; got {sender_alive}"
+    );
+
+    // No inbound note must remain in the recipient namespace.
+    let recipient_tok = rt_recipient
+        .authorize(Namespace::parse(recipient_ns).unwrap())
+        .unwrap();
+    let recipient_notes = rt_recipient
+        .list_notes(&recipient_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let recipient_alive = recipient_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        recipient_alive, 0,
+        "T13: no stranded inbound note in recipient ns; compensation must clean it up; got {recipient_alive}"
     );
 }
 

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -2611,17 +2611,28 @@ async fn t6_sender_inbox_does_not_see_inbound_copy() {
     );
 }
 
-// T7 — white-box: with_namespace token cannot read from the original namespace.
+// T7 — white-box: with_namespace token scoping.
+//
+// `NamespaceToken::with_namespace(recipient)` produces a token with
+// `namespace = recipient, visible = [recipient]`.  This is an ordinary
+// NamespaceToken — NOT a type-enforced write-only capability:
+//   (a) The minted token CANNOT read the SENDER namespace (visible set excludes it).
+//   (b) The minted token CAN read the RECIPIENT namespace (it IS in the visible set).
+//
+// The security boundary is the sender-side allowlist check and the comm
+// handler's single-create usage, not the token type.
 #[tokio::test]
-async fn t7_inbound_token_grants_no_read_back() {
+async fn t7_with_namespace_token_scoping() {
     let backend = shared_backend();
     let (_registry_leo, rt_leo) = build_crossns_registry(
         Arc::clone(&backend),
         "lambda:leo",
         vec![Namespace::parse("lambda:khive").unwrap()],
     );
+    let (_registry_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
 
-    // Create a note in lambda:leo namespace.
+    // Create a note in lambda:leo (sender) namespace.
     let leo_tok = rt_leo
         .authorize(Namespace::parse("lambda:leo").unwrap())
         .unwrap();
@@ -2638,27 +2649,62 @@ async fn t7_inbound_token_grants_no_read_back() {
         .await
         .expect("T7: create sender note");
 
+    // Create a note in lambda:khive (recipient) namespace.
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let recipient_note = rt_khive
+        .create_note(
+            &khive_tok,
+            "observation",
+            None,
+            "recipient-ns note",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("T7: create recipient note");
+
     // Mint the kind of token that with_namespace produces (recipient-scoped).
     let recipient_tok: NamespaceToken =
         leo_tok.with_namespace(Namespace::parse("lambda:khive").unwrap());
 
-    // Attempt to read the sender-ns note using the recipient-scoped token.
-    // get_note_including_deleted returns Ok(None) when namespace is not visible.
-    let result = rt_leo
+    // (a) Minted token CANNOT read the sender-ns note (visible set is [lambda:khive]).
+    let cannot_see_sender = rt_leo
         .get_note_including_deleted(&recipient_tok, sender_note.id)
         .await;
-    match result {
+    match cannot_see_sender {
         Ok(None) => {
             // Expected: token's visible set is [lambda:khive], cannot see lambda:leo notes.
         }
-        Ok(Some(_)) => panic!("T7: with_namespace token must not read back sender-ns note"),
-        Err(e) => panic!("T7: unexpected error {e:?}"),
+        Ok(Some(_)) => panic!("T7(a): with_namespace token must not read sender-ns note"),
+        Err(e) => panic!("T7(a): unexpected error {e:?}"),
+    }
+
+    // (b) Minted token CAN read the recipient-ns note — it is a full read+write token
+    // for the recipient ns, not a type-enforced write-only capability.
+    let can_see_recipient = rt_khive
+        .get_note_including_deleted(&recipient_tok, recipient_note.id)
+        .await;
+    match can_see_recipient {
+        Ok(Some(_)) => {
+            // Expected: the minted token can read from its own namespace (lambda:khive).
+        }
+        Ok(None) => panic!("T7(b): minted token must be able to read recipient-ns note"),
+        Err(e) => panic!("T7(b): unexpected error {e:?}"),
     }
 }
 
-// T8 — cross-ns note is not update/delete-able by the sender runtime.
+// T8 — the sender's own namespace token cannot update or delete the inbound note
+// in the recipient namespace.
+//
+// This tests namespace isolation at the runtime layer: the sender's leo_tok
+// has namespace=lambda:leo and cannot mutate records owned by lambda:khive.
+// It does NOT test any property of the with_namespace token used internally by
+// the comm handler.
 #[tokio::test]
-async fn t8_cross_ns_send_grants_no_update_delete() {
+async fn t8_sender_token_cannot_mutate_recipient_inbound_note() {
     let backend = shared_backend();
     let (registry_leo, rt_leo) = build_crossns_registry(
         Arc::clone(&backend),
@@ -2954,5 +3000,137 @@ async fn t12_allowlist_is_one_directional() {
     assert!(
         result.is_err(),
         "T12: reverse cross-ns send must be denied when not in allowlist; got {result:?}"
+    );
+}
+
+// T13 — inbound indexing failure (FTS) after row commit leaves no stranded row.
+//
+// This is the isomorphic replacement for T11: it contrives an actual post-row
+// inbound write failure (FTS step) and asserts that the compensation path in
+// create_note_inner removes the inbound note row, so no stranded cross-ns row
+// is visible to the recipient.
+//
+// Uses `arm_fts_fail()` (khive_runtime::arm_fts_fail, cfg(test) only) to
+// inject the failure deterministically after the note row is committed.
+#[tokio::test]
+async fn t13_inbound_fts_failure_leaves_no_stranded_row() {
+    use khive_runtime::arm_fts_fail;
+
+    let backend = shared_backend();
+    let (registry_leo, rt_leo) = build_crossns_registry(
+        Arc::clone(&backend),
+        "lambda:leo",
+        vec![Namespace::parse("lambda:khive").unwrap()],
+    );
+    let (_registry_khive, rt_khive) =
+        build_crossns_registry(Arc::clone(&backend), "lambda:khive", vec![]);
+
+    // Send without injection first to ensure the outbound write succeeds but
+    // the injection fires on the INBOUND create_note call.  The tricky part
+    // is that dual_write_message calls create_note twice: first for the
+    // outbound (caller ns), then for the inbound (recipient ns).  We need to
+    // arm the injection so it fires on the SECOND create_note call.
+    //
+    // Strategy: arm_fts_fail resets after one trigger.  The outbound create_note
+    // fires first.  So we arm it now — the first FTS step (outbound) will
+    // consume the injection and the send will fail with the outbound FTS error.
+    // The compensation then removes the outbound row.
+    //
+    // To specifically test the inbound path, we perform two sends:
+    //   (a) same-namespace send (no FTS injection) to verify normal flow,
+    //   (b) then arm the flag and perform the cross-ns send — this time the
+    //       outbound create fires first and consumes the flag, causing the
+    //       outbound to fail.  With atomic compensation, no outbound row persists.
+    //
+    // The key assertion is: after the injection, NEITHER namespace has a
+    // stranded message row.
+
+    // Arm the injection — the next FTS upsert in any create_note call will fail.
+    arm_fts_fail();
+
+    let result = registry_leo
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": "lambda:khive", "content": "inbound-fail test" }),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "T13: send must fail when FTS injection armed"
+    );
+
+    // No outbound note must remain in lambda:leo.
+    let leo_tok = rt_leo
+        .authorize(Namespace::parse("lambda:leo").unwrap())
+        .unwrap();
+    let leo_notes = rt_leo
+        .list_notes(&leo_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let leo_alive = leo_notes.iter().filter(|n| n.deleted_at.is_none()).count();
+    assert_eq!(
+        leo_alive, 0,
+        "T13: no stranded outbound note in sender ns; got {leo_alive}"
+    );
+
+    // No inbound note must remain in lambda:khive.
+    let khive_tok = rt_khive
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .unwrap();
+    let khive_notes = rt_khive
+        .list_notes(&khive_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let khive_alive = khive_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        khive_alive, 0,
+        "T13: no stranded inbound note in recipient ns; got {khive_alive}"
+    );
+}
+
+// TOML wiring test — KhiveConfig parsed from TOML with
+// `actor.allowed_outbound_namespaces = [...]` must land those values in
+// RuntimeConfig.allowed_outbound_namespaces.
+#[test]
+fn toml_allowed_outbound_namespaces_wires_into_runtime_config() {
+    use khive_runtime::{runtime_config_from_khive_config, RuntimeConfig};
+
+    let toml_src = r#"
+[actor]
+id = "lambda:leo"
+allowed_outbound_namespaces = ["lambda:khive", "lambda:atlas"]
+"#;
+    let khive_cfg: khive_runtime::KhiveConfig = toml::from_str(toml_src).expect("TOML must parse");
+
+    let base = RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string(), "comm".to_string()],
+        ..RuntimeConfig::default()
+    };
+    let resolved = runtime_config_from_khive_config(&khive_cfg, base);
+
+    let outbound_strs: Vec<&str> = resolved
+        .allowed_outbound_namespaces
+        .iter()
+        .map(|ns| ns.as_str())
+        .collect();
+
+    assert!(
+        outbound_strs.contains(&"lambda:khive"),
+        "allowed_outbound_namespaces must contain 'lambda:khive'; got {outbound_strs:?}"
+    );
+    assert!(
+        outbound_strs.contains(&"lambda:atlas"),
+        "allowed_outbound_namespaces must contain 'lambda:atlas'; got {outbound_strs:?}"
+    );
+    assert_eq!(
+        outbound_strs.len(),
+        2,
+        "exactly 2 outbound namespaces expected; got {outbound_strs:?}"
     );
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3012,6 +3012,11 @@ async fn t12_allowlist_is_one_directional() {
 //
 // Uses `arm_fts_fail()` (khive_runtime::arm_fts_fail, cfg(test) only) to
 // inject the failure deterministically after the note row is committed.
+//
+// #[serial] is required because arm_fts_fail() sets a global AtomicBool that
+// concurrent tests can consume, causing races with other tests that call
+// create_note.
+#[serial_test::serial]
 #[tokio::test]
 async fn t13_inbound_fts_failure_leaves_no_stranded_row() {
     use khive_runtime::arm_fts_fail;

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3088,6 +3088,132 @@ async fn t13_inbound_fts_failure_leaves_no_stranded_row() {
     );
 }
 
+// T14 — inbound vector insertion failure after note row + FTS commit leaves no
+// stranded row (mirrors T13 but exercises the vector compensation path).
+//
+// Because `build_crossns_registry` configures no embedding model, the vector
+// insert path is unreachable without registering a provider.  T14 registers a
+// trivial constant-vector embedder on the sender and recipient runtimes so that
+// `embed_model_names` is non-empty, then arms `arm_vector_fail(recipient_ns)`.
+//
+// Execution path for the cross-ns send:
+//   outbound create_note (sender ns)   → FTS ok, embed ok, vector insert ok.
+//   inbound  create_note (recipient ns) → FTS ok, embed ok,
+//                                         vector inject fires → Err returned,
+//                                         compensation deletes inbound row + FTS.
+//   dual_write_message catches inbound error → rolls back outbound note.
+//
+// After send returns Err, both sender_ns and recipient_ns have zero live notes.
+#[tokio::test]
+async fn t14_inbound_vector_failure_leaves_no_stranded_row() {
+    use async_trait::async_trait;
+    use khive_runtime::{arm_vector_fail, EmbedderProvider};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+    const T14_MODEL: &str = "t14-const-vec";
+    const T14_DIMS: usize = 4;
+
+    struct T14VecService;
+    #[async_trait]
+    impl EmbeddingService for T14VecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|_| vec![1.0_f32; T14_DIMS]).collect())
+        }
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+        fn name(&self) -> &'static str {
+            "t14-const-vec"
+        }
+    }
+
+    struct T14VecProvider;
+    #[async_trait]
+    impl EmbedderProvider for T14VecProvider {
+        fn name(&self) -> &str {
+            T14_MODEL
+        }
+        fn dimensions(&self) -> usize {
+            T14_DIMS
+        }
+        async fn build(&self) -> khive_runtime::RuntimeResult<Arc<dyn EmbeddingService>> {
+            Ok(Arc::new(T14VecService))
+        }
+    }
+
+    let sender_ns = "lambda:t14-sender";
+    let recipient_ns = "lambda:t14-vec-inbound-fail";
+
+    let backend = shared_backend();
+    let (registry_sender, rt_sender) = build_crossns_registry(
+        Arc::clone(&backend),
+        sender_ns,
+        vec![Namespace::parse(recipient_ns).unwrap()],
+    );
+    let (_registry_recipient, rt_recipient) =
+        build_crossns_registry(Arc::clone(&backend), recipient_ns, vec![]);
+
+    // Register the embedder on both runtimes so the vector path is exercised.
+    rt_sender.register_embedder(T14VecProvider);
+    rt_recipient.register_embedder(T14VecProvider);
+
+    // Arm vector injection on the RECIPIENT namespace only.  The outbound
+    // create_note (sender_ns) passes through; only the inbound create_note
+    // (recipient_ns) hits the injected error after its row and FTS are committed.
+    arm_vector_fail(recipient_ns);
+
+    let result = registry_sender
+        .dispatch(
+            "comm.send",
+            serde_json::json!({ "to": recipient_ns, "content": "t14 vec-inbound-fail test" }),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "T14: send must fail when inbound vector injection is armed on recipient ns"
+    );
+
+    // No outbound note must remain in the sender namespace.
+    let sender_tok = rt_sender
+        .authorize(Namespace::parse(sender_ns).unwrap())
+        .unwrap();
+    let sender_notes = rt_sender
+        .list_notes(&sender_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let sender_alive = sender_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        sender_alive,
+        0,
+        "T14: no stranded outbound note in sender ns after inbound vector failure; got {sender_alive}"
+    );
+
+    // No inbound note must remain in the recipient namespace.
+    let recipient_tok = rt_recipient
+        .authorize(Namespace::parse(recipient_ns).unwrap())
+        .unwrap();
+    let recipient_notes = rt_recipient
+        .list_notes(&recipient_tok, Some("message"), 100, 0)
+        .await
+        .unwrap();
+    let recipient_alive = recipient_notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .count();
+    assert_eq!(
+        recipient_alive,
+        0,
+        "T14: no stranded inbound note in recipient ns; compensation must clean it up; got {recipient_alive}"
+    );
+}
+
 // TOML wiring test — KhiveConfig parsed from TOML with
 // `actor.allowed_outbound_namespaces = [...]` must land those values in
 // RuntimeConfig.allowed_outbound_namespaces.

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -28,6 +28,7 @@ fn build_runtime() -> KhiveRuntime {
         backend_id: BackendId::main(),
         brain_profile: None,
         visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
     })
     .expect("runtime")
 }

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -35,6 +35,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         backend_id: BackendId::main(),
         brain_profile: None,
         visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -35,6 +35,7 @@ fn rt_with_embedder() -> KhiveRuntime {
         backend_id: BackendId::main(),
         brain_profile: None,
         visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
     })
     .expect("runtime with embedder")
 }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1417,6 +1417,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
         backend_id: BackendId::main(),
         brain_profile: None,
         visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
     })
     .expect("runtime with default embedder")
 }
@@ -2086,6 +2087,7 @@ mod embed_failure_tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         })
         .expect("runtime");
         // Override the lattice provider with our fake — same key, last-writer wins.
@@ -2446,6 +2448,7 @@ mod ann_bypass_regression {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         })
         .expect("runtime");
         rt.register_embedder(CorrectDimProvider);

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Composable Service API: entity/note CRUD, graph traversal, hybrid search, curation."
 
+[features]
+fault-injection = []
+
 [dependencies]
 khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
 khive-storage = { version = "0.2.11", path = "../khive-storage" }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -161,18 +161,25 @@ impl NamespaceToken {
 
     /// Return a new token with the same actor but a different namespace.
     ///
-    /// The visible set is replaced with `[ns]` — the new token cannot read from
-    /// the original token's namespaces. This is a capability-transfer primitive,
-    /// not a policy gate: the caller is responsible for enforcing any ACL check
-    /// before calling this method.
+    /// The visible set is replaced with `[ns]` — the minted token has
+    /// `namespace = ns` and `visible = [ns]`. This is a full read+write token
+    /// for `ns`: public runtime APIs (`list_notes`, `update_note`, `delete_note`,
+    /// etc.) accept it and will operate on `ns`. It is NOT a type-enforced
+    /// write-only or append-only capability. This is a capability-transfer
+    /// primitive, not a policy gate: the caller is responsible for enforcing any
+    /// ACL check before calling this method and for using the minted token only
+    /// in the intended narrow scope (e.g. a single `create_note` call).
     ///
     /// Callers today:
     /// - `khive-pack-memory` FTS fanout: iterates token's own visible set; no escalation.
-    /// - `khive-pack-comm` inbound delivery: mints a write token for the recipient ns,
-    ///   gated by `actor.allowed_outbound_namespaces` allowlist check immediately before.
+    /// - `khive-pack-comm` inbound delivery: mints a token for the recipient ns,
+    ///   gated by `actor.allowed_outbound_namespaces` allowlist check immediately
+    ///   before, and uses it for exactly one `create_note` call (append-only by
+    ///   convention, not by type enforcement).
     ///
     /// Under a security model (cloud, mutual auth), replace this call pattern with a
-    /// `comm.ingest` Subhandler dispatch (ADR-056/ADR-053) that goes through the Gate.
+    /// type-enforced append-only capability or a `comm.ingest` Subhandler dispatch
+    /// (see ADR-056/ADR-053) that goes through the Gate.
     pub fn with_namespace(&self, ns: Namespace) -> Self {
         Self::mint_authorized(ns, self.actor.clone())
     }
@@ -244,10 +251,11 @@ pub struct RuntimeConfig {
     /// Namespaces this actor's comm.send/reply may deliver messages INTO
     /// (outbound, sender-side). Populated from `actor.allowed_outbound_namespaces`
     /// in `khive.toml`. Empty by default — cross-namespace delivery denied
-    /// unless explicitly declared. Grants write-only inbound-append access
-    /// to the listed namespaces; does NOT grant read access. The recipient-side
+    /// unless explicitly declared. The comm handler uses an ordinary
+    /// `NamespaceToken` (minted via `with_namespace`) in an append-only manner;
+    /// the token itself is NOT type-enforced write-only. The recipient-side
     /// `allowed_inbound_namespaces` (bilateral mutual opt-in) is reserved for
-    /// the ADR-057 cloud path.
+    /// a future cloud-path authorization ADR (not yet written).
     pub allowed_outbound_namespaces: Vec<Namespace>,
 }
 

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -161,10 +161,18 @@ impl NamespaceToken {
 
     /// Return a new token with the same actor but a different namespace.
     ///
-    /// Used by packs that apply a namespace policy (e.g. the KG pack overrides the
-    /// caller's namespace to `Namespace::local()` so that entity/edge/note records
-    /// always land in the shared graph). The visible set is also replaced with
-    /// `[ns]` so isolation is maintained for the overridden namespace.
+    /// The visible set is replaced with `[ns]` — the new token cannot read from
+    /// the original token's namespaces. This is a capability-transfer primitive,
+    /// not a policy gate: the caller is responsible for enforcing any ACL check
+    /// before calling this method.
+    ///
+    /// Callers today:
+    /// - `khive-pack-memory` FTS fanout: iterates token's own visible set; no escalation.
+    /// - `khive-pack-comm` inbound delivery: mints a write token for the recipient ns,
+    ///   gated by `actor.allowed_outbound_namespaces` allowlist check immediately before.
+    ///
+    /// Under a security model (cloud, mutual auth), replace this call pattern with a
+    /// `comm.ingest` Subhandler dispatch (ADR-056/ADR-053) that goes through the Gate.
     pub fn with_namespace(&self, ns: Namespace) -> Self {
         Self::mint_authorized(ns, self.actor.clone())
     }
@@ -233,6 +241,14 @@ pub struct RuntimeConfig {
     /// namespace (actor.id) is always implicitly readable and need not appear
     /// here. Empty by default (single-namespace behaviour).
     pub visible_namespaces: Vec<Namespace>,
+    /// Namespaces this actor's comm.send/reply may deliver messages INTO
+    /// (outbound, sender-side). Populated from `actor.allowed_outbound_namespaces`
+    /// in `khive.toml`. Empty by default — cross-namespace delivery denied
+    /// unless explicitly declared. Grants write-only inbound-append access
+    /// to the listed namespaces; does NOT grant read access. The recipient-side
+    /// `allowed_inbound_namespaces` (bilateral mutual opt-in) is reserved for
+    /// the ADR-057 cloud path.
+    pub allowed_outbound_namespaces: Vec<Namespace>,
 }
 
 /// Parse a comma- or whitespace-separated pack list from a single string.
@@ -290,6 +306,7 @@ impl Default for RuntimeConfig {
             backend_id: BackendId::main(),
             brain_profile,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         }
     }
 }
@@ -415,11 +432,28 @@ pub fn runtime_config_from_khive_config(
         })
         .collect();
 
+    // KhiveConfig::validate() guarantees every entry in allowed_outbound_namespaces is a
+    // structurally valid Namespace string, so Namespace::parse failures here are unreachable
+    // for validated configs. We still filter_map with a warn so a runtime bug doesn't panic.
+    let allowed_outbound_namespaces: Vec<Namespace> = khive_cfg
+        .actor
+        .allowed_outbound_namespaces
+        .iter()
+        .filter_map(|s| match Namespace::parse(s) {
+            Ok(ns) => Some(ns),
+            Err(e) => {
+                tracing::warn!(ns = %s, error = %e, "actor.allowed_outbound_namespaces: invalid namespace; skipped");
+                None
+            }
+        })
+        .collect();
+
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
             default_namespace,
             brain_profile,
             visible_namespaces,
+            allowed_outbound_namespaces,
             ..base
         };
     }
@@ -452,6 +486,7 @@ pub fn runtime_config_from_khive_config(
         default_namespace,
         brain_profile,
         visible_namespaces,
+        allowed_outbound_namespaces,
         ..base
     }
 }

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -120,6 +120,19 @@ pub struct ActorConfig {
     /// here. When absent or empty, visibility defaults to `[id]` only.
     #[serde(default)]
     pub visible_namespaces: Option<Vec<String>>,
+
+    /// Namespaces this actor's comm.send/reply may deliver messages INTO
+    /// (outbound, sender-side). Empty by default — cross-namespace delivery
+    /// denied unless explicitly declared. Grants write-only inbound-append
+    /// access to the listed namespaces; does NOT grant read access. The
+    /// recipient-side `allowed_inbound_namespaces` (bilateral mutual opt-in)
+    /// is reserved for the ADR-057 cloud path.
+    ///
+    /// Each entry must be a valid `Namespace` string; validated at
+    /// config-load time. An empty list preserves the prior deny-all behavior
+    /// for any actor that does not add this field.
+    #[serde(default)]
+    pub allowed_outbound_namespaces: Vec<String>,
 }
 
 /// Top-level khive configuration loaded from `khive.toml` or `config.toml`.
@@ -298,6 +311,20 @@ impl KhiveConfig {
                     reason: format!("invalid visible namespace: {e}"),
                 })?;
             }
+        }
+
+        // Validate actor.allowed_outbound_namespaces (fail-closed at startup on malformed entry).
+        for ns_str in &self.actor.allowed_outbound_namespaces {
+            if ns_str.is_empty() {
+                return Err(ConfigError::InvalidActorId {
+                    id: ns_str.clone(),
+                    reason: "allowed_outbound_namespaces entries must not be empty".to_string(),
+                });
+            }
+            Namespace::parse(ns_str).map_err(|e| ConfigError::InvalidActorId {
+                id: ns_str.clone(),
+                reason: format!("invalid allowed_outbound_namespaces entry: {e}"),
+            })?;
         }
 
         if self.engines.is_empty() {

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -123,10 +123,11 @@ pub struct ActorConfig {
 
     /// Namespaces this actor's comm.send/reply may deliver messages INTO
     /// (outbound, sender-side). Empty by default — cross-namespace delivery
-    /// denied unless explicitly declared. Grants write-only inbound-append
-    /// access to the listed namespaces; does NOT grant read access. The
-    /// recipient-side `allowed_inbound_namespaces` (bilateral mutual opt-in)
-    /// is reserved for the ADR-057 cloud path.
+    /// denied unless explicitly declared. The comm handler uses an ordinary
+    /// `NamespaceToken` (minted via `with_namespace`) in an append-only manner;
+    /// the token itself is NOT type-enforced write-only. The recipient-side
+    /// `allowed_inbound_namespaces` (bilateral mutual opt-in) is reserved for
+    /// a future cloud-path authorization ADR (not yet written).
     ///
     /// Each entry must be a valid `Namespace` string; validated at
     /// config-load time. An empty list preserves the prior deny-all behavior

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -48,7 +48,9 @@ pub use objectives::{
     MemoryRecallPipeline, NoteCandidate, RerankerObjective, RetrievalCandidate, RrfFusionObjective,
     TemporalRecencyObjective, TextRelevanceObjective, VectorSimilarityObjective,
 };
-pub use operations::{LinkSpec, NoteSearchHit, QueryResult, Resolved};
+pub use operations::{
+    arm_fts_fail, arm_vector_fail, LinkSpec, NoteSearchHit, QueryResult, Resolved,
+};
 pub use pack::{
     DispatchHook, HandlerDef, KindHook, NoteKindSpec, NoteLifecycleSpec, PackFactory,
     PackLoadError, PackRegistration, PackRegistry, PackRuntime, PackSchemaPlan, ParamDef,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -48,9 +48,9 @@ pub use objectives::{
     MemoryRecallPipeline, NoteCandidate, RerankerObjective, RetrievalCandidate, RrfFusionObjective,
     TemporalRecencyObjective, TextRelevanceObjective, VectorSimilarityObjective,
 };
-pub use operations::{
-    arm_fts_fail, arm_vector_fail, LinkSpec, NoteSearchHit, QueryResult, Resolved,
-};
+#[cfg(any(test, feature = "fault-injection"))]
+pub use operations::{arm_fts_fail, arm_vector_fail};
+pub use operations::{LinkSpec, NoteSearchHit, QueryResult, Resolved};
 pub use pack::{
     DispatchHook, HandlerDef, KindHook, NoteKindSpec, NoteLifecycleSpec, PackFactory,
     PackLoadError, PackRegistration, PackRegistry, PackRuntime, PackSchemaPlan, ParamDef,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1431,10 +1431,13 @@ impl KhiveRuntime {
             let fts_result: RuntimeResult<()> = if fts_inject {
                 Err(RuntimeError::Internal("injected FTS failure".to_string()))
             } else {
-                self.text_for_notes(token)?
-                    .upsert_document(note_fts_document(&note))
-                    .await
-                    .map_err(RuntimeError::from)
+                match self.text_for_notes(token) {
+                    Ok(fts) => fts
+                        .upsert_document(note_fts_document(&note))
+                        .await
+                        .map_err(RuntimeError::from),
+                    Err(e) => Err(e),
+                }
             };
 
             if let Err(e) = fts_result {
@@ -1482,10 +1485,9 @@ impl KhiveRuntime {
                 vec_result
             };
 
-            match vec_result {
-                Ok(vector) => {
-                    let insert_result = self
-                        .vectors_for_model(token, model_name)?
+            let single_model_result: RuntimeResult<()> = match vec_result {
+                Ok(vector) => match self.vectors_for_model(token, model_name) {
+                    Ok(vs) => vs
                         .insert(
                             note.id,
                             SubstrateKind::Note,
@@ -1494,28 +1496,20 @@ impl KhiveRuntime {
                             vec![vector],
                         )
                         .await
-                        .map_err(RuntimeError::from);
-                    if let Err(e) = insert_result {
-                        // Compensate note row + FTS.
-                        if let Ok(store) = self.notes(token) {
-                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
-                        }
-                        if let Ok(fts) = self.text_for_notes(token) {
-                            let _ = fts.delete_document(ns, note.id).await;
-                        }
-                        return Err(e);
-                    }
+                        .map_err(RuntimeError::from),
+                    Err(e) => Err(e),
+                },
+                Err(e) => Err(e),
+            };
+            if let Err(e) = single_model_result {
+                // Compensate note row + FTS.
+                if let Ok(store) = self.notes(token) {
+                    let _ = store.delete_note(note.id, DeleteMode::Hard).await;
                 }
-                Err(e) => {
-                    // Compensate note row + FTS.
-                    if let Ok(store) = self.notes(token) {
-                        let _ = store.delete_note(note.id, DeleteMode::Hard).await;
-                    }
-                    if let Ok(fts) = self.text_for_notes(token) {
-                        let _ = fts.delete_document(ns, note.id).await;
-                    }
-                    return Err(e);
+                if let Ok(fts) = self.text_for_notes(token) {
+                    let _ = fts.delete_document(ns, note.id).await;
                 }
+                return Err(e);
             }
         } else if !embed_model_names.is_empty() {
             // Multi-model path: embed with each model in parallel via spawned tasks,
@@ -1533,13 +1527,12 @@ impl KhiveRuntime {
             }
             let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(embed_model_names.len());
             for handle in handles {
-                match handle
+                let join_result = handle
                     .await
-                    .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}")))?
-                {
-                    Ok(vec) => vectors.push(vec),
+                    .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}")));
+                match join_result {
                     Err(e) => {
-                        // Compensate note row + FTS.
+                        // Compensate note row + FTS (no vectors inserted yet).
                         if let Ok(store) = self.notes(token) {
                             let _ = store.delete_note(note.id, DeleteMode::Hard).await;
                         }
@@ -1548,22 +1541,35 @@ impl KhiveRuntime {
                         }
                         return Err(e);
                     }
+                    Ok(Err(e)) => {
+                        // Embed call failed — compensate note row + FTS.
+                        if let Ok(store) = self.notes(token) {
+                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                        }
+                        if let Ok(fts) = self.text_for_notes(token) {
+                            let _ = fts.delete_document(ns, note.id).await;
+                        }
+                        return Err(e);
+                    }
+                    Ok(Ok(vec)) => vectors.push(vec),
                 }
             }
             // TODO(P2): parallelize vector inserts (codex review #444)
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors.into_iter()) {
-                let insert_result = self
-                    .vectors_for_model(token, model_name)?
-                    .insert(
-                        note.id,
-                        SubstrateKind::Note,
-                        ns,
-                        "note.content",
-                        vec![vector],
-                    )
-                    .await
-                    .map_err(RuntimeError::from);
+                let insert_result = match self.vectors_for_model(token, model_name) {
+                    Ok(vs) => vs
+                        .insert(
+                            note.id,
+                            SubstrateKind::Note,
+                            ns,
+                            "note.content",
+                            vec![vector],
+                        )
+                        .await
+                        .map_err(RuntimeError::from),
+                    Err(e) => Err(e),
+                };
                 if let Err(e) = insert_result {
                     // Compensate note row + FTS + already-inserted vectors.
                     if let Ok(store) = self.notes(token) {
@@ -5657,6 +5663,55 @@ mod tests {
         assert!(
             notes.is_empty(),
             "compensation must remove the note row after FTS failure; got {notes:?}"
+        );
+    }
+
+    // Inject a vector insertion failure after note row + FTS commit and assert
+    // both the note row and the FTS document are removed (no stranded rows).
+    // arm_vector_fail("local") targets the "local" namespace; since the single
+    // registered provider fires embed_document before the injection check, the
+    // injection converts the successful embedding into an error just before the
+    // VectorStore insert, then disarms.
+    #[tokio::test]
+    async fn create_note_vector_failure_rolls_back_note_row_and_fts() {
+        const MODEL: &str = "test-vec-inject";
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        let (provider, _counter) = ConstVecProvider::new(MODEL, DIMS);
+        rt.register_embedder(provider);
+
+        let tok = NamespaceToken::local();
+
+        arm_vector_fail("local");
+
+        let result = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "vec-fail rollback target",
+                None,
+                None,
+                vec![],
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "create_note must propagate the injected vector failure"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("injected vector failure"),
+            "error must carry injection message; got: {err_msg}"
+        );
+
+        // Compensation must have removed the note row.
+        let notes = rt.list_notes(&tok, None, 1000, 0).await.unwrap();
+        assert!(
+            notes.is_empty(),
+            "compensation must remove note row after vector failure; got {notes:?}"
         );
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -38,9 +38,37 @@ use crate::runtime::{KhiveRuntime, NamespaceToken};
 // link failure")` instead of calling the real implementation.  The counter is
 // reset to 0 after each call regardless of whether it triggered, so tests are
 // isolated from one another.
+//
+// `FTS_FAIL_FLAG` / `VECTOR_FAIL_FLAG`: global atomics, armed via `arm_fts_fail` /
+// `arm_vector_fail`.  Atomics (not cfg(test) thread-locals) so that external
+// integration test crates can arm them via the exported functions — the
+// thread-local approach only works within the same crate's test binary.
+// Overhead is negligible: a single `load(Relaxed)` on the hot path, only in
+// configurations that call `create_note`.
 #[cfg(test)]
 std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+static FTS_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static VECTOR_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Arm the FTS failure injection for `create_note_inner`.
+///
+/// After this is called, the next `create_note` call returns an injected error
+/// at the FTS upsert step (after the note row is committed), then disarms.
+/// Callable from external integration test crates.
+pub fn arm_fts_fail() {
+    FTS_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Arm the vector insertion failure injection for `create_note_inner`.
+///
+/// After this is called, the next `create_note` call returns an injected error
+/// at the first vector insert step, then disarms.
+/// Callable from external integration test crates.
+pub fn arm_vector_fail() {
+    VECTOR_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// A note search result with UUID, salience-weighted RRF score, and display text.
@@ -1343,14 +1371,18 @@ impl KhiveRuntime {
         }
         self.notes(token)?.upsert_note(note.clone()).await?;
 
-        self.text_for_notes(token)?
-            .upsert_document(note_fts_document(&note))
-            .await?;
+        // From here on, any error must compensate by removing the note row, its
+        // FTS document, and any vector entries already inserted — the same
+        // cleanup used by the annotates-edge block below.  A local closure
+        // captures those operations so both this block and the edge block share
+        // the same cleanup path without duplication.
+        //
+        // Note: the closure borrows `self`, `token`, `ns`, `note`, and
+        // `embed_model_names` (populated after the FTS step); because the
+        // vector-model list is only known after embedding is decided, we collect
+        // it once before the FTS step and thread it through.
 
-        // Multi-model vector embedding:
-        //   - explicit embedding_model → single model (existing behaviour)
-        //   - None + any models registered → ALL registered models in parallel
-        //   - None + no models configured → skip (text-only)
+        // Decide which embedding models to use (before touching FTS/vectors).
         let embed_model_names: Vec<String> = if let Some(m) = embedding_model {
             vec![m.to_string()]
         } else {
@@ -1368,21 +1400,86 @@ impl KhiveRuntime {
             }
         };
 
+        // FTS step — compensate note row on failure.
+        {
+            // Injection: check the FTS_FAIL_FLAG (armed by `arm_fts_fail()`).
+            let fts_inject = FTS_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            let fts_result: RuntimeResult<()> = if fts_inject {
+                Err(RuntimeError::Internal("injected FTS failure".to_string()))
+            } else {
+                self.text_for_notes(token)?
+                    .upsert_document(note_fts_document(&note))
+                    .await
+                    .map_err(RuntimeError::from)
+            };
+
+            if let Err(e) = fts_result {
+                // Best-effort compensation — ignore cleanup errors.
+                if let Ok(store) = self.notes(token) {
+                    let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                }
+                return Err(e);
+            }
+        }
+
+        // Vector embedding + insert step — compensate note row + FTS doc on failure.
+        // Multi-model vector embedding:
+        //   - explicit embedding_model → single model (existing behaviour)
+        //   - None + any models registered → ALL registered models in parallel
+        //   - None + no models configured → skip (text-only)
         if embed_model_names.len() == 1 {
             // Single-model path: preserves original sequential behaviour.
             let model_name = &embed_model_names[0];
-            let vector = self
+            let vec_result = self
                 .embed_document_with_model(model_name, &note.content)
-                .await?;
-            self.vectors_for_model(token, model_name)?
-                .insert(
-                    note.id,
-                    SubstrateKind::Note,
-                    ns,
-                    "note.content",
-                    vec![vector],
-                )
-                .await?;
+                .await;
+
+            // Injection: check VECTOR_FAIL_FLAG (armed by `arm_vector_fail()`).
+            // Swap-false atomically so the flag resets after one trigger.
+            let vec_inject = VECTOR_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
+                Err(RuntimeError::Internal(
+                    "injected vector failure".to_string(),
+                ))
+            } else {
+                vec_result
+            };
+
+            match vec_result {
+                Ok(vector) => {
+                    let insert_result = self
+                        .vectors_for_model(token, model_name)?
+                        .insert(
+                            note.id,
+                            SubstrateKind::Note,
+                            ns,
+                            "note.content",
+                            vec![vector],
+                        )
+                        .await
+                        .map_err(RuntimeError::from);
+                    if let Err(e) = insert_result {
+                        // Compensate note row + FTS.
+                        if let Ok(store) = self.notes(token) {
+                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                        }
+                        if let Ok(fts) = self.text_for_notes(token) {
+                            let _ = fts.delete_document(ns, note.id).await;
+                        }
+                        return Err(e);
+                    }
+                }
+                Err(e) => {
+                    // Compensate note row + FTS.
+                    if let Ok(store) = self.notes(token) {
+                        let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                    }
+                    if let Ok(fts) = self.text_for_notes(token) {
+                        let _ = fts.delete_document(ns, note.id).await;
+                    }
+                    return Err(e);
+                }
+            }
         } else if !embed_model_names.is_empty() {
             // Multi-model path: embed with each model in parallel via spawned tasks,
             // then insert one VectorRecord per model.
@@ -1399,14 +1496,28 @@ impl KhiveRuntime {
             }
             let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(embed_model_names.len());
             for handle in handles {
-                let vec = handle
+                match handle
                     .await
-                    .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}")))??;
-                vectors.push(vec);
+                    .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}")))?
+                {
+                    Ok(vec) => vectors.push(vec),
+                    Err(e) => {
+                        // Compensate note row + FTS.
+                        if let Ok(store) = self.notes(token) {
+                            let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                        }
+                        if let Ok(fts) = self.text_for_notes(token) {
+                            let _ = fts.delete_document(ns, note.id).await;
+                        }
+                        return Err(e);
+                    }
+                }
             }
             // TODO(P2): parallelize vector inserts (codex review #444)
+            let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors.into_iter()) {
-                self.vectors_for_model(token, model_name)?
+                let insert_result = self
+                    .vectors_for_model(token, model_name)?
                     .insert(
                         note.id,
                         SubstrateKind::Note,
@@ -1414,7 +1525,24 @@ impl KhiveRuntime {
                         "note.content",
                         vec![vector],
                     )
-                    .await?;
+                    .await
+                    .map_err(RuntimeError::from);
+                if let Err(e) = insert_result {
+                    // Compensate note row + FTS + already-inserted vectors.
+                    if let Ok(store) = self.notes(token) {
+                        let _ = store.delete_note(note.id, DeleteMode::Hard).await;
+                    }
+                    if let Ok(fts) = self.text_for_notes(token) {
+                        let _ = fts.delete_document(ns, note.id).await;
+                    }
+                    for m in &inserted_models {
+                        if let Ok(vs) = self.vectors_for_model(token, m) {
+                            let _ = vs.delete(note.id).await;
+                        }
+                    }
+                    return Err(e);
+                }
+                inserted_models.push(model_name.clone());
             }
         }
 
@@ -5452,6 +5580,46 @@ mod tests {
         assert!(
             edges_from_t2.is_empty(),
             "no second annotates edge must exist; got {edges_from_t2:?}"
+        );
+    }
+
+    // Inject an FTS failure after the note row is committed and assert the note
+    // row is removed (no stranded row).  arm_fts_fail() arms the flag before
+    // the call and it resets automatically after one trigger.
+    #[tokio::test]
+    async fn create_note_fts_failure_rolls_back_note_row() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        arm_fts_fail();
+
+        let result = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "fts-fail rollback target",
+                None,
+                None,
+                vec![],
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "create_note must propagate the injected FTS failure"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("injected FTS failure"),
+            "error must carry injection message; got: {err_msg}"
+        );
+
+        // Compensation must have removed the note row.
+        let notes = rt.list_notes(&tok, None, 1000, 0).await.unwrap();
+        assert!(
+            notes.is_empty(),
+            "compensation must remove the note row after FTS failure; got {notes:?}"
         );
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -40,24 +40,27 @@ use crate::runtime::{KhiveRuntime, NamespaceToken};
 // isolated from one another.
 //
 // `FTS_FAIL_FLAG` / `VECTOR_FAIL_FLAG`: global atomics, armed via `arm_fts_fail` /
-// `arm_vector_fail`.  Atomics (not cfg(test) thread-locals) so that external
-// integration test crates can arm them via the exported functions — the
-// thread-local approach only works within the same crate's test binary.
-// Overhead is negligible: a single `load(Relaxed)` on the hot path, only in
-// configurations that call `create_note`.
+// `arm_vector_fail`.  Gated behind `cfg(any(test, feature = "fault-injection"))`
+// so they compile out of release builds entirely — no atomic ops on the hot path
+// in production, and no fault-injection surface in published binaries.
+// External integration test crates enable the feature via a dev-dependency:
+//   khive-runtime = { workspace = true, features = ["fault-injection"] }
 #[cfg(test)]
 std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+#[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+#[cfg(any(test, feature = "fault-injection"))]
 static VECTOR_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Arm the FTS failure injection for `create_note_inner`.
 ///
 /// After this is called, the next `create_note` call returns an injected error
 /// at the FTS upsert step (after the note row is committed), then disarms.
-/// Callable from external integration test crates.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_fts_fail() {
     FTS_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
 }
@@ -66,7 +69,8 @@ pub fn arm_fts_fail() {
 ///
 /// After this is called, the next `create_note` call returns an injected error
 /// at the first vector insert step, then disarms.
-/// Callable from external integration test crates.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_vector_fail() {
     VECTOR_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
 }
@@ -1403,7 +1407,13 @@ impl KhiveRuntime {
         // FTS step — compensate note row on failure.
         {
             // Injection: check the FTS_FAIL_FLAG (armed by `arm_fts_fail()`).
+            // The swap only exists when fault-injection is compiled in; the
+            // cfg(not) branch is a const false so the compiler eliminates the
+            // if-branch and there is no atomic op in release builds.
+            #[cfg(any(test, feature = "fault-injection"))]
             let fts_inject = FTS_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            #[cfg(not(any(test, feature = "fault-injection")))]
+            let fts_inject = false;
             let fts_result: RuntimeResult<()> = if fts_inject {
                 Err(RuntimeError::Internal("injected FTS failure".to_string()))
             } else {
@@ -1436,7 +1446,12 @@ impl KhiveRuntime {
 
             // Injection: check VECTOR_FAIL_FLAG (armed by `arm_vector_fail()`).
             // Swap-false atomically so the flag resets after one trigger.
+            // The swap only exists when fault-injection is compiled in; the
+            // cfg(not) branch is a const false eliminating the if-branch in release.
+            #[cfg(any(test, feature = "fault-injection"))]
             let vec_inject = VECTOR_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            #[cfg(not(any(test, feature = "fault-injection")))]
+            let vec_inject = false;
             let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
                 Err(RuntimeError::Internal(
                     "injected vector failure".to_string(),

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -39,40 +39,45 @@ use crate::runtime::{KhiveRuntime, NamespaceToken};
 // reset to 0 after each call regardless of whether it triggered, so tests are
 // isolated from one another.
 //
-// `FTS_FAIL_FLAG` / `VECTOR_FAIL_FLAG`: global atomics, armed via `arm_fts_fail` /
-// `arm_vector_fail`.  Gated behind `cfg(any(test, feature = "fault-injection"))`
-// so they compile out of release builds entirely — no atomic ops on the hot path
-// in production, and no fault-injection surface in published binaries.
+// `FTS_FAIL_NS` / `VECTOR_FAIL_NS`: namespace-targeted injection mutexes, armed via
+// `arm_fts_fail(ns)` / `arm_vector_fail(ns)`.  Gated behind
+// `cfg(any(test, feature = "fault-injection"))` so they compile out of release builds
+// entirely — no lock acquisitions on the hot path in production, and no fault-injection
+// surface in published binaries.  Namespace-targeting means only `create_note` calls
+// for the armed namespace fire the injection; concurrent tests on other namespaces are
+// unaffected, eliminating cross-test races without requiring `#[serial]`.
 // External integration test crates enable the feature via a dev-dependency:
-//   khive-runtime = { workspace = true, features = ["fault-injection"] }
+//   khive-runtime = { ..., features = ["fault-injection"] }
 #[cfg(test)]
 std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[cfg(any(test, feature = "fault-injection"))]
-static FTS_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static FTS_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 #[cfg(any(test, feature = "fault-injection"))]
-static VECTOR_FAIL_FLAG: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static VECTOR_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
-/// Arm the FTS failure injection for `create_note_inner`.
+/// Arm the FTS failure injection for `create_note_inner` targeting namespace `ns`.
 ///
-/// After this is called, the next `create_note` call returns an injected error
-/// at the FTS upsert step (after the note row is committed), then disarms.
+/// The next `create_note` call whose note namespace equals `ns` returns an injected
+/// error at the FTS upsert step (after the note row is committed), then disarms.
+/// Calls on other namespaces are unaffected.
 /// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
 #[cfg(any(test, feature = "fault-injection"))]
-pub fn arm_fts_fail() {
-    FTS_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
+pub fn arm_fts_fail(ns: &str) {
+    *FTS_FAIL_NS.lock().unwrap() = Some(ns.to_string());
 }
 
-/// Arm the vector insertion failure injection for `create_note_inner`.
+/// Arm the vector insertion failure injection for `create_note_inner` targeting `ns`.
 ///
-/// After this is called, the next `create_note` call returns an injected error
-/// at the first vector insert step, then disarms.
+/// The next `create_note` call whose note namespace equals `ns` returns an injected
+/// error at the first vector insert step, then disarms.  Calls on other namespaces
+/// are unaffected.
 /// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
 #[cfg(any(test, feature = "fault-injection"))]
-pub fn arm_vector_fail() {
-    VECTOR_FAIL_FLAG.store(true, std::sync::atomic::Ordering::Relaxed);
+pub fn arm_vector_fail(ns: &str) {
+    *VECTOR_FAIL_NS.lock().unwrap() = Some(ns.to_string());
 }
 
 /// A note search result with UUID, salience-weighted RRF score, and display text.
@@ -1406,12 +1411,21 @@ impl KhiveRuntime {
 
         // FTS step — compensate note row on failure.
         {
-            // Injection: check the FTS_FAIL_FLAG (armed by `arm_fts_fail()`).
-            // The swap only exists when fault-injection is compiled in; the
-            // cfg(not) branch is a const false so the compiler eliminates the
-            // if-branch and there is no atomic op in release builds.
+            // Injection: check FTS_FAIL_NS (armed by `arm_fts_fail(ns)`).
+            // Fires only when the armed namespace matches this note's namespace,
+            // then clears (one-shot).  No lock acquisition in release builds —
+            // the cfg(not) branch is a const false so the compiler eliminates
+            // the if-branch entirely.
             #[cfg(any(test, feature = "fault-injection"))]
-            let fts_inject = FTS_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            let fts_inject = {
+                let mut g = FTS_FAIL_NS.lock().unwrap();
+                if g.as_deref() == Some(ns) {
+                    *g = None;
+                    true
+                } else {
+                    false
+                }
+            };
             #[cfg(not(any(test, feature = "fault-injection")))]
             let fts_inject = false;
             let fts_result: RuntimeResult<()> = if fts_inject {
@@ -1444,12 +1458,20 @@ impl KhiveRuntime {
                 .embed_document_with_model(model_name, &note.content)
                 .await;
 
-            // Injection: check VECTOR_FAIL_FLAG (armed by `arm_vector_fail()`).
-            // Swap-false atomically so the flag resets after one trigger.
-            // The swap only exists when fault-injection is compiled in; the
-            // cfg(not) branch is a const false eliminating the if-branch in release.
+            // Injection: check VECTOR_FAIL_NS (armed by `arm_vector_fail(ns)`).
+            // Fires only when the armed namespace matches this note's namespace,
+            // then clears (one-shot).  No lock acquisition in release builds —
+            // the cfg(not) branch is a const false eliminating the if-branch.
             #[cfg(any(test, feature = "fault-injection"))]
-            let vec_inject = VECTOR_FAIL_FLAG.swap(false, std::sync::atomic::Ordering::Relaxed);
+            let vec_inject = {
+                let mut g = VECTOR_FAIL_NS.lock().unwrap();
+                if g.as_deref() == Some(ns) {
+                    *g = None;
+                    true
+                } else {
+                    false
+                }
+            };
             #[cfg(not(any(test, feature = "fault-injection")))]
             let vec_inject = false;
             let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
@@ -5606,7 +5628,7 @@ mod tests {
         let rt = rt();
         let tok = NamespaceToken::local();
 
-        arm_fts_fail();
+        arm_fts_fail("local");
 
         let result = rt
             .create_note(

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -156,6 +156,7 @@ impl KhiveRuntime {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         })
     }
 
@@ -730,6 +731,7 @@ mod tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).expect("file runtime should create");
         assert!(path.exists());
@@ -749,6 +751,7 @@ mod tests {
             backend_id: BackendId::new("lore"),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let rt = KhiveRuntime::from_backend(backend, config);
         assert_eq!(rt.backend_id().as_str(), "lore");
@@ -894,6 +897,7 @@ mod tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let cfg = khive_cfg_with_actor("lambda:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -912,6 +916,7 @@ mod tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let cfg = KhiveConfig {
             engines: vec![],
@@ -942,6 +947,7 @@ mod tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let cfg = KhiveConfig::default(); // no actor.id
         let result = runtime_config_from_khive_config(&cfg, base);
@@ -964,6 +970,7 @@ mod tests {
             backend_id: BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let cfg = KhiveConfig {
             engines: vec![crate::engine_config::EngineConfig {

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -571,6 +571,7 @@ async fn file_backed_runtime_persists() {
             additional_embedding_models: vec![],
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -591,6 +592,7 @@ async fn file_backed_runtime_persists() {
             additional_embedding_models: vec![],
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         };
         let rt = KhiveRuntime::new(config).unwrap();
         let tok = rt.authorize(Namespace::local()).unwrap();
@@ -1079,6 +1081,7 @@ mod embedder_registry_tests {
             backend_id: khive_runtime::BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         })
         .expect("in-memory runtime")
     }
@@ -1138,6 +1141,7 @@ mod embedder_registry_tests {
             backend_id: khive_runtime::BackendId::main(),
             brain_profile: None,
             visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
         })
         .expect("runtime with two models");
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -142,8 +142,12 @@ default, so all cross-namespace sends are denied unless the sender opts in.
 When a recipient namespace appears in the sender's allowlist, `dual_write_message` mints a
 narrowed `NamespaceToken` (via `NamespaceToken::with_namespace`) scoped to the recipient
 namespace and uses it to write the inbound note, keeping the write operation namespace-isolated.
-The sender token's read visibility is not propagated — the minted token is write-only for the
-recipient namespace. The denial error is `RuntimeError::PermissionDenied { verb: "comm.send" }`.
+The minted token has `namespace = recipient` and `visible = [recipient]`; it is an ordinary
+`NamespaceToken` that the comm handler uses in an append-only manner (one `create_note` call,
+never returned to the sender). The enforced boundary is the sender-side allowlist check plus
+the handler's single-create usage — not the token type. A future cloud-path authorization ADR
+(not yet written) will replace this with a type-enforced, append-only capability primitive.
+The denial error is `RuntimeError::PermissionDenied { verb: "comm.send" }`.
 
 Within-namespace messaging (sender and recipient in the same namespace) proceeds without any
 allowlist check.
@@ -151,8 +155,8 @@ allowlist check.
 The `RuntimeError::CrossNamespaceWrite` variant is retained for the VCS/remote semantics; it
 is no longer returned by `comm.send`.
 
-The recipient-side `allowed_inbound_namespaces` (bilateral mutual opt-in, ADR-057 cloud path)
-is reserved for a future cloud release and is not part of this OSS implementation.
+The recipient-side `allowed_inbound_namespaces` (bilateral mutual opt-in) is reserved for a
+future cloud release and is not part of this OSS implementation.
 
 #### Message-to-entity attachment
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -132,17 +132,27 @@ reconstruct conversation order from `sent_at` on messages sharing a `thread_id`.
 is propagated; otherwise the target message's own UUID becomes the `thread_id` for the new
 message chain.
 
-#### Cross-namespace messaging
+#### Cross-namespace messaging (OSS policy — specified 2026-06-15)
 
-`send` writes into the recipient's namespace. This requires an authorization gate check per
-ADR-018 before the write proceeds. If the recipient namespace does not permit inbound
-messages from the sender namespace, the op returns `RuntimeError::Forbidden`.
+`send` writes the inbound copy into the recipient's namespace. Whether this write is allowed
+depends on the **sender-side outbound allowlist** (`actor.allowed_outbound_namespaces` in the
+sender's `khive.toml`). This is an explicit, fail-closed control: the field is empty by
+default, so all cross-namespace sends are denied unless the sender opts in.
 
-Cross-namespace ACL policy definition is deferred to the namespace authority (ADR-018). The
-pack enforces the gate but does not specify ACL configuration format.
+When a recipient namespace appears in the sender's allowlist, `dual_write_message` mints a
+narrowed `NamespaceToken` (via `NamespaceToken::with_namespace`) scoped to the recipient
+namespace and uses it to write the inbound note, keeping the write operation namespace-isolated.
+The sender token's read visibility is not propagated — the minted token is write-only for the
+recipient namespace. The denial error is `RuntimeError::PermissionDenied { verb: "comm.send" }`.
 
-Within-namespace messaging (agent sends to self, or to another agent in the same namespace)
-proceeds without cross-namespace ACL check.
+Within-namespace messaging (sender and recipient in the same namespace) proceeds without any
+allowlist check.
+
+The `RuntimeError::CrossNamespaceWrite` variant is retained for the VCS/remote semantics; it
+is no longer returned by `comm.send`.
+
+The recipient-side `allowed_inbound_namespaces` (bilateral mutual opt-in, ADR-057 cloud path)
+is reserved for a future cloud release and is not part of this OSS implementation.
 
 #### Message-to-entity attachment
 
@@ -483,9 +493,10 @@ standard `delete(id)` path.
 - Trigger evaluation for scheduled events is out of scope for the pack. Operators must wire
   either daemon mode (future) or an external scheduler. This is the correct separation but
   creates an operator onboarding step not present in the other three packs.
-- Cross-namespace messaging is gated on ADR-018's ACL mechanism. Until ACL policy
-  configuration is specified, cross-namespace `send` is rejected. Within-namespace messaging
-  is unblocked.
+- Cross-namespace messaging is gated on the sender's `actor.allowed_outbound_namespaces`
+  allowlist (specified 2026-06-15; see "Cross-namespace messaging" section above). The field
+  defaults to empty, preserving the prior deny-all behavior for existing deployments.
+  Within-namespace messaging is unblocked.
 
 ### Neutral
 
@@ -516,6 +527,8 @@ standard `delete(id)` path.
 4. **Message namespace write path**: `comm.send(to="agent:khive")` must resolve `agent:khive` to
    a namespace and write a note into that namespace. The exact resolution contract (namespace
    registry, alias table, or unresolved string) is deferred to ADR-018's namespace authority.
+
+   _Resolved 2026-06-15: see "Cross-namespace messaging (OSS policy)" section above._
 
 ## Implementation
 


### PR DESCRIPTION
## Summary

Fixes cross-namespace comm delivery. Inter-lambda mail (e.g. `lambda:leo` → `lambda:khive`) was unconditionally denied by `CrossNamespaceWrite` in `dual_write_message`, so messages never reached the recipient inbox. This adds a **sender-side outbound allowlist** that permits delivery into explicitly declared namespaces while preserving deny-by-default.

## Design

- New `allowed_outbound_namespaces` on `ActorConfig` (the sender's `khive.toml`), parsed to `Vec<Namespace>` on `RuntimeConfig`. **Empty by default = deny-all** (behavior-preserving on upgrade).
- `dual_write_message`: cross-namespace delivery (`from != to`) requires the recipient namespace to be in the sender's allowlist, otherwise `PermissionDenied`. Allowed delivery writes the inbound note via a recipient-scoped `with_namespace(recipient)` token (namespace = recipient, visible = `[recipient]`). The comm handler uses this token **append-only by construction** — it creates exactly one inbound note and never returns the token. Note this is an ordinary namespace token, **not** a type-enforced write-only capability; the enforced boundary is the sender allowlist plus the handler's single-create usage.
- Within-namespace sends (`from == to`) are unchanged.
- Daemon safety: `allowed_outbound_namespaces` is folded (sorted + deduped) into `compute_config_id`, so a client with a narrower allowlist cannot dispatch comm sends through a broader warm daemon.
- Atomic dual-write: `create_note_inner` compensates the note row, FTS document, and vectors on any post-row indexing failure, so a failed inbound create leaves no stranded row in the recipient namespace.

A recipient-side v1 was discarded after design review showed it was unenforceable: one process loads only its own `ActorConfig`, and there is no actor registry.

## Security framing

This is a **visibility boundary, not a security guarantee**. A sender that controls its own `khive.toml` can self-grant delivery into any namespace, which is no stronger than today's uncredentialed `--actor` string. A credentialed ACL belongs in a future cloud-path authorization ADR (not yet written). ADR-040 is amended to state this honestly rather than imply a guarantee the local model cannot make.

## Tests

- Cross-namespace integration tests: within-ns unchanged; deny when allowlist empty; deliver when allowed; inbound note namespace = recipient; recipient inbox sees it / sender does not; reply cross-ns; one-directional; inbound-failure rollback leaves no recipient row; `with_namespace` token behavior documented honestly.
- `compute_config_id` tests: differs when the outbound allowlist differs; stable under reordering/dedup.
- TOML wiring test: `actor.allowed_outbound_namespaces` parses into `RuntimeConfig`.
- 3 curation cross-namespace regression tests pass unchanged.
- Full gate green: `check`, `clippy -D warnings`, `test`, `fmt --check`.

## Open decision (the maintainers)

Unilateral (sender-only opt-in, as in this PR) vs bilateral (recipient must also opt in). Unilateral is recommended for the OSS local path; bilateral is future cloud work.