### PR TITLE
fix(khive-runtime): isolate fault-injection tests with unique namespaces

### DIFF
--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -5632,9 +5632,15 @@ mod tests {
     #[tokio::test]
     async fn create_note_fts_failure_rolls_back_note_row() {
         let rt = rt();
-        let tok = NamespaceToken::local();
+        // Unique namespace: the process-global FTS_FAIL_NS one-shot flag armed
+        // below must be consumable only by THIS test's create_note. Sharing the
+        // "local" namespace let a concurrent "local" create_note consume the
+        // armed flag, flaking this test and its victim under parallel
+        // `cargo test` (latent since #129; surfaced by #131 CI timing).
+        let ns = Namespace::parse("fault-fts-rollback").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
 
-        arm_fts_fail("local");
+        arm_fts_fail(ns.as_str());
 
         let result = rt
             .create_note(
@@ -5668,10 +5674,11 @@ mod tests {
 
     // Inject a vector insertion failure after note row + FTS commit and assert
     // both the note row and the FTS document are removed (no stranded rows).
-    // arm_vector_fail("local") targets the "local" namespace; since the single
-    // registered provider fires embed_document before the injection check, the
-    // injection converts the successful embedding into an error just before the
-    // VectorStore insert, then disarms.
+    // Uses a unique namespace (see create_note_fts_failure_rolls_back_note_row)
+    // so the process-global VECTOR_FAIL_NS flag is consumed only by this test.
+    // Since the single registered provider fires embed_document before the
+    // injection check, the injection converts the successful embedding into an
+    // error just before the VectorStore insert, then disarms.
     #[tokio::test]
     async fn create_note_vector_failure_rolls_back_note_row_and_fts() {
         const MODEL: &str = "test-vec-inject";
@@ -5681,9 +5688,10 @@ mod tests {
         let (provider, _counter) = ConstVecProvider::new(MODEL, DIMS);
         rt.register_embedder(provider);
 
-        let tok = NamespaceToken::local();
+        let ns = Namespace::parse("fault-vec-rollback").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
 
-        arm_vector_fail("local");
+        arm_vector_fail(ns.as_str());
 
         let result = rt
             .create_note(


### PR DESCRIPTION
## Problem

CI on PR #131 went red with two khive-runtime failures that **do not touch #131's changed code**:

- `create_note_creates_annotates_edges` — `create_note` returned `Err` when it should succeed
- `create_note_fts_failure_rolls_back_note_row` — `create_note` returned `Ok` when it should fail

The **opposite** symptoms are the tell: a shared one-shot fault flag was consumed by the wrong test.

## Root cause (latent since #129)

`FTS_FAIL_NS` / `VECTOR_FAIL_NS` are **process-global** `Mutex<Option<String>>` statics, keyed by namespace and consumed one-shot. Both fault tests armed them against the shared `"local"` namespace. Under parallel `cargo test`, a concurrent `"local"` `create_note` (e.g. `create_note_creates_annotates_edges`) consumed the armed flag before the owning test ran — flaking both. `#131` only perturbed scheduling enough to lose a race that has been latent since the fault machinery landed in #129.

Single-threaded the whole suite passes; the production logic (incl. #131's transactional `SqliteVecStore::insert`) is correct.

## Fix

Mint a unique namespace per fault test via the existing `NamespaceToken::for_namespace` + `Namespace::parse` seam, so each one-shot flag is consumable only by its own `create_note`. Test-only; no production change.

## Verification

`cargo test -p khive-runtime --lib` (default parallel) — **411 passed / 0 failed** across **4 consecutive runs** (CI was 409/2). `cargo fmt --all -- --check` RC=0, `cargo clippy -p khive-runtime --all-targets -- -D warnings` clean.