### PR TITLE
fix(khive-runtime): fan out entity/note embed to all registered models (#10)

### DIFF
--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -301,22 +301,22 @@ impl KhiveRuntime {
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
             .collect();
         let fts_table = format!("fts_entities_{}", sanitized_ns);
-        let vec_table = self.config().embedding_model.map(|model| {
-            let key: String = model
-                .to_string()
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-                .collect();
-            format!("vec_{}", key)
-        });
+        let vec_tables: Vec<String> = self
+            .registered_embedding_model_names()
+            .iter()
+            .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
+            .collect();
 
         // Ensure all required tables exist before entering the transaction.
         // Each accessor applies its DDL idempotently via `CREATE TABLE IF NOT EXISTS`.
         let _ = self.entities(token)?;
         let _ = self.graph(token)?;
         let _ = self.text(token)?;
-        if !self.registered_embedding_model_names().is_empty() {
-            let _ = self.vectors(token)?;
+        // Prime DDL for every registered model's vec table.  Use vectors_for_model
+        // (not the default-model-only self.vectors()) so that custom-only runtimes
+        // (embedding_model: None but custom providers registered) work correctly.
+        for model_name in &self.registered_embedding_model_names() {
+            let _ = self.vectors_for_model(token, model_name)?;
         }
 
         let pool = self.backend().pool_arc();
@@ -325,7 +325,7 @@ impl KhiveRuntime {
             let guard = pool.writer()?;
             guard.transaction(|conn| {
                 merge_entity_sql(
-                    conn, ns, fts_table, vec_table, into_id, from_id, strategy, dry_run,
+                    conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
                 )
             })
         })
@@ -333,12 +333,8 @@ impl KhiveRuntime {
         .map_err(|e| RuntimeError::Internal(e.to_string()))??;
 
         // If vectors are configured, reindex into_entity (requires async embedding).
-        // FTS and vec-delete were already committed inside the transaction above.
-        // TODO(#135): merge_entity's SQLite transaction deletes only the from-entity's
-        // default-model vector (vec_table above). Non-default-model vectors from the
-        // from-entity are NOT deleted inside the transaction and become orphaned after
-        // merge. Fixing this requires the spawn_blocking closure to fan out across all
-        // registered model vec_table names, which is a non-trivial schema-level change.
+        // FTS and vec-deletes for all registered models were already committed inside
+        // the transaction above.
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_entity(token, &updated_entity).await?;
         }
@@ -625,14 +621,11 @@ impl KhiveRuntime {
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
             .collect();
         let fts_table = format!("fts_notes_{}", sanitized_ns);
-        let vec_table = self.config().embedding_model.map(|model| {
-            let key: String = model
-                .to_string()
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-                .collect();
-            format!("vec_{}", key)
-        });
+        let vec_tables: Vec<String> = self
+            .registered_embedding_model_names()
+            .iter()
+            .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
+            .collect();
 
         let note_store = self.notes(token)?;
         let into_note = note_store
@@ -649,8 +642,9 @@ impl KhiveRuntime {
 
         let _ = self.graph(token)?;
         let _ = self.text_for_notes(token)?;
-        if !self.registered_embedding_model_names().is_empty() {
-            let _ = self.vectors(token)?;
+        // Prime DDL for every registered model's vec table (mirrors merge_entity fix).
+        for model_name in &self.registered_embedding_model_names() {
+            let _ = self.vectors_for_model(token, model_name)?;
         }
 
         let pool = self.backend().pool_arc();
@@ -661,7 +655,7 @@ impl KhiveRuntime {
                     conn,
                     ns,
                     fts_table,
-                    vec_table,
+                    vec_tables,
                     into_id,
                     from_id,
                     strategy,
@@ -874,7 +868,7 @@ fn merge_entity_sql(
     conn: &rusqlite::Connection,
     namespace: String,
     fts_table: String,
-    vec_table: Option<String>,
+    vec_tables: Vec<String>,
     into_id: Uuid,
     from_id: Uuid,
     strategy: EntityDedupMergePolicy,
@@ -1150,8 +1144,8 @@ fn merge_entity_sql(
             rusqlite::params![&namespace, &from_str],
         )?;
 
-        // --- Delete from_id from vector index if configured ---
-        if let Some(ref vec_tbl) = vec_table {
+        // --- Delete from_id from all registered model vector tables ---
+        for vec_tbl in &vec_tables {
             conn.execute(
                 &format!(
                     "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
@@ -1314,7 +1308,7 @@ fn merge_note_sql(
     conn: &rusqlite::Connection,
     namespace: String,
     fts_table: String,
-    vec_table: Option<String>,
+    vec_tables: Vec<String>,
     into_id: Uuid,
     from_id: Uuid,
     strategy: EntityDedupMergePolicy,
@@ -1609,8 +1603,8 @@ fn merge_note_sql(
             rusqlite::params![&namespace, &from_str],
         )?;
 
-        // Delete from-note from vector index if configured.
-        if let Some(ref vec_tbl) = vec_table {
+        // Delete from-note from all registered model vector tables.
+        for vec_tbl in &vec_tables {
             conn.execute(
                 &format!(
                     "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
@@ -3093,6 +3087,302 @@ mod tests {
 
         assert_eq!(stored.title, expected.title, "title after update");
         assert_eq!(stored.body, expected.body, "body after update");
+    }
+
+    // ── Fix #135 regression tests ────────────────────────────────────────────
+    //
+    // Verify that merge_entity / merge_note delete from_id vectors from ALL
+    // registered model vec tables, not just the default-model table.
+    //
+    // Uses the same ConstVecProvider/ConstVecService pattern as operations.rs
+    // so no real model files are required.
+
+    struct MergeTestVecService {
+        dims: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl lattice_embed::EmbeddingService for MergeTestVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: lattice_embed::EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            Ok(texts.iter().map(|_| vec![1.0_f32; self.dims]).collect())
+        }
+
+        fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "merge-test-const-vec"
+        }
+    }
+
+    struct MergeTestVecProvider {
+        provider_name: String,
+        dims: usize,
+    }
+
+    impl MergeTestVecProvider {
+        fn new(name: &str, dims: usize) -> Self {
+            Self {
+                provider_name: name.to_owned(),
+                dims,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::embedder_registry::EmbedderProvider for MergeTestVecProvider {
+        fn name(&self) -> &str {
+            &self.provider_name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        async fn build(
+            &self,
+        ) -> crate::error::RuntimeResult<std::sync::Arc<dyn lattice_embed::EmbeddingService>>
+        {
+            Ok(std::sync::Arc::new(MergeTestVecService { dims: self.dims }))
+        }
+    }
+
+    /// merge_entity must delete from_id vectors from ALL registered model tables.
+    ///
+    /// Two custom embedders ("merge-vec-a", "merge-vec-b") are registered.  Both
+    /// entities are embedded so each has a row in both model tables.  After merge,
+    /// from_id must have zero surviving rows in either table.
+    #[tokio::test]
+    async fn merge_entity_clears_vectors_from_all_registered_models() {
+        const DIMS: usize = 4;
+        let rt = KhiveRuntime::memory().unwrap();
+        rt.register_embedder(MergeTestVecProvider::new("merge-vec-a", DIMS));
+        rt.register_embedder(MergeTestVecProvider::new("merge-vec-b", DIMS));
+
+        let ns_str = "merge-entity-vec-cleanup";
+        let ns = crate::Namespace::parse(ns_str).unwrap();
+        let tok = NamespaceToken::for_namespace(ns);
+
+        let into_e = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "IntoVecEntity",
+                Some("desc a"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create into");
+        let from_e = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "FromVecEntity",
+                Some("desc b"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create from");
+
+        // Confirm both entities have vectors in both model tables before merge.
+        let vs_a = rt.vectors_for_model(&tok, "merge-vec-a").unwrap();
+        let vs_b = rt.vectors_for_model(&tok, "merge-vec-b").unwrap();
+        use khive_storage::types::VectorSearchRequest;
+        let query = vec![1.0_f32; DIMS];
+        let pre_a = vs_a
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("merge-vec-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            pre_a.len(),
+            2,
+            "both entities must be in model-a before merge"
+        );
+
+        rt.merge_entity(
+            &tok,
+            into_e.id,
+            from_e.id,
+            EntityDedupMergePolicy::PreferInto,
+            false,
+        )
+        .await
+        .expect("merge_entity");
+
+        // from_id must have ZERO rows in EITHER model table after merge.
+        let post_a = vs_a
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("merge-vec-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        let from_ids_a: Vec<_> = post_a
+            .iter()
+            .filter(|h| h.subject_id == from_e.id)
+            .collect();
+        assert!(
+            from_ids_a.is_empty(),
+            "from_id must have no vectors in model-a after merge; got {from_ids_a:?}"
+        );
+
+        let post_b = vs_b
+            .search(VectorSearchRequest {
+                query_vectors: vec![query],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("merge-vec-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        let from_ids_b: Vec<_> = post_b
+            .iter()
+            .filter(|h| h.subject_id == from_e.id)
+            .collect();
+        assert!(
+            from_ids_b.is_empty(),
+            "from_id must have no vectors in model-b after merge; got {from_ids_b:?}"
+        );
+    }
+
+    /// merge_note must delete from_id vectors from ALL registered model tables.
+    ///
+    /// Two custom embedders ("merge-note-vec-a", "merge-note-vec-b") are registered.
+    /// Both notes are embedded so each has a row in both model tables.  After merge,
+    /// from_id must have zero surviving rows in either table.
+    #[tokio::test]
+    async fn merge_note_clears_vectors_from_all_registered_models() {
+        const DIMS: usize = 4;
+        let rt = KhiveRuntime::memory().unwrap();
+        rt.register_embedder(MergeTestVecProvider::new("merge-note-vec-a", DIMS));
+        rt.register_embedder(MergeTestVecProvider::new("merge-note-vec-b", DIMS));
+
+        let ns_str = "merge-note-vec-cleanup";
+        let ns = crate::Namespace::parse(ns_str).unwrap();
+        let tok = NamespaceToken::for_namespace(ns);
+
+        let into_n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "IntoVecNote content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create into note");
+        let from_n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "FromVecNote content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create from note");
+
+        let vs_a = rt.vectors_for_model(&tok, "merge-note-vec-a").unwrap();
+        let vs_b = rt.vectors_for_model(&tok, "merge-note-vec-b").unwrap();
+        use khive_storage::types::VectorSearchRequest;
+        let query = vec![1.0_f32; DIMS];
+
+        let pre_a = vs_a
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("merge-note-vec-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(pre_a.len(), 2, "both notes must be in model-a before merge");
+
+        rt.merge_note(
+            &tok,
+            into_n.id,
+            from_n.id,
+            EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::PreferInto,
+            false,
+        )
+        .await
+        .expect("merge_note");
+
+        // from_id must have ZERO rows in EITHER model table after merge.
+        let post_a = vs_a
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("merge-note-vec-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        let from_ids_a: Vec<_> = post_a
+            .iter()
+            .filter(|h| h.subject_id == from_n.id)
+            .collect();
+        assert!(
+            from_ids_a.is_empty(),
+            "from_id must have no vectors in model-a after merge; got {from_ids_a:?}"
+        );
+
+        let post_b = vs_b
+            .search(VectorSearchRequest {
+                query_vectors: vec![query],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("merge-note-vec-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        let from_ids_b: Vec<_> = post_b
+            .iter()
+            .filter(|h| h.subject_id == from_n.id)
+            .collect();
+        assert!(
+            from_ids_b.is_empty(),
+            "from_id must have no vectors in model-b after merge; got {from_ids_b:?}"
+        );
     }
 
     // Cross-path equality: merge_entity must produce a stored FTS document for

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -3210,10 +3210,30 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(
-            pre_a.len(),
-            2,
-            "both entities must be in model-a before merge"
+        assert!(
+            pre_a.iter().any(|h| h.subject_id == into_e.id)
+                && pre_a.iter().any(|h| h.subject_id == from_e.id),
+            "both entities must be in model-a before merge; got {pre_a:?}"
+        );
+
+        // model-b must ALSO hold both entities pre-merge, else the post-merge
+        // model-b emptiness check below is vacuous (nothing to delete).
+        let pre_b = vs_b
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("merge-vec-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            pre_b.iter().any(|h| h.subject_id == into_e.id)
+                && pre_b.iter().any(|h| h.subject_id == from_e.id),
+            "both entities must be in model-b before merge; got {pre_b:?}"
         );
 
         rt.merge_entity(
@@ -3328,7 +3348,31 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(pre_a.len(), 2, "both notes must be in model-a before merge");
+        assert!(
+            pre_a.iter().any(|h| h.subject_id == into_n.id)
+                && pre_a.iter().any(|h| h.subject_id == from_n.id),
+            "both notes must be in model-a before merge; got {pre_a:?}"
+        );
+
+        // model-b must ALSO hold both notes pre-merge, else the post-merge
+        // model-b emptiness check below is vacuous (nothing to delete).
+        let pre_b = vs_b
+            .search(VectorSearchRequest {
+                query_vectors: vec![query.clone()],
+                top_k: 100,
+                namespace: Some(ns_str.to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("merge-note-vec-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            pre_b.iter().any(|h| h.subject_id == into_n.id)
+                && pre_b.iter().any(|h| h.subject_id == from_n.id),
+            "both notes must be in model-b before merge; got {pre_b:?}"
+        );
 
         rt.merge_note(
             &tok,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -334,7 +334,7 @@ impl KhiveRuntime {
 
         // If vectors are configured, reindex into_entity (requires async embedding).
         // FTS and vec-delete were already committed inside the transaction above.
-        // TODO(#NN): merge_entity's SQLite transaction deletes only the from-entity's
+        // TODO(#135): merge_entity's SQLite transaction deletes only the from-entity's
         // default-model vector (vec_table above). Non-default-model vectors from the
         // from-entity are NOT deleted inside the transaction and become orphaned after
         // merge. Fixing this requires the spawn_blocking closure to fan out across all

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -315,7 +315,7 @@ impl KhiveRuntime {
         let _ = self.entities(token)?;
         let _ = self.graph(token)?;
         let _ = self.text(token)?;
-        if self.config().embedding_model.is_some() {
+        if !self.registered_embedding_model_names().is_empty() {
             let _ = self.vectors(token)?;
         }
 
@@ -334,7 +334,12 @@ impl KhiveRuntime {
 
         // If vectors are configured, reindex into_entity (requires async embedding).
         // FTS and vec-delete were already committed inside the transaction above.
-        if !dry_run && self.config().embedding_model.is_some() {
+        // TODO(#NN): merge_entity's SQLite transaction deletes only the from-entity's
+        // default-model vector (vec_table above). Non-default-model vectors from the
+        // from-entity are NOT deleted inside the transaction and become orphaned after
+        // merge. Fixing this requires the spawn_blocking closure to fan out across all
+        // registered model vec_table names, which is a non-trivial schema-level change.
+        if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_entity(token, &updated_entity).await?;
         }
 
@@ -369,11 +374,18 @@ impl KhiveRuntime {
 
     // ---- Internal helpers ----
 
-    /// Re-upsert FTS5 document (and vector if model configured) for the entity.
+    /// Re-upsert FTS5 document and vector(s) for the entity across all registered models.
     ///
     /// Uses `entity.namespace` — the authoritative namespace stored on the record — rather
     /// than the caller-supplied `namespace` parameter. This prevents a cross-namespace
     /// reindex from writing the search document into the wrong namespace's FTS index.
+    ///
+    /// Best-effort for vectors: if embedding or inserting for a particular model fails,
+    /// logs a warning and continues to the next model. The FTS step is fail-closed
+    /// (propagates error). Callers (update_entity, merge_entity) have already committed
+    /// the entity row, so a partial embed miss leaves a stale vector rather than
+    /// rolling back the update — acceptable because SqliteVecStore::insert is an upsert
+    /// (the prior vector stays intact on failure, keeping the record searchable).
     pub(crate) async fn reindex_entity(
         &self,
         token: &NamespaceToken,
@@ -385,23 +397,53 @@ impl KhiveRuntime {
         let embed_body = doc.body.clone();
         self.text(token)?.upsert_document(doc).await?;
 
-        if self.config().embedding_model.is_some() {
-            let vector = self.embed_document(&embed_body).await?;
-            self.vectors(token)?
-                .insert(
-                    entity.id,
-                    SubstrateKind::Entity,
-                    &ns,
-                    "entity.body",
-                    vec![vector],
-                )
-                .await?;
+        let embed_model_names = self.registered_embedding_model_names();
+        for model_name in &embed_model_names {
+            match self
+                .embed_document_with_model(model_name, &embed_body)
+                .await
+            {
+                Ok(vector) => match self.vectors_for_model(token, model_name) {
+                    Ok(vs) => {
+                        if let Err(e) = vs
+                            .insert(
+                                entity.id,
+                                SubstrateKind::Entity,
+                                &ns,
+                                "entity.body",
+                                vec![vector],
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                model = model_name,
+                                id = %entity.id,
+                                "reindex_entity: vector insert failed, skipping model: {e}"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            model = model_name,
+                            id = %entity.id,
+                            "reindex_entity: could not access vector store for model, skipping: {e}"
+                        );
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        model = model_name,
+                        id = %entity.id,
+                        "reindex_entity: embed failed for model, skipping: {e}"
+                    );
+                }
+            }
         }
 
         Ok(())
     }
 
-    /// Remove an entity from FTS5 and (if configured) vector indexes.
+    /// Remove an entity from FTS5 and vector indexes across all registered models.
     pub(crate) async fn remove_from_indexes(
         &self,
         token: &NamespaceToken,
@@ -409,13 +451,17 @@ impl KhiveRuntime {
     ) -> RuntimeResult<()> {
         let ns = token.namespace().as_str().to_owned();
         self.text(token)?.delete_document(&ns, id).await?;
-        if self.config().embedding_model.is_some() {
-            self.vectors(token)?.delete(id).await?;
+        for model_name in self.registered_embedding_model_names() {
+            self.vectors_for_model(token, &model_name)?
+                .delete(id)
+                .await?;
         }
         Ok(())
     }
 
-    /// Re-upsert FTS5 document (and vector if model configured) for the note.
+    /// Re-upsert FTS5 document and vector(s) for the note across all registered models.
+    ///
+    /// Best-effort for vectors: mirrors reindex_entity's warn-and-continue policy.
     pub(crate) async fn reindex_note(
         &self,
         token: &NamespaceToken,
@@ -425,18 +471,48 @@ impl KhiveRuntime {
             .upsert_document(note_fts_document(note))
             .await?;
 
-        if self.config().embedding_model.is_some() {
-            let ns = note.namespace.clone();
-            let vector = self.embed_document(&note.content).await?;
-            self.vectors(token)?
-                .insert(
-                    note.id,
-                    SubstrateKind::Note,
-                    &ns,
-                    "note.content",
-                    vec![vector],
-                )
-                .await?;
+        let ns = note.namespace.clone();
+        let embed_model_names = self.registered_embedding_model_names();
+        for model_name in &embed_model_names {
+            match self
+                .embed_document_with_model(model_name, &note.content)
+                .await
+            {
+                Ok(vector) => match self.vectors_for_model(token, model_name) {
+                    Ok(vs) => {
+                        if let Err(e) = vs
+                            .insert(
+                                note.id,
+                                SubstrateKind::Note,
+                                &ns,
+                                "note.content",
+                                vec![vector],
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                model = model_name,
+                                id = %note.id,
+                                "reindex_note: vector insert failed, skipping model: {e}"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            model = model_name,
+                            id = %note.id,
+                            "reindex_note: could not access vector store for model, skipping: {e}"
+                        );
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        model = model_name,
+                        id = %note.id,
+                        "reindex_note: embed failed for model, skipping: {e}"
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -573,7 +649,7 @@ impl KhiveRuntime {
 
         let _ = self.graph(token)?;
         let _ = self.text_for_notes(token)?;
-        if self.config().embedding_model.is_some() {
+        if !self.registered_embedding_model_names().is_empty() {
             let _ = self.vectors(token)?;
         }
 
@@ -597,7 +673,7 @@ impl KhiveRuntime {
         .await
         .map_err(|e| RuntimeError::Internal(e.to_string()))??;
 
-        if !dry_run && self.config().embedding_model.is_some() {
+        if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_note(token, &updated_note).await?;
         }
         Ok(summary)

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -49,7 +49,7 @@ pub use objectives::{
     TemporalRecencyObjective, TextRelevanceObjective, VectorSimilarityObjective,
 };
 #[cfg(any(test, feature = "fault-injection"))]
-pub use operations::{arm_fts_fail, arm_vector_fail};
+pub use operations::{arm_fts_fail, arm_vector_fail, arm_vector_fail_after};
 pub use operations::{LinkSpec, NoteSearchHit, QueryResult, Resolved};
 pub use pack::{
     DispatchHook, HandlerDef, KindHook, NoteKindSpec, NoteLifecycleSpec, PackFactory,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -449,7 +449,13 @@ impl KhiveRuntime {
             };
             if let Err(e) = fts_result {
                 if let Ok(store) = self.entities(token) {
-                    let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                    if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
+                        tracing::error!(
+                            error = %ce,
+                            id = %entity.id,
+                            "create_entity: failed to roll back entity row after FTS failure"
+                        );
+                    }
                 }
                 return Err(e);
             }
@@ -510,10 +516,22 @@ impl KhiveRuntime {
             };
             if let Err(e) = single_result {
                 if let Ok(store) = self.entities(token) {
-                    let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                    if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
+                        tracing::error!(
+                            error = %ce,
+                            id = %entity.id,
+                            "create_entity: failed to roll back entity row after vector failure"
+                        );
+                    }
                 }
                 if let Ok(fts) = self.text(token) {
-                    let _ = fts.delete_document(ns, entity.id).await;
+                    if let Err(ce) = fts.delete_document(ns, entity.id).await {
+                        tracing::error!(
+                            error = %ce,
+                            id = %entity.id,
+                            "create_entity: failed to roll back FTS document after vector failure"
+                        );
+                    }
                 }
                 return Err(e);
             }
@@ -539,19 +557,45 @@ impl KhiveRuntime {
                 match join_result {
                     Err(e) => {
                         if let Ok(store) = self.entities(token) {
-                            let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                            if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await
+                            {
+                                tracing::error!(
+                                    error = %ce,
+                                    id = %entity.id,
+                                    "create_entity: failed to roll back entity row after embed task panic"
+                                );
+                            }
                         }
                         if let Ok(fts) = self.text(token) {
-                            let _ = fts.delete_document(ns, entity.id).await;
+                            if let Err(ce) = fts.delete_document(ns, entity.id).await {
+                                tracing::error!(
+                                    error = %ce,
+                                    id = %entity.id,
+                                    "create_entity: failed to roll back FTS document after embed task panic"
+                                );
+                            }
                         }
                         return Err(e);
                     }
                     Ok(Err(e)) => {
                         if let Ok(store) = self.entities(token) {
-                            let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                            if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await
+                            {
+                                tracing::error!(
+                                    error = %ce,
+                                    id = %entity.id,
+                                    "create_entity: failed to roll back entity row after embed failure"
+                                );
+                            }
                         }
                         if let Ok(fts) = self.text(token) {
-                            let _ = fts.delete_document(ns, entity.id).await;
+                            if let Err(ce) = fts.delete_document(ns, entity.id).await {
+                                tracing::error!(
+                                    error = %ce,
+                                    id = %entity.id,
+                                    "create_entity: failed to roll back FTS document after embed failure"
+                                );
+                            }
                         }
                         return Err(e);
                     }
@@ -599,14 +643,33 @@ impl KhiveRuntime {
                 if let Err(e) = insert_result {
                     // Compensate entity row + FTS + already-inserted vectors.
                     if let Ok(store) = self.entities(token) {
-                        let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                        if let Err(ce) = store.delete_entity(entity.id, DeleteMode::Hard).await {
+                            tracing::error!(
+                                error = %ce,
+                                id = %entity.id,
+                                "create_entity: failed to roll back entity row after vector insert failure"
+                            );
+                        }
                     }
                     if let Ok(fts) = self.text(token) {
-                        let _ = fts.delete_document(ns, entity.id).await;
+                        if let Err(ce) = fts.delete_document(ns, entity.id).await {
+                            tracing::error!(
+                                error = %ce,
+                                id = %entity.id,
+                                "create_entity: failed to roll back FTS document after vector insert failure"
+                            );
+                        }
                     }
                     for m in &inserted_models {
                         if let Ok(vs) = self.vectors_for_model(token, m) {
-                            let _ = vs.delete(entity.id).await;
+                            if let Err(ce) = vs.delete(entity.id).await {
+                                tracing::error!(
+                                    error = %ce,
+                                    model = m,
+                                    id = %entity.id,
+                                    "create_entity: failed to roll back vector for model after insert failure"
+                                );
+                            }
                         }
                     }
                     return Err(e);

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -53,6 +53,25 @@ std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+// Count-targetable vector-INSERT fault injection: when set to N (N > 0), the next N
+// vector insert calls succeed and the (N+1)-th returns an injected error.  After
+// triggering the counter resets to 0.  `thread_local!` provides per-thread isolation;
+// `#[tokio::test]` uses a current-thread runtime so there is no thread migration
+// mid-test.  This lets T-E3 let model-a's insert succeed and fail on model-b's.
+#[cfg(any(test, feature = "fault-injection"))]
+std::thread_local! {
+    static VECTOR_FAIL_AFTER: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Arm the count-targetable vector-INSERT fault: let `n` inserts succeed, then fail
+/// the next one.  Set `n = 0` to fail immediately on the first insert.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
+pub fn arm_vector_fail_after(n: usize) {
+    VECTOR_FAIL_AFTER.with(|cell| cell.set(Some(n)));
+}
+
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 #[cfg(any(test, feature = "fault-injection"))]
@@ -405,19 +424,195 @@ impl KhiveRuntime {
 
         let doc = entity_fts_document(&entity);
         let embed_body = doc.body.clone();
-        self.text(token)?.upsert_document(doc).await?;
 
-        if self.config().embedding_model.is_some() {
-            let vector = self.embed_document(&embed_body).await?;
-            self.vectors(token)?
-                .insert(
-                    entity.id,
-                    SubstrateKind::Entity,
-                    ns,
-                    "entity.body",
-                    vec![vector],
-                )
-                .await?;
+        // FTS step — compensate entity row on failure (mirrors create_note_inner).
+        {
+            #[cfg(any(test, feature = "fault-injection"))]
+            let fts_inject = {
+                let mut g = FTS_FAIL_NS.lock().unwrap();
+                if g.as_deref() == Some(ns) {
+                    *g = None;
+                    true
+                } else {
+                    false
+                }
+            };
+            #[cfg(not(any(test, feature = "fault-injection")))]
+            let fts_inject = false;
+            let fts_result: RuntimeResult<()> = if fts_inject {
+                Err(RuntimeError::Internal("injected FTS failure".to_string()))
+            } else {
+                match self.text(token) {
+                    Ok(fts) => fts.upsert_document(doc).await.map_err(RuntimeError::from),
+                    Err(e) => Err(e),
+                }
+            };
+            if let Err(e) = fts_result {
+                if let Ok(store) = self.entities(token) {
+                    let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                }
+                return Err(e);
+            }
+        }
+
+        // Vector embedding + insert step — compensate entity row + FTS doc on failure.
+        // Fan out to ALL registered models (mirrors create_note_inner multi-model path).
+        let embed_model_names = {
+            let names = self.registered_embedding_model_names();
+            if names.is_empty() {
+                vec![]
+            } else {
+                names
+            }
+        };
+
+        if embed_model_names.len() == 1 {
+            let model_name = &embed_model_names[0];
+            let vec_result = self
+                .embed_document_with_model(model_name, &embed_body)
+                .await;
+
+            #[cfg(any(test, feature = "fault-injection"))]
+            let vec_inject = {
+                let mut g = VECTOR_FAIL_NS.lock().unwrap();
+                if g.as_deref() == Some(ns) {
+                    *g = None;
+                    true
+                } else {
+                    false
+                }
+            };
+            #[cfg(not(any(test, feature = "fault-injection")))]
+            let vec_inject = false;
+            let vec_result: RuntimeResult<Vec<f32>> = if vec_inject {
+                Err(RuntimeError::Internal(
+                    "injected vector failure".to_string(),
+                ))
+            } else {
+                vec_result
+            };
+
+            let single_result: RuntimeResult<()> = match vec_result {
+                Ok(vector) => match self.vectors_for_model(token, model_name) {
+                    Ok(vs) => vs
+                        .insert(
+                            entity.id,
+                            SubstrateKind::Entity,
+                            ns,
+                            "entity.body",
+                            vec![vector],
+                        )
+                        .await
+                        .map_err(RuntimeError::from),
+                    Err(e) => Err(e),
+                },
+                Err(e) => Err(e),
+            };
+            if let Err(e) = single_result {
+                if let Ok(store) = self.entities(token) {
+                    let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                }
+                if let Ok(fts) = self.text(token) {
+                    let _ = fts.delete_document(ns, entity.id).await;
+                }
+                return Err(e);
+            }
+        } else if !embed_model_names.is_empty() {
+            // Multi-model path: embed with each model in parallel, then insert sequentially
+            // with inserted_models tracking for rollback on partial failure.
+            let rt_clone = self.clone();
+            let body_owned = embed_body.clone();
+            let mut handles = Vec::with_capacity(embed_model_names.len());
+            for model_name in &embed_model_names {
+                let rt = rt_clone.clone();
+                let text = body_owned.clone();
+                let name = model_name.clone();
+                handles.push(tokio::spawn(async move {
+                    rt.embed_document_with_model(&name, &text).await
+                }));
+            }
+            let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(embed_model_names.len());
+            for handle in handles {
+                let join_result = handle
+                    .await
+                    .map_err(|e| RuntimeError::Internal(format!("embed task panicked: {e}")));
+                match join_result {
+                    Err(e) => {
+                        if let Ok(store) = self.entities(token) {
+                            let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                        }
+                        if let Ok(fts) = self.text(token) {
+                            let _ = fts.delete_document(ns, entity.id).await;
+                        }
+                        return Err(e);
+                    }
+                    Ok(Err(e)) => {
+                        if let Ok(store) = self.entities(token) {
+                            let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                        }
+                        if let Ok(fts) = self.text(token) {
+                            let _ = fts.delete_document(ns, entity.id).await;
+                        }
+                        return Err(e);
+                    }
+                    Ok(Ok(vec)) => vectors.push(vec),
+                }
+            }
+            // TODO(P2): parallelize vector inserts
+            let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
+            for (model_name, vector) in embed_model_names.iter().zip(vectors.into_iter()) {
+                // Count-targetable fault injection for multi-model insert path (T-E3).
+                #[cfg(any(test, feature = "fault-injection"))]
+                let count_inject = VECTOR_FAIL_AFTER.with(|cell| match cell.get() {
+                    Some(0) => {
+                        cell.set(None);
+                        true
+                    }
+                    Some(n) => {
+                        cell.set(Some(n - 1));
+                        false
+                    }
+                    None => false,
+                });
+                #[cfg(not(any(test, feature = "fault-injection")))]
+                let count_inject = false;
+
+                let insert_result = if count_inject {
+                    Err(RuntimeError::Internal(
+                        "injected vector insert failure".to_string(),
+                    ))
+                } else {
+                    match self.vectors_for_model(token, model_name) {
+                        Ok(vs) => vs
+                            .insert(
+                                entity.id,
+                                SubstrateKind::Entity,
+                                ns,
+                                "entity.body",
+                                vec![vector],
+                            )
+                            .await
+                            .map_err(RuntimeError::from),
+                        Err(e) => Err(e),
+                    }
+                };
+                if let Err(e) = insert_result {
+                    // Compensate entity row + FTS + already-inserted vectors.
+                    if let Ok(store) = self.entities(token) {
+                        let _ = store.delete_entity(entity.id, DeleteMode::Hard).await;
+                    }
+                    if let Ok(fts) = self.text(token) {
+                        let _ = fts.delete_document(ns, entity.id).await;
+                    }
+                    for m in &inserted_models {
+                        if let Ok(vs) = self.vectors_for_model(token, m) {
+                            let _ = vs.delete(entity.id).await;
+                        }
+                    }
+                    return Err(e);
+                }
+                inserted_models.push(model_name.clone());
+            }
         }
 
         Ok(entity)
@@ -6699,6 +6894,366 @@ mod tests {
             count_edge_rows_by_id(&rt, base_edge_uuid, &ns).await,
             0,
             "hard-delete must physically remove the base edge row"
+        );
+    }
+
+    // ---- Issue #10: entity create/update multi-model embed fan-out tests ----
+
+    // T-E1: FTS failure after entity row commit rolls back the entity row.
+    // Mirrors create_note_fts_failure_rolls_back_note_row but for entities.
+    // Uses a unique namespace so the process-global FTS_FAIL_NS one-shot is
+    // consumed only by this test's create_entity call.
+    #[tokio::test]
+    async fn create_entity_fts_failure_rolls_back_entity_row() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let ns = Namespace::parse("fault-entity-fts").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        arm_fts_fail(ns.as_str());
+
+        let result = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "fts-fail rollback target",
+                None,
+                None,
+                vec![],
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "create_entity must propagate the injected FTS failure"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("injected FTS failure"),
+            "error must carry injection message; got: {err_msg}"
+        );
+
+        let entities = rt.list_entities(&tok, None, None, 1000, 0).await.unwrap();
+        assert!(
+            entities.is_empty(),
+            "compensation must remove the entity row after FTS failure; got {entities:?}"
+        );
+    }
+
+    // T-E2: Vector insert failure after entity row + FTS commit rolls back both.
+    // Uses a unique namespace to avoid consuming the VECTOR_FAIL_NS flag from
+    // a concurrent test's create_entity or create_note.
+    #[tokio::test]
+    async fn create_entity_vector_failure_rolls_back_entity_row_and_fts() {
+        const MODEL: &str = "test-entity-vec-inject";
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        let (provider, _counter) = ConstVecProvider::new(MODEL, DIMS);
+        rt.register_embedder(provider);
+
+        let ns = Namespace::parse("fault-entity-vec").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        arm_vector_fail(ns.as_str());
+
+        let result = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "vec-fail rollback target",
+                Some("description so embed body is non-empty"),
+                None,
+                vec![],
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "create_entity must propagate the injected vector failure"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("injected vector failure"),
+            "error must carry injection message; got: {err_msg}"
+        );
+
+        let entities = rt.list_entities(&tok, None, None, 1000, 0).await.unwrap();
+        assert!(
+            entities.is_empty(),
+            "compensation must remove entity row after vector failure; got {entities:?}"
+        );
+
+        // FTS document must also be removed.
+        use khive_storage::types::{TextFilter, TextQueryMode, TextSearchRequest};
+        let fts_hits = rt
+            .text(&tok)
+            .unwrap()
+            .search(TextSearchRequest {
+                query: "vec-fail rollback target".to_string(),
+                mode: TextQueryMode::Plain,
+                filter: Some(TextFilter {
+                    namespaces: vec![ns.as_str().to_string()],
+                    ..Default::default()
+                }),
+                top_k: 10,
+                snippet_chars: 100,
+            })
+            .await
+            .unwrap();
+        assert!(
+            fts_hits.is_empty(),
+            "compensation must remove FTS document after vector failure; got {fts_hits:?}"
+        );
+    }
+
+    // T-E3: Multi-model create_entity — second model's vector INSERT fails after the
+    // first model's insert succeeds, triggering inserted_models rollback.
+    // Uses arm_vector_fail_after(1) so the first insert passes and the second fails,
+    // exercising the inserted_models compensation path in create_entity.
+    // Thread-local VECTOR_FAIL_AFTER is per-thread isolated (current-thread tokio runtime),
+    // so this test does not race with namespace-targeted VECTOR_FAIL_NS tests.
+    #[tokio::test]
+    async fn create_entity_multi_model_second_vector_failure_rolls_back_all() {
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        let (provider_a, _ca) = ConstVecProvider::new("model-a", DIMS);
+        let (provider_b, _cb) = ConstVecProvider::new("model-b", DIMS);
+        rt.register_embedder(provider_a);
+        rt.register_embedder(provider_b);
+
+        let ns = Namespace::parse("fault-entity-multi").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        // Let the first vector insert succeed, fail on the second.
+        arm_vector_fail_after(1);
+
+        let result = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "multi-model rollback target",
+                Some("description for embedding"),
+                None,
+                vec![],
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "create_entity must propagate the injected multi-model vector failure"
+        );
+
+        let entities = rt.list_entities(&tok, None, None, 1000, 0).await.unwrap();
+        assert!(
+            entities.is_empty(),
+            "compensation must remove entity row; got {entities:?}"
+        );
+
+        // Both model-a and model-b vector stores must be empty for the entity id.
+        // (The entity was never returned so we can't get its id from the result;
+        // list_entities returning empty is the primary assertion. Additionally confirm
+        // both stores have zero rows via a broad vector search.)
+        use khive_storage::types::VectorSearchRequest;
+        let query_vec = vec![1.0_f32; DIMS];
+        let hits_a = rt
+            .vectors_for_model(&tok, "model-a")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec.clone()],
+                top_k: 100,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("model-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_a.is_empty(),
+            "model-a vector store must be empty after rollback; got {hits_a:?}"
+        );
+        let hits_b = rt
+            .vectors_for_model(&tok, "model-b")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec],
+                top_k: 100,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("model-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_b.is_empty(),
+            "model-b vector store must be empty after rollback; got {hits_b:?}"
+        );
+    }
+
+    // T-U1: update_entity fans out to ALL registered models.
+    // After create + update with a changed description, both model-a and model-b
+    // vector stores hold a row for the entity id.
+    #[tokio::test]
+    async fn update_entity_fans_out_to_all_registered_models() {
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        let (provider_a, _ca) = ConstVecProvider::new("embed-a", DIMS);
+        let (provider_b, _cb) = ConstVecProvider::new("embed-b", DIMS);
+        rt.register_embedder(provider_a);
+        rt.register_embedder(provider_b);
+
+        let ns = Namespace::parse("update-entity-fanout").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "FanOutEntity",
+                Some("initial description"),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create_entity must succeed");
+
+        use crate::curation::EntityPatch;
+        let patch = EntityPatch {
+            description: Some(Some("updated description after fan-out fix".to_string())),
+            ..Default::default()
+        };
+        rt.update_entity(&tok, entity.id, patch)
+            .await
+            .expect("update_entity must succeed");
+
+        use khive_storage::types::VectorSearchRequest;
+        let query_vec = vec![1.0_f32; DIMS];
+
+        let hits_a = rt
+            .vectors_for_model(&tok, "embed-a")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec.clone()],
+                top_k: 10,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("embed-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_a.iter().any(|h| h.subject_id == entity.id),
+            "embed-a must hold a vector for the entity after update; got {hits_a:?}"
+        );
+
+        let hits_b = rt
+            .vectors_for_model(&tok, "embed-b")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec],
+                top_k: 10,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Entity),
+                embedding_model: Some("embed-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_b.iter().any(|h| h.subject_id == entity.id),
+            "embed-b must hold a vector for the entity after update; got {hits_b:?}"
+        );
+    }
+
+    // T-U2: update_note fans out to ALL registered models.
+    // After create + update with changed content, both embed-a and embed-b
+    // vector stores hold a row for the note id.
+    #[tokio::test]
+    async fn update_note_fans_out_to_all_registered_models() {
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::memory().unwrap();
+        let (provider_a, _ca) = ConstVecProvider::new("embed-a", DIMS);
+        let (provider_b, _cb) = ConstVecProvider::new("embed-b", DIMS);
+        rt.register_embedder(provider_a);
+        rt.register_embedder(provider_b);
+
+        let ns = Namespace::parse("update-note-fanout").unwrap();
+        let tok = NamespaceToken::for_namespace(ns.clone());
+
+        let note = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "initial note content for fan-out test",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create_note must succeed");
+
+        use crate::curation::NotePatch;
+        let patch = NotePatch {
+            content: Some("updated content after fan-out fix".to_string()),
+            ..Default::default()
+        };
+        rt.update_note(&tok, note.id, patch)
+            .await
+            .expect("update_note must succeed");
+
+        use khive_storage::types::VectorSearchRequest;
+        let query_vec = vec![1.0_f32; DIMS];
+
+        let hits_a = rt
+            .vectors_for_model(&tok, "embed-a")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec.clone()],
+                top_k: 10,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("embed-a".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_a.iter().any(|h| h.subject_id == note.id),
+            "embed-a must hold a vector for the note after update; got {hits_a:?}"
+        );
+
+        let hits_b = rt
+            .vectors_for_model(&tok, "embed-b")
+            .unwrap()
+            .search(VectorSearchRequest {
+                query_vectors: vec![query_vec],
+                top_k: 10,
+                namespace: Some(ns.as_str().to_string()),
+                kind: Some(khive_types::SubstrateKind::Note),
+                embedding_model: Some("embed-b".to_string()),
+                filter: None,
+                backend_hints: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            hits_b.iter().any(|h| h.subject_id == note.id),
+            "embed-b must hold a vector for the note after update; got {hits_b:?}"
         );
     }
 }

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -395,6 +395,7 @@ mod tests {
             db_path: Some(db_path.clone()),
             default_namespace: ns.clone(),
             embedding_model: None,
+            additional_embedding_models: vec![],
             ..Default::default()
         };
         let runtime = KhiveRuntime::new(config).unwrap();
@@ -431,6 +432,7 @@ mod tests {
             db_path: Some(db_path.clone()),
             default_namespace: ns.clone(),
             embedding_model: None,
+            additional_embedding_models: vec![],
             ..Default::default()
         };
         let runtime = KhiveRuntime::new(config).unwrap();
@@ -470,6 +472,7 @@ mod tests {
             db_path: Some(db_path.clone()),
             default_namespace: ns.clone(),
             embedding_model: None,
+            additional_embedding_models: vec![],
             ..Default::default()
         };
         let runtime = KhiveRuntime::new(config).unwrap();


### PR DESCRIPTION
## Problem (#10)

`create_entity`, `update_entity`/`reindex_entity`, `update_note`/`reindex_note`, `remove_from_indexes`, and `merge_entity` all gated embedding on `config().embedding_model.is_some()` — i.e. the **default** model only — and then embedded via `embed_document` / `vectors(token)`, which silently resolve to the default model. In a multi-embedder setup (e.g. `all-minilm-l6-v2` + `paraphrase-multilingual-minilm-l12-v2`), entities and notes were **never embedded into the non-default model's vector store**, so recall against the secondary model missed all entity/note records. (Notes created via `create_note_inner` already fanned out correctly; entities and the reindex/update paths did not.)

## Fix

- Gate every embed site on `!registered_embedding_model_names().is_empty()` (all registered models, not just the default).
- Fan out at every site via `embed_document_with_model(name, …)` + `vectors_for_model(token, name)` — never the default-resolving `embed_document` / `vectors(token)`.
- **CREATE path (`create_entity`)**: fail-closed with full compensation — on FTS or any per-model vector failure, roll back the entity row + FTS doc + already-inserted vectors (`inserted_models` tracking), mirroring `create_note_inner`.
- **REINDEX/update path (`reindex_entity`/`reindex_note`)**: best-effort warn-and-continue per model (FTS stays fail-closed). The entity/note row is already committed, so a per-model embed miss leaves a stale vector rather than rolling back — safe because `SqliteVecStore::insert` is a transactional upsert since #131 (no-worse-than-stale; the prior vector survives).
- **`remove_from_indexes`**: fan out the vector delete across all registered models, fail-closed.

## Tests (5 new, all green)

- `create_entity_fts_failure_rolls_back_entity_row` (T-E1)
- `create_entity_vector_failure_rolls_back_entity_row_and_fts` (T-E2)
- `create_entity_multi_model_second_vector_failure_rolls_back_all` (T-E3) — `arm_vector_fail_after(1)`, exercises `inserted_models` rollback
- `update_entity_fans_out_to_all_registered_models` (T-U1)
- `update_note_fans_out_to_all_registered_models` (T-U2)

Each fault test uses a **unique namespace** so the process-global one-shot fault flags are not consumed by a concurrent test (the #132 parallel-test-race lesson). `VECTOR_FAIL_AFTER` is a `thread_local!` (per-thread isolated under the current-thread tokio test runtime).

## Scope / follow-up

- `kkernel/src/reindex.rs` already fans out correctly — untouched.
- **#135** (filed): `merge_entity`'s in-transaction vec-delete only drops the from-entity's *default*-model vector; non-default-model vectors are orphaned. Documented with a `TODO(#135)` at the merge_entity block; deferred as a non-trivial schema-level change out of #10 scope.

Closes #10.