### PR TITLE
docs: sync taxonomy counts + ADR status (M-17/18/19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ khive gives your agent:
 8. **Knowledge corpus** — atom/domain CRUD, FTS + embedding search, compose briefings
 9. **Brain** — Bayesian profile tuning from feedback signals
 
-All 7 packs load by default. **63 public verbs** across the packs.
+All 7 packs load by default. **65 public verbs** across the packs.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 
@@ -232,18 +232,19 @@ Use `create(kind="note", note_kind="observation", ...)` for notes.
 
 ---
 
-## The 8 entity kinds (closed set — [ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md))
+## The 9 entity kinds (closed set — [ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-resource-entity-kind.md))
 
-| Kind       | What it represents                                      |
-| ---------- | ------------------------------------------------------- |
-| `concept`  | Algorithms, techniques, architectures, theories, models |
-| `document` | Papers, preprints, technical reports, blog posts, books |
-| `dataset`  | Benchmarks, corpora, evaluation sets                    |
-| `project`  | Codebases, libraries, tools, frameworks                 |
-| `person`   | Researchers, engineers, authors                         |
-| `org`      | Labs, companies, institutions                           |
-| `artifact` | Binaries, model checkpoints, Docker images, packages    |
-| `service`  | APIs, hosted endpoints, SaaS products                   |
+| Kind       | What it represents                                                         |
+| ---------- | -------------------------------------------------------------------------- |
+| `concept`  | Algorithms, techniques, architectures, theories, models                    |
+| `document` | Papers, preprints, technical reports, blog posts, books                    |
+| `dataset`  | Benchmarks, corpora, evaluation sets                                       |
+| `project`  | Codebases, libraries, tools, frameworks                                    |
+| `person`   | Researchers, engineers, authors                                            |
+| `org`      | Labs, companies, institutions                                              |
+| `artifact` | Binaries, model checkpoints, Docker images, packages                       |
+| `service`  | APIs, hosted endpoints, SaaS products                                      |
+| `resource` | Actionable content agents consume: atoms, domains, skills, tools, runbooks |
 
 `concept` is the default. Use `properties` for finer distinctions (`type: "paper"`,
 `domain: "attention"`, `status: "implemented"`).
@@ -265,7 +266,7 @@ annotates=[entity_id], ...)`.
 
 ---
 
-## The 15-relation ontology (closed set — [ADR-002](docs/adr/ADR-002-edge-ontology.md))
+## The 17-relation ontology (closed set — [ADR-002](docs/adr/ADR-002-edge-ontology.md) base 15; [ADR-055](docs/adr/ADR-055-epistemic-edge-relations.md) +2 epistemic)
 
 When you `link` nodes, use ONLY these relations:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ concepts, links ideas, records decisions — khive gives that work a typed, quer
 persists across sessions.
 
 It is NOT a general-purpose database, a vector DB, or a chat memory system. It has opinions:
-8 entity kinds, 15 edge relations, 5 note kinds — all closed sets. If your data doesn't fit the
+9 entity kinds, 17 edge relations, 5 note kinds — all closed sets. If your data doesn't fit the
 schema, change how you model it, not the schema. Schema changes require an ADR.
 
 ---
@@ -55,9 +55,9 @@ behavior isn't written there, it is an unspecified design decision → escalate,
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch
 ┌──────────────────────────────────────────────────────────────┐
-│  khive-pack-kg     — KG vocabulary + 11 verb handlers (ADR-017)     │
+│  khive-pack-kg     — KG vocabulary + 16 verb handlers (ADR-017)     │
 │  khive-pack-gtd    — GTD lifecycle, 5 verbs (ADR-019, optional)     │
-│  khive-pack-memory — memory/recall verbs + decay (ADR-021, optional)│
+│  khive-pack-memory — memory/recall verbs + feedback + decay (ADR-021, optional)│
 │  khive-vcs         — KG versioning: snapshots/branches (ADR-010)    │
 │  khive-merge       — KG merge algorithm (ADR-039)                   │
 └──────────────────────────────────────────────────────────────┘
@@ -99,9 +99,9 @@ not shipped.
 | `crates/khive-query`       | GQL + SPARQL parsers, AST validation, SQL compiler                                                                     |
 | `crates/khive-runtime`     | Service API + VerbRegistry + PackRuntime trait                                                                         |
 | `crates/khive-request`     | Request DSL parser (function-call + JSON; pipe/LNDL planned)                                                           |
-| `crates/khive-pack-kg`     | KG pack: vocabulary, 11 verb handlers, kind validation                                                                 |
+| `crates/khive-pack-kg`     | KG pack: vocabulary, 16 verb handlers, kind validation                                                                 |
 | `crates/khive-pack-gtd`    | GTD pack: 5 verbs over notes (assign / next / complete / tasks / transition)                                           |
-| `crates/khive-pack-memory` | Memory pack: `remember`/`recall` verbs, decay-weighted recall ([ADR-021](docs/adr/ADR-021-memory-pack.md))             |
+| `crates/khive-pack-memory` | Memory pack: `remember`/`recall`/`feedback` verbs, decay-weighted recall ([ADR-021](docs/adr/ADR-021-memory-pack.md))  |
 | `crates/khive-vcs`         | KG versioning: content-addressed snapshots, branch pointers, push/pull ([ADR-010](docs/adr/ADR-010-kg-versioning.md))  |
 | `crates/khive-merge`       | KG merge: three-way merge with LCA walk, conflict enum, strategy shortcuts ([ADR-039](docs/adr/ADR-039-note-merge.md)) |
 | `crates/khive-mcp`         | Stdio MCP binary — single `request` tool over VerbRegistry; auto-spawns daemon                                         |
@@ -114,11 +114,11 @@ not shipped.
 
 ## Closed taxonomies (DO NOT extend without an ADR)
 
-### 8 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md))
+### 9 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-resource-entity-kind.md))
 
-`concept` | `document` | `dataset` | `project` | `person` | `org` | `artifact` | `service`
+`concept` | `document` | `dataset` | `project` | `person` | `org` | `artifact` | `service` | `resource`
 
-### 15 edge relations ([ADR-002](docs/adr/ADR-002-edge-ontology.md))
+### 17 edge relations ([ADR-002](docs/adr/ADR-002-edge-ontology.md) base 15; [ADR-055](docs/adr/ADR-055-epistemic-edge-relations.md) +2 epistemic)
 
 Structure: `contains` | `part_of` | `instance_of`
 Derivation: `extends` | `variant_of` | `introduced_by` | `supersedes`
@@ -128,6 +128,7 @@ Dependency: `depends_on` | `enables`
 Implementation: `implements`
 Lateral: `competes_with` | `composed_with`
 Annotation: `annotates`
+Epistemic: `supports` | `refutes`
 
 ### 5 note kinds ([ADR-013](docs/adr/ADR-013-note-kind-taxonomy.md))
 
@@ -166,9 +167,9 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
 loads all 7 production packs: kg, gtd, memory, brain, comm, schedule, knowledge
-(63 verbs total).
+(65 verbs total).
 
-### KG pack verbs (11 — ADR-017)
+### KG pack verbs (16 — ADR-017, ADR-046)
 
 `create`, `list`, and `search` take a `kind` discriminant. It accepts either the substrate-level
 name (`entity`, `note`, `edge`) **or** a pack-registered granular kind (`concept`, `document`,
@@ -180,6 +181,7 @@ Mixing a granular `kind` with a contradicting `entity_kind`/`note_kind` sub-filt
 | `create`    | `kind=<substrate\|granular>` + fields        | Create an entity or note                                      |
 | `get`       | `id` (UUID)                                  | Fetch any record — auto-detects entity/note/edge              |
 | `list`      | `kind=<substrate\|granular>\|edge` + filters | Structured browse with pagination                             |
+| `stats`     | —                                            | Return aggregate KG substrate counts (entities, edges, notes) |
 | `update`    | `id` + patch fields                          | Patch entity (name/desc/props/tags) or edge (relation/weight) |
 | `delete`    | `id`, `hard?`                                | Soft-delete (default) or hard-delete with edge cascade        |
 | `merge`     | `into_id`, `from_id`                         | Deduplicate two entities (v0.1: entity-only)                  |
@@ -188,6 +190,10 @@ Mixing a granular `kind` with a contradicting `entity_kind`/`note_kind` sub-filt
 | `neighbors` | `node_id`, `direction?`, `relations?`        | Immediate graph neighbors                                     |
 | `traverse`  | `roots`, `max_depth?`, `relations?`          | Multi-hop BFS with filters                                    |
 | `query`     | GQL or SPARQL string                         | Pattern matching compiled to SQL                              |
+| `propose`   | `title`, `description`, `changeset`          | Create an event-sourced change proposal (ADR-046)             |
+| `review`    | `id`, `decision`, `comment?`                 | Approve, reject, or comment on a proposal                     |
+| `withdraw`  | `id`, `rationale?`                           | Rescind an open proposal (proposer-only)                      |
+| `verbs`     | `category?`, `pack?`                         | List all MCP-callable verbs registered on this server         |
 
 ### GTD pack verbs (5 — ADR-019, optional)
 
@@ -201,14 +207,15 @@ Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 | `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                       |
 | `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation  |
 
-### Memory pack verbs (2 — ADR-021, optional)
+### Memory pack verbs (3 — ADR-021, optional)
 
 Load with `KHIVE_PACKS=kg,memory` or `--pack memory`. Adds the `memory` note kind.
 
-| Verb       | Args                                                                  | What it does                                                              |
-| ---------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source |
-| `recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking        |
+| Verb              | Args                                                                  | What it does                                                              |
+| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source |
+| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking        |
+| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors    |
 
 `get`/`update`/`delete`/`merge` are UUID-only — no `kind` needed, the handler resolves
 the substrate from the UUID. `create`/`list`/`search` require `kind`.
@@ -328,19 +335,19 @@ ADRs specify. Changing the schema or interface requires an ADR **before** code l
 
 Key ADRs for contributors:
 
-| ADR                                                  | What it governs                                      |
-| ---------------------------------------------------- | ---------------------------------------------------- |
-| [001](docs/adr/ADR-001-entity-kind-taxonomy.md)      | 8 entity kinds — don't add without this              |
-| [002](docs/adr/ADR-002-edge-ontology.md)             | 15 edge relations — closed set                       |
-| [005](docs/adr/ADR-005-storage-capability-traits.md) | Storage traits — the abstraction boundary            |
-| [008](docs/adr/ADR-008-query-layer-separation.md)    | Query crate — parser/validator/compiler separation   |
-| [013](docs/adr/ADR-013-note-kind-taxonomy.md)        | 5 base note kinds                                    |
-| [015](docs/adr/ADR-015-schema-migrations.md)         | Migration system — how to change the DB schema       |
-| [016](docs/adr/ADR-016-request-dsl.md)               | Request DSL — verb-dispatch syntax for `request`     |
-| [017](docs/adr/ADR-017-pack-standard.md)             | Pack trait, `EDGE_RULES`, pack-extensible endpoints  |
-| [023](docs/adr/ADR-023-declarative-pack-format.md)   | Pack verb surface, visibility, and composition       |
-| [027](docs/adr/ADR-027-dynamic-pack-loading.md)      | Dynamic pack loading via self-registration           |
-| [028](docs/adr/ADR-028-pack-scoped-backends.md)      | Pack-scoped backends and per-pack schema declaration |
+| ADR                                                  | What it governs                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------- |
+| [001](docs/adr/ADR-001-entity-kind-taxonomy.md)      | 9 entity kinds (8 base + resource ADR-048) — don't add without this |
+| [002](docs/adr/ADR-002-edge-ontology.md)             | 15 base edge relations; +2 epistemic via ADR-055 = 17 total         |
+| [005](docs/adr/ADR-005-storage-capability-traits.md) | Storage traits — the abstraction boundary                           |
+| [008](docs/adr/ADR-008-query-layer-separation.md)    | Query crate — parser/validator/compiler separation                  |
+| [013](docs/adr/ADR-013-note-kind-taxonomy.md)        | 5 base note kinds                                                   |
+| [015](docs/adr/ADR-015-schema-migrations.md)         | Migration system — how to change the DB schema                      |
+| [016](docs/adr/ADR-016-request-dsl.md)               | Request DSL — verb-dispatch syntax for `request`                    |
+| [017](docs/adr/ADR-017-pack-standard.md)             | Pack trait, `EDGE_RULES`, pack-extensible endpoints                 |
+| [023](docs/adr/ADR-023-declarative-pack-format.md)   | Pack verb surface, visibility, and composition                      |
+| [027](docs/adr/ADR-027-dynamic-pack-loading.md)      | Dynamic pack loading via self-registration                          |
+| [028](docs/adr/ADR-028-pack-scoped-backends.md)      | Pack-scoped backends and per-pack schema declaration                |
 
 Full index: [docs/adr/README.md](docs/adr/README.md).
 

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -147,7 +147,7 @@ corruption at scale).
 
 ### ANN warm-start
 
-ANN warm-start is owned by the **daemon** process (`khive-mcp --daemon`), not by
+ANN warm-start is owned by the **daemon** process (`kkernel mcp --daemon`), not by
 the stdio server. After the daemon socket is bound, `warm_all()` runs in a
 background task, loading persisted Vamana snapshots into memory. The stdio MCP
 server forwards requests to the warm daemon via Unix socket (`forward_or_spawn`);

--- a/docs/adr/ADR-057-comm-actor-addressed-delivery.md
+++ b/docs/adr/ADR-057-comm-actor-addressed-delivery.md
@@ -1,6 +1,6 @@
 # ADR-057: Comm Actor-Addressed Delivery
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-06-15\
 **Authors**: Ocean, lambda:khive\
 **Depends on**: ADR-007 (Namespace), ADR-017 (Pack Standard), ADR-040 (Communication and


### PR DESCRIPTION
## Summary

- **M-17 (taxonomy counts)**: Corrected stale counts throughout `CLAUDE.md` and `AGENTS.md`:
  - Entity kinds 8 → 9 (`resource` added by ADR-048; `EntityKind::ALL: [Self; 9]` in `crates/khive-pack-kg/src/vocab.rs:30`)
  - Edge relations 15 → 17 (`supports`/`refutes` added by ADR-055; `EdgeRelation::ALL: [Self; 17]` in `crates/khive-types/src/edge.rs:76`)
  - KG pack verbs 11 → 16 (`stats`, `propose`, `review`, `withdraw`, `verbs` added by ADR-046; `KG_HANDLERS: [HandlerDef; 16]` in `crates/khive-pack-kg/src/handler_defs.rs:17`, all `Visibility::Verb`)
  - Memory pack verbs 2 → 3 (`memory.feedback` is `Visibility::Verb`; the 5 `recall_*` entries are `Visibility::Subhandler` and excluded; `MEMORY_HANDLERS: [HandlerDef; 8]` in `crates/khive-pack-memory/src/pack.rs:80`)
  - Total verb count 63 → 65 (KG:16 + GTD:5 + Memory:3 + Brain:13 + Comm:5 + Schedule:4 + Knowledge:19)
  - Added `Epistemic: supports | refutes` group to the edge relation list in `CLAUDE.md`
  - Added ADR-048 and ADR-055 citations alongside ADR-001 and ADR-002 throughout

- **M-18 (ADR status)**: `docs/adr/ADR-057-comm-actor-addressed-delivery.md` status `Proposed` → `Accepted` (merged PR #138, commit cdcb394).

- **M-19 (binary topology)**: `docs/adr/ADR-051-section-embeddings-hybrid-compose.md` line 150 — `khive-mcp --daemon` → `kkernel mcp --daemon` (single stale binary reference; ADR-049 already has the full kkernel amendment).

## Test plan

- [ ] All counts in `CLAUDE.md` and `AGENTS.md` match the source arrays: `EntityKind::ALL` (9), `EdgeRelation::ALL` (17), `KG_HANDLERS` (16 Verb), `MEMORY_HANDLERS` (3 Verb), total 65
- [ ] ADR-057 status reads "Accepted"
- [ ] ADR-051 contains no references to `khive-mcp --daemon`
- [ ] `deno fmt` passes (enforced by pre-commit hook)
- [ ] No `.rs`, `.sql`, or `Cargo.toml` files changed