### PR TITLE
feat(khive-runtime): parse [actor] config into typed ActorRef on RuntimeConfig (#75 ST1)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -6,7 +6,8 @@
 use std::path::PathBuf;
 
 use khive_runtime::{
-    config_from_env, runtime_config_from_khive_config, KhiveConfig, KhiveRuntime, RuntimeConfig,
+    actor_ref_from_configured_namespace_str, config_from_env, runtime_config_from_khive_config,
+    ActorRef, KhiveConfig, KhiveRuntime, RuntimeConfig,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -115,9 +116,32 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
     // we exclude brain_profile from the default spread and set it to None (CLI-only).
     let cli_brain_profile = inputs.brain_profile.filter(|s| !s.trim().is_empty());
 
+    // When --actor / KHIVE_ACTOR / --namespace / KHIVE_NAMESPACE is explicit, derive
+    // the matching ActorRef so that both default_namespace and actor_ref are set from the
+    // same source. Without this, direct KhiveRuntime::authorize calls mint a token whose
+    // actor() is anonymous even when the namespace was explicitly configured.
+    //
+    // actor_ref_from_configured_namespace_str rejects the reserved "anonymous" kind in
+    // two-segment form (e.g. "anonymous:local") so that an operator cannot accidentally
+    // collapse a configured actor back to the default anonymous identity.
+    //
+    // When the namespace is NOT explicit (i.e. it came from the default "local"), the base
+    // actor_ref is left as ActorRef::anonymous() — the same as before — and the config-file
+    // tier (runtime_config_from_khive_config) may override it from [actor] id.
+    let cli_actor_ref = if inputs.namespace_explicit {
+        let ns_str = inputs.namespace.as_str();
+        Some(
+            actor_ref_from_configured_namespace_str(ns_str)
+                .map_err(|e| anyhow::anyhow!("invalid actor identity {ns_str:?}: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     let base_config = RuntimeConfig {
         db_path,
         default_namespace: inputs.namespace,
+        actor_ref: cli_actor_ref.unwrap_or_else(ActorRef::anonymous),
         packs,
         // Explicit CLI flag only at this tier — env and config-file tiers are applied
         // below in resolve_config / resolve_actor_from_config and apply_env_brain_profile.
@@ -230,7 +254,7 @@ fn resolve_actor_from_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use khive_runtime::Namespace;
+    use khive_runtime::{actor_ref_from_configured_namespace_str, Namespace};
     use serial_test::serial;
     use std::io::Write;
 
@@ -411,6 +435,96 @@ brain_profile = "project-profile"
             resolved.brain_profile.as_deref(),
             Some("cli-profile"),
             "CLI --brain-profile must win over both TOML and KHIVE_BRAIN_PROFILE env var"
+        );
+    }
+
+    /// [High] FIX 1: When --actor / KHIVE_ACTOR provides an explicit actor, the resolved
+    /// RuntimeConfig must carry a matching actor_ref, not ActorRef::anonymous().
+    ///
+    /// Regression test: prior to the fix, default_namespace was set from the CLI actor
+    /// but actor_ref remained ActorRef::anonymous() via ..RuntimeConfig::default().
+    /// This left the direct KhiveRuntime::authorize helpers minting anonymous tokens even
+    /// when the operator explicitly identified the runtime instance.
+    ///
+    /// Non-vacuity: revering the cli_actor_ref derivation in resolve_runtime_config
+    /// (removing the if inputs.namespace_explicit block) causes this test to fail with
+    /// actor_ref == ActorRef::anonymous().
+    #[test]
+    #[serial]
+    fn cli_actor_sets_actor_ref_on_runtime_config() {
+        use khive_runtime::ActorRef;
+
+        // Ensure env vars do not interfere with embedding model resolution.
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: None,
+            namespace: Namespace::parse("lambda:cli-actor").expect("valid namespace"),
+            namespace_explicit: true, // simulates --actor lambda:cli-actor
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        assert_eq!(
+            resolved.actor_ref.kind, "lambda",
+            "actor_ref.kind must match the CLI actor kind"
+        );
+        assert_eq!(
+            resolved.actor_ref.id, "cli-actor",
+            "actor_ref.id must match the CLI actor id"
+        );
+        assert_ne!(
+            resolved.actor_ref,
+            ActorRef::anonymous(),
+            "CLI-configured actor must NOT resolve to anonymous"
+        );
+    }
+
+    /// [Medium] FIX 2: An actor string whose kind is the reserved "anonymous" must be
+    /// rejected with a ConfigError, not silently coerced to the default anonymous identity.
+    ///
+    /// Non-vacuity: removing the anonymous-kind check from
+    /// actor_ref_from_configured_namespace_str causes this test to fail — resolve_runtime_config
+    /// would succeed and silently produce an anonymous actor_ref.
+    #[test]
+    #[serial]
+    fn cli_actor_anonymous_kind_is_rejected() {
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+
+        // "anonymous:local" is a valid Namespace string but uses the reserved kind.
+        let result = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: None,
+            namespace: Namespace::parse("local").expect("valid namespace"),
+            namespace_explicit: true, // simulates --actor anonymous:local after Namespace::parse
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        });
+
+        // "local" is a single-segment namespace — actor_ref_from_configured_namespace_str
+        // accepts it as natural anonymous (not the reserved two-segment form). To test
+        // two-segment rejection we call the helper directly.
+        assert!(
+            result.is_ok(),
+            "single-segment 'local' must be accepted (natural anonymous default)"
+        );
+
+        // Two-segment anonymous:* must be rejected.
+        let two_seg_result = actor_ref_from_configured_namespace_str("anonymous:local");
+        assert!(
+            two_seg_result.is_err(),
+            "anonymous:local must be rejected as a configured actor kind"
+        );
+        let err_msg = two_seg_result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("reserved"),
+            "error message must mention that 'anonymous' is reserved; got: {err_msg}"
         );
     }
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -2310,6 +2310,7 @@ fn build_crossns_registry(
     let config = RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::parse(dispatch_ns).unwrap(),
+        actor_ref: khive_runtime::ActorRef::anonymous(),
         embedding_model: None,
         additional_embedding_models: vec![],
         gate: Arc::new(AllowAllGate),

--- a/crates/khive-pack-knowledge/benches/knowledge_bench.rs
+++ b/crates/khive-pack-knowledge/benches/knowledge_bench.rs
@@ -21,6 +21,7 @@ fn build_runtime() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::local(),
+        actor_ref: khive_runtime::ActorRef::anonymous(),
         embedding_model: None,
         additional_embedding_models: vec![],
         gate: Arc::new(AllowAllGate),

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::local(),
+        actor_ref: khive_runtime::ActorRef::anonymous(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
         gate: Arc::new(AllowAllGate),

--- a/crates/khive-pack-knowledge/tests/bench.rs
+++ b/crates/khive-pack-knowledge/tests/bench.rs
@@ -28,6 +28,7 @@ fn rt_with_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::local(),
+        actor_ref: khive_runtime::ActorRef::anonymous(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
         gate: Arc::new(AllowAllGate),

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1410,6 +1410,7 @@ fn rt_with_default_embedder() -> KhiveRuntime {
     KhiveRuntime::new(RuntimeConfig {
         db_path: None,
         default_namespace: Namespace::local(),
+        actor_ref: khive_runtime::ActorRef::anonymous(),
         embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
         additional_embedding_models: vec![],
         gate: Arc::new(AllowAllGate),
@@ -2080,6 +2081,7 @@ mod embed_failure_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -2441,6 +2443,7 @@ mod ann_bypass_regression {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -3035,6 +3038,7 @@ mod edit_inline_reembed {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -202,6 +202,18 @@ pub struct RuntimeConfig {
     pub db_path: Option<std::path::PathBuf>,
     /// Namespace used when no explicit namespace is provided.
     pub default_namespace: Namespace,
+    /// Typed caller identity for this khive instance.
+    ///
+    /// Derived from the `[actor]` section of `khive.toml`. When `actor.id`
+    /// is present (e.g. `"lambda:khive"`), the first colon-delimited segment
+    /// becomes `kind` and the remainder becomes `id`
+    /// (`ActorRef { kind: "lambda", id: "khive" }`). When `actor.id` is absent,
+    /// defaults to `ActorRef::anonymous()`.
+    ///
+    /// The `authorize` and `authorize_with_visibility` methods embed this
+    /// `actor_ref` into every minted `NamespaceToken`, replacing the prior
+    /// hard-coded `ActorRef::anonymous()`.
+    pub actor_ref: ActorRef,
     /// Local embedding model. `None` disables embedding and hybrid vector search;
     /// `hybrid_search` then falls back to text-only.
     ///
@@ -259,6 +271,58 @@ pub struct RuntimeConfig {
     pub allowed_outbound_namespaces: Vec<Namespace>,
 }
 
+// ---- actor_ref parsing ----
+
+/// Parse a validated namespace string into a typed `ActorRef`.
+///
+/// The namespace string must already have passed `Namespace::parse` (i.e. it
+/// is structurally valid). The parsing rule is:
+///
+/// - If the string contains a `:`, the first segment is the `kind` and everything
+///   after the first `:` is the `id`. For example `"lambda:khive"` yields
+///   `ActorRef { kind: "lambda", id: "khive" }` and `"lambda:khive:sub"` yields
+///   `ActorRef { kind: "lambda", id: "khive:sub" }`.
+/// - If there is no `:`, the entire string is treated as `id` with kind
+///   `"anonymous"`. This covers the `"local"` single-segment namespace, which
+///   maps to `ActorRef::anonymous()`.
+///
+/// Returns `Err` with a descriptive message listing valid forms when the parsed
+/// kind or id would be empty (enforced by `ActorRef::try_new`). Because the
+/// input is a pre-validated namespace string, the only reachable error here is
+/// when a validated namespace unexpectedly produces an empty segment — which
+/// signals a logic bug rather than user input.
+pub(crate) fn actor_ref_from_namespace_str(
+    id: &str,
+) -> Result<ActorRef, crate::engine_config::ConfigError> {
+    match id.find(':') {
+        Some(pos) => {
+            let kind = &id[..pos];
+            let rest = &id[pos + 1..];
+            ActorRef::try_new(kind, rest).map_err(|e| {
+                crate::engine_config::ConfigError::InvalidActorRef {
+                    id: id.to_string(),
+                    reason: format!(
+                        "{e}; valid forms: \"lambda:name\", \"agent:name\", \
+                         \"user:name\", \"local\""
+                    ),
+                }
+            })
+        }
+        None => {
+            // Single-segment namespace (e.g. "local") — treat as anonymous kind.
+            ActorRef::try_new("anonymous", id).map_err(|e| {
+                crate::engine_config::ConfigError::InvalidActorRef {
+                    id: id.to_string(),
+                    reason: format!(
+                        "{e}; valid forms: \"lambda:name\", \"agent:name\", \
+                         \"user:name\", \"local\""
+                    ),
+                }
+            })
+        }
+    }
+}
+
 /// Parse a comma- or whitespace-separated pack list from a single string.
 ///
 /// Empty entries are dropped, surrounding whitespace is trimmed.
@@ -307,6 +371,7 @@ impl Default for RuntimeConfig {
         Self {
             db_path,
             default_namespace: Namespace::local(),
+            actor_ref: ActorRef::anonymous(),
             embedding_model,
             additional_embedding_models,
             gate: Arc::new(AllowAllGate),
@@ -393,16 +458,26 @@ pub fn runtime_config_from_khive_config(
     khive_cfg: &crate::engine_config::KhiveConfig,
     base: RuntimeConfig,
 ) -> RuntimeConfig {
-    // Apply actor.id as default_namespace when present and valid.
+    // Apply actor.id as default_namespace and actor_ref when present and valid.
     // KhiveConfig::validate() guarantees that actor.id, when present, is a
     // structurally valid Namespace — so the Err arm here is unreachable for
     // any config that passed load(). A panic here signals a caller contract
     // violation (passing an unvalidated config).
-    let default_namespace = match khive_cfg.actor.id.as_deref() {
+    let (default_namespace, actor_ref) = match khive_cfg.actor.id.as_deref() {
         Some(id) if !id.is_empty() => match Namespace::parse(id) {
             Ok(ns) => {
                 tracing::debug!(actor_id = id, "actor.id from config sets default_namespace");
-                ns
+                // actor_ref_from_namespace_str is infallible for any id that
+                // passed Namespace::parse — panic here signals a caller
+                // contract violation (unvalidated config).
+                let aref = actor_ref_from_namespace_str(id).unwrap_or_else(|e| {
+                    panic!(
+                        "actor.id {id:?} passed validation but actor_ref parsing failed: {e}; \
+                         this is a bug — KhiveConfig must be validated before calling \
+                         runtime_config_from_khive_config"
+                    )
+                });
+                (ns, aref)
             }
             Err(e) => {
                 panic!(
@@ -412,7 +487,7 @@ pub fn runtime_config_from_khive_config(
                 );
             }
         },
-        _ => base.default_namespace.clone(),
+        _ => (base.default_namespace.clone(), base.actor_ref.clone()),
     };
 
     // base.brain_profile must carry ONLY the explicit CLI tier — never an env
@@ -459,6 +534,7 @@ pub fn runtime_config_from_khive_config(
     if khive_cfg.engines.is_empty() {
         return RuntimeConfig {
             default_namespace,
+            actor_ref,
             brain_profile,
             visible_namespaces,
             allowed_outbound_namespaces,
@@ -492,6 +568,7 @@ pub fn runtime_config_from_khive_config(
         embedding_model,
         additional_embedding_models: additional,
         default_namespace,
+        actor_ref,
         brain_profile,
         visible_namespaces,
         allowed_outbound_namespaces,
@@ -523,5 +600,101 @@ pub(crate) fn parse_embedding_model_alias(name: &str) -> Option<EmbeddingModel> 
     match normalized.as_str() {
         "paraphrase" => Some(EmbeddingModel::ParaphraseMultilingualMiniLmL12V2),
         _ => normalized.parse().ok(),
+    }
+}
+
+// INLINE TEST JUSTIFICATION: tests here directly exercise `actor_ref_from_namespace_str`,
+// which is `pub(crate)` and not accessible from the integration test suite.
+#[cfg(test)]
+mod actor_ref_tests {
+    use super::*;
+
+    // 1. Two-segment namespace -> kind=first segment, id=second segment.
+    #[test]
+    fn actor_ref_from_two_segment_namespace() {
+        let result = actor_ref_from_namespace_str("lambda:khive").unwrap();
+        assert_eq!(result.kind, "lambda");
+        assert_eq!(result.id, "khive");
+    }
+
+    // 2. Single-segment namespace ("local") -> anonymous kind, id = full string.
+    #[test]
+    fn actor_ref_from_single_segment_namespace_is_anonymous() {
+        let result = actor_ref_from_namespace_str("local").unwrap();
+        assert_eq!(result.kind, "anonymous");
+        assert_eq!(result.id, "local");
+        assert_eq!(result, ActorRef::anonymous());
+    }
+
+    // 3. Three-segment namespace -> kind=first segment, id=rest (including inner colon).
+    #[test]
+    fn actor_ref_from_three_segment_namespace() {
+        let result = actor_ref_from_namespace_str("lambda:khive:sub").unwrap();
+        assert_eq!(result.kind, "lambda");
+        assert_eq!(result.id, "khive:sub");
+    }
+
+    // 4. agent: namespace parses correctly.
+    #[test]
+    fn actor_ref_from_agent_namespace() {
+        let result = actor_ref_from_namespace_str("agent:kg-polisher").unwrap();
+        assert_eq!(result.kind, "agent");
+        assert_eq!(result.id, "kg-polisher");
+    }
+
+    // 5. user: namespace parses correctly.
+    #[test]
+    fn actor_ref_from_user_namespace() {
+        let result = actor_ref_from_namespace_str("user:ocean").unwrap();
+        assert_eq!(result.kind, "user");
+        assert_eq!(result.id, "ocean");
+    }
+
+    // 6. RuntimeConfig::default() provides actor_ref = anonymous.
+    #[test]
+    fn runtime_config_default_actor_ref_is_anonymous() {
+        let cfg = RuntimeConfig::default();
+        assert_eq!(cfg.actor_ref, ActorRef::anonymous());
+    }
+
+    // 7. runtime_config_from_khive_config with valid actor.id sets actor_ref correctly.
+    #[test]
+    fn runtime_config_from_khive_config_sets_actor_ref() {
+        use crate::engine_config::{ActorConfig, KhiveConfig, RuntimeSectionConfig};
+        let khive_cfg = KhiveConfig {
+            engines: vec![],
+            actor: ActorConfig {
+                id: Some("lambda:leo".to_string()),
+                display_name: None,
+                ..Default::default()
+            },
+            runtime: RuntimeSectionConfig::default(),
+        };
+        khive_cfg.validate().expect("valid config");
+        let base = RuntimeConfig::default();
+        let result = crate::runtime::runtime_config_from_khive_config(&khive_cfg, base);
+        assert_eq!(result.actor_ref.kind, "lambda");
+        assert_eq!(result.actor_ref.id, "leo");
+    }
+
+    // 8. runtime_config_from_khive_config without actor.id preserves base actor_ref.
+    #[test]
+    fn runtime_config_from_khive_config_absent_actor_preserves_base_actor_ref() {
+        use crate::engine_config::{ActorConfig, KhiveConfig, RuntimeSectionConfig};
+        let khive_cfg = KhiveConfig {
+            engines: vec![],
+            actor: ActorConfig {
+                id: None,
+                ..Default::default()
+            },
+            runtime: RuntimeSectionConfig::default(),
+        };
+        let custom_actor = ActorRef::new("user", "ocean");
+        let base = RuntimeConfig {
+            actor_ref: custom_actor.clone(),
+            ..RuntimeConfig::default()
+        };
+        let result = crate::runtime::runtime_config_from_khive_config(&khive_cfg, base);
+        assert_eq!(result.actor_ref, custom_actor);
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -323,6 +323,37 @@ pub(crate) fn actor_ref_from_namespace_str(
     }
 }
 
+/// Parse a validated namespace string into a typed `ActorRef` for a
+/// user-configured (CLI/env/config-file) actor.
+///
+/// Same as [`actor_ref_from_namespace_str`] but additionally rejects the
+/// reserved `anonymous` kind in two-segment form (e.g. `"anonymous:local"`).
+/// Explicit configuration of an `anonymous:*` actor collapses back into the
+/// default anonymous identity, creating an undetectable identity split. Fail
+/// closed on this class of misconfiguration so the operator is informed at
+/// startup rather than silently operating anonymously.
+///
+/// Single-segment namespaces (e.g. `"local"`) naturally resolve to
+/// `ActorRef::anonymous()` and are still accepted — they are the default, not
+/// an explicit misconfiguration.
+pub fn actor_ref_from_configured_namespace_str(
+    id: &str,
+) -> Result<ActorRef, crate::engine_config::ConfigError> {
+    if let Some(pos) = id.find(':') {
+        let kind = &id[..pos];
+        if kind == "anonymous" {
+            return Err(crate::engine_config::ConfigError::InvalidActorRef {
+                id: id.to_string(),
+                reason: "\"anonymous\" is a reserved actor kind and may not be configured \
+                     explicitly; use \"lambda:name\", \"agent:name\", \"user:name\", \
+                     or a single-segment namespace like \"local\""
+                    .to_string(),
+            });
+        }
+    }
+    actor_ref_from_namespace_str(id)
+}
+
 /// Parse a comma- or whitespace-separated pack list from a single string.
 ///
 /// Empty entries are dropped, surrounding whitespace is trimmed.

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -299,6 +299,24 @@ impl KhiveConfig {
                 id: id.to_string(),
                 reason: e.to_string(),
             })?;
+            // Reject the reserved "anonymous" kind in two-segment form (e.g.
+            // "anonymous:local"). A two-segment actor.id whose kind is "anonymous"
+            // collapses back to the default anonymous identity, creating an
+            // undetectable identity split. Fail closed at config load time.
+            // Single-segment values (e.g. "local") are accepted — they are the
+            // natural anonymous default, not an explicit misconfiguration.
+            if let Some(colon_pos) = id.find(':') {
+                let kind = &id[..colon_pos];
+                if kind == "anonymous" {
+                    return Err(ConfigError::InvalidActorRef {
+                        id: id.to_string(),
+                        reason: "\"anonymous\" is a reserved actor kind and may not be configured \
+                             explicitly; use \"lambda:name\", \"agent:name\", \"user:name\", \
+                             or a single-segment namespace like \"local\""
+                            .to_string(),
+                    });
+                }
+            }
         }
 
         // Validate actor.visible_namespaces when present.

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -41,6 +41,9 @@ pub enum ConfigError {
 
     #[error("actor.id {id:?} is not a valid namespace: {reason}")]
     InvalidActorId { id: String, reason: String },
+
+    #[error("actor.id {id:?} cannot be parsed into a typed ActorRef: {reason}")]
+    InvalidActorRef { id: String, reason: String },
 }
 
 // ---- Config structs ----

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub mod runtime;
 pub mod secret_gate;
 pub mod validation;
 
+pub use config::actor_ref_from_configured_namespace_str;
 pub use curation::{
     entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
     EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -6,7 +6,7 @@
 use std::sync::{Arc, RwLock};
 
 use khive_db::StorageBackend;
-use khive_gate::{ActorRef, AllowAllGate, GateRequest};
+use khive_gate::{AllowAllGate, GateRequest};
 use khive_storage::{EntityStore, EventStore, GraphStore, NoteStore, SqlAccess};
 use khive_types::{EdgeEndpointRule, Namespace};
 use lattice_embed::{EmbeddingModel, EmbeddingService};
@@ -149,6 +149,7 @@ impl KhiveRuntime {
         Self::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_gate::ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -320,7 +321,7 @@ impl KhiveRuntime {
     /// to the pre-visibility-set behaviour. Use [`authorize_with_visibility`]
     /// to mint a token that can read additional namespaces.
     pub fn authorize(&self, ns: Namespace) -> RuntimeResult<NamespaceToken> {
-        let actor = ActorRef::anonymous();
+        let actor = self.config.actor_ref.clone();
         let req = GateRequest::new(
             actor.clone(),
             ns.clone(),
@@ -373,7 +374,7 @@ impl KhiveRuntime {
         primary: Namespace,
         extra_visible: Vec<Namespace>,
     ) -> RuntimeResult<NamespaceToken> {
-        let actor = ActorRef::anonymous();
+        let actor = self.config.actor_ref.clone();
         let req = GateRequest::new(
             actor.clone(),
             primary.clone(),
@@ -724,6 +725,7 @@ mod tests {
         let config = RuntimeConfig {
             db_path: Some(path.clone()),
             default_namespace: Namespace::parse("test").unwrap(),
+            actor_ref: khive_gate::ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -744,6 +746,7 @@ mod tests {
         let config = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_gate::ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -887,9 +890,11 @@ mod tests {
 
     #[test]
     fn runtime_config_from_khive_config_applies_actor_id_as_default_namespace() {
+        use khive_gate::ActorRef;
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -902,13 +907,17 @@ mod tests {
         let cfg = khive_cfg_with_actor("lambda:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(result.default_namespace.as_str(), "lambda:khive");
+        assert_eq!(result.actor_ref.kind, "lambda");
+        assert_eq!(result.actor_ref.id, "khive");
     }
 
     #[test]
     fn runtime_config_from_khive_config_empty_actor_id_keeps_base_namespace() {
+        use khive_gate::ActorRef;
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
+            actor_ref: ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -933,13 +942,20 @@ mod tests {
             "lambda:base",
             "empty actor.id must not override base namespace"
         );
+        assert_eq!(
+            result.actor_ref,
+            ActorRef::anonymous(),
+            "empty actor.id must leave actor_ref as anonymous"
+        );
     }
 
     #[test]
     fn runtime_config_from_khive_config_absent_actor_id_keeps_base_namespace() {
+        use khive_gate::ActorRef;
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::parse("lambda:base").unwrap(),
+            actor_ref: ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -956,13 +972,20 @@ mod tests {
             "lambda:base",
             "absent actor.id must not override base namespace"
         );
+        assert_eq!(
+            result.actor_ref,
+            ActorRef::anonymous(),
+            "absent actor.id must leave actor_ref as anonymous"
+        );
     }
 
     #[test]
     fn runtime_config_from_khive_config_actor_id_with_engines() {
+        use khive_gate::ActorRef;
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -990,6 +1013,8 @@ mod tests {
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(result.default_namespace.as_str(), "lambda:test");
         assert!(result.embedding_model.is_some());
+        assert_eq!(result.actor_ref.kind, "lambda");
+        assert_eq!(result.actor_ref.id, "test");
     }
 
     // ---- list_embedding_models tests ----

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -3,7 +3,7 @@
 //! Tests cover entity CRUD, graph operations, note memory, GQL query,
 //! and namespace isolation using an in-memory runtime.
 
-use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+use khive_runtime::{ActorRef, KhiveConfig, KhiveRuntime, Namespace, RuntimeConfig};
 use khive_storage::types::{Direction, TraversalOptions, TraversalRequest};
 use khive_storage::{EdgeRelation, Event};
 use khive_types::{EventKind, SubstrateKind};
@@ -2323,5 +2323,84 @@ async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
     assert_eq!(
         fetched.id, entity_in_extra.id,
         "visible-set read of extra-namespace entity must succeed"
+    );
+}
+
+// =============================================================================
+// ST1 actor_ref wiring — direct authorize helpers (PR #147 / issue #75-ST1)
+// =============================================================================
+
+/// [ST1-FIX3] KhiveRuntime::authorize must embed the configured actor_ref in the
+/// minted NamespaceToken, not hard-code ActorRef::anonymous().
+///
+/// This is the direct-helper proof for ST1's deliverable: a typed ActorRef is
+/// correctly stored on RuntimeConfig and flows through to every token minted by
+/// the authorize / authorize_with_visibility helpers. The live MCP dispatch path
+/// (GateRequest + NamespaceToken minted inside VerbRegistry::dispatch) is wired
+/// in #75-ST2 and is intentionally NOT covered here.
+///
+/// Non-vacuity: removing the `actor: self.config.actor_ref.clone()` lines from
+/// KhiveRuntime::authorize / authorize_with_visibility (reverting to
+/// ActorRef::anonymous()) causes this test to fail — both assertions would produce
+/// `actor_ref == anonymous:local` instead of the expected lambda actor.
+#[test]
+fn st1_authorize_embeds_configured_actor_ref() {
+    let configured_actor = ActorRef::new("lambda", "cli-actor");
+    let cfg = RuntimeConfig {
+        db_path: None, // in-memory
+        actor_ref: configured_actor.clone(),
+        ..RuntimeConfig::default()
+    };
+    let rt = KhiveRuntime::new(cfg).expect("runtime from config");
+    let ns = Namespace::parse("lambda:cli-actor").expect("valid namespace");
+
+    // authorize: token actor must match the configured actor.
+    let tok = rt.authorize(ns.clone()).expect("authorize must succeed");
+    assert_eq!(
+        tok.actor(),
+        &configured_actor,
+        "authorize: token actor must be the configured actor, not anonymous"
+    );
+
+    // authorize_with_visibility: same guarantee with an extra visibility set.
+    let extra = vec![Namespace::parse("lambda:other").expect("valid ns")];
+    let vis_tok = rt
+        .authorize_with_visibility(ns, extra)
+        .expect("authorize_with_visibility must succeed");
+    assert_eq!(
+        vis_tok.actor(),
+        &configured_actor,
+        "authorize_with_visibility: token actor must be the configured actor, not anonymous"
+    );
+}
+
+/// [ST1-FIX2-config] The reserved "anonymous" kind in a two-segment actor.id must
+/// be rejected at config load time, not silently coerced to anonymous identity.
+///
+/// Non-vacuity: removing the anonymous-kind check from KhiveConfig::validate causes
+/// this test to fail — KhiveConfig::load succeeds and silently produces an anonymous
+/// actor_ref when runtime_config_from_khive_config is called.
+#[test]
+fn st1_config_file_anonymous_kind_is_rejected_at_load() {
+    use khive_runtime::ConfigError;
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("config.toml");
+    writeln!(
+        std::fs::File::create(&path).unwrap(),
+        "[actor]\nid = \"anonymous:local\"\n"
+    )
+    .unwrap();
+
+    let err = KhiveConfig::load(Some(&path))
+        .expect_err("anonymous:local actor.id must fail at config load");
+    assert!(
+        matches!(err, ConfigError::InvalidActorRef { .. }),
+        "expected ConfigError::InvalidActorRef for reserved anonymous kind, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("reserved"),
+        "error message must explain the reserved-kind rejection; got: {err}"
     );
 }

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -564,6 +564,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             db_path: Some(path.clone()),
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: None,
             gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
             packs: vec!["kg".to_string()],
@@ -585,6 +586,7 @@ async fn file_backed_runtime_persists() {
         let config = RuntimeConfig {
             db_path: Some(path.clone()),
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: None,
             gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
             packs: vec!["kg".to_string()],
@@ -1074,6 +1076,7 @@ mod embedder_registry_tests {
         KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: None,
             additional_embedding_models: vec![],
             gate: Arc::new(AllowAllGate),
@@ -1134,6 +1137,7 @@ mod embedder_registry_tests {
         let rt = KhiveRuntime::new(RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
+            actor_ref: khive_runtime::ActorRef::anonymous(),
             embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
             additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],
             gate: Arc::new(AllowAllGate),


### PR DESCRIPTION
## Summary

Implements ST1 of issue #75: parse the \`[actor]\` section from khive config into a typed \`ActorRef\` on \`RuntimeConfig\`, and wire it through the direct \`KhiveRuntime::authorize\` / \`authorize_with_visibility\` helpers.

### ST1 scope (this PR)

- **Parse and store** a typed \`ActorRef\` on \`RuntimeConfig\` from ALL config sources: config-file \`[actor] id\`, CLI \`--actor\` / \`KHIVE_ACTOR\`, and the legacy \`--namespace\` / \`KHIVE_NAMESPACE\` alias.
- **Wire the direct authorize helpers**: \`KhiveRuntime::authorize\` and \`authorize_with_visibility\` embed \`self.config.actor_ref\` into every minted \`NamespaceToken\` (replacing the prior hardcoded \`ActorRef::anonymous()\`).
- **Fail closed on reserved kinds**: explicit configuration of an \`anonymous:*\` actor is rejected at load/parse time with \`ConfigError::InvalidActorRef\`.

### ST2 scope (NOT in this PR — tracked in #75-ST2)

The live MCP/pack dispatch path (\`GateRequest\` construction at \`pack.rs:686\` and \`NamespaceToken::mint\` at \`pack.rs:767-770\`) wires the configured actor in **ST2, not here**. Until ST2 lands, \`VerbRegistry::dispatch\` still constructs \`GateRequest::new(ActorRef::anonymous(), ...)\` and mints an anonymous token — this is **by design** for ST1. Files \`crates/khive-runtime/src/pack.rs\` and \`crates/khive-mcp/src/server.rs\` are intentionally untouched in this PR.

## Changes

- \`crates/khive-runtime/src/config.rs\` — \`actor_ref_from_namespace_str()\` helper (pub(crate)), new \`actor_ref_from_configured_namespace_str()\` (pub) that additionally rejects reserved \`anonymous\` kind in two-segment form; \`RuntimeConfig::actor_ref\` field; \`runtime_config_from_khive_config\` updated; 8 unit tests
- \`crates/khive-runtime/src/engine_config.rs\` — \`ConfigError::InvalidActorRef\` variant; \`KhiveConfig::validate()\` rejects \`anonymous:*\` actor.id at load time
- \`crates/khive-runtime/src/lib.rs\` — re-export \`actor_ref_from_configured_namespace_str\`
- \`crates/khive-runtime/src/runtime.rs\` — wire \`actor_ref\` into both authorize paths
- \`crates/khive-mcp/src/serve.rs\` — derive \`actor_ref\` from CLI namespace when \`namespace_explicit=true\`; 2 new serve-layer tests
- \`crates/khive-runtime/tests/integration.rs\` — 2 new ST1 integration tests

## Follow-up findings addressed

- **Critical** (parsed actor never reaches VerbRegistry::dispatch): re-attributed to ST2 by design; not fixed here.
- **High** (CLI/env actor_ref hole): fixed — \`resolve_runtime_config\` now derives \`actor_ref\` from the CLI namespace string via \`actor_ref_from_configured_namespace_str\` when \`namespace_explicit=true\`.
- **Medium** (ambiguous reserved actor kinds): fixed — \`anonymous:*\` in two-segment form is rejected at both config-file load (\`KhiveConfig::validate\`) and CLI parse time; test confirms rejection with clear error message.

## New tests (4 added in this round, on top of the 8 earlier tests)

- \`serve::tests::cli_actor_sets_actor_ref_on_runtime_config\` — proves the High fix: CLI actor produces non-anonymous \`actor_ref\`
- \`serve::tests::cli_actor_anonymous_kind_is_rejected\` — proves the Medium fix: \`anonymous:*\` two-segment form is rejected
- \`st1_authorize_embeds_configured_actor_ref\` — proves the ST1 deliverable: \`rt.authorize(ns).actor()\` and \`rt.authorize_with_visibility(ns, …).actor()\` return the configured actor
- \`st1_config_file_anonymous_kind_is_rejected_at_load\` — proves config-file path also rejects \`anonymous:local\`

## Gate results (commit b6c3b85)

- \`cargo test -p khive-runtime -p khive-mcp\`: RC=0
- \`cargo clippy -p khive-runtime -p khive-mcp --all-targets -- -D warnings\`: RC=0
- \`cargo fmt --all -- --check\`: RC=0

## Test plan

- [x] Run \`cargo test -p khive-runtime -p khive-mcp\` — all pass
- [x] Confirm new tests fail when corresponding fix is reverted (non-vacuity verified for each)
- [x] Scope fence confirmed: \`pack.rs\` and \`server.rs\` are untouched