### PR TITLE
fix(storage): drop storage-layer + by-ID namespace enforcement (ADR-007 dumb storage) [PR-A1]

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -864,13 +864,14 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn purge_incident_edges(&self, node_id: Uuid) -> Result<u64, StorageError> {
-        let namespace = self.namespace.clone();
         let id_str = node_id.to_string();
+        // No namespace filter: UUID v4 is globally unique. Hard-delete cascade must
+        // remove ALL incident edges regardless of which namespace they were written in
+        // (ADR-002 no-dangling-references, ADR-007 by-ID contract).
         self.with_writer("purge_incident_edges", move |conn| {
             let affected = conn.execute(
-                "DELETE FROM graph_edges \
-                 WHERE namespace = ?1 AND (source_id = ?2 OR target_id = ?2)",
-                rusqlite::params![namespace, id_str],
+                "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1",
+                rusqlite::params![id_str],
             )?;
             Ok(affected as u64)
         })

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -32,11 +32,20 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 pub struct SqlGraphStore {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
+    /// Default namespace for multi-record queries (ADR-007 PARAM-ONLY: used as a
+    /// WHERE filter on `query_edges`/`neighbors`/`traverse`, never as an
+    /// enforcement gate on by-ID operations).
     namespace: String,
 }
 
 impl SqlGraphStore {
-    /// Create a new store scoped to one namespace.
+    /// Create a new store with a default namespace for multi-record query filtering.
+    ///
+    /// The namespace is a PARAM-ONLY hint (ADR-007 rule 4) — it is used as a
+    /// WHERE filter in multi-record queries and as the write namespace stamped on
+    /// upserted edges, but it does NOT enforce isolation: `upsert_edge` accepts
+    /// edges from any namespace, and by-ID ops (`get_edge`, `delete_edge`) ignore
+    /// the namespace entirely.
     pub fn new_scoped(
         pool: Arc<ConnectionPool>,
         is_file_backed: bool,
@@ -321,17 +330,7 @@ fn canonical_edge_endpoints(
 #[async_trait]
 impl GraphStore for SqlGraphStore {
     async fn upsert_edge(&self, edge: Edge) -> Result<(), StorageError> {
-        let namespace = self.namespace.clone();
-        if edge.namespace != namespace {
-            return Err(StorageError::InvalidInput {
-                capability: StorageCapability::Graph,
-                operation: "upsert_edge".into(),
-                message: format!(
-                    "edge namespace {:?} does not match store namespace {:?}",
-                    edge.namespace, namespace
-                ),
-            });
-        }
+        let namespace = edge.namespace.clone();
         let id_str = Uuid::from(edge.id).to_string();
         let (source_id, target_id) =
             canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
@@ -386,21 +385,6 @@ impl GraphStore for SqlGraphStore {
 
     async fn upsert_edges(&self, edges: Vec<Edge>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = edges.len() as u64;
-        let namespace = self.namespace.clone();
-
-        // Validate namespaces before acquiring writer.
-        for edge in &edges {
-            if edge.namespace != namespace {
-                return Err(StorageError::InvalidInput {
-                    capability: StorageCapability::Graph,
-                    operation: "upsert_edges".into(),
-                    message: format!(
-                        "edge namespace {:?} does not match store namespace {:?}",
-                        edge.namespace, namespace
-                    ),
-                });
-            }
-        }
 
         self.with_writer("upsert_edges", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
@@ -440,7 +424,7 @@ impl GraphStore for SqlGraphStore {
                          metadata = excluded.metadata, \
                          target_backend = excluded.target_backend",
                     rusqlite::params![
-                        &namespace,
+                        edge.namespace.as_str(),
                         id_str,
                         src_str,
                         tgt_str,
@@ -474,16 +458,15 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn get_edge(&self, id: LinkId) -> Result<Option<Edge>, StorageError> {
-        let namespace = self.namespace.clone();
         let id_str = Uuid::from(id).to_string();
 
         self.with_reader("get_edge", move |conn| {
             let mut stmt = conn.prepare(
                 "SELECT namespace, id, source_id, target_id, relation, weight, \
                         created_at, updated_at, deleted_at, metadata, target_backend \
-                 FROM graph_edges WHERE namespace = ?1 AND id = ?2 AND deleted_at IS NULL",
+                 FROM graph_edges WHERE id = ?1 AND deleted_at IS NULL",
             )?;
-            let mut rows = stmt.query(rusqlite::params![namespace, id_str])?;
+            let mut rows = stmt.query(rusqlite::params![id_str])?;
             match rows.next()? {
                 Some(row) => Ok(Some(read_edge(row)?)),
                 None => Ok(None),
@@ -493,16 +476,15 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn get_edge_including_deleted(&self, id: LinkId) -> Result<Option<Edge>, StorageError> {
-        let namespace = self.namespace.clone();
         let id_str = Uuid::from(id).to_string();
 
         self.with_reader("get_edge_including_deleted", move |conn| {
             let mut stmt = conn.prepare(
                 "SELECT namespace, id, source_id, target_id, relation, weight, \
                         created_at, updated_at, deleted_at, metadata, target_backend \
-                 FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+                 FROM graph_edges WHERE id = ?1",
             )?;
-            let mut rows = stmt.query(rusqlite::params![namespace, id_str])?;
+            let mut rows = stmt.query(rusqlite::params![id_str])?;
             match rows.next()? {
                 Some(row) => Ok(Some(read_edge(row)?)),
                 None => Ok(None),
@@ -512,19 +494,18 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> Result<bool, StorageError> {
-        let namespace = self.namespace.clone();
         let id_str = Uuid::from(id).to_string();
 
         self.with_writer("delete_edge", move |conn| {
             let affected = match mode {
                 DeleteMode::Soft => conn.execute(
-                    "UPDATE graph_edges SET deleted_at = ?3, updated_at = ?3 \
-                     WHERE namespace = ?1 AND id = ?2 AND deleted_at IS NULL",
-                    rusqlite::params![namespace, id_str, chrono::Utc::now().timestamp_micros(),],
+                    "UPDATE graph_edges SET deleted_at = ?2, updated_at = ?2 \
+                     WHERE id = ?1 AND deleted_at IS NULL",
+                    rusqlite::params![id_str, chrono::Utc::now().timestamp_micros()],
                 )?,
                 DeleteMode::Hard => conn.execute(
-                    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
-                    rusqlite::params![namespace, id_str],
+                    "DELETE FROM graph_edges WHERE id = ?1",
+                    rusqlite::params![id_str],
                 )?,
             };
             Ok(affected > 0)

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -548,3 +548,72 @@ async fn upsert_edge_non_symmetric_relation_preserves_direction() {
         "non-symmetric edge direction must be preserved"
     );
 }
+
+// ADR-007 PR-A1 regression: upsert must accept edges whose namespace differs
+// from the store's construction-time namespace.  Before the fix, `upsert_edge`
+// rejected this with InvalidInput; after, it stores the edge with whatever
+// namespace the edge carries and get_edge finds it by UUID alone.
+#[tokio::test]
+async fn upsert_edge_cross_namespace_accepted() {
+    // Store is constructed with "local" as its default multi-record query namespace.
+    let store = setup_memory_store(); // uses "default" as construction namespace
+
+    let src = Uuid::new_v4();
+    let tgt = Uuid::new_v4();
+    let now = Utc::now();
+
+    // Edge carries "lambda:leo" — different from store's "default".
+    let edge = Edge {
+        id: Uuid::new_v4().into(),
+        namespace: "lambda:leo".to_string(),
+        source_id: src,
+        target_id: tgt,
+        relation: EdgeRelation::Extends,
+        weight: 0.9,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+        metadata: None,
+        target_backend: None,
+    };
+    let edge_id = edge.id;
+
+    // Must not error (V1 violation removed).
+    store.upsert_edge(edge).await.unwrap();
+
+    // get_edge by UUID must find it regardless of namespace.
+    let stored = store.get_edge(edge_id).await.unwrap();
+    assert!(
+        stored.is_some(),
+        "cross-namespace edge must be retrievable by UUID"
+    );
+    let stored = stored.unwrap();
+    assert_eq!(
+        stored.namespace, "lambda:leo",
+        "namespace column must be preserved as stored"
+    );
+}
+
+// ADR-007 PR-A1 regression: namespace column is preserved on the record even
+// after upsert — not silently overwritten with the store's construction namespace.
+#[tokio::test]
+async fn upsert_edge_namespace_stored_on_record() {
+    let store = setup_memory_store();
+
+    let edge = make_edge(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        EdgeRelation::Implements,
+        1.0,
+    );
+    let edge_id = edge.id;
+    let ns = edge.namespace.clone();
+
+    store.upsert_edge(edge).await.unwrap();
+
+    let stored = store.get_edge(edge_id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.namespace, ns,
+        "namespace column must survive the write/read roundtrip"
+    );
+}

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -132,7 +132,11 @@ mod tests {
 
     use super::*;
 
-    /// Entity created under `tenant-a` is visible to `tenant-a` and opaque to `tenant-b`.
+    /// Entity created under `tenant-a` is namespaced correctly; by-ID get is namespace-agnostic.
+    ///
+    /// PR-A1 (ADR-007): by-ID `get` returns a record regardless of the caller's namespace.
+    /// Namespace on the returned record must still reflect the creator's namespace.
+    /// list/search still filter by namespace (PR-B scope).
     #[tokio::test]
     async fn kg_create_entity_honors_caller_namespace() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -157,7 +161,7 @@ mod tests {
                 json!({
                     "kind": "concept",
                     "name": "TenantConcept",
-                    "description": "concept visible only to tenant-a"
+                    "description": "concept created by tenant-a"
                 }),
                 &registry,
                 &tenant_a,
@@ -170,12 +174,21 @@ mod tests {
             .and_then(|v| v.as_str())
             .expect("result must contain id");
 
+        // namespace on the stored record must be tenant-a's namespace.
+        assert_eq!(
+            result
+                .get("namespace")
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            "tenant-a",
+            "entity namespace must be the creator's namespace"
+        );
+
         // tenant-a can retrieve the entity it created.
         let get_result = pack
             .dispatch("get", json!({ "id": entity_id }), &registry, &tenant_a)
             .await
             .expect("tenant-a must retrieve entity in its own namespace");
-
         assert_eq!(
             get_result
                 .get("name")
@@ -185,14 +198,35 @@ mod tests {
             "tenant-a must read back the entity it created"
         );
 
-        // tenant-b cannot see tenant-a's entity.
-        let not_found = pack
+        // PR-A1: tenant-b can also retrieve the entity by UUID — by-ID get is namespace-agnostic.
+        let cross_ns = pack
             .dispatch("get", json!({ "id": entity_id }), &registry, &tenant_b)
-            .await;
+            .await
+            .expect("tenant-b must find entity by UUID after PR-A1");
+        assert_eq!(
+            cross_ns
+                .get("namespace")
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            "tenant-a",
+            "namespace on fetched record must still be tenant-a (not rewritten to caller ns)"
+        );
+
+        // list from tenant-b must NOT return tenant-a's entity (list is namespace-scoped — PR-B).
+        let list = pack
+            .dispatch("list", json!({ "kind": "entity" }), &registry, &tenant_b)
+            .await
+            .expect("list must succeed");
+        let items = list
+            .get("items")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
         assert!(
-            matches!(not_found, Err(RuntimeError::NotFound(_))),
-            "tenant-b must not see tenant-a's entity (expected NotFound, got {:?})",
-            not_found
+            items
+                .iter()
+                .all(|e| e.get("namespace").and_then(|v| v.as_str()) != Some("tenant-a")),
+            "list from tenant-b must not include tenant-a entities; got {items:?}"
         );
     }
 

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -61,6 +61,8 @@ impl KgPack {
             Err(e) => return Err(e),
         }
 
+        // PR-A1: by-ID get returns the note regardless of namespace (UUID v4 is globally unique).
+        // Visible-set gating removed here; list/search keep their namespace filter (PR-B scope).
         if let Some(note) = self
             .runtime
             .notes(token)?
@@ -68,17 +70,13 @@ impl KgPack {
             .await
             .map_err(RuntimeError::Storage)?
         {
-            if token
-                .visible_namespace_strs()
-                .contains(&note.namespace.as_str())
-            {
-                let note_val = normalize_entity_timestamps(to_json(&note)?);
-                let remapped = remap_note_status(note_val);
-                return flatten_get_result("note", remapped);
-            }
+            let note_val = normalize_entity_timestamps(to_json(&note)?);
+            let remapped = remap_note_status(note_val);
+            return flatten_get_result("note", remapped);
         }
 
-        if let Some(edge) = self.runtime.get_edge_visible(token, id).await? {
+        // PR-A1: by-ID edge get returns the edge regardless of namespace.
+        if let Some(edge) = self.runtime.get_edge(token, id).await? {
             return flatten_get_result("edge", to_json(&edge)?);
         }
 

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -22,7 +22,9 @@ impl KgPack {
         id_str: &str,
     ) -> Result<KindSpec, RuntimeError> {
         use khive_runtime::Resolved;
-        match self.runtime.resolve(token, id).await? {
+        // PR-A1 (codex r2): by-ID substrate inference must NOT gate on caller namespace.
+        // UUID v4 is globally unique — resolve without visible-set or primary-ns check.
+        match self.runtime.resolve_by_id(token, id).await? {
             Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
             Some(Resolved::Note(_)) => Ok(KindSpec::Note { specific: None }),
             _ => {
@@ -42,7 +44,12 @@ impl KgPack {
         id_str: &str,
     ) -> Result<KindSpec, RuntimeError> {
         use khive_runtime::Resolved;
-        match self.runtime.resolve_including_deleted(token, id).await? {
+        // PR-A1 (codex r2): hard-delete path must also locate foreign records.
+        match self
+            .runtime
+            .resolve_by_id_including_deleted(token, id)
+            .await?
+        {
             Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
             Some(Resolved::Note(_)) => Ok(KindSpec::Note { specific: None }),
             _ => {

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3861,6 +3861,239 @@ async fn update_edge_to_symmetric_relation_no_duplicate_when_canonical_exists() 
     );
 }
 
+/// Cross-namespace update_edge (weight-only, non-symmetric): must succeed.
+///
+/// ADR-007 rule 2: by-ID update applies NO namespace filter. UUID v4 is globally
+/// unique. The caller's namespace is attribution only.
+#[tokio::test]
+async fn update_edge_cross_namespace_weight_update_succeeds() {
+    let f = pack();
+
+    let src = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CrossNsEdgeSrc"}),
+        )
+        .await
+        .expect("create src");
+    let tgt = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CrossNsEdgeTgt"}),
+        )
+        .await
+        .expect("create tgt");
+    let src_id = src["id"].as_str().unwrap();
+    let tgt_id = tgt["id"].as_str().unwrap();
+
+    // Link in the default (local) namespace.
+    let link = f
+        .dispatch(
+            "link",
+            json!({"source_id": src_id, "target_id": tgt_id, "relation": "extends", "weight": 0.5}),
+        )
+        .await
+        .expect("link extends must succeed");
+    let edge_id = link["id"].as_str().unwrap().to_string();
+
+    // Update weight from a DIFFERENT namespace — must succeed (by-ID contract).
+    let updated = f
+        .dispatch(
+            "update",
+            json!({"kind": "edge", "id": edge_id, "weight": 0.9, "namespace": "ns-caller"}),
+        )
+        .await;
+    assert!(
+        updated.is_ok(),
+        "cross-namespace weight update must succeed (ADR-007); got: {updated:?}"
+    );
+    let updated = updated.unwrap();
+    assert_eq!(
+        updated.get("weight").and_then(Value::as_f64),
+        Some(0.9),
+        "weight must be updated to 0.9"
+    );
+    // The stored namespace must remain the record's original namespace (local), not the caller's.
+    assert_eq!(
+        updated.get("namespace").and_then(Value::as_str),
+        Some("local"),
+        "edge namespace must remain the record's stored namespace after cross-ns update"
+    );
+}
+
+/// Cross-namespace update_edge (weight-only, symmetric relation): must succeed.
+///
+/// Symmetric relations use the raw-SQL path with namespace predicates. Confirm that
+/// `record_ns` (not caller ns) is used so the UPDATE matches the row.
+#[tokio::test]
+async fn update_edge_cross_namespace_weight_update_symmetric_succeeds() {
+    let f = pack();
+
+    let a = f
+        .dispatch("create", json!({"kind": "concept", "name": "CrossNsSymA"}))
+        .await
+        .expect("create A");
+    let b = f
+        .dispatch("create", json!({"kind": "concept", "name": "CrossNsSymB"}))
+        .await
+        .expect("create B");
+    let a_id = a["id"].as_str().unwrap();
+    let b_id = b["id"].as_str().unwrap();
+
+    // Link as competes_with (symmetric) in the default namespace.
+    let link = f
+        .dispatch(
+            "link",
+            json!({"source_id": a_id, "target_id": b_id, "relation": "competes_with", "weight": 0.4}),
+        )
+        .await
+        .expect("link competes_with must succeed");
+    let edge_id = link["id"].as_str().unwrap().to_string();
+
+    // Update weight from a DIFFERENT namespace (symmetric raw-SQL path).
+    let updated = f
+        .dispatch(
+            "update",
+            json!({"kind": "edge", "id": edge_id, "weight": 0.8, "namespace": "ns-caller"}),
+        )
+        .await;
+    assert!(
+        updated.is_ok(),
+        "cross-namespace weight update (symmetric) must succeed; got: {updated:?}"
+    );
+    assert_eq!(
+        updated.unwrap().get("weight").and_then(Value::as_f64),
+        Some(0.8),
+        "weight must be updated to 0.8"
+    );
+}
+
+/// Cross-namespace update_edge (relation change): must succeed.
+///
+/// Relation validation uses `record_tok` (not caller token) to look up endpoints.
+/// Endpoints live in the edge's own namespace (local); caller is in ns-caller.
+#[tokio::test]
+async fn update_edge_cross_namespace_relation_change_succeeds() {
+    let f = pack();
+
+    let src = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CrossNsRelSrc"}),
+        )
+        .await
+        .expect("create src");
+    let tgt = f
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "CrossNsRelTgt"}),
+        )
+        .await
+        .expect("create tgt");
+    let src_id = src["id"].as_str().unwrap();
+    let tgt_id = tgt["id"].as_str().unwrap();
+
+    // Link as extends in the default (local) namespace.
+    let link = f
+        .dispatch(
+            "link",
+            json!({"source_id": src_id, "target_id": tgt_id, "relation": "extends"}),
+        )
+        .await
+        .expect("link extends must succeed");
+    let edge_id = link["id"].as_str().unwrap().to_string();
+
+    // Change relation to supersedes from a DIFFERENT namespace.
+    // Endpoint validation must use record_tok (local) — src and tgt are in local ns.
+    let updated = f
+        .dispatch(
+            "update",
+            json!({"kind": "edge", "id": edge_id, "relation": "supersedes", "namespace": "ns-caller"}),
+        )
+        .await;
+    assert!(
+        updated.is_ok(),
+        "cross-namespace relation change must succeed when endpoints are in record ns; got: {updated:?}"
+    );
+    assert_eq!(
+        updated.unwrap().get("relation").and_then(Value::as_str),
+        Some("supersedes"),
+        "relation must be updated to supersedes"
+    );
+}
+
+/// Update a note's content from a DIFFERENT namespace — must succeed.
+///
+/// ADR-007 rule 2: by-ID update applies NO namespace filter. This test exercises
+/// `infer_kind_from_uuid`, which uses `resolve_by_id` (not `resolve`). The old
+/// `resolve` gated notes on the visible-set, which excluded the record's namespace
+/// when the caller token's primary ns differed — causing spurious NotFound.
+///
+/// Non-vacuity: this test FAILS if `infer_kind_from_uuid` calls `resolve` instead
+/// of `resolve_by_id`, because `resolve` applies `ensure_namespace_visible`, which
+/// rejects the note in "local" when the token's primary is "ns-caller".
+#[tokio::test]
+async fn update_note_cross_namespace_succeeds() {
+    let f = pack();
+
+    // Create note in the default (local) namespace.
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "original content"}),
+        )
+        .await
+        .expect("create note must succeed");
+    let note_id = created["id"].as_str().unwrap().to_string();
+
+    // Update the note from a DIFFERENT namespace — must succeed (by-ID contract).
+    let updated = f
+        .dispatch(
+            "update",
+            json!({"id": note_id, "content": "updated content", "namespace": "ns-caller"}),
+        )
+        .await;
+    assert!(
+        updated.is_ok(),
+        "cross-namespace note update must succeed (ADR-007 rule 2); got: {updated:?}"
+    );
+    assert_eq!(
+        updated.unwrap().get("content").and_then(Value::as_str),
+        Some("updated content"),
+        "content must be updated"
+    );
+}
+
+/// Soft-delete a note from a DIFFERENT namespace — must succeed.
+///
+/// Same ADR-007 rule 2 contract as above, but exercises the soft-delete path
+/// through `infer_kind_from_uuid`. Non-vacuity: FAILS with old `resolve`.
+#[tokio::test]
+async fn delete_note_cross_namespace_succeeds() {
+    let f = pack();
+
+    let created = f
+        .dispatch(
+            "create",
+            json!({"kind": "observation", "content": "delete me cross ns"}),
+        )
+        .await
+        .expect("create note must succeed");
+    let note_id = created["id"].as_str().unwrap().to_string();
+
+    let result = f
+        .dispatch("delete", json!({"id": note_id, "namespace": "ns-caller"}))
+        .await;
+    assert!(
+        result.is_ok(),
+        "cross-namespace soft delete of a note must succeed (ADR-007); got: {result:?}"
+    );
+    assert_eq!(
+        result.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
 // ADR-045 §5 round-5 blocker: payload-level Timestamp fields must be ISO-8601
 // strings at the MCP boundary, not raw integer microseconds.
 //
@@ -5597,11 +5830,15 @@ async fn hard_delete_soft_deleted_entity_cascades_edges() {
     );
 }
 
-/// Hard-delete a soft-deleted entity from a different namespace must be denied.
+/// Hard-delete a soft-deleted entity from a different namespace must SUCCEED.
+///
+/// ADR-007 rule 2: by-ID delete applies NO namespace filter. UUID v4 is globally unique.
+/// The caller's namespace is attribution only — it does not gate the operation.
 #[tokio::test]
-async fn hard_delete_soft_deleted_entity_cross_namespace_denied() {
+async fn hard_delete_soft_deleted_entity_cross_namespace_succeeds() {
     let f = pack();
 
+    // Create entity in the default (local) namespace.
     let created = f
         .dispatch(
             "create",
@@ -5611,19 +5848,33 @@ async fn hard_delete_soft_deleted_entity_cross_namespace_denied() {
         .expect("create must succeed");
     let id = created["id"].as_str().unwrap().to_string();
 
+    // Soft-delete from the record's own namespace.
     f.dispatch("delete", json!({"id": id}))
         .await
         .expect("soft delete must succeed");
 
+    // Hard-delete from a DIFFERENT namespace — must succeed (by-ID contract).
     let result = f
         .dispatch(
             "delete",
-            json!({"id": id, "hard": true, "namespace": "ns-attacker"}),
+            json!({"id": id, "hard": true, "namespace": "ns-caller"}),
         )
         .await;
     assert!(
-        result.is_err(),
-        "cross-namespace hard delete of a soft-deleted entity must be denied; got: {result:?}"
+        result.is_ok(),
+        "cross-namespace hard delete of a soft-deleted entity must succeed (ADR-007); got: {result:?}"
+    );
+    assert_eq!(
+        result.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true),
+        "hard delete result must carry deleted=true"
+    );
+
+    // Confirm the row is physically gone — a second hard delete must return not-found.
+    let second = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        second.is_err(),
+        "second hard delete must fail — entity row is physically gone; got: {second:?}"
     );
 }
 
@@ -5665,11 +5916,14 @@ async fn hard_delete_purges_soft_deleted_note() {
     );
 }
 
-/// Hard-delete a soft-deleted note from a different namespace must be denied.
+/// Hard-delete a soft-deleted note from a different namespace must SUCCEED.
+///
+/// ADR-007 rule 2: by-ID delete applies NO namespace filter. UUID v4 is globally unique.
 #[tokio::test]
-async fn hard_delete_soft_deleted_note_cross_namespace_denied() {
+async fn hard_delete_soft_deleted_note_cross_namespace_succeeds() {
     let f = pack();
 
+    // Create note in the default (local) namespace.
     let created = f
         .dispatch(
             "create",
@@ -5679,19 +5933,33 @@ async fn hard_delete_soft_deleted_note_cross_namespace_denied() {
         .expect("create note must succeed");
     let id = created["id"].as_str().unwrap().to_string();
 
+    // Soft-delete from the record's own namespace.
     f.dispatch("delete", json!({"id": id}))
         .await
         .expect("soft delete must succeed");
 
+    // Hard-delete from a DIFFERENT namespace — must succeed (by-ID contract).
     let result = f
         .dispatch(
             "delete",
-            json!({"id": id, "hard": true, "namespace": "ns-attacker"}),
+            json!({"id": id, "hard": true, "namespace": "ns-caller"}),
         )
         .await;
     assert!(
-        result.is_err(),
-        "cross-namespace hard delete of a soft-deleted note must be denied; got: {result:?}"
+        result.is_ok(),
+        "cross-namespace hard delete of a soft-deleted note must succeed (ADR-007); got: {result:?}"
+    );
+    assert_eq!(
+        result.unwrap().get("deleted").and_then(Value::as_bool),
+        Some(true),
+        "hard delete result must carry deleted=true"
+    );
+
+    // Confirm the row is physically gone — a second hard delete must return not-found.
+    let second = f.dispatch("delete", json!({"id": id, "hard": true})).await;
+    assert!(
+        second.is_err(),
+        "second hard delete must fail — note row is physically gone; got: {second:?}"
     );
 }
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3919,6 +3919,24 @@ async fn update_edge_cross_namespace_weight_update_succeeds() {
         Some("local"),
         "edge namespace must remain the record's stored namespace after cross-ns update"
     );
+
+    // Non-vacuity: re-fetch the edge from storage and assert the persisted row has
+    // the new weight and original record namespace. This test FAILS (RC 101) if the
+    // non-symmetric upsert_edge persistence call is removed/no-op'd.
+    let fetched = f
+        .dispatch("get", json!({"id": edge_id}))
+        .await
+        .expect("get edge after cross-ns update must succeed");
+    assert_eq!(
+        fetched.get("weight").and_then(Value::as_f64),
+        Some(0.9),
+        "persisted weight must be 0.9 after cross-ns update (storage persistence check)"
+    );
+    assert_eq!(
+        fetched.get("namespace").and_then(Value::as_str),
+        Some("local"),
+        "persisted namespace must remain 'local' (record ns) after cross-ns update"
+    );
 }
 
 /// Cross-namespace update_edge (weight-only, symmetric relation): must succeed.

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -199,8 +199,6 @@ impl KhiveRuntime {
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))?;
 
-        Self::ensure_namespace(&entity.namespace, token.namespace().as_str())?;
-
         let mut text_changed = false;
         let mut changed_fields: Vec<&'static str> = Vec::new();
 
@@ -535,8 +533,6 @@ impl KhiveRuntime {
             .get_note(id)
             .await?
             .ok_or_else(|| RuntimeError::NotFound(format!("note {id}")))?;
-
-        Self::ensure_namespace(&note.namespace, token.namespace().as_str())?;
 
         let mut text_changed = false;
 
@@ -2867,11 +2863,10 @@ mod tests {
         );
     }
 
-    // ── #hardening Item 5: cross-namespace entity update/merge must be denied ──
+    // ADR-007 PR-A1: cross-namespace update now succeeds (shared-brain model).
 
     #[tokio::test]
-    async fn update_entity_cross_namespace_returns_not_found_and_preserves_source() {
-        use crate::error::RuntimeError;
+    async fn update_entity_cross_namespace_succeeds() {
         use crate::Namespace;
 
         let rt = rt();
@@ -2891,33 +2886,30 @@ mod tests {
             .await
             .unwrap();
 
-        let err = rt
+        // ADR-007 PR-A1: update from ns_b token must now succeed on an ns_a entity.
+        let result = rt
             .update_entity(
                 &ns_b,
                 entity.id,
                 EntityPatch {
-                    name: Some("Compromised".into()),
+                    name: Some("Updated".into()),
                     ..Default::default()
                 },
             )
             .await;
 
         assert!(
-            matches!(err, Err(RuntimeError::NotFound(_))),
-            "cross-namespace update must return opaque NotFound, got {err:?}"
+            result.is_ok(),
+            "cross-namespace update must succeed in shared-brain OSS; got {result:?}"
         );
-
-        let after = rt.get_entity(&ns_a, entity.id).await.unwrap();
-        assert_eq!(
-            after.name, "Alpha",
-            "foreign update must not mutate source row"
-        );
-        assert_eq!(after.description.as_deref(), Some("original"));
+        assert_eq!(result.unwrap().name, "Updated");
     }
 
+    // merge_entity still requires both entities to be in the same namespace as
+    // the token's write namespace (enforced at the SQL transaction layer, not the
+    // runtime layer).  This is a merge-semantic constraint, not tenant isolation.
     #[tokio::test]
-    async fn merge_entity_cross_namespace_either_id_returns_not_found() {
-        use crate::error::RuntimeError;
+    async fn merge_entity_cross_namespace_ids_fail_at_sql_layer() {
         use crate::Namespace;
 
         let rt = rt();
@@ -2937,7 +2929,7 @@ mod tests {
             .await
             .unwrap();
 
-        // foreign into_id: foreign_b belongs to ns_b, caller token is ns_a
+        // foreign into_id: SQL read_merge_entity checks ns matches token namespace.
         let foreign_into = rt
             .merge_entity(
                 &ns_a,
@@ -2948,11 +2940,11 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(foreign_into, Err(RuntimeError::NotFound(_))),
-            "foreign into_id must be denied before merge, got {foreign_into:?}"
+            foreign_into.is_err(),
+            "cross-namespace into_id must still fail at SQL layer; got {foreign_into:?}"
         );
 
-        // foreign from_id: foreign_b belongs to ns_b, caller token is ns_a
+        // foreign from_id: same SQL constraint.
         let foreign_from = rt
             .merge_entity(
                 &ns_a,
@@ -2963,8 +2955,8 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(foreign_from, Err(RuntimeError::NotFound(_))),
-            "foreign from_id must be denied before merge, got {foreign_from:?}"
+            foreign_from.is_err(),
+            "cross-namespace from_id must still fail at SQL layer; got {foreign_from:?}"
         );
 
         // All three entities survive the failed merges.

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2315,13 +2315,16 @@ impl KhiveRuntime {
     ///
     /// Returns `Ok(false)` if the note does not exist or belongs to a different
     /// namespace (wrong-namespace is indistinguishable from absent).
+    /// Soft-delete or hard-delete a note by ID.
+    ///
+    /// PR-A1: UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// Cascade and index cleanup target the RECORD's stored namespace, not the caller token's.
     pub async fn delete_note(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         hard: bool,
     ) -> RuntimeResult<bool> {
-        let ns = token.namespace().as_str();
         let note_store = self.notes(token)?;
         let note = if hard {
             match note_store.get_note_including_deleted(id).await? {
@@ -2334,30 +2337,33 @@ impl KhiveRuntime {
                 None => return Ok(false),
             }
         };
-        if Self::ensure_namespace(&note.namespace, ns).is_err() {
-            return Ok(false);
-        }
         let mode = if hard {
             DeleteMode::Hard
         } else {
             DeleteMode::Soft
         };
 
+        // Route index cleanup through the RECORD's namespace, not the caller's.
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&note.namespace)
+                .map_err(|e| RuntimeError::Internal(format!("note namespace invalid: {e}")))?,
+        );
+        let record_ns = note.namespace.clone();
+
         // On hard delete, cascade-remove all incident edges (including soft-deleted) and clean up
         // indexes. Uses purge_incident_edges so that already-soft-deleted edges are also removed,
         // preventing dangling graph_edges rows (ADR-002 no-dangling-references).
         if hard {
-            let graph = self.graph(token)?;
+            let graph = self.graph(&record_tok)?;
             graph.purge_incident_edges(id).await?;
-            let ns_str = ns.to_string();
-            self.text_for_notes(token)?
-                .delete_document(&ns_str, id)
+            self.text_for_notes(&record_tok)?
+                .delete_document(&record_ns, id)
                 .await?;
             // Codex High 2 (PR #407): scoped delete — iterate over EVERY
             // registered embedding model's vector store so non-default vectors
             // don't orphan when the note is deleted.
             for model_name in self.registered_embedding_model_names() {
-                self.vectors_for_model(token, &model_name)?
+                self.vectors_for_model(&record_tok, &model_name)?
                     .delete(id)
                     .await?;
             }
@@ -2365,28 +2371,26 @@ impl KhiveRuntime {
 
         let deleted = note_store.delete_note(id, mode).await?;
         if !hard && deleted {
-            let ns_str = ns.to_string();
-            self.text_for_notes(token)?
-                .delete_document(&ns_str, id)
+            self.text_for_notes(&record_tok)?
+                .delete_document(&record_ns, id)
                 .await?;
             for model_name in self.registered_embedding_model_names() {
-                self.vectors_for_model(token, &model_name)?
+                self.vectors_for_model(&record_tok, &model_name)?
                     .delete(id)
                     .await?;
             }
         }
         if deleted {
             let event_store = self.events(token)?;
-            let ns_str = ns.to_string();
             let event = khive_storage::event::Event::new(
-                ns_str.clone(),
+                record_ns.clone(),
                 "delete",
                 EventKind::NoteDeleted,
                 SubstrateKind::Note,
                 "",
             )
             .with_target(id)
-            .with_payload(serde_json::json!({"id": id, "namespace": ns_str, "hard": hard}));
+            .with_payload(serde_json::json!({"id": id, "namespace": record_ns, "hard": hard}));
             event_store.append_event(event).await.map_err(|e| {
                 RuntimeError::Internal(format!("delete_note: event store write failed: {e}"))
             })?;
@@ -2497,18 +2501,24 @@ impl KhiveRuntime {
             DeleteMode::Soft
         };
 
+        // Route cascade and index cleanup through the RECORD's namespace, not the caller's.
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&entity.namespace)
+                .map_err(|e| RuntimeError::Internal(format!("entity namespace invalid: {e}")))?,
+        );
+
         // On hard delete, cascade-remove all incident edges (including soft-deleted) to prevent
         // dangling refs. Uses purge_incident_edges so that already-soft-deleted edges are also
         // removed (ADR-002 no-dangling-references).
         if hard {
-            let graph = self.graph(token)?;
+            let graph = self.graph(&record_tok)?;
             graph.purge_incident_edges(id).await?;
-            self.remove_from_indexes(token, id).await?;
+            self.remove_from_indexes(&record_tok, id).await?;
         }
 
         let deleted = self.entities(token)?.delete_entity(id, mode).await?;
         if !hard && deleted {
-            self.remove_from_indexes(token, id).await?;
+            self.remove_from_indexes(&record_tok, id).await?;
         }
         if deleted {
             let event_store = self.events(token)?;
@@ -2550,13 +2560,13 @@ impl KhiveRuntime {
 
     // ---- Edge CRUD operations ----
 
-    /// Fetch a single edge by id, enforcing namespace isolation.
+    /// Fetch a single edge by id.
     ///
-    /// Returns `Err(NotFound)` if the edge exists in a different namespace,
-    /// `Ok(None)` if no edge with that id exists at all.
+    /// PR-A1: UUID v4 is globally unique — returns the edge regardless of which
+    /// namespace the token carries. `Ok(None)` means the edge does not exist at all.
     pub async fn get_edge(
         &self,
-        token: &NamespaceToken,
+        _token: &NamespaceToken,
         edge_id: Uuid,
     ) -> RuntimeResult<Option<Edge>> {
         let mut reader = self.sql().reader().await?;
@@ -2573,55 +2583,38 @@ impl KhiveRuntime {
         let Some(SqlValue::Text(record_ns)) = record_ns else {
             return Ok(None);
         };
-        // Absent and foreign-namespace IDs must be indistinguishable.
-        if Self::ensure_namespace(&record_ns, token.namespace().as_str()).is_err() {
-            return Ok(None);
-        }
-
-        Ok(self.graph(token)?.get_edge(LinkId::from(edge_id)).await?)
+        // Route the storage fetch through the record's own namespace — the token is
+        // just the caller context; by-ID ops cross namespace boundaries (ADR-007).
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&record_ns)
+                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+        );
+        Ok(self
+            .graph(&record_tok)?
+            .get_edge(LinkId::from(edge_id))
+            .await?)
     }
 
-    /// Fetch a single edge by id from any namespace in the token's visible set.
+    /// Fetch a single edge by id.
     ///
-    /// Returns `Ok(None)` when the edge is absent or its namespace is not in the
-    /// visible set. Used by read paths (e.g. `get` verb) so that a caller with
-    /// cross-namespace visibility can retrieve edges from non-primary namespaces.
+    /// PR-A1: delegates to `get_edge` — visible-set check removed.  By-ID ops are
+    /// namespace-agnostic; UUID v4 is globally unique (ADR-007 rule 2).
     pub async fn get_edge_visible(
         &self,
         token: &NamespaceToken,
         edge_id: Uuid,
     ) -> RuntimeResult<Option<Edge>> {
-        let mut reader = self.sql().reader().await?;
-        let record_ns = reader
-            .query_scalar(SqlStatement {
-                sql: "SELECT namespace FROM graph_edges \
-                      WHERE id = ?1 AND deleted_at IS NULL LIMIT 1"
-                    .into(),
-                params: vec![SqlValue::Text(edge_id.to_string())],
-                label: Some("get_edge_visible_namespace".into()),
-            })
-            .await?;
-        let Some(SqlValue::Text(record_ns)) = record_ns else {
-            return Ok(None);
-        };
-        if Self::ensure_namespace_visible(&record_ns, token).is_err() {
-            return Ok(None);
-        }
-        // Re-use the primary-namespace graph store; the edge row is already confirmed
-        // visible so the namespace token is just used for backend routing here.
-        let temp = NamespaceToken::for_namespace(
-            khive_types::Namespace::parse(&record_ns)
-                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
-        );
-        Ok(self.graph(&temp)?.get_edge(LinkId::from(edge_id)).await?)
+        self.get_edge(token, edge_id).await
     }
 
-    /// Fetch an edge by UUID including soft-deleted rows, returning `None` if absent or if the
-    /// record belongs to a different namespace. Used by the hard-delete path so that a
-    /// soft-deleted primary edge can still be purged via its edge ID.
+    /// Fetch an edge by UUID including soft-deleted rows.
+    ///
+    /// PR-A1: returns the edge regardless of which namespace the token carries —
+    /// UUID v4 is globally unique. Used by the hard-delete path so that a
+    /// soft-deleted edge can still be purged via its edge ID.
     pub async fn get_edge_including_deleted(
         &self,
-        token: &NamespaceToken,
+        _token: &NamespaceToken,
         edge_id: Uuid,
     ) -> RuntimeResult<Option<Edge>> {
         let mut reader = self.sql().reader().await?;
@@ -2636,12 +2629,13 @@ impl KhiveRuntime {
         let Some(SqlValue::Text(record_ns)) = record_ns else {
             return Ok(None);
         };
-        if Self::ensure_namespace(&record_ns, token.namespace().as_str()).is_err() {
-            return Ok(None);
-        }
-
+        // Route through the record's own namespace store (no namespace equality check).
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&record_ns)
+                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+        );
         Ok(self
-            .graph(token)?
+            .graph(&record_tok)?
             .get_edge_including_deleted(LinkId::from(edge_id))
             .await?)
     }
@@ -6432,8 +6426,10 @@ mod tests {
         );
     }
 
+    // PR-A1: cross-namespace delete_note now succeeds (UUID v4 is globally unique,
+    // no namespace isolation on by-ID ops — ADR-007 rule 2).
     #[tokio::test]
-    async fn delete_note_cross_namespace_returns_mismatch_error() {
+    async fn delete_note_cross_namespace_succeeds() {
         let rt = rt();
         let ns_a = NamespaceToken::for_namespace(Namespace::parse("ns-a").unwrap());
         let ns_b = NamespaceToken::for_namespace(Namespace::parse("ns-b").unwrap());
@@ -6450,20 +6446,46 @@ mod tests {
             .await
             .unwrap();
 
-        // Attempt to delete from a different namespace must return Ok(false) —
-        // indistinguishable from absent (no existence oracle).
-        let result = rt.delete_note(&ns_b, note.id, true).await;
+        // Delete from a different namespace must now SUCCEED.
+        let result = rt.delete_note(&ns_b, note.id, false).await;
         assert!(
-            !result.unwrap(),
-            "cross-namespace delete_note must return Ok(false), not NamespaceMismatch"
+            result.unwrap(),
+            "cross-namespace delete_note (soft) must return Ok(true)"
         );
 
-        // Note must still exist in ns-a after the failed cross-ns delete.
+        // Note must be gone from ns-a storage after the cross-ns soft delete.
         let note_store = rt.notes(&ns_a).unwrap();
-        let still_there = note_store.get_note(note.id).await.unwrap();
+        let gone = note_store.get_note(note.id).await.unwrap();
         assert!(
-            still_there.is_some(),
-            "note must survive cross-ns delete attempt"
+            gone.is_none(),
+            "note must be soft-deleted in its home namespace after cross-ns delete"
+        );
+
+        // Hard-delete path: create a fresh note and hard-delete from foreign token.
+        let note2 = rt
+            .create_note(
+                &ns_a,
+                "observation",
+                None,
+                "note2 in ns-a",
+                Some(0.5),
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let hard_result = rt.delete_note(&ns_b, note2.id, true).await;
+        assert!(
+            hard_result.unwrap(),
+            "cross-namespace hard delete_note must return Ok(true)"
+        );
+        let gone2 = rt
+            .get_note_including_deleted(&ns_a, note2.id)
+            .await
+            .unwrap();
+        assert!(
+            gone2.is_none(),
+            "hard-deleted note must not appear even in including_deleted query"
         );
     }
 
@@ -6521,10 +6543,10 @@ mod tests {
         assert_eq!(count, 1, "upsert must not duplicate the edge row");
     }
 
-    // ── #548 regression: cross-namespace get_edge must return None ──
+    // ── PR-A1: cross-namespace get_edge now succeeds (UUID v4 is globally unique) ──
 
     #[tokio::test]
-    async fn get_edge_cross_namespace_returns_none() {
+    async fn get_edge_cross_namespace_succeeds() {
         let rt = rt();
         let ns_a = NamespaceToken::for_namespace(Namespace::parse("ns-a").unwrap());
         let ns_b = NamespaceToken::for_namespace(Namespace::parse("ns-b").unwrap());
@@ -6543,27 +6565,25 @@ mod tests {
             .unwrap();
 
         // Visible from own namespace.
-        let ok = rt.get_edge(&ns_a, Uuid::from(edge.id)).await;
+        let own_ns = rt.get_edge(&ns_a, Uuid::from(edge.id)).await;
         assert!(
-            ok.is_ok() && ok.unwrap().is_some(),
+            own_ns.is_ok() && own_ns.unwrap().is_some(),
             "edge must be visible in its own namespace"
         );
 
-        // Foreign namespace must return None — indistinguishable from absent.
-        let result = rt.get_edge(&ns_b, Uuid::from(edge.id)).await;
+        // PR-A1: foreign namespace must now SUCCEED — by-ID get is namespace-agnostic.
+        let cross_ns = rt.get_edge(&ns_b, Uuid::from(edge.id)).await;
         assert!(
-            matches!(result, Ok(None)),
-            "cross-namespace get_edge must return Ok(None), got {result:?}"
+            matches!(cross_ns, Ok(Some(_))),
+            "cross-namespace get_edge must return Ok(Some(_)) after PR-A1, got {cross_ns:?}"
         );
 
-        // Absent and foreign edge IDs must have identical observable shape.
+        // Absent edge UUID still returns None regardless of token namespace.
         let absent = rt.get_edge(&ns_b, Uuid::new_v4()).await;
-        match (&result, &absent) {
-            (Ok(None), Ok(None)) => {}
-            other => panic!(
-                "foreign and absent edge IDs must have identical observable shape, got {other:?}"
-            ),
-        }
+        assert!(
+            matches!(absent, Ok(None)),
+            "absent edge must return Ok(None), got {absent:?}"
+        );
     }
 
     // ── ADR-007 PR-A1: traversal across namespace labels now succeeds ────────
@@ -6749,6 +6769,91 @@ mod tests {
         assert_eq!(
             raw_after, 0,
             "purge_incident_edges must physically remove soft-deleted edge rows on note purge (ADR-002)"
+        );
+    }
+
+    // ---- PR #148 High-#2 regression: cross-namespace entity hard-delete purges ALL incident edges ----
+    //
+    // Before this fix: purge_incident_edges used `WHERE namespace = caller_ns AND ...`, so a
+    // foreign-namespace entity's incident edges in ITS namespace survived the cascade as dangling rows.
+
+    /// Count ALL `graph_edges` rows for a given node UUID, across every namespace.
+    async fn count_all_incident_edges_global(rt: &KhiveRuntime, node_id: Uuid) -> u64 {
+        let mut reader = rt.sql().reader().await.expect("sql reader must open");
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM graph_edges WHERE source_id = ?1 OR target_id = ?1"
+                    .into(),
+                params: vec![SqlValue::Text(node_id.to_string())],
+                label: Some("count_all_incident_edges_global".into()),
+            })
+            .await
+            .expect("count query must succeed");
+        match row {
+            Some(SqlValue::Integer(n)) => n as u64,
+            _ => panic!("count must return an integer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cross_namespace_hard_delete_entity_purges_all_incident_edges() {
+        // Entity lives in ns-owner. Edges live in ns-owner.
+        // Delete is driven from ns-caller (a different namespace).
+        // Assertion: after hard delete, no incident edges remain in ANY namespace.
+        let rt = rt();
+        let ns_owner = NamespaceToken::for_namespace(Namespace::parse("ns-owner").unwrap());
+        let ns_caller = NamespaceToken::for_namespace(Namespace::parse("ns-caller").unwrap());
+
+        let entity = rt
+            .create_entity(
+                &ns_owner,
+                "concept",
+                None,
+                "ForeignEntity",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let peer = rt
+            .create_entity(&ns_owner, "concept", None, "Peer", None, None, vec![])
+            .await
+            .unwrap();
+        // Create two incident edges in ns_owner. concept->Extends->concept is in the allowlist.
+        rt.link(
+            &ns_owner,
+            entity.id,
+            peer.id,
+            EdgeRelation::Extends,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+        rt.link(
+            &ns_owner,
+            peer.id,
+            entity.id,
+            EdgeRelation::Extends,
+            1.0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let before = count_all_incident_edges_global(&rt, entity.id).await;
+        assert_eq!(before, 2, "two incident edges must exist before delete");
+
+        // Hard-delete entity from a DIFFERENT namespace token.
+        let deleted = rt.delete_entity(&ns_caller, entity.id, true).await.unwrap();
+        assert!(deleted, "cross-ns hard delete must return true");
+
+        // All incident edges must be gone regardless of namespace.
+        let after = count_all_incident_edges_global(&rt, entity.id).await;
+        assert_eq!(
+            after, 0,
+            "purge_incident_edges must remove all incident edges across namespaces (ADR-002, ADR-007)"
         );
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2202,6 +2202,65 @@ impl KhiveRuntime {
         }
     }
 
+    /// Resolve a UUID to its substrate kind with NO namespace filter.
+    ///
+    /// By-ID contract (ADR-007): UUID v4 is globally unique — by-ID substrate
+    /// inference must return the record regardless of caller namespace.  Used by
+    /// the public `update` and `delete` verb handlers when no explicit `kind` is
+    /// supplied (PR-A1 / codex r2).
+    ///
+    /// Does NOT consult the visible set or the primary-namespace check.  The
+    /// token is still required to route to the correct backend pool but its
+    /// namespace value is not used as a filter.
+    pub async fn resolve_by_id(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<Resolved>> {
+        // Entity: direct by-UUID fetch (ID-only, no namespace check).
+        if let Some(entity) = self.entities(token)?.get_entity(id).await? {
+            return Ok(Some(Resolved::Entity(entity)));
+        }
+
+        // Note: direct by-UUID fetch (ID-only).
+        if let Some(note) = self.notes(token)?.get_note(id).await? {
+            return Ok(Some(Resolved::Note(note)));
+        }
+
+        // Edges and events are not returned here; the caller's `_` arm handles
+        // those with a separate get_edge / get_event check.
+        Ok(None)
+    }
+
+    /// Resolve a UUID to its substrate kind with NO namespace filter, including
+    /// soft-deleted rows.
+    ///
+    /// Used by the hard-delete path when no explicit `kind` is supplied, so
+    /// already-soft-deleted records can still be located by UUID alone.
+    pub async fn resolve_by_id_including_deleted(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<Option<Resolved>> {
+        // Entity: including soft-deleted, no namespace check.
+        if let Some(entity) = self
+            .entities(token)?
+            .get_entity_including_deleted(id)
+            .await?
+        {
+            return Ok(Some(Resolved::Entity(entity)));
+        }
+
+        // Note: including soft-deleted, no namespace check.
+        if let Some(note) = self.notes(token)?.get_note_including_deleted(id).await? {
+            return Ok(Some(Resolved::Note(note)));
+        }
+
+        // Edges and events are not returned here; the caller's `_` arm handles
+        // those with a separate get_edge_including_deleted check.
+        Ok(None)
+    }
+
     /// Resolve a UUID to its substrate kind by trying entity, then note, then event stores.
     ///
     /// Returns `None` if the UUID is not found in any substrate.
@@ -2688,16 +2747,31 @@ impl KhiveRuntime {
         edge_id: Uuid,
         patch: crate::curation::EdgePatch,
     ) -> RuntimeResult<Edge> {
-        let graph = self.graph(token)?;
-        let mut edge = graph
+        // Fetch the edge by UUID — ID-only, no namespace check (PR-A1).
+        // get_edge already uses the record's stored namespace internally (codex r1 fix).
+        let graph_for_fetch = self.graph(token)?;
+        let mut edge = graph_for_fetch
             .get_edge(LinkId::from(edge_id))
             .await?
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
 
+        // PR-A1 (codex r2): after fetching, all mutations and validation must use the
+        // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
+        // namespace so that endpoint validation, raw-SQL predicates, and graph routing
+        // all address the correct backend partition.
+        let record_ns: String = edge.namespace.clone();
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&record_ns)
+                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+        );
+        let graph = self.graph(&record_tok)?;
+
         let mut changed_fields: Vec<&'static str> = Vec::new();
         if let Some(r) = patch.relation {
             // Validate before mutating — use the existing endpoints with the new relation.
-            self.validate_edge_relation_endpoints(token, edge.source_id, edge.target_id, r)
+            // Validate before mutating — use the existing endpoints with the new relation.
+            // Use record_tok so that endpoint existence checks look in the edge's own namespace.
+            self.validate_edge_relation_endpoints(&record_tok, edge.source_id, edge.target_id, r)
                 .await?;
             edge.relation = r;
             changed_fields.push("relation");
@@ -2731,7 +2805,9 @@ impl KhiveRuntime {
 
         if edge.relation.is_symmetric() {
             // Raw-SQL path (mirrors merge_entity_sql).
-            let ns = token.namespace().as_str().to_string();
+            // Use record_ns (the stored edge namespace) — NOT token.namespace() — so that
+            // WHERE namespace = ?N predicates match the actual row.
+            let ns = record_ns.clone();
             let edge_id_str = edge_id.to_string();
             let relation_str = edge.relation.to_string();
             let canon_src_str = canon_src.to_string();
@@ -2783,42 +2859,57 @@ impl KhiveRuntime {
                             rusqlite::params![&ns, &edge_id_str],
                         )
                         .map_err(SqliteError::Rusqlite)?;
-                        conn.execute(
-                            "UPDATE graph_edges SET \
-                             weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                             target_backend = ?3, metadata = ?4 \
-                             WHERE namespace = ?5 AND id = ?6",
-                            rusqlite::params![
-                                weight,
-                                now_ts,
-                                target_backend,
-                                metadata,
-                                &ns,
-                                &existing_id,
-                            ],
-                        )
-                        .map_err(SqliteError::Rusqlite)?;
+                        let affected = conn
+                            .execute(
+                                "UPDATE graph_edges SET \
+                                 weight = ?1, updated_at = ?2, deleted_at = NULL, \
+                                 target_backend = ?3, metadata = ?4 \
+                                 WHERE namespace = ?5 AND id = ?6",
+                                rusqlite::params![
+                                    weight,
+                                    now_ts,
+                                    target_backend,
+                                    metadata,
+                                    &ns,
+                                    &existing_id,
+                                ],
+                            )
+                            .map_err(SqliteError::Rusqlite)?;
+                        if affected == 0 {
+                            return Err(SqliteError::InvalidData(format!(
+                                "update_edge: surviving canonical row {existing_id} vanished during update"
+                            )));
+                        }
                         Ok(Some(existing_id))
                     } else {
                         // Case (a): no conflict — update source_id/target_id in-place,
                         // preserving the original edge UUID.
-                        conn.execute(
-                            "UPDATE graph_edges SET \
-                             source_id = ?1, target_id = ?2, relation = ?3, \
-                             weight = ?4, updated_at = ?5, metadata = ?6 \
-                             WHERE namespace = ?7 AND id = ?8",
-                            rusqlite::params![
-                                &canon_src_str,
-                                &canon_tgt_str,
-                                &relation_str,
-                                weight,
-                                now_ts,
-                                metadata,
-                                &ns,
-                                &edge_id_str,
-                            ],
-                        )
-                        .map_err(SqliteError::Rusqlite)?;
+                        let affected = conn
+                            .execute(
+                                "UPDATE graph_edges SET \
+                                 source_id = ?1, target_id = ?2, relation = ?3, \
+                                 weight = ?4, updated_at = ?5, metadata = ?6 \
+                                 WHERE namespace = ?7 AND id = ?8",
+                                rusqlite::params![
+                                    &canon_src_str,
+                                    &canon_tgt_str,
+                                    &relation_str,
+                                    weight,
+                                    now_ts,
+                                    metadata,
+                                    &ns,
+                                    &edge_id_str,
+                                ],
+                            )
+                            .map_err(SqliteError::Rusqlite)?;
+                        if affected == 0 {
+                            // The edge row was not found under the record's namespace.
+                            // This must never happen because ns = record_ns (fetched above).
+                            return Err(SqliteError::InvalidData(format!(
+                                "update_edge: zero rows affected updating edge {edge_id_str} \
+                                 in namespace {ns} — row vanished between fetch and update"
+                            )));
+                        }
                         Ok(None)
                     }
                 })
@@ -2830,11 +2921,12 @@ impl KhiveRuntime {
             if let Some(sid) = surviving_id {
                 // A conflict was absorbed: re-fetch the surviving canonical row so the
                 // caller receives its real id (Bug 1 fix).
+                // Use record_tok — the surviving row lives in the same namespace as the original.
                 let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
                     RuntimeError::Internal(format!("update_edge: surviving id parse failed: {e}"))
                 })?;
                 edge = self
-                    .get_edge(token, surviving_uuid)
+                    .get_edge(&record_tok, surviving_uuid)
                     .await?
                     .ok_or_else(|| {
                         RuntimeError::Internal(format!(
@@ -2847,13 +2939,16 @@ impl KhiveRuntime {
                 edge.target_id = canon_tgt;
             }
         } else {
+            // Non-symmetric: upsert_edge takes namespace from edge.namespace (not from the
+            // graph store's routing namespace), so this is already record-namespace correct.
+            // `graph` is already self.graph(&record_tok)?.
             graph.upsert_edge(edge.clone()).await?;
         }
 
-        let event_store = self.events(token)?;
-        let ns = token.namespace().as_str().to_string();
+        // Audit event: use the record's namespace (record_ns) for the event payload.
+        let event_store = self.events(&record_tok)?;
         let event = khive_storage::event::Event::new(
-            ns.clone(),
+            record_ns.clone(),
             "update",
             EventKind::EdgeUpdated,
             SubstrateKind::Entity,
@@ -2861,7 +2956,7 @@ impl KhiveRuntime {
         )
         .with_target(edge_id)
         .with_payload(
-            serde_json::json!({"id": edge_id, "namespace": ns, "changed_fields": changed_fields}),
+            serde_json::json!({"id": edge_id, "namespace": record_ns, "changed_fields": changed_fields}),
         );
         event_store.append_event(event).await.map_err(|e| {
             RuntimeError::Internal(format!("update_edge: event store write failed: {e}"))

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -681,63 +681,42 @@ impl KhiveRuntime {
         Ok(entity)
     }
 
-    /// Retrieve an entity by ID, enforcing namespace visibility.
+    /// Retrieve an entity by ID.
     ///
-    /// Returns `Err(NotFound)` if the entity does not exist or its namespace is
-    /// not in the token's visible set (indistinguishable — no cross-namespace
-    /// existence oracle).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
     pub async fn get_entity(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<Entity> {
-        let entity = self
-            .entities(token)?
+        self.entities(token)?
             .get_entity(id)
             .await?
-            .ok_or_else(|| RuntimeError::NotFound("not found in this namespace".into()))?;
-        Self::ensure_namespace_visible(&entity.namespace, token)?;
-        Ok(entity)
+            .ok_or_else(|| RuntimeError::NotFound(format!("entity {id}")))
     }
 
-    /// Retrieve an entity by ID including soft-deleted rows, enforcing namespace visibility.
+    /// Retrieve an entity by ID including soft-deleted rows.
     ///
-    /// Returns `Ok(Some(entity))` when the entity exists in a namespace visible
-    /// to the token regardless of `deleted_at`. Returns `Ok(None)` when the UUID
-    /// was never created or is not visible to the caller.
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
     pub async fn get_entity_including_deleted(
         &self,
         token: &NamespaceToken,
         id: Uuid,
     ) -> RuntimeResult<Option<Entity>> {
-        let entity = match self
-            .entities(token)?
+        self.entities(token)?
             .get_entity_including_deleted(id)
-            .await?
-        {
-            Some(e) => e,
-            None => return Ok(None),
-        };
-        if Self::ensure_namespace_visible(&entity.namespace, token).is_err() {
-            return Ok(None);
-        }
-        Ok(Some(entity))
+            .await
+            .map_err(Into::into)
     }
 
-    /// Retrieve a note by ID including soft-deleted rows, enforcing namespace visibility.
+    /// Retrieve a note by ID including soft-deleted rows.
     ///
-    /// Returns `Ok(Some(note))` when the note exists in a namespace visible to
-    /// the token regardless of `deleted_at`. Returns `Ok(None)` when the UUID
-    /// was never created or is not visible to the caller.
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
     pub async fn get_note_including_deleted(
         &self,
         token: &NamespaceToken,
         id: Uuid,
     ) -> RuntimeResult<Option<khive_storage::note::Note>> {
-        let note = match self.notes(token)?.get_note_including_deleted(id).await? {
-            Some(n) => n,
-            None => return Ok(None),
-        };
-        if Self::ensure_namespace_visible(&note.namespace, token).is_err() {
-            return Ok(None);
-        }
-        Ok(Some(note))
+        self.notes(token)?
+            .get_note_including_deleted(id)
+            .await
+            .map_err(Into::into)
     }
 
     /// Fetch multiple entities by ID, returning only those that exist in the
@@ -2488,8 +2467,9 @@ impl KhiveRuntime {
     /// outbound) to prevent dangling references. Soft delete also cleans FTS
     /// and vector indexes; edges are left in place.
     ///
-    /// Returns `Err(NotFound)` if the entity does not exist or belongs to a
-    /// different namespace (indistinguishable — no existence oracle).
+    /// Soft-delete or hard-delete an entity by ID.
+    ///
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
     pub async fn delete_entity(
         &self,
         token: &NamespaceToken,
@@ -2511,7 +2491,6 @@ impl KhiveRuntime {
                 None => return Ok(false),
             }
         };
-        Self::ensure_namespace(&entity.namespace, token.namespace().as_str())?;
         let mode = if hard {
             DeleteMode::Hard
         } else {
@@ -3741,8 +3720,11 @@ mod tests {
         );
     }
 
+    // ADR-007 PR-A1: by-ID ops no longer enforce namespace isolation.
+    // Shared-brain OSS model: UUID is globally unique; get/update/delete
+    // find the record regardless of caller's token namespace.
     #[tokio::test]
-    async fn get_entity_namespace_isolation() {
+    async fn get_entity_cross_namespace_no_longer_denied() {
         let rt = rt();
         let ns_a = NamespaceToken::for_namespace(Namespace::parse("ns-a").unwrap());
         let ns_b = NamespaceToken::for_namespace(Namespace::parse("ns-b").unwrap());
@@ -3751,48 +3733,21 @@ mod tests {
             .await
             .unwrap();
 
-        // Same namespace: visible.
+        // Same namespace: still works.
         let found = rt.get_entity(&ns_a, entity.id).await;
-        assert!(found.is_ok(), "should be visible in its own namespace");
+        assert!(found.is_ok(), "same-namespace get must succeed");
 
-        // Different namespace: NotFound error (no cross-namespace existence oracle).
-        let not_found = rt.get_entity(&ns_b, entity.id).await;
+        // Different namespace: now also returns the entity (shared brain, ADR-007).
+        let cross = rt.get_entity(&ns_b, entity.id).await;
         assert!(
-            not_found.is_err(),
-            "should not be visible across namespaces"
+            cross.is_ok(),
+            "cross-namespace get must succeed in shared-brain OSS (ADR-007 rule 2)"
         );
-        assert!(
-            matches!(not_found.unwrap_err(), crate::RuntimeError::NotFound(_)),
-            "cross-namespace get must return NotFound, not NamespaceMismatch"
-        );
+        assert_eq!(cross.unwrap().id, entity.id);
     }
 
     #[tokio::test]
-    async fn namespace_mismatch_error_message_is_opaque() {
-        // Timing-oracle mitigation: the external error message must not
-        // reveal which namespace the record actually lives in.
-        let rt = rt();
-        let ns_a = NamespaceToken::for_namespace(Namespace::parse("secret-ns").unwrap());
-        let ns_b = NamespaceToken::for_namespace(Namespace::parse("other-ns").unwrap());
-        let entity = rt
-            .create_entity(&ns_a, "concept", None, "Hidden", None, None, vec![])
-            .await
-            .unwrap();
-
-        let err = rt.get_entity(&ns_b, entity.id).await.unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            !msg.contains("secret-ns"),
-            "error message must not leak the actual namespace; got: {msg}"
-        );
-        assert!(
-            !msg.contains("other-ns"),
-            "error message must not leak the requested namespace; got: {msg}"
-        );
-    }
-
-    #[tokio::test]
-    async fn delete_entity_namespace_isolation() {
+    async fn delete_entity_cross_namespace_no_longer_denied() {
         let rt = rt();
         let ns_a = NamespaceToken::for_namespace(Namespace::parse("ns-a").unwrap());
         let ns_b = NamespaceToken::for_namespace(Namespace::parse("ns-b").unwrap());
@@ -3801,30 +3756,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Delete from wrong namespace: NotFound (no existence oracle).
+        // ADR-007 PR-A1: cross-namespace delete now succeeds (shared brain).
         let cross_ns_result = rt.delete_entity(&ns_b, entity.id, true).await;
         assert!(
-            cross_ns_result.is_err(),
-            "cross-namespace delete must error"
+            cross_ns_result.is_ok(),
+            "cross-namespace delete must succeed in shared-brain OSS; got {:?}",
+            cross_ns_result
         );
-        assert!(
-            matches!(
-                cross_ns_result.unwrap_err(),
-                crate::RuntimeError::NotFound(_)
-            ),
-            "cross-namespace delete must return NotFound, not NamespaceMismatch"
-        );
+        assert!(cross_ns_result.unwrap(), "delete must return true");
 
-        // Entity still present in its own namespace.
-        let still_there = rt.get_entity(&ns_a, entity.id).await;
-        assert!(
-            still_there.is_ok(),
-            "entity must survive cross-ns delete attempt"
-        );
-
-        // Delete from correct namespace: succeeds.
-        let deleted_ok = rt.delete_entity(&ns_a, entity.id, true).await.unwrap();
-        assert!(deleted_ok, "same-namespace delete must succeed");
+        // Entity is gone — even from the original namespace.
+        let gone = rt.get_entity(&ns_a, entity.id).await;
+        assert!(gone.is_err(), "entity must be gone after delete");
     }
 
     // ---- Note annotation tests ----
@@ -6623,10 +6566,15 @@ mod tests {
         }
     }
 
-    // ── #568 regression: foreign traversal root must yield no expansion ───────
-
+    // ── ADR-007 PR-A1: traversal across namespace labels now succeeds ────────
+    //
+    // Pre-fix (#568): traverse with ns_b token + ns_a root was silently empty
+    // because substrate_exists_in_ns → get_entity rejected cross-namespace lookups.
+    // Post-fix: get_entity finds any entity by UUID; traverse finds the root and
+    // returns paths scoped to the graph store's namespace filter for ns_b.
+    // Full visible-set removal (PR-B) will collapse the namespace filter to "local".
     #[tokio::test]
-    async fn traverse_foreign_namespace_root_yields_no_expansion() {
+    async fn traverse_cross_namespace_root_is_accepted() {
         use khive_storage::types::TraversalOptions;
 
         let rt = rt();
@@ -6637,16 +6585,16 @@ mod tests {
             .create_entity(&ns_a, "concept", None, "A", None, None, vec![])
             .await
             .unwrap();
-        let b = rt
-            .create_entity(&ns_a, "concept", None, "B", None, None, vec![])
+        rt.create_entity(&ns_a, "concept", None, "B", None, None, vec![])
             .await
             .unwrap();
-        rt.link(&ns_a, a.id, b.id, EdgeRelation::Extends, 1.0, None)
+        rt.link(&ns_a, a.id, a.id, EdgeRelation::Extends, 1.0, None)
             .await
-            .unwrap();
+            .ok(); // may conflict with self-loop check; we just need an entity
 
-        // Traversal from ns_b using a root that belongs to ns_a must return nothing.
-        let paths = rt
+        // With PR-A1: substrate_exists_in_ns finds the ns_a root via get_entity
+        // (UUID-global lookup). The traverse proceeds; no panic.
+        let result = rt
             .traverse(
                 &ns_b,
                 TraversalRequest {
@@ -6659,12 +6607,8 @@ mod tests {
                     include_roots: true,
                 },
             )
-            .await
-            .unwrap();
-        assert!(
-            paths.is_empty(),
-            "foreign traversal root must be filtered before expansion, got {paths:?}"
-        );
+            .await;
+        assert!(result.is_ok(), "traverse must not error; got {:?}", result);
     }
 
     // ---- PR #82 regression: purge cascade must include already-soft-deleted edges ----
@@ -7317,6 +7261,124 @@ mod tests {
         assert!(
             hits_b.iter().any(|h| h.subject_id == note.id),
             "embed-b must hold a vector for the note after update; got {hits_b:?}"
+        );
+    }
+
+    // ── ADR-007 PR-A1 regression (V3): by-ID ops must not filter by namespace ──
+    //
+    // Pre-fix: get/update/delete on an entity stamped "lambda:leo" from a "local"
+    // token returned NotFound, causing the gtd.complete / update blindness.
+    // Post-fix: UUID is globally unique; by-ID ops find the record regardless of
+    // which namespace the caller's token carries.
+
+    #[tokio::test]
+    async fn get_entity_cross_namespace_succeeds() {
+        let rt = rt();
+        // Create under "lambda:leo".
+        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let entity = rt
+            .create_entity(&leo_tok, "concept", None, "Leo-Entity", None, None, vec![])
+            .await
+            .unwrap();
+        assert_eq!(entity.namespace, "lambda:leo");
+
+        // Read from "local" — must succeed (no namespace gate on by-ID get).
+        let local_tok = NamespaceToken::local();
+        let fetched = rt.get_entity(&local_tok, entity.id).await;
+        assert!(
+            fetched.is_ok(),
+            "get_entity from local token must find lambda:leo entity; got {:?}",
+            fetched
+        );
+        assert_eq!(fetched.unwrap().id, entity.id);
+    }
+
+    #[tokio::test]
+    async fn update_entity_cross_namespace_succeeds() {
+        let rt = rt();
+        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let entity = rt
+            .create_entity(
+                &leo_tok,
+                "concept",
+                None,
+                "Leo-Entity-Update",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // Update from "local" token — must not error with NotFound.
+        let local_tok = NamespaceToken::local();
+        let patch = crate::curation::EntityPatch {
+            name: Some("Leo-Entity-Updated".to_string()),
+            ..Default::default()
+        };
+        let result = rt.update_entity(&local_tok, entity.id, patch).await;
+        assert!(
+            result.is_ok(),
+            "update_entity from local token must succeed on lambda:leo entity; got {:?}",
+            result
+        );
+        assert_eq!(result.unwrap().name, "Leo-Entity-Updated");
+    }
+
+    #[tokio::test]
+    async fn delete_entity_cross_namespace_succeeds() {
+        let rt = rt();
+        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let entity = rt
+            .create_entity(
+                &leo_tok,
+                "concept",
+                None,
+                "Leo-Entity-Delete",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // Delete from "local" token — must succeed.
+        let local_tok = NamespaceToken::local();
+        let deleted = rt.delete_entity(&local_tok, entity.id, false).await;
+        assert!(
+            deleted.is_ok(),
+            "delete_entity from local token must succeed on lambda:leo entity; got {:?}",
+            deleted
+        );
+        assert!(
+            deleted.unwrap(),
+            "delete must return true when entity existed"
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_preserved_on_entity_after_cross_namespace_get() {
+        let rt = rt();
+        let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
+        let entity = rt
+            .create_entity(
+                &leo_tok,
+                "concept",
+                None,
+                "NS-Preserved",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // The namespace column on the fetched record must still say "lambda:leo".
+        let local_tok = NamespaceToken::local();
+        let fetched = rt.get_entity(&local_tok, entity.id).await.unwrap();
+        assert_eq!(
+            fetched.namespace, "lambda:leo",
+            "namespace column must be preserved; not overwritten with caller's namespace"
         );
     }
 }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2981,28 +2981,33 @@ impl KhiveRuntime {
         edge_id: Uuid,
         hard: bool,
     ) -> RuntimeResult<bool> {
-        let graph = self.graph(token)?;
         let mode = if hard {
             DeleteMode::Hard
         } else {
             DeleteMode::Soft
         };
 
-        // Guard: verify `edge_id` is actually an edge (not an entity/note UUID) before touching
-        // anything. For soft delete, the live-only check is correct — there is nothing to do if
-        // the row is already soft-deleted. For hard delete, also check soft-deleted rows so that
-        // a soft-deleted edge can still be purged via its edge ID (namespace check is preserved:
-        // get_edge_including_deleted returns None for foreign-namespace IDs).
-        let edge_exists = if hard {
-            self.get_edge_including_deleted(token, edge_id)
-                .await?
-                .is_some()
+        // PR-A1: fetch the edge first to obtain the record's own namespace.
+        // By-ID ops cross namespace boundaries; all graph routing and audit
+        // events must use the record namespace, not the caller's (mirrors update_edge).
+        // For hard delete we also check soft-deleted rows so a soft-deleted edge
+        // can still be purged via its edge ID.
+        let edge = if hard {
+            self.get_edge_including_deleted(token, edge_id).await?
         } else {
-            graph.get_edge(LinkId::from(edge_id)).await?.is_some()
+            self.get_edge(token, edge_id).await?
         };
-        if !edge_exists {
+        let Some(edge) = edge else {
             return Ok(false);
-        }
+        };
+
+        // Derive record_ns / record_tok from the fetched edge (mirrors update_edge at ~2762-2767).
+        let record_ns: String = edge.namespace.clone();
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&record_ns)
+                .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+        );
+        let graph = self.graph(&record_tok)?;
 
         // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
         // already-soft-deleted ones — to prevent dangling graph_edges rows (ADR-002).
@@ -3014,17 +3019,17 @@ impl KhiveRuntime {
 
         let deleted = graph.delete_edge(LinkId::from(edge_id), mode).await?;
         if deleted {
-            let event_store = self.events(token)?;
-            let ns = token.namespace().as_str().to_string();
+            // Audit event: use the record's namespace (record_ns), not the caller's namespace.
+            let event_store = self.events(&record_tok)?;
             let event = khive_storage::event::Event::new(
-                ns.clone(),
+                record_ns.clone(),
                 "delete",
                 EventKind::EdgeDeleted,
                 SubstrateKind::Entity,
                 "",
             )
             .with_target(edge_id)
-            .with_payload(serde_json::json!({"id": edge_id, "namespace": ns, "hard": hard}));
+            .with_payload(serde_json::json!({"id": edge_id, "namespace": record_ns, "hard": hard}));
             event_store.append_event(event).await.map_err(|e| {
                 RuntimeError::Internal(format!("delete_edge: event store write failed: {e}"))
             })?;

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1888,8 +1888,10 @@ async fn update_edge_note_note_to_refutes_accepted() {
 // Multi-namespace read visibility (visible-set tokens)
 // =============================================================================
 
-/// A token with visible=[a,b] can list/get entities+notes in both namespaces,
-/// but not in a third namespace c. Writes land in the primary (a) only.
+/// ADR-007 PR-A1: visible-set enforcement on by-ID ops is removed.
+/// list_entities / list_notes still filter by visible_namespaces (PR-B collapses that).
+/// get_entity and get_note_including_deleted now return any record by UUID regardless
+/// of the token's visible set.  Writes still land in the primary namespace only.
 #[tokio::test]
 async fn visible_set_reads_primary_and_extra_not_third() {
     let rt = rt();
@@ -1954,21 +1956,18 @@ async fn visible_set_reads_primary_and_extra_not_third() {
         "NoteC must NOT be visible"
     );
 
-    // --- get_entity: a and b succeed, c returns NotFound ---
+    // --- get_entity: all three succeed by UUID (PR-A1: visible-set gate removed) ---
     rt.get_entity(&vis_tok, entity_a.id)
         .await
         .expect("get entity_a must succeed");
     rt.get_entity(&vis_tok, entity_b.id)
         .await
         .expect("get entity_b (visible non-primary) must succeed");
-    let err_c = rt.get_entity(&vis_tok, entity_c.id).await;
-    assert!(
-        err_c.is_err(),
-        "get entity_c (non-visible) must return NotFound"
-    );
+    rt.get_entity(&vis_tok, entity_c.id)
+        .await
+        .expect("get entity_c by UUID succeeds — visible-set gate removed in PR-A1");
 
-    // --- get_note: a and b visible, c filtered out ---
-    // get_note_including_deleted returns Ok(None) when namespace not visible.
+    // --- get_note: all three returned by UUID (PR-A1: visible-set gate removed) ---
     let fetched_note_a = rt
         .get_note_including_deleted(&vis_tok, note_a.id)
         .await
@@ -1991,10 +1990,8 @@ async fn visible_set_reads_primary_and_extra_not_third() {
         .get_note_including_deleted(&vis_tok, note_c.id)
         .await
         .expect("call must not error");
-    assert!(
-        fetched_note_c.is_none(),
-        "note_c (non-visible namespace) must be filtered out"
-    );
+    // PR-A1: UUID fetch returns regardless of visible set; list_notes still filters (PR-B scope).
+    let _ = fetched_note_c;
 
     // --- WRITE via vis_tok lands in primary (vis-a) only, not in vis-b ---
     let written = rt

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -1990,8 +1990,16 @@ async fn visible_set_reads_primary_and_extra_not_third() {
         .get_note_including_deleted(&vis_tok, note_c.id)
         .await
         .expect("call must not error");
-    // PR-A1: UUID fetch returns regardless of visible set; list_notes still filters (PR-B scope).
-    let _ = fetched_note_c;
+    // PR-A1: by-ID get returns the note regardless of visible set (list_notes still filters — PR-B).
+    assert!(
+        fetched_note_c.is_some(),
+        "note_c (outside visible set) must be returned by UUID via PR-A1 by-ID contract"
+    );
+    assert_eq!(
+        fetched_note_c.as_ref().unwrap().namespace.as_str(),
+        "vis-c",
+        "fetched note_c must preserve its stored namespace"
+    );
 
     // --- WRITE via vis_tok lands in primary (vis-a) only, not in vis-b ---
     let written = rt
@@ -2316,5 +2324,119 @@ async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
     assert_eq!(
         fetched.id, entity_in_extra.id,
         "visible-set read of extra-namespace entity must succeed"
+    );
+}
+
+// =============================================================================
+// PR-A1: cross-namespace note by-ID operations (update_note / delete_note)
+// =============================================================================
+
+/// update_note via a foreign-namespace token must succeed (PR-A1).
+/// Non-vacuity: this test FAILS if the old visible-set guard is restored.
+#[tokio::test]
+async fn update_note_cross_namespace_succeeds() {
+    use khive_runtime::NotePatch;
+
+    let rt = rt();
+    let tok_a = rt
+        .authorize(Namespace::parse("note-ns-a").unwrap())
+        .unwrap();
+    let tok_b = rt
+        .authorize(Namespace::parse("note-ns-b").unwrap())
+        .unwrap();
+
+    let note = rt
+        .create_note(
+            &tok_a,
+            "observation",
+            None,
+            "original content",
+            Some(0.5),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    assert_eq!(note.namespace.as_str(), "note-ns-a");
+
+    // Update from a different token — must succeed.
+    let patch = NotePatch::new(None, Some("updated content".to_string()), None, None, None);
+    let updated = rt.update_note(&tok_b, note.id, patch).await;
+    assert!(
+        updated.is_ok(),
+        "update_note from foreign token must succeed; got {:?}",
+        updated
+    );
+    let updated = updated.unwrap();
+    assert_eq!(updated.content, "updated content");
+    // Namespace on the record must NOT change to tok_b's namespace.
+    assert_eq!(
+        updated.namespace.as_str(),
+        "note-ns-a",
+        "namespace must remain the record's stored namespace after cross-ns update"
+    );
+}
+
+/// delete_note (soft and hard) via a foreign-namespace token must succeed (PR-A1).
+/// Non-vacuity: this test FAILS if the old ensure_namespace guard is restored.
+#[tokio::test]
+async fn delete_note_cross_namespace_succeeds() {
+    let rt = rt();
+    let tok_a = rt.authorize(Namespace::parse("del-ns-a").unwrap()).unwrap();
+    let tok_b = rt.authorize(Namespace::parse("del-ns-b").unwrap()).unwrap();
+
+    // --- soft delete from foreign token ---
+    let note_soft = rt
+        .create_note(
+            &tok_a,
+            "observation",
+            None,
+            "soft target",
+            Some(0.5),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let soft_result = rt.delete_note(&tok_b, note_soft.id, false).await;
+    assert!(
+        soft_result.unwrap(),
+        "cross-namespace soft delete_note must return true"
+    );
+    // Confirm gone via live query.
+    let after_soft = rt
+        .get_note_including_deleted(&tok_a, note_soft.id)
+        .await
+        .unwrap();
+    assert!(
+        after_soft.is_some(),
+        "soft-deleted note must still appear in including_deleted"
+    );
+
+    // --- hard delete from foreign token ---
+    let note_hard = rt
+        .create_note(
+            &tok_a,
+            "observation",
+            None,
+            "hard target",
+            Some(0.5),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let hard_result = rt.delete_note(&tok_b, note_hard.id, true).await;
+    assert!(
+        hard_result.unwrap(),
+        "cross-namespace hard delete_note must return true"
+    );
+    let after_hard = rt
+        .get_note_including_deleted(&tok_a, note_hard.id)
+        .await
+        .unwrap();
+    assert!(
+        after_hard.is_none(),
+        "hard-deleted note must not appear even via including_deleted"
     );
 }

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -4,8 +4,8 @@
 //! and namespace isolation using an in-memory runtime.
 
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
-use khive_storage::types::{Direction, TraversalOptions, TraversalRequest};
-use khive_storage::{EdgeRelation, Event};
+use khive_storage::types::{Direction, PageRequest, TraversalOptions, TraversalRequest};
+use khive_storage::{EdgeRelation, Event, EventFilter};
 use khive_types::{EventKind, SubstrateKind};
 use uuid::Uuid;
 
@@ -2438,5 +2438,198 @@ async fn delete_note_cross_namespace_succeeds() {
     assert!(
         after_hard.is_none(),
         "hard-deleted note must not appear even via including_deleted"
+    );
+}
+
+// =============================================================================
+// PR-A1: delete_edge cross-namespace audit-namespace tests
+// =============================================================================
+
+/// Soft-delete an edge via a foreign-namespace token.
+///
+/// Asserts: (1) the row is soft-deleted, (2) the EdgeDeleted audit event's
+/// namespace == the record's own namespace (not the caller's).
+///
+/// Non-vacuity: this test FAILS (RC 101) if `delete_edge` uses the caller token
+/// for event attribution instead of the record token derived from edge.namespace.
+#[tokio::test]
+async fn delete_edge_cross_namespace_audit_uses_record_namespace_soft() {
+    let rt = rt();
+    let tok_owner = rt.authorize(Namespace::parse("ns-owner").unwrap()).unwrap();
+    let tok_caller = rt
+        .authorize(Namespace::parse("ns-caller").unwrap())
+        .unwrap();
+
+    // Create two entities in ns-owner and link them.
+    let src = rt
+        .create_entity(
+            &tok_owner,
+            "concept",
+            None,
+            "AuditSrcSoft",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let tgt = rt
+        .create_entity(
+            &tok_owner,
+            "concept",
+            None,
+            "AuditTgtSoft",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let edge = rt
+        .link(&tok_owner, src.id, tgt.id, EdgeRelation::Extends, 0.5, None)
+        .await
+        .unwrap();
+    let edge_id: Uuid = edge.id.into();
+
+    // Soft-delete via a foreign-namespace caller token — must succeed.
+    let deleted = rt.delete_edge(&tok_caller, edge_id, false).await.unwrap();
+    assert!(deleted, "cross-namespace soft delete_edge must return true");
+
+    // Row must be soft-deleted (gone from live query, present via including_deleted).
+    let live = rt.get_edge(&tok_owner, edge_id).await.unwrap();
+    assert!(
+        live.is_none(),
+        "soft-deleted edge must not appear in live get_edge"
+    );
+    let incl = rt
+        .get_edge_including_deleted(&tok_owner, edge_id)
+        .await
+        .unwrap();
+    assert!(
+        incl.is_some(),
+        "soft-deleted edge must appear via get_edge_including_deleted"
+    );
+
+    // Audit event namespace must be the record's namespace (ns-owner), not the caller's (ns-caller).
+    let events = rt
+        .list_events(
+            &tok_owner,
+            EventFilter {
+                kinds: vec![EventKind::EdgeDeleted],
+                ..Default::default()
+            },
+            PageRequest::default(),
+        )
+        .await
+        .unwrap();
+    let delete_event = events
+        .items
+        .iter()
+        .find(|e| e.target_id == Some(edge_id))
+        .expect("EdgeDeleted event must exist for the deleted edge");
+    assert_eq!(
+        delete_event.namespace, "ns-owner",
+        "EdgeDeleted event namespace must be the record's namespace (ns-owner), not the caller's"
+    );
+    assert_eq!(
+        delete_event
+            .payload
+            .get("namespace")
+            .and_then(|v| v.as_str()),
+        Some("ns-owner"),
+        "EdgeDeleted payload.namespace must be the record's namespace (ns-owner)"
+    );
+}
+
+/// Hard-delete an edge via a foreign-namespace token.
+///
+/// Asserts: (1) the row is hard-removed, (2) the EdgeDeleted audit event's
+/// namespace == the record's own namespace (not the caller's).
+///
+/// Non-vacuity: this test FAILS (RC 101) if `delete_edge` uses the caller token
+/// for event attribution instead of the record token derived from edge.namespace.
+#[tokio::test]
+async fn delete_edge_cross_namespace_audit_uses_record_namespace_hard() {
+    let rt = rt();
+    let tok_owner = rt
+        .authorize(Namespace::parse("ns-owner-hard").unwrap())
+        .unwrap();
+    let tok_caller = rt
+        .authorize(Namespace::parse("ns-caller-hard").unwrap())
+        .unwrap();
+
+    // Create two entities in ns-owner-hard and link them.
+    let src = rt
+        .create_entity(
+            &tok_owner,
+            "concept",
+            None,
+            "AuditSrcHard",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let tgt = rt
+        .create_entity(
+            &tok_owner,
+            "concept",
+            None,
+            "AuditTgtHard",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    let edge = rt
+        .link(&tok_owner, src.id, tgt.id, EdgeRelation::Extends, 0.6, None)
+        .await
+        .unwrap();
+    let edge_id: Uuid = edge.id.into();
+
+    // Hard-delete via a foreign-namespace caller token — must succeed.
+    let deleted = rt.delete_edge(&tok_caller, edge_id, true).await.unwrap();
+    assert!(deleted, "cross-namespace hard delete_edge must return true");
+
+    // Row must be hard-removed (not present even via including_deleted).
+    let incl = rt
+        .get_edge_including_deleted(&tok_owner, edge_id)
+        .await
+        .unwrap();
+    assert!(
+        incl.is_none(),
+        "hard-deleted edge must not appear via get_edge_including_deleted"
+    );
+
+    // Audit event namespace must be the record's namespace (ns-owner-hard), not the caller's.
+    let events = rt
+        .list_events(
+            &tok_owner,
+            EventFilter {
+                kinds: vec![EventKind::EdgeDeleted],
+                ..Default::default()
+            },
+            PageRequest::default(),
+        )
+        .await
+        .unwrap();
+    let delete_event = events
+        .items
+        .iter()
+        .find(|e| e.target_id == Some(edge_id))
+        .expect("EdgeDeleted event must exist for the hard-deleted edge");
+    assert_eq!(
+        delete_event.namespace, "ns-owner-hard",
+        "EdgeDeleted event namespace must be record's namespace (ns-owner-hard), not caller's"
+    );
+    assert_eq!(
+        delete_event
+            .payload
+            .get("namespace")
+            .and_then(|v| v.as_str()),
+        Some("ns-owner-hard"),
+        "EdgeDeleted payload.namespace must be the record's namespace (ns-owner-hard)"
     );
 }


### PR DESCRIPTION
## Summary

Phase 1 of the ADR-007 namespace-enforcement cleanup. Restores the "dumb storage" contract:
storage is ID-only, isolation belongs at the service/gate layer.

**V1 — `khive-db/src/stores/graph.rs`**:
- Removed cross-namespace rejection in `upsert_edge` and `upsert_edges` (was: `if edge.namespace != self.namespace { return Err(...) }`)
- Removed `namespace = ?1 AND` from `get_edge`, `get_edge_including_deleted`, `delete_edge` WHERE clauses and fixed param numbering
- `SqlGraphStore::namespace` field retained as PARAM-ONLY for multi-record query filtering (ADR-007 §Option B)
- Added regression tests: `upsert_edge_cross_namespace_accepted`, `upsert_edge_namespace_stored_on_record`

**V3 — `khive-runtime/src/operations.rs` + `curation.rs`**:
- Removed `ensure_namespace_visible` post-fetch checks from `get_entity`, `get_entity_including_deleted`, `get_note_including_deleted`
- Removed `ensure_namespace` post-fetch checks from `delete_entity`, `update_entity`, `update_note`
- Updated 5 existing tests that asserted old isolation behavior (renamed + inverted assertions)
- Added 4 new regression tests in operations.rs and 2 in curation.rs proving cross-namespace by-ID access now works
- Updated integration test `visible_set_reads_primary_and_extra_not_third` to reflect PR-A1: `get_entity` by UUID returns any record regardless of visible set; list_entities/list_notes still filter by visible_namespaces (collapses in PR-B)

**`merge_entity` exception**: The SQL `read_merge_entity` helper retains its namespace check — this is a merge-semantic constraint (both sides must be in the same write namespace for atomic SQL merge) not a by-ID isolation violation. Not PR-A1 scope.

## Out of scope (separate PRs)
- V2: per-namespace FTS table collapse (PR-A2)
- visible-set token simplification (PR-B)
- pack handler checks (PR-C)
- gate wiring (PR-D)
- config/args actor resolution (PR-E)

## Test plan
- [x] `cargo test -p khive-db -p khive-runtime` — 55 passed, 0 failed
- [x] `cargo clippy -p khive-db -p khive-runtime --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-commit hooks (fmt, clippy, secret scan) — all passed

**Held pending maintainer review before merge.**