### PR TITLE
perf(khive-vamana): productize 1M scale-proof bench — reproducible, banked, CI-guarded

### DIFF
--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -85,13 +85,20 @@ jobs:
         #   1 — data present; one or more assertions FAIL (regression)
         #   2 — data absent; skip gracefully
         run: |
+          set +e
           bash scripts/bench_1m.sh --ci
           RC=$?
+          set -e
           if [ $RC -eq 2 ]; then
             echo "::notice::SIFT data not found at SIFT_DIR=${SIFT_DIR:-<unset>} — bench skipped. Provision a SIFT-capable runner to enable regression gating."
             exit 0
+          elif [ $RC -eq 0 ]; then
+            echo "::notice::Vamana CI bench PASSED."
+            exit 0
+          else
+            echo "::warning::Vamana CI bench FAILED (regression detected, exit $RC)."
+            exit $RC
           fi
-          exit $RC
         env:
           SIFT_DIR: ${{ env.SIFT_DIR || '' }}
           BENCH_OUT: /tmp/bench-out

--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -1,0 +1,97 @@
+name: Vamana 1M scale-proof bench
+
+# Blocking / non-blocking decision:
+#
+#   NON-BLOCKING in main CI (continue-on-error: true).
+#
+# Rationale: The bench requires the SIFT-1M dataset (~500 MB, .fvecs format)
+# to be present at SIFT_DIR. GitHub-hosted runners do not have this data; it
+# lives on a self-hosted runner or must be downloaded. If SIFT_DIR is not set
+# or the files are absent, the script exits with code 2 (prerequisite missing)
+# rather than a regression (code 1). Treating a missing-data exit as a CI
+# failure would block every PR on all developers' machines.
+#
+# When a SIFT-capable self-hosted runner is provisioned, flip
+# continue-on-error to false for this job to make it fully blocking.
+#
+# What IS blocking: the bench script itself fails with exit 1 if the bench
+# runs but assertions fail. This will block only when SIFT data is present and
+# a regression is detected — exactly the desired behavior.
+
+on:
+  push:
+    branches: [main, "integration/**"]
+    paths:
+      - "crates/khive-vamana/**"
+      - "perf/targets.toml"
+      - "scripts/bench_1m.sh"
+      - "scripts/perf/ingest_scale_proof.py"
+  pull_request:
+    branches: [main, "integration/**"]
+    paths:
+      - "crates/khive-vamana/**"
+      - "perf/targets.toml"
+      - "scripts/bench_1m.sh"
+      - "scripts/perf/ingest_scale_proof.py"
+  workflow_dispatch:
+    inputs:
+      sift_dir:
+        description: "Path to SIFT data dir (overrides SIFT_DIR env)"
+        required: false
+        default: ""
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench-1m-ci:
+    name: Vamana ANN regression check (CI subset)
+    # Use a self-hosted runner when SIFT data is available; fall back to
+    # ubuntu-latest for the prerequisite-check path (exits 2, not 1).
+    runs-on: ubuntu-latest
+
+    # NON-BLOCKING: missing SIFT data is exit 2, not a regression.
+    # Flip to false when a SIFT-capable self-hosted runner is in place.
+    continue-on-error: true
+
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates
+          cache-on-failure: true
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set SIFT_DIR from workflow_dispatch input (if provided)
+        if: ${{ github.event.inputs.sift_dir != '' }}
+        run: echo "SIFT_DIR=${{ github.event.inputs.sift_dir }}" >> "$GITHUB_ENV"
+
+      - name: Run Vamana CI bench (10K/50K subset, <60 s when data present)
+        # Exit codes:
+        #   0 — data present; all assertions PASS
+        #   1 — data present; one or more assertions FAIL (regression)
+        #   2 — data absent; skip gracefully
+        run: |
+          bash scripts/bench_1m.sh --ci
+          RC=$?
+          if [ $RC -eq 2 ]; then
+            echo "::notice::SIFT data not found at SIFT_DIR=${SIFT_DIR:-<unset>} — bench skipped. Provision a SIFT-capable runner to enable regression gating."
+            exit 0
+          fi
+          exit $RC
+        env:
+          SIFT_DIR: ${{ env.SIFT_DIR || '' }}
+          BENCH_OUT: /tmp/bench-out

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check clippy test contract-test fmt fmt-check build clean ci docs-check publish publish-dry local proof-check check-fwd
+.PHONY: check clippy test contract-test fmt fmt-check build clean ci docs-check publish publish-dry local proof-check check-fwd bench-1m bench-1m-ci
 
 check:
 	cd crates && cargo check --workspace
@@ -45,6 +45,16 @@ publish-dry:
 
 publish:
 	./scripts/publish.sh --live
+
+bench-1m:
+	@echo "==> Running Vamana 1M scale-proof bench (3-point: 100K/316K/1M, ~7 min)..."
+	@echo "    Set SIFT_DIR to the sift_base.fvecs / sift_query.fvecs directory."
+	bash scripts/bench_1m.sh
+
+bench-1m-ci:
+	@echo "==> Running Vamana CI smoke bench (2-point: 10K/50K, <60 s)..."
+	@echo "    Set SIFT_DIR to the sift_base.fvecs / sift_query.fvecs directory."
+	bash scripts/bench_1m.sh --ci
 
 local:
 	@echo "==> Building kkernel (release)..."

--- a/crates/khive-vamana/PERF.md
+++ b/crates/khive-vamana/PERF.md
@@ -1,0 +1,98 @@
+# khive-vamana — 1M-Vector Scale-Proof Results
+
+This document banks the measured ANN scaling behaviour of khive-vamana on the
+SIFT-1M benchmark. It is the authoritative record for the "sublinear query
+scaling" claim made in the project documentation.
+
+## Run configuration
+
+| Parameter       | Value         |
+|-----------------|---------------|
+| max_degree (R)  | 64            |
+| search_list_size (L) | 128      |
+| alpha           | 1.0           |
+| build_batch     | 1024          |
+| k (neighbours)  | 10            |
+| target_recall   | 0.95          |
+| n_gt_queries    | 1000          |
+| n_latency_queries | 1000        |
+
+**Dataset**: SIFT-1M — 128-dimensional L2-normalized float32 vectors, BIGANN
+format (`.fvecs`). Ground-truth recomputed by brute-force on each subset
+(the provided ANN GT file indexes the full 1M base and is invalid for subsets).
+
+**Runner**: macos-arm64 | loadavg1 = 5.54 (high-load, see Caveats)
+
+**git sha**: eb6696c (PR #137)
+
+**Produced**: 2026-06-15T20:04:45Z
+
+## Results
+
+| N | iso-recall beam | recall@10 | p50 (µs) | p95 (µs) | p99 (µs) | build (ms) | speedup vs brute |
+|---|-----------------|-----------|----------|----------|----------|------------|-----------------|
+| 100 000 | 30 | 0.9504 | 71.0 | 92.9 | 102.3 | 11 123 | 88.8x |
+| 316 228 | 43 | 0.9523 | 129.8 | 176.6 | 200.3 | 54 590 | 152.6x |
+| 1 000 000 | 49 | 0.9521 | 170.8 | 216.1 | 234.2 | 320 777 | 341.4x |
+
+## Fitted scaling exponents (3-point power-law fit)
+
+| Signal | Exponent | R² | Interpretation |
+|--------|----------|----|----------------|
+| beam growth | 0.213 | 0.932 | Sub-linear (flat) |
+| iso-recall query (warm) | 0.381 | 0.955 | Sub-linear |
+| build wall-clock | 1.460 | 0.999 | Super-linear (Omega(N)) |
+| brute-force (reference) | 0.966 | 1.000 | Near-linear |
+
+## Decisive-question verdict
+
+YES — all criteria met:
+
+- beam flat (exponent 0.213 < threshold 0.5)
+- query sub-linear (exponent 0.381 < threshold 0.8)
+- recall >= 0.95 at all three N
+- ANN beats brute-force (341x at 1M)
+
+## Speedup note
+
+The 341x speedup is measured vs a NAIVE SCALAR L2 brute-force baseline — it
+is a sanity check, NOT a competitive number. A credible head-to-head requires
+a vectorized / faiss-flat baseline (tracked as M-06).
+
+## Caveats
+
+1. **3-point fit** — power-law exponents are fitted over 3 points only (100K,
+   316K, 1M). A 4+ point fit would tighten R² confidence.
+2. **Ground-truth policy** — the BIGANN GT file indexes the full 1M base and
+   is not valid for the 100K or 316K subsets. GT was recomputed by brute-force
+   L2 scan on each subset before evaluating recall.
+3. **Build is Omega(N)** — the build wall-clock exponent is 1.46 (super-linear).
+   The sub-linear claim applies to query and update latency only, not to
+   index construction.
+4. **Warm-cache latency** — query latency was measured with the index resident
+   in memory (warm cache). Cold-cache first-query latency will be higher,
+   especially at 1M vectors.
+5. **High-load run** — loadavg1 = 5.54 at measurement time. Latency numbers
+   may be inflated vs a quiescent machine; the scaling shape (exponents) is
+   unaffected by constant additive noise.
+6. **Regime boundary** — sub-linear query scaling holds at low intrinsic
+   dimensionality (SIFT intrinsic dim ~10). Benchmarks on higher intrinsic-dim
+   corpora (e.g. GloVe-100, intrinsic dim ~20) show near-linear query growth.
+   khive's production embedding model (all-MiniLM-L6-v2) has measured
+   intrinsic dim ~14, placing it in the sub-linear regime.
+
+## Reproducing this result
+
+```bash
+# Set SIFT_DIR to the directory containing sift_base.fvecs and sift_query.fvecs.
+export SIFT_DIR=/path/to/sift
+
+# Full 1M run (~7 minutes on Apple Silicon):
+make bench-1m
+
+# CI smoke-check (10K/50K, <60 seconds):
+make bench-1m-ci
+```
+
+Output JSON lands in `target/bench-out/` (gitignored). The ledger row is
+appended to `perf/ledger.csv` on success.

--- a/crates/khive-vamana/PERF.md
+++ b/crates/khive-vamana/PERF.md
@@ -51,7 +51,7 @@ YES — all criteria met:
 - beam flat (exponent 0.213 < threshold 0.5)
 - query sub-linear (exponent 0.381 < threshold 0.8)
 - recall >= 0.95 at all three N
-- ANN beats brute-force (341x at 1M)
+- ANN exceeds the configured 10x sanity threshold at 1M (measured 341x only against naive scalar L2, not FAISS / vectorized flat search — see Speedup note)
 
 ## Speedup note
 

--- a/crates/khive-vamana/examples/vec_bench.rs
+++ b/crates/khive-vamana/examples/vec_bench.rs
@@ -663,7 +663,8 @@ fn evaluate_check(spec: &CheckSpec, rows: &[RowResult], fits: &FitsResult) -> (V
         }
         "max_n" => {
             let v = rows
-                .last()
+                .iter()
+                .max_by_key(|r| r.n)
                 .map(|r| get_row_metric(&spec.metric, r))
                 .unwrap_or(f64::NAN);
             let pass = compare(v, &spec.operator, effective_threshold);

--- a/perf/ledger.csv
+++ b/perf/ledger.csv
@@ -1,1 +1,4 @@
-date,sha,pr,target,p50_us,p95_us,p99_us,max_us,pass,runner_os,loadavg1,notes
+date,sha,target,n,beam,recall_at_10,p50_us,p95_us,p99_us,build_ms,speedup,pass,loadavg,notes
+2026-06-15T20:04:45Z,eb6696c,khive-vamana/1m-scale-proof/sift-1m,100000,30,0.9504,71.0,92.917,102.333,11123.379,88.8,PASS,5.54,SIFT-1M-honest-3pt macos-arm64
+2026-06-15T20:04:45Z,eb6696c,khive-vamana/1m-scale-proof/sift-1m,316228,43,0.9523,129.792,176.584,200.25,54589.638,152.6,PASS,5.54,SIFT-1M-honest-3pt macos-arm64
+2026-06-15T20:04:45Z,eb6696c,khive-vamana/1m-scale-proof/sift-1m,1000000,49,0.9521,170.792,216.083,234.167,320776.873,341.4,PASS,5.54,SIFT-1M-honest-3pt macos-arm64

--- a/perf/targets.toml
+++ b/perf/targets.toml
@@ -78,17 +78,16 @@ name = "khive-vamana/scale-proof/khive-real-384"
   tolerance = 0.10
 
 # -------------------------------------------------------------------
-# Target 2: SIFT-1M (reproducible 1M proof; 128-dim, 4-point 100K/200K/500K/1M)
+# Target 2: SIFT-1M (reproducible 1M proof; 128-dim, 3-point 100K/316K/1M)
 #
-# Measured baselines (probe-results-sift-3pt.json + 1M probe, 2026-06-14):
-#   recall@10:  0.986 @1M
-#   beam:       64 (floor); exponent ≈ 0.303 (R²=0.99) over 100K–1M
-#   query p50:  ~334 µs @1M, warm
-#   query p95:  estimated ~430–500 µs @1M  # FLAG: λ-review — p95 not directly measured
-#   speedup:    ~34x @1M vs brute-force
+# Measured baselines (sift-1m-honest-3pt.json, 2026-06-15, sha eb6696c):
+#   recall@10:  0.9504 / 0.9523 / 0.9521  (all >= 0.95)
+#   beam:       30 / 43 / 49  (exponent = 0.213, R²=0.932)
+#   query p50:  71 / 130 / 171 µs  (well below 600 µs)
+#   query p95:  93 / 177 / 216 µs  (well below 900 µs)
+#   speedup:    89 / 153 / 341x vs scalar brute-force
 #
-# SIFT is harder than khive-real (ID ~10 vs 14, but unnormalized 128-dim).
-# Beam exponent 0.303 < 0.5 passes the flat criterion.
+# Updated from PR #137 stale estimates to actual honest-3pt measured values.
 # -------------------------------------------------------------------
 
 [[scale-proof.target]]
@@ -101,8 +100,8 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   threshold = 0.95
   tolerance = 0.0
 
-  # Measured SIFT beam exponent ≈ 0.303 (4-point, 100K–1M, R²=0.99).
-  # Threshold 0.5 passes with margin; 0.303 < 0.5.
+  # Measured SIFT beam exponent = 0.213 (3-point, 100K–1M, R²=0.932).
+  # Threshold 0.5 passes with margin; 0.213 < 0.5.
   [[scale-proof.target.check]]
   metric = "beam_growth_exponent"
   scope = "fits"
@@ -110,11 +109,8 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   threshold = 0.5
   tolerance = 0.0
 
-  # Measured SIFT query exponent: not directly reported for 4-point fit.
-  # FLAG: λ-review — iso_recall_query_exponent_warm threshold for SIFT-1M set
-  # conservatively at 0.8 (same as khive-real). SIFT has higher intrinsic dim
-  # than khive-real; if the 4-point fit shows a higher exponent, tighten
-  # after the actual 1M run. Measured 3-point SIFT showed near-sublinear.
+  # Measured SIFT query exponent = 0.381 (3-point, iso-recall warm, R²=0.955).
+  # Threshold 0.8 gives headroom; 0.381 < 0.8.
   [[scale-proof.target.check]]
   metric = "iso_recall_query_exponent_warm"
   scope = "fits"
@@ -122,7 +118,8 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   threshold = 0.8
   tolerance = 0.0
 
-  # Measured SIFT speedup at 1M: ~34x. Threshold 10x is a conservative floor.
+  # Measured SIFT speedup at 1M: 341x vs naive scalar L2 brute-force.
+  # Threshold 10x is a conservative floor to catch regressions.
   [[scale-proof.target.check]]
   metric = "speedup_vs_brute_force"
   scope = "max_n"
@@ -130,7 +127,7 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   threshold = 10.0
   tolerance = 0.0
 
-  # Measured SIFT p50 @1M: ~334 µs. Threshold 600 µs = ~1.8x headroom.
+  # Measured SIFT p50 @1M: 171 µs. Threshold 600 µs = ~3.5x headroom.
   [[scale-proof.target.check]]
   metric = "query_warm_p50_us"
   scope = "max_n"
@@ -138,10 +135,7 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   threshold = 600.0
   tolerance = 0.10
 
-  # FLAG: λ-review — SIFT-1M p95 threshold set at 900 µs.
-  # p95 was not directly measured in the 3-point probe. Estimate based on
-  # p95/p50 ratio from khive-real (~1.3x): 334 * 1.3 ≈ 434 µs.
-  # 900 µs = ~2x the p50 estimate — conservative; tighten after real 1M run.
+  # Measured SIFT p95 @1M: 216 µs. Threshold 900 µs = ~4.2x headroom.
   [[scale-proof.target.check]]
   metric = "query_warm_p95_us"
   scope = "max_n"

--- a/scripts/bench_1m.sh
+++ b/scripts/bench_1m.sh
@@ -14,7 +14,7 @@
 #
 # Environment:
 #   SIFT_DIR   directory containing sift_base.fvecs and sift_query.fvecs
-#              (default: /Users/lion/projects/khive/khive-sublinear/data/sift)
+#              (required; no default — script exits 2 if unset or empty)
 #   BENCH_OUT  output directory for bench JSON and logs
 #              (default: target/bench-out; gitignored via target/)
 #
@@ -40,7 +40,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CRATES_DIR="$REPO_ROOT/crates"
 
 # ── Defaults ────────────────────────────────────────────────────────────────
-SIFT_DIR="${SIFT_DIR:-/Users/lion/projects/khive/khive-sublinear/data/sift}"
+SIFT_DIR="${SIFT_DIR:-}"
 BENCH_OUT="${BENCH_OUT:-$REPO_ROOT/target/bench-out}"
 NS="100000,316228,1000000"
 DATASET="SIFT-1M-honest-3pt"
@@ -91,6 +91,11 @@ echo "" | tee -a "$LOG_FILE"
 # ── Prerequisites ────────────────────────────────────────────────────────────
 prereq_fail=0
 
+if [[ -z "$SIFT_DIR" ]]; then
+  echo "ERROR: SIFT_DIR is not set. Set SIFT_DIR to the directory containing sift_base.fvecs and sift_query.fvecs." >&2
+  exit 2
+fi
+
 if [[ ! -f "$BASE_FILE" ]]; then
   echo "ERROR: SIFT base vectors not found: $BASE_FILE" >&2
   echo "  Set SIFT_DIR to the directory containing sift_base.fvecs and sift_query.fvecs" >&2
@@ -119,7 +124,7 @@ fi
 # ── Run the bench ────────────────────────────────────────────────────────────
 echo "--- Running vec_bench ---" | tee -a "$LOG_FILE"
 
-BENCH_EXIT=0
+set +e
 (
   cd "$CRATES_DIR"
   cargo run --release -p khive-vamana --example vec_bench -- \
@@ -132,19 +137,21 @@ BENCH_EXIT=0
     --out "$BENCH_JSON"
 ) 2>&1 | tee -a "$LOG_FILE"
 BENCH_EXIT="${PIPESTATUS[0]}"
+set -e
 
 echo "" | tee -a "$LOG_FILE"
 echo "--- vec_bench exit code: $BENCH_EXIT ---" | tee -a "$LOG_FILE"
 
 if [[ $BENCH_EXIT -ne 0 ]]; then
   echo "ERROR: vec_bench exited with code $BENCH_EXIT" >&2
+  echo "=== RESULT: FAIL (bench assertions failed) ===" | tee -a "$LOG_FILE"
   exit 1
 fi
 
 # ── Ingest into ledger ───────────────────────────────────────────────────────
 if [[ -f "$BENCH_JSON" ]]; then
   echo "--- Ingesting into ledger: $LEDGER_CSV ---" | tee -a "$LOG_FILE"
-  INGEST_EXIT=0
+  set +e
   (
     cd "$REPO_ROOT"
     python3 scripts/perf/ingest_scale_proof.py \
@@ -152,6 +159,7 @@ if [[ -f "$BENCH_JSON" ]]; then
       --ledger "$LEDGER_CSV"
   ) 2>&1 | tee -a "$LOG_FILE"
   INGEST_EXIT="${PIPESTATUS[0]}"
+  set -e
 
   if [[ $INGEST_EXIT -ne 0 ]]; then
     echo "WARNING: ledger ingest failed (exit $INGEST_EXIT) — bench result is still valid" >&2
@@ -162,12 +170,7 @@ fi
 
 # ── Report overall result ────────────────────────────────────────────────────
 echo "" | tee -a "$LOG_FILE"
-if [[ $BENCH_EXIT -eq 0 ]]; then
-  echo "=== RESULT: PASS ===" | tee -a "$LOG_FILE"
-  echo "    JSON: $BENCH_JSON" | tee -a "$LOG_FILE"
-  echo "    Log:  $LOG_FILE" | tee -a "$LOG_FILE"
-  exit 0
-else
-  echo "=== RESULT: FAIL (bench assertions failed) ===" | tee -a "$LOG_FILE"
-  exit 1
-fi
+echo "=== RESULT: PASS ===" | tee -a "$LOG_FILE"
+echo "    JSON: $BENCH_JSON" | tee -a "$LOG_FILE"
+echo "    Log:  $LOG_FILE" | tee -a "$LOG_FILE"
+exit 0

--- a/scripts/bench_1m.sh
+++ b/scripts/bench_1m.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# scripts/bench_1m.sh — reproducible Vamana 1M-vector scale-proof bench
+#
+# Produces the SIFT-1M 3-point (100K/316K/1M) proof that confirms sublinear
+# query scaling on khive-vamana. Results are written to BENCH_OUT as a JSON
+# file and every row is appended to perf/ledger.csv.
+#
+# Usage:
+#   bash scripts/bench_1m.sh [--ns <N1,N2,...>] [--dataset <name>] [--ci]
+#
+#   --ns       comma-separated subset sizes (default: 100000,316228,1000000)
+#   --dataset  dataset name tag written into bench JSON (default: SIFT-1M-honest-3pt)
+#   --ci       shorthand for --ns 10000,50000 (fast CI smoke-check)
+#
+# Environment:
+#   SIFT_DIR   directory containing sift_base.fvecs and sift_query.fvecs
+#              (default: /Users/lion/projects/khive/khive-sublinear/data/sift)
+#   BENCH_OUT  output directory for bench JSON and logs
+#              (default: target/bench-out; gitignored via target/)
+#
+# Exit codes:
+#   0   bench ran and all assertions PASSed
+#   1   bench ran but one or more assertions FAILed
+#   2   prerequisite missing (SIFT data, binary, etc.)
+#   3   usage error
+#
+# Notes:
+#   - Run from the worktree root (the directory containing scripts/).
+#   - Cargo is invoked from the crates/ subdirectory (no root Cargo.toml).
+#   - Raw bench JSON is written to BENCH_OUT; that directory is outside the
+#     repo tree by default (target/bench-out) and is gitignored.
+#   - On success, ledger rows are appended to perf/ledger.csv.
+#   - For CI, use --ci (runs 10K/50K; fast; still asserts PASS criteria).
+
+set -euo pipefail
+
+# ── Locate repo root (the directory that contains scripts/) ─────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CRATES_DIR="$REPO_ROOT/crates"
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+SIFT_DIR="${SIFT_DIR:-/Users/lion/projects/khive/khive-sublinear/data/sift}"
+BENCH_OUT="${BENCH_OUT:-$REPO_ROOT/target/bench-out}"
+NS="100000,316228,1000000"
+DATASET="SIFT-1M-honest-3pt"
+CI_MODE=0
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ns)
+      NS="$2"; shift 2 ;;
+    --dataset)
+      DATASET="$2"; shift 2 ;;
+    --ci)
+      CI_MODE=1
+      NS="10000,50000"
+      DATASET="SIFT-CI-smoke"
+      shift ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | grep '^#' | sed 's/^# \?//'
+      exit 0 ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      exit 3 ;;
+  esac
+done
+
+# ── Derived paths ────────────────────────────────────────────────────────────
+BASE_FILE="$SIFT_DIR/sift_base.fvecs"
+QUERY_FILE="$SIFT_DIR/sift_query.fvecs"
+TARGETS_TOML="$REPO_ROOT/perf/targets.toml"
+LEDGER_CSV="$REPO_ROOT/perf/ledger.csv"
+TARGET_KEY="khive-vamana/1m-scale-proof/sift-1m"
+
+mkdir -p "$BENCH_OUT"
+BENCH_JSON="$BENCH_OUT/${DATASET}.json"
+LOG_FILE="$BENCH_OUT/${DATASET}.log"
+
+echo "=== khive-vamana 1M scale-proof bench ===" | tee "$LOG_FILE"
+echo "Date:       $(date -Iseconds)" | tee -a "$LOG_FILE"
+echo "Repo:       $REPO_ROOT" | tee -a "$LOG_FILE"
+echo "SIFT_DIR:   $SIFT_DIR" | tee -a "$LOG_FILE"
+echo "BENCH_OUT:  $BENCH_OUT" | tee -a "$LOG_FILE"
+echo "ns:         $NS" | tee -a "$LOG_FILE"
+echo "dataset:    $DATASET" | tee -a "$LOG_FILE"
+echo "CI mode:    $CI_MODE" | tee -a "$LOG_FILE"
+echo "" | tee -a "$LOG_FILE"
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+prereq_fail=0
+
+if [[ ! -f "$BASE_FILE" ]]; then
+  echo "ERROR: SIFT base vectors not found: $BASE_FILE" >&2
+  echo "  Set SIFT_DIR to the directory containing sift_base.fvecs and sift_query.fvecs" >&2
+  prereq_fail=1
+fi
+
+if [[ ! -f "$QUERY_FILE" ]]; then
+  echo "ERROR: SIFT query vectors not found: $QUERY_FILE" >&2
+  prereq_fail=1
+fi
+
+if [[ ! -f "$TARGETS_TOML" ]]; then
+  echo "ERROR: targets.toml not found: $TARGETS_TOML" >&2
+  prereq_fail=1
+fi
+
+if ! command -v cargo &>/dev/null; then
+  echo "ERROR: cargo not found in PATH" >&2
+  prereq_fail=1
+fi
+
+if [[ $prereq_fail -ne 0 ]]; then
+  exit 2
+fi
+
+# ── Run the bench ────────────────────────────────────────────────────────────
+echo "--- Running vec_bench ---" | tee -a "$LOG_FILE"
+
+BENCH_EXIT=0
+(
+  cd "$CRATES_DIR"
+  cargo run --release -p khive-vamana --example vec_bench -- \
+    --base "$BASE_FILE" \
+    --query "$QUERY_FILE" \
+    --ns "$NS" \
+    --dataset "$DATASET" \
+    --targets "$TARGETS_TOML" \
+    --target-key "$TARGET_KEY" \
+    --out "$BENCH_JSON"
+) 2>&1 | tee -a "$LOG_FILE"
+BENCH_EXIT="${PIPESTATUS[0]}"
+
+echo "" | tee -a "$LOG_FILE"
+echo "--- vec_bench exit code: $BENCH_EXIT ---" | tee -a "$LOG_FILE"
+
+if [[ $BENCH_EXIT -ne 0 ]]; then
+  echo "ERROR: vec_bench exited with code $BENCH_EXIT" >&2
+  exit 1
+fi
+
+# ── Ingest into ledger ───────────────────────────────────────────────────────
+if [[ -f "$BENCH_JSON" ]]; then
+  echo "--- Ingesting into ledger: $LEDGER_CSV ---" | tee -a "$LOG_FILE"
+  INGEST_EXIT=0
+  (
+    cd "$REPO_ROOT"
+    python3 scripts/perf/ingest_scale_proof.py \
+      --in "$BENCH_JSON" \
+      --ledger "$LEDGER_CSV"
+  ) 2>&1 | tee -a "$LOG_FILE"
+  INGEST_EXIT="${PIPESTATUS[0]}"
+
+  if [[ $INGEST_EXIT -ne 0 ]]; then
+    echo "WARNING: ledger ingest failed (exit $INGEST_EXIT) — bench result is still valid" >&2
+  fi
+else
+  echo "WARNING: bench JSON not found after run ($BENCH_JSON) — ledger not updated" >&2
+fi
+
+# ── Report overall result ────────────────────────────────────────────────────
+echo "" | tee -a "$LOG_FILE"
+if [[ $BENCH_EXIT -eq 0 ]]; then
+  echo "=== RESULT: PASS ===" | tee -a "$LOG_FILE"
+  echo "    JSON: $BENCH_JSON" | tee -a "$LOG_FILE"
+  echo "    Log:  $LOG_FILE" | tee -a "$LOG_FILE"
+  exit 0
+else
+  echo "=== RESULT: FAIL (bench assertions failed) ===" | tee -a "$LOG_FILE"
+  exit 1
+fi

--- a/scripts/perf/ingest_scale_proof.py
+++ b/scripts/perf/ingest_scale_proof.py
@@ -2,18 +2,15 @@
 """Ingest a scale-proof bench JSON into the perf ledger CSV.
 
 Usage:
-    uv run scripts/perf/ingest_scale_proof.py \\
-        --in    probe-results-1m.json \\
+    python3 scripts/perf/ingest_scale_proof.py \\
+        --in    <bench-output>.json \\
         --ledger perf/ledger.csv
 
-The script appends ONE row per run (the max-N row from the bench JSON).
-It creates perf/ledger.csv with a header row if the file does not exist.
+Appends ONE ROW PER N POINT from the bench JSON (not just the max-N row).
+Creates perf/ledger.csv with a header row if the file does not exist.
 
-CSV schema:
-    date,sha,pr,target,p50_us,p95_us,p99_us,max_us,pass,runner_os,loadavg1,notes
-
-This script is separate from any Criterion ingest.py; it reads the
-canonical scale-proof JSON schema (schema_version = "1.0").
+CSV schema (one row per N):
+    date,sha,target,n,beam,recall_at_10,p50_us,p95_us,p99_us,build_ms,speedup,pass,loadavg,notes
 
 Stdlib-only: json, csv, sys, os, argparse, pathlib — no third-party deps.
 """
@@ -23,28 +20,31 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import os
 import pathlib
 import sys
 
 LEDGER_HEADER = [
     "date",
     "sha",
-    "pr",
     "target",
+    "n",
+    "beam",
+    "recall_at_10",
     "p50_us",
     "p95_us",
     "p99_us",
-    "max_us",
+    "build_ms",
+    "speedup",
     "pass",
-    "runner_os",
-    "loadavg1",
+    "loadavg",
     "notes",
 ]
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Ingest scale-proof bench JSON into perf ledger CSV.")
+    p = argparse.ArgumentParser(
+        description="Ingest scale-proof bench JSON into perf ledger CSV (one row per N)."
+    )
     p.add_argument("--in", dest="bench_json", required=True, help="Path to bench JSON file")
     p.add_argument(
         "--ledger",
@@ -58,22 +58,13 @@ def ensure_ledger(ledger_path: pathlib.Path) -> None:
     if not ledger_path.exists():
         ledger_path.parent.mkdir(parents=True, exist_ok=True)
         with ledger_path.open("w", newline="") as f:
-            writer = csv.writer(f)
+            writer = csv.writer(f, lineterminator="\n")
             writer.writerow(LEDGER_HEADER)
         print(f"Created new ledger: {ledger_path}", file=sys.stderr)
 
 
-def build_notes(max_row: dict, loadavg1: float, all_checks_pass: bool) -> str:
-    n = max_row["n"]
-    recall = max_row.get("recall_at_10", float("nan"))
-    speedup = max_row.get("speedup_vs_brute_force", float("nan"))
-    notes = f"n={n},recall={recall:.4f},speedup={speedup:.1f}x"
-    if loadavg1 > 4.0:
-        notes += ",high_load"
-    if not all_checks_pass:
-        # Check if any check is a latency-related fail.
-        notes += ",assertion_fail"
-    return notes
+def build_notes(bench_row: dict, runner_os: str, dataset_name: str) -> str:
+    return f"{dataset_name} {runner_os}"
 
 
 def main() -> None:
@@ -94,58 +85,85 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    rows = data.get("rows", [])
-    if not rows:
+    bench_rows = data.get("rows", [])
+    if not bench_rows:
         print("ERROR: bench JSON has no rows", file=sys.stderr)
         sys.exit(1)
-
-    # Max-N row is the last element (bench writes rows in ascending N order).
-    max_row = max(rows, key=lambda r: r.get("n", 0))
 
     produced_at = data.get("produced_at", "")
     git_sha = data.get("git_sha", "")
     runner_os = data.get("runner_os", "")
     loadavg1 = float(data.get("loadavg1", 0.0))
-    pr = os.environ.get("GITHUB_PR_NUMBER", "")
 
     assertions = data.get("assertions", {})
     target_key = assertions.get("target_key", data.get("dataset", {}).get("name", ""))
     overall = assertions.get("overall", "SKIPPED")
-    pass_str = "true" if overall == "PASS" else "false"
+    pass_str = "PASS" if overall == "PASS" else "FAIL"
 
-    checks = assertions.get("checks", [])
-    all_checks_pass = all(c.get("result") == "PASS" for c in checks) if checks else (overall == "SKIPPED")
+    dataset_name = data.get("dataset", {}).get("name", "")
 
-    notes = build_notes(max_row, loadavg1, all_checks_pass)
-
-    row = {
-        "date": produced_at,
-        "sha": git_sha,
-        "pr": pr,
-        "target": target_key,
-        "p50_us": max_row.get("query_warm_p50_us", ""),
-        "p95_us": max_row.get("query_warm_p95_us", ""),
-        "p99_us": max_row.get("query_warm_p99_us", ""),
-        "max_us": max_row.get("query_warm_max_us", ""),
-        "pass": pass_str,
-        "runner_os": runner_os,
-        "loadavg1": loadavg1,
-        "notes": notes,
-    }
+    # Sort rows by ascending N (bench writes them in order, but be defensive).
+    bench_rows = sorted(bench_rows, key=lambda r: r.get("n", 0))
 
     ledger_path = pathlib.Path(args.ledger)
     ensure_ledger(ledger_path)
 
+    appended = []
     with ledger_path.open("a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=LEDGER_HEADER)
-        writer.writerow(row)
+        writer = csv.DictWriter(f, fieldnames=LEDGER_HEADER, lineterminator="\n")
+        for bench_row in bench_rows:
+            n = bench_row.get("n", "")
+            beam = bench_row.get("iso_recall_beam", "")
+            recall = bench_row.get("recall_at_10", "")
+            p50 = bench_row.get("query_warm_p50_us", "")
+            p95 = bench_row.get("query_warm_p95_us", "")
+            p99 = bench_row.get("query_warm_p99_us", "")
+            build_ms = bench_row.get("build_ms", "")
+            speedup = bench_row.get("speedup_vs_brute_force", "")
 
-    print(f"Appended row to {ledger_path}:")
-    print(
-        f"  date={produced_at}  sha={git_sha[:8]}...  target={target_key}  "
-        f"p50={row['p50_us']}  p95={row['p95_us']}  p99={row['p99_us']}  "
-        f"max={row['max_us']}  pass={pass_str}  notes={notes}"
-    )
+            # Round floats to reasonable precision for readability.
+            if isinstance(recall, float):
+                recall = round(recall, 4)
+            if isinstance(speedup, float):
+                speedup = round(speedup, 1)
+            if isinstance(build_ms, float):
+                build_ms = round(build_ms, 3)
+            if isinstance(p50, float):
+                p50 = round(p50, 3)
+            if isinstance(p95, float):
+                p95 = round(p95, 3)
+            if isinstance(p99, float):
+                p99 = round(p99, 3)
+
+            notes = build_notes(bench_row, runner_os, dataset_name)
+
+            ledger_row = {
+                "date": produced_at,
+                "sha": git_sha[:7],
+                "target": target_key,
+                "n": n,
+                "beam": beam,
+                "recall_at_10": recall,
+                "p50_us": p50,
+                "p95_us": p95,
+                "p99_us": p99,
+                "build_ms": build_ms,
+                "speedup": speedup,
+                "pass": pass_str,
+                "loadavg": loadavg1,
+                "notes": notes,
+            }
+            writer.writerow(ledger_row)
+            appended.append(ledger_row)
+
+    print(f"Appended {len(appended)} row(s) to {ledger_path}:")
+    for r in appended:
+        sha_short = str(r["sha"])[:8]
+        print(
+            f"  n={r['n']:>8}  beam={r['beam']:>4}  recall={r['recall_at_10']}  "
+            f"p50={r['p50_us']}µs  p95={r['p95_us']}µs  "
+            f"speedup={r['speedup']}x  {r['pass']}  sha={sha_short}"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/perf/ingest_scale_proof.py
+++ b/scripts/perf/ingest_scale_proof.py
@@ -51,6 +51,11 @@ def parse_args() -> argparse.Namespace:
         default="perf/ledger.csv",
         help="Path to ledger CSV (created if absent, default: perf/ledger.csv)",
     )
+    p.add_argument(
+        "--ledger-only",
+        action="store_true",
+        help="Append row even when assertions.overall != PASS and exit 0 (archival mode).",
+    )
     return p.parse_args()
 
 
@@ -164,6 +169,14 @@ def main() -> None:
             f"p50={r['p50_us']}µs  p95={r['p95_us']}µs  "
             f"speedup={r['speedup']}x  {r['pass']}  sha={sha_short}"
         )
+
+    if overall != "PASS" and not args.ledger_only:
+        print(
+            f"ERROR: assertions.overall={overall!r} — bench did not PASS. "
+            "Use --ledger-only to append failed rows for archival.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Productizes the SIFT-1M scale-proof benchmark for `khive-vamana` into reproducible
infrastructure: a parameterized runner, banked results, assertion thresholds, a perf ledger,
and a non-blocking CI smoke-check. Banks the honest 3-point SIFT-1M run (sha `eb6696c`, from
#137) as the authoritative record for the sublinear-query-scaling claim.

## Measured results (SIFT-1M, macos-arm64, loadavg 5.54)

| N    | recall@10 | p50    | p95    | beam | speedup vs naive scalar |
|------|-----------|--------|--------|------|-------------------------|
| 100K | 0.9504    | 71 µs  | 93 µs  | 30   | 88.8x                   |
| 316K | 0.9523    | 130 µs | 177 µs | 43   | 152.6x                  |
| 1M   | 0.9521    | 171 µs | 216 µs | 49   | 341.4x                  |

Fitted exponents: beam growth 0.213 (R² 0.93, flat), iso-recall query 0.381 (R² 0.96,
sublinear), build 1.46 (R² 0.999, Ω(N) super-linear).

**Headline: recall@10 0.95 at 171 µs p50 on 1M vectors on a laptop.**

The 341x is measured against a naive scalar-L2 baseline. It is a sanity check, not a
competitive number. A credible head-to-head needs a vectorized / faiss-flat baseline, tracked
as M-06. Do not lead with 341x.

## Files

- `scripts/bench_1m.sh` — parameterized runner; appends ledger on PASS
- `scripts/perf/ingest_scale_proof.py` — stdlib-only JSON to CSV ledger ingest
- `perf/targets.toml` — vendored assertion thresholds (no absolute paths)
- `perf/ledger.csv` — 3 banked proof rows
- `crates/khive-vamana/PERF.md` — banked results, exponents, caveats
- `crates/khive-vamana/examples/vec_bench.rs` — bench example (from #137)
- `.github/workflows/bench-1m.yml` — non-blocking CI gate
- `Makefile` — `bench-1m` and `bench-1m-ci` targets

## Caveats (all recorded in PERF.md)

3-point fit; build is Ω(N) so the sublinear claim covers query and update latency only;
warm-cache latency; high-load run (loadavg 5.54); sublinear query scaling holds at low
intrinsic dimensionality (SIFT ~10, khive production model all-MiniLM-L6-v2 ~14, both in
regime; GloVe-100 ~20 breaks it).

## Verification

Banked numbers match the validated #137 source run and the recorded honest-3pt findings.
Assertion thresholds in `targets.toml` are conservative regression floors (recall ≥ 0.95, beam
exp ≤ 0.5, query exp < 0.8, speedup ≥ 10x, p50 ≤ 600 µs, p95 ≤ 900 µs), not flattered claims.
One review flag is noted inline in `targets.toml`: the khive-real-384 target maxes at 500K, so
its p95 threshold derives from the 500K measurement.

Held pending maintainer review before merge.