### PR TITLE
docs(adr): ADR-007 Rev 2 — namespace as attribution-only, all-local; withdraw ADR-059

### DIFF
--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,511 +1,266 @@
-# ADR-007: Namespace
+# ADR-007 Rev 2: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate
 
-**Status**: accepted\
-**Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Status**: Proposed (pending Ocean ratification of C1 and C3 in Part C of the synthesis)
+**Date**: 2026-06-16
+**Authors**: lambda:khive, alpha:architect
+**Amends**: ADR-007-namespace.md (replaces v1 base text and both 2026-05 amendments in full)
+**Supersedes (partial)**: ADR-050 §"Decision"; ADR-059 §"Decision" and §"Visibility tiers"
+**Superseded-by-none**: ADR-053 (ActorStore, SessionStore, cloud-tier actor threading) survives in full
+**ADR chain**: ADR-018 (Gate trait, single dispatch site) | ADR-014 (curation, merge semantics)
+| ADR-002 (edge cascade, no dangling refs)
+
+---
 
 ## Context
 
-Namespace is khive's logical isolation primitive. Every entity, note, event, and edge record
-carries a namespace. Queries are namespace-scoped. In a hosted deployment, namespace isolation
-failure is a data breach.
+khive accumulated four namespace documents in the v1 series that disagree on what namespace is
+for. ADR-007 v1 base text treated namespace as a type-level authorization proof
+(NamespaceToken, NamespaceView, by-ID post-fetch checks). The 2026-05-25 amendment introduced
+AllowAllGate as the OSS default. The 2026-05-27 Namespace-by-Layer amendment split packs into
+two routing groups. ADR-050 proposed removing the KG-pack token rebinding introduced by that
+split. ADR-059 drafted a three-tier visibility model.
 
-The isolation model must satisfy:
+Ocean's ruling (CLAUDE.md "Authorization — the gate is a seam, by design" and "Namespace and
+authorization") resolves the divergence: namespace is attribution, not isolation. Storage is
+dumb. The Gate is the one enforcement seam.
 
-1. **OSS simplicity.** Single-user local deployment should work with zero configuration. No
-   tenant IDs, no auth tokens, no isolation layers to understand.
-2. **Cloud correctness.** In hosted multi-tenant deployment, one tenant's data must be
-   unreachable from another tenant's context. Accidental namespace fallback must be impossible
-   to express.
-3. **Federation safety.** A single verb may fan out to multiple backends (ADR-029, Substrate Coordinator).
-   Namespace enforcement must propagate through every backend call, not just the entry point.
-4. **Type-level enforcement.** Convention fails; types hold. The design should make isolation
-   breaks impossible to express in Rust, not merely documented as forbidden.
-5. **Wire compatibility.** Namespace is stored as a TEXT column in SQLite. Changes to the
-   `Namespace` representation must not require database migrations for existing deployments.
+PR-A1 (commit 2607e263, merged 2026-06-16) shipped the by-ID half: all ensure_namespace /
+ensure_namespace_visible post-fetch checks removed from get_entity, get_note, delete_entity,
+delete_note, update_entity, update_note, update_edge, delete_edge. The multi-record half
+(list, search, recall, neighbors, traverse, query) still filters by visible_namespaces. This
+ADR specifies collapsing that to the single shared "local" set (PR-B).
+
+This ADR does not specify cloud multi-tenant isolation. That is behind the Gate trait. This ADR
+specifies the OSS contract and the seam that cloud plugs into.
+
+---
 
 ## Decision
 
-### Opaque newtype with validated factories
-
-`Namespace` is a string-backed newtype with no public unchecked constructor. Callers
-construct namespaces through validated factories.
-
-```rust
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-#[serde(try_from = "String", into = "String")]
-pub struct Namespace(String);
-
-impl Namespace {
-    pub const LOCAL: &'static str = "local";
-
-    pub fn parse(value: &str) -> Result<Self, NamespaceError> {
-        validate_namespace(value)?;
-        Ok(Self(String::from(value)))
-    }
-
-    pub fn local() -> Self {
-        Self(String::from(Self::LOCAL))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-}
-
-impl TryFrom<String> for Namespace { /* validates through Namespace::parse */ }
-impl TryFrom<&str> for Namespace { /* validates through Namespace::parse */ }
-```
-
-`Namespace` is a string-backed newtype with no public unchecked constructor. The
-shipped public construction surface is `Namespace::parse(&str)`, `Namespace::local()`,
-`TryFrom<String>`, and `TryFrom<&str>`. Earlier `project(slug)`, `tenant(id)`,
-`system(name)`, and `from_trusted_unchecked` examples are deferred sketches, not
-accepted API. Hosted deployments derive namespace strings from authenticated
-context, parse them, and mint `NamespaceToken` through runtime/gate dispatch;
-caller input never receives an unchecked namespace factory.
-
-### No `Default`
-
-`Namespace` does not implement `Default`.
-
-Single-user OSS deployments obtain `Namespace::local()` from runtime configuration, not
-from the namespace type itself:
-
-```rust
-pub struct RuntimeConfig {
-    pub default_namespace: Namespace,
-}
-
-impl RuntimeConfig {
-    pub fn local_dev() -> Self {
-        Self {
-            default_namespace: Namespace::local(),
-        }
-    }
-}
-```
-
-Hosted deployments must mint namespaces from authenticated tenant context before verb
-dispatch. If `Default` existed, a misconfigured cloud tenant could accidentally fall into
-`"local"` and access other `"local"`-namespaced data.
-
-### Structural validation
-
-Structural invariants are enforced at `Namespace` construction time. A valid `Namespace`
-value is definitionally well-formed.
-
-```text
-Structural validation (at construction):
-- non-empty
-- length-bounded (max 256 characters)
-- valid character set (alphanumeric, '-', '_', ':', '.')
-- no trailing separator
-- no empty path segments ("local::project" is invalid)
-- tenant namespace contains valid UUID
-- reserved prefixes ("system:", "tenant:") controlled by factories
-```
-
-### `NamespaceToken`: type-level authorization proof
-
-`NamespaceToken` is a non-forgeable proof that structural validation and semantic
-authorization have both occurred. It is minted only by the auth/runtime layer.
-
-```rust
-pub struct NamespaceToken {
-    namespace: Namespace,
-    principal: PrincipalId,
-    grants: NamespaceGrants,
-    _sealed: private::Sealed,
-}
-
-mod private {
-    pub struct Sealed;
-}
-
-impl NamespaceToken {
-    pub(crate) fn mint(
-        auth: &AuthContext,
-        namespace: Namespace,
-        requested: NamespaceAccess,
-    ) -> Result<Self, AuthError> {
-        auth.authorize_namespace(&namespace, requested)?;
-        Ok(Self {
-            namespace,
-            principal: auth.principal_id(),
-            grants: auth.grants_for(&namespace),
-            _sealed: private::Sealed,
-        })
-    }
-
-    pub fn namespace(&self) -> &Namespace {
-        &self.namespace
-    }
-}
-```
-
-Semantic authorization (at token minting):
-
-```text
-- namespace exists in tenant registry (cloud) or is well-formed (OSS)
-- principal owns or has been granted access to namespace
-- requested access mode (read / write / admin) is permitted
-- cross-namespace access grant exists (if requesting foreign namespace)
-```
-
-A `Namespace` value proves structural well-formedness. A `NamespaceToken` proves
-authorization for a principal and access mode.
-
-### Runtime enforcement via `NamespaceView`
-
-Agent/user code never receives the raw coordinator or raw storage. It receives a
-`NamespaceView`, created from a `NamespaceToken`:
-
-```rust
-pub struct NamespaceView<'a> {
-    coordinator: &'a SubstrateCoordinator,
-    token: NamespaceToken,
-}
-
-impl<'a> NamespaceView<'a> {
-    pub async fn search(&self, req: SearchRequest) -> Result<SearchResult, RuntimeError> {
-        self.coordinator.search(&self.token, req).await
-    }
-
-    pub async fn get_entity(&self, id: Uuid) -> Result<Entity, RuntimeError> {
-        self.coordinator.get_entity(&self.token, id).await
-    }
-}
-```
-
-All runtime methods that read/write namespace-scoped records require `NamespaceToken`.
-In the shipped runtime, `VerbRegistry::dispatch` resolves and validates the operation
-namespace, consults the gate, mints `NamespaceToken` at the dispatch boundary, strips
-the transport `namespace` field before ordinary pack handlers, and passes
-`&NamespaceToken` into pack code. Single-record ID operations still require token
-verification after fetching by UUID.
-
-First-party packs may apply documented namespace policy by rebinding a token with
-`NamespaceToken::with_namespace`, for example KG graph verbs using the shared default
-namespace under the Namespace-by-Layer rule. This is trusted pack policy, not a
-caller-visible namespace factory.
-
-The enforcement pattern:
-
-```rust
-// Write path
-if entity.namespace != *token.namespace() {
-    return Err(RuntimeError::NamespaceMismatch);
-}
-
-// Read-by-ID path
-let record = storage.get(id).await?;
-if record.namespace != *token.namespace() {
-    return Err(RuntimeError::NamespaceDenied);
-}
-```
-
-Physical stores remain unscoped persistence connections. They execute what they are told.
-Enforcement happens in the runtime/coordinator layer, not at the storage level.
-
-**Timing oracle mitigation**: Error responses for "UUID exists but wrong namespace" and
-"UUID does not exist" MUST be identical in type, message, and observable timing. Both
-return `RuntimeError::NotFound` with the message "not found in this namespace" — no
-indication of whether the record exists in another namespace. This prevents UUID
-enumeration attacks against foreign namespaces.
-
-### Namespace vs backend: independent axes
-
-Namespace and backend are independent isolation dimensions.
-
-```text
-Namespace answers: "Which principal may access this record?"
-Backend answers: "Where is this record physically stored and what operational policy applies?"
-```
-
-A namespace may span multiple backends. A backend may contain multiple namespaces.
-
-Authorization is always evaluated against namespace, not backend name. The coordinator
-composes both axes during fan-out: it routes to the correct backends AND enforces namespace
-filtering on every backend call.
-
-Neither dimension subsumes the other. Namespace isolation is necessary but not sufficient
-for full isolation — a record in the correct namespace on the wrong backend is a routing
-bug. A record on the correct backend in the wrong namespace is a security bug.
-
-### Hierarchy helper: naming utility, not authorization
-
-The shipped namespace module exposes `has_segment_prefix(child, parent)` as a public
-helper for naming-convention checks. It is not a semantic guarantee and MUST NOT be
-used for authorization. Authorization decisions use `NamespaceToken` and gate policy.
-
-```rust
-// khive-types/src/namespace.rs — naming-convention helper, NOT authorization
-pub fn has_segment_prefix(child: &Namespace, parent: &Namespace) -> bool {
-    let c = child.as_str();
-    let p = parent.as_str();
-    c.len() > p.len()
-        && c.starts_with(p)
-        && c.as_bytes().get(p.len()) == Some(&b':')
-}
-```
-
-Authorization decisions use `NamespaceToken`, not string-prefix checks.
-
-### Pack namespace policy: out of scope
-
-ADR-007 defines the namespace primitive and enforcement model. Pack-specific namespace
-behavior (memory pack scoped to agent namespace, lore pack as global read-only) belongs
-in ADR-017 (Pack Standard) or a future pack capability ADR.
-
-Any pack namespace policy must compile down to `NamespaceToken` / `NamespaceView`
-permissions. Packs must not bypass namespace enforcement or construct namespaces from
-raw strings.
-
-## Rationale
-
-### Why no public constructor?
-
-`Namespace::new(arbitrary_string)` allows typos (`""`, `"local:"`, `"tenant:not-a-uuid"`)
-and namespace guessing attacks in hosted deployments. Factories enforce invariants at
-construction time. Every call site that currently passes an arbitrary string must go through
-validation — this is good breakage because it identifies every unvalidated namespace entry
-point.
-
-### Why no Default?
-
-`Default` produces `Namespace::local()`. In a cloud deployment, any code path that reaches
-`Default::default()` without going through auth falls into the `"local"` namespace. A
-misconfigured cloud tenant reading `"local"` data is a data breach. Moving the default to
-runtime configuration makes the OSS path explicit (`RuntimeConfig::local_dev()`) and the
-cloud path impossible to accidentally bypass.
-
-### Why NamespaceToken (not just ingress validation)?
-
-Ingress validation (option A from the question file) is a single chokepoint at verb
-dispatch. Any code path that skips verb dispatch — internal maintenance, background tasks,
-admin operations, future hot paths — can access any namespace without validation. A
-token makes bypass impossible to express in the type system: if you don't have a
-`NamespaceToken`, you cannot call namespace-scoped operations.
-
-### Why independent axes (not namespace-primary)?
-
-Backend is not merely an implementation detail once federation exists. A namespace can span
-`main.db` and `archive.db`. A backend can hold namespaces from different tenants. The
-coordinator must compose both: route to the right backends AND filter by namespace. Treating
-backend as "just an implementation detail" encourages developers to assume backend placement
-is irrelevant to isolation — but placing tenant A's data on tenant B's dedicated backend is
-a placement bug even if namespace filtering would prevent reads.
-
-### Why remove hierarchy from core type?
-
-`is_child_of` performs a string-prefix check. It has no semantic relationship to
-authorization. In cloud deployments, tenant namespaces are UUIDs — there is no hierarchy.
-The method would be dead code on half the deployment surface and a security footgun on the
-other half.
-
-### Why read-by-ID still requires token?
-
-UUID is globally unique, but namespace-scoped. Storage fetches by UUID without namespace
-filtering (the UUID is sufficient for the lookup). But the runtime must verify the result
-belongs to the caller's namespace before returning it. Without this check, an attacker who
-guesses or observes a UUID from another namespace can read that record.
+### Rule 0 — One shared brain, one namespace
+
+khive's local (OSS) deployment is a single shared brain: one SQLite file, one namespace
+("local"), all lambdas and agents reading and writing together.
+
+Actor identity (lambda:khive, lambda:leo, agent:*, user:ocean) is attribution only: stamped on
+write records and gate-request context, available for logging, filtering, and cloud policy
+input. It never silently becomes the storage namespace and never gates by-ID access.
+
+Source: CLAUDE.md "The local system is a single shared brain: one namespace (`local`), and
+every lambda / agent / subagent reads and writes it."
+
+### Rule 1 — Storage is dumb
+
+Stores (khive-db, khive-storage traits) are unscoped database connections. Namespace is a
+column on every record, written as-is from the record struct. Stores execute what they are
+told.
+
+- Multi-record methods (list, search, FTS, vector search, neighbors, traverse, query) accept
+  namespace as a caller-supplied parameter used in the SQL WHERE clause.
+- By-ID methods (get, update, delete, upsert) use WHERE id = ? only. No namespace equality
+  check in the store or in the runtime above it.
+
+Source: v0 archive ADR-007-namespace-as-open-string.md (2026-05-15) rules 1-4 ("stores are
+unscoped database connections"), re-affirmed for v1.
+
+No inline namespace == checks in handlers or stores are permitted. No per-namespace storage
+partitioning. These make the Gate redundant — the exact regression this seam exists to prevent.
+
+### Rule 2 — By-ID ops are namespace-agnostic (SHIPPED, PR-A1)
+
+get, update, delete by UUID resolve a globally-unique UUID with no namespace check at any
+layer: not in the store SQL, not in the runtime post-fetch check, not in the pack handler.
+
+Status: SHIPPED in commit 2607e263. Covered by regression tests added in that PR.
+
+Affected functions confirmed clean post-PR-A1 (operations.rs): get_entity,
+get_entity_including_deleted, get_note_including_deleted, delete_entity, delete_note,
+update_entity, update_note, update_edge, delete_edge.
+
+### Rule 3 — Multi-record ops scope to the single shared "local" set (PR-B, pending)
+
+CHANGE FROM ADR-007 v1: The 2026-05-27 Namespace-by-Layer amendment routed memory, gtd, comm,
+brain, and schedule multi-record ops by actor namespace ("WHERE namespace = <actor_namespace>"),
+while routing KG and knowledge to "local". Gemini REFUTE Finding 2 correctly identified this
+as a contradiction of Rule 0: framing per-pack actor routing as "explicit pack policy"
+re-introduces the exact actor-as-namespace isolation coupling Ocean ordered removed. Finding 1
+added that memory is live-audited as bulk "local" and that cross-lambda learning via
+memory.recall over one pool depends on the shared store. The lambda synthesis confirms: there
+is no actor-namespace routing rule. ALL packs store in "local". The per-pack distinction is
+dissolved.
+
+Under this ADR: list, search, recall, neighbors, traverse, and query for ALL packs pass
+WHERE namespace = 'local' (or the configured default_namespace, which is "local" for OSS).
+
+Per-actor distinctions for operational packs are view-layer filters, not namespace partitions:
+
+- GTD: filter by the "assignee" column (tag or field), not by namespace.
+- Comm: filter by "from" and "to" addressing fields, not by namespace.
+- Memory: filter by actor_id attribution column when an owner-scoped view is needed; the
+  underlying pool is shared and cross-lambda recall operates over it.
+- Brain: profile resolution is its own scoping mechanism (brain.resolve, profile bindings),
+  independent of namespace.
+- Schedule: attribution columns carry the scheduling actor; namespace is "local".
+
+This dissolves the Rule 0 vs Rule 3 contradiction present in the draft (gemini Finding 2) and
+resolves the memory-pack scoping incoherence (gemini Finding 1).
+
+Status: PR-B, not yet built.
+
+### Rule 4 — Authorization enforced at one seam: the Gate
+
+VerbRegistry::dispatch (crates/khive-runtime/src/pack.rs) calls self.gate.check(&gate_req)
+before every verb invocation. This is the single enforcement point.
+
+- OSS default: AllowAllGate — every request passes. Zero embedded cost.
+- Cloud: a TenantGate (non-OSS, separate crate behind the Gate trait) validates the caller's
+  authenticated identity and enforces per-tenant namespace access.
+- No policy DSL ships in khive. khive-gate-rego is a dev-dep only; cloud policy lives behind
+  the Gate trait, outside this repository.
+
+The gate call is live code, not dead code. It is the seam that makes OSS single-tenant and
+cloud multi-tenant share the same binary without structural change.
+
+**Cloud-tier clarification.** Namespace is attribution and a gate policy-input — never a
+storage boundary, at either tier. The invariant that holds in OSS holds unchanged in cloud:
+storage is never partitioned by namespace, and by-ID ops resolve a globally-unique UUID with
+no namespace check. The only OSS/cloud difference is which Gate is installed. The gate receives
+the acting actor, the request namespace, and the target records' attribution as policy input,
+and returns allow/deny:
+
+- OSS AllowAllGate ignores all of it and returns allow.
+- A cloud TenantGate MAY key per-tenant isolation on the namespace string (or any attribution
+  field). That is the gate reading namespace as policy input — not storage partitioning on it.
+
+How a cloud gate maps authenticated tenants to allow/deny is cloud policy, behind the trait,
+out of this repository's scope. This ADR specifies only the gate's input contract and the
+storage-dumb / by-ID-global invariant that both tiers preserve. "Namespace never becomes the
+storage namespace" is absolute. "Namespace may be a cloud gate's policy key" is consistent
+with it: a policy input is not a storage boundary.
+
+Source: CLAUDE.md "The `Gate` is a replaceable trait. The runtime holds an `Arc<dyn Gate>` and
+consults it on every verb dispatch — one authorization boundary."
+
+### Rule 5 — Merge semantics: same-namespace guard survives as substrate check, not isolation
+
+CHANGE FROM ADR-007 v1: The v1 base text and Namespace-by-Layer amendment defended the
+merge_entity same-namespace guard on the grounds that it prevents merging a "local KG entity
+with an actor-scoped operational note." Gemini Finding 4 correctly refuted this: entities and
+notes are different substrates merged by different verbs (merge_entity vs merge_note), so the
+cross-substrate scenario is structurally impossible regardless of namespace values. In an
+all-"local" world the guard is circular ("local" == "local") and is dead code with respect to
+isolation.
+
+This ADR retains the guard as merge semantics (ADR-014 curation), specifically as a
+same-substrate deduplication quality gate, not as an isolation mechanism. It does not prevent
+anything in the current deployment. It is dead-but-harmless and may be cleaned up in a future
+PR. It must not be defended as isolation.
+
+Source: curation.rs line 2908-2910 ("a merge-semantic constraint, not tenant isolation"),
+gemini Finding 4.
+
+### Rule 6 — Namespace type: open string with validated factory
+
+Namespace is a string-backed newtype. The validated factory Namespace::parse(s) is the
+construction surface (non-empty, length <= 256, character set [a-zA-Z0-9\-_:.], no trailing
+separator, no empty segments). Namespace::local() returns the "local" singleton.
+
+Structural validation from ADR-007 v1 is retained. It is not isolation machinery; it prevents
+accidental garbage in the namespace column.
+
+Removed from scope vs ADR-007 v1:
+
+- NamespaceToken as a proof-of-authorization for by-ID access (superseded by Rule 2).
+- NamespaceView wrapper that gates coordinator access (superseded by Rule 2).
+- Timing oracle mitigation (returning identical errors for "wrong namespace" vs "not found")
+  because by-ID ops no longer do namespace checks.
+- NamespaceGrants, AuthContext, PrincipalId types from the base text — cloud types, behind
+  the Gate trait, outside this repository.
+- Read-by-ID namespace post-fetch verification. SHIPPED removed by PR-A1.
+
+NamespaceToken may be retained as the attribution carrier passed into pack handlers (it carries
+actor, namespace, visible-set metadata), but it is no longer a by-ID access guard.
+
+### Rule 7 — Attribution stamping
+
+Writes stamp namespace, actor_id, and actor_kind on records from the dispatch context.
+Attribution is informational: queryable, filterable, loggable, and available to the gate as
+policy input. It does not route storage.
+
+---
+
+## Supersession Map
+
+| Document                                          | Status                      | Superseded clauses                                                                                                                                                                          | Surviving clauses                                                                                                                                                                                                                 |
+| ------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-007 v1 base text (this file, prior revision)  | Superseded (Rev 2 replaces) | NamespaceToken as by-ID guard; NamespaceView; Read-by-ID namespace check; Timing oracle mitigation; NamespaceGrants / AuthContext / PrincipalId                                             | Namespace::parse structural validation; "No Default"; Namespace vs backend independent axes; Hierarchy helper naming utility                                                                                                      |
+| ADR-007 2026-05-25 amendment                      | Partially superseded        | OSS vs Cloud two-model framing (collapsed: OSS IS the model; cloud plugs in via Gate)                                                                                                       | AllowAllGate as OSS default; [actor] id as attribution config; 4-tier config search path; display_name advisory-only                                                                                                              |
+| ADR-007 2026-05-27 amendment (Namespace-by-Layer) | Superseded                  | KG-pack namespace override via token.with_namespace(); per-pack actor namespace routing for memory/gtd/comm — this ADR replaces routing with view-layer tag filters                         | None; the routing intent is now stated correctly in Rule 3                                                                                                                                                                        |
+| ADR-050                                           | Partially superseded        | Decision: removal of KG-pack override (this ADR absorbs and confirms)                                                                                                                       | Context: documents the override as a historical bug; Rationale "Why not token rebinding"                                                                                                                                          |
+| ADR-053                                           | Survives in full            | No conflict                                                                                                                                                                                 | All: ActorStore, SessionStore, DispatchRequest, cloud-tier actor threading. Attribution threading is orthogonal to namespace isolation.                                                                                           |
+| ADR-059 (draft)                                   | Substantially superseded    | Decision: visibility tiers (shared + private + proposal-only); visibility filter checking all three namespace columns; subagents submit proposals; legacy "local" maps to private namespace | Context: multi-lambda cooperation description (retained as background); Gemini-mirror corrections on edge namespace storage (edge carries its own namespace column, not derived from endpoints) — a storage schema fact, retained |
+
+Note on ADR-058: PR #143 proposes a new ADR-058 for the brain posterior read-path. That
+number is orthogonal to the namespace work. The supersession map above does not reference
+ADR-058 because this ADR does not touch the brain read-path. PR #143 may proceed without
+collision.
+
+---
+
+## Alternatives Considered
+
+| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                         |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                           |
+| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Rejected (gemini Finding 1, Finding 2; lambda synthesis)            |
+| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Superseded by this ADR                                              |
+| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                            |
+| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not |
+
+---
 
 ## Consequences
 
 ### Positive
 
-- Namespace isolation enforced by the Rust type system, not convention.
-- Cloud deployment cannot accidentally fall into `"local"`.
-- Every namespace-scoped code path requires an authorized token.
-- Read-by-ID verifies namespace after fetch — no UUID-guessing bypass.
-- Hierarchy helpers cannot be confused with authorization.
-- Pack namespace policy deferred to the right layer (ADR-017, Pack Standard).
+- By-ID ops are namespace-agnostic (SHIPPED). Agents can reach any record they know the UUID of.
+- Storage is dumb: no authorization logic at the store or runtime-post-fetch layer.
+- Gate is the single enforcement seam: cloud isolation is one Gate implementation swap.
+- "local" as the universal namespace means cross-project KG edges and cross-lambda memory.recall
+  work without gymnastics.
+- Memory pool is shared: lambdas learn from each other's recalled experience.
+- Removes the KG-pack token rebinding bug (ADR-050 context) that caused cross-tenant bleed.
+- Removes the Rule 0/Rule 3 contradiction present in the prior amendment.
 
 ### Negative
 
-- Removing `Default` and the public constructor breaks existing call sites.
-  Mitigated: these are the call sites that need audit — the breakage is diagnostic.
-- `NamespaceToken` adds a parameter to every runtime/coordinator method.
-  Mitigated: the parameter is the authorization proof — omitting it would be the bug.
-- Two-layer validation (structural + semantic) is more complex than single-layer.
-  Mitigated: each layer is simple and independently testable.
+- PR-A2/PR-F require a full reindex, not just a WHERE-clause change: FTS5 is physically
+  per-namespace and ANN snapshots are per-namespace graph blobs, both regenerated from the
+  relabeled base rows. Vector base data needs no movement (vec_* tables are per-model,
+  namespace-agnostic — live-DB verified). Higher-cost than the prior amendment implied, but a
+  single reindex pass is the mechanism.
+- PR-F is a live-data mutation with no automatic rollback. Requires snapshot discipline.
+- Until PR-B lands, KG list/search may include stranded non-"local" records or miss them
+  depending on current visible-set config. This is the current state post-PR-A1.
 
 ### Neutral
 
-- SQLite TEXT column unchanged. Namespace strings stored the same way.
-- `Namespace::local()` still works for OSS. The factory is the same; the default is
-  moved to config.
-- Wire format unchanged — namespaces are strings in JSON/MCP.
-
-## Implementation
-
-- `khive-types/src/namespace.rs`: `Namespace` struct with factories, `TryFrom<String>`,
-  `NamespaceError`. No `Default`. No `new(String)`. No `is_child_of`.
-- `khive-runtime/src/runtime.rs`: `NamespaceToken` with sealed constructor,
-  `NamespaceView` wrapper. Token minting via `VerbRegistry::dispatch`.
-- `khive-types/src/namespace.rs`: `has_segment_prefix` utility for OSS hierarchical
-  naming convention (lives with the `Namespace` type, not in the runtime).
-- Runtime methods: all namespace-scoped operations take `&NamespaceToken`. Read-by-ID
-  methods verify `record.namespace == token.namespace()` after fetch.
+- Namespace::parse structural validation survives.
+- merge_entity / merge_note same-namespace guard survives as dead-but-harmless merge semantics.
+- ADR-053 (ActorStore, DispatchRequest) survives in full.
+- Wire format unchanged: namespace is a string in JSON/MCP.
 
 ---
 
-## Amendment: OSS vs Cloud Namespace Models (2026-05-25)
+## References
 
-**Authors**: lambda:khive (Wave 4 — k-actor-config)
-
-### Two products, two models
-
-The original ADR describes the complete enforcement model that will apply in cloud (hosted,
-multi-tenant) deployments. OSS single-binary deployments use a deliberately lighter model.
-These are different products and the distinction is intentional.
-
-```text
-OSS model:   config-default actor + per-op override + no enforcement
-Cloud model: NamespaceToken from authenticated session + full enforcement
-```
-
-OSS never enforces namespace isolation — it is a single-user local tool. The namespace
-field exists to give agents logical grouping and to prevent accidental cross-session
-contamination, not to provide security.
-
-### OSS namespace resolution (priority order)
-
-When `khive-mcp` starts, it resolves the default namespace for the session in the
-following priority order (highest wins):
-
-1. `--actor <id>` CLI flag (or `KHIVE_ACTOR` env var)
-2. `--namespace <id>` CLI flag (or `KHIVE_NAMESPACE` env var) — legacy alias for `--actor`
-3. `[actor] id` in the config file (`--config` / `KHIVE_CONFIG` / `khive.toml` /
-   `.khive/config.toml` / `~/.khive/config.toml`)
-4. Hard default: `"local"`
-
-Every verb that does not supply an explicit `namespace` argument inherits the session
-default. Verbs that supply `namespace` explicitly use that value unconditionally — the gate
-is still consulted (as required by ADR-018), but the OSS default `AllowAllGate` allows all
-requests, so there is no denying enforcement. Cloud deployments swap in `TenantGate`, which
-rejects namespace requests that do not match the authenticated session JWT.
-
-### TOML config format
-
-```toml
-[actor]
-id = "lambda:myproject"           # sets default_namespace for this session
-display_name = "My Project Agent" # optional, advisory only
-```
-
-`display_name` is stored in the config struct and available for display/logging; it has no
-effect on namespace routing or enforcement.
-
-### Why no enforcement in OSS
-
-1. **Single-user deployment.** There is no second principal to protect against. The user
-   who sets `--actor lambda:foo` is the same user who could set `--actor lambda:bar`. An
-   enforcement layer would only add friction with zero security benefit.
-2. **AllowAllGate.** The OSS binary uses `AllowAllGate` — every verb dispatch succeeds
-   authorization. `NamespaceToken` is still minted (structural validation still fires), but
-   the gate never rejects. Cloud swaps in `TenantGate` which verifies the session JWT and
-   enforces that the requested namespace matches the authenticated tenant.
-3. **Contamination prevention, not isolation.** The main value of `--actor` in OSS is
-   preventing accidental cross-session contamination: two agents sharing a single `khive-mcp`
-   instance with the same `"local"` default will interleave their tasks. Giving each agent
-   its own actor ID (`lambda:agent-a`, `lambda:agent-b`) keeps their records separate without
-   any security boundary.
-
-### Cloud enforcement (future)
-
-Cloud deployments replace the `AllowAllGate` with a real gate that:
-
-- Receives the session JWT from the incoming connection context
-- Extracts the tenant namespace from the token claims
-- Rejects any verb that requests a namespace not permitted by the JWT
-
-The `NamespaceToken` minting in `VerbRegistry::dispatch` is unchanged — only the gate
-implementation differs. OSS and cloud share the same type system; enforcement is a
-deployment-time configuration, not a code change.
-
-### Consequences of this amendment
-
-- `RuntimeConfig::default_namespace` is the single place where the OSS actor default
-  is stored. All config-loading code sets it; the runtime never reads `[actor]` directly.
-- `khive-runtime/src/engine_config.rs` gains `ActorConfig { id, display_name }` as a
-  `[actor]` section in `KhiveConfig`.
-- `runtime_config_from_khive_config` applies `actor.id` to `default_namespace` when present.
-- `khive-mcp` binary gains `--actor` / `KHIVE_ACTOR` as the preferred namespace override,
-  with `--namespace` retained as a legacy alias.
-- `KhiveConfig::load_with_home_fallback` implements the 4-tier config search path.
-
----
-
-## Amendment: Namespace-by-Layer Rule (2026-05-27)
-
-**Authors**: Ocean, lambda:khive
-
-### Problem
-
-When different projects (lionagi, khive, lattice) each run MCP with `--actor lambda:{project}`,
-their KG entities land in separate namespaces. This makes shared concepts invisible across
-projects, creates duplicates, and prevents cross-project edges — defeating the purpose of a
-shared knowledge graph.
-
-### Rule: KG uses shared namespace, scoped packs use actor namespace
-
-| Pack layer                      | Namespace                 | Rationale                                             |
-| ------------------------------- | ------------------------- | ----------------------------------------------------- |
-| **KG** (entities, edges, notes) | `local` (default, shared) | One "LoRA" entity — all projects link to it via edges |
-| **Memory** (remember/recall)    | `lambda:{project}`        | Scoped episodic/semantic memory per agent             |
-| **GTD** (assign/next/complete)  | `lambda:{project}`        | Scoped task queues per orchestrator                   |
-| **Comm** (send/inbox)           | `lambda:{project}`        | Scoped messaging between agents                       |
-| **Brain** (profiles/feedback)   | `lambda:{project}`        | Scoped priors per agent context                       |
-| **Schedule** (agenda/remind)    | `lambda:{project}`        | Scoped schedules per agent                            |
-| **Knowledge** (learn/cite)      | `local` (shared)          | Extends KG — same shared namespace                    |
-
-**Invariant**: `create`, `link`, `search`, `list`, `get`, `neighbors`, `traverse`, `query`,
-`knowledge.learn`, `knowledge.cite` MUST use the default shared namespace. Agents MUST NOT
-override the namespace for KG operations with `lambda:*` actor namespaces.
-
-### Why not one namespace for everything?
-
-Memory recall under `lambda:lionagi` returns only lionagi's working memories. If all memory
-went to `local`, every agent would recall every other agent's episodic notes — noise that
-degrades recall precision. The separation is correct for scoped operational data and wrong
-for shared structural knowledge.
-
-### Cross-project connection model
-
-Projects connect through the edge ontology, not through namespace sharing:
-
-```text
-Entity: "LoRA" (concept, namespace=local)
-  ←implements— "lattice-lora" (project, namespace=local)
-  ←depends_on— "lionagi-finetune" (project, namespace=local)
-  ←introduced_by— "Hu et al. 2021" (concept, namespace=local)
-```
-
-Each project's `project` entity lives in the shared graph. The `implements`, `depends_on`,
-`competes_with` edges ARE the cross-project synergy layer.
-
-### Implementation
-
-1. **MCP server**: KG pack verbs always use `RuntimeConfig::default_namespace` (already
-   `Namespace::local()` by default). The `--actor` flag affects memory/gtd/comm/brain
-   namespace selection but NOT KG verbs.
-2. **Pack dispatch**: Each pack determines its own namespace policy. KG pack ignores actor
-   override for entity/edge/note operations. Memory/GTD/Comm packs use actor namespace.
-3. **Plugin skills**: All KG plugin skills (digest, expand, polish, gap, explore, etc.)
-   document that they operate in the shared namespace.
-4. **Agent instructions**: Agents using `--actor lambda:{project}` must understand that KG
-   operations are cross-project by design.
-
-### Consequences
-
-- No duplicate entities across projects — one canonical concept per name.
-- Cross-project edges work without namespace gymnastics.
-- Memory/task isolation preserved — agents don't pollute each other's working state.
-- Requires pack-level namespace routing (KG pack → shared, memory pack → actor) rather than
-  a single session-wide namespace.
+- CLAUDE.md "Authorization — the gate is a seam, by design" — Ocean's ratified design.
+- CLAUDE.md "Namespace and authorization" — coding standards.
+- v0 archive: khive-old/docs/_archive/adr_v0/ADR-007-namespace-as-open-string.md — original
+  dumb-storage rules 1-4.
+- Commit 2607e263 — PR-A1 implementation, by-ID contract SHIPPED.
+- gemini_refute_adr007.md (resume 44078a77) — REFUTE findings 1-6, authoritative corrections.
+- ADR-014 — curation operations, merge semantics.
+- ADR-018 — Gate trait, single dispatch site, AllowAllGate.
+- ADR-002 — edge cascade, no dangling refs.
+- ADR-053 — ActorStore, SessionStore, cloud-tier actor threading (survives).

--- a/docs/adr/ADR-050-kg-token-namespace-contract.md
+++ b/docs/adr/ADR-050-kg-token-namespace-contract.md
@@ -1,9 +1,15 @@
 # ADR-050: KG Token Namespace Contract
 
+> **Partially superseded by ADR-007 Rev 2 (2026-06-16).** The §"Decision" clause (removal of
+> the KG-pack namespace override) is absorbed and confirmed by ADR-007 Rev 2 Rule 2 and Rule 3.
+> The by-ID namespace check aspects are superseded by ADR-007 Rev 2 Rule 2 (SHIPPED, PR-A1).
+> The §"Context" and §"Rationale / Why not token rebinding" sections remain authoritative
+> historical background for why the override was introduced and why it was removed.
+
 **Status**: Proposed — pending Ocean review
 **Date**: 2026-06-03
 **Supersedes**: ADR-007 §"Namespace-by-Layer Rule" (KG pack rebinding only)
-**References**: ADR-007, ADR-028, ADR-029
+**References**: ADR-007 (Rev 2), ADR-028, ADR-029
 
 ---
 

--- a/docs/adr/ADR-059-namespace-write-tiers.md
+++ b/docs/adr/ADR-059-namespace-write-tiers.md
@@ -1,0 +1,478 @@
+# ADR-059: Namespace Write Tiers and Cross-Namespace Link Access Control
+
+**Status**: Withdrawn — superseded before acceptance by ADR-007 Rev 2 (2026-06-16).
+
+This ADR introduced a three-tier visibility model (shared / private / proposal-only) and
+associated per-namespace write enforcement. ADR-007 Rev 2 establishes that namespace is
+attribution-only and that all packs store in the single shared "local" namespace; actor
+identity is a view-layer tag filter, never a namespace partition. The write-tier model
+re-introduced the actor-as-namespace coupling that Ocean's "one shared brain" ruling ordered
+removed, making the core mechanism of this ADR incompatible with the ratified design.
+The subagent propose-only tier, which is operationally separable, may be proposed as a future
+ADR scoped to the propose/review verb lifecycle (ADR-046) rather than to namespace scoping.
+The ADR number 059 is burned — this file is preserved as a record of the withdrawn design.
+
+**Date**: 2026-06-15
+**Authors**: lambda:khive, Ocean
+**Withdrawn**: 2026-06-16 (superseded by ADR-007 Rev 2)
+**Depends on**:
+
+- ADR-007 (Namespace contract — data-breach boundary, OSS vs cloud axes)
+- ADR-017 (Pack standard — pack-extensible edge endpoints)
+- ADR-018 (Authorization gate — single dispatch-site enforcement)
+- ADR-046 (Event-sourced proposals — the mutation path for subagents)
+- ADR-050 (KG token namespace contract — pack honors token without override)
+- ADR-053 (Authorization gate actor store — ActorRef.kind precedent)
+- ADR-057 (Comm actor-addressed delivery — actor-label vs namespace-string distinction)
+
+**Related issues**: #75 (actor identity on every request), #57 (cross-namespace comm), #13 (AllowAll gate)
+
+---
+
+## Context
+
+Three lambda orchestrators (lambda:leo, lambda:khive, lambda:lionagi) and an arbitrary number
+of ephemeral subagents share one SQLite knowledge graph via the khive MCP server. All sessions
+currently run as namespace `"local"` -- the fall-back when no `[actor] id` is configured. This
+is a deliberate stop-gap: a prior attempt to give each lambda a distinct namespace identifier
+in `khive.toml` broke all cross-read access because `ensure_namespace` enforces strict
+primary-namespace equality on write-guarded paths and the data corpus (approximately 12,380
+notes, 2,744 entities) lives entirely in `"local"`.
+
+Ocean's design intent (2026-06-15):
+
+- All lambdas may read and write to a **shared** cooperative KG namespace.
+- All lambdas may also maintain a **private** namespace for their own working state.
+- Subagents (ephemeral task-runners spawned by lambdas) may read from visible namespaces but
+  must not directly mutate; they submit proposals via the ADR-046 lifecycle which a lambda
+  approves or rejects.
+- An edge whose endpoints span namespaces is a **cross-namespace link**. The edge itself is
+  stored in the creator's namespace and the visibility filter must check all three namespace
+  columns (edge, source endpoint, target endpoint) to avoid leaks.
+
+A gemini REFUTE-mirror review (2026-06-14) produced three binding corrections incorporated
+here:
+
+1. Edge namespace is stored on the edge (scheme B1), not derived from endpoint namespaces.
+   The visibility filter MUST check all three namespace columns. Checking only the two
+   endpoint columns would make a private edge between two shared-namespace nodes globally
+   visible -- a real leak.
+2. A link whose creator cannot reach both endpoints is rejected at link time. The error code
+   is `NotFound`, not `Forbidden`. `Forbidden` is a UUID-existence oracle and violates the
+   fail-closed rule.
+3. The legacy `"local"` namespace must map to a private `lambda:khive` namespace plus a fresh
+   empty shared namespace -- not become the shared namespace. Making `"local"` the shared
+   namespace would expose operator working memory (tasks, episodic memories, session notes) to
+   every cooperating agent, which is a privacy leak and pollutes a clean demo environment.
+
+### What this ADR does and does not guarantee
+
+This ADR defines a **visibility boundary for cooperating agents running on the same SQLite
+database**. Agents that honor the token contract cannot access records outside their visible
+set. This is sufficient for the multi-lambda cooperative use case in an OSS single-machine
+deployment.
+
+This ADR does NOT establish a **security boundary against a hostile local actor**. Any process
+with filesystem access to the SQLite file can read or write records directly. Authentication
+against an independent authority, row-level encryption, and mTLS caller propagation are
+cloud-tier concerns addressed in ADR-053 and its successors. The phrase "access control" in
+this document always refers to the visibility-boundary sense, never to hardened security.
+
+---
+
+## Decision
+
+### 1. Namespace Tiers
+
+Two tiers are defined. A single deployment always has exactly one shared namespace and zero or
+more private namespaces.
+
+| Tier                 | Identifier convention | Owner                     |
+| -------------------- | --------------------- | ------------------------- |
+| Shared               | `shared` (default)    | All participating lambdas |
+| Private (per-lambda) | `lambda:<name>`       | The named lambda only     |
+
+The shared namespace is the cooperative KG: research entities, cross-project concepts, edges
+linking them. Private namespaces hold working memory, session notes, task queues, and episodic
+memories that belong to one lambda.
+
+No other tiers exist in this ADR. A subagent does not own a namespace; it borrows its
+sponsoring lambda's token with a visibility set appropriate to its task.
+
+### 2. Actor Kinds
+
+Two actor kinds are recognized for namespace write-tier enforcement. They map directly to the
+`ActorRef.kind` field already defined in `khive-gate/src/actor.rs`.
+
+| Kind     | `ActorRef.kind` value | Who                                          |
+| -------- | --------------------- | -------------------------------------------- |
+| Lambda   | `"lambda"`            | Standing orchestrators (leo, khive, lionagi) |
+| Subagent | `"subagent"`          | Ephemeral task-runners spawned by a lambda   |
+
+The `"anonymous"` kind (the current OSS default) is treated as a lambda for backward
+compatibility: unauthenticated local sessions retain full write access. A future ADR may
+tighten this once `[actor] kind` is declared in `khive.toml`.
+
+### 3. Permission Matrix
+
+| Action                           |        Lambda (shared ns)        | Lambda (own private ns) | Lambda (other private ns) | Subagent (shared ns) | Subagent (own private ns) |
+| -------------------------------- | :------------------------------: | :---------------------: | :-----------------------: | :------------------: | :-----------------------: |
+| Read (get / list / search)       |               Yes                |           Yes           | If in visible_namespaces  |         Yes          |            Yes            |
+| Write (create / update / delete) |               Yes                |           Yes           |            No             |  No -- propose only  |    No -- propose only     |
+| Link (cross-namespace edge)      | Yes, if both endpoints reachable |           Yes           |            No             |  No -- propose only  |    No -- propose only     |
+| Propose (ADR-046)                |               Yes                |           Yes           |            No             |         Yes          |            Yes            |
+| Review / apply proposal          |         Yes (any lambda)         |           Yes           |            No             |          No          |            No             |
+
+"Propose only" for subagents means: the verb `propose` succeeds; the verbs `create`, `update`,
+`delete`, `link`, and `annotates` return `NotFound` (fail-closed, no existence oracle).
+
+### 4. Token Shape Changes
+
+#### 4.1 ActorConfig additions (engine_config.rs)
+
+Two new fields are added to `ActorConfig` in `khive-runtime/src/engine_config.rs`:
+
+```toml
+[actor]
+id           = "lambda:khive"        # primary write namespace (existing)
+kind         = "lambda"              # NEW: "lambda" | "subagent" | "anonymous"
+visible_namespaces  = ["shared"]     # existing: readable beyond primary
+writable_namespaces = ["shared"]     # NEW: namespaces this actor may write to
+                                     #       beyond its own primary namespace
+```
+
+`kind` defaults to `"anonymous"` when absent, preserving backward compatibility.
+`writable_namespaces` defaults to `[]` when absent, meaning only the primary namespace is
+writable. This preserves the current behavior for all existing configurations.
+
+#### 4.2 NamespaceToken additions (config.rs)
+
+`NamespaceToken` gains a `writable` field parallel to `visible`:
+
+```rust
+pub struct NamespaceToken {
+    namespace: Namespace,          // primary write namespace (existing)
+    visible:   Vec<Namespace>,     // read visibility set (existing)
+    writable:  Vec<Namespace>,     // NEW: full write-authorized namespaces
+    actor:     ActorRef,           // (existing, already carries .kind)
+    _sealed:   private::Sealed,
+}
+```
+
+Construction invariant: the primary `namespace` is always in both `visible` and `writable`.
+`mint_with_visibility` is extended to accept `extra_writable: Vec<Namespace>` alongside
+`extra_visible`.
+
+#### 4.3 ActorRef.kind propagation
+
+`ActorConfig.kind` is resolved at token-mint time and stored in `ActorRef.kind` within the
+token. The runtime reads `token.actor().kind` to enforce propose-only for subagents. The
+field already exists (`khive-gate/src/actor.rs:14`); this ADR defines its OSS values and
+enforcement semantics.
+
+### 5. Write Enforcement
+
+#### 5.1 New check: `ensure_namespace_writable`
+
+A new helper is added to `KhiveRuntime` in `operations.rs`, parallel to `ensure_namespace_visible`:
+
+```rust
+pub(crate) fn ensure_namespace_writable(
+    record_ns: &str,
+    token: &NamespaceToken,
+) -> RuntimeResult<()> {
+    if token.actor().kind == "subagent" {
+        return Err(RuntimeError::NotFound("not found in this namespace".into()));
+    }
+    for ns in token.writable_namespaces() {
+        if record_ns == ns.as_str() {
+            return Ok(());
+        }
+    }
+    Err(RuntimeError::NotFound("not found in this namespace".into()))
+}
+```
+
+The error is `NotFound` in all cases, not `PermissionDenied`, to preserve the
+fail-closed no-existence-oracle rule.
+
+#### 5.2 Call site changes
+
+The existing `ensure_namespace` (strict primary-equality check) at write paths is replaced
+with `ensure_namespace_writable`. This affects the following call sites in `operations.rs`:
+
+| Line (approx.) | Operation                       | Change                                            |
+| -------------- | ------------------------------- | ------------------------------------------------- |
+| 2272--2286     | `get_by_ids` entity/note/event  | No change (read path, uses `ensure_namespace`)    |
+| 2310--2322     | `hard_delete` entity/note/event | `ensure_namespace` -> `ensure_namespace_writable` |
+| 2358           | `complete_note`                 | `ensure_namespace` -> `ensure_namespace_writable` |
+| 2514           | `update_entity`                 | `ensure_namespace` -> `ensure_namespace_writable` |
+| 2598           | `update_note`                   | `ensure_namespace` -> `ensure_namespace_writable` |
+| 2660           | `delete_entity`                 | `ensure_namespace` -> `ensure_namespace_writable` |
+
+`create_entity` and `create_note` do not call `ensure_namespace` today; they stamp
+`token.namespace().as_str()` directly onto new records. After this ADR, the target
+namespace for a create is chosen from `token.namespace()` (primary write namespace) -- no
+change needed. If a lambda wishes to create a record in the shared namespace, it sets its
+primary namespace to shared, or uses an explicit `namespace=` parameter validated against
+`ensure_namespace_writable`.
+
+#### 5.3 Subagent propose routing
+
+When a subagent calls `create`, `update`, `delete`, or `link`, `ensure_namespace_writable`
+returns `NotFound` immediately. The verb handler returns `{ok: false, error: "..."}` without
+reaching storage. The subagent must use `propose(title, description, changeset)` (ADR-046)
+instead.
+
+A lambda reviewing a proposal applies the changeset through its own token, which passes
+`ensure_namespace_writable`. The apply path in the proposal worker is unchanged.
+
+### 6. Cross-Namespace Links (Scheme B1)
+
+#### 6.1 Edge namespace storage
+
+An edge is stored with its own `namespace` column equal to the creator's primary write
+namespace at link time. This is scheme B1 (mirror decision, 2026-06-14: confirmed over
+scheme B2 where edge namespace is derived from endpoints).
+
+No change to the edge schema is required; the `namespace` column already exists on the
+`edges` table.
+
+#### 6.2 Three-column visibility filter
+
+The existing `list_edges`, `neighbors`, and `traverse` operations filter edges by namespace.
+After this ADR, the filter condition is:
+
+```sql
+edge.namespace IN (visible_set)
+AND source_entity.namespace IN (visible_set)
+AND target_entity.namespace IN (visible_set)
+```
+
+All three namespace columns must be in the caller's visible set. Checking only the two
+endpoint columns would make a private edge between two shared nodes globally visible to any
+caller who can see the shared namespace -- a real leak. Checking only the edge column would
+make an edge invisible even when both endpoints are reachable (unnecessary opacity).
+
+This is an additive change to the query filter. The ADR-002 endpoint kind contract
+(which `(source_kind, relation, target_kind)` triples are legal) is unaffected. Namespace
+scope and entity-kind scope are orthogonal validation axes.
+
+#### 6.3 Link-time cross-namespace rejection
+
+Before creating an edge, the `link` verb handler calls `ensure_namespace_visible` for both
+the source and target entity. If either check fails, the edge creation is aborted with
+`NotFound` for that entity. The response is indistinguishable from the entity not existing.
+
+```rust
+// Pseudocode -- implementation lives in khive-pack-kg/src/handlers.rs
+Self::ensure_namespace_visible(&source_entity.namespace, token)?;
+Self::ensure_namespace_visible(&target_entity.namespace, token)?;
+// Only after both checks pass:
+self.runtime.create_edge(token, ...).await
+```
+
+The error is `NotFound`, not `Forbidden`. Returning `Forbidden` would confirm that the UUID
+exists in a namespace the caller cannot reach (existence oracle).
+
+Additionally, `ensure_namespace_writable` is checked against `edge.namespace` (the creator's
+primary namespace) before any storage write, consistent with all other write paths.
+
+### 7. GraphStore Trait Scope
+
+The current `GraphStore` trait methods accept a single `namespace: &str` parameter for
+list and search operations. To support multi-namespace visible sets, these signatures must
+accept `namespaces: &[&str]` (or an equivalent `IN`-clause parameter). This is a
+breaking change to the trait contract and requires updates to all `GraphStore`
+implementations.
+
+This change is a cost callout (gemini mirror finding, 2026-06-14) and is tracked in a
+separate implementation ticket. The ADR specifies the required end state; the migration path
+is implementation-owned.
+
+### 8. ANN Index Multi-Namespace Gather
+
+The Vamana ANN index (`khive-vamana`) is keyed per-namespace. Shared and private namespaces
+have separate index files. A search that spans multiple visible namespaces must gather results
+from each index separately and apply RRF fusion to produce a unified ranked list.
+
+This is a cost callout. The current single-index recall path in `operations.rs:1947-2011` must
+be extended to iterate over visible namespaces, query each index, and fuse results. The
+`memory.recall` verb is the primary consumer.
+
+### 9. Migration of the Legacy `"local"` Namespace
+
+Existing data in the `"local"` namespace must not be deleted or moved. The migration is a
+namespace relabel via SQL UPDATE, applied as a numbered `VersionedMigration` (ADR-015).
+
+The relabel policy:
+
+| Record kind                                                                | Relabel target               | Rationale                                          |
+| -------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| `memory` notes (episodic / semantic)                                       | `lambda:khive` (private)     | Operator working memory; not for subagents to read |
+| `task` notes                                                               | `lambda:khive` (private)     | lambda:khive task queue                            |
+| `message` notes                                                            | `lambda:khive` (private)     | Comm pack messages are actor-addressed internally  |
+| `scheduled_event` notes                                                    | `lambda:khive` (private)     | Schedule pack intent is per-actor                  |
+| All other note kinds (observation, insight, question, decision, reference) | OPEN FORK F1                 | See Forks                                          |
+| All entities (concept, document, project, etc.)                            | OPEN FORK F1                 | See Forks                                          |
+| All edges                                                                  | Follow source entity relabel | Edge namespace = creator's namespace               |
+
+The fresh shared namespace (`shared` by default, configurable) begins empty. Lambdas
+populate it intentionally over time by creating records with their primary namespace set to
+`shared`, or by using the `namespace=` explicit argument on supported verbs.
+
+The `"local"` identifier is not retired. Any existing config or process that passes
+`namespace="local"` will target a now-private-but-renamed namespace. Once all active sessions
+are reconfigured to use `lambda:khive` or `shared`, `"local"` becomes an orphan and can be
+aliased in config.
+
+**Data preservation invariant**: no record UUID changes. No edge is deleted. The migration is
+UPDATE-only. The data-vs-view principle (CLAUDE.md) applies: changing which namespace a query
+returns is a view-layer decision; the migration changes the stored namespace string to align
+the data model with the new tier design, not to alter query semantics.
+
+The live SQLite file must never be deleted or `rm`'d. The migration runs through the
+VersionedMigration system; adding a version `N+1` pointing at a new `.sql` file that applies
+the UPDATE statements.
+
+### 10. Configuration Examples
+
+After this ADR, a typical `khive.toml` for each actor:
+
+```toml
+# kkernel serving as lambda:khive
+[actor]
+id                  = "lambda:khive"
+kind                = "lambda"
+visible_namespaces  = ["shared"]
+writable_namespaces = ["shared"]
+```
+
+```toml
+# kkernel serving as lambda:leo
+[actor]
+id                  = "lambda:leo"
+kind                = "lambda"
+visible_namespaces  = ["shared", "lambda:khive"]   # can read khive's private ns
+writable_namespaces = ["shared"]                   # writes to shared only
+```
+
+```toml
+# Subagent spawned for a task (token minted by its sponsor lambda, not from config)
+# ActorConfig is not used; token is minted by the runtime with kind="subagent"
+```
+
+---
+
+## Alternatives Considered
+
+### A1. Keep all lambdas in `"local"`, differentiate only by comm actor label
+
+ADR-057 showed that actor-addressed delivery within a shared namespace is sufficient for comm
+routing without per-lambda namespaces. The same argument could be extended to the KG: all
+lambdas share `"local"`, and propose-only for subagents is enforced by a config flag rather
+than namespace separation.
+
+Rejected because: (a) there is no write isolation between lambdas -- a misbehaving lambda
+can overwrite another's private notes; (b) Ocean's explicit requirement is per-lambda
+private namespaces for working state; (c) without namespace separation, cross-namespace link
+semantics have no surface to operate on.
+
+### A2. Subagent propose-only enforced at token-mint only, not per-verb
+
+The sponsoring lambda mints a token for a subagent that lacks any writable namespace. The
+subagent then receives `NotFound` on every write attempt without any additional per-verb check.
+
+This is architecturally cleaner and avoids adding `actor.kind` checks inside verb handlers.
+The issue is that `with_namespace` (used today by comm and memory pack fanout) can upgrade a
+subagent's token to write-capable in a different namespace. Per-verb enforcement adds a
+defense-in-depth layer. Both mechanisms should be present.
+
+This ADR specifies both: token-level writable set (primary enforcement) and actor.kind check
+in `ensure_namespace_writable` (defense-in-depth). The two are redundant for an honest
+runtime and additive for a misconfigured one.
+
+### A3. Make `"local"` the shared namespace
+
+All existing data becomes shared immediately. No migration required.
+
+Rejected by the gemini mirror (2026-06-14): lambda:khive's working memory (tasks, episodic
+notes, session state) is not appropriate shared content. Dumping it into the shared namespace
+pollutes the cooperative KG and exposes operator context to every cooperating agent.
+
+### A4. Database-level enforcement (per-row ownership column, SQLite ATTACH)
+
+Add a `owner_kind` column to every substrate table. Storage queries enforce ownership. Or use
+SQLite ATTACH to give each namespace a separate file with filesystem-level permissions.
+
+Rejected for OSS scope: this requires schema changes to all three substrate tables (entities,
+notes, edges), adds storage-layer coupling, and still provides no hardened security against
+a process with filesystem access. The visibility-boundary model is sufficient for cooperative
+agents and does not need storage-layer enforcement in OSS. Cloud-tier isolation uses
+per-tenant database files (ADR-028 routing) rather than row-level ownership.
+
+---
+
+## Consequences
+
+### Benefits
+
+- Lambda orchestrators can maintain private working memory that subagents and other lambdas
+  cannot overwrite.
+- The cooperative KG (shared namespace) is populated intentionally, not as a side effect of
+  all-in-`"local"` operation.
+- Subagent proposals are auditable and reversible via the ADR-046 lifecycle; direct mutations
+  from ephemeral agents are eliminated.
+- Cross-namespace edges are governed: the three-column filter prevents edge-induced namespace
+  leaks.
+- The legacy `"local"` corpus is preserved without UUID changes; migration is a relabel.
+
+### Costs and Risks
+
+- **GraphStore trait breaking change**: accepting `namespaces: &[&str]` instead of a single
+  namespace string is a breaking change to all GraphStore implementations. This is the largest
+  implementation cost.
+- **ANN multi-index gather**: recall across shared and private namespaces requires fusing
+  results from two Vamana index files. The current single-index path in `operations.rs`
+  must be extended.
+- **Migration SQL**: UPDATE-ing namespace strings on approximately 15,000 records requires
+  careful transaction design and index rebuild after the migration.
+- **Config rollout order**: the shared namespace must be empty when lambdas start writing to
+  it; all three lambda configs must be updated in a single coordinated deployment.
+- **Backward compatibility**: any existing test or integration that creates records with
+  `namespace="local"` and reads them back will continue to work (local is still valid); tests
+  that explicitly verify namespace values will need updating after migration.
+
+---
+
+## Open Questions (Forks for Ocean)
+
+See `.khive/workspaces/20260615/namespace-write-tiers/FORKS.md` for the full fork list with
+decision guidance. The questions that require Ocean's judgment before code lands are:
+
+- **F1**: Which existing `"local"` note kinds and entities map to shared vs private?
+- **F2**: How is the shared namespace identifier chosen and where is it declared?
+- **F3**: Is subagent propose-only enforced at token-mint time, at per-verb time, or both?
+- **F4**: Does the migration run automatically at server start or require an explicit operator
+  command?
+
+---
+
+## Implementation Notes (non-normative)
+
+No implementation is prescribed in this ADR. The following notes are for the implementer
+agent when this ADR is approved.
+
+Files that change:
+
+| File                                        | Change                                                                            |
+| ------------------------------------------- | --------------------------------------------------------------------------------- |
+| `crates/khive-runtime/src/engine_config.rs` | Add `kind`, `writable_namespaces` to `ActorConfig`                                |
+| `crates/khive-runtime/src/config.rs`        | Add `writable: Vec<Namespace>` to `NamespaceToken`; extend `mint_with_visibility` |
+| `crates/khive-runtime/src/operations.rs`    | Add `ensure_namespace_writable`; update 6 write-path call sites                   |
+| `crates/khive-runtime/src/runtime.rs`       | Thread `writable_namespaces` from config into token mint                          |
+| `crates/khive-pack-kg/src/handlers.rs`      | Three-column visibility filter in link handler; cross-ns endpoint check           |
+| `crates/khive-db/sql/`                      | New numbered migration SQL for `"local"` namespace relabel                        |
+| `crates/khive-db/src/migrations.rs`         | Register new `VersionedMigration`                                                 |
+| `crates/khive-storage/src/`                 | Update `GraphStore` trait signatures to accept namespace slice                    |
+| All `GraphStore` impls                      | Update to match new trait signature                                               |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,23 +6,23 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## Foundation
 
-| #                                               | Title                                |
-| ----------------------------------------------- | ------------------------------------ |
-| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                 |
-| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                 |
-| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                  |
-| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                |
-| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits            |
-| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                |
-| [ADR-007](ADR-007-namespace.md)                 | Namespace                            |
-| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation               |
-| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                 |
-| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy               |
-| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture |
-| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                |
-| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                   |
-| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                  |
-| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                    |
+| #                                               | Title                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------ |
+| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                         |
+| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                         |
+| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                          |
+| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                        |
+| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                    |
+| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                        |
+| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 2 — attribution-only, all-local, single Gate) |
+| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                       |
+| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                         |
+| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                       |
+| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                         |
+| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                        |
+| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                           |
+| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                          |
+| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                            |
 
 ## MCP / Pack Surface
 
@@ -89,6 +89,9 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)  | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
 | [ADR-055](ADR-055-epistemic-edge-relations.md)           | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |
 | [ADR-056](ADR-056-channel-transport-layer.md)            | Channel Transport Layer — `khive-channel` and External Messaging Adapters (Proposed)                            |
+| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)      | Comm Actor-Addressed Delivery (Accepted)                                                                        |
+| [ADR-058](ADR-058-brain-posterior-read-path.md)          | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking (Proposed)                            |
+| [ADR-059](ADR-059-namespace-write-tiers.md)              | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

- **ADR-007 Rev 2**: replaces v1 base text and both 2026-05 amendments (Namespace-by-Layer and OSS vs Cloud) with Rules 0–7. Core collapse: namespace is attribution-only; ALL packs store in \"local\"; per-actor distinctions (gtd assignee, comm from/to, memory actor_id) are view-layer column filters, never namespace partitions. By-ID ops are namespace-agnostic (SHIPPED PR-A1, commit 2607e263). Multi-record collapse to \"local\" is PR-B (pending). Gate is the single enforcement seam at both OSS and cloud tiers.
- **ADR-059 (Withdrawn)**: three-tier visibility model (shared / private / proposal-only) withdrawn before acceptance. The write-tier model re-introduced actor-as-namespace coupling that the ADR-007 shared-storage decision removed. Number 059 is burned; file preserved as historical record with rationale.
- **ADR-050 partial supersession note**: added at top of file. §Decision absorbed by ADR-007 Rev 2 Rules 2 and 3; §Context and §Rationale survive as authoritative historical background.
- **README index**: ADR-007 descriptor updated to Rev 2; ADR-057, ADR-058, and ADR-059 (Withdrawn) rows added.

## Files changed

| File | Change |
|---|---|
| `docs/adr/ADR-007-namespace.md` | Full rewrite to Rev 2 (Rules 0–7, Supersession Map, Alternatives, Consequences, References) |
| `docs/adr/ADR-059-namespace-write-tiers.md` | New file (copied from draft + Withdrawn status + rationale paragraph) |
| `docs/adr/ADR-050-kg-token-namespace-contract.md` | Partial supersession note added at top |
| `docs/adr/README.md` | ADR-007 descriptor updated; ADR-057/058/059 rows added |

## Test plan

- [ ] No `.rs` files touched — zero cargo needed
- [ ] `deno fmt docs/` passed (3 files reformatted, 75 checked, all clean)
- [ ] All pre-commit hooks passed (including `deno fmt` markdown check, secret scan)
- [ ] ADR-007 Rules 0–7 faithfully transcribed from synthesis PART A
- [ ] ADR-059 Withdrawn rationale matches C3 recommendation in synthesis PART C
- [ ] ADR-050 note is additive (does not rewrite ADR-050 body)
- [ ] README rows for ADR-057/058/059 match their file headers