### PR TITLE
fix(runtime): honor explicit namespace= at dispatch (ADR-007 Rev 2)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -133,7 +133,7 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
         };
         resolve_actor_from_config(inputs.config, no_embed_base, inputs.namespace_explicit)?
     } else {
-        resolve_config(inputs.config, base_config, inputs.namespace_explicit)?
+        resolve_config(inputs.config, base_config)?
     };
 
     // Tier-3 env fallback: KHIVE_BRAIN_PROFILE is applied AFTER CLI (tier-1) and
@@ -154,12 +154,15 @@ fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
     cfg
 }
 
-/// Resolve the full config (embedding engines + actor namespace) from file or env.
+/// Resolve the full config (embedding engines + namespace) from file or env.
 ///
-/// Precedence for actor/namespace (highest to lowest):
-/// 1. CLI `--actor` / `--namespace` (cli_namespace_explicit=true skips config tier)
-/// 2. Config file `[actor] id` (applied here when !cli_namespace_explicit)
-/// 3. Default "local" from RuntimeConfig
+/// Precedence for the storage namespace (highest to lowest):
+/// 1. CLI `--actor` / `--namespace` (carried in `base.default_namespace`)
+/// 2. Default "local" from RuntimeConfig
+///
+/// Config file `[actor] id` is attribution only and does NOT route the storage
+/// namespace (ADR-007 Rev 2 Rule 0); `runtime_config_from_khive_config` preserves
+/// `base.default_namespace` regardless of the configured actor.
 ///
 /// Precedence for embedding engines:
 /// 1. Config file `[[engines]]`
@@ -167,7 +170,6 @@ fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
 fn resolve_config(
     config_path: Option<&std::path::Path>,
     base: RuntimeConfig,
-    cli_namespace_explicit: bool,
 ) -> anyhow::Result<RuntimeConfig> {
     match KhiveConfig::load_with_home_fallback(config_path)
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
@@ -182,15 +184,7 @@ fn resolve_config(
                 );
             }
 
-            let effective_cfg = if cli_namespace_explicit {
-                let mut c = khive_cfg;
-                c.actor.id = None;
-                c
-            } else {
-                khive_cfg
-            };
-
-            Ok(runtime_config_from_khive_config(&effective_cfg, base))
+            Ok(runtime_config_from_khive_config(&khive_cfg, base))
         }
         None => {
             let env_cfg = config_from_env();

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2396,9 +2396,13 @@ fn actor_precedence_default_local_with_no_config() {
     );
 }
 
-/// Tier 3 (config file): no CLI, config has actor.id → config actor applied.
+/// Tier 3 (config file): no CLI, config has actor.id. Under ADR-007 Rev 2 Rule 0
+/// the config `[actor] id` is attribution only and must NOT route the storage
+/// namespace — `default_namespace` stays at the `local` hard default. (Actor
+/// attribution threading is deferred to ADR-053; `[actor] id` is inert in OSS
+/// until then.)
 #[test]
-fn actor_precedence_config_actor_applied_when_no_cli() {
+fn actor_precedence_config_actor_id_does_not_route_namespace() {
     use khive_runtime::{runtime_config_from_khive_config, KhiveConfig, Namespace, RuntimeConfig};
     use std::io::Write;
 
@@ -2415,13 +2419,14 @@ fn actor_precedence_config_actor_applied_when_no_cli() {
         .expect("file found");
     assert_eq!(khive_cfg.actor.id.as_deref(), Some("lambda:from-config"));
 
-    // Simulate: no CLI actor → base stays at "local" default.
+    // No CLI actor → base stays at "local" default; config actor.id must not move it.
     let base = RuntimeConfig::default();
     let resolved = runtime_config_from_khive_config(&khive_cfg, base);
     assert_eq!(
         resolved.default_namespace,
-        Namespace::parse("lambda:from-config").unwrap(),
-        "config actor.id must override the hard default when no CLI actor is set"
+        Namespace::parse("local").unwrap(),
+        "config actor.id is attribution only and must NOT become default_namespace \
+         (ADR-007 Rev 2 Rule 0); the local hard default must be preserved"
     );
 }
 
@@ -3971,179 +3976,142 @@ fn compute_config_id_is_stable_under_allowed_outbound_namespace_reorder() {
 }
 
 // =============================================================================
-// ADR-007 Rev 2 Rule 0/3 (PR-B): non-local actor/default namespace must not
-// route storage — all packs write and read the shared "local" store.
+// ADR-007 Rev 2: dispatch honors the resolved namespace — an explicit `namespace=`
+// request param when supplied, else `default_namespace` (`local` for OSS). Actor
+// identity never silently routes storage (Rule 0, enforced at the config layer:
+// see runtime.rs `..._actor_id_does_not_override_default_namespace`).
 // =============================================================================
 
-/// Proves ADR-007 Rev 2 Rule 0/3 at the real MCP server boundary.
+/// Proves the dispatch-side namespace contract at the real MCP server boundary.
 ///
-/// A server built with `KhiveMcpServer::with_packs` whose `RuntimeConfig`
-/// carries a non-local `default_namespace` ("lambda:leo") and non-empty
-/// `visible_namespaces` must still route all storage through `"local"`.
+/// All ops go through `dispatch_request_local`, so a regression at the
+/// `VerbRegistry::dispatch` mint site (`pack.rs`) is caught here:
 ///
-/// Three assertions, all dispatched through `dispatch_request_local` so a
-/// regression at the `VerbRegistry::dispatch` mint site (`pack.rs:772`) would
-/// be caught here — not by a direct runtime helper call:
+///   (a) with `default_namespace = local`, a plain `create` lands in `"local"`.
 ///
-///   (a) `create` returns an entity whose `namespace` field is `"local"`, not
-///       `"lambda:leo"`.  This fails if `dispatch` regresses to using the
-///       default_namespace as the token primary.
+///   (b) an explicit `create(namespace="lambda:leo")` lands in `"lambda:leo"` —
+///       the caller deliberately targeting a namespace (Rule 1).  This is exactly
+///       what #159's unconditional `Namespace::local()` hard-pin wrongly collapsed
+///       to `"local"`.
 ///
-///   (b) `list(kind=entity)` via the same server (same mint path) includes the
-///       entity id, proving that MCP reads also operate on `"local"`.  This
-///       fails if list were scoped to the non-local namespace.
+///   (c) a default `list` (local) sees the local entity but NOT the lambda:leo one,
+///       and `list(namespace="lambda:leo")` sees the lambda:leo entity but NOT the
+///       local one — multi-record reads filter by the supplied namespace.
 ///
-///   (c) A `NamespaceToken` pinned directly to `"lambda:leo"` (bypassing
-///       dispatch) sees an empty list, confirming nothing was written to the
-///       actor namespace.  This assertion would NOT catch a mint regression on
-///       its own, but together with (a) and (b) it forms a complete sandwich
-///       proof that storage is exclusively in `"local"`.
-///
-/// Regression sensitivity: if `pack.rs:772` reverts to
-/// `NamespaceToken::mint_with_visibility(primary, ...)` where `primary` comes
-/// from `default_namespace`, assertion (a) fails because the entity's namespace
-/// field would be `"lambda:leo"`, and assertion (b) fails because
-/// `list(kind=entity)` via the minted token would scope reads to `"lambda:leo"`
-/// where the store is empty.
+/// Regression sensitivity: if dispatch reverts to pinning `Namespace::local()`,
+/// assertion (b) fails (the entity namespace would be `"local"`) and the scoped
+/// list in (c) would be empty.
 #[tokio::test]
-async fn non_local_actor_config_routes_storage_to_local_adr007_prb() {
+async fn dispatch_honors_explicit_namespace_else_local_adr007() {
     use khive_mcp::tools::request::RequestParams;
-    use khive_pack_kg::KgPack;
     use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
 
     disable_daemon();
 
-    let actor_ns = Namespace::parse("lambda:leo").unwrap();
-
-    // Build a RuntimeConfig equivalent to:
-    //   [actor]
-    //   id          = "lambda:leo"
-    //   visible_namespaces = ["lambda:extra"]
-    // This is the scenario where a non-local actor identity would historically
-    // route storage — PR-B must suppress that.
-    let extra_ns = Namespace::parse("lambda:extra").unwrap();
+    // OSS default: default_namespace = local; actor identity is attribution only.
     let cfg = RuntimeConfig {
         db_path: None,
-        default_namespace: actor_ns.clone(),
+        default_namespace: Namespace::local(),
         embedding_model: None,
         additional_embedding_models: vec![],
         packs: vec!["kg".to_string()],
-        visible_namespaces: vec![extra_ns.clone()],
         ..RuntimeConfig::default()
     };
 
     let rt = KhiveRuntime::new(cfg).expect("in-memory runtime");
+    let server =
+        KhiveMcpServer::with_packs(rt.clone(), &["kg".to_string()]).expect("server builds");
 
-    // Build through with_packs — the same constructor the production MCP binary
-    // uses, so the full wiring chain (RuntimeConfig → builder → registry →
-    // dispatch → mint) is exercised.
-    let server = KhiveMcpServer::with_packs(rt.clone(), &["kg".to_string()])
-        .expect("server builds with non-local actor config");
+    // Dispatch one `create`/`list` op and return the parsed `results[0]` body.
+    async fn dispatch_op(server: &KhiveMcpServer, ops: &str) -> Value {
+        let out = server
+            .dispatch_request_local(RequestParams {
+                ops: ops.to_string(),
+                presentation: Some("verbose".to_string()),
+                presentation_per_op: None,
+            })
+            .await
+            .expect("dispatch must not error at the MCP level");
+        let body: Value = serde_json::from_str(&out).expect("response must be valid JSON");
+        body["results"][0].clone()
+    }
 
-    // ── (a) CREATE: entity must land in "local", not the actor namespace ──────
-    let create_out = server
-        .dispatch_request_local(RequestParams {
-            ops: r#"create(kind="concept", name="MintProbe")"#.to_string(),
-            presentation: Some("verbose".to_string()),
-            presentation_per_op: None,
-        })
-        .await
-        .expect("dispatch create must not error at the MCP level");
+    fn list_ids(result: &Value) -> Vec<String> {
+        match result["result"].as_array() {
+            Some(arr) => arr
+                .iter()
+                .filter_map(|e| e.get("id").and_then(|v| v.as_str()).map(str::to_string))
+                .collect(),
+            None => match result["result"]["items"].as_array() {
+                Some(arr) => arr
+                    .iter()
+                    .filter_map(|e| e.get("id").and_then(|v| v.as_str()).map(str::to_string))
+                    .collect(),
+                None => {
+                    panic!("list result must be a JSON array or object with items; got: {result}")
+                }
+            },
+        }
+    }
 
-    let create_body: Value =
-        serde_json::from_str(&create_out).expect("create response must be valid JSON");
-    let create_result = &create_body["results"][0];
+    // ── (a) DEFAULT CREATE: lands in "local" ─────────────────────────────────
+    let default_res = dispatch_op(&server, r#"create(kind="concept", name="DefaultProbe")"#).await;
     assert_eq!(
-        create_result["ok"],
+        default_res["ok"],
         json!(true),
-        "create via non-local actor config must succeed; got: {create_result}"
+        "default create must succeed; got: {default_res}"
     );
-    let entity_id = create_result["result"]["id"]
-        .as_str()
-        .expect("create result must carry 'id'");
     assert_eq!(
-        create_result["result"]["namespace"].as_str().unwrap_or(""),
+        default_res["result"]["namespace"].as_str().unwrap_or(""),
         "local",
-        "entity must land in 'local' even when default_namespace='lambda:leo'; \
-         actor identity must not silently become the storage namespace (ADR-007 Rule 0); \
-         got: {create_result}"
+        "a create with no explicit namespace must land in 'local'; got: {default_res}"
     );
+    let default_id = default_res["result"]["id"]
+        .as_str()
+        .expect("create result must carry 'id'")
+        .to_string();
 
-    // ── (b) LIST: same MCP path must see the entity from "local" ─────────────
-    let list_out = server
-        .dispatch_request_local(RequestParams {
-            ops: r#"list(kind="entity")"#.to_string(),
-            presentation: Some("verbose".to_string()),
-            presentation_per_op: None,
-        })
-        .await
-        .expect("dispatch list must not error at the MCP level");
-
-    let list_body: Value =
-        serde_json::from_str(&list_out).expect("list response must be valid JSON");
-    let list_result = &list_body["results"][0];
+    // ── (b) EXPLICIT CREATE: namespace="lambda:leo" is honored ───────────────
+    let named_res = dispatch_op(
+        &server,
+        r#"create(kind="concept", name="NamedProbe", namespace="lambda:leo")"#,
+    )
+    .await;
     assert_eq!(
-        list_result["ok"],
+        named_res["ok"],
         json!(true),
-        "list via non-local actor config must succeed; got: {list_result}"
+        "explicit-namespace create must succeed; got: {named_res}"
     );
-    let ids_in_list: Vec<&str> = match list_result["result"].as_array() {
-        Some(arr) => arr
-            .iter()
-            .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
-            .collect(),
-        None => match list_result["result"].as_object() {
-            Some(obj) => obj
-                .get("items")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
-                        .collect()
-                })
-                .unwrap_or_default(),
-            None => {
-                panic!("list result must be a JSON array or object with items; got: {list_result}")
-            }
-        },
-    };
+    assert_eq!(
+        named_res["result"]["namespace"].as_str().unwrap_or(""),
+        "lambda:leo",
+        "create(namespace=\"lambda:leo\") must land in 'lambda:leo', not be collapsed to \
+         'local' (ADR-007 Rev 2 Rule 1 — explicit namespace is honored); got: {named_res}"
+    );
+    let named_id = named_res["result"]["id"]
+        .as_str()
+        .expect("create result must carry 'id'")
+        .to_string();
+
+    // ── (c) LIST scoping: default(local) vs explicit(lambda:leo) ─────────────
+    let local_ids = list_ids(&dispatch_op(&server, r#"list(kind="entity")"#).await);
     assert!(
-        ids_in_list.contains(&entity_id),
-        "entity created via non-local actor registry must be readable from 'local' list \
-         through MCP dispatch; got ids: {ids_in_list:?}"
+        local_ids.contains(&default_id),
+        "default list must see the local entity; got: {local_ids:?}"
+    );
+    assert!(
+        !local_ids.contains(&named_id),
+        "default(local) list must NOT see the lambda:leo entity; got: {local_ids:?}"
     );
 
-    // ── (c) DIRECT NON-LOCAL TOKEN: must see an empty store ──────────────────
-    // This is NOT via dispatch — it uses a token pinned to "lambda:leo" directly.
-    // Together with (a) and (b) it proves storage was never routed to that namespace.
-    let pack = KgPack::new(rt.clone());
-    // We need a VerbRegistry to call pack.dispatch; build a minimal one.
-    let mut builder = VerbRegistryBuilder::new();
-    builder.register(KgPack::new(rt.clone()));
-    let probe_registry = builder.build().expect("probe registry builds");
-    let actor_token = rt
-        .authorize(actor_ns.clone())
-        .expect("authorize lambda:leo token");
-    let actor_list = pack
-        .dispatch(
-            "list",
-            json!({ "kind": "entity" }),
-            &probe_registry,
-            &actor_token,
-        )
-        .await
-        .expect("direct pack list via actor-ns token must succeed");
-    let ids_in_actor_ns: Vec<&str> = match &actor_list {
-        serde_json::Value::Array(arr) => arr
-            .iter()
-            .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
-            .collect(),
-        other => panic!("list must return a JSON array; got: {other:?}"),
-    };
+    let leo_ids =
+        list_ids(&dispatch_op(&server, r#"list(kind="entity", namespace="lambda:leo")"#).await);
     assert!(
-        !ids_in_actor_ns.contains(&entity_id),
-        "storage must not have been routed to 'lambda:leo'; \
-         entity must NOT appear when listing directly under that namespace \
-         (ADR-007 Rule 0/3, PR-B); got ids: {ids_in_actor_ns:?}"
+        leo_ids.contains(&named_id),
+        "list(namespace=lambda:leo) must see the lambda:leo entity; got: {leo_ids:?}"
+    );
+    assert!(
+        !leo_ids.contains(&default_id),
+        "list(namespace=lambda:leo) must NOT see the local entity; got: {leo_ids:?}"
     );
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -391,27 +391,12 @@ pub fn runtime_config_from_khive_config(
     khive_cfg: &crate::engine_config::KhiveConfig,
     base: RuntimeConfig,
 ) -> RuntimeConfig {
-    // Apply actor.id as default_namespace when present and valid.
-    // KhiveConfig::validate() guarantees that actor.id, when present, is a
-    // structurally valid Namespace — so the Err arm here is unreachable for
-    // any config that passed load(). A panic here signals a caller contract
-    // violation (passing an unvalidated config).
-    let default_namespace = match khive_cfg.actor.id.as_deref() {
-        Some(id) if !id.is_empty() => match Namespace::parse(id) {
-            Ok(ns) => {
-                tracing::debug!(actor_id = id, "actor.id from config sets default_namespace");
-                ns
-            }
-            Err(e) => {
-                panic!(
-                    "actor.id {id:?} passed validation but Namespace::parse failed: {e}; \
-                     this is a bug — KhiveConfig must be validated before calling \
-                     runtime_config_from_khive_config"
-                );
-            }
-        },
-        _ => base.default_namespace.clone(),
-    };
+    // ADR-007 Rev 2 Rule 0: `[actor] id` is attribution only and never becomes the
+    // storage namespace. `default_namespace` is whatever the caller resolved into
+    // `base` (explicit `--namespace` / `KHIVE_NAMESPACE`, else `local`). A caller
+    // targets a named namespace per request (`create(namespace=...)`), not by virtue
+    // of which actor is configured — actor identity must not silently route storage.
+    let default_namespace = base.default_namespace.clone();
 
     // base.brain_profile must carry ONLY the explicit CLI tier — never an env
     // value (env sits BELOW toml per ADR-035; the MCP resolver applies it after).

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -840,9 +840,12 @@ id = "lambda:"
         );
     }
 
-    // 18. runtime_config_from_khive_config applies valid actor.id to default_namespace.
+    // 18. ADR-007 Rev 2 Rule 0: actor.id is attribution only and must NOT become
+    //     default_namespace. Storage namespace stays whatever `base` carried (local
+    //     by default for OSS); a caller targets a named namespace per request, not
+    //     by virtue of which actor is configured.
     #[test]
-    fn test_runtime_config_actor_id_applied() {
+    fn test_runtime_config_actor_id_does_not_override_namespace() {
         use crate::runtime::runtime_config_from_khive_config;
         use crate::RuntimeConfig;
         use khive_types::namespace::Namespace;
@@ -862,8 +865,9 @@ id = "lambda:"
         let result = runtime_config_from_khive_config(&cfg, base);
         assert_eq!(
             result.default_namespace,
-            Namespace::parse("lambda:test-actor").unwrap(),
-            "actor.id must become default_namespace"
+            Namespace::local(),
+            "actor.id must NOT become default_namespace (ADR-007 Rev 2 Rule 0); \
+             base local namespace must be preserved"
         );
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -834,20 +834,28 @@ impl VerbRegistry {
             });
         }
 
-        // Mint the authorized namespace token at the dispatch boundary.
+        // Mint the authorized storage token at the dispatch boundary.
         //
-        // ADR-007 Rev 2, Rule 0 + Rule 3 (PR-B): the OSS dispatch path pins the storage
-        // token's primary to `local`. Actor identity, CLI `--actor`, and config `[actor] id`
-        // are gate/attribution inputs only — they never route storage. The request/default
-        // namespace (`ns_str`) reaches the gate via `gate_req` for policy evaluation, but
-        // the token handed to packs always has primary = local, so all packs write and read
-        // the shared "local" store regardless of which actor is configured.
-        // `actor.visible_namespaces` is dissolved; per-actor distinctions are view-layer tag
-        // filters (assignee, actor_id, from/to), not namespace partitions.
-        // `with_visible_namespaces()` is retained on the builder for future cloud-gate policy
-        // input but no longer widens this dispatch token's read scope.
-        let token =
-            NamespaceToken::mint_with_visibility(Namespace::local(), vec![], ActorRef::anonymous());
+        // ADR-007 Rev 2 Rule 0/3: storage pins to `local` by default. Actor identity,
+        // CLI `--actor`, and config `[actor] id` (carried in `default_namespace`) are
+        // attribution and gate-context inputs only — they never route storage. The one
+        // escape is an explicit `namespace=` request param (Rule 1): a caller may
+        // deliberately read/write a named set, e.g. `create(namespace="lambda:khive")`
+        // or `list(namespace="ns-beta")`. `default_namespace` reaches the gate via
+        // `gate_req` above for policy evaluation, but the storage token stays `local`
+        // unless the caller named a namespace explicitly.
+        //
+        // #159 pinned `local` *unconditionally*, collapsing even an explicit param and
+        // breaking namespace isolation between caller-named sets; this restores the
+        // Rule 1 escape without reviving actor-as-namespace routing. `visible_namespaces`
+        // stays dissolved (empty extra-visible set); per-actor distinctions are
+        // view-layer tag filters (assignee, actor_id, from/to), not namespace partitions.
+        let primary = match params.get("namespace").and_then(Value::as_str) {
+            Some(ns) => Namespace::parse(ns)
+                .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?,
+            None => Namespace::local(),
+        };
+        let token = NamespaceToken::mint_with_visibility(primary, vec![], ActorRef::anonymous());
 
         for pack in self.packs.iter() {
             if let Some(handler_def) = pack.handlers().iter().find(|v| v.name == verb) {

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -887,7 +887,10 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_from_khive_config_applies_actor_id_as_default_namespace() {
+    fn runtime_config_from_khive_config_actor_id_does_not_override_default_namespace() {
+        // ADR-007 Rev 2 Rule 0: `[actor] id` is attribution only and never becomes
+        // the storage namespace. A configured actor must NOT silently route storage —
+        // default_namespace stays whatever `base` carried (here, `local`).
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
@@ -902,7 +905,11 @@ mod tests {
         };
         let cfg = khive_cfg_with_actor("lambda:khive");
         let result = runtime_config_from_khive_config(&cfg, base);
-        assert_eq!(result.default_namespace.as_str(), "lambda:khive");
+        assert_eq!(
+            result.default_namespace.as_str(),
+            "local",
+            "actor.id must not become the storage namespace (ADR-007 Rev 2 Rule 0)"
+        );
     }
 
     #[test]
@@ -989,7 +996,12 @@ mod tests {
             runtime: RuntimeSectionConfig::default(),
         };
         let result = runtime_config_from_khive_config(&cfg, base);
-        assert_eq!(result.default_namespace.as_str(), "lambda:test");
+        assert_eq!(
+            result.default_namespace.as_str(),
+            "local",
+            "actor.id is attribution only and must not override default_namespace \
+             (ADR-007 Rev 2 Rule 0); engine config is still applied"
+        );
         assert!(result.embedding_model.is_some());
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1075,12 +1075,14 @@ mod tests {
         );
     }
 
-    // Namespace resolution parity with `kkernel mcp`: when --namespace is omitted,
-    // the config file `[actor] id` must set the effective namespace — same as the
-    // MCP path. When --namespace is explicit, it must override the config tier.
+    // Namespace resolution parity with `kkernel mcp` under ADR-007 Rev 2 Rule 0:
+    // when --namespace is omitted, the config file `[actor] id` is attribution only
+    // and does NOT set the effective namespace — it stays `local`, same as the MCP
+    // path. When --namespace is explicit, it routes storage (Rule 1 / reindex's
+    // explicit namespace channel) and overrides the local default.
     #[test]
     #[serial]
-    fn namespace_absent_honors_config_actor_id() {
+    fn namespace_absent_defers_to_local_not_config_actor_id() {
         use std::io::Write;
         std::env::remove_var("KHIVE_NAMESPACE");
         std::env::remove_var("KHIVE_EMBEDDING_MODEL");
@@ -1092,7 +1094,8 @@ mod tests {
         f.write_all(b"[actor]\nid = \"lambda:prod\"\n")
             .expect("write config");
 
-        // No --namespace: must pick up [actor] id from config file.
+        // No --namespace: config [actor] id is attribution only (Rule 0), so the
+        // effective namespace stays `local` — it must NOT become lambda:prod.
         let resolved = resolve_runtime_config(RuntimeConfigInputs {
             db: Some(":memory:"),
             config: Some(&config_path),
@@ -1105,8 +1108,9 @@ mod tests {
         .expect("resolve config");
         assert_eq!(
             resolved.default_namespace.as_str(),
-            "lambda:prod",
-            "omitted --namespace must defer to config [actor] id"
+            "local",
+            "omitted --namespace must stay local; config [actor] id is attribution \
+             only (ADR-007 Rev 2 Rule 0)"
         );
 
         // Explicit --namespace must override [actor] id.

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -46,6 +46,14 @@ Actor identity (lambda:khive, lambda:leo, agent:*, user:ocean) is attribution on
 write records and gate-request context, available for logging, filtering, and cloud policy
 input. It never silently becomes the storage namespace and never gates by-ID access.
 
+Config-layer realization: the `[actor] id` config key is attribution only and does not set
+`default_namespace`. `runtime_config_from_khive_config` preserves whatever the caller resolved
+into the base config (an explicit `--namespace` / `KHIVE_NAMESPACE`, else `local`), regardless
+of which actor is configured. Threading actor identity onto write records is deferred to
+ADR-053; until that lands, `[actor] id` is inert at the storage layer in OSS. This is the
+distinction Rule 0 turns on: a caller may target a named namespace per request, but the actor a
+deployment is configured as must not route storage on its own.
+
 Source: CLAUDE.md "The local system is a single shared brain: one namespace (`local`), and
 every lambda / agent / subagent reads and writes it."
 
@@ -85,19 +93,34 @@ while routing KG and knowledge to "local". Gemini REFUTE Finding 2 correctly ide
 as a contradiction of Rule 0: framing per-pack actor routing as "explicit pack policy"
 re-introduces the exact actor-as-namespace isolation coupling Ocean ordered removed. Finding 1
 added that memory is live-audited as bulk "local" and that cross-lambda learning via
-memory.recall over one pool depends on the shared store. The lambda synthesis confirms: there
-is no actor-namespace routing rule. ALL packs store in "local". The per-pack distinction is
-dissolved.
+memory.recall over one pool depends on the shared store. The lambda synthesis rejected
+_blanket_ per-pack routing (every pack keyed by actor namespace), and Ocean (2026-06-17) confirms
+kg, knowledge, gtd, and brain are no-carry. What stays open is a _narrow_ carry for the genuinely
+per-actor packs: comm (Ocean leans yes — messages are inherently addressed) and memory
+(undecided). The current release ships the uniform no-carry default for ALL packs; narrow
+per-pack carry is deferred to Rev 3 (see the per-pack note below).
 
 Under this ADR: list, search, recall, neighbors, traverse, and query for ALL packs pass
-WHERE namespace = 'local' (or the configured default_namespace, which is "local" for OSS).
+WHERE namespace = 'local' by default. The single exception is an explicit `namespace=` request
+parameter (Rule 1 — a caller may deliberately read a named set, e.g.
+`list(namespace="lambda:khive")` or `create(namespace="ns-beta")`), which routes that one
+operation to the named set. There is no per-pack actor routing, and `default_namespace` (the
+actor/config identity) does NOT route storage: it reaches the gate as policy context, but the
+storage token stays "local" unless the caller named a namespace explicitly.
+
+The dispatch boundary (VerbRegistry::dispatch, pack.rs) mints the storage token with primary =
+the explicit `namespace=` parameter when present, else `Namespace::local()`. The "local" pin is
+the default; the explicit parameter is the only escape.
 
 Per-actor distinctions for operational packs are view-layer filters, not namespace partitions:
 
 - GTD: filter by the "assignee" column (tag or field), not by namespace.
-- Comm: filter by "from" and "to" addressing fields, not by namespace.
+- Comm: in the current release, filters by "from"/"to" addressing fields over the shared
+  "local" store. Open (Rev 3): Ocean (2026-06-17) leans toward comm _carrying_ the caller's
+  namespace into storage by default, since messages are inherently per-actor.
 - Memory: filter by actor_id attribution column when an owner-scoped view is needed; the
-  underlying pool is shared and cross-lambda recall operates over it.
+  underlying pool is shared and cross-lambda recall operates over it. Whether memory should
+  carry the caller's namespace by default is undecided (Rev 3).
 - Brain: profile resolution is its own scoping mechanism (brain.resolve, profile bindings),
   independent of namespace.
 - Schedule: attribution columns carry the scheduling actor; namespace is "local".
@@ -105,7 +128,12 @@ Per-actor distinctions for operational packs are view-layer filters, not namespa
 This dissolves the Rule 0 vs Rule 3 contradiction present in the draft (gemini Finding 2) and
 resolves the memory-pack scoping incoherence (gemini Finding 1).
 
-Status: PR-B, not yet built.
+Status: implemented. VerbRegistry::dispatch mints the storage token with primary = the explicit
+`namespace=` parameter when present, else `Namespace::local()`; `default_namespace` feeds only
+the gate request, never the storage token. `runtime_config_from_khive_config` treats `[actor] id`
+as attribution only. The earlier pin of `Namespace::local()` at the dispatch mint site (PR #159)
+applied _unconditionally_ — collapsing even an explicit parameter and so breaking namespace
+isolation between caller-named sets — and is superseded by this explicit-parameter escape.
 
 ### Rule 4 — Authorization enforced at one seam: the Gate
 
@@ -209,13 +237,13 @@ collision.
 
 ## Alternatives Considered
 
-| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                         |
-| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                           |
-| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Rejected (gemini Finding 1, Finding 2; lambda synthesis)            |
-| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Superseded by this ADR                                              |
-| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                            |
-| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not |
+| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                                                                                             |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                                                                                               |
+| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Blanket form rejected; kg/knowledge/gtd/brain confirmed no-carry (Ocean 2026-06-17); narrow comm-only (±memory) carry deferred to Rev 3 |
+| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Superseded by this ADR                                                                                                                  |
+| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                                                                                                |
+| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not                                                                     |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes main CI (red since #159). `VerbRegistry::dispatch` now honors an explicit
`namespace=` request parameter for storage routing, while keeping ADR-007 Rev 2's
all-local default. Adds "Full Rule 0": config `[actor] id` is attribution-only
and never sets the storage namespace.

## The bug

#159 (d8039983) pinned the dispatch storage token to `Namespace::local()`
**unconditionally**, collapsing even an explicit per-request `namespace=` param. This
broke the `namespace_isolation` contract: `create(namespace="ns-alpha")` then
`list(namespace="ns-beta")` returned the ns-alpha entity (both forced to local).

## The fix

- **`pack.rs` mint site**: storage token primary = explicit `namespace=` request param
  if present, else `Namespace::local()`. `default_namespace` feeds only the gate
  request (policy context), never the storage token. Invalid `namespace=` returns a
  per-op `{ok:false}` error, not a panic.
- **`config.rs`** (`runtime_config_from_khive_config`): `[actor] id` no longer sets
  `default_namespace` (Full Rule 0). Caveat: `[actor] id` is inert at the storage layer
  in OSS until actor-attribution threading (ADR-053) lands.
- **`serve.rs`**: removed now-dead `cli_namespace_explicit` branch in `resolve_config`.
- **Tests realigned**: `runtime.rs` (2), `engine_config.rs` (1),
  `khive-mcp/tests/integration.rs` (rewrote 1 → `dispatch_honors_explicit_namespace_else_local_adr007`,
  flipped 1), `kkernel/src/reindex.rs` (1 → `namespace_absent_defers_to_local_not_config_actor_id`).
- **ADR-007** Rule 0 / Rule 3 / Status amended for the explicit-param escape and to mark
  per-pack carry as an open Rev 3 question (see below).

## Per-pack namespace carry (2026-06-17)

Namespace-carry — whether a pack defaults its storage to the caller's namespace vs pins
"local" — is **per-pack**, governed by whether the pack's substrate is shared-collective
or per-actor:

| Pack      | Carry?            | Why                                                       |
| --------- | ----------------- | --------------------------------------------------------- |
| kg        | no                | shared graph                                              |
| knowledge | no                | shared canonical corpus                                   |
| gtd       | no                | `assignee` (+ optional `assigned_by`) is the filter       |
| brain     | no                | profile resolution is its own scoping axis                |
| schedule  | local (deferred)  | barely used; revisit later                                |
| comm      | **carry** (leans) | messages are inherently per-actor / addressed             |
| memory    | undecided         | episodic personal vs semantic collective                  |

**This PR ships the uniform no-carry default**, which is correct for kg/knowledge/gtd/brain
+ schedule, and leaves comm working in its current all-local mode. **comm-carry (and the
memory decision) are deferred to ADR-007 Rev 3** — that work adds a `Pack`-declared
`carries_caller_namespace` per-verb policy so dispatch picks
`param || (carry ? default_namespace : local)`. Enabling comm-carry will revert ~19 of
#162's comm all-local test assertions, so it gets its own critic + mirror pass.

## Verification

- `cargo test --workspace`: green (every crate) — on this exact code.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check` + `deno fmt docs/ --check`: clean.
- `tests/contract_test.py`: 9/9 (live-binary, restores the originally-red `namespace_isolation` leg).

The amend after the green run touched only ADR prose (docs-only); the Rust is byte-identical.

## Follow-ups (non-blocking)

- **ADR-007 Rev 3**: per-pack `carries_caller_namespace`; settle comm (carry) + memory.
- Finish `serve.rs` no-embed-path symmetry (`resolve_actor_from_config` still threads
  `namespace_explicit`; not dead, but asymmetric with the embed path).
- One-line ADR-007 note that gate-namespace and storage-namespace can legitimately differ
  under a future real (cloud) gate.

