### PR TITLE
docs(adr): ratify ADR-007 Rev 3 — namespace attribution-only, all packs no-carry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,11 +527,19 @@ rebuild, kill zombie processes: `pkill -f khive-mcp` then reconnect.
 
 ---
 
-## Namespace isolation
+## Namespace (attribution-only — ADR-007 Rev 3)
 
-Every ID-based operation (`get`, `update`, `delete`, `merge`) verifies that the record belongs to
-the caller's namespace at the runtime layer. Storage is ID-only by design; the runtime is the trust
-boundary. Cross-namespace access is denied.
+Namespace is a write-stamp on records. In OSS, every record is stored under namespace `"local"` by
+default. It is attribution, not isolation: queryable and filterable as a data column, but never a
+storage boundary.
+
+By-ID operations (`get`, `update`, `delete`, `merge`) are namespace-agnostic. They resolve the
+globally-unique UUID with no namespace check at any layer. Authorization is enforced at the Gate
+(ADR-018), not in storage or by-ID post-fetch checks.
+
+Multi-record operations (`list`, `search`, `recall`, `neighbors`, `traverse`, `query`) default to
+`WHERE namespace='local'`. The only way to target a different namespace is an explicit `namespace=`
+parameter in the verb call.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,11 +272,18 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
   `request`. **Per-verb validation failure** (unknown kind, bad UUID, etc.) returns a per-op
   `{ok: false, error: "..."}` entry — the batch does not abort.
 
-### Namespace isolation
+### Namespace (attribution-only — ADR-007 Rev 3, 2026-06-17)
 
-- **Enforced at the runtime layer.** Every ID-based operation (get, delete, update, merge)
-  must verify `record.namespace == caller_namespace` after fetching by UUID.
-- Storage stores are ID-only. The runtime is the trust boundary.
+- **Namespace is attribution, not isolation.** It is a write-stamp on records, queryable and
+  filterable, available to the Gate as policy input. It is never a storage boundary.
+- **By-ID ops are namespace-agnostic** (get, update, delete, merge). No `record.namespace ==
+  caller_namespace` check exists at the store, runtime, or handler layer. This was the
+  prior v1 behavior; it was removed by PR-A1 (commit 2607e263) and is no longer correct.
+  Do not add such checks.
+- **Authorization lives at one seam: the Gate** (ADR-018). Storage stores are ID-only. The
+  Gate is the trust boundary.
+- **Multi-record ops default to `WHERE namespace='local'`**; the only escape is an explicit
+  `namespace=` parameter from the caller.
 
 ### Edge cascade
 
@@ -379,8 +386,10 @@ Full index: [docs/adr/README.md](docs/adr/README.md).
   language, call the MCP server — don't rewrite the storage logic.
 - **Don't silently coerce invalid input.** Invalid entity kinds, note kinds, and edge relations
   must return errors with the valid values listed. Never `unwrap_or_default()`.
-- **Don't bypass namespace isolation.** Every ID-based runtime method checks namespace.
-  Storage is ID-only by design — the runtime enforces access control.
+- **Don't add namespace checks to by-ID ops.** By-ID methods (get, update, delete, merge)
+  are namespace-agnostic by design (ADR-007 Rev 3). Authorization is at the Gate. Adding
+  `record.namespace == caller_namespace` post-fetch checks is the prior v1 bug pattern; it
+  was removed by PR-A1 and must not return.
 - **Don't edit V1 migrations.** Append a new version. V1 is immutable on existing databases.
 - **Don't store research findings only as notes.** Notes are for context; entities + edges
   are for structure. If a concept is worth naming, it's an entity.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No Neo4j. No SPARQL endpoint to deploy. SQLite on disk, MCP over stdio, `cargo t
 | **Salience-weighted notes** | Notes carry salience scores; search ranks by semantic relevance × salience                                               |
 | **Cross-substrate links**   | Notes annotate entities (and vice versa) via the same edge system                                                        |
 | **Soft delete + supersede** | History-preserving: old records stay, newer ones supersede via graph edges                                               |
-| **Namespace isolation**     | Tenant scoping on every operation — share one DB, isolate many agents                                                    |
+| **Namespace attribution**   | Every record stamped with a namespace; one shared store in OSS, tenant isolation enforced at the Gate in cloud           |
 
 ---
 

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,13 +1,20 @@
-# ADR-007 Rev 2: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate
+# ADR-007 Rev 3: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, All Packs No-Carry
 
-**Status**: Proposed (pending Ocean ratification of C1 and C3 in Part C of the synthesis)
-**Date**: 2026-06-16
+**Status**: Accepted/Ratified (2026-06-17)
+**Date**: 2026-06-17
 **Authors**: lambda:khive, alpha:architect
-**Amends**: ADR-007-namespace.md (replaces v1 base text and both 2026-05 amendments in full)
+**Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, and Rev 2 in full)
 **Supersedes (partial)**: ADR-050 §"Decision"; ADR-059 §"Decision" and §"Visibility tiers"
 **Superseded-by-none**: ADR-053 (ActorStore, SessionStore, cloud-tier actor threading) survives in full
 **ADR chain**: ADR-018 (Gate trait, single dispatch site) | ADR-014 (curation, merge semantics)
 | ADR-002 (edge cascade, no dangling refs)
+
+**Rev 3 summary (2026-06-17)**: Promoted from Proposed to Accepted/Ratified. Closes the two
+Rev-2-deferred per-pack carry questions as NO-CARRY: comm = no-carry (reverses the Rev-2 "leans
+yes"); memory = no-carry (resolves the Rev-2 "undecided"). All seven production packs store in
+the single shared "local" namespace by default. Per-actor distinction is a view-layer tag, never
+a namespace partition. Edge namespace is attribution-only, stamped "local" by default, never an
+isolation mechanism; the ADR-059 three-column filter is rejected. ADR-059 remains withdrawn.
 
 ---
 
@@ -27,8 +34,11 @@ dumb. The Gate is the one enforcement seam.
 PR-A1 (commit 2607e263, merged 2026-06-16) shipped the by-ID half: all ensure_namespace /
 ensure_namespace_visible post-fetch checks removed from get_entity, get_note, delete_entity,
 delete_note, update_entity, update_note, update_edge, delete_edge. The multi-record half
-(list, search, recall, neighbors, traverse, query) still filters by visible_namespaces. This
-ADR specifies collapsing that to the single shared "local" set (PR-B).
+(list, search, recall, neighbors, traverse, query) is also collapsed to the single shared
+"local" set at dispatch: VerbRegistry::dispatch mints the storage token with an empty
+extra-visible set and primary = "local" (pack.rs, verified). What remains is a one-time data
+backfill (PR-A2/PR-F): relabeling the stranded non-"local" base rows to "local" and reindexing
+FTS5/ANN, so the already-collapsed query scope actually returns them.
 
 This ADR does not specify cloud multi-tenant isolation. That is behind the Gate trait. This ADR
 specifies the OSS contract and the seam that cloud plugs into.
@@ -85,7 +95,7 @@ Affected functions confirmed clean post-PR-A1 (operations.rs): get_entity,
 get_entity_including_deleted, get_note_including_deleted, delete_entity, delete_note,
 update_entity, update_note, update_edge, delete_edge.
 
-### Rule 3 — Multi-record ops scope to the single shared "local" set (PR-B, pending)
+### Rule 3 — Multi-record ops scope to the single shared "local" set (routing SHIPPED; data backfill pending)
 
 CHANGE FROM ADR-007 v1: The 2026-05-27 Namespace-by-Layer amendment routed memory, gtd, comm,
 brain, and schedule multi-record ops by actor namespace ("WHERE namespace = <actor_namespace>"),
@@ -93,47 +103,78 @@ while routing KG and knowledge to "local". Gemini REFUTE Finding 2 correctly ide
 as a contradiction of Rule 0: framing per-pack actor routing as "explicit pack policy"
 re-introduces the exact actor-as-namespace isolation coupling Ocean ordered removed. Finding 1
 added that memory is live-audited as bulk "local" and that cross-lambda learning via
-memory.recall over one pool depends on the shared store. The lambda synthesis rejected
-_blanket_ per-pack routing (every pack keyed by actor namespace), and Ocean (2026-06-17) confirms
-kg, knowledge, gtd, and brain are no-carry. What stays open is a _narrow_ carry for the genuinely
-per-actor packs: comm (Ocean leans yes — messages are inherently addressed) and memory
-(undecided). The current release ships the uniform no-carry default for ALL packs; narrow
-per-pack carry is deferred to Rev 3 (see the per-pack note below).
+memory.recall over one pool depends on the shared store.
+
+Ocean ruling (2026-06-17, Rev 3): ALL packs are NO-CARRY. There is no per-pack namespace
+carry, now or planned. This closes the two questions that Rev 2 left deferred to Rev 3:
+
+- Comm is NO-CARRY (reverses the Rev-2 "leans yes"). Messages are inherently actor-addressed,
+  but actor addressing is a view-layer tag filter on `from_actor`/`to_actor` in message
+  properties (ADR-057), not a namespace partition. Both copies of a comm.send stay in the
+  caller's namespace (`"local"` by default); the actor label is attribution only.
+- Memory is NO-CARRY (resolves the Rev-2 "undecided"). The memory pool is shared, and
+  cross-lambda recall via memory.recall over one pool is the intended behavior. Per-actor
+  distinction on memory reads is a view-layer filter on `actor_id` attribution (deferred to
+  ADR-053); it does not become a namespace partition.
 
 Under this ADR: list, search, recall, neighbors, traverse, and query for ALL packs pass
 WHERE namespace = 'local' by default. The single exception is an explicit `namespace=` request
-parameter (Rule 1 — a caller may deliberately read a named set, e.g.
-`list(namespace="lambda:khive")` or `create(namespace="ns-beta")`), which routes that one
-operation to the named set. There is no per-pack actor routing, and `default_namespace` (the
-actor/config identity) does NOT route storage: it reaches the gate as policy context, but the
-storage token stays "local" unless the caller named a namespace explicitly.
+parameter (a caller may deliberately read a named set, e.g. `list(namespace="lambda:khive")`
+or `create(namespace="ns-beta")`), which routes that one operation to the named set. There is
+no per-pack actor routing, and `default_namespace` (the actor/config identity) does NOT route
+storage: it reaches the gate as policy context, but the storage token stays "local" unless the
+caller named a namespace explicitly.
 
 The dispatch boundary (VerbRegistry::dispatch, pack.rs) mints the storage token with primary =
 the explicit `namespace=` parameter when present, else `Namespace::local()`. The "local" pin is
 the default; the explicit parameter is the only escape.
 
-Per-actor distinctions for operational packs are view-layer filters, not namespace partitions:
+Per-actor distinctions for operational packs are view-layer tag filters, not namespace
+partitions:
 
-- GTD: filter by the "assignee" column (tag or field), not by namespace.
-- Comm: in the current release, filters by "from"/"to" addressing fields over the shared
-  "local" store. Open (Rev 3): Ocean (2026-06-17) leans toward comm _carrying_ the caller's
-  namespace into storage by default, since messages are inherently per-actor.
-- Memory: filter by actor_id attribution column when an owner-scoped view is needed; the
-  underlying pool is shared and cross-lambda recall operates over it. Whether memory should
-  carry the caller's namespace by default is undecided (Rev 3).
+- GTD: filter by the `assignee` column (tag or field), not by namespace.
+- Comm: actor addressing uses `from_actor`/`to_actor` in message `properties` (ADR-057,
+  implemented). Both copies of a comm.send stay in the caller's namespace ("local"). Actor
+  label is attribution only; namespace carry is NO.
+- Memory: filter by `actor_id` attribution column when an owner-scoped view is needed; the
+  underlying pool is shared and cross-lambda recall operates over it. Namespace carry is NO.
+  The `actor_id` attribution column is deferred to ADR-053; interim attribution is via
+  `properties`.
 - Brain: profile resolution is its own scoping mechanism (brain.resolve, profile bindings),
-  independent of namespace.
-- Schedule: attribution columns carry the scheduling actor; namespace is "local".
+  independent of namespace. Namespace carry is NO.
+- Schedule: attribution columns carry the scheduling actor; namespace is "local". Namespace
+  carry is NO.
+- KG / knowledge: shared "local" store. Namespace carry was NO (confirmed in Rev 2; unchanged).
 
-This dissolves the Rule 0 vs Rule 3 contradiction present in the draft (gemini Finding 2) and
-resolves the memory-pack scoping incoherence (gemini Finding 1).
+This dissolves the Rule 0 vs Rule 3 contradiction present in the prior amendment (gemini
+Finding 2) and resolves the memory-pack scoping incoherence (gemini Finding 1). The Rev-2
+deferred carry questions for comm and memory are now closed: both are NO-CARRY.
 
 Status: implemented. VerbRegistry::dispatch mints the storage token with primary = the explicit
 `namespace=` parameter when present, else `Namespace::local()`; `default_namespace` feeds only
 the gate request, never the storage token. `runtime_config_from_khive_config` treats `[actor] id`
 as attribution only. The earlier pin of `Namespace::local()` at the dispatch mint site (PR #159)
-applied _unconditionally_ — collapsing even an explicit parameter and so breaking namespace
+applied unconditionally — collapsing even an explicit parameter and so breaking namespace
 isolation between caller-named sets — and is superseded by this explicit-parameter escape.
+
+### Rule 3a — Edge namespace is attribution-only, never isolation
+
+Every edge record carries a `namespace` column. In OSS, that column is stamped "local" by
+default. Edge namespace is attribution only: it records who created the edge. It is not an
+isolation mechanism and is not used for access control.
+
+The ADR-059 "three-column edge-visibility filter" — filtering on edge.namespace AND
+source_entity.namespace AND target_entity.namespace — is REJECTED and remains rejected. No
+per-edge namespace-join appears in any query, at either the OSS or cloud tier. The graph is
+shared structure; no actor "owns" an edge via namespace.
+
+Edge namespace is NOT derived from the endpoints. The B1 storage-schema fact from the ADR-059
+gemini mirror (edge carries its own namespace column, not derived from endpoints) is retained
+as a storage-schema description, not as an isolation mechanism.
+
+Source: ADR-059 §"Context" — gemini REFUTE correction 1 confirmed scheme B1 (edge carries its
+own namespace column). That storage fact is accurate. What ADR-059's decision built on top of
+it (the three-column visibility filter) is withdrawn.
 
 ### Rule 4 — Authorization enforced at one seam: the Gate
 
@@ -219,14 +260,15 @@ policy input. It does not route storage.
 
 ## Supersession Map
 
-| Document                                          | Status                      | Superseded clauses                                                                                                                                                                          | Surviving clauses                                                                                                                                                                                                                 |
-| ------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ADR-007 v1 base text (this file, prior revision)  | Superseded (Rev 2 replaces) | NamespaceToken as by-ID guard; NamespaceView; Read-by-ID namespace check; Timing oracle mitigation; NamespaceGrants / AuthContext / PrincipalId                                             | Namespace::parse structural validation; "No Default"; Namespace vs backend independent axes; Hierarchy helper naming utility                                                                                                      |
-| ADR-007 2026-05-25 amendment                      | Partially superseded        | OSS vs Cloud two-model framing (collapsed: OSS IS the model; cloud plugs in via Gate)                                                                                                       | AllowAllGate as OSS default; [actor] id as attribution config; 4-tier config search path; display_name advisory-only                                                                                                              |
-| ADR-007 2026-05-27 amendment (Namespace-by-Layer) | Superseded                  | KG-pack namespace override via token.with_namespace(); per-pack actor namespace routing for memory/gtd/comm — this ADR replaces routing with view-layer tag filters                         | None; the routing intent is now stated correctly in Rule 3                                                                                                                                                                        |
-| ADR-050                                           | Partially superseded        | Decision: removal of KG-pack override (this ADR absorbs and confirms)                                                                                                                       | Context: documents the override as a historical bug; Rationale "Why not token rebinding"                                                                                                                                          |
-| ADR-053                                           | Survives in full            | No conflict                                                                                                                                                                                 | All: ActorStore, SessionStore, DispatchRequest, cloud-tier actor threading. Attribution threading is orthogonal to namespace isolation.                                                                                           |
-| ADR-059 (draft)                                   | Substantially superseded    | Decision: visibility tiers (shared + private + proposal-only); visibility filter checking all three namespace columns; subagents submit proposals; legacy "local" maps to private namespace | Context: multi-lambda cooperation description (retained as background); Gemini-mirror corrections on edge namespace storage (edge carries its own namespace column, not derived from endpoints) — a storage schema fact, retained |
+| Document                                          | Status                      | Superseded clauses                                                                                                                                                                                                                            | Surviving clauses                                                                                                                                                                                        |
+| ------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-007 v1 base text (this file, prior revision)  | Superseded (Rev 3 replaces) | NamespaceToken as by-ID guard; NamespaceView; Read-by-ID namespace check; Timing oracle mitigation; NamespaceGrants / AuthContext / PrincipalId                                                                                               | Namespace::parse structural validation; "No Default"; Namespace vs backend independent axes; Hierarchy helper naming utility                                                                             |
+| ADR-007 2026-05-25 amendment                      | Superseded (Rev 3 replaces) | OSS vs Cloud two-model framing (collapsed: OSS IS the model; cloud plugs in via Gate)                                                                                                                                                         | AllowAllGate as OSS default; [actor] id as attribution config; 4-tier config search path; display_name advisory-only                                                                                     |
+| ADR-007 2026-05-27 amendment (Namespace-by-Layer) | Superseded (Rev 3 replaces) | KG-pack namespace override via token.with_namespace(); per-pack actor namespace routing for memory/gtd/comm — this ADR replaces routing with view-layer tag filters                                                                           | None; the routing intent is now stated correctly in Rule 3                                                                                                                                               |
+| ADR-007 Rev 2 (2026-06-16)                        | Superseded (Rev 3 replaces) | Status: Proposed; Rev-3-deferred comm carry question ("leans yes"); Rev-3-deferred memory carry question ("undecided")                                                                                                                        | All substantive rules 0-7 (retained and sharpened); gemini REFUTE findings; PR-A1 shipped status                                                                                                         |
+| ADR-050                                           | Partially superseded        | Decision: removal of KG-pack override (this ADR absorbs and confirms)                                                                                                                                                                         | Context: documents the override as a historical bug; Rationale "Why not token rebinding"                                                                                                                 |
+| ADR-053                                           | Survives in full            | No conflict                                                                                                                                                                                                                                   | All: ActorStore, SessionStore, DispatchRequest, cloud-tier actor threading. Attribution threading is orthogonal to namespace isolation.                                                                  |
+| ADR-059 (withdrawn)                               | Withdrawn before acceptance | Decision: visibility tiers (shared + private + proposal-only); three-column edge-visibility filter; subagents submit proposals; legacy "local" maps to private namespace. The three-column filter (Rule 3a) is rejected and remains rejected. | Gemini-mirror B1 storage-schema fact: edge carries its own namespace column, not derived from endpoints. Retained as a storage fact in Rule 3a; the isolation mechanism built on top of it is withdrawn. |
 
 Note on ADR-058: PR #143 proposes a new ADR-058 for the brain posterior read-path. That
 number is orthogonal to the namespace work. The supersession map above does not reference
@@ -237,13 +279,14 @@ collision.
 
 ## Alternatives Considered
 
-| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                                                                                             |
-| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                                                                                               |
-| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Blanket form rejected; kg/knowledge/gtd/brain confirmed no-carry (Ocean 2026-06-17); narrow comm-only (±memory) carry deferred to Rev 3 |
-| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Superseded by this ADR                                                                                                                  |
-| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                                                                                                |
-| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not                                                                     |
+| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                                                                                                                                                   |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                                                                                                                                                     |
+| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Rejected in full. Blanket form rejected in Rev 2; narrow comm-only carry and memory carry both closed as NO-CARRY by Ocean ruling 2026-06-17 (Rev 3). No per-pack carry exists or is planned. |
+| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Withdrawn before acceptance (ADR-007 Rev 2). Withdrawn status reaffirmed by Rev 3.                                                                                                            |
+| ADR-059 three-column edge visibility filter                  | Prevents edge-induced namespace leaks                          | Complexity; joins across three namespace columns on every edge query; incompatible with "edges are shared structure" | Rejected (Rule 3a). Edge namespace is attribution-only, stamped "local" by default. No per-edge namespace-join at any tier.                                                                   |
+| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                                                                                                                                                      |
+| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not                                                                                                                           |
 
 ---
 
@@ -268,8 +311,10 @@ collision.
   namespace-agnostic — live-DB verified). Higher-cost than the prior amendment implied, but a
   single reindex pass is the mechanism.
 - PR-F is a live-data mutation with no automatic rollback. Requires snapshot discipline.
-- Until PR-B lands, KG list/search may include stranded non-"local" records or miss them
-  depending on current visible-set config. This is the current state post-PR-A1.
+- The dispatch routing is shipped (local-only scope, empty visible set). Until the PR-A2/PR-F
+  data backfill lands, KG list/search will MISS the stranded non-"local" base rows (they sit
+  under lambda:* namespaces that the default local scope no longer returns) until those rows
+  are relabeled to "local". This is a data-state gap, not a routing gap.
 
 ### Neutral
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -132,7 +132,14 @@ reconstruct conversation order from `sent_at` on messages sharing a `thread_id`.
 is propagated; otherwise the target message's own UUID becomes the `thread_id` for the new
 message chain.
 
-#### Cross-namespace messaging (OSS policy — specified 2026-06-15)
+#### Cross-namespace messaging (deferred Option B — cloud path)
+
+**Note (2026-06-17, ADR-007 Rev 3)**: The cross-namespace allowlist model described in this
+section is the deferred Option B (cloud/multi-tenant path) from ADR-057. It is NOT the current
+OSS implementation. Under ADR-007 Rev 3, comm is NO-CARRY: all comm messages stay in the
+caller's shared "local" namespace. Actor addressing uses `from_actor`/`to_actor` properties
+on message notes (ADR-057), not namespace partitions. The `allowed_outbound_namespaces`
+mechanism below is preserved for the future cloud path (Option B), but is not active in OSS.
 
 `send` writes the inbound copy into the recipient's namespace. Whether this write is allowed
 depends on the **sender-side outbound allowlist** (`actor.allowed_outbound_namespaces` in the
@@ -146,8 +153,8 @@ The minted token has `namespace = recipient` and `visible = [recipient]`; it is 
 `NamespaceToken` that the comm handler uses in an append-only manner (one `create_note` call,
 never returned to the sender). The enforced boundary is the sender-side allowlist check plus
 the handler's single-create usage — not the token type. A future cloud-path authorization ADR
-(not yet written) will replace this with a type-enforced, append-only capability primitive.
-The denial error is `RuntimeError::PermissionDenied { verb: "comm.send" }`.
+will replace this with a type-enforced, append-only capability primitive. The denial error is
+`RuntimeError::PermissionDenied { verb: "comm.send" }`.
 
 Within-namespace messaging (sender and recipient in the same namespace) proceeds without any
 allowlist check.

--- a/docs/adr/ADR-050-kg-token-namespace-contract.md
+++ b/docs/adr/ADR-050-kg-token-namespace-contract.md
@@ -1,15 +1,16 @@
 # ADR-050: KG Token Namespace Contract
 
-> **Partially superseded by ADR-007 Rev 2 (2026-06-16).** The §"Decision" clause (removal of
-> the KG-pack namespace override) is absorbed and confirmed by ADR-007 Rev 2 Rule 2 and Rule 3.
-> The by-ID namespace check aspects are superseded by ADR-007 Rev 2 Rule 2 (SHIPPED, PR-A1).
+> **Partially superseded by ADR-007 Rev 3 (2026-06-17, which replaces Rev 2 in full).** The
+> §"Decision" clause (removal of the KG-pack namespace override) is absorbed and confirmed by
+> ADR-007 Rev 3 Rule 2 and Rule 3. The by-ID namespace check aspects are superseded by ADR-007
+> Rev 3 Rule 2 (SHIPPED, PR-A1).
 > The §"Context" and §"Rationale / Why not token rebinding" sections remain authoritative
 > historical background for why the override was introduced and why it was removed.
 
 **Status**: Proposed — pending Ocean review
 **Date**: 2026-06-03
 **Supersedes**: ADR-007 §"Namespace-by-Layer Rule" (KG pack rebinding only)
-**References**: ADR-007 (Rev 2), ADR-028, ADR-029
+**References**: ADR-007 (Rev 3), ADR-028, ADR-029
 
 ---
 

--- a/docs/adr/ADR-057-comm-actor-addressed-delivery.md
+++ b/docs/adr/ADR-057-comm-actor-addressed-delivery.md
@@ -44,13 +44,16 @@ scope reads and writes by actor. That is the correct long-term model. However, #
 changes to the dispatch layer, gate stack, and several packs. Gating comm actor-addressed
 delivery on #75 would leave agent-to-agent messaging broken for an extended period.
 
-### Namespace isolation is a security boundary
+### Namespace is attribution, not isolation (ADR-007 Rev 3)
 
-ADR-007 specifies that namespace isolation is a data-breach boundary in hosted deployments.
-The local shared-namespace deployment intentionally places all lambdas in `"local"` so that
-memory and KG records are cross-visible. Per-lambda namespaces would orphan the existing
-corpus from every lambda's view. Actor identity and data visibility are orthogonal axes;
-conflating them by creating per-lambda namespaces is the wrong fix.
+ADR-007 Rev 3 (2026-06-17, Accepted/Ratified) establishes that namespace is attribution-only:
+a write-stamp on records, queryable and filterable, available to the Gate as policy input, but
+not a storage boundary. Isolation is enforced at one seam — the Gate (ADR-018, ADR-053) — not
+in storage partitions or by-ID namespace checks. The local shared-namespace deployment
+intentionally places all lambdas in `"local"` so that memory and KG records are cross-visible.
+Per-lambda namespaces would orphan the existing corpus from every lambda's view. Actor identity
+and data visibility are orthogonal axes; conflating them by creating per-lambda namespaces is
+the wrong fix.
 
 ## Decision
 
@@ -209,13 +212,14 @@ No changes to thread resolution or read-marking logic. Thread queries filter by
 `properties.thread_id`, which is namespace-scoped and independent of actor labels. Read
 marking is a per-message operation gated on namespace membership, which is unchanged.
 
-### Interaction with ADR-007 (namespace isolation)
+### Interaction with ADR-007 Rev 3 (namespace as attribution)
 
 Option A writes both copies to the caller's namespace. No `NamespaceToken::with_namespace`
-is called. No cross-namespace write is attempted. Namespace isolation as defined in ADR-007
-is fully preserved. The safety argument: actor-addressed delivery is a routing abstraction
-implemented within a single namespace; it changes the actor label on message properties, not
-the namespace of stored records.
+is called. No cross-namespace write is attempted. ADR-007 Rev 3 is fully satisfied: namespace
+is attribution, storage is dumb, and the Gate is the single enforcement seam. The safety
+argument: actor-addressed delivery is a routing abstraction implemented within a single
+namespace; it changes the actor label on message properties (`from_actor`, `to_actor`), not
+the namespace of stored records. Comm is NO-CARRY per ADR-007 Rev 3 Rule 3.
 
 ### Interaction with ADR-040 cross-namespace allowlist
 

--- a/docs/adr/ADR-059-namespace-write-tiers.md
+++ b/docs/adr/ADR-059-namespace-write-tiers.md
@@ -17,7 +17,7 @@ The ADR number 059 is burned — this file is preserved as a record of the withd
 **Withdrawn**: 2026-06-16 (superseded by ADR-007 Rev 2)
 **Depends on**:
 
-- ADR-007 (Namespace contract — data-breach boundary, OSS vs cloud axes)
+- ADR-007 (Namespace contract — attribution-only, OSS vs cloud axes; now Rev 3)
 - ADR-017 (Pack standard — pack-extensible edge endpoints)
 - ADR-018 (Authorization gate — single dispatch-site enforcement)
 - ADR-046 (Event-sourced proposals — the mutation path for subagents)


### PR DESCRIPTION
## What

Promotes **ADR-007 to Rev 3** (Accepted/Ratified, 2026-06-17) and sweeps every doc that contradicted it into agreement. Doc-only — no code changes.

### Decisions baked in (2026-06-17)
- **All 7 packs are NO-CARRY.** OSS is one shared brain: every record stored under `namespace="local"` by default.
- **Namespace is attribution, not isolation** — a queryable/filterable write-stamp and Gate policy input, never a storage partition.
- Closes the two Rev-2-deferred carry questions: **comm** = NO-CARRY (reverses Rev-2 "leans yes"), **memory** = NO-CARRY (resolves Rev-2 "undecided"). Per-actor distinction is a view-layer tag (`from_actor`/`to_actor`, `assignee`, `actor_id`, profile bindings).
- By-ID ops (get/update/delete/merge) namespace-agnostic (already SHIPPED, PR-A1 / `2607e263`).
- Multi-record ops default `WHERE namespace='local'`; only escape is an explicit `namespace=` param.
- **New Rule 3a:** edge namespace is attribution-only (stamped local); the ADR-059 three-column visibility filter stays **rejected**; the B1 fact (edge carries its own ns column, not endpoint-derived) retained as a *storage* description only.
- Authorization at one seam: the Gate (ADR-018).

### Files
- `docs/adr/ADR-007-namespace.md` — Rev 3 rewrite (Rules 0–4 + new 3a, supersession map, alternatives).
- `docs/adr/ADR-057` — attribution framing (core actor-addressed design unchanged).
- `docs/adr/ADR-040` — cross-namespace allowlist demoted to deferred cloud Option B.
- `docs/adr/ADR-050`, `docs/adr/ADR-059` — cross-refs bumped to Rev 3; dropped "data-breach boundary" framing.
- `CLAUDE.md`, `AGENTS.md` — removed the erroneous by-ID `record.namespace == caller` claim; anti-pattern now warns against re-adding it.
- `README.md` — "Namespace isolation" headline → "Namespace attribution".

## Verification
- Drafted, then independently reviewed: confirmed each decision encoded, doc-only, no over-reach; caught 1 internal contradiction + 3 stale cross-refs, all fixed.
- Load-bearing code fact verified directly: `crates/khive-runtime/src/pack.rs:853-858` mints `Namespace::local()` + empty visible set → multi-record **routing is shipped**; only the data backfill (relabel stranded non-local rows + reindex) is pending, tracked separately.
- `deno fmt --check` clean; pre-commit secret + data-leak guards passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
