### PR TITLE
feat(runtime,memory): ADR-007 Rev 4 — additive read visible-set + recall fanout

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -160,9 +160,10 @@ fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
 /// 1. CLI `--actor` / `--namespace` (carried in `base.default_namespace`)
 /// 2. Default "local" from RuntimeConfig
 ///
-/// Config file `[actor] id` is attribution only and does NOT route the storage
-/// namespace (ADR-007 Rev 2 Rule 0); `runtime_config_from_khive_config` preserves
-/// `base.default_namespace` regardless of the configured actor.
+/// Config file `[actor] id` does NOT set `default_namespace` — writes stay
+/// pinned to `local` (ADR-007 Rev 4 Rule 0). A non-`'local'` `actor.id` IS
+/// folded into the default READ visible-set (Rule 3b), but `runtime_config_from_khive_config`
+/// preserves `base.default_namespace` regardless of the configured actor.
 ///
 /// Precedence for embedding engines:
 /// 1. Config file `[[engines]]`

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2396,11 +2396,11 @@ fn actor_precedence_default_local_with_no_config() {
     );
 }
 
-/// Tier 3 (config file): no CLI, config has actor.id. Under ADR-007 Rev 2 Rule 0
-/// the config `[actor] id` is attribution only and must NOT route the storage
-/// namespace — `default_namespace` stays at the `local` hard default. (Actor
-/// attribution threading is deferred to ADR-053; `[actor] id` is inert in OSS
-/// until then.)
+/// Tier 3 (config file): no CLI, config has actor.id. Under ADR-007 Rev 4 Rule 0
+/// the config `[actor] id` must NOT route the storage `default_namespace` — writes
+/// stay pinned to `local`. Note: a non-`'local'` `actor.id` IS folded into the
+/// default READ visible-set (ADR-007 Rev 4 Rule 3b), but that does not change
+/// `default_namespace`. This test asserts only the write-routing invariant.
 #[test]
 fn actor_precedence_config_actor_id_does_not_route_namespace() {
     use khive_runtime::{runtime_config_from_khive_config, KhiveConfig, Namespace, RuntimeConfig};
@@ -2425,8 +2425,9 @@ fn actor_precedence_config_actor_id_does_not_route_namespace() {
     assert_eq!(
         resolved.default_namespace,
         Namespace::parse("local").unwrap(),
-        "config actor.id is attribution only and must NOT become default_namespace \
-         (ADR-007 Rev 2 Rule 0); the local hard default must be preserved"
+        "config actor.id must NOT become default_namespace (ADR-007 Rev 4 Rule 0); \
+         writes stay pinned to local (actor.id does contribute to READ visible-set per Rule 3b, \
+         but that does not affect default_namespace)"
     );
 }
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3810,10 +3810,10 @@ async fn test_propose_pipe_withdraw_chain() -> anyhow::Result<()> {
 /// Two RuntimeConfigs that are identical except for their `visible_namespaces`
 /// must produce different `compute_config_id` fingerprints.
 ///
-/// `visible_namespaces` is retained for configuration identity; OSS dispatch
-/// does NOT use it to widen read scope (ADR-007 Rev 2). The fingerprint still
-/// includes it so configs with different visible sets are treated as distinct
-/// daemon configurations (e.g. for future cloud-gate policy).
+/// `visible_namespaces` widens the default multi-record read scope to
+/// `['local'] ∪ visible_namespaces` on the OSS dispatch path (ADR-007 Rev 4
+/// Rule 3b). The fingerprint includes the visible set so configs with different
+/// read scopes are treated as distinct daemon configurations.
 #[test]
 fn compute_config_id_differs_when_visible_namespaces_differ() {
     use khive_mcp::server::compute_config_id;

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -587,7 +587,7 @@ mod tests {
         );
     }
 
-    /// ADR-007 Rev 2, Rule 0 regression: non-local actor config does NOT route storage.
+    /// ADR-007 Rev 4, Rule 0 regression: non-local actor config does NOT route WRITE storage.
     ///
     /// Builds a VerbRegistry whose `default_namespace` is `"lambda:leo"` (simulating
     /// `[actor] id = "lambda:leo"` or `--actor lambda:leo`).  Dispatches `create` and

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -276,22 +276,20 @@ mod tests {
             .expect("Beta must be retrievable via local token");
     }
 
-    /// ADR-007 Rev 2, Rule 3 (PR-B): shared-brain visible-set regression.
+    /// ADR-007 Rev 4, Rule 3b: default read scope honors configured visible set.
     ///
-    /// The dispatch token minted by VerbRegistry must always have visible = [primary_namespace]
-    /// regardless of what `actor.visible_namespaces` was configured on the registry. All
-    /// multi-record ops (list) scope to the single shared "local" set.
+    /// The dispatch token minted by VerbRegistry on the default (no explicit `namespace=`)
+    /// path widens the read scope to `['local'] ∪ visible_namespaces`. Both the 'local'
+    /// entity AND the entity written to a configured extra namespace must appear in a
+    /// registry-dispatched list without any explicit `namespace=` parameter.
     ///
-    /// This test verifies two invariants:
+    /// This test verifies:
     ///
-    /// 1. Records written to "local" (the OSS default namespace) are visible in a list
-    ///    dispatched via the registry — the shared-brain property.
-    /// 2. A record written to a non-"local" namespace (stranded record, written via a
-    ///    directly-minted token) does NOT appear in the "local" list even when that
-    ///    extra namespace appears in the registry's visible_namespaces config — proving
-    ///    the visible set is collapsed to [primary] and not widened by the config field.
+    /// 1. Records written to "local" are visible in the list — the shared-brain property.
+    /// 2. A record written to a configured visible namespace (via a directly-minted token)
+    ///    ALSO appears in the registry-dispatched list — the Rev 4 read-scope widening.
     #[tokio::test]
-    async fn dispatch_list_scopes_to_primary_namespace_only_adr007_prb() {
+    async fn dispatch_list_honors_configured_visible_namespaces_adr007_rev4() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
 
         let extra_ns = Namespace::parse("alpha-test-ns").expect("valid namespace");
@@ -331,7 +329,7 @@ mod tests {
         let entity_in_extra = pack
             .dispatch(
                 "create",
-                json!({ "kind": "concept", "name": "StrandedConcept" }),
+                json!({ "kind": "concept", "name": "ConfiguredVisibleConcept" }),
                 &registry,
                 &extra_token,
             )
@@ -370,9 +368,222 @@ mod tests {
             "shared-brain: 'local' entity must appear in list; got ids: {ids:?}"
         );
         assert!(
-            !ids.contains(&extra_id),
-            "visible-set collapse: 'alpha-test-ns' entity must NOT appear in list \
-             even though that namespace was in registry.visible_namespaces; got ids: {ids:?}"
+            ids.contains(&extra_id),
+            "Rev 4 read-scope widening: 'alpha-test-ns' entity MUST appear in list \
+             because that namespace is in registry.visible_namespaces; got ids: {ids:?}"
+        );
+    }
+
+    /// ADR-007 Rev 4: backward-compat — with visible_namespaces UNSET, default read scope = ['local'] only.
+    ///
+    /// A registry with no `visible_namespaces` configured has the same behavior as Rev 3:
+    /// list returns only records in 'local'. A record written to a different namespace via
+    /// a directly-minted token does NOT appear in the registry list.
+    #[tokio::test]
+    async fn dispatch_list_empty_visible_namespaces_scopes_to_local_only_adr007_rev4() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+
+        // Registry with NO visible_namespaces — backward-compat with Rev 3.
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        // Intentionally NOT calling with_visible_namespaces — default is empty.
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry builds");
+
+        let pack = KgPack::new(rt.clone());
+        let local_token = rt.authorize(Namespace::local()).expect("authorize local");
+        let other_token = rt
+            .authorize(Namespace::parse("other-ns").expect("valid"))
+            .expect("authorize other-ns");
+
+        let entity_in_local = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "LocalConcept" }),
+                &registry,
+                &local_token,
+            )
+            .await
+            .expect("create in local must succeed");
+        let local_id = entity_in_local
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("id");
+
+        let entity_in_other = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "OtherNsConcept" }),
+                &registry,
+                &other_token,
+            )
+            .await
+            .expect("create in other-ns must succeed");
+        let other_id = entity_in_other
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("id");
+
+        let list_result = registry
+            .dispatch("list", json!({ "kind": "entity" }))
+            .await
+            .expect("list must succeed");
+        let items: Vec<serde_json::Value> = match list_result {
+            serde_json::Value::Array(arr) => arr,
+            other => panic!("list must return a JSON array; got: {other:?}"),
+        };
+        let ids: Vec<&str> = items
+            .iter()
+            .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
+            .collect();
+
+        assert!(
+            ids.contains(&local_id),
+            "backward-compat: 'local' entity must appear in list; got ids: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&other_id),
+            "backward-compat: 'other-ns' entity must NOT appear when visible_namespaces is unset; \
+             got ids: {ids:?}"
+        );
+    }
+
+    /// ADR-007 Rev 4: 'local' is always included in the default read scope,
+    /// even when visible_namespaces does not explicitly list it.
+    ///
+    /// Configuring visible_namespaces = ["other-ns"] (without "local") must still
+    /// return records from BOTH 'local' and 'other-ns' in the registry list.
+    #[tokio::test]
+    async fn dispatch_list_local_always_included_when_visible_ns_set_adr007_rev4() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+
+        let other_ns = Namespace::parse("other-ns").expect("valid namespace");
+
+        // Registry with visible_namespaces = ["other-ns"] — does NOT contain "local".
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.with_visible_namespaces(vec![other_ns.clone()]);
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry builds");
+
+        let pack = KgPack::new(rt.clone());
+        let local_token = rt.authorize(Namespace::local()).expect("authorize local");
+        let other_token = rt.authorize(other_ns.clone()).expect("authorize other-ns");
+
+        let entity_local = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "LocalEntity" }),
+                &registry,
+                &local_token,
+            )
+            .await
+            .expect("create in local must succeed");
+        let local_id = entity_local.get("id").and_then(|v| v.as_str()).expect("id");
+
+        let entity_other = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "OtherEntity" }),
+                &registry,
+                &other_token,
+            )
+            .await
+            .expect("create in other-ns must succeed");
+        let other_id = entity_other.get("id").and_then(|v| v.as_str()).expect("id");
+
+        let list_result = registry
+            .dispatch("list", json!({ "kind": "entity" }))
+            .await
+            .expect("list must succeed");
+        let items: Vec<serde_json::Value> = match list_result {
+            serde_json::Value::Array(arr) => arr,
+            other => panic!("list must return a JSON array; got: {other:?}"),
+        };
+        let ids: Vec<&str> = items
+            .iter()
+            .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
+            .collect();
+
+        assert!(
+            ids.contains(&local_id),
+            "'local' must always appear in list even when not in visible_namespaces config; \
+             got ids: {ids:?}"
+        );
+        assert!(
+            ids.contains(&other_id),
+            "'other-ns' must appear because it is in visible_namespaces; got ids: {ids:?}"
+        );
+    }
+
+    /// ADR-007 Rev 4: explicit namespace= param is a precise single-namespace escape, NOT widened.
+    ///
+    /// With visible_namespaces=["other-ns"] configured, a list(namespace="other-ns") call
+    /// scopes to EXACTLY ["other-ns"] and does NOT include 'local' or the union set.
+    /// This preserves the ability to read a single named set precisely.
+    #[tokio::test]
+    async fn dispatch_explicit_namespace_param_is_precise_not_widened_adr007_rev4() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+
+        let other_ns = Namespace::parse("other-ns").expect("valid namespace");
+
+        // Registry with visible_namespaces = ["other-ns"].
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.with_visible_namespaces(vec![other_ns.clone()]);
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry builds");
+
+        let pack = KgPack::new(rt.clone());
+        let local_token = rt.authorize(Namespace::local()).expect("authorize local");
+        let other_token = rt.authorize(other_ns.clone()).expect("authorize other-ns");
+
+        // Write one entity in 'local' and one in 'other-ns'.
+        let entity_local = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "LocalPrecise" }),
+                &registry,
+                &local_token,
+            )
+            .await
+            .expect("create in local must succeed");
+        let local_id = entity_local.get("id").and_then(|v| v.as_str()).expect("id");
+
+        let entity_other = pack
+            .dispatch(
+                "create",
+                json!({ "kind": "concept", "name": "OtherPrecise" }),
+                &registry,
+                &other_token,
+            )
+            .await
+            .expect("create in other-ns must succeed");
+        let other_id = entity_other.get("id").and_then(|v| v.as_str()).expect("id");
+
+        // list(namespace="other-ns") — explicit escape: must scope to EXACTLY "other-ns".
+        let list_result = registry
+            .dispatch("list", json!({ "kind": "entity", "namespace": "other-ns" }))
+            .await
+            .expect("list with explicit namespace must succeed");
+        let items: Vec<serde_json::Value> = match list_result {
+            serde_json::Value::Array(arr) => arr,
+            other => panic!("list must return a JSON array; got: {other:?}"),
+        };
+        let ids: Vec<&str> = items
+            .iter()
+            .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
+            .collect();
+
+        assert!(
+            ids.contains(&other_id),
+            "explicit namespace='other-ns' must return the other-ns entity; got ids: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&local_id),
+            "explicit namespace='other-ns' must NOT include 'local' entity — \
+             the explicit param is a precise escape, not widened by visible_namespaces; \
+             got ids: {ids:?}"
         );
     }
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -594,16 +594,13 @@ impl MemoryPack {
             fts_gather,
         } = opts;
 
-        // FTS recall fans out across all visible namespaces by iterating each
-        // namespace's own FTS virtual table (fts_notes_{ns}) — there is NO global
-        // FTS table and TextFilter.namespaces does NOT yield cross-namespace hits.
-        // Each namespace is selected by minting a token via token.with_namespace(ns)
-        // (see multi-namespace fanout path below at line 633+).
-        //
-        // Phase-1.5 limitation: vector/ANN recall stays primary-namespace-only.
-        // Each namespace owns a separate ANN index instance; cross-namespace
-        // recall on the vector path requires fanout+fusion across index instances,
-        // which is deferred to a follow-up PR.
+        // FTS and vector recall both fan out across all visible namespaces (ADR-007
+        // Rev 4 Phase 1.5). FTS: each namespace has its own FTS virtual table
+        // (fts_notes_{ns}); token.with_namespace(ns) selects it. Vector: each
+        // namespace has its own ANN index keyed by (namespace, model); tokens are
+        // minted via self.runtime.authorize(ns) (same pattern as warm_existing_memory_indexes
+        // in ann.rs:318) so that token.namespace().as_str() inside ensure_ann_for_model
+        // (ann.rs:344) resolves to the target namespace.
         let visible = token.visible_namespace_strs();
         let primary_ns = token.namespace().as_str().to_string();
 
@@ -664,26 +661,61 @@ impl MemoryPack {
                 .await?;
             all_text_hits.extend(hits);
         }
-        // Vector recall stays in primary namespace (single index).
-        let vector_result = self
-            .collect_recall_vector_hits(
-                token,
-                query,
-                &primary_ns,
-                RecallVectorCandidateParams {
-                    candidate_limit,
-                    embedding_model,
-                    use_multilingual,
-                    scoring_cfg,
-                },
-            )
-            .await?;
+        // Vector recall fans out across all visible namespaces (ADR-007 Rev 4 Phase 1.5).
+        // Each per-namespace token is minted via self.runtime.authorize(ns) so that
+        // token.namespace().as_str() inside ensure_ann_for_model (ann.rs:344) reads the
+        // target namespace, producing the correct AnnKey. token.with_namespace would
+        // preserve the primary namespace in the ANN key lookup, missing the legacy index.
+        //
+        // Each call receives the full candidate_limit. With N visible namespaces the total
+        // candidate pool before RRF fusion can reach N * candidate_limit — this improves
+        // recall quality and is intentional (RRF then reduces to the configured result limit).
+        let mut all_vector_per_model: Vec<(String, Vec<VectorSearchHit>)> = Vec::new();
+        let mut final_multilingual_routed = false;
+        for ns_str in &visible {
+            let ns_parsed = match khive_runtime::Namespace::parse(ns_str) {
+                Ok(ns) => ns,
+                Err(_) => continue,
+            };
+            let ns_token = match self.runtime.authorize(ns_parsed) {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(ns = %ns_str, error = %e,
+                        "memory vector fanout: authorize failed; skipping namespace");
+                    continue;
+                }
+            };
+            let result = self
+                .collect_recall_vector_hits(
+                    &ns_token,
+                    query,
+                    ns_str,
+                    RecallVectorCandidateParams {
+                        candidate_limit,
+                        embedding_model,
+                        use_multilingual,
+                        scoring_cfg,
+                    },
+                )
+                .await?;
+            final_multilingual_routed |= result.multilingual_routed;
+            for (model_name, hits) in result.vector_hits_per_model {
+                if let Some(entry) = all_vector_per_model
+                    .iter_mut()
+                    .find(|(m, _)| m == &model_name)
+                {
+                    entry.1.extend(hits);
+                } else {
+                    all_vector_per_model.push((model_name, hits));
+                }
+            }
+        }
 
         Ok(RecallCandidateSet {
             namespace: primary_ns,
             text_hits: all_text_hits,
-            vector_hits_per_model: vector_result.vector_hits_per_model,
-            multilingual_routed: vector_result.multilingual_routed,
+            vector_hits_per_model: all_vector_per_model,
+            multilingual_routed: final_multilingual_routed,
         })
     }
 

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3452,3 +3452,76 @@ async fn adr007_rev4_default_recall_surfaces_actor_ns_via_both_legs() {
          even with a lexically-disjoint query (no FTS match possible); got: {ids_5b:?}"
     );
 }
+
+/// (a2) ADR-007 Rev 4: FTS-leg isolation — with the vector leg disabled (no embedder),
+/// default recall surfaces a lambda:khive note via the FTS fanout alone.
+///
+/// Builds a `KhiveRuntime` with `embedding_model: None` and registers NO embedder,
+/// so the vector leg is dead. Asserts `registered_embedding_model_names()` is empty
+/// (self-documenting premise). Dispatches `memory.remember` with
+/// `namespace="lambda:khive"` (explicit-param write into that namespace), then
+/// `memory.recall` with a lexically matching query and no `namespace=` param.
+/// The note id must appear — with the vector leg dead, the ONLY path that can
+/// surface it is the FTS fanout (`with_namespace` selecting `fts_notes_lambda:khive`).
+#[tokio::test]
+async fn adr007_rev4_default_recall_surfaces_actor_ns_via_fts_leg() {
+    // Build a runtime with visible_namespaces = ["lambda:khive"] and NO embedder,
+    // so the vector leg is dead.
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+
+    // Assert the vector leg is dead — no embedder registered.
+    // This makes the test premise self-documenting: if an embedder were registered,
+    // the vector leg could carry the result without FTS, and the test would prove nothing.
+    assert!(
+        rt.registered_embedding_model_names().is_empty(),
+        "FTS-leg isolation premise: no embedder must be registered (vector leg must be dead)"
+    );
+
+    // Build the registry with with_visible_namespaces mirroring tests (b)/(d).
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_visible_namespaces(rt.config().visible_namespaces.clone());
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // Write the note into lambda:khive via the Rule-3 explicit-namespace escape.
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "alpha beta gamma delta",
+                "salience": 0.8,
+                "namespace": "lambda:khive"
+            }),
+        )
+        .await
+        .expect("memory.remember with explicit namespace must succeed");
+    let note_id = result["id"].as_str().expect("note id present").to_owned();
+    assert!(!note_id.is_empty());
+
+    // Default recall with a lexically matching query and no namespace= param.
+    // With the vector leg dead, the ONLY path that can surface the note is the
+    // FTS fanout (with_namespace selecting fts_notes_lambda:khive). This isolates
+    // the FTS leg as the sole return path.
+    let recall = registry
+        .dispatch("memory.recall", json!({ "query": "alpha beta" }))
+        .await
+        .expect("memory.recall must succeed");
+    let hits = recall.as_array().expect("recall returns array");
+    let ids: Vec<&str> = hits
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        ids.contains(&note_id.as_str()),
+        "FTS-leg: default recall must surface the lambda:khive note via FTS fanout alone \
+         (vector leg is dead — no embedder registered); got: {ids:?}"
+    );
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3117,3 +3117,253 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
          its presence proves the old greedy retain was used instead of the prefix cut"
     );
 }
+
+// =============================================================================
+// ADR-007 Rev 4 regression tests — additive read visible-set
+// =============================================================================
+
+/// (b) Writes stamp the local namespace even when actor.id = "lambda:khive".
+///
+/// A `memory.remember` dispatched with no explicit `namespace=` param must
+/// produce a note with `namespace == "local"`. Actor identity must not route
+/// storage writes.
+#[tokio::test]
+async fn adr007_rev4_writes_stamp_local() {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_visible_namespaces(rt.config().visible_namespaces.clone());
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "adr007 rev4 write test — must land in local",
+                "memory_type": "semantic",
+                "salience": 0.6
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let note_id = result["id"].as_str().expect("note id present");
+    let tok_local = rt.authorize(Namespace::local()).expect("authorize local");
+    let note = rt
+        .get_note_including_deleted(&tok_local, Uuid::parse_str(note_id).unwrap())
+        .await
+        .expect("get must succeed")
+        .expect("note must exist in local");
+    assert_eq!(
+        note.namespace, "local",
+        "write must stamp local, not actor namespace; got: {}",
+        note.namespace
+    );
+}
+
+/// (c) No actor configured → default visible-set is exactly {local}.
+///
+/// A registry built with no visible_namespaces must NOT surface notes written
+/// to a foreign namespace via default-path recall.
+#[tokio::test]
+async fn adr007_rev4_no_actor_yields_local_only_visible_set() {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        // no visible_namespaces — same as Rev 3 behavior
+        visible_namespaces: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+
+    // Write a note directly into the foreign namespace.
+    let tok_foreign = rt
+        .authorize(Namespace::parse("ns-foreign-c").unwrap())
+        .expect("authorize foreign");
+    rt.create_note(
+        &tok_foreign,
+        "memory",
+        None,
+        "adr007-c-foreign-content-unique-marker",
+        None,
+        None,
+        vec![],
+    )
+    .await
+    .expect("create note in foreign ns");
+
+    // Build the registry with no visible_namespaces (zero actor extras).
+    let mut builder = VerbRegistryBuilder::new();
+    // deliberately NOT calling with_visible_namespaces
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // Default recall must NOT surface the foreign note.
+    let hits = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "adr007-c-foreign-content-unique-marker" }),
+        )
+        .await
+        .expect("memory.recall must succeed");
+    let hits = hits.as_array().expect("recall returns array");
+    let foreign_visible = hits.iter().any(|h| {
+        h["content"]
+            .as_str()
+            .unwrap_or("")
+            .contains("adr007-c-foreign-content-unique-marker")
+    });
+    assert!(
+        !foreign_visible,
+        "no-actor config: foreign-namespace note must NOT appear in default recall (visible-set={{local}} only)"
+    );
+}
+
+/// (d) Explicit namespace= is strict — Reading 2 regression guard.
+///
+/// When `namespace="lambda:khive"` is passed explicitly, the result set must
+/// be EXACTLY that namespace. A note written to `local` must NOT appear in the
+/// results (the explicit param is not widened by visible_namespaces).
+#[tokio::test]
+async fn adr007_rev4_explicit_namespace_is_strict_reading2() {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+
+    // Write a note to local (default path — no explicit namespace).
+    let tok_local = rt.authorize(Namespace::local()).expect("authorize local");
+    rt.create_note(
+        &tok_local,
+        "memory",
+        None,
+        "adr007-d-local-content-marker",
+        None,
+        None,
+        vec![],
+    )
+    .await
+    .expect("create local note");
+
+    // Write a note to lambda:khive (explicit namespace).
+    let tok_lk = rt
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .expect("authorize lambda:khive");
+    let lk_note = rt
+        .create_note(
+            &tok_lk,
+            "memory",
+            None,
+            "adr007-d-lambdakhive-content-marker",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create lambda:khive note");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_visible_namespaces(rt.config().visible_namespaces.clone());
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // Explicit namespace="lambda:khive" → strict {lambda:khive} only.
+    // The local note must NOT appear even though visible_namespaces includes it.
+    let results = registry
+        .dispatch(
+            "memory.recall",
+            json!({
+                "query": "adr007-d",
+                "namespace": "lambda:khive"
+            }),
+        )
+        .await
+        .expect("recall with explicit namespace must succeed");
+    let hits = results.as_array().expect("recall returns array");
+
+    let local_leaked = hits.iter().any(|h| {
+        h["content"]
+            .as_str()
+            .unwrap_or("")
+            .contains("adr007-d-local-content-marker")
+    });
+    assert!(
+        !local_leaked,
+        "Reading 2 violation: explicit namespace=lambda:khive must NOT return local-namespace notes; \
+         visible_namespaces must not widen explicit-namespace escapes"
+    );
+
+    let lk_found = hits.iter().any(|h| {
+        h["id"].as_str() == Some(&lk_note.id.to_string())
+            || h["content"]
+                .as_str()
+                .unwrap_or("")
+                .contains("adr007-d-lambdakhive-content-marker")
+    });
+    assert!(
+        lk_found,
+        "explicit namespace=lambda:khive must return the lambda:khive note"
+    );
+}
+
+/// (e) By-ID get of a lambda:khive-attributed note works namespace-agnostically.
+///
+/// Rule 2 (shipped PR-A1): get by UUID is globally resolved regardless of token.
+/// This test is a regression guard that the Rev 4 changes did not re-introduce
+/// any namespace check on the by-ID path.
+#[tokio::test]
+async fn adr007_rev4_get_byid_is_namespace_agnostic() {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        visible_namespaces: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+
+    // Create a note attributed to lambda:khive.
+    let tok_lk = rt
+        .authorize(Namespace::parse("lambda:khive").unwrap())
+        .expect("authorize lambda:khive");
+    let lk_note = rt
+        .create_note(
+            &tok_lk,
+            "memory",
+            None,
+            "adr007-e-byid-content",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create lambda:khive note");
+
+    let mut builder = VerbRegistryBuilder::new();
+    // No visible_namespaces — local-only token will be minted by dispatch default.
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // get by UUID with no namespace= param → must resolve the lambda:khive note.
+    let result = registry
+        .dispatch("get", json!({ "id": lk_note.id.to_string() }))
+        .await
+        .expect("get by UUID must succeed regardless of namespace");
+
+    let record = result.get("record").unwrap_or(&result);
+    let returned_id = record["id"].as_str().expect("id present in get result");
+    assert_eq!(
+        returned_id,
+        lk_note.id.to_string().as_str(),
+        "by-ID get must return the lambda:khive-attributed note (Rule 2 / PR-A1 regression guard)"
+    );
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3367,3 +3367,88 @@ async fn adr007_rev4_get_byid_is_namespace_agnostic() {
         "by-ID get must return the lambda:khive-attributed note (Rule 2 / PR-A1 regression guard)"
     );
 }
+
+/// (a) ADR-007 Rev 4: [actor] id=lambda:khive ⇒ default recall surfaces a lambda:khive note via
+/// BOTH the FTS leg (5a) and the vector leg (5b, lexically-disjoint query).
+///
+/// A `KhiveRuntime` with `visible_namespaces = ["lambda:khive"]` and a registered
+/// `ConstVecProvider` (so the vector leg is live) writes a note into `lambda:khive`
+/// via the Rule-3 explicit-namespace escape, then asserts:
+///   5a — default recall with a matching query returns the note (FTS + vector both reachable).
+///   5b — default recall with a lexically-disjoint query (no shared trigrams) still returns the
+///        note, isolating the vector leg via the `authorize(ns)` fanout.
+#[tokio::test]
+async fn adr007_rev4_default_recall_surfaces_actor_ns_via_both_legs() {
+    const MODEL_A: &str = "custom-enc-a";
+    const DIMS: usize = 4;
+
+    // Build a runtime with visible_namespaces = ["lambda:khive"] and a registered
+    // ConstVecProvider so the vector leg is live (no lattice model needed).
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+    rt.register_embedder(ConstVecProvider::new(MODEL_A, DIMS, 0.9));
+
+    // Build the registry with with_visible_namespaces, mirroring tests (b)/(d).
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_visible_namespaces(rt.config().visible_namespaces.clone());
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // Step 3: write the note into lambda:khive via the Rule-3 explicit-namespace escape.
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "alpha beta gamma delta",
+                "salience": 0.8,
+                "namespace": "lambda:khive"
+            }),
+        )
+        .await
+        .expect("memory.remember with explicit namespace must succeed");
+    let note_id = result["id"].as_str().expect("note id present").to_owned();
+    assert!(!note_id.is_empty());
+
+    // Step 5a: default recall with a query that shares trigrams with the content.
+    // Both FTS and vector legs can surface the note here.
+    let recall_5a = registry
+        .dispatch("memory.recall", json!({ "query": "alpha beta" }))
+        .await
+        .expect("memory.recall (5a) must succeed");
+    let hits_5a = recall_5a.as_array().expect("recall returns array");
+    let ids_5a: Vec<&str> = hits_5a
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        ids_5a.contains(&note_id.as_str()),
+        "5a: default recall must surface the lambda:khive note (both legs); got: {ids_5a:?}"
+    );
+
+    // Step 5b: default recall with a lexically-disjoint query — no shared letters with
+    // "alpha beta gamma delta" (content uses a,l,p,h,b,e,t,g,m,d; query uses j,x,w,v,z,r,f,k)
+    // so zero shared trigrams. FTS cannot match; only the vector leg can surface the note
+    // via the constant-vector ANN index fanned out through authorize("lambda:khive").
+    // This isolates the vector-leg fanout as the sole return path.
+    let recall_5b = registry
+        .dispatch("memory.recall", json!({ "query": "jxwvz qrpfk" }))
+        .await
+        .expect("memory.recall (5b) must succeed");
+    let hits_5b = recall_5b.as_array().expect("recall returns array");
+    let ids_5b: Vec<&str> = hits_5b
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        ids_5b.contains(&note_id.as_str()),
+        "5b: vector-leg fanout via authorize(lambda:khive) must surface the note \
+         even with a lexically-disjoint query (no FTS match possible); got: {ids_5b:?}"
+    );
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3131,6 +3131,10 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
 async fn adr007_rev4_writes_stamp_local() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: None,
+        // No real embedder: this test exercises namespace scoping, not embedding.
+        // The CI runner has no model files, so loading one would fail (see a/a2).
+        embedding_model: None,
+        additional_embedding_models: vec![],
         visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
         ..RuntimeConfig::default()
     })
@@ -3176,6 +3180,9 @@ async fn adr007_rev4_writes_stamp_local() {
 async fn adr007_rev4_no_actor_yields_local_only_visible_set() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: None,
+        // No real embedder: scoping test, FTS recall only (see a/a2). CI has no model files.
+        embedding_model: None,
+        additional_embedding_models: vec![],
         // no visible_namespaces — same as Rev 3 behavior
         visible_namespaces: vec![],
         ..RuntimeConfig::default()
@@ -3233,12 +3240,22 @@ async fn adr007_rev4_no_actor_yields_local_only_visible_set() {
 /// results (the explicit param is not widened by visible_namespaces).
 #[tokio::test]
 async fn adr007_rev4_explicit_namespace_is_strict_reading2() {
+    const MODEL_A: &str = "custom-enc-a";
+    const DIMS: usize = 4;
+
+    // No real model (CI has no model files); a ConstVecProvider drives the vector leg
+    // instead. The constant vector is identical across notes, so the local note WOULD
+    // surface if the explicit namespace= weren't strict — making this a sharp Reading-2
+    // guard rather than relying on FTS lexical luck for the hyphenated marker query.
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
         visible_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
         ..RuntimeConfig::default()
     })
     .expect("in-memory runtime");
+    rt.register_embedder(ConstVecProvider::new(MODEL_A, DIMS, 0.9));
 
     // Write a note to local (default path — no explicit namespace).
     let tok_local = rt.authorize(Namespace::local()).expect("authorize local");
@@ -3325,6 +3342,9 @@ async fn adr007_rev4_explicit_namespace_is_strict_reading2() {
 async fn adr007_rev4_get_byid_is_namespace_agnostic() {
     let rt = KhiveRuntime::new(RuntimeConfig {
         db_path: None,
+        // No real embedder: by-ID get needs no embedding (see a/a2). CI has no model files.
+        embedding_model: None,
+        additional_embedding_models: vec![],
         visible_namespaces: vec![],
         ..RuntimeConfig::default()
     })

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -242,9 +242,13 @@ pub struct RuntimeConfig {
     /// 2. Namespace-bound profile resolved via `brain.resolve` at feedback time
     /// 3. Pack-local global tuning prior (default fallback)
     pub brain_profile: Option<String>,
-    /// Extra namespaces retained for configuration identity; NOT consumed by
-    /// OSS dispatch (storage token is always pinned to `local`, ADR-007 Rev 2).
-    /// Populated from `actor.visible_namespaces` in `khive.toml`.
+    /// Operator-configured read-visibility set (ADR-007 Rev 4 Rule 3b).
+    ///
+    /// OSS dispatch widens the DEFAULT multi-record read scope to
+    /// `['local'] ∪ visible_namespaces`. Writes remain pinned to `'local'`.
+    /// An explicit `namespace=` request param is a precise single-namespace
+    /// escape and is not widened. Populated from `actor.visible_namespaces`
+    /// in `khive.toml`.
     pub visible_namespaces: Vec<Namespace>,
     /// Namespaces this actor's comm.send/reply may deliver messages INTO
     /// (outbound, sender-side). Populated from `actor.allowed_outbound_namespaces`
@@ -391,11 +395,10 @@ pub fn runtime_config_from_khive_config(
     khive_cfg: &crate::engine_config::KhiveConfig,
     base: RuntimeConfig,
 ) -> RuntimeConfig {
-    // ADR-007 Rev 2 Rule 0: `[actor] id` is attribution only and never becomes the
-    // storage namespace. `default_namespace` is whatever the caller resolved into
-    // `base` (explicit `--namespace` / `KHIVE_NAMESPACE`, else `local`). A caller
-    // targets a named namespace per request (`create(namespace=...)`), not by virtue
-    // of which actor is configured — actor identity must not silently route storage.
+    // ADR-007 Rev 4 Rule 0: `[actor] id` does NOT become the storage namespace
+    // (writes always pin to `local`). `default_namespace` is whatever the caller
+    // resolved into `base` (explicit `--namespace` / `KHIVE_NAMESPACE`, else `local`).
+    // `actor.id` contributes to the read visible-set only (see fold-in below).
     let default_namespace = base.default_namespace.clone();
 
     // base.brain_profile must carry ONLY the explicit CLI tier — never an env
@@ -422,6 +425,26 @@ pub fn runtime_config_from_khive_config(
             }
         })
         .collect();
+
+    // ADR-007 Rev 4: fold actor.id's namespace into visible_namespaces so that
+    // default reads widen to {local} ∪ {actor namespace}. Skipped when actor.id
+    // parses to `local` (mint already includes primary=local on the default path,
+    // adding it here would create a duplicate). Also skipped when it is already
+    // present from actor.visible_namespaces above.
+    let visible_namespaces = if let Some(id) = khive_cfg.actor.id.as_deref() {
+        match Namespace::parse(id) {
+            Ok(actor_ns) if actor_ns != Namespace::local() => {
+                let mut v = visible_namespaces;
+                if !v.contains(&actor_ns) {
+                    v.push(actor_ns);
+                }
+                v
+            }
+            _ => visible_namespaces,
+        }
+    } else {
+        visible_namespaces
+    };
 
     // KhiveConfig::validate() guarantees every entry in allowed_outbound_namespaces is a
     // structurally valid Namespace string, so Namespace::parse failures here are unreachable

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -85,20 +85,22 @@ pub struct EngineConfig {
 ///
 /// Corresponds to the `[actor]` TOML section. `id` is used as the
 /// `default_namespace` for gate/attribution policy input. OSS dispatch pins
-/// storage to the shared `local` namespace regardless of this value (ADR-007
-/// Rev 2); cloud deployments derive the namespace from an authenticated
+/// writes to the shared `local` namespace regardless of this value (ADR-007
+/// Rev 4 Rule 0); cloud deployments derive the namespace from an authenticated
 /// `NamespaceToken` instead.
 ///
 /// ```toml
 /// [actor]
 /// id = "lambda:leo"                          # attribution identity (required)
 /// display_name = "Leo global orchestrator"   # human label (optional)
-/// visible_namespaces = ["lambda:khive", "local"]  # configuration identity; not consumed by OSS dispatch
+/// visible_namespaces = ["lambda:khive", "local"]  # widens default read scope (ADR-007 Rev 4 Rule 3b)
 /// ```
 ///
-/// `visible_namespaces` is retained for configuration identity and future
-/// cloud-gate policy. OSS dispatch does NOT use it to widen read scope
-/// (storage token is always local-only, ADR-007 Rev 2).
+/// `visible_namespaces` is consumed by OSS dispatch to widen the DEFAULT
+/// multi-record read scope to `['local'] ∪ visible_namespaces` (ADR-007 Rev 4
+/// Rule 3b). Writes remain pinned to `'local'`. An explicit `namespace=` request
+/// param is a precise single-namespace escape and is not widened. A cloud gate
+/// may also consult this list as policy input at its own layer.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ActorConfig {
     /// Namespace identifier used as the default actor for all operations.
@@ -114,10 +116,11 @@ pub struct ActorConfig {
     #[serde(default)]
     pub display_name: Option<String>,
 
-    /// Additional namespaces retained for configuration identity and future
-    /// cloud-gate policy. Each string must be a valid `Namespace`. OSS
-    /// dispatch does NOT consume this list — storage is always pinned to
-    /// `local` regardless (ADR-007 Rev 2).
+    /// Additional namespaces that widen the DEFAULT multi-record read scope
+    /// to `['local'] ∪ visible_namespaces` (ADR-007 Rev 4 Rule 3b). Each string
+    /// must be a valid `Namespace`. Writes remain pinned to `'local'`. An
+    /// explicit `namespace=` request param is a precise escape and is not widened
+    /// by this list. A cloud gate may also consult it as policy input.
     #[serde(default)]
     pub visible_namespaces: Option<Vec<String>>,
 

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -156,9 +156,10 @@ pub struct KhiveConfig {
     /// Default actor identity for this khive instance.
     ///
     /// When present, `actor.id` feeds configuration identity and gate/attribution
-    /// policy input.  OSS dispatch pins storage to the shared `local` namespace
-    /// regardless of this setting (ADR-007 Rev 2).  Cloud model derives actor
-    /// identity from an authenticated token.
+    /// policy input.  A non-`'local'` `actor.id` is folded into the default READ
+    /// visible-set at config load (ADR-007 Rev 4 Rule 3b) — it widens what default
+    /// multi-record reads return, but never routes writes or sets `default_namespace`.
+    /// Cloud model derives actor identity from an authenticated token.
     #[serde(default)]
     pub actor: ActorConfig,
 
@@ -843,10 +844,10 @@ id = "lambda:"
         );
     }
 
-    // 18. ADR-007 Rev 2 Rule 0: actor.id is attribution only and must NOT become
-    //     default_namespace. Storage namespace stays whatever `base` carried (local
-    //     by default for OSS); a caller targets a named namespace per request, not
-    //     by virtue of which actor is configured.
+    // 18. ADR-007 Rev 4 Rule 0: actor.id must NOT become default_namespace — writes
+    //     stay pinned to `local`. A non-`'local'` actor.id IS folded into the
+    //     default READ visible-set (ADR-007 Rev 4 Rule 3b), but that does not affect
+    //     default_namespace. This test asserts the write-routing invariant only.
     #[test]
     fn test_runtime_config_actor_id_does_not_override_namespace() {
         use crate::runtime::runtime_config_from_khive_config;
@@ -869,8 +870,8 @@ id = "lambda:"
         assert_eq!(
             result.default_namespace,
             Namespace::local(),
-            "actor.id must NOT become default_namespace (ADR-007 Rev 2 Rule 0); \
-             base local namespace must be preserved"
+            "actor.id must NOT become default_namespace (ADR-007 Rev 4 Rule 0); \
+             writes stay pinned to local"
         );
     }
 

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -317,13 +317,13 @@ pub struct VerbRegistryBuilder {
     resolvers: Vec<(String, Box<dyn PackByIdResolver>)>,
     gate: GateRef,
     default_namespace: String,
-    /// Retained for future cloud-gate policy wiring only.
+    /// Operator-configured read-visibility set (ADR-007 Rev 4 Rule 3b).
     ///
-    /// After ADR-007 Rev 2 (PR-B), `VerbRegistry::dispatch` always mints the
-    /// storage token with `Namespace::local()` and an empty extra-visible set.
-    /// This field is NOT a read-scope-widening mechanism and is ignored by the
-    /// OSS dispatch path.  A cloud gate implementation may consult it as a
-    /// policy input, but it does not flow into the storage token.
+    /// Threads into `VerbRegistry::visible_namespaces` and is consumed by the
+    /// default dispatch path to widen read scope to `['local'] ∪ visible_namespaces`.
+    /// Writes remain pinned to `'local'`. An explicit `namespace=` request param
+    /// is a precise escape and is not widened by this set. A cloud gate may also
+    /// consult the list as policy input at its own layer.
     visible_namespaces: Vec<Namespace>,
     /// Optional audit event sink.
     ///
@@ -354,14 +354,13 @@ impl VerbRegistryBuilder {
         }
     }
 
-    /// Store extra namespaces for future cloud-gate policy wiring.
+    /// Set the operator-configured read-visibility set (ADR-007 Rev 4 Rule 3b).
     ///
-    /// After ADR-007 Rev 2 (PR-B), these namespaces are **not** threaded into
-    /// dispatch tokens and do **not** widen read scope.  The OSS dispatch path
-    /// always mints `Namespace::local()` with an empty extra-visible set
-    /// regardless of what is supplied here.  This setter is retained so that a
-    /// cloud gate implementation can read the value as policy input without
-    /// requiring a builder API change.
+    /// On the default (no explicit `namespace=` param) dispatch path, reads fan
+    /// out over `['local'] ∪ ns`. Writes remain pinned to `'local'`. An explicit
+    /// `namespace=` request parameter is a precise single-namespace escape and
+    /// is not widened by this set. A cloud gate may also consult the list as
+    /// policy input at its own layer.
     pub fn with_visible_namespaces(&mut self, ns: Vec<Namespace>) -> &mut Self {
         self.visible_namespaces = ns;
         self
@@ -536,6 +535,7 @@ impl VerbRegistryBuilder {
             resolvers: Arc::new(self.resolvers),
             gate: self.gate,
             default_namespace: self.default_namespace,
+            visible_namespaces: self.visible_namespaces,
             event_store: self.event_store,
             dispatch_hook: self.dispatch_hook,
         })
@@ -665,6 +665,13 @@ pub struct VerbRegistry {
     resolvers: std::sync::Arc<Vec<(String, Box<dyn PackByIdResolver>)>>,
     gate: GateRef,
     default_namespace: String,
+    /// Operator-configured read-visibility set (ADR-007 Rev 4 Rule 3b).
+    ///
+    /// On the default (no explicit `namespace=` param) dispatch path, reads fan
+    /// out over `['local'] ∪ visible_namespaces`. Writes are unaffected — they
+    /// still pin to `'local'`. An explicit `namespace=` request param is a
+    /// precise single-namespace escape and is not widened by this set.
+    visible_namespaces: Vec<Namespace>,
     /// Audit event sink — `None` means tracing-only (v0.2 default).
     event_store: Option<Arc<dyn EventStore>>,
     /// Post-dispatch hook — `None` means no real-time observation (Issue #158).
@@ -836,26 +843,32 @@ impl VerbRegistry {
 
         // Mint the authorized storage token at the dispatch boundary.
         //
-        // ADR-007 Rev 2 Rule 0/3: storage pins to `local` by default. Actor identity,
-        // CLI `--actor`, and config `[actor] id` (carried in `default_namespace`) are
-        // attribution and gate-context inputs only — they never route storage. The one
-        // escape is an explicit `namespace=` request param (Rule 1): a caller may
-        // deliberately read/write a named set, e.g. `create(namespace="lambda:khive")`
-        // or `list(namespace="ns-beta")`. `default_namespace` reaches the gate via
-        // `gate_req` above for policy evaluation, but the storage token stays `local`
-        // unless the caller named a namespace explicitly.
+        // ADR-007 Rev 4 Rule 0/3/3b: writes pin to `local` by default. Actor
+        // identity and config `[actor] id` are attribution and gate-context inputs
+        // only — they never route storage. The explicit `namespace=` request param
+        // is a precise single-namespace escape (Rule 3): the caller deliberately
+        // reads/writes exactly that one set; it is NOT widened by `visible_namespaces`.
         //
-        // #159 pinned `local` *unconditionally*, collapsing even an explicit param and
-        // breaking namespace isolation between caller-named sets; this restores the
-        // Rule 1 escape without reviving actor-as-namespace routing. `visible_namespaces`
-        // stays dissolved (empty extra-visible set); per-actor distinctions are
-        // view-layer tag filters (assignee, actor_id, from/to), not namespace partitions.
-        let primary = match params.get("namespace").and_then(Value::as_str) {
-            Some(ns) => Namespace::parse(ns)
-                .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?,
-            None => Namespace::local(),
+        // Rule 3b (Rev 4): on the default (no explicit `namespace=`) path, the read
+        // scope widens to `['local'] ∪ self.visible_namespaces`. `'local'` is always
+        // included (mint_with_visibility deduplicates). Writes remain pinned to
+        // `'local'`. Per-actor distinctions use view-layer tag filters
+        // (assignee, actor_id, from/to), not namespace partitions.
+        let token = match params.get("namespace").and_then(Value::as_str) {
+            Some(ns) => {
+                // Rule 3 explicit escape: precise single-namespace scope, read+write. NOT widened.
+                let primary = Namespace::parse(ns)
+                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
+                NamespaceToken::mint_with_visibility(primary, vec![], ActorRef::anonymous())
+            }
+            None => {
+                // Rule 3b: default path. Write namespace = local; read scope = ['local'] ∪ visible_namespaces.
+                let primary = Namespace::local();
+                let mut extra_visible = self.visible_namespaces.clone();
+                extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
+                NamespaceToken::mint_with_visibility(primary, extra_visible, ActorRef::anonymous())
+            }
         };
-        let token = NamespaceToken::mint_with_visibility(primary, vec![], ActorRef::anonymous());
 
         for pack in self.packs.iter() {
             if let Some(handler_def) = pack.handlers().iter().find(|v| v.name == verb) {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -351,15 +351,21 @@ impl KhiveRuntime {
     /// that right-kind hits ranked below `limit` in the raw fusion still surface when
     /// higher-ranked candidates are wrong-kind or soft-deleted.
     ///
-    /// # Cross-namespace visibility (Phase 1.5 limitation — primary namespace only)
+    /// # Cross-namespace visibility (entity search — primary namespace only; deferred)
     ///
-    /// Both the **FTS leg** and the **vector/ANN leg** are currently restricted to
-    /// the **primary namespace only** for search.
+    /// Both the **FTS leg** and the **vector/ANN leg** of entity search (`hybrid_search`)
+    /// are restricted to the **primary namespace only**.
     ///
     /// Rationale: each namespace owns a separate FTS table (`fts_entities_{ns}`)
-    /// and a separate ANN index instance. Cross-namespace fanout requires iterating
-    /// over every visible namespace's store, issuing parallel search requests, and
-    /// fusing the results — this is deferred to Phase 1.5.
+    /// and a separate ANN index instance. Cross-namespace entity-search fanout
+    /// requires iterating over every visible namespace's store, issuing parallel
+    /// search requests, and fusing the results — this is deferred (entity-search
+    /// cross-namespace fanout is the outstanding follow-up).
+    ///
+    /// Note: this is distinct from memory recall's cross-namespace fanout, which
+    /// ships in ADR-007 Rev 4 (`memory.recall` iterates `visible_namespaces` across
+    /// both the FTS and vector legs). Entity search fanout is the remaining deferred
+    /// piece; memory recall fanout is not deferred.
     ///
     /// The `visible_ns` list is forwarded in the `TextFilter.namespaces` field,
     /// which limits results to those namespaces within the primary store. Because
@@ -368,7 +374,7 @@ impl KhiveRuntime {
     ///
     /// Callers with a multi-namespace visible set can READ cross-namespace entities
     /// directly via `get_entity` / `resolve`, but `hybrid_search` returns only
-    /// primary-namespace hits until Phase 1.5 cross-namespace fanout ships.
+    /// primary-namespace hits until entity-search cross-namespace fanout ships.
     #[allow(clippy::too_many_arguments)]
     pub async fn hybrid_search(
         &self,

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -168,11 +168,12 @@ impl KhiveRuntime {
         &self.config.backend_id
     }
 
-    /// Return the extra-visible namespaces from config.
+    /// Return the extra-visible namespaces assembled at config load.
     ///
-    /// Retained for configuration identity and future cloud-gate policy. OSS
-    /// dispatch does NOT use these to mint read tokens — storage is always
-    /// local-only (ADR-007 Rev 2).
+    /// OSS dispatch uses this set to widen the DEFAULT multi-record read scope
+    /// to `['local'] ∪ visible_namespaces` (ADR-007 Rev 4 Rule 3b). Writes are
+    /// unchanged — always pinned to `'local'`. This set is also available as
+    /// gate/cloud policy input.
     pub fn visible_namespaces(&self) -> &[Namespace] {
         &self.config.visible_namespaces
     }
@@ -888,9 +889,10 @@ mod tests {
 
     #[test]
     fn runtime_config_from_khive_config_actor_id_does_not_override_default_namespace() {
-        // ADR-007 Rev 2 Rule 0: `[actor] id` is attribution only and never becomes
-        // the storage namespace. A configured actor must NOT silently route storage —
-        // default_namespace stays whatever `base` carried (here, `local`).
+        // ADR-007 Rev 4 Rule 0: `[actor] id` must NOT set `default_namespace` —
+        // writes stay pinned to `local`. Note: a non-`'local'` actor.id IS folded
+        // into the default READ visible-set (Rule 3b), but that does not change
+        // default_namespace. This test asserts the write-routing invariant only.
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
@@ -908,7 +910,7 @@ mod tests {
         assert_eq!(
             result.default_namespace.as_str(),
             "local",
-            "actor.id must not become the storage namespace (ADR-007 Rev 2 Rule 0)"
+            "actor.id must not become default_namespace (ADR-007 Rev 4 Rule 0); writes pin to local"
         );
     }
 
@@ -999,8 +1001,8 @@ mod tests {
         assert_eq!(
             result.default_namespace.as_str(),
             "local",
-            "actor.id is attribution only and must not override default_namespace \
-             (ADR-007 Rev 2 Rule 0); engine config is still applied"
+            "actor.id must not override default_namespace (ADR-007 Rev 4 Rule 0); \
+             writes pin to local; engine config is still applied"
         );
         assert!(result.embedding_model.is_some());
     }

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1075,11 +1075,12 @@ mod tests {
         );
     }
 
-    // Namespace resolution parity with `kkernel mcp` under ADR-007 Rev 2 Rule 0:
-    // when --namespace is omitted, the config file `[actor] id` is attribution only
-    // and does NOT set the effective namespace — it stays `local`, same as the MCP
-    // path. When --namespace is explicit, it routes storage (Rule 1 / reindex's
-    // explicit namespace channel) and overrides the local default.
+    // Namespace resolution parity with `kkernel mcp` under ADR-007 Rev 4 Rule 0:
+    // when --namespace is omitted, the config file `[actor] id` does NOT set
+    // default_namespace — it stays `local` (writes pin to local). A non-`'local'`
+    // actor.id IS folded into the default READ visible-set (Rule 3b), but that
+    // does not affect default_namespace. When --namespace is explicit, it routes
+    // storage (Rule 1 / reindex's explicit namespace channel) and overrides local.
     #[test]
     #[serial]
     fn namespace_absent_defers_to_local_not_config_actor_id() {
@@ -1109,8 +1110,8 @@ mod tests {
         assert_eq!(
             resolved.default_namespace.as_str(),
             "local",
-            "omitted --namespace must stay local; config [actor] id is attribution \
-             only (ADR-007 Rev 2 Rule 0)"
+            "omitted --namespace must stay local; config [actor] id does NOT set \
+             default_namespace (ADR-007 Rev 4 Rule 0)"
         );
 
         // Explicit --namespace must override [actor] id.

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -12,16 +12,22 @@
 **Rev 4 summary (2026-06-17)**: Generalizes the Rev 3 default read scope. Rev 3 fixed the
 default multi-record read scope at exactly `['local']`, with an explicit `namespace=` request
 parameter as the only escape. Rev 4 widens the default read scope to `['local'] ∪
-visible_namespaces`, where `visible_namespaces` is an operator-configured list in `khive.toml`
-(`[actor] visible_namespaces`). `'local'` is always included. With `visible_namespaces` unset
-(the default), behavior is identical to Rev 3 — fully backward-compatible. Writes are unchanged
-(still pin `'local'` by default, explicit `namespace=` escape unchanged), by-ID ops are
-unchanged (namespace-agnostic, Rule 2), and the Gate remains the single enforcement seam. The
-new config field is an explicit, additive, read-only view filter; it is NOT derived from actor
-identity and does NOT route writes, so it does not re-introduce the actor-as-namespace coupling
-Rev 3 rejected (Rule 0). Rev 4 obviates the Rev-3-pending PR-A2/PR-F relabel backfill: legacy
-non-`'local'` rows become visible by configuring `visible_namespaces`, without mutating stored
-attribution. See Rule 3b.
+visible_namespaces`, where `visible_namespaces` is assembled at config load from two sources:
+the operator-configured `[actor] visible_namespaces` list in `khive.toml`, and the configured
+`[actor] id` when it is non-`'local'` (folded in, deduplicated). `'local'` is always included.
+With neither configured (the default), behavior is identical to Rev 3 — fully
+backward-compatible. Writes are unchanged (still pin `'local'` by default, explicit
+`namespace=` escape unchanged), by-ID ops are unchanged (namespace-agnostic, Rule 2), and the
+Gate remains the single enforcement seam. Rev 4 deliberately AMENDS the Rev 3
+"attribution-only" reading of `[actor] id` (Rule 0): a non-`'local'` actor identity now
+contributes to the DEFAULT READ visible-set. It still never routes writes and never sets
+`default_namespace`. This is read-augmentation, not the actor-as-namespace isolation Rev 3
+rejected: it only ever ADDS namespaces to what a default read sees — it never hides records,
+never silos, and never breaks by-ID resolution (the failure modes of the rejected model, which
+hid data behind per-actor partitions for both reads and writes). Rev 4 obviates the
+Rev-3-pending PR-A2/PR-F relabel backfill: legacy non-`'local'` rows become visible by
+configuring `[actor] id` or `visible_namespaces`, without mutating stored attribution. See
+Rule 3b.
 
 **Rev 3 summary (2026-06-17)**: Promoted from Proposed to Accepted/Ratified. Closes the two
 Rev-2-deferred per-pack carry questions as NO-CARRY: comm = no-carry (reverses the Rev-2 "leans
@@ -182,11 +188,14 @@ parameter is supplied) is:
 ['local'] ∪ visible_namespaces
 ```
 
-where `visible_namespaces` is the operator-configured `[actor] visible_namespaces` list in
-`khive.toml`. `'local'` is always a member, whether or not it appears in the configured list.
-When `visible_namespaces` is unset or empty, the default read scope is exactly `['local']`,
-identical to Rev 3. The widening is therefore opt-in: a deployment that configures nothing keeps
-Rev 3 behavior verbatim.
+where `visible_namespaces` is assembled at config load from two sources: the
+operator-configured `[actor] visible_namespaces` list in `khive.toml`, and the configured
+`[actor] id` when it is non-`'local'` (folded in, deduplicated; an actor.id of `'local'` adds
+nothing since `'local'` is always present). `'local'` is always a member, whether or not it
+appears in either source. When neither source contributes a non-`'local'` namespace, the
+default read scope is exactly `['local']`, identical to Rev 3. The widening is therefore
+opt-in: a deployment that configures neither `[actor] id` nor `[actor] visible_namespaces`
+keeps Rev 3 behavior verbatim.
 
 The scope applies to all multi-record reads for all packs: list, search, recall, neighbors,
 traverse, query. The runtime supplies the set to the store as a `WHERE namespace IN (...)`
@@ -198,7 +207,8 @@ What Rev 4 does NOT change:
 - Writes. The write namespace is `'local'` by default, or the explicit `namespace=` parameter
   when present. `visible_namespaces` does NOT widen the write namespace. Rule 0 holds: actor
   identity never becomes the storage namespace, and a non-`'local'` `[actor] id` does not route
-  writes.
+  writes. (A non-`'local'` `[actor] id` does, however, contribute to the default READ
+  visible-set — see the Rev 4 amendment to Rule 0 above and Rule 3b.)
 - The explicit `namespace=X` escape (Rule 3). An explicit request parameter scopes that one
   operation to exactly `[X]` for both read and write. It is the precise-targeting escape and is
   NOT widened by `visible_namespaces`: `list(namespace="ns-beta")` returns only `ns-beta`,
@@ -211,13 +221,16 @@ What Rev 4 does NOT change:
   field.
 
 Why this is not the rejected actor-routing (Rev 3 Rule 0, ADR-059): the rejected model derived
-the storage namespace from actor IDENTITY (writes and reads both followed `[actor] id`),
-coupling identity to storage and breaking the shared brain. `visible_namespaces` is an explicit
-operator config list that is read-only (never routes writes), additive (always includes
-`'local'`), and attribution-preserving (records keep their stored namespace; nothing is
-relabeled). It does not derive from actor identity and does not partition storage. It is a
-caller-supplied generalization of the Rule 1 multi-record namespace parameter from a single
-value to a set, applied to the default read path.
+the storage namespace from actor IDENTITY for BOTH writes and reads — writes followed `[actor]
+id` into a per-actor partition and reads were confined to it, coupling identity to storage,
+hiding records behind partitions, and breaking by-ID resolution and the shared brain. Rev 4
+lets `[actor] id` contribute ONLY to the default READ visible-set, and only ever additively:
+writes still pin `'local'` (never an actor partition), `'local'` is always included, by-ID ops
+stay namespace-agnostic, and records keep their stored namespace (nothing is relabeled).
+Read-augmentation cannot reproduce the rejected model's failures because it only ever shows
+MORE, never hides, silos, or reroutes. The visible-set is a caller/config-supplied
+generalization of the Rule 1 multi-record namespace parameter from a single value to a set,
+applied to the default read path.
 
 Relation to the Rev 3 data backfill: Rev 3 §Consequences flagged a pending PR-A2/PR-F relabel
 of stranded non-`'local'` base rows to `'local'` (a live data mutation with no automatic

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,6 +1,6 @@
 # ADR-007 Rev 4: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility
 
-**Status**: Accepted/Ratified (2026-06-17)
+**Status**: Proposed (pending HC-7 review, 2026-06-18)
 **Date**: 2026-06-17
 **Authors**: lambda:khive, alpha:architect
 **Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, and Rev 3 read-scope clause)

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,6 +1,6 @@
 # ADR-007 Rev 4: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility
 
-**Status**: Proposed (pending HC-7 review, 2026-06-18)
+**Status**: Accepted/Ratified (2026-06-18)
 **Date**: 2026-06-17
 **Authors**: lambda:khive, alpha:architect
 **Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, and Rev 3 read-scope clause)

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,13 +1,27 @@
-# ADR-007 Rev 3: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, All Packs No-Carry
+# ADR-007 Rev 4: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility
 
 **Status**: Accepted/Ratified (2026-06-17)
 **Date**: 2026-06-17
 **Authors**: lambda:khive, alpha:architect
-**Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, and Rev 2 in full)
+**Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, and Rev 3 read-scope clause)
 **Supersedes (partial)**: ADR-050 §"Decision"; ADR-059 §"Decision" and §"Visibility tiers"
 **Superseded-by-none**: ADR-053 (ActorStore, SessionStore, cloud-tier actor threading) survives in full
 **ADR chain**: ADR-018 (Gate trait, single dispatch site) | ADR-014 (curation, merge semantics)
 | ADR-002 (edge cascade, no dangling refs)
+
+**Rev 4 summary (2026-06-17)**: Generalizes the Rev 3 default read scope. Rev 3 fixed the
+default multi-record read scope at exactly `['local']`, with an explicit `namespace=` request
+parameter as the only escape. Rev 4 widens the default read scope to `['local'] ∪
+visible_namespaces`, where `visible_namespaces` is an operator-configured list in `khive.toml`
+(`[actor] visible_namespaces`). `'local'` is always included. With `visible_namespaces` unset
+(the default), behavior is identical to Rev 3 — fully backward-compatible. Writes are unchanged
+(still pin `'local'` by default, explicit `namespace=` escape unchanged), by-ID ops are
+unchanged (namespace-agnostic, Rule 2), and the Gate remains the single enforcement seam. The
+new config field is an explicit, additive, read-only view filter; it is NOT derived from actor
+identity and does NOT route writes, so it does not re-introduce the actor-as-namespace coupling
+Rev 3 rejected (Rule 0). Rev 4 obviates the Rev-3-pending PR-A2/PR-F relabel backfill: legacy
+non-`'local'` rows become visible by configuring `visible_namespaces`, without mutating stored
+attribution. See Rule 3b.
 
 **Rev 3 summary (2026-06-17)**: Promoted from Proposed to Accepted/Ratified. Closes the two
 Rev-2-deferred per-pack carry questions as NO-CARRY: comm = no-carry (reverses the Rev-2 "leans
@@ -15,6 +29,7 @@ yes"); memory = no-carry (resolves the Rev-2 "undecided"). All seven production 
 the single shared "local" namespace by default. Per-actor distinction is a view-layer tag, never
 a namespace partition. Edge namespace is attribution-only, stamped "local" by default, never an
 isolation mechanism; the ADR-059 three-column filter is rejected. ADR-059 remains withdrawn.
+(Rev 4 retains all Rev 3 rules; it generalizes only the Rule 3 default read scope.)
 
 ---
 
@@ -156,6 +171,70 @@ the gate request, never the storage token. `runtime_config_from_khive_config` tr
 as attribution only. The earlier pin of `Namespace::local()` at the dispatch mint site (PR #159)
 applied unconditionally — collapsing even an explicit parameter and so breaking namespace
 isolation between caller-named sets — and is superseded by this explicit-parameter escape.
+
+### Rule 3b — Default read scope MAY be widened by an operator-configured visible set (Rev 4)
+
+CHANGE FROM Rev 3: Rev 3 fixed the default multi-record read scope at exactly `['local']`. Rev 4
+generalizes it. The default read scope (the scope applied when no explicit `namespace=` request
+parameter is supplied) is:
+
+```
+['local'] ∪ visible_namespaces
+```
+
+where `visible_namespaces` is the operator-configured `[actor] visible_namespaces` list in
+`khive.toml`. `'local'` is always a member, whether or not it appears in the configured list.
+When `visible_namespaces` is unset or empty, the default read scope is exactly `['local']`,
+identical to Rev 3. The widening is therefore opt-in: a deployment that configures nothing keeps
+Rev 3 behavior verbatim.
+
+The scope applies to all multi-record reads for all packs: list, search, recall, neighbors,
+traverse, query. The runtime supplies the set to the store as a `WHERE namespace IN (...)`
+filter. Storage stays dumb (Rule 1): the set is caller/config-supplied, not actor-derived
+routing, and the store executes the filter it is told.
+
+What Rev 4 does NOT change:
+
+- Writes. The write namespace is `'local'` by default, or the explicit `namespace=` parameter
+  when present. `visible_namespaces` does NOT widen the write namespace. Rule 0 holds: actor
+  identity never becomes the storage namespace, and a non-`'local'` `[actor] id` does not route
+  writes.
+- The explicit `namespace=X` escape (Rule 3). An explicit request parameter scopes that one
+  operation to exactly `[X]` for both read and write. It is the precise-targeting escape and is
+  NOT widened by `visible_namespaces`: `list(namespace="ns-beta")` returns only `ns-beta`,
+  never `ns-beta ∪ local ∪ visible_namespaces`. This preserves the ability to read a single
+  named set precisely.
+- By-ID ops (Rule 2). get, update, delete, merge by UUID remain namespace-agnostic.
+- The Gate (Rule 4). Authorization remains a single seam. `visible_namespaces` is an OSS
+  configuration convenience, not an authorization mechanism. A cloud TenantGate continues to
+  mint the read-visibility set from the authenticated identity, independent of this OSS config
+  field.
+
+Why this is not the rejected actor-routing (Rev 3 Rule 0, ADR-059): the rejected model derived
+the storage namespace from actor IDENTITY (writes and reads both followed `[actor] id`),
+coupling identity to storage and breaking the shared brain. `visible_namespaces` is an explicit
+operator config list that is read-only (never routes writes), additive (always includes
+`'local'`), and attribution-preserving (records keep their stored namespace; nothing is
+relabeled). It does not derive from actor identity and does not partition storage. It is a
+caller-supplied generalization of the Rule 1 multi-record namespace parameter from a single
+value to a set, applied to the default read path.
+
+Relation to the Rev 3 data backfill: Rev 3 §Consequences flagged a pending PR-A2/PR-F relabel
+of stranded non-`'local'` base rows to `'local'` (a live data mutation with no automatic
+rollback) so the local-only scope would return them. Rev 4 makes that backfill unnecessary for
+visibility: configuring `visible_namespaces` to include those namespaces makes the legacy rows
+visible without rewriting their stored attribution. Per the "data vs view" principle, the
+invisibility of legacy rows is a read-scope (view) problem; the correct fix is to widen the read
+scope, not to mutate stored attribution. A deployment MAY still consolidate namespaces via
+curation verbs as a deliberate data decision, but it is no longer required to restore
+visibility.
+
+Status: see implementation note in Rule 3 §Status. The visible-set machinery
+(NamespaceToken.visible, operations.rs multi-namespace read fanout over
+token.visible_namespaces(), VerbRegistryBuilder::with_visible_namespaces, server.rs config
+plumbing) was already present from the shared-brain visible-set work; Rev 4 connects it by
+minting the dispatch token with the configured visible set on the default (no-explicit-param)
+read path instead of an empty extra-visible set.
 
 ### Rule 3a — Edge namespace is attribution-only, never isolation
 
@@ -311,10 +390,34 @@ collision.
   namespace-agnostic — live-DB verified). Higher-cost than the prior amendment implied, but a
   single reindex pass is the mechanism.
 - PR-F is a live-data mutation with no automatic rollback. Requires snapshot discipline.
-- The dispatch routing is shipped (local-only scope, empty visible set). Until the PR-A2/PR-F
-  data backfill lands, KG list/search will MISS the stranded non-"local" base rows (they sit
-  under lambda:* namespaces that the default local scope no longer returns) until those rows
-  are relabeled to "local". This is a data-state gap, not a routing gap.
+- The dispatch routing shipped local-only (empty visible set). Rev 3 closed the resulting
+  data-state gap (KG list/search/recall MISS stranded non-"local" base rows) by a pending
+  PR-A2/PR-F relabel of those rows to "local". Rev 4 closes it differently: configuring
+  `visible_namespaces` to include the stranded namespaces makes the rows visible without
+  relabeling. The relabel backfill is therefore no longer required for visibility (Rule 3b).
+
+### Rev 4 deltas
+
+Positive:
+
+- Legacy non-"local" rows (e.g. v1-era lambda:* writes) become visible by configuration, with
+  no live data mutation and no FTS/ANN reindex. The Rev 3 PR-A2/PR-F relabel — a no-rollback
+  live mutation — is no longer required to restore visibility.
+- Stored attribution is preserved: a record written under lambda:leo keeps namespace=lambda:leo
+  and is readable, rather than being flattened to "local". This honors the "data vs view"
+  principle: read scope is a view decision, attribution is data.
+- Cross-actor read sharing (a configured set of namespaces visible to one deployment) without
+  granting write access to those namespaces — reads widen, writes stay pinned to "local".
+
+Negative:
+
+- A misconfigured `visible_namespaces` widens reads beyond intent. In OSS single-tenant this is
+  low-risk (one operator, one brain) but the field must be validated (non-empty entries,
+  Namespace::parse) and is logged. It is not an authorization control; a cloud TenantGate must
+  not rely on it.
+- Two read-scope mechanisms now coexist: the default widened set (Rule 3b) and the explicit
+  `namespace=` precise escape (Rule 3). The distinction (set-union default vs single-namespace
+  override) must be documented at the call site to avoid surprise.
 
 ### Neutral
 


### PR DESCRIPTION
## What

Implements ADR-007 Rev 4. When `[actor] id` (e.g. `lambda:khive`) is configured, **default reads** (no explicit `namespace=`) widen their read visible-set to `{local} ∪ {actor.id ns} ∪ {actor.visible_namespaces}`, so an actor's own legacy-attributed rows become recall candidates again — **without mutating stored data**. This obviates the Rev-3-pending PR-A2/PR-F relabel backfill.

## Invariants preserved

- **Writes still pin `local`.** `actor.id` does not route writes and does not set `default_namespace`.
- **By-ID ops stay global** (get/update/delete/merge unchanged — Rule 2).
- **Explicit `namespace=X` reads stay strictly `{X}`** (Reading 2). Two-branch mint: the `Some(ns)` path passes `vec![]` for extras, so a targeted read is never widened.
- Read-augmentation only: it adds namespaces to what a default read sees. It never hides records, never silos, never breaks by-ID resolution.

## Coverage

Both legs of `memory.recall` fan out across the visible-set:
- **FTS leg** via `token.with_namespace(ns)` (each namespace owns its own FTS table).
- **Vector leg** via `runtime.authorize(ns)` (resolves the correct per-namespace ANN index key).

Entity/KG `search` stays primary-only on both legs (per-ns FTS tables make the IN-filter inert; `vector_search` scopes to `token.namespace()`), so there is no partial keyword-yes/semantic-no flicker. Cross-namespace fanout for entity `search` is a documented Phase 2 follow-up.

## Gates

- Independent adversarial review: 4 objections raised and refuted, design confirmed sound.
- Second independent review round: 0 blocking issues; 3 minor fixes applied and re-verified.
- Full-workspace CI green locally: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (117 `test result: ok`, 0 failed).

## ADR

`docs/adr/ADR-007-namespace.md` amended to Rev 4; status Accepted/Ratified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
