### PR TITLE
ci(perf): daemon-path pipeline + 1M synthetic ANN regression gates

### DIFF
--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -1,22 +1,34 @@
-name: Vamana 1M scale-proof bench
+name: Vamana ANN Regression Gate
 
-# Blocking / non-blocking decision:
+# Two distinct jobs with different purposes:
 #
-#   NON-BLOCKING in main CI (continue-on-error: true).
+# (1) ann-ci-gate — BLOCKING per-PR structural ANN regression gate.
+#     Runs on ubuntu-latest. Generates hermetic deterministic synthetic
+#     clustered-vector fixtures (no network, no committed binary data,
+#     no SIFT download) via scripts/perf/gen_synthetic_fvecs.py and
+#     drives the existing vec_bench harness. Asserts recall@10 >= floor,
+#     beam growth exponent <= ceiling, and ANN beats brute-force.
+#     Cannot silent-skip: fixture is always generated; prereq-missing
+#     means generator or build failure = hard CI failure. continue-on-error
+#     is false. The gate BLOCKS on regression (exit 1) and on infra
+#     failure (exit 2 or non-zero).
 #
-# Rationale: The bench requires the SIFT-1M dataset (~500 MB, .fvecs format)
-# to be present at SIFT_DIR. GitHub-hosted runners do not have this data; it
-# lives on a self-hosted runner or must be downloaded. If SIFT_DIR is not set
-# or the files are absent, the script exits with code 2 (prerequisite missing)
-# rather than a regression (code 1). Treating a missing-data exit as a CI
-# failure would block every PR on all developers' machines.
+#     What this gate PROVES: the index still builds correctly and
+#     retrieves at high recall on clusterable (low-intrinsic-dim) data.
+#     This catches structural collapse — broken graph build, broken
+#     greedy search, broken pruning. It does NOT prove real-SIFT quality
+#     or sublinear scaling; those are tested by the banked SIFT-1M job
+#     below. At small N (10K/50K), query latency is near-linear even for
+#     a correct index, so latency and query-exponent checks are not gated
+#     here; they are tracked in the artifact ledger for trend analysis.
 #
-# When a SIFT-capable self-hosted runner is provisioned, flip
-# continue-on-error to false for this job to make it fully blocking.
-#
-# What IS blocking: the bench script itself fails with exit 1 if the bench
-# runs but assertions fail. This will block only when SIFT data is present and
-# a regression is detected — exactly the desired behavior.
+# (2) bench-1m-sift — OPTIONAL real SIFT-1M scale-proof (manual only).
+#     Gated to workflow_dispatch; never runs on pull_request or push.
+#     Requires the SIFT-1M dataset (~500 MB) at SIFT_DIR, which is only
+#     available on self-hosted runners or via manual download. Exit 2
+#     (data absent) is handled gracefully (skip notice, not a failure).
+#     This is the banked 3-point (100K/316K/1M) sublinear scaling proof.
+#     continue-on-error: true because data may be absent on manual runs.
 
 on:
   push:
@@ -26,6 +38,8 @@ on:
       - "perf/targets.toml"
       - "scripts/bench_1m.sh"
       - "scripts/perf/ingest_scale_proof.py"
+      - "scripts/perf/gen_synthetic_fvecs.py"
+      - ".github/workflows/bench-1m.yml"
   pull_request:
     branches: [main, "integration/**"]
     paths:
@@ -33,10 +47,12 @@ on:
       - "perf/targets.toml"
       - "scripts/bench_1m.sh"
       - "scripts/perf/ingest_scale_proof.py"
+      - "scripts/perf/gen_synthetic_fvecs.py"
+      - ".github/workflows/bench-1m.yml"
   workflow_dispatch:
     inputs:
       sift_dir:
-        description: "Path to SIFT data dir (overrides SIFT_DIR env)"
+        description: "Path to SIFT data dir for the real SIFT-1M job (overrides SIFT_DIR env)"
         required: false
         default: ""
 
@@ -44,15 +60,75 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  bench-1m-ci:
-    name: Vamana ANN regression check (CI subset)
-    # Use a self-hosted runner when SIFT data is available; fall back to
-    # ubuntu-latest for the prerequisite-check path (exits 2, not 1).
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1: Blocking per-PR structural ANN regression gate (hermetic synthetic)
+  # ─────────────────────────────────────────────────────────────────────────────
+  ann-ci-gate:
+    name: ANN structural regression gate (synthetic, hermetic)
     runs-on: ubuntu-latest
 
-    # NON-BLOCKING: missing SIFT data is exit 2, not a regression.
-    # Flip to false when a SIFT-capable self-hosted runner is in place.
+    # BLOCKING: this gate must not be bypassed. Structural ANN regression
+    # (recall collapse, broken build) must block the PR. Infra failures
+    # (generator crash, cargo build failure) also block — they signal
+    # something is wrong, not that data is absent.
+    continue-on-error: false
+
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates
+          cache-on-failure: true
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Run synthetic ANN structural regression gate
+        # Generates hermetic clustered-vector fixtures (no network, seed=42),
+        # builds vec_bench, runs at NS=10000,50000, asserts recall@10 >= 0.90.
+        # Exit codes propagate directly:
+        #   0 — all assertions PASS (gate green)
+        #   1 — assertion FAIL (recall regression, beam regression, etc.)
+        #   2 — prereq missing (generator crash or cargo build failure)
+        # All non-zero exits block the PR.
+        run: bash scripts/bench_1m.sh --ci-synthetic
+        env:
+          BENCH_OUT: /tmp/bench-out
+
+      - name: Upload synthetic ledger artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-synthetic-ledger
+          path: perf/ci-synthetic-ledger.csv
+          if-no-files-found: ignore
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2: Real SIFT-1M scale-proof (banked, manual/self-hosted only)
+  # ─────────────────────────────────────────────────────────────────────────────
+  bench-1m-sift:
+    name: Vamana SIFT-1M scale-proof (banked, manual)
+    runs-on: ubuntu-latest
+
+    # This job is workflow_dispatch-only (see 'on' triggers above, which do
+    # not include pull_request/push for this job path). It runs gracefully
+    # when SIFT data is absent (exit 2 → skip notice). continue-on-error
+    # remains true because missing data on a manual run is expected.
     continue-on-error: true
+
+    # Only run on manual dispatch, not on push/pull_request.
+    if: github.event_name == 'workflow_dispatch'
 
     defaults:
       run:
@@ -79,24 +155,27 @@ jobs:
         if: ${{ github.event.inputs.sift_dir != '' }}
         run: echo "SIFT_DIR=${{ github.event.inputs.sift_dir }}" >> "$GITHUB_ENV"
 
-      - name: Run Vamana CI bench (10K/50K subset, <60 s when data present)
-        # Exit codes:
+      - name: Run real SIFT-1M bench (3-point 100K/316K/1M)
+        # Runs the full default NS (100000,316228,1000000) — the real banked
+        # scale-proof, not the subset. Requires the full SIFT-1M dataset at
+        # SIFT_DIR (provide via the sift_dir dispatch input or a self-hosted
+        # runner). Exit codes:
         #   0 — data present; all assertions PASS
         #   1 — data present; one or more assertions FAIL (regression)
         #   2 — data absent; skip gracefully
         run: |
           set +e
-          bash scripts/bench_1m.sh --ci
+          bash scripts/bench_1m.sh
           RC=$?
           set -e
           if [ $RC -eq 2 ]; then
-            echo "::notice::SIFT data not found at SIFT_DIR=${SIFT_DIR:-<unset>} — bench skipped. Provision a SIFT-capable runner to enable regression gating."
+            echo "::notice::SIFT data not found at SIFT_DIR=${SIFT_DIR:-<unset>} — bench skipped. Provision a SIFT-capable runner to run the banked scale-proof."
             exit 0
           elif [ $RC -eq 0 ]; then
-            echo "::notice::Vamana CI bench PASSED."
+            echo "::notice::Vamana SIFT-1M bench PASSED."
             exit 0
           else
-            echo "::warning::Vamana CI bench FAILED (regression detected, exit $RC)."
+            echo "::warning::Vamana SIFT-1M bench FAILED (regression detected, exit $RC)."
             exit $RC
           fi
         env:

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -1,0 +1,73 @@
+name: Pipeline Regression Gate
+
+# Runs on any PR that touches the retrieval/fusion/memory stack.
+# Builds kkernel with the bench-embedder feature (deterministic FNV-1a hash,
+# no model download) then drives the full daemon path end-to-end.
+
+on:
+  pull_request:
+    paths:
+      - "crates/khive-pack-memory/**"
+      - "crates/khive-runtime/**"
+      - "crates/khive-db/**"
+      - "crates/khive-retrieval/**"
+      - "crates/khive-fusion/**"
+      - "crates/khive-bm25/**"
+      - "crates/khive-vamana/**"
+      - "crates/khive-hnsw/**"
+      - "crates/khive-score/**"
+      - "crates/khive-mcp/**"
+      - "crates/kkernel/**"
+      - "scripts/perf/bench_pipeline_daemon.py"
+      - ".github/workflows/bench-pipeline.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  pipeline-gate:
+    name: Pipeline Regression Gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          components: rustfmt, clippy
+
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates
+          cache-on-failure: true
+
+      # Build the bench binary (bench-embedder injects FNV-1a, no lattice model download)
+      - name: Build kkernel (bench-embedder feature)
+        run: |
+          set -euo pipefail
+          cargo build --release -p kkernel --features bench-embedder
+          cp target/release/kkernel target/release/kkernel-bench
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Run pipeline regression gate
+        working-directory: .
+        env:
+          KKERNEL_BENCH_BINARY: crates/target/release/kkernel-bench
+        run: |
+          set -euo pipefail
+          uv run python scripts/perf/bench_pipeline_daemon.py
+
+      - name: Upload pipeline ledger
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-ledger
+          path: perf/pipeline-ledger.csv
+          if-no-files-found: ignore

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -1,8 +1,16 @@
 name: Pipeline Regression Gate
 
 # Runs on any PR that touches the retrieval/fusion/memory stack.
-# Builds kkernel with the bench-embedder feature (deterministic FNV-1a hash,
-# no model download) then drives the full daemon path end-to-end.
+# Uses a deterministic LEXICAL hash embedder (bench-embedder / FNV-1a, no model
+# download) to drive the full daemon path end-to-end. What this gate verifies:
+# (a) daemon-path engagement — front-end spawns warm daemon child, binds bench
+# socket, all traffic routes through it; (b) fused-pipeline mean Precision@K
+# floor (>= 0.70 across 15 queries, both legs active); (c) per-leg structural
+# retrieval — vector leg (dense ANN: khive-vamana / khive-hnsw) and keyword leg
+# (FTS5 / bm25) each meet their own floor (VECTOR_FLOOR / KEYWORD_FLOOR = 0.70)
+# in isolation via fusion_strategy="vector_only" / "keyword_only". What it does
+# NOT gate: semantic-quality regression on real embeddings — that is covered by
+# the banked 1M-scale Vamana benchmarks.
 
 on:
   pull_request:
@@ -46,6 +54,14 @@ jobs:
         with:
           workspaces: crates
           cache-on-failure: true
+
+      # Lock the embedder clustering invariant the vector-leg gate depends on:
+      # if same-cluster vectors stop being more similar than cross-cluster ones,
+      # the vector leg degenerates to noise and the per-leg floor is meaningless.
+      - name: Test bench-embedder clustering invariant
+        run: |
+          set -euo pipefail
+          cargo test -p khive-mcp --features bench-embedder bench_embedder
 
       # Build the bench binary (bench-embedder injects FNV-1a, no lattice model download)
       - name: Build kkernel (bench-embedder feature)

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ uv.lock
 pyproject.toml
 
 *results.json
+
+# Pipeline ledger — written locally and uploaded as CI artifact; not committed.
+perf/pipeline-ledger.csv

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ pyproject.toml
 
 # Pipeline ledger — written locally and uploaded as CI artifact; not committed.
 perf/pipeline-ledger.csv
+
+# Synthetic ANN regression gate ledger — written by --ci-synthetic, uploaded as CI artifact; not committed.
+perf/ci-synthetic-ledger.csv

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -32,6 +32,12 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }
+lattice-embed = { workspace = true, optional = true }
+
+[features]
+# bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
+# Bench-only — never enabled in release/publish builds.
+bench-embedder = ["lattice-embed"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-mcp/src/bench_embedder.rs
+++ b/crates/khive-mcp/src/bench_embedder.rs
@@ -72,12 +72,28 @@ impl EmbeddingService for FeatureHashService {
     }
 }
 
-pub(crate) struct FeatureHashProvider;
+pub(crate) struct FeatureHashProvider {
+    model_name: String,
+}
+
+impl FeatureHashProvider {
+    pub(crate) fn new(name: impl Into<String>) -> Self {
+        Self {
+            model_name: name.into(),
+        }
+    }
+}
+
+impl Default for FeatureHashProvider {
+    fn default() -> Self {
+        Self::new(MODEL_NAME)
+    }
+}
 
 #[async_trait]
 impl EmbedderProvider for FeatureHashProvider {
     fn name(&self) -> &str {
-        MODEL_NAME
+        &self.model_name
     }
 
     fn dimensions(&self) -> usize {

--- a/crates/khive-mcp/src/bench_embedder.rs
+++ b/crates/khive-mcp/src/bench_embedder.rs
@@ -1,0 +1,83 @@
+// Bench-only deterministic embedder — never compiled into release/publish builds.
+// Registered under the `all-minilm-l6-v2` name so it overrides the real lattice
+// provider for that slot while leaving `compute_config_id` unchanged (the
+// configured model NAME stays `all-minilm-l6-v2`; only the impl changes).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use khive_runtime::{EmbedderProvider, RuntimeResult};
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+const DIM: usize = 384;
+pub(crate) const MODEL_NAME: &str = "all-minilm-l6-v2";
+
+fn fnv1a_64(data: &[u8]) -> u64 {
+    const BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = BASIS;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h
+}
+
+fn hash_embed(text: &str) -> Vec<f32> {
+    let bytes = text.as_bytes();
+    let mut v = vec![0.0f32; DIM];
+    for (i, slot) in v.iter_mut().enumerate() {
+        let seed = (i as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+        let salted: Vec<u8> = seed
+            .to_le_bytes()
+            .iter()
+            .chain(bytes.iter())
+            .copied()
+            .collect();
+        let h = fnv1a_64(&salted);
+        let h2 = fnv1a_64(&h.to_le_bytes());
+        let raw = (h ^ h2.rotate_right(17)) as i64;
+        *slot = raw as f32;
+    }
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
+    v.iter_mut().for_each(|x| *x /= norm);
+    v
+}
+
+struct FeatureHashService;
+
+#[async_trait]
+impl EmbeddingService for FeatureHashService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|t| hash_embed(t)).collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        MODEL_NAME
+    }
+}
+
+pub(crate) struct FeatureHashProvider;
+
+#[async_trait]
+impl EmbedderProvider for FeatureHashProvider {
+    fn name(&self) -> &str {
+        MODEL_NAME
+    }
+
+    fn dimensions(&self) -> usize {
+        DIM
+    }
+
+    async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
+        Ok(Arc::new(FeatureHashService))
+    }
+}

--- a/crates/khive-mcp/src/bench_embedder.rs
+++ b/crates/khive-mcp/src/bench_embedder.rs
@@ -23,25 +23,32 @@ fn fnv1a_64(data: &[u8]) -> u64 {
     h
 }
 
+/// Feature-hashing embedder: tokenise → per-token (dim, sign) → accumulate → L2-normalise.
+///
+/// Lexically similar texts share tokens and therefore accumulate signal in the
+/// same dimensions with the same sign, producing correlated vectors. This lets
+/// the gate exercise the vector/ANN/fusion legs rather than treating them as
+/// pure noise (as the previous whole-text FNV avalanche did).
 fn hash_embed(text: &str) -> Vec<f32> {
-    let bytes = text.as_bytes();
     let mut v = vec![0.0f32; DIM];
-    for (i, slot) in v.iter_mut().enumerate() {
-        let seed = (i as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
-        let salted: Vec<u8> = seed
-            .to_le_bytes()
-            .iter()
-            .chain(bytes.iter())
-            .copied()
-            .collect();
-        let h = fnv1a_64(&salted);
-        let h2 = fnv1a_64(&h.to_le_bytes());
-        let raw = (h ^ h2.rotate_right(17)) as i64;
-        *slot = raw as f32;
+    for token in text
+        .to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+    {
+        let h = fnv1a_64(token.as_bytes());
+        let dim = ((h >> 1) as usize) % DIM;
+        let sign = if h & 1 == 0 { 1.0_f32 } else { -1.0_f32 };
+        v[dim] += sign;
     }
     let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
     v.iter_mut().for_each(|x| *x /= norm);
     v
+}
+
+#[cfg(test)]
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
 struct FeatureHashService;
@@ -79,5 +86,28 @@ impl EmbedderProvider for FeatureHashProvider {
 
     async fn build(&self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
         Ok(Arc::new(FeatureHashService))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Same-cluster strings (sharing several topic words) must be more similar
+    /// to each other than cross-cluster strings (disjoint vocabularies).
+    /// This locks the clustering property of the feature-hashing embedder.
+    #[test]
+    fn feature_hash_same_cluster_more_similar_than_cross_cluster() {
+        let a = hash_embed("knowledge graph entity edge relation ontology");
+        let b = hash_embed("knowledge graph concept node link schema");
+        let c = hash_embed("Rust cargo clippy fmt workspace crate lint");
+
+        let sim_same = cosine(&a, &b);
+        let sim_cross = cosine(&a, &c);
+
+        assert!(
+            sim_same > sim_cross,
+            "same-cluster cosine ({sim_same:.4}) must be > cross-cluster cosine ({sim_cross:.4})"
+        );
     }
 }

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -258,7 +258,7 @@ fn argv_is_khive_daemon(args: &str) -> bool {
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("");
-    if basename != "kkernel" {
+    if basename != "kkernel" && basename != "kkernel-bench" {
         return false;
     }
     let rest: Vec<&str> = tokens.collect();
@@ -1324,6 +1324,16 @@ mod tests {
     fn argv_daemon_true_with_surrounding_and_inner_whitespace() {
         assert!(argv_is_khive_daemon(
             "  /Users/x/.cargo/bin/kkernel   mcp    --daemon  "
+        ));
+    }
+
+    #[test]
+    fn argv_daemon_true_kkernel_bench_basename() {
+        // bench binary copy is named "kkernel-bench"; pid management must treat it
+        // as a valid daemon so stale bench daemons are SIGTERM'd on respawn.
+        assert!(argv_is_khive_daemon("kkernel-bench mcp --daemon"));
+        assert!(argv_is_khive_daemon(
+            "/Users/x/.cargo/bin/kkernel-bench mcp --daemon"
         ));
     }
 

--- a/crates/khive-mcp/src/lib.rs
+++ b/crates/khive-mcp/src/lib.rs
@@ -11,3 +11,6 @@ pub mod serve;
 pub mod server;
 pub mod tools;
 pub mod transport;
+
+#[cfg(feature = "bench-embedder")]
+pub(crate) mod bench_embedder;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -62,6 +62,8 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
     })?;
 
     let runtime = KhiveRuntime::new(config)?;
+    #[cfg(feature = "bench-embedder")]
+    runtime.register_embedder(crate::bench_embedder::FeatureHashProvider);
     KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))
 }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -63,7 +63,15 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
 
     let runtime = KhiveRuntime::new(config)?;
     #[cfg(feature = "bench-embedder")]
-    runtime.register_embedder(crate::bench_embedder::FeatureHashProvider);
+    {
+        // Replace ALL configured embedding models with the deterministic FNV-1a
+        // bench embedder so that CI never attempts to load a lattice model file.
+        // The registry's last-wins semantics ensure every LatticeEmbedderProvider
+        // (primary + additional) is replaced before any embed() call can fire.
+        for name in runtime.registered_embedding_model_names() {
+            runtime.register_embedder(crate::bench_embedder::FeatureHashProvider::new(name));
+        }
+    }
     KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"))
 }
 

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -42,6 +42,10 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 serial_test = { workspace = true }
 
+[features]
+# Pass-through: enables the deterministic hash embedder in the serve path (bench use only).
+bench-embedder = ["khive-mcp/bench-embedder"]
+
 [[bin]]
 name = "kkernel"
 path = "src/main.rs"

--- a/perf/pipeline-ledger.csv
+++ b/perf/pipeline-ledger.csv
@@ -1,3 +1,0 @@
-git_sha,runner_os,loadavg1,produced_at,precision_at_k,p50_us,p95_us,n_queries,n_corpus
-31c335805f2b0d497f0dc5f98f4ddfbe00f1d5a1,darwin-arm64,4.04,2026-06-18T21:07:07Z,0.9267,4946,5212,15,600
-31c335805f2b0d497f0dc5f98f4ddfbe00f1d5a1,darwin-arm64,10.74,2026-06-18T21:08:31Z,0.9267,5136,5480,15,600

--- a/perf/pipeline-ledger.csv
+++ b/perf/pipeline-ledger.csv
@@ -1,0 +1,3 @@
+git_sha,runner_os,loadavg1,produced_at,precision_at_k,p50_us,p95_us,n_queries,n_corpus
+31c335805f2b0d497f0dc5f98f4ddfbe00f1d5a1,darwin-arm64,4.04,2026-06-18T21:07:07Z,0.9267,4946,5212,15,600
+31c335805f2b0d497f0dc5f98f4ddfbe00f1d5a1,darwin-arm64,10.74,2026-06-18T21:08:31Z,0.9267,5136,5480,15,600

--- a/perf/targets.toml
+++ b/perf/targets.toml
@@ -142,3 +142,78 @@ name = "khive-vamana/1m-scale-proof/sift-1m"
   operator = "<="
   threshold = 900.0
   tolerance = 0.10
+
+# -------------------------------------------------------------------
+# Target 3: ci-synthetic/clustered-128 — per-PR STRUCTURAL ANN regression gate
+#
+# This is a HERMETIC, DETERMINISTIC gate that runs on every PR touching
+# crates/khive-vamana/**. It uses synthetic clustered vectors generated
+# by scripts/perf/gen_synthetic_fvecs.py (stdlib-only Python, seed=42,
+# no network, no committed binary data) with:
+#   n=50000 base vectors, 1000 queries, dim=128, 64 clusters, sigma=0.08
+#
+# Purpose: structural regression detection — catches index-build or
+# search breakage (e.g. recall collapse, speedup regression). It does
+# NOT prove real-SIFT quality; that is the banked workflow_dispatch job.
+#
+# Because vec_bench computes ground truth by brute-force internally on
+# the same synthetic dataset, recall@10 is ANN-vs-brute-force on self-
+# consistent data. On clusterable (low-intrinsic-dim) data, ANN recall
+# is high; a drop signals structural breakage.
+#
+# Measured baselines (gen_synthetic_fvecs.py --n 50000 --seed 42,
+# vec_bench --ns 10000,50000, 2026-06-18 on macOS arm64):
+#   recall@10:     0.9522 @ N=10000  /  0.9531 @ N=50000
+#   beam:          14 @ N=10000  /  26 @ N=50000
+#   beam exponent: 0.3846 (2-point fit)
+#   speedup:       76x @ N=10000  /  69x @ N=50000
+#   p50:           8 µs @ N=10000  /  46 µs @ N=50000
+#   p95:           10 µs @ N=10000  /  69 µs @ N=50000
+#
+# NOTE: iso_recall_query_exponent_warm is NOT checked here. At small N
+# (10K/50K) query latency is near-linear even for a correct index, so
+# the exponent check would always fail. Sublinear scaling is verified by
+# the banked SIFT-1M job.
+#
+# NOTE: Latency thresholds are NOT checked here. Shared CI runners have
+# high and variable latency; structural breakage shows up in recall, not
+# in µs numbers. p50/p95 are tracked in ci-synthetic-ledger.csv for
+# trend analysis but are not gated.
+# -------------------------------------------------------------------
+
+[[scale-proof.target]]
+name = "khive-vamana/ci-synthetic/clustered-128"
+
+  # Primary structural gate: recall must stay above this floor at all N.
+  # NOTE: reported recall (~0.952) is the recall AT the iso-recall beam, which
+  # vec_bench binary-searches to hit TARGET_RECALL=0.95 — so it sits at ~0.95
+  # by construction, NOT as free headroom. The real margin to the 0.90 floor is
+  # ~0.05. That is sufficient: a genuine structural regression collapses recall
+  # far below 0.90 (empirically ~0.675 at max_degree=4, ~0.01 at degree 3),
+  # well clear of any runner-to-runner clustering variation.
+  [[scale-proof.target.check]]
+  metric = "recall_at_10"
+  scope = "all_rows"
+  operator = ">="
+  threshold = 0.90
+  tolerance = 0.0
+
+  # Beam growth: exponent < 0.6 confirms beam does not explode with N.
+  # Measured: 0.385 (2-point fit). Threshold 0.6 is generous but still
+  # catches a runaway-beam regression that would make CI very slow.
+  [[scale-proof.target.check]]
+  metric = "beam_growth_exponent"
+  scope = "fits"
+  operator = "<="
+  threshold = 0.6
+  tolerance = 0.0
+
+  # ANN must beat brute-force at max_n (N=50000). Measured: 69x.
+  # Threshold 5.0x is a very conservative floor; anything below it
+  # indicates the ANN search itself is broken or degenerate.
+  [[scale-proof.target.check]]
+  metric = "speedup_vs_brute_force"
+  scope = "max_n"
+  operator = ">="
+  threshold = 5.0
+  tolerance = 0.0

--- a/scripts/bench_1m.sh
+++ b/scripts/bench_1m.sh
@@ -6,15 +6,17 @@
 # file and every row is appended to perf/ledger.csv.
 #
 # Usage:
-#   bash scripts/bench_1m.sh [--ns <N1,N2,...>] [--dataset <name>] [--ci]
+#   bash scripts/bench_1m.sh [--ns <N1,N2,...>] [--dataset <name>] [--ci] [--ci-synthetic]
 #
-#   --ns       comma-separated subset sizes (default: 100000,316228,1000000)
-#   --dataset  dataset name tag written into bench JSON (default: SIFT-1M-honest-3pt)
-#   --ci       shorthand for --ns 10000,50000 (fast CI smoke-check)
+#   --ns            comma-separated subset sizes (default: 100000,316228,1000000)
+#   --dataset       dataset name tag written into bench JSON (default: SIFT-1M-honest-3pt)
+#   --ci            shorthand for --ns 10000,50000 (fast CI smoke-check on real SIFT data)
+#   --ci-synthetic  generate hermetic synthetic fixtures and run a structural ANN regression
+#                   gate; no SIFT data required; writes to perf/ci-synthetic-ledger.csv
 #
 # Environment:
 #   SIFT_DIR   directory containing sift_base.fvecs and sift_query.fvecs
-#              (required; no default — script exits 2 if unset or empty)
+#              (required for real-SIFT paths; not needed for --ci-synthetic)
 #   BENCH_OUT  output directory for bench JSON and logs
 #              (default: target/bench-out; gitignored via target/)
 #
@@ -29,8 +31,12 @@
 #   - Cargo is invoked from the crates/ subdirectory (no root Cargo.toml).
 #   - Raw bench JSON is written to BENCH_OUT; that directory is outside the
 #     repo tree by default (target/bench-out) and is gitignored.
-#   - On success, ledger rows are appended to perf/ledger.csv.
-#   - For CI, use --ci (runs 10K/50K; fast; still asserts PASS criteria).
+#   - On success, ledger rows are appended to the appropriate ledger CSV.
+#   - For CI on real SIFT data, use --ci (runs 10K/50K; fast).
+#   - For hermetic per-PR structural regression gate, use --ci-synthetic.
+#     The synthetic gate generates clustered data via gen_synthetic_fvecs.py
+#     (stdlib-only Python), runs vec_bench, and asserts recall@10 >= floor.
+#     It never touches perf/ledger.csv; results go to perf/ci-synthetic-ledger.csv.
 
 set -euo pipefail
 
@@ -45,6 +51,9 @@ BENCH_OUT="${BENCH_OUT:-$REPO_ROOT/target/bench-out}"
 NS="100000,316228,1000000"
 DATASET="SIFT-1M-honest-3pt"
 CI_MODE=0
+CI_SYNTHETIC=0
+TARGET_KEY="khive-vamana/1m-scale-proof/sift-1m"
+LEDGER_CSV="$REPO_ROOT/perf/ledger.csv"
 
 # ── Argument parsing ────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -58,8 +67,15 @@ while [[ $# -gt 0 ]]; do
       NS="10000,50000"
       DATASET="SIFT-CI-smoke"
       shift ;;
+    --ci-synthetic)
+      CI_SYNTHETIC=1
+      NS="10000,50000"
+      DATASET="SIFT-CI-synthetic"
+      TARGET_KEY="khive-vamana/ci-synthetic/clustered-128"
+      LEDGER_CSV="$REPO_ROOT/perf/ci-synthetic-ledger.csv"
+      shift ;;
     -h|--help)
-      sed -n '2,40p' "${BASH_SOURCE[0]}" | grep '^#' | sed 's/^# \?//'
+      sed -n '2,57p' "${BASH_SOURCE[0]}" | grep '^#' | sed 's/^# \?//'
       exit 0 ;;
     *)
       echo "ERROR: Unknown argument: $1" >&2
@@ -67,12 +83,28 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# ── Synthetic fixture generation (--ci-synthetic only) ──────────────────────
+if [[ $CI_SYNTHETIC -eq 1 ]]; then
+  SYNTH_TMPDIR="$(mktemp -d)"
+  # Generate exactly max(NS) base vectors so vec_bench's `N <= base size`
+  # assertion always holds even if --ci-synthetic's NS is later changed.
+  SYNTH_N="$(echo "$NS" | tr ',' '\n' | sort -n | tail -1)"
+  echo "=== Generating synthetic fvecs fixture ===" >&2
+  python3 "$REPO_ROOT/scripts/perf/gen_synthetic_fvecs.py" \
+    --out "$SYNTH_TMPDIR" \
+    --n "$SYNTH_N" \
+    --queries 1000 \
+    --dim 128 \
+    --clusters 64 \
+    --sigma 0.08 \
+    --seed 42
+  SIFT_DIR="$SYNTH_TMPDIR"
+fi
+
 # ── Derived paths ────────────────────────────────────────────────────────────
 BASE_FILE="$SIFT_DIR/sift_base.fvecs"
 QUERY_FILE="$SIFT_DIR/sift_query.fvecs"
 TARGETS_TOML="$REPO_ROOT/perf/targets.toml"
-LEDGER_CSV="$REPO_ROOT/perf/ledger.csv"
-TARGET_KEY="khive-vamana/1m-scale-proof/sift-1m"
 
 mkdir -p "$BENCH_OUT"
 BENCH_JSON="$BENCH_OUT/${DATASET}.json"
@@ -86,6 +118,9 @@ echo "BENCH_OUT:  $BENCH_OUT" | tee -a "$LOG_FILE"
 echo "ns:         $NS" | tee -a "$LOG_FILE"
 echo "dataset:    $DATASET" | tee -a "$LOG_FILE"
 echo "CI mode:    $CI_MODE" | tee -a "$LOG_FILE"
+echo "CI synthetic: $CI_SYNTHETIC" | tee -a "$LOG_FILE"
+echo "target_key: $TARGET_KEY" | tee -a "$LOG_FILE"
+echo "ledger:     $LEDGER_CSV" | tee -a "$LOG_FILE"
 echo "" | tee -a "$LOG_FILE"
 
 # ── Prerequisites ────────────────────────────────────────────────────────────
@@ -144,7 +179,17 @@ echo "--- vec_bench exit code: $BENCH_EXIT ---" | tee -a "$LOG_FILE"
 
 if [[ $BENCH_EXIT -ne 0 ]]; then
   echo "ERROR: vec_bench exited with code $BENCH_EXIT" >&2
-  echo "=== RESULT: FAIL (bench assertions failed) ===" | tee -a "$LOG_FILE"
+  if [[ -f "$BENCH_JSON" ]] && grep -q '"overall": *"SKIPPED"' "$BENCH_JSON"; then
+    # Assertions did not run — target-key absent from targets.toml or targets
+    # unreadable. The gate still exits non-zero (fails closed), but this is a
+    # CONFIG fault, not a measured recall regression. Surface it distinctly so
+    # a red CI is not misread as a real index regression.
+    echo "::error::Bench assertions were SKIPPED (target-key '$TARGET_KEY' not found in $TARGETS_TOML, or targets unreadable) — the gate self-disabled and is NOT asserting recall. Fix the target-key, not the index." >&2
+    echo "=== RESULT: FAIL (assertions SKIPPED — gate misconfigured, see above) ===" | tee -a "$LOG_FILE"
+  else
+    echo "::error::Vamana bench assertions FAILED — measured regression against target-key '$TARGET_KEY'." >&2
+    echo "=== RESULT: FAIL (bench assertions failed) ===" | tee -a "$LOG_FILE"
+  fi
   exit 1
 fi
 

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Pipeline regression gate — drives the daemon path.
+
+Ingest 600 deterministic notes (15 topic clusters x 40), run 15 recall
+queries through the kkernel mcp binary over stdio (which forwards to the
+warm daemon on first use), measure Precision@K and round-trip latency.
+
+Gate: mean Precision@K >= 0.70. Exit 0 = PASS, exit 1 = FAIL.
+Latency is tracked (ledger row) but never gated.
+
+Safety:
+  - A fresh temp DB is created per run; live ~/.khive/khive.db is never touched.
+  - The bench binary is identified by the path passed via KKERNEL_BENCH_BINARY
+    env var or discovered at crates/target/release/kkernel-bench. The live
+    daemon keyed on ~/.khive/khive.db is untouched because config_id differs.
+  - Both the front-end process and its bench daemon child are terminated on exit.
+"""
+
+import csv
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+# ── Tunables ──────────────────────────────────────────────────────────────────
+
+TOP_K = 10
+RECALL_FLOOR = 0.70
+N_REPS = 5  # repetitions per query for latency measurement
+
+TOPICS = [
+    ("knowledge graph", ["entity", "edge", "relation", "graph", "node", "ontology", "triple", "schema", "link", "concept"]),
+    ("memory recall",   ["recall", "memory", "episodic", "semantic", "salience", "decay", "retrieval", "forget", "remember", "rank"]),
+    ("vector search",   ["vector", "embedding", "ANN", "cosine", "similarity", "nearest", "index", "HNSW", "Vamana", "fusion"]),
+    ("Rust cargo",      ["Rust", "cargo", "clippy", "fmt", "workspace", "crate", "lint", "test", "build", "compile"]),
+    ("agent orchestration", ["agent", "orchestration", "dispatch", "task", "workflow", "lambda", "spawn", "parallel", "schedule", "async"]),
+    ("git workflow",    ["git", "commit", "branch", "PR", "merge", "pull", "push", "diff", "review", "rebase"]),
+    ("FTS text search", ["FTS5", "text", "search", "BM25", "trigram", "tokenise", "index", "query", "rank", "keyword"]),
+    ("brain profile",   ["brain", "profile", "Bayesian", "posterior", "prior", "feedback", "signal", "calibration", "score", "update"]),
+    ("namespace",       ["namespace", "isolation", "security", "gate", "policy", "auth", "token", "scope", "local", "actor"]),
+    ("embedding model", ["MiniLM", "lattice", "model", "dimension", "sentence", "transformer", "embed", "passage", "query", "multilingual"]),
+    ("lionagi SDK",     ["lionagi", "SDK", "flow", "package", "Python", "API", "integration", "session", "tool", "hypothesis"]),
+    ("formal verification", ["lean4", "proof", "formal", "theorem", "styx", "type", "dependent", "logic", "verification", "soundness"]),
+    ("CI pipeline",     ["CI", "GitHub", "workflow", "runner", "action", "build", "pass", "fail", "test", "regression"]),
+    ("data storage",    ["SQLite", "WAL", "storage", "database", "migration", "schema", "DDL", "backend", "pool", "transaction"]),
+    ("scoring ranking", ["score", "rank", "RRF", "fusion", "weight", "threshold", "MMR", "diversity", "relevance", "temporal"]),
+]
+
+QUERIES = [
+    ("knowledge graph entity edge relation",          "knowledge graph"),
+    ("memory recall salience decay ranking",          "memory recall"),
+    ("vector embedding ANN similarity search",        "vector search"),
+    ("Rust cargo workspace lint build",               "Rust cargo"),
+    ("agent orchestration parallel dispatch workflow","agent orchestration"),
+    ("git commit branch PR review",                   "git workflow"),
+    ("FTS text search BM25 trigram keyword",          "FTS text search"),
+    ("brain profile Bayesian posterior feedback",     "brain profile"),
+    ("namespace isolation security gate token",       "namespace"),
+    ("MiniLM lattice embedding model dimension",      "embedding model"),
+    ("lionagi SDK flow Python integration",           "lionagi SDK"),
+    ("lean4 formal proof verification styx",          "formal verification"),
+    ("CI GitHub workflow runner regression",          "CI pipeline"),
+    ("SQLite storage migration database schema",      "data storage"),
+    ("score rank RRF fusion weight relevance",        "scoring ranking"),
+]
+
+# ── Corpus generator (mirrors pipeline_gate.rs:generate_corpus) ──────────────
+
+def generate_corpus():
+    notes = []
+    for topic, words in TOPICS:
+        for i in range(40):
+            w0 = words[i % len(words)]
+            w1 = words[(i + 1) % len(words)]
+            w2 = words[(i + 3) % len(words)]
+            prefix = "core" if i % 3 == 0 else ("detail" if i % 3 == 1 else "context")
+            notes.append(f"{prefix} {w0}: {topic} with {w1} and {w2} — note {i}")
+    return notes
+
+# ── MCP stdio driver (mirrors smoke_test.py pattern) ─────────────────────────
+
+_request_id = 0
+
+def _next_id():
+    global _request_id
+    _request_id += 1
+    return _request_id
+
+
+def _send(proc, method, params=None):
+    msg = {"jsonrpc": "2.0", "id": _next_id(), "method": method}
+    if params is not None:
+        msg["params"] = params
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+
+
+def _recv(proc):
+    line = proc.stdout.readline()
+    if not line:
+        raise RuntimeError("MCP binary closed stdout unexpectedly")
+    return json.loads(line)
+
+
+def _call_request(proc, ops_string):
+    _send(proc, "tools/call", {"name": "request", "arguments": {"ops": ops_string}})
+    resp = _recv(proc)
+    if "error" in resp:
+        raise RuntimeError(f"MCP RPC error: {resp['error']}")
+    result = resp.get("result", {})
+    if result.get("isError"):
+        content = result.get("content", [])
+        text = content[0]["text"] if content else "(no text)"
+        raise RuntimeError(f"request returned protocol error: {text}")
+    content = result.get("content", [])
+    text = content[0]["text"] if content else ""
+    return json.loads(text) if text else None
+
+
+def _call_verb(proc, verb, args):
+    ops = json.dumps([{"tool": verb, "args": args}])
+    body = _call_request(proc, ops)
+    if body is None:
+        raise RuntimeError(f"Empty response for verb {verb}")
+    results = body.get("results") or []
+    if not results:
+        raise RuntimeError(f"No results in response for verb {verb}: {body}")
+    first = results[0]
+    if not first.get("ok", False):
+        raise RuntimeError(f"Verb {verb} failed: {first.get('error', '<no error>')}")
+    return first.get("result")
+
+
+def _handshake(proc):
+    _send(proc, "initialize", {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "bench-pipeline", "version": "1.0.0"},
+    })
+    init = _recv(proc)
+    if "error" in init:
+        raise RuntimeError(f"initialize failed: {init['error']}")
+    notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+    proc.stdin.write((json.dumps(notify) + "\n").encode())
+    proc.stdin.flush()
+
+# ── Quality ───────────────────────────────────────────────────────────────────
+
+def precision_at_k(contents, expected_topic):
+    if not contents:
+        return 0.0
+    return sum(1 for c in contents if expected_topic in c) / len(contents)
+
+# ── Provenance ────────────────────────────────────────────────────────────────
+
+def _git_sha():
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(pathlib.Path(__file__).parent.parent.parent),
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _runner_os():
+    runner = os.environ.get("RUNNER_OS", "").lower()
+    if runner:
+        return runner
+    import platform
+    s = platform.system().lower()
+    m = platform.machine().lower()
+    return f"{s}-{m}"
+
+
+def _loadavg1():
+    try:
+        with open("/proc/loadavg") as f:
+            return float(f.read().split()[0])
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(["sysctl", "-n", "vm.loadavg"], stderr=subprocess.DEVNULL)
+        s = out.decode().strip().strip("{}").strip()
+        return float(s.split()[0])
+    except Exception:
+        return 0.0
+
+
+def _iso_now():
+    t = time.gmtime()
+    return f"{t.tm_year:04d}-{t.tm_mon:02d}-{t.tm_mday:02d}T{t.tm_hour:02d}:{t.tm_min:02d}:{t.tm_sec:02d}Z"
+
+# ── Ledger ────────────────────────────────────────────────────────────────────
+
+LEDGER_PATH = pathlib.Path(__file__).parent.parent.parent / "perf" / "pipeline-ledger.csv"
+LEDGER_HEADER = ["git_sha", "runner_os", "loadavg1", "produced_at",
+                 "precision_at_k", "p50_us", "p95_us", "n_queries", "n_corpus"]
+
+
+def _append_ledger(row):
+    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not LEDGER_PATH.exists()
+    with open(LEDGER_PATH, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=LEDGER_HEADER)
+        if write_header:
+            w.writeheader()
+        w.writerow(row)
+
+
+def _read_baseline_p50():
+    if not LEDGER_PATH.exists():
+        return None
+    rows = []
+    try:
+        with open(LEDGER_PATH) as f:
+            reader = csv.DictReader(f)
+            for r in reader:
+                try:
+                    rows.append(float(r["p50_us"]))
+                except (KeyError, ValueError):
+                    pass
+    except Exception:
+        return None
+    return rows[0] if rows else None
+
+# ── Safety guard ──────────────────────────────────────────────────────────────
+
+_LIVE_DB_PATHS = frozenset([
+    os.path.expanduser("~/.khive/khive.db"),
+    os.path.expanduser("~/.khive/khive-graph.db"),
+])
+
+
+def _assert_not_live_db(path):
+    resolved = str(pathlib.Path(path).resolve())
+    for live in _LIVE_DB_PATHS:
+        live_resolved = str(pathlib.Path(live).resolve())
+        if resolved == live_resolved or resolved.startswith(str(pathlib.Path(live).parent.resolve())):
+            print(f"FATAL: bench DB path {path!r} resolves to live DB location. Aborting.", file=sys.stderr)
+            sys.exit(2)
+
+# ── Percentile ────────────────────────────────────────────────────────────────
+
+def _pct(sorted_list, p):
+    if not sorted_list:
+        return 0.0
+    idx = min(int(len(sorted_list) * p), len(sorted_list) - 1)
+    return sorted_list[idx]
+
+# ── Ingest ────────────────────────────────────────────────────────────────────
+
+_BATCH_SIZE = 50
+
+
+def _ingest(proc, corpus):
+    print(f"Ingesting {len(corpus)} notes in batches of {_BATCH_SIZE}...", flush=True)
+    for start in range(0, len(corpus), _BATCH_SIZE):
+        batch = corpus[start:start + _BATCH_SIZE]
+        ops_list = [
+            {"tool": "memory.remember", "args": {"content": text, "memory_type": "semantic", "salience": 0.7, "decay_factor": 0.0}}
+            for text in batch
+        ]
+        ops = json.dumps(ops_list)
+        body = _call_request(proc, ops)
+        if body is None:
+            raise RuntimeError(f"Empty response ingesting batch starting at {start}")
+        summary = body.get("summary", {})
+        failed = summary.get("failed", 0)
+        if failed:
+            raise RuntimeError(f"Ingest batch at {start}: {failed} ops failed; {body}")
+    print("Ingest done.", flush=True)
+
+# ── Query ─────────────────────────────────────────────────────────────────────
+
+def _query_once(proc, query_text):
+    t0 = time.perf_counter_ns()
+    result = _call_verb(proc, "memory.recall", {"query": query_text, "limit": TOP_K, "full_content": True})
+    elapsed_us = (time.perf_counter_ns() - t0) // 1000
+
+    if isinstance(result, list):
+        arr = result
+    elif isinstance(result, dict):
+        arr = result.get("results") or result.get("items") or []
+    else:
+        arr = []
+
+    contents = [r["content"] for r in arr if isinstance(r, dict) and "content" in r]
+    return elapsed_us, contents
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    repo_root = pathlib.Path(__file__).parent.parent.parent
+
+    binary = os.environ.get(
+        "KKERNEL_BENCH_BINARY",
+        str(repo_root / "crates" / "target" / "release" / "kkernel-bench"),
+    )
+    if not pathlib.Path(binary).exists():
+        print(f"FATAL: bench binary not found at {binary!r}. Build with:", file=sys.stderr)
+        print(f"  cd crates && cargo build --release -p kkernel --features bench-embedder", file=sys.stderr)
+        print(f"  cp crates/target/release/kkernel crates/target/release/kkernel-bench", file=sys.stderr)
+        sys.exit(2)
+
+    tmpdir = tempfile.mkdtemp(prefix="khive-bench-")
+    bench_db = os.path.join(tmpdir, "bench.db")
+    _assert_not_live_db(bench_db)
+
+    proc = None
+    try:
+        env = {**os.environ}
+        # KHIVE_NO_DAEMON=0 means we WANT daemon forwarding (the production path).
+        # Remove any env var that would suppress the daemon.
+        env.pop("KHIVE_NO_DAEMON", None)
+
+        print(f"Spawning {binary} mcp --db {bench_db}", flush=True)
+        proc = subprocess.Popen(
+            [binary, "mcp", "--db", bench_db, "--log", "error"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+
+        _handshake(proc)
+        print("[ok] MCP handshake", flush=True)
+
+        corpus = generate_corpus()
+        _ingest(proc, corpus)
+
+        # Assert recall is non-empty before measuring
+        _, warmup_hits = _query_once(proc, QUERIES[0][0])
+        if not warmup_hits:
+            raise RuntimeError(
+                f"Recall returned 0 results for warm-up query {QUERIES[0][0]!r}. "
+                "FTS and vector paths may both be empty. Check ingest."
+            )
+        print(f"[ok] Warm-up returned {len(warmup_hits)} hit(s)", flush=True)
+
+        # Additional warm-up rounds (discard timings)
+        for q, _ in QUERIES:
+            _query_once(proc, q)
+
+        # Measure
+        per_query = []
+        all_latencies = []
+        all_pass = True
+
+        print(f"\nRunning {len(QUERIES)} queries x {N_REPS} reps:", flush=True)
+        for query_text, expected_topic in QUERIES:
+            rep_latencies = []
+            last_contents = []
+            for _ in range(N_REPS):
+                us, contents = _query_once(proc, query_text)
+                rep_latencies.append(us)
+                last_contents = contents
+
+            all_latencies.extend(rep_latencies)
+            p_at_k = precision_at_k(last_contents, expected_topic)
+            q_pass = p_at_k >= RECALL_FLOOR
+            if not q_pass:
+                all_pass = False
+
+            rep_latencies.sort()
+            q_p50 = _pct(rep_latencies, 0.5)
+            print(
+                f"  {expected_topic:<22} P@K={p_at_k:.2f} ({len(last_contents)} hits)"
+                f"  p50={q_p50}µs  {'PASS' if q_pass else 'FAIL'}",
+                flush=True,
+            )
+            per_query.append({
+                "query": query_text,
+                "expected_topic": expected_topic,
+                "precision_at_k": p_at_k,
+                "top_k_count": len(last_contents),
+                "query_pass": q_pass,
+                "p50_us": q_p50,
+            })
+
+        all_latencies.sort()
+        p50_us = _pct(all_latencies, 0.5)
+        p95_us = _pct(all_latencies, 0.95)
+        mean_pak = sum(r["precision_at_k"] for r in per_query) / len(per_query)
+
+        print(f"\nMean Precision@K={mean_pak:.3f}  floor={RECALL_FLOOR}", flush=True)
+        print(f"p50={p50_us}µs  p95={p95_us}µs  n_latencies={len(all_latencies)}", flush=True)
+        verdict = "PASS" if all_pass else "FAIL"
+        print(f"Gate: {verdict}", flush=True)
+
+        # Ledger
+        sha = _git_sha()
+        runner_os = _runner_os()
+        loadavg1 = _loadavg1()
+        produced_at = _iso_now()
+        baseline_p50 = _read_baseline_p50()
+        row = {
+            "git_sha": sha,
+            "runner_os": runner_os,
+            "loadavg1": loadavg1,
+            "produced_at": produced_at,
+            "precision_at_k": f"{mean_pak:.4f}",
+            "p50_us": p50_us,
+            "p95_us": p95_us,
+            "n_queries": len(QUERIES),
+            "n_corpus": len(corpus),
+        }
+        try:
+            _append_ledger(row)
+            print(f"Ledger row written: {LEDGER_PATH}", flush=True)
+        except Exception as exc:
+            print(f"NOTE: ledger write failed (non-fatal): {exc}", flush=True)
+
+        if baseline_p50 is not None and p50_us > baseline_p50 * 1.5:
+            print(
+                f"NOTE: p50 latency {p50_us}µs > 1.5x baseline {baseline_p50}µs. "
+                "This is a soft warning — latency is tracked but not gated.",
+                flush=True,
+            )
+
+        return 0 if all_pass else 1
+
+    finally:
+        if proc is not None:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+            # Give the front-end a moment to relay shutdown to its daemon child.
+            # The bench daemon's config_id differs from the live one so we only
+            # need to ensure the front-end exits (which drains its daemon child).
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+        # Cleanup bench DB
+        import shutil
+        try:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -5,8 +5,23 @@ Ingest 600 deterministic notes (15 topic clusters x 40), run 15 recall
 queries through the kkernel mcp binary over stdio (which forwards to the
 warm daemon on first use), measure Precision@K and round-trip latency.
 
-Gate: mean Precision@K >= 0.70. Exit 0 = PASS, exit 1 = FAIL.
-Latency is tracked (ledger row) but never gated.
+What this gate DOES verify:
+  (a) Daemon-path engagement: the front-end binary spawns a warm daemon
+      child, binds the bench socket, and routes all recall traffic through it.
+  (b) Fused-pipeline mean Precision@K: mean P@K across 15 queries must be
+      >= RECALL_FLOOR (0.70) when both legs are active (default fusion).
+  (c) Per-leg structural retrieval: the vector leg (dense ANN — khive-vamana
+      / khive-hnsw) and the keyword leg (FTS5 / bm25) are each exercised in
+      isolation via fusion_strategy="vector_only" / "keyword_only". Each must
+      meet its own floor (VECTOR_FLOOR / KEYWORD_FLOOR = 0.70) per-query.
+
+What this gate does NOT verify:
+  This harness uses a deterministic LEXICAL hash embedder (cargo feature
+  bench-embedder / FNV-1a), not a real embedding model. It therefore does NOT
+  measure semantic-quality or recall@K regression on real embeddings. That is
+  covered separately by the banked 1M-scale Vamana benchmarks. The per-leg
+  floors prove that each retrieval leg is structurally functional; they do not
+  gate semantic ranking quality.
 
 Safety:
   - A fresh temp DB is created per run; live ~/.khive/khive.db is never touched.
@@ -14,6 +29,10 @@ Safety:
     env var or discovered at crates/target/release/kkernel-bench. The live
     daemon keyed on ~/.khive/khive.db is untouched because config_id differs.
   - Both the front-end process and its bench daemon child are terminated on exit.
+
+NOTE: P@K is NOT bit-identical run-to-run — downstream ANN candidate ordering
+and over-fetch retry introduce small variance. The floor must keep healthy
+headroom and must NOT be tightened toward the observed mean.
 """
 
 import csv
@@ -30,7 +49,20 @@ import time
 
 TOP_K = 10
 RECALL_FLOOR = 0.70
+# Per-leg structural floors. Both legs score 1.000 (zero spread) on this corpus
+# across all measured runs (3 clean runs, all 15 queries, both legs). Floors are
+# set at 0.70 — same 30% headroom as the fused gate — so any total leg failure
+# (i.e. a leg returning zero or wrong-topic hits) will drop P@K to 0.0 or near
+# zero, well below the floor. Gating is per-query (not just per-mean) because
+# the zero-spread observed means make per-query gating safe without false fails.
+VECTOR_FLOOR = 0.70
+KEYWORD_FLOOR = 0.70
 N_REPS = 5  # repetitions per query for latency measurement
+
+# Default production pack set (must match RuntimeConfig::default().packs in
+# crates/khive-runtime/src/config.rs so config_id agrees between front-end
+# and daemon child).
+_DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge"
 
 TOPICS = [
     ("knowledge graph", ["entity", "edge", "relation", "graph", "node", "ontology", "triple", "schema", "link", "concept"]),
@@ -151,9 +183,152 @@ def _handshake(proc):
 # ── Quality ───────────────────────────────────────────────────────────────────
 
 def precision_at_k(contents, expected_topic):
+    # Standard P@K: divide by TOP_K (not by returned count) so under-filling
+    # is penalized. A truncation regression returning 1 result when TOP_K=10
+    # yields P@K = 1/10 = 0.10 (correctly fails the gate), not 1/1 = 1.00.
     if not contents:
         return 0.0
-    return sum(1 for c in contents if expected_topic in c) / len(contents)
+    return sum(1 for c in contents if expected_topic in c) / TOP_K
+
+# ── Daemon engagement assertions ──────────────────────────────────────────────
+
+def _read_pid_file(pid_path):
+    """Return (pid:int, raw:str) from pid file, or (None, None) if absent/bad."""
+    try:
+        raw = pathlib.Path(pid_path).read_text().strip()
+        return int(raw), raw
+    except Exception:
+        return None, None
+
+
+def _pid_alive(pid):
+    """Return True if the process is alive (signal 0)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def _argv_is_khive_daemon(pid):
+    """Return True if ps shows this PID running kkernel (or kkernel-bench) mcp --daemon."""
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "args="],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        tokens = out.split()
+        if not tokens:
+            return False
+        basename = os.path.basename(tokens[0])
+        # Accept kkernel (production) or kkernel-bench (bench binary, which spawns
+        # itself as the daemon via current_exe() in spawn_daemon()).
+        if basename not in ("kkernel", "kkernel-bench"):
+            return False
+        rest = tokens[1:]
+        return "mcp" in rest and "--daemon" in rest
+    except Exception:
+        return False
+
+
+def _lsof_has_bench_db(pid, bench_db):
+    """Return True if the process has bench_db open (best-effort, skips if lsof absent)."""
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-p", str(pid)],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+        bench_db_real = str(pathlib.Path(bench_db).resolve())
+        return bench_db_real in out
+    except FileNotFoundError:
+        print("[SKIP] lsof not available — skipping open-file sub-check", flush=True)
+        return None  # None means skipped, not False
+    except Exception:
+        return False
+
+
+def assert_daemon_engaged(sock_path, pid_path, bench_db, label="main"):
+    """Assert all three daemon-engagement checks pass. Exit non-zero on failure."""
+    errors = []
+
+    # Check 1: socket file exists
+    if not pathlib.Path(sock_path).exists():
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} does not exist. "
+            "The front-end must have silently fallen back to local dispatch."
+        )
+    else:
+        print(f"[DAEMON-CHECK-{label}] PASS: bench socket {sock_path!r} exists", flush=True)
+
+    # Check 2: PID file exists, PID is alive, and argv is kkernel mcp --daemon
+    pid, _ = _read_pid_file(pid_path)
+    if pid is None:
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: bench PID file {pid_path!r} absent or unreadable."
+        )
+    elif not _pid_alive(pid):
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} from {pid_path!r} is not alive."
+        )
+    elif not _argv_is_khive_daemon(pid):
+        try:
+            argv_out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "args="], stderr=subprocess.DEVNULL
+            ).decode().strip()
+        except Exception:
+            argv_out = "<ps failed>"
+        errors.append(
+            f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is alive but argv does not match "
+            f"'kkernel mcp --daemon'. Got: {argv_out!r}"
+        )
+    else:
+        print(
+            f"[DAEMON-CHECK-{label}] PASS: PID {pid} is a live kkernel mcp --daemon process",
+            flush=True,
+        )
+
+        # Check 3: that daemon has bench.db open (best-effort)
+        db_open = _lsof_has_bench_db(pid, bench_db)
+        if db_open is None:
+            pass  # skipped
+        elif db_open:
+            print(
+                f"[DAEMON-CHECK-{label}] PASS: PID {pid} has {bench_db!r} open (lsof confirmed)",
+                flush=True,
+            )
+        else:
+            errors.append(
+                f"[DAEMON-CHECK-{label}] FAIL: PID {pid} is 'kkernel mcp --daemon' but does NOT "
+                f"have {bench_db!r} open. It may be attached to the live DB instead."
+            )
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr, flush=True)
+        print(
+            f"FATAL: daemon-engagement assertions failed ({label} run). "
+            "The gate CANNOT rely on this run's P@K. Exiting.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
+
+def assert_no_daemon_spawned(sock_path, label="nodaemon"):
+    """Assert no bench daemon was spawned (KHIVE_NO_DAEMON control run)."""
+    if pathlib.Path(sock_path).exists():
+        print(
+            f"[DAEMON-CHECK-{label}] FAIL: bench socket {sock_path!r} exists when "
+            "KHIVE_NO_DAEMON=1 was set — something spawned a daemon unexpectedly.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+    print(
+        f"[DAEMON-CHECK-{label}] PASS: no bench socket with KHIVE_NO_DAEMON=1 (correct)",
+        flush=True,
+    )
+
 
 # ── Provenance ────────────────────────────────────────────────────────────────
 
@@ -201,7 +376,8 @@ def _iso_now():
 
 LEDGER_PATH = pathlib.Path(__file__).parent.parent.parent / "perf" / "pipeline-ledger.csv"
 LEDGER_HEADER = ["git_sha", "runner_os", "loadavg1", "produced_at",
-                 "precision_at_k", "p50_us", "p95_us", "n_queries", "n_corpus"]
+                 "precision_at_k", "precision_vector_only", "precision_keyword_only",
+                 "p50_us", "p95_us", "n_queries", "n_corpus"]
 
 
 def _append_ledger(row):
@@ -279,9 +455,21 @@ def _ingest(proc, corpus):
 
 # ── Query ─────────────────────────────────────────────────────────────────────
 
-def _query_once(proc, query_text):
+def _query_once(proc, query_text, fusion_strategy=None):
+    """Issue one memory.recall and return (elapsed_us, contents).
+
+    When fusion_strategy is provided (e.g. "vector_only" or "keyword_only"),
+    it is passed as-is to the memory.recall verb. The daemon accepts the
+    snake_case strings defined in parse_fusion_strategy_str:
+      "vector_only"  — dense ANN leg only (khive-vamana / khive-hnsw)
+      "keyword_only" — FTS5 / bm25 leg only
+    Confirmed live against the daemon: both return hits without parse errors.
+    """
     t0 = time.perf_counter_ns()
-    result = _call_verb(proc, "memory.recall", {"query": query_text, "limit": TOP_K, "full_content": True})
+    args = {"query": query_text, "limit": TOP_K, "full_content": True}
+    if fusion_strategy is not None:
+        args["fusion_strategy"] = fusion_strategy
+    result = _call_verb(proc, "memory.recall", args)
     elapsed_us = (time.perf_counter_ns() - t0) // 1000
 
     if isinstance(result, list):
@@ -293,6 +481,88 @@ def _query_once(proc, query_text):
 
     contents = [r["content"] for r in arr if isinstance(r, dict) and "content" in r]
     return elapsed_us, contents
+
+# ── Daemon teardown helper ────────────────────────────────────────────────────
+
+def _teardown_daemon(pid_path, tmpdir):
+    """SIGTERM the bench daemon (if any), then rmtree the tmpdir."""
+    import shutil
+    pid, _ = _read_pid_file(pid_path)
+    if pid is not None and _pid_alive(pid) and _argv_is_khive_daemon(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            # Give it a moment to exit cleanly.
+            for _ in range(20):
+                time.sleep(0.1)
+                if not _pid_alive(pid):
+                    break
+        except Exception:
+            pass
+    try:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    except Exception:
+        pass
+
+# ── No-daemon control run ─────────────────────────────────────────────────────
+
+def _run_nodaemon_control(binary):
+    """Run a lightweight NO_DAEMON control: one ingest + one recall, assert no daemon spawns."""
+    import shutil
+    tmpdir = tempfile.mkdtemp(prefix="khive-bench-nodaemon-")
+    bench_db = os.path.join(tmpdir, "bench.db")
+    sock_path = os.path.join(tmpdir, "khived.sock")
+    pid_path_file = os.path.join(tmpdir, "khived.pid")
+    _assert_not_live_db(bench_db)
+
+    print("\n[CONTROL] Running KHIVE_NO_DAEMON=1 control run (one ingest + one recall)...", flush=True)
+    proc = None
+    try:
+        env = {**os.environ}
+        env["KHIVE_DB"] = bench_db
+        env["KHIVE_SOCKET"] = sock_path
+        env["KHIVE_PID"] = pid_path_file
+        env["KHIVE_LOCK"] = os.path.join(tmpdir, "khived.recovery.lock")
+        env["KHIVE_PACKS"] = _DEFAULT_PACKS
+        env["KHIVE_NO_DAEMON"] = "1"
+
+        proc = subprocess.Popen(
+            [binary, "mcp", "--log", "error"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        _handshake(proc)
+
+        # Minimal ingest: just first 2 notes
+        corpus = generate_corpus()
+        mini = corpus[:2]
+        ops_list = [
+            {"tool": "memory.remember", "args": {"content": t, "memory_type": "semantic", "salience": 0.7, "decay_factor": 0.0}}
+            for t in mini
+        ]
+        _call_request(proc, json.dumps(ops_list))
+
+        # One recall
+        _call_verb(proc, "memory.recall", {"query": QUERIES[0][0], "limit": 2, "full_content": True})
+
+        # Assert: no daemon socket, no kkernel mcp --daemon process
+        assert_no_daemon_spawned(sock_path, label="nodaemon")
+        print("[CONTROL] PASS: KHIVE_NO_DAEMON=1 control run completed without spawning a daemon.", flush=True)
+
+    finally:
+        if proc is not None:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        # No daemon was spawned (that's the point), so just rmtree
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
@@ -311,18 +581,30 @@ def main():
 
     tmpdir = tempfile.mkdtemp(prefix="khive-bench-")
     bench_db = os.path.join(tmpdir, "bench.db")
+    sock_path = os.path.join(tmpdir, "khived.sock")
+    pid_path_file = os.path.join(tmpdir, "khived.pid")
+    lock_path = os.path.join(tmpdir, "khived.recovery.lock")
     _assert_not_live_db(bench_db)
 
     proc = None
     try:
+        # Pass DB and all daemon-isolation knobs as ENVIRONMENT VARIABLES so the
+        # spawned daemon child inherits them. CLI args are NOT inherited by the
+        # daemon child that spawn_daemon() launches via current_exe().
         env = {**os.environ}
-        # KHIVE_NO_DAEMON=0 means we WANT daemon forwarding (the production path).
-        # Remove any env var that would suppress the daemon.
+        env["KHIVE_DB"] = bench_db
+        env["KHIVE_SOCKET"] = sock_path
+        env["KHIVE_PID"] = pid_path_file
+        env["KHIVE_LOCK"] = lock_path
+        # Set KHIVE_PACKS explicitly to the default production set so that the
+        # front-end and its daemon child compute identical config_id values.
+        env["KHIVE_PACKS"] = _DEFAULT_PACKS
+        # Do NOT set KHIVE_NO_DAEMON — we WANT the daemon path.
         env.pop("KHIVE_NO_DAEMON", None)
 
-        print(f"Spawning {binary} mcp --db {bench_db}", flush=True)
+        print(f"Spawning {binary} mcp (DB via env: {bench_db})", flush=True)
         proc = subprocess.Popen(
-            [binary, "mcp", "--db", bench_db, "--log", "error"],
+            [binary, "mcp", "--log", "warn"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -344,6 +626,18 @@ def main():
             )
         print(f"[ok] Warm-up returned {len(warmup_hits)} hit(s)", flush=True)
 
+        # ── Daemon engagement assertions ──────────────────────────────────────
+        # After the first warmup request, the daemon must have been spawned and
+        # bound the bench socket. These assertions fail loudly if the gate is
+        # silently falling back to local (in-process) dispatch.
+        print("\n[DAEMON-CHECKS] Verifying daemon engagement...", flush=True)
+        # Give daemon a moment to write PID file and bind socket (it may have
+        # just been spawned by the warmup request).
+        deadline = time.time() + 5.0
+        while not pathlib.Path(sock_path).exists() and time.time() < deadline:
+            time.sleep(0.1)
+        assert_daemon_engaged(sock_path, pid_path_file, bench_db, label="main")
+
         # Additional warm-up rounds (discard timings)
         for q, _ in QUERIES:
             _query_once(proc, q)
@@ -362,25 +656,42 @@ def main():
                 rep_latencies.append(us)
                 last_contents = contents
 
+            # Per-leg structural recalls (one shot each — no latency tracking)
+            _, vec_contents = _query_once(proc, query_text, fusion_strategy="vector_only")
+            _, kw_contents = _query_once(proc, query_text, fusion_strategy="keyword_only")
+
             all_latencies.extend(rep_latencies)
             p_at_k = precision_at_k(last_contents, expected_topic)
+            p_vec = precision_at_k(vec_contents, expected_topic)
+            p_kw = precision_at_k(kw_contents, expected_topic)
+
             q_pass = p_at_k >= RECALL_FLOOR
-            if not q_pass:
+            vec_pass = p_vec >= VECTOR_FLOOR
+            kw_pass = p_kw >= KEYWORD_FLOOR
+            if not q_pass or not vec_pass or not kw_pass:
                 all_pass = False
 
             rep_latencies.sort()
             q_p50 = _pct(rep_latencies, 0.5)
+            fused_verdict = "PASS" if q_pass else "FAIL"
+            vec_verdict = "PASS" if vec_pass else "FAIL"
+            kw_verdict = "PASS" if kw_pass else "FAIL"
             print(
-                f"  {expected_topic:<22} P@K={p_at_k:.2f} ({len(last_contents)} hits)"
-                f"  p50={q_p50}µs  {'PASS' if q_pass else 'FAIL'}",
+                f"  {expected_topic:<22} P@K={p_at_k:.2f}  "
+                f"vec={p_vec:.2f}({vec_verdict})  kw={p_kw:.2f}({kw_verdict})  "
+                f"({len(last_contents)} hits)  p50={q_p50}µs  {fused_verdict}",
                 flush=True,
             )
             per_query.append({
                 "query": query_text,
                 "expected_topic": expected_topic,
                 "precision_at_k": p_at_k,
+                "precision_vector_only": p_vec,
+                "precision_keyword_only": p_kw,
                 "top_k_count": len(last_contents),
                 "query_pass": q_pass,
+                "vec_pass": vec_pass,
+                "kw_pass": kw_pass,
                 "p50_us": q_p50,
             })
 
@@ -388,8 +699,12 @@ def main():
         p50_us = _pct(all_latencies, 0.5)
         p95_us = _pct(all_latencies, 0.95)
         mean_pak = sum(r["precision_at_k"] for r in per_query) / len(per_query)
+        mean_vec = sum(r["precision_vector_only"] for r in per_query) / len(per_query)
+        mean_kw = sum(r["precision_keyword_only"] for r in per_query) / len(per_query)
 
         print(f"\nMean Precision@K={mean_pak:.3f}  floor={RECALL_FLOOR}", flush=True)
+        print(f"Mean VectorOnly P@K={mean_vec:.3f}  floor={VECTOR_FLOOR}", flush=True)
+        print(f"Mean KeywordOnly P@K={mean_kw:.3f}  floor={KEYWORD_FLOOR}", flush=True)
         print(f"p50={p50_us}µs  p95={p95_us}µs  n_latencies={len(all_latencies)}", flush=True)
         verdict = "PASS" if all_pass else "FAIL"
         print(f"Gate: {verdict}", flush=True)
@@ -406,6 +721,8 @@ def main():
             "loadavg1": loadavg1,
             "produced_at": produced_at,
             "precision_at_k": f"{mean_pak:.4f}",
+            "precision_vector_only": f"{mean_vec:.4f}",
+            "precision_keyword_only": f"{mean_kw:.4f}",
             "p50_us": p50_us,
             "p95_us": p95_us,
             "n_queries": len(QUERIES),
@@ -433,21 +750,29 @@ def main():
             except Exception:
                 pass
             # Give the front-end a moment to relay shutdown to its daemon child.
-            # The bench daemon's config_id differs from the live one so we only
-            # need to ensure the front-end exits (which drains its daemon child).
             try:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait()
 
-        # Cleanup bench DB
-        import shutil
-        try:
-            shutil.rmtree(tmpdir, ignore_errors=True)
-        except Exception:
-            pass
+        # Reap the bench daemon child (it survives the front-end).
+        _teardown_daemon(pid_path_file, tmpdir)
+
+    # Run KHIVE_NO_DAEMON=1 control after main teardown so it uses a fresh tmpdir.
+
+
+def _main_with_control():
+    binary = os.environ.get(
+        "KKERNEL_BENCH_BINARY",
+        str(pathlib.Path(__file__).parent.parent.parent / "crates" / "target" / "release" / "kkernel-bench"),
+    )
+    rc = main()
+    # Only run the control when the binary exists (it was already checked in main).
+    if pathlib.Path(binary).exists():
+        _run_nodaemon_control(binary)
+    return rc
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(_main_with_control())

--- a/scripts/perf/gen_synthetic_fvecs.py
+++ b/scripts/perf/gen_synthetic_fvecs.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Generate deterministic synthetic clustered fvecs fixtures for ANN regression testing.
+
+Produces sift_base.fvecs and sift_query.fvecs in <--out> using only Python stdlib.
+Files are byte-identical across runs given the same --seed (fully deterministic).
+
+Usage:
+    python3 scripts/perf/gen_synthetic_fvecs.py --out /tmp/synth-fvecs
+    python3 scripts/perf/gen_synthetic_fvecs.py --out /tmp/synth-fvecs \\
+        --n 50000 --queries 1000 --dim 128 --clusters 64 --sigma 0.08 --seed 42
+
+Output files:
+    <out>/sift_base.fvecs   -- --n vectors in fvecs format
+    <out>/sift_query.fvecs  -- --queries vectors in fvecs format
+
+fvecs format (per record):
+    int32 LE dim, then dim * float32 LE values
+
+The clustering structure (low intrinsic dimension) makes this suitable for
+verifying that ANN index build and search behave correctly: well-separated
+clusters yield high recall@10, so a recall drop signals structural breakage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import math
+import os
+import random
+import struct
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate deterministic synthetic fvecs fixtures.")
+    p.add_argument("--out", required=True, help="Output directory (created if absent)")
+    p.add_argument("--n", type=int, default=50000, help="Number of base vectors (default: 50000)")
+    p.add_argument(
+        "--queries", type=int, default=1000, help="Number of query vectors (default: 1000)"
+    )
+    p.add_argument("--dim", type=int, default=128, help="Vector dimension (default: 128)")
+    p.add_argument(
+        "--clusters", type=int, default=64, help="Number of cluster centers (default: 64)"
+    )
+    p.add_argument(
+        "--sigma",
+        type=float,
+        default=0.08,
+        help="Gaussian noise std relative to cluster spacing (default: 0.08). "
+        "Lower values produce tighter clusters and higher ANN recall.",
+    )
+    p.add_argument("--seed", type=int, default=42, help="RNG seed (default: 42)")
+    return p.parse_args()
+
+
+def _gauss_pair(rng: random.Random) -> tuple[float, float]:
+    """Box-Muller transform producing two independent N(0,1) samples."""
+    while True:
+        u = rng.random()
+        v = rng.random()
+        if u > 0.0:
+            break
+    mag = math.sqrt(-2.0 * math.log(u))
+    return mag * math.cos(2.0 * math.pi * v), mag * math.sin(2.0 * math.pi * v)
+
+
+def _gauss_vector(rng: random.Random, dim: int) -> list[float]:
+    """Return a dim-length list of independent N(0,1) samples."""
+    out: list[float] = []
+    for _ in range(dim // 2):
+        a, b = _gauss_pair(rng)
+        out.append(a)
+        out.append(b)
+    if dim % 2 == 1:
+        a, _ = _gauss_pair(rng)
+        out.append(a)
+    return out
+
+
+def generate_centers(rng: random.Random, n_clusters: int, dim: int) -> list[list[float]]:
+    """Generate cluster centers uniformly in [-1, 1]^dim."""
+    centers = []
+    for _ in range(n_clusters):
+        c = [rng.uniform(-1.0, 1.0) for _ in range(dim)]
+        centers.append(c)
+    return centers
+
+
+def generate_vectors(
+    rng: random.Random,
+    n: int,
+    centers: list[list[float]],
+    sigma: float,
+) -> list[list[float]]:
+    """Generate n vectors by assigning each to a cluster center + Gaussian noise."""
+    n_clusters = len(centers)
+    dim = len(centers[0])
+    vectors = []
+    for i in range(n):
+        cluster_idx = i % n_clusters
+        center = centers[cluster_idx]
+        noise = _gauss_vector(rng, dim)
+        vec = [center[d] + sigma * noise[d] for d in range(dim)]
+        vectors.append(vec)
+    # Shuffle so cluster assignment isn't trivially sequential in the file.
+    rng.shuffle(vectors)
+    return vectors
+
+
+def generate_queries(
+    rng: random.Random,
+    n_queries: int,
+    centers: list[list[float]],
+    sigma: float,
+) -> list[list[float]]:
+    """Generate query vectors: each picks a random center + Gaussian noise."""
+    dim = len(centers[0])
+    n_clusters = len(centers)
+    queries = []
+    for _ in range(n_queries):
+        cluster_idx = rng.randrange(n_clusters)
+        center = centers[cluster_idx]
+        noise = _gauss_vector(rng, dim)
+        vec = [center[d] + sigma * noise[d] for d in range(dim)]
+        queries.append(vec)
+    return queries
+
+
+def write_fvecs(path: str, vectors: list[list[float]], dim: int) -> str:
+    """Write vectors to path in fvecs format. Returns hex sha256 of the file."""
+    record = struct.pack("<i", dim)  # 4-byte LE int32 dim header per record
+    fmt = f"<{dim}f"
+    h = hashlib.sha256()
+    with open(path, "wb") as f:
+        for vec in vectors:
+            header = record
+            payload = struct.pack(fmt, *vec)
+            f.write(header)
+            f.write(payload)
+            h.update(header)
+            h.update(payload)
+    return h.hexdigest()
+
+
+def main() -> None:
+    args = parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+
+    rng = random.Random(args.seed)
+
+    centers = generate_centers(rng, args.clusters, args.dim)
+    base_vecs = generate_vectors(rng, args.n, centers, args.sigma)
+    query_vecs = generate_queries(rng, args.queries, centers, args.sigma)
+
+    base_path = os.path.join(args.out, "sift_base.fvecs")
+    query_path = os.path.join(args.out, "sift_query.fvecs")
+
+    base_sha = write_fvecs(base_path, base_vecs, args.dim)
+    query_sha = write_fvecs(query_path, query_vecs, args.dim)
+
+    print(
+        f"Generated: n={args.n} queries={args.queries} dim={args.dim} "
+        f"clusters={args.clusters} sigma={args.sigma} seed={args.seed}"
+    )
+    print(f"  base:  {base_path}  sha256={base_sha}")
+    print(f"  query: {query_path}  sha256={query_sha}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds CI regression gates for the retrieval/recall perf pipeline, enforced on the **daemon path** (ADR-049 default) so downstream consumers of a changed crate are benched per-PR without running a full bench suite on every change.

Two gates:

1. **Daemon-path pipeline gate** (`bench-pipeline.yml`). Spawns an isolated `kkernel mcp --daemon` against a temp DB and drives the whole request pipeline over stdio. A deterministic FNV-1a 384-d embedder, injected via the `bench-embedder` cargo feature and registered under the production embedder name (so `config_id` is unchanged), makes Precision@K path-independent. Hard gate: Precision@K >= 0.70. Warm p50/p95 round-trip latency is recorded to a provenance-stamped ledger (git_sha / runner_os / loadavg) but is not hard-gated, because runner jitter makes a latency threshold flaky. Path-triggered on changes to runtime / memory / kg / retrieval / fusion.

2. **1M synthetic ANN gate** (`bench-1m.yml`). Replaces the previous 1M bench, which silently skipped and always exited green on GitHub runners because the SIFT dataset is absent there, with a blocking per-PR structural gate driven by deterministic synthetic clustered fvecs. No SIFT download, no repo bloat. Real SIFT-1M is demoted to `workflow_dispatch`-only.

## Why the daemon path

Per ADR-049 the daemon is the default runtime. Benching in-process (`registry.dispatch`) would measure a path users never hit. Temp-DB `config_id` isolation (the db_path folds into `compute_config_id`) guarantees the bench spawns its own daemon and physically cannot touch the live `~/.khive/khive.db`.

## Testing

The gate is verified to bite via defect injection: degrading `max_degree` collapses recall, which blocks the gate.

## Notes for review

- This branch is the perf changeset rebased onto `origin/main`, independent of the stacked V4 / fts-ann-consolidation work (that lands via its own PR).
- Two branch-protection follow-ups are out of this diff: add the ANN gate as a required status check, and one cosmetic `vec_bench` exit-code nit (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
