### PR TITLE
feat(db,memory): ADR-062 FTS+ANN consolidation (schema V4) + namespace-agnostic memory fixes

### DIFF
--- a/crates/khive-db/sql/004-fts-consolidation.sql
+++ b/crates/khive-db/sql/004-fts-consolidation.sql
@@ -1,0 +1,33 @@
+-- 004-fts-consolidation.sql
+-- Consolidate per-namespace FTS5 tables into single shared tables.
+-- Strategy: create unified tables (namespace UNINDEXED column).
+-- Per-namespace partition cleanup is performed at runtime (namespace-agnostic sweep),
+-- not in this SQL, to avoid hardcoding namespace names.
+-- Repopulation: run `kkernel reindex --no-knowledge` after this migration.
+-- Out of scope: fts_knowledge, fts_sections (knowledge-pack corpus).
+
+-- Unified entity FTS table (one table for all namespaces; namespace is a filter column)
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_entities USING fts5(
+    subject_id UNINDEXED,
+    kind UNINDEXED,
+    title,
+    body,
+    tags UNINDEXED,
+    namespace UNINDEXED,
+    metadata UNINDEXED,
+    updated_at UNINDEXED,
+    tokenize = 'trigram'
+);
+
+-- Unified notes FTS table (one table for all namespaces; namespace is a filter column)
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_notes USING fts5(
+    subject_id UNINDEXED,
+    kind UNINDEXED,
+    title,
+    body,
+    tags UNINDEXED,
+    namespace UNINDEXED,
+    metadata UNINDEXED,
+    updated_at UNINDEXED,
+    tokenize = 'trigram'
+);

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -106,6 +106,8 @@ const V2_UP: &str = include_str!("../sql/002-narrow-fts-sections-update-trigger.
 
 const V3_UP: &str = include_str!("../sql/003-backfill-domain-mirror-atoms.sql");
 
+const V4_UP: &str = include_str!("../sql/004-fts-consolidation.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -129,6 +131,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 3,
         name: "backfill_domain_mirror_atoms",
         up: V3_UP,
+    },
+    VersionedMigration {
+        version: 4,
+        name: "fts_consolidation",
+        up: V4_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -27,14 +27,25 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
 fn fresh_db_migrates_to_latest() {
     let mut conn = open_memory();
     let version = run_migrations(&mut conn).expect("migrations should succeed");
-    assert_eq!(version, 3, "latest migration version");
+    assert_eq!(version, 4, "latest migration version");
 
     let recorded: i64 = conn
         .query_row("SELECT COUNT(*) FROM _schema_migrations", [], |row| {
             row.get(0)
         })
         .unwrap();
-    assert_eq!(recorded, 3);
+    assert_eq!(recorded, 4);
+}
+
+#[test]
+fn v4_creates_consolidated_fts_tables() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    assert!(
+        table_exists(&conn, "fts_entities"),
+        "V4 must create fts_entities"
+    );
+    assert!(table_exists(&conn, "fts_notes"), "V4 must create fts_notes");
 }
 
 #[test]
@@ -138,7 +149,7 @@ fn run_migrations_twice_is_idempotent() {
             row.get(0)
         })
         .unwrap();
-    assert_eq!(recorded, 3, "no duplicate migration rows on re-run");
+    assert_eq!(recorded, 4, "no duplicate migration rows on re-run");
 }
 
 // ── _embedding_models.dim u32 range tests ───────────────────────────────────

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -502,6 +502,41 @@ impl VectorStore for SqliteVecStore {
         self.info().await
     }
 
+    async fn delete_subjects(&self, ids: &[Uuid]) -> Result<u64, StorageError> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let table = self.table_name.clone();
+        let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+        let mut total_deleted: u64 = 0;
+
+        // Batch in ≤400 IDs per statement to stay within SQLite's variable limit.
+        for chunk in id_strings.chunks(400) {
+            let placeholders: String = (1..=chunk.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!("DELETE FROM {table} WHERE subject_id IN ({placeholders})");
+            let chunk_owned = chunk.to_vec();
+            let table_cl = table.clone();
+            let deleted = self
+                .with_writer("vec_delete_subjects", move |conn| {
+                    let mut stmt = conn.prepare(&sql)?;
+                    for (i, id_str) in chunk_owned.iter().enumerate() {
+                        stmt.raw_bind_parameter(i + 1, id_str.as_str())?;
+                    }
+                    stmt.raw_execute().map(|n| n as u64)
+                })
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, table = %table_cl, "delete_subjects chunk failed");
+                    0
+                });
+            total_deleted += deleted;
+        }
+        Ok(total_deleted)
+    }
+
     async fn batch_exists(
         &self,
         ids: &[Uuid],

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -528,10 +528,10 @@ impl VectorStore for SqliteVecStore {
                     stmt.raw_execute().map(|n| n as u64)
                 })
                 .await
-                .unwrap_or_else(|e| {
+                .map_err(|e| {
                     tracing::warn!(error = %e, table = %table_cl, "delete_subjects chunk failed");
-                    0
-                });
+                    e
+                })?;
             total_deleted += deleted;
         }
         Ok(total_deleted)

--- a/crates/khive-pack-memory/benches/fts_gather.rs
+++ b/crates/khive-pack-memory/benches/fts_gather.rs
@@ -273,10 +273,11 @@ async fn production_search(
     cfg: &RecallFtsGatherConfig,
     terms: &[String],
 ) -> Vec<TextSearchHit> {
+    let ns_vec = vec![NS.to_string()];
     collect_text_hits(
         searcher,
         "",
-        NS,
+        &ns_vec,
         CANDIDATE_LIMIT,
         TextSnippetPolicy::Omit,
         false,

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -37,6 +37,10 @@ impl AnnKey {
 pub(crate) struct AnnBridge {
     index: VamanaIndex,
     id_map: Vec<Uuid>,
+    /// Distinct namespaces present in the indexed corpus.
+    /// Used by the recall retry gate to short-circuit when the global index
+    /// contains no vectors outside the caller's visible namespace set.
+    pub(crate) namespace_set: HashSet<String>,
 }
 
 /// Shared ANN state: per-`(namespace, model)` indexes with at-most-one-background-build guard.
@@ -78,6 +82,7 @@ impl AnnBridge {
         mut vectors: Vec<f32>,
         dim: usize,
         id_map: Vec<Uuid>,
+        namespace_set: HashSet<String>,
     ) -> Result<Self, RuntimeError> {
         if dim == 0 {
             return Err(RuntimeError::Internal("dimension must be > 0".into()));
@@ -101,7 +106,11 @@ impl AnnBridge {
         let cfg = VamanaConfig::with_dimensions(dim);
         let index =
             VamanaIndex::build(&vectors, cfg).map_err(|e| RuntimeError::Internal(e.to_string()))?;
-        Ok(Self { index, id_map })
+        Ok(Self {
+            index,
+            id_map,
+            namespace_set,
+        })
     }
 
     pub(crate) fn search(&self, query: &[f32], k: usize) -> Result<Vec<(Uuid, f32)>, RuntimeError> {
@@ -145,7 +154,19 @@ impl AnnBridge {
             .collect::<Result<_, _>>()?;
         let index = VamanaIndex::from_snapshot(&snapshot)
             .map_err(|e| RuntimeError::Internal(format!("snapshot restore: {e}")))?;
-        Ok(Self { index, id_map })
+        Ok(Self {
+            index,
+            id_map,
+            // Namespace set is populated after restore via `populate_namespace_set`.
+            // Until then it is left empty, which causes the retry gate to be
+            // conservative (assume the index may contain non-visible namespaces).
+            namespace_set: HashSet::new(),
+        })
+    }
+
+    /// Populate `namespace_set` from an already-queried set of namespace strings.
+    pub(crate) fn set_namespace_set(&mut self, ns_set: HashSet<String>) {
+        self.namespace_set = ns_set;
     }
 }
 
@@ -205,6 +226,16 @@ pub(crate) async fn search_loaded(
             bridge.search(query, k).map(Some)
         }
     }
+}
+
+/// Return the namespace set for the loaded index, or `None` on cache miss.
+///
+/// An empty set (returned for snapshot-restored indexes before their set is
+/// populated) must be treated conservatively by the caller — i.e. assume the
+/// index may contain non-visible namespaces and proceed with the retry loop.
+pub(crate) async fn index_namespace_set(ann: &SharedAnn, key: &AnnKey) -> Option<HashSet<String>> {
+    let guard = ann.indexes.read().await;
+    guard.get(key).map(|b| b.namespace_set.clone())
 }
 
 /// Remove a single in-memory ANN slot and its warming guard entry.
@@ -317,7 +348,13 @@ pub(crate) async fn ensure_ann_for_model(
         if let Some(fp) = current_fp {
             if snapshot.fingerprint == fp {
                 match AnnBridge::from_snapshot(snapshot) {
-                    Ok(bridge) => {
+                    Ok(mut bridge) => {
+                        // Populate namespace set from a cheap DISTINCT query so the
+                        // retry gate in recall can short-circuit when appropriate.
+                        let ns_set = query_distinct_namespaces(rt, token, model)
+                            .await
+                            .unwrap_or_default();
+                        bridge.set_namespace_set(ns_set);
                         ann.indexes.write().await.entry(key).or_insert(bridge);
                         tracing::debug!(namespace = %ns, model = %model, "memory ANN loaded from snapshot");
                         return Ok(AnnEnsureStatus::LoadedSnapshot);
@@ -374,6 +411,46 @@ pub(crate) async fn ensure_ann_for_model(
 }
 
 // ── corpus loading ────────────────────────────────────────────────────────────
+
+/// Query the set of distinct `namespace` values present in the vector corpus for `model`.
+/// Used after snapshot restore to populate the in-memory namespace set.
+async fn query_distinct_namespaces(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+) -> Option<HashSet<String>> {
+    let store = rt.vectors_for_model(token, model).ok()?;
+    let _ = store; // ensure store is accessible; actual query goes to SQL layer
+    let model_key = sanitize_model_key(model);
+    let table_name = format!("vec_{model_key}");
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.ok()?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT DISTINCT n.namespace FROM {table_name} v \
+                 JOIN notes n ON n.id = v.subject_id \
+                 WHERE v.embedding_model = ?1 \
+                   AND v.kind = 'note' AND v.field = 'note.content' \
+                   AND n.deleted_at IS NULL"
+            ),
+            params: vec![SqlValue::Text(model.to_owned())],
+            label: Some("memory_ann_distinct_namespaces".into()),
+        })
+        .await
+        .ok()?;
+    let set: HashSet<String> = rows
+        .into_iter()
+        .filter_map(|row| {
+            if let Some(SqlValue::Text(ns)) = row.get("namespace") {
+                Some(ns.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    Some(set)
+}
 
 /// Compute a fingerprint for all non-deleted memory note vectors for `model` (all namespaces).
 async fn compute_memory_fingerprint(
@@ -442,7 +519,7 @@ async fn load_and_build_from_vector_store(
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT v.subject_id, v.embedding FROM {table_name} v \
+                "SELECT v.subject_id, v.embedding, n.namespace FROM {table_name} v \
                  JOIN notes n ON n.id = v.subject_id \
                  WHERE v.embedding_model = ?1 \
                    AND v.kind = 'note' AND v.field = 'note.content' \
@@ -461,6 +538,7 @@ async fn load_and_build_from_vector_store(
 
     let mut id_map: Vec<Uuid> = Vec::with_capacity(rows.len());
     let mut flat: Vec<f32> = Vec::with_capacity(rows.len() * dims);
+    let mut namespace_set: HashSet<String> = HashSet::new();
 
     for row in &rows {
         let id_str = match row.get("subject_id") {
@@ -482,6 +560,9 @@ async fn load_and_build_from_vector_store(
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect();
+        if let Some(SqlValue::Text(ns)) = row.get("namespace") {
+            namespace_set.insert(ns.clone());
+        }
         id_map.push(uuid);
         flat.extend_from_slice(&vec);
     }
@@ -490,7 +571,7 @@ async fn load_and_build_from_vector_store(
         return Ok(None);
     }
 
-    AnnBridge::build(flat, dims, id_map).map(Some)
+    AnnBridge::build(flat, dims, id_map, namespace_set).map(Some)
 }
 
 // ── persistence ───────────────────────────────────────────────────────────────
@@ -652,7 +733,8 @@ mod tests {
             0.0, 1.0, 0.0, // id_b
             0.0, 0.0, 1.0, // id_c
         ];
-        let bridge = AnnBridge::build(vectors, 3, vec![id_a, id_b, id_c]).expect("build");
+        let bridge =
+            AnnBridge::build(vectors, 3, vec![id_a, id_b, id_c], HashSet::new()).expect("build");
 
         // query close to id_a
         let hits = bridge.search(&[1.0, 0.0, 0.0], 1).expect("search");
@@ -664,8 +746,8 @@ mod tests {
     #[test]
     fn ann_search_dimension_error_returns_err() {
         let id = Uuid::new_v4();
-        let bridge =
-            AnnBridge::build(vec![1.0f32, 0.0, 0.0], 3, vec![id]).expect("build 3-dim bridge");
+        let bridge = AnnBridge::build(vec![1.0f32, 0.0, 0.0], 3, vec![id], HashSet::new())
+            .expect("build 3-dim bridge");
         // query with wrong dimension (2 instead of 3)
         let result = bridge.search(&[1.0, 0.0], 1);
         assert!(result.is_err(), "wrong dimension must return Err");
@@ -696,10 +778,10 @@ mod tests {
         let id_a = Uuid::new_v4();
         let id_b = Uuid::new_v4();
 
-        let bridge_a =
-            AnnBridge::build(vec![1.0f32, 0.0, 0.0, 0.0], 4, vec![id_a]).expect("build a");
-        let bridge_b =
-            AnnBridge::build(vec![0.0f32, 1.0, 0.0, 0.0], 4, vec![id_b]).expect("build b");
+        let bridge_a = AnnBridge::build(vec![1.0f32, 0.0, 0.0, 0.0], 4, vec![id_a], HashSet::new())
+            .expect("build a");
+        let bridge_b = AnnBridge::build(vec![0.0f32, 1.0, 0.0, 0.0], 4, vec![id_b], HashSet::new())
+            .expect("build b");
 
         // Keys are model-only; namespace arg is ignored.
         let key_a = AnnKey::new("any-ns", model_a);

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -1,4 +1,5 @@
-//! Warm ANN bridge: wraps `VamanaIndex` per `(namespace, model)` to cache memory-note vector search.
+//! Warm ANN bridge: wraps `VamanaIndex` per model to cache memory-note vector search.
+//! One index per model covers all namespaces; namespace filtering is applied at recall time.
 
 use std::collections::{HashMap, HashSet};
 #[cfg(test)]
@@ -13,23 +14,23 @@ use uuid::Uuid;
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
-/// Cache key for a per-`(namespace, model)` ANN slot.
+/// Cache key for a per-model ANN slot (one index per model, all namespaces combined).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct AnnKey {
-    pub(crate) namespace: String,
     pub(crate) model: String,
 }
 
 impl AnnKey {
-    pub(crate) fn new(namespace: impl Into<String>, model: impl Into<String>) -> Self {
+    pub(crate) fn new(_namespace: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
-            namespace: namespace.into(),
             model: model.into(),
         }
     }
 
-    pub(crate) fn from_token(token: &NamespaceToken, model: &str) -> Self {
-        Self::new(token.namespace().as_str(), model)
+    pub(crate) fn from_token(_token: &NamespaceToken, model: &str) -> Self {
+        Self {
+            model: model.to_owned(),
+        }
     }
 }
 
@@ -166,10 +167,10 @@ pub(crate) fn sanitize_model_key(s: &str) -> String {
         .collect()
 }
 
-/// Snapshot namespace key for memory Vamana — distinct from knowledge's
-/// `{ns}::vamana::{model}` to prevent corpus identity collisions.
-pub(crate) fn snapshot_key(namespace: &str, model: &str) -> String {
-    format!("{namespace}::memory_vamana::{model}")
+/// Snapshot key for the global memory Vamana index for a model.
+/// Distinct from knowledge's `{ns}::vamana::{model}` to prevent corpus identity collisions.
+pub(crate) fn snapshot_key(_namespace: &str, model: &str) -> String {
+    format!("global::memory_vamana::{model}")
 }
 
 const MEMORY_VAMANA_INDEX_TYPE: &str = "memory_vamana";
@@ -212,25 +213,20 @@ pub(crate) async fn clear_key(ann: &SharedAnn, key: &AnnKey) {
     ann.warming.lock().await.remove(key);
 }
 
-/// Remove all in-memory ANN slots and warming-guard entries for `namespace`.
-pub(crate) async fn clear_namespace(ann: &SharedAnn, namespace: &str) {
-    ann.indexes
-        .write()
-        .await
-        .retain(|k, _| k.namespace != namespace);
-    ann.warming
-        .lock()
-        .await
-        .retain(|k| k.namespace != namespace);
+/// Remove all in-memory ANN slots and warming-guard entries.
+/// Because the index is global per model, any namespace write invalidates all slots.
+pub(crate) async fn clear_namespace(ann: &SharedAnn, _namespace: &str) {
+    ann.indexes.write().await.clear();
+    ann.warming.lock().await.clear();
 }
 
-/// Clear in-memory cache and delete persisted snapshots for `namespace`.
-pub(crate) async fn invalidate_namespace(rt: &KhiveRuntime, ann: &SharedAnn, namespace: &str) {
-    clear_namespace(ann, namespace).await;
-    invalidate_snapshots(rt, namespace).await;
+/// Clear in-memory cache and delete persisted snapshots.
+pub(crate) async fn invalidate_namespace(rt: &KhiveRuntime, ann: &SharedAnn, _namespace: &str) {
+    clear_namespace(ann, _namespace).await;
+    invalidate_snapshots(rt).await;
 }
 
-/// Fire-once per-key background warm for `model`. Returns `true` if a new task was started.
+/// Fire-once per-model background warm. Returns `true` if a new task was started.
 pub(crate) async fn ensure_ann_background(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -258,10 +254,9 @@ pub(crate) async fn ensure_ann_background(
 
     let rt = rt.clone();
     let ann = ann.clone();
-    let token_ns = token.namespace().clone();
     let model = model.to_owned();
     tokio::spawn(async move {
-        if let Ok(token) = rt.authorize(token_ns) {
+        if let Ok(token) = rt.authorize(Namespace::local()) {
             match ensure_ann_for_model(&rt, &token, &ann, &model).await {
                 Ok(status) => {
                     tracing::debug!(?status, model = %model, "memory ANN background warm complete");
@@ -280,58 +275,26 @@ pub(crate) async fn ensure_ann_background(
     true
 }
 
-/// Warm all `(namespace, model)` ANN indexes at startup — skips already-loaded keys.
+/// Warm the global per-model ANN indexes at startup — skips already-loaded keys.
 pub(crate) async fn warm_existing_memory_indexes(rt: &KhiveRuntime, ann: &SharedAnn) {
     let models = rt.registered_embedding_model_names();
     for model in &models {
-        let model_key = sanitize_model_key(model);
-        let table_name = format!("vec_{model_key}");
-        let sql = rt.sql();
-        let mut reader = match sql.reader().await {
-            Ok(r) => r,
+        let token = match rt.authorize(Namespace::local()) {
+            Ok(t) => t,
             Err(_) => continue,
         };
-        let rows = match reader
-            .query_all(SqlStatement {
-                sql: format!(
-                    "SELECT DISTINCT namespace FROM {table_name} \
-                     WHERE embedding_model = ?1 AND kind = 'note' AND field = 'note.content'"
-                ),
-                params: vec![SqlValue::Text(model.clone())],
-                label: Some("memory_ann_warm_namespaces".into()),
-            })
-            .await
-        {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-
-        for row in &rows {
-            let ns_str = match row.get("namespace") {
-                Some(SqlValue::Text(s)) => s.as_str(),
-                _ => continue,
-            };
-            let ns = match Namespace::parse(ns_str) {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            let token = match rt.authorize(ns) {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-            match ensure_ann_for_model(rt, &token, ann, model).await {
-                Ok(status) => {
-                    tracing::debug!(?status, namespace = %ns_str, model = %model, "memory ANN warm complete");
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, namespace = %ns_str, model = %model, "memory ANN warm failed");
-                }
+        match ensure_ann_for_model(rt, &token, ann, model).await {
+            Ok(status) => {
+                tracing::debug!(?status, model = %model, "memory ANN warm complete");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, model = %model, "memory ANN warm failed");
             }
         }
     }
 }
 
-/// Lazy warm-load for a specific `(namespace, model)`: snapshot restore or rebuild with double-fingerprint check.
+/// Lazy warm-load for the global index for `model`: snapshot restore or rebuild with double-fingerprint check.
 pub(crate) async fn ensure_ann_for_model(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -341,15 +304,15 @@ pub(crate) async fn ensure_ann_for_model(
     if model.is_empty() {
         return Ok(AnnEnsureStatus::EmptyCorpus);
     }
-    let ns = token.namespace().as_str().to_owned();
-    let key = AnnKey::new(&ns, model);
+    let ns = "global";
+    let key = AnnKey::new(ns, model);
 
     if ann.indexes.read().await.contains_key(&key) {
         return Ok(AnnEnsureStatus::AlreadyLoaded);
     }
 
     // Try snapshot warm-load.
-    if let Some(snapshot) = try_load_snapshot(rt, &ns, model).await {
+    if let Some(snapshot) = try_load_snapshot(rt, ns, model).await {
         let current_fp = compute_memory_fingerprint(rt, token, model).await;
         if let Some(fp) = current_fp {
             if snapshot.fingerprint == fp {
@@ -389,7 +352,7 @@ pub(crate) async fn ensure_ann_for_model(
             }
             let vector_count = bridge.id_map.len();
             if let Some(fingerprint) = fp_after {
-                if let Err(e) = persist_snapshot(rt, &ns, model, &bridge, fingerprint).await {
+                if let Err(e) = persist_snapshot(rt, ns, model, &bridge, fingerprint).await {
                     tracing::warn!(error = %e, "failed to persist memory Vamana snapshot");
                 }
             }
@@ -412,8 +375,7 @@ pub(crate) async fn ensure_ann_for_model(
 
 // ── corpus loading ────────────────────────────────────────────────────────────
 
-/// Compute a fingerprint scoped strictly to memory note vectors
-/// (`kind='note'`, `field='note.content'`) for `(namespace, model)`.
+/// Compute a fingerprint for all non-deleted memory note vectors for `model` (all namespaces).
 async fn compute_memory_fingerprint(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -421,18 +383,19 @@ async fn compute_memory_fingerprint(
 ) -> Option<CorpusFingerprint> {
     let store = rt.vectors_for_model(token, model).ok()?;
     let info = store.info().await.ok()?;
-    let namespace = token.namespace().as_str().to_owned();
     let table_name = format!("vec_{}", sanitize_model_key(model));
     let sql = rt.sql();
     let mut reader = sql.reader().await.ok()?;
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT COUNT(*) AS n FROM {table_name} \
-                 WHERE namespace = ?1 AND embedding_model = ?2 \
-                   AND kind = 'note' AND field = 'note.content'"
+                "SELECT COUNT(*) AS n FROM {table_name} v \
+                 JOIN notes n ON n.id = v.subject_id \
+                 WHERE v.embedding_model = ?1 \
+                   AND v.kind = 'note' AND v.field = 'note.content' \
+                   AND n.deleted_at IS NULL"
             ),
-            params: vec![SqlValue::Text(namespace), SqlValue::Text(model.to_owned())],
+            params: vec![SqlValue::Text(model.to_owned())],
             label: Some("memory_ann_fingerprint".into()),
         })
         .await
@@ -447,7 +410,7 @@ async fn compute_memory_fingerprint(
     })
 }
 
-/// Scan all `note.content` vectors for `(namespace, model)` and build an
+/// Scan all non-deleted `note.content` vectors across all namespaces for `model` and build an
 /// `AnnBridge`. Returns `Ok(None)` when the corpus is empty or inaccessible.
 async fn load_and_build_from_vector_store(
     rt: &KhiveRuntime,
@@ -462,12 +425,11 @@ async fn load_and_build_from_vector_store(
         .info()
         .await
         .map_err(|e| RuntimeError::Internal(e.to_string()))?;
-    if info.entry_count == 0 || info.dimensions == 0 {
+    if info.dimensions == 0 {
         return Ok(None);
     }
     let dims = info.dimensions;
 
-    let ns = token.namespace().as_str().to_owned();
     let model_key = sanitize_model_key(model);
     let table_name = format!("vec_{model_key}");
 
@@ -480,12 +442,14 @@ async fn load_and_build_from_vector_store(
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT subject_id, embedding FROM {table_name} \
-                 WHERE namespace = ?1 AND embedding_model = ?2 \
-                   AND kind = 'note' AND field = 'note.content' \
-                 ORDER BY subject_id"
+                "SELECT v.subject_id, v.embedding FROM {table_name} v \
+                 JOIN notes n ON n.id = v.subject_id \
+                 WHERE v.embedding_model = ?1 \
+                   AND v.kind = 'note' AND v.field = 'note.content' \
+                   AND n.deleted_at IS NULL \
+                 ORDER BY v.subject_id"
             ),
-            params: vec![SqlValue::Text(ns), SqlValue::Text(model.to_owned())],
+            params: vec![SqlValue::Text(model.to_owned())],
             label: Some("memory_ann_corpus_scan".into()),
         })
         .await
@@ -629,10 +593,10 @@ async fn try_load_snapshot(
     }
 }
 
-/// Delete all memory Vamana snapshot rows for `namespace` from
-/// `retrieval_snapshots`. Best-effort — missing table is silently ignored.
-async fn invalidate_snapshots(rt: &KhiveRuntime, namespace: &str) {
-    let pattern = format!("{namespace}::memory_vamana::%");
+/// Delete the global memory Vamana snapshot rows from `retrieval_snapshots`.
+/// Best-effort — missing table is silently ignored.
+async fn invalidate_snapshots(rt: &KhiveRuntime) {
+    let pattern = "global::memory_vamana::%".to_string();
     let sql = rt.sql();
     let mut w = match sql.writer().await {
         Ok(w) => w,
@@ -664,12 +628,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ann_key_includes_namespace_and_model() {
+    fn ann_key_is_model_only() {
+        // After FTS+ANN consolidation AnnKey is model-only; namespace is ignored.
         let k1 = AnnKey::new("ns:a", "model-x");
-        let k2 = AnnKey::new("ns:b", "model-x");
-        let k3 = AnnKey::new("ns:a", "model-x");
-        assert_ne!(k1, k2, "same model, different namespace must differ");
-        assert_eq!(k1, k3, "identical keys must be equal");
+        let k2 = AnnKey::new("ns:b", "model-x"); // same model, different ns → same key
+        let k3 = AnnKey::new("ns:a", "model-y"); // different model → different key
+        assert_eq!(
+            k1, k2,
+            "same model, different namespace must produce the same key"
+        );
+        assert_ne!(k1, k3, "different models must produce different keys");
     }
 
     #[test]
@@ -717,22 +685,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidate_namespace_clears_indexes_and_warming() {
+    async fn invalidate_namespace_clears_global_index() {
+        // After FTS+ANN consolidation, AnnKey is model-only (namespace is ignored).
+        // invalidate_namespace clears the single global index for all models.
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let ann = new_shared();
-        let model = "test-model";
+        let model_a = "model-a";
+        let model_b = "model-b";
 
         let id_a = Uuid::new_v4();
         let id_b = Uuid::new_v4();
 
-        // Insert two keys: one in ns:a, one in ns:b.
         let bridge_a =
             AnnBridge::build(vec![1.0f32, 0.0, 0.0, 0.0], 4, vec![id_a]).expect("build a");
         let bridge_b =
             AnnBridge::build(vec![0.0f32, 1.0, 0.0, 0.0], 4, vec![id_b]).expect("build b");
 
-        let key_a = AnnKey::new("ns:a", model);
-        let key_b = AnnKey::new("ns:b", model);
+        // Keys are model-only; namespace arg is ignored.
+        let key_a = AnnKey::new("any-ns", model_a);
+        let key_b = AnnKey::new("any-ns", model_b);
 
         {
             let mut idxs = ann.indexes.write().await;
@@ -745,24 +716,16 @@ mod tests {
             warming.insert(key_b.clone());
         }
 
-        // Invalidate ns:a only.
-        invalidate_namespace(&rt, &ann, "ns:a").await;
+        // invalidate_namespace evicts ALL in-memory indexes (global index serves all namespaces).
+        invalidate_namespace(&rt, &ann, "any-ns").await;
 
         assert!(
-            !ann.indexes.read().await.contains_key(&key_a),
-            "ns:a index must be removed"
+            ann.indexes.read().await.is_empty(),
+            "all indexes must be cleared after invalidation"
         );
         assert!(
-            ann.indexes.read().await.contains_key(&key_b),
-            "ns:b index must survive"
-        );
-        assert!(
-            !ann.warming.lock().await.contains(&key_a),
-            "ns:a warming guard must be removed"
-        );
-        assert!(
-            ann.warming.lock().await.contains(&key_b),
-            "ns:b warming guard must survive"
+            ann.warming.lock().await.is_empty(),
+            "all warming guards must be cleared after invalidation"
         );
     }
 }

--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -85,6 +85,15 @@ pub struct RecallConfig {
     // --- FTS candidate-gather optimization ---
     /// Controls the two-stage FTS gather path (default: disabled, existing behavior).
     pub fts_gather: RecallFtsGatherConfig,
+
+    // --- ANN over-fetch retry ---
+    /// Maximum rounds for the ANN namespace over-fetch retry loop.
+    ///
+    /// Round 1 is the initial over-fetch; rounds 2–N double the fetch window
+    /// until enough visible-namespace candidates are found or the corpus is
+    /// exhausted. When `None`, falls back to the `ANN_OVERFETCH_MAX_ROUNDS`
+    /// env var (default 3). Pass `Some(1)` to disable widening entirely.
+    pub ann_overfetch_max_rounds: Option<usize>,
 }
 
 /// Brain-profile hint for score boosting during recall.
@@ -384,6 +393,7 @@ impl Default for RecallConfig {
             scoring: None,
             brain_profile: None,
             fts_gather: RecallFtsGatherConfig::default(),
+            ann_overfetch_max_rounds: None,
         }
     }
 }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -776,7 +776,12 @@ impl MemoryPack {
             // Maximum rounds for the ANN over-fetch retry loop. Round 1 is the initial
             // over-fetch; rounds 2–N double the fetch window until the corpus is
             // exhausted or enough visible-namespace candidates are found.
-            const ANN_OVERFETCH_MAX_ROUNDS: usize = 3;
+            // Can be overridden via ANN_OVERFETCH_MAX_ROUNDS env var (tests use 1 to
+            // verify the gate fires correctly, i.e. that round 1 alone is insufficient).
+            let ann_overfetch_max_rounds: usize = std::env::var("ANN_OVERFETCH_MAX_ROUNDS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3);
 
             let t_ann_total = if prof { Some(Instant::now()) } else { None };
             let mut ann_route = "ann";
@@ -830,18 +835,35 @@ impl MemoryPack {
                     let note_store = self.runtime.notes(token)?;
                     let visible_set: std::collections::HashSet<&str> =
                         visible_namespaces.iter().map(String::as_str).collect();
-                    let is_multi_ns = visible_namespaces.len() > 1
-                        || visible_namespaces
-                            .first()
-                            .is_some_and(|ns| ns.as_str() != "local");
+
+                    // Gate: run the retry loop only when the global ANN index contains
+                    // vectors from namespaces outside the caller's visible set.
+                    //
+                    // We query the namespace set stored on the loaded AnnBridge. If the
+                    // set is empty (e.g. freshly snapshot-restored bridge whose set has
+                    // not yet been populated) we treat it conservatively as "may contain
+                    // non-visible namespaces" and proceed with the loop. If the index
+                    // namespace set is a subset of visible_set then all indexed vectors
+                    // pass the post-filter on round 1 — no retry needed.
+                    let index_has_non_visible =
+                        match ann::index_namespace_set(&self.ann, &key).await {
+                            Some(index_ns) if !index_ns.is_empty() => {
+                                !index_ns.iter().all(|ns| visible_set.contains(ns.as_str()))
+                            }
+                            // Empty set (snapshot-restored without population yet) or cache miss:
+                            // be conservative — assume non-visible namespaces may be present.
+                            _ => true,
+                        };
 
                     let mut best_raw = first_raw;
                     let mut current_fetch_limit = ann_fetch_limit;
 
-                    // Only run the retry loop when there are multiple visible namespaces;
-                    // single-namespace stores always get all local candidates on round 1.
-                    if is_multi_ns {
-                        for _round in 1..ANN_OVERFETCH_MAX_ROUNDS {
+                    // Run the retry loop only when the index spans namespaces outside
+                    // the caller's visible set. On a single-namespace store where the
+                    // index only covers the visible namespace, this is skipped entirely
+                    // at zero extra cost (no note-batch fetch, no extra ANN searches).
+                    if index_has_non_visible {
+                        for _round in 1..ann_overfetch_max_rounds {
                             let corpus_exhausted = best_raw.len() < current_fetch_limit;
                             if corpus_exhausted {
                                 break;

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -40,6 +40,16 @@ pub(super) fn recall_profile_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("KHIVE_RECALL_PROFILE").is_ok())
 }
 
+pub(super) fn ann_overfetch_max_rounds() -> usize {
+    static ROUNDS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *ROUNDS.get_or_init(|| {
+        std::env::var("ANN_OVERFETCH_MAX_ROUNDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3)
+    })
+}
+
 #[inline(always)]
 pub(super) fn plog(call_id: u64, stage: &str, us: u128) {
     eprintln!(r#"{{"c":{},"s":"{}","us":{}}}"#, call_id, stage, us);
@@ -776,12 +786,9 @@ impl MemoryPack {
             // Maximum rounds for the ANN over-fetch retry loop. Round 1 is the initial
             // over-fetch; rounds 2–N double the fetch window until the corpus is
             // exhausted or enough visible-namespace candidates are found.
-            // Can be overridden via ANN_OVERFETCH_MAX_ROUNDS env var (tests use 1 to
-            // verify the gate fires correctly, i.e. that round 1 alone is insufficient).
-            let ann_overfetch_max_rounds: usize = std::env::var("ANN_OVERFETCH_MAX_ROUNDS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(3);
+            // Resolved once per process via OnceLock (see ann_overfetch_max_rounds());
+            // tests must set ANN_OVERFETCH_MAX_ROUNDS before process start.
+            let ann_overfetch_max_rounds = ann_overfetch_max_rounds();
 
             let t_ann_total = if prof { Some(Instant::now()) } else { None };
             let mut ann_route = "ann";

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -773,76 +773,131 @@ impl MemoryPack {
                 }
             }
 
+            // Maximum rounds for the ANN over-fetch retry loop. Round 1 is the initial
+            // over-fetch; rounds 2–N double the fetch window until the corpus is
+            // exhausted or enough visible-namespace candidates are found.
+            const ANN_OVERFETCH_MAX_ROUNDS: usize = 3;
+
             let t_ann_total = if prof { Some(Instant::now()) } else { None };
             let mut ann_route = "ann";
             let mut results = Vec::with_capacity(query_vecs.len());
             for (model_name, vec) in query_vecs {
                 let key = AnnKey::new(ns, &model_name);
 
-                // ANN path: search the global index with ann_fetch_limit (over-fetch).
-                // The index spans all namespaces; namespace filtering is applied later
-                // at load_memory_candidate_notes where note rows carry their namespace.
-                match ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await {
-                    Ok(Some(raw_hits)) => {
-                        tracing::debug!(
-                            model = %model_name,
-                            namespace = %ns,
-                            hits = raw_hits.len(),
-                            "memory recall via warm ANN"
-                        );
-                        let hits: Vec<VectorSearchHit> = raw_hits
-                            .into_iter()
-                            .enumerate()
-                            .map(|(idx, (uuid, score))| VectorSearchHit {
-                                subject_id: uuid,
-                                score: khive_score::DeterministicScore::from_f64(score as f64),
-                                rank: (idx + 1) as u32,
-                            })
-                            .collect();
-                        results.push((model_name, hits));
-                        continue;
-                    }
-                    Ok(None) => {
-                        let status =
-                            ann::ensure_ann_for_model(&self.runtime, token, &self.ann, &model_name)
-                                .await?;
-                        tracing::debug!(
-                            ?status,
-                            model = %model_name,
-                            namespace = %ns,
-                            "memory ANN ensured on recall miss"
-                        );
-                        if let Some(raw_hits) =
+                // ANN path: search the global index with ann_fetch_limit (over-fetch)
+                // plus a bounded widening retry. The index spans all namespaces;
+                // namespace scoping is enforced here by counting how many returned IDs
+                // belong to the caller's visible_namespaces set. If fewer than
+                // candidate_limit candidates survive, we double the fetch window and
+                // retry — up to ANN_OVERFETCH_MAX_ROUNDS total rounds, or until the
+                // index is exhausted (returned hits < requested k). Single-namespace
+                // stores fill on round 1 at zero extra cost.
+                let initial_raw_hits: Option<Vec<(Uuid, f32)>> =
+                    match ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await {
+                        Ok(Some(hits)) => Some(hits),
+                        Ok(None) => {
+                            let status = ann::ensure_ann_for_model(
+                                &self.runtime,
+                                token,
+                                &self.ann,
+                                &model_name,
+                            )
+                            .await?;
+                            tracing::debug!(
+                                ?status,
+                                model = %model_name,
+                                namespace = %ns,
+                                "memory ANN ensured on recall miss"
+                            );
                             ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
-                        {
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                namespace = %ns,
+                                model = %model_name,
+                                "memory ANN search failed; falling back to exact sqlite-vec"
+                            );
+                            ann::clear_key(&self.ann, &key).await;
+                            None
+                        }
+                    };
+
+                if let Some(first_raw) = initial_raw_hits {
+                    // Bounded retry: widen fetch window if visible-namespace survivors
+                    // are short. Termination: enough survivors OR corpus exhausted (returned
+                    // hits < requested k means the index has no more candidates).
+                    let note_store = self.runtime.notes(token)?;
+                    let visible_set: std::collections::HashSet<&str> =
+                        visible_namespaces.iter().map(String::as_str).collect();
+                    let is_multi_ns = visible_namespaces.len() > 1
+                        || visible_namespaces
+                            .first()
+                            .is_some_and(|ns| ns.as_str() != "local");
+
+                    let mut best_raw = first_raw;
+                    let mut current_fetch_limit = ann_fetch_limit;
+
+                    // Only run the retry loop when there are multiple visible namespaces;
+                    // single-namespace stores always get all local candidates on round 1.
+                    if is_multi_ns {
+                        for _round in 1..ANN_OVERFETCH_MAX_ROUNDS {
+                            let corpus_exhausted = best_raw.len() < current_fetch_limit;
+                            if corpus_exhausted {
+                                break;
+                            }
+                            // Count visible-namespace survivors via a lightweight note batch fetch.
+                            let candidate_ids: Vec<Uuid> =
+                                best_raw.iter().map(|(id, _)| *id).collect();
+                            let notes = note_store.get_notes_batch(&candidate_ids).await?;
+                            let visible_count = notes
+                                .iter()
+                                .filter(|n| {
+                                    n.deleted_at.is_none()
+                                        && n.kind == "memory"
+                                        && visible_set.contains(n.namespace.as_str())
+                                })
+                                .count();
+                            if visible_count >= candidate_limit as usize {
+                                break;
+                            }
+                            // Widen and retry.
+                            current_fetch_limit *= 2;
                             tracing::debug!(
                                 model = %model_name,
                                 namespace = %ns,
-                                hits = raw_hits.len(),
-                                "memory recall via warm ANN (after build)"
+                                visible_count,
+                                candidate_limit,
+                                new_fetch_limit = current_fetch_limit,
+                                "memory ANN: widening over-fetch (visible survivors short)"
                             );
-                            let hits: Vec<VectorSearchHit> = raw_hits
-                                .into_iter()
-                                .enumerate()
-                                .map(|(idx, (uuid, score))| VectorSearchHit {
-                                    subject_id: uuid,
-                                    score: khive_score::DeterministicScore::from_f64(score as f64),
-                                    rank: (idx + 1) as u32,
-                                })
-                                .collect();
-                            results.push((model_name, hits));
-                            continue;
+                            if let Ok(Some(wider)) =
+                                ann::search_loaded(&self.ann, &key, &vec, current_fetch_limit).await
+                            {
+                                best_raw = wider;
+                            } else {
+                                break;
+                            }
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            namespace = %ns,
-                            model = %model_name,
-                            "memory ANN search failed; falling back to exact sqlite-vec"
-                        );
-                        ann::clear_key(&self.ann, &key).await;
-                    }
+
+                    tracing::debug!(
+                        model = %model_name,
+                        namespace = %ns,
+                        hits = best_raw.len(),
+                        "memory recall via warm ANN"
+                    );
+                    let hits: Vec<VectorSearchHit> = best_raw
+                        .into_iter()
+                        .enumerate()
+                        .map(|(idx, (uuid, score))| VectorSearchHit {
+                            subject_id: uuid,
+                            score: khive_score::DeterministicScore::from_f64(score as f64),
+                            rank: (idx + 1) as u32,
+                        })
+                        .collect();
+                    results.push((model_name, hits));
+                    continue;
                 }
 
                 // sqlite-vec fallback: the query includes namespace IN (...) so it

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -278,10 +278,13 @@ pub(super) fn make_pipeline(cfg: &RecallConfig) -> MemoryRecallPipeline {
 pub(super) struct RecallCandidateSet {
     pub(super) namespace: String,
     pub(super) text_hits: Vec<TextSearchHit>,
-    /// One entry per embedding model: (model_name, hits).
+    /// One entry per embedding model: (model_name, hits). These have already been
+    /// filtered to the caller's visible namespace set via over-fetch + post-filter.
     pub(super) vector_hits_per_model: Vec<(String, Vec<VectorSearchHit>)>,
     /// True when multilingual dense routing was requested AND a multilingual model was found.
     pub(super) multilingual_routed: bool,
+    /// The caller's full visible namespace set (primary + any explicit extras).
+    pub(super) visible_namespaces: Vec<String>,
 }
 
 impl RecallCandidateSet {
@@ -351,6 +354,9 @@ pub(super) struct RecallVectorCandidateParams<'a> {
     /// Route the dense/vector path to the multilingual model. Keyed on `needs_multilingual`.
     pub(super) use_multilingual: bool,
     pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
+    /// Namespace set the caller is allowed to read. ANN returns global candidates;
+    /// post-filter trims to this set before returning hits.
+    pub(super) visible_namespaces: Vec<String>,
 }
 
 pub(super) struct RecallVectorCandidateResult {
@@ -596,8 +602,9 @@ impl MemoryPack {
 
         // FTS recall uses the single shared fts_notes table. Namespace filtering
         // is applied via TextFilter.namespaces with the full visible set.
-        // ANN recall uses the single global index per model; namespace filtering
-        // is applied post-search by passing visible_namespaces to the vector path.
+        // ANN recall uses the single global index per model (spans all namespaces).
+        // Namespace scoping is applied post-search: the vector path over-fetches,
+        // then filters candidates to the caller's visible set before returning.
         let visible: Vec<String> = token
             .visible_namespace_strs()
             .into_iter()
@@ -623,6 +630,7 @@ impl MemoryPack {
                 embedding_model,
                 use_multilingual,
                 scoring_cfg,
+                visible_namespaces: visible.clone(),
             },
         );
         let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
@@ -631,10 +639,22 @@ impl MemoryPack {
             text_hits,
             vector_hits_per_model: vector_result.vector_hits_per_model,
             multilingual_routed: vector_result.multilingual_routed,
+            visible_namespaces: visible,
         })
     }
 
     /// Collect vector (ANN / sqlite-vec) recall candidates.
+    ///
+    /// ANN path: the global index spans all namespaces. To respect the caller's
+    /// visible namespace set we over-fetch and then apply a post-filter at note
+    /// hydration time (see `load_memory_candidate_notes`). The over-fetch factor
+    /// is F=4 with a fixed margin M=32: k' = max(k * 4, k + 32). This ensures
+    /// enough candidates survive the namespace filter to fill `k` results on a
+    /// single-namespace store at no extra cost (all candidates pass the filter
+    /// on round 1). On a multi-namespace store the margin absorbs foreign hits.
+    ///
+    /// sqlite-vec fallback: namespace filter is passed directly into the query
+    /// (`namespace = ?`) so no over-fetch is required.
     pub(super) async fn collect_recall_vector_hits(
         &self,
         token: &NamespaceToken,
@@ -647,7 +667,16 @@ impl MemoryPack {
             embedding_model,
             use_multilingual,
             scoring_cfg,
+            visible_namespaces,
         } = opts;
+
+        // Over-fetch factor for the ANN path: F=4, M=32.
+        // k' = max(k * F, k + M) so a 4× wider search compensates for foreign-namespace hits.
+        // On a single-namespace store round-1 always satisfies k (zero foreign hits).
+        const ANN_OVERFETCH_FACTOR: usize = 4;
+        const ANN_OVERFETCH_MARGIN: usize = 32;
+        let ann_fetch_limit = (candidate_limit as usize * ANN_OVERFETCH_FACTOR)
+            .max(candidate_limit as usize + ANN_OVERFETCH_MARGIN);
         let prof = recall_profile_enabled();
         let call_id = PROF_CID.with(|c| c.get());
 
@@ -750,7 +779,10 @@ impl MemoryPack {
             for (model_name, vec) in query_vecs {
                 let key = AnnKey::new(ns, &model_name);
 
-                match ann::search_loaded(&self.ann, &key, &vec, candidate_limit as usize).await {
+                // ANN path: search the global index with ann_fetch_limit (over-fetch).
+                // The index spans all namespaces; namespace filtering is applied later
+                // at load_memory_candidate_notes where note rows carry their namespace.
+                match ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await {
                     Ok(Some(raw_hits)) => {
                         tracing::debug!(
                             model = %model_name,
@@ -781,8 +813,7 @@ impl MemoryPack {
                             "memory ANN ensured on recall miss"
                         );
                         if let Some(raw_hits) =
-                            ann::search_loaded(&self.ann, &key, &vec, candidate_limit as usize)
-                                .await?
+                            ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await?
                         {
                             tracing::debug!(
                                 model = %model_name,
@@ -814,22 +845,36 @@ impl MemoryPack {
                     }
                 }
 
+                // sqlite-vec fallback: the query includes namespace IN (...) so it
+                // respects the caller's visible set directly without over-fetch.
+                // When visible_namespaces has multiple entries we fan out one search
+                // per namespace and union the results, since VectorSearchRequest
+                // accepts a single namespace string.
                 tracing::debug!(model = %model_name, namespace = %ns, "memory recall via exact sqlite-vec");
                 ann_route = "sqlite_vec";
-                let hits = self
-                    .runtime
-                    .vectors_for_model(token, &model_name)?
-                    .search(VectorSearchRequest {
-                        query_vectors: vec![vec],
-                        top_k: candidate_limit,
-                        namespace: Some(ns.to_string()),
-                        kind: Some(SubstrateKind::Note),
-                        embedding_model: Some(model_name.clone()),
-                        filter: None,
-                        backend_hints: None,
-                    })
-                    .await?;
-                results.push((model_name, hits));
+                let store = self.runtime.vectors_for_model(token, &model_name)?;
+                let mut all_hits: Vec<VectorSearchHit> = Vec::new();
+                for search_ns in &visible_namespaces {
+                    let ns_hits = store
+                        .search(VectorSearchRequest {
+                            query_vectors: vec![vec.clone()],
+                            top_k: candidate_limit,
+                            namespace: Some(search_ns.clone()),
+                            kind: Some(SubstrateKind::Note),
+                            embedding_model: Some(model_name.clone()),
+                            filter: None,
+                            backend_hints: None,
+                        })
+                        .await?;
+                    all_hits.extend(ns_hits);
+                }
+                // Merge + re-rank by score descending.
+                all_hits.sort_by(|a, b| b.score.cmp(&a.score));
+                all_hits.truncate(candidate_limit as usize);
+                for (idx, hit) in all_hits.iter_mut().enumerate() {
+                    hit.rank = (idx + 1) as u32;
+                }
+                results.push((model_name, all_hits));
             }
             if prof {
                 if let Some(t) = t_ann_total {
@@ -878,8 +923,18 @@ impl MemoryPack {
         let batch = note_store.get_notes_batch(&candidate_ids).await?;
         let mut memory_ids = HashSet::new();
         let mut notes_by_id = HashMap::new();
+        let visible_set: std::collections::HashSet<&str> = candidates
+            .visible_namespaces
+            .iter()
+            .map(String::as_str)
+            .collect();
         for note in batch {
-            if note.deleted_at.is_none() && note.kind == "memory" {
+            // Post-filter: ANN over-fetch may include rows from outside the caller's
+            // visible namespace set. Drop them here where the note row carries its namespace.
+            if note.deleted_at.is_none()
+                && note.kind == "memory"
+                && visible_set.contains(note.namespace.as_str())
+            {
                 memory_ids.insert(note.id);
                 notes_by_id.insert(note.id, note);
             }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -524,7 +524,7 @@ impl MemoryPack {
         &self,
         token: &NamespaceToken,
         query: &str,
-        ns: &str,
+        namespaces: &[String],
         candidate_limit: u32,
         snippet_policy: TextSnippetPolicy,
         cjk_fts_bypass: bool,
@@ -543,7 +543,7 @@ impl MemoryPack {
             crate::text_gather::collect_text_hits(
                 searcher.as_ref(),
                 query,
-                ns,
+                namespaces,
                 candidate_limit,
                 snippet_policy,
                 cjk_fts_bypass,
@@ -557,7 +557,7 @@ impl MemoryPack {
                     query: terms.join(" "),
                     mode: TextQueryMode::AnyTerm,
                     filter: Some(TextFilter {
-                        namespaces: vec![ns.to_string()],
+                        namespaces: namespaces.to_vec(),
                         kinds: vec![SubstrateKind::Note],
                         ..TextFilter::default()
                     }),
@@ -594,94 +594,41 @@ impl MemoryPack {
             fts_gather,
         } = opts;
 
-        // FTS recall fans out across all visible namespaces by iterating each
-        // namespace's own FTS virtual table (fts_notes_{ns}) — there is NO global
-        // FTS table and TextFilter.namespaces does NOT yield cross-namespace hits.
-        // Each namespace is selected by minting a token via token.with_namespace(ns)
-        // (see multi-namespace fanout path below at line 633+).
-        //
-        // Phase-1.5 limitation: vector/ANN recall stays primary-namespace-only.
-        // Each namespace owns a separate ANN index instance; cross-namespace
-        // recall on the vector path requires fanout+fusion across index instances,
-        // which is deferred to a follow-up PR.
-        let visible = token.visible_namespace_strs();
+        // FTS recall uses the single shared fts_notes table. Namespace filtering
+        // is applied via TextFilter.namespaces with the full visible set.
+        // ANN recall uses the single global index per model; namespace filtering
+        // is applied post-search by passing visible_namespaces to the vector path.
+        let visible: Vec<String> = token
+            .visible_namespace_strs()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let primary_ns = token.namespace().as_str().to_string();
 
-        // For single-namespace (common case) take the fast path.
-        if visible.len() <= 1 {
-            let text_fut = self.collect_recall_text_hits(
-                token,
-                query,
-                &primary_ns,
+        let text_fut = self.collect_recall_text_hits(
+            token,
+            query,
+            &visible,
+            candidate_limit,
+            snippet_policy,
+            cjk_fts_bypass,
+            fts_gather,
+        );
+        let vector_fut = self.collect_recall_vector_hits(
+            token,
+            query,
+            &primary_ns,
+            RecallVectorCandidateParams {
                 candidate_limit,
-                snippet_policy,
-                cjk_fts_bypass,
-                fts_gather,
-            );
-            let vector_fut = self.collect_recall_vector_hits(
-                token,
-                query,
-                &primary_ns,
-                RecallVectorCandidateParams {
-                    candidate_limit,
-                    embedding_model,
-                    use_multilingual,
-                    scoring_cfg,
-                },
-            );
-            let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
-            return Ok(RecallCandidateSet {
-                namespace: primary_ns,
-                text_hits,
-                vector_hits_per_model: vector_result.vector_hits_per_model,
-                multilingual_routed: vector_result.multilingual_routed,
-            });
-        }
-
-        // Multi-namespace: fanout FTS across all visible namespaces.
-        //
-        // Each namespace has its own FTS virtual table (fts_notes_{ns}); we must
-        // select that table by minting a token whose primary namespace matches the
-        // target namespace. `token.with_namespace` creates such a token while
-        // preserving the actor context.
-        let mut all_text_hits = Vec::new();
-        for ns_str in &visible {
-            let ns_parsed = match khive_runtime::Namespace::parse(ns_str) {
-                Ok(ns) => ns,
-                Err(_) => continue,
-            };
-            let ns_token = token.with_namespace(ns_parsed);
-            let hits = self
-                .collect_recall_text_hits(
-                    &ns_token,
-                    query,
-                    ns_str,
-                    candidate_limit,
-                    snippet_policy,
-                    cjk_fts_bypass,
-                    fts_gather,
-                )
-                .await?;
-            all_text_hits.extend(hits);
-        }
-        // Vector recall stays in primary namespace (single index).
-        let vector_result = self
-            .collect_recall_vector_hits(
-                token,
-                query,
-                &primary_ns,
-                RecallVectorCandidateParams {
-                    candidate_limit,
-                    embedding_model,
-                    use_multilingual,
-                    scoring_cfg,
-                },
-            )
-            .await?;
-
+                embedding_model,
+                use_multilingual,
+                scoring_cfg,
+            },
+        );
+        let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
         Ok(RecallCandidateSet {
             namespace: primary_ns,
-            text_hits: all_text_hits,
+            text_hits,
             vector_hits_per_model: vector_result.vector_hits_per_model,
             multilingual_routed: vector_result.multilingual_routed,
         })

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -356,6 +356,10 @@ pub(super) struct RecallCandidateParams<'a> {
     pub(super) scoring_cfg: &'a crate::scoring::ScoringConfig,
     pub(super) snippet_policy: TextSnippetPolicy,
     pub(super) fts_gather: &'a crate::config::RecallFtsGatherConfig,
+    /// Maximum rounds for the ANN over-fetch retry loop. Threaded from
+    /// `RecallConfig::ann_overfetch_max_rounds` (with OnceLock env fallback)
+    /// so tests can drive both branches in-process without env mutation.
+    pub(super) ann_overfetch_max_rounds: usize,
 }
 
 pub(super) struct RecallVectorCandidateParams<'a> {
@@ -367,6 +371,13 @@ pub(super) struct RecallVectorCandidateParams<'a> {
     /// Namespace set the caller is allowed to read. ANN returns global candidates;
     /// post-filter trims to this set before returning hits.
     pub(super) visible_namespaces: Vec<String>,
+    /// Maximum rounds for the ANN over-fetch retry loop.
+    ///
+    /// Resolved from `RecallConfig::ann_overfetch_max_rounds` (per-request) with
+    /// fallback to the process-wide `ANN_OVERFETCH_MAX_ROUNDS` env OnceLock.
+    /// Passed explicitly so tests can drive both branches in-process without
+    /// mutating the process-wide env.
+    pub(super) ann_overfetch_max_rounds: usize,
 }
 
 pub(super) struct RecallVectorCandidateResult {
@@ -608,6 +619,7 @@ impl MemoryPack {
             scoring_cfg,
             snippet_policy,
             fts_gather,
+            ann_overfetch_max_rounds,
         } = opts;
 
         // FTS recall uses the single shared fts_notes table (V4 migration). Namespace
@@ -643,6 +655,7 @@ impl MemoryPack {
                 use_multilingual,
                 scoring_cfg,
                 visible_namespaces: visible.clone(),
+                ann_overfetch_max_rounds,
             },
         );
         let (text_hits, vector_result) = tokio::try_join!(text_fut, vector_fut)?;
@@ -680,6 +693,7 @@ impl MemoryPack {
             use_multilingual,
             scoring_cfg,
             visible_namespaces,
+            ann_overfetch_max_rounds,
         } = opts;
 
         // Over-fetch factor for the ANN path: F=4, M=32.
@@ -785,12 +799,10 @@ impl MemoryPack {
                 }
             }
 
-            // Maximum rounds for the ANN over-fetch retry loop. Round 1 is the initial
-            // over-fetch; rounds 2–N double the fetch window until the corpus is
-            // exhausted or enough visible-namespace candidates are found.
-            // Resolved once per process via OnceLock (see ann_overfetch_max_rounds());
-            // tests must set ANN_OVERFETCH_MAX_ROUNDS before process start.
-            let ann_overfetch_max_rounds = ann_overfetch_max_rounds();
+            // ann_overfetch_max_rounds is resolved by the caller (from RecallConfig or
+            // the process-wide OnceLock env fallback) and threaded via
+            // RecallVectorCandidateParams so both branches are exercisable in-process
+            // without env mutation.
 
             let t_ann_total = if prof { Some(Instant::now()) } else { None };
             let mut ann_route = "ann";

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -127,6 +127,12 @@ impl MemoryPack {
             .map_err(|e| RuntimeError::InvalidInput(format!("fts_gather env parse error: {e}")))?
             .unwrap_or_else(|| cfg.fts_gather.clone());
 
+        // Prefer the per-request config param; fall back to the process-wide OnceLock
+        // env so production callers without an explicit config field get the default (3).
+        let ann_overfetch_max_rounds = cfg
+            .ann_overfetch_max_rounds
+            .unwrap_or_else(super::common::ann_overfetch_max_rounds);
+
         let candidates = self
             .collect_recall_candidates(
                 query_trimmed,
@@ -139,6 +145,7 @@ impl MemoryPack {
                     scoring_cfg: &scoring_cfg,
                     snippet_policy: TextSnippetPolicy::Omit,
                     fts_gather: &effective_fts_gather,
+                    ann_overfetch_max_rounds,
                 },
             )
             .await?;

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -104,6 +104,9 @@ impl MemoryPack {
         let effective_fts_gather_cand = crate::config::RecallFtsGatherConfig::from_env()
             .map_err(|e| RuntimeError::InvalidInput(format!("fts_gather env parse error: {e}")))?
             .unwrap_or_else(|| cfg.fts_gather.clone());
+        let ann_overfetch_max_rounds_cand = cfg
+            .ann_overfetch_max_rounds
+            .unwrap_or_else(super::common::ann_overfetch_max_rounds);
 
         let candidates = self
             .collect_recall_candidates(
@@ -119,6 +122,7 @@ impl MemoryPack {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,
                     },
                     fts_gather: &effective_fts_gather_cand,
+                    ann_overfetch_max_rounds: ann_overfetch_max_rounds_cand,
                 },
             )
             .await?;
@@ -206,6 +210,9 @@ impl MemoryPack {
         let effective_fts_gather_fuse = crate::config::RecallFtsGatherConfig::from_env()
             .map_err(|e| RuntimeError::InvalidInput(format!("fts_gather env parse error: {e}")))?
             .unwrap_or_else(|| cfg.fts_gather.clone());
+        let ann_overfetch_max_rounds_fuse = cfg
+            .ann_overfetch_max_rounds
+            .unwrap_or_else(super::common::ann_overfetch_max_rounds);
 
         let candidates = self
             .collect_recall_candidates(
@@ -221,6 +228,7 @@ impl MemoryPack {
                         chars: RECALL_DIAGNOSTIC_SNIPPET_CHARS,
                     },
                     fts_gather: &effective_fts_gather_fuse,
+                    ann_overfetch_max_rounds: ann_overfetch_max_rounds_fuse,
                 },
             )
             .await?;

--- a/crates/khive-pack-memory/src/handlers/sub_handlers.rs
+++ b/crates/khive-pack-memory/src/handlers/sub_handlers.rs
@@ -140,8 +140,11 @@ impl MemoryPack {
             .collect();
 
         let all_vector_hits = candidates.all_vector_hits();
+        // Filter to memory_ids: this drops over-fetched hits from outside the
+        // caller's visible namespace set (those were filtered at hydration time).
         let vector_candidates: Vec<Value> = all_vector_hits
             .iter()
+            .filter(|hit| memory_ids.contains(&hit.subject_id))
             .map(|hit| {
                 json!({
                     "id": hit.subject_id.to_string(),

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -225,6 +225,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         text_hits: text_hits.clone(),
         vector_hits_per_model: vec![("mock".to_string(), vector_hits.clone())],
         multilingual_routed: false,
+        visible_namespaces: vec!["local".to_string()],
     };
     let cfg_rrf = RecallConfig {
         fuse_strategy: FusionStrategy::Rrf { k: 60 },
@@ -238,6 +239,7 @@ fn fusion_strategy_change_produces_observable_ordering_difference() {
         text_hits,
         vector_hits_per_model: vec![("mock".to_string(), vector_hits)],
         multilingual_routed: false,
+        visible_namespaces: vec!["local".to_string()],
     };
     let cfg_weighted = RecallConfig {
         fuse_strategy: FusionStrategy::Weighted {
@@ -578,6 +580,7 @@ fn vector_candidates_per_model_shape_is_array_of_model_objects() {
             ("model-b".to_string(), hits_b),
         ],
         multilingual_routed: false,
+        visible_namespaces: vec!["test".to_string()],
     };
 
     let per_model: Vec<Value> = candidates

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -330,6 +330,7 @@ impl PackRuntime for MemoryPack {
 
     async fn warm(&self) {
         crate::ann::warm_existing_memory_indexes(&self.runtime, &self.ann).await;
+        fts_population_guard(&self.runtime).await;
     }
 
     async fn dispatch(
@@ -351,6 +352,77 @@ impl PackRuntime for MemoryPack {
             _ => Err(RuntimeError::InvalidInput(format!(
                 "memory pack does not handle verb {verb:?}"
             ))),
+        }
+    }
+}
+
+/// Check that the unified FTS tables are adequately populated relative to the
+/// base `notes` and `entities` tables. Called at daemon warm time (after
+/// `kkernel mcp` starts) to detect the V3→V4 migration footgun where the
+/// empty unified tables silently strand FTS recall at ~1% until a manual
+/// `kkernel reindex` is run.
+///
+/// Threshold: warns when `base_count > 100 AND fts_count < base_count / 2`.
+/// A legitimately fresh or empty database (base_count ≤ 100) never warns.
+/// Does NOT hard-fail — boot must succeed even on empty databases.
+async fn fts_population_guard(rt: &KhiveRuntime) {
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    let sql = rt.sql();
+
+    let Ok(mut reader) = sql.reader().await else {
+        tracing::warn!("fts_population_guard: could not open SQL reader — skipping check");
+        return;
+    };
+
+    for (base_table, fts_table) in [("notes", "fts_notes"), ("entities", "fts_entities")] {
+        let base_row = reader
+            .query_row(SqlStatement {
+                sql: format!("SELECT COUNT(*) AS cnt FROM {base_table} WHERE deleted_at IS NULL"),
+                params: vec![],
+                label: None,
+            })
+            .await;
+
+        let base_count: u64 = match base_row {
+            Ok(Some(r)) => match r.get("cnt") {
+                Some(SqlValue::Integer(n)) => *n as u64,
+                _ => 0,
+            },
+            _ => 0,
+        };
+
+        if base_count <= 100 {
+            continue;
+        }
+
+        let fts_row = reader
+            .query_row(SqlStatement {
+                sql: format!("SELECT COUNT(*) AS cnt FROM {fts_table}"),
+                params: vec![],
+                label: None,
+            })
+            .await;
+
+        let fts_count: u64 = match fts_row {
+            Ok(Some(r)) => match r.get("cnt") {
+                Some(SqlValue::Integer(n)) => *n as u64,
+                _ => 0,
+            },
+            _ => 0,
+        };
+
+        if fts_count < base_count / 2 {
+            tracing::warn!(
+                base_table,
+                fts_table,
+                base_count,
+                fts_count,
+                "FTS table is severely under-populated relative to base rows. \
+                 FTS recall will return near-nothing. This is typically caused by \
+                 a V3→V4 schema migration that did not run `kkernel reindex`. \
+                 Fix: run `kkernel reindex --no-knowledge` to repopulate {fts_table}."
+            );
         }
     }
 }

--- a/crates/khive-pack-memory/src/text_gather.rs
+++ b/crates/khive-pack-memory/src/text_gather.rs
@@ -84,7 +84,7 @@ pub fn select_terms_by_stats(
 pub async fn collect_text_hits(
     searcher: &dyn TextSearch,
     _query: &str,
-    ns: &str,
+    namespaces: &[String],
     candidate_limit: u32,
     snippet_policy: TextSnippetPolicy,
     cjk_fts_bypass: bool,
@@ -94,7 +94,7 @@ pub async fn collect_text_hits(
     use khive_storage::types::TextQueryMode;
 
     let filter = Some(TextFilter {
-        namespaces: vec![ns.to_string()],
+        namespaces: namespaces.to_vec(),
         kinds: vec![SubstrateKind::Note],
         ..TextFilter::default()
     });
@@ -133,7 +133,7 @@ pub async fn collect_text_hits(
             .term_stats(TextTermStatsRequest {
                 terms: all_terms.to_vec(),
                 filter: Some(TextFilter {
-                    namespaces: vec![ns.to_string()],
+                    namespaces: namespaces.to_vec(),
                     kinds: vec![SubstrateKind::Note],
                     ..TextFilter::default()
                 }),
@@ -350,7 +350,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "quantum_xqzzy_unique signal_phrase_fixture",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -385,7 +385,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "boundary_token_zzq",
-            ns,
+            &[ns.to_string()],
             150,
             TextSnippetPolicy::Omit,
             false,
@@ -412,7 +412,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -476,7 +476,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "common_word_term rare_xqzzy_token",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -523,7 +523,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "common_alpha common_beta common_gamma",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -574,7 +574,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "机器学习",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             true, // cjk_fts_bypass=true
@@ -632,7 +632,7 @@ mod collect_text_hits_tests {
         let baseline_hits = collect_text_hits(
             &*searcher,
             "alpha_tok beta_tok",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -650,7 +650,7 @@ mod collect_text_hits_tests {
         let ranked_hits = collect_text_hits(
             &*searcher,
             "alpha_tok beta_tok",
-            ns,
+            &[ns.to_string()],
             10,
             TextSnippetPolicy::Omit,
             false,
@@ -693,7 +693,7 @@ mod collect_text_hits_tests {
         let hits = collect_text_hits(
             &*searcher,
             "candidate_tok",
-            ns,
+            &[ns.to_string()],
             5,
             TextSnippetPolicy::Omit,
             false,

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3283,26 +3283,124 @@ async fn test_multi_namespace_recall_overfetch_filter() {
     }
 }
 
-// C1 regression: ANN bounded retry — local memories must be found even when the
-// first over-fetch round is dominated by foreign-namespace hits.
+// ── C1 regression (rewritten) ─────────────────────────────────────────────────
 //
-// Stores N_FOREIGN "foreign" memories followed by N_LOCAL "local" memories in an
-// ANN index that spans both namespaces.  For a wide token (visible = local + foreign),
-// recall@N_LOCAL with `ann_fetch_limit` < total corpus is forced to widen and retry
-// until local candidates accumulate.
+// ANN bounded retry — local memories must be found even when the first over-fetch
+// round is dominated by foreign-namespace vectors that cluster NEAR the query.
 //
-// The retry loop fires when: (a) `is_multi_ns` is true, (b) visible-local survivors
-// from round 1 < candidate_limit, and (c) corpus is not yet exhausted.  Round 2
-// doubles the fetch window; at most ANN_OVERFETCH_MAX_ROUNDS = 3 total rounds.
+// Setup (deterministic, hand-constructed geometry):
+//   - N_FOREIGN=50 "foreign" vectors embedded near the query direction [1,0,0,0].
+//   - N_LOCAL=3  "local"   vectors embedded far from the query direction [0,1,0,0].
+//   - Query text maps to [1,0,0,0] (same cluster as foreign).
+//   - candidate_limit = Some(8) → ann_fetch_limit = max(8×4, 8+32) = 40.
+//   - Round 1: ANN returns 40 nearest → all foreign (locals are far). 0 local survivors.
+//   - The retry gate must fire (index spans "foreign" which is NOT in visible {"local"}).
+//   - Round 2: doubles fetch to 80 > 53 total → exhausts corpus, finds all 3 locals.
 //
-// Correctness assertion: ALL local memory IDs appear in the recall result set,
-// regardless of which round they were found in.
-#[tokio::test]
-async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_cluster() {
-    use khive_runtime::PackRuntime;
+// Correctness:
+//   - Default (ANN_OVERFETCH_MAX_ROUNDS env unset → 3 rounds): all locals FOUND.
+//   - ANN_OVERFETCH_MAX_ROUNDS=1 (single round only): locals MISSING.
+//     Run as: ANN_OVERFETCH_MAX_ROUNDS=1 cargo test -p khive-pack-memory \
+//                test_ann_overfetch_retry_stalls_without_widening
+//
+// Token: uses a DEFAULT local-only token — the production default-recall scenario.
 
-    const MODEL: &str = "c1-retry-enc";
-    const DIMS: usize = 4;
+/// Content-keyed embedding service.
+///
+/// Foreign cluster (query direction):
+///   texts containing "xforeign", or the query "xforeign dominant cluster" → [1,0,0,0]
+///   cosine with query = 1.0 — closest to query, fill top-40 ANN results.
+///
+/// Local cluster (far from query but NOT orthogonal):
+///   texts containing "xlocal" → [0.15, 0.9887, 0.0, 0.0] (pre-normalised unit vector)
+///   cosine with query [1,0,0,0] = 0.15 — above the default min_raw_relevance=0.10 floor,
+///   but cosine < 1.0 so ANN ranks locals behind all 50 foreign vectors.
+///
+/// Geometry guarantee:
+///   ann_fetch_limit=40 < 50 foreign vectors → round 1 returns only foreign hits;
+///   locals are unreachable until the retry widens the window to >53.
+struct ClusteredVecService;
+
+#[async_trait]
+impl EmbeddingService for ClusteredVecService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .map(|t| {
+                if t.contains("xlocal") {
+                    // Far cluster: cosine=0.15 with query direction → above score floor,
+                    // but farther than all 50 foreign vectors (cosine=1.0).
+                    // Pre-normalised: 0.15² + 0.9887² ≈ 0.0225 + 0.9775 = 1.0000.
+                    vec![0.15_f32, 0.9887, 0.0, 0.0]
+                } else {
+                    // "xforeign" content and the query both map to the foreign cluster.
+                    vec![1.0_f32, 0.0, 0.0, 0.0]
+                }
+            })
+            .collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "clustered-vec"
+    }
+}
+
+struct ClusteredVecProvider {
+    provider_name: String,
+}
+
+impl ClusteredVecProvider {
+    fn new(name: &str) -> Self {
+        Self {
+            provider_name: name.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl EmbedderProvider for ClusteredVecProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn dimensions(&self) -> usize {
+        4
+    }
+
+    async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+        Ok(Arc::new(ClusteredVecService))
+    }
+}
+
+/// Shared setup for the C1 regression tests. Returns `(rt, registry, pack, local_ids)`.
+///
+/// Corpus layout:
+///   - 50 foreign memories with vector [1,0,0,0]        (cosine=1.0, nearest to query)
+///   - 3  local  memories with vector [0.15,0.9887,0,0] (cosine=0.15, farther from query)
+///   - Query "xforeign dominant cluster" → vector [1,0,0,0]
+///   - candidate_limit = Some(8) → ann_fetch_limit = 40 < total 53
+///
+/// With only 40 candidates fetched in round 1, all 40 are foreign (nearest to query).
+/// Locals are ranked 51-53 (behind all 50 foreign) and NOT retrieved until the fetch
+/// window is widened to ≥53 (round 2 doubles to 80, exhausting the corpus).
+///
+/// Local cosine=0.15 is above the default min_raw_relevance=0.10 score floor so locals
+/// survive the final scoring step once the retry loop surfaces them.
+async fn c1_setup() -> (
+    KhiveRuntime,
+    khive_runtime::VerbRegistry,
+    MemoryPack,
+    Vec<String>,
+) {
+    const MODEL: &str = "c1-clustered-enc";
     const N_FOREIGN: usize = 50;
     const N_LOCAL: usize = 3;
 
@@ -3313,17 +3411,18 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
         ..RuntimeConfig::default()
     })
     .expect("runtime");
-    rt.register_embedder(ConstVecProvider::new(MODEL, DIMS, 0.5));
+    rt.register_embedder(ClusteredVecProvider::new(MODEL));
 
     let registry = make_registry(rt.clone());
 
-    // Insert N_FOREIGN memories in the "foreign" namespace.
+    // Insert N_FOREIGN memories in "foreign" namespace. Content contains "xforeign"
+    // so the embedder returns [1,0,0,0] — same direction as the query vector.
     for i in 0..N_FOREIGN {
         registry
             .dispatch(
                 "memory.remember",
                 json!({
-                    "content": format!("foreign memory {i} occupying ann slot"),
+                    "content": format!("xforeign memory slot {i} cluster-a"),
                     "salience": 0.6,
                     "namespace": "foreign"
                 }),
@@ -3332,15 +3431,16 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
             .unwrap_or_else(|e| panic!("foreign remember {i} failed: {e}"));
     }
 
-    // Insert N_LOCAL memories in the "local" namespace AFTER foreign ones,
-    // so in insertion-order ANN they appear at the end.
+    // Insert N_LOCAL memories in "local" namespace. Content contains "xlocal"
+    // so the embedder returns [0.15,0.9887,0,0] — far from query (cosine=0.15),
+    // ranked behind all 50 foreign vectors but above the min_raw_relevance floor.
     let mut local_ids = Vec::new();
     for i in 0..N_LOCAL {
         let r = registry
             .dispatch(
                 "memory.remember",
                 json!({
-                    "content": format!("local memory {i} that must be recalled"),
+                    "content": format!("xlocal memory {i} must be recalled"),
                     "salience": 0.8,
                     "namespace": "local"
                 }),
@@ -3350,34 +3450,45 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
         local_ids.push(r["id"].as_str().expect("note_id").to_string());
     }
 
-    // Warm the ANN so all vectors are indexed.
     let pack = MemoryPack::new(rt.clone());
-    pack.warm().await;
+    {
+        use khive_runtime::PackRuntime;
+        pack.warm().await;
+    }
 
-    // Wide token: visible = [local, foreign].  The global ANN index spans all
-    // N_FOREIGN + N_LOCAL = 53 vectors.  With candidate_limit = N_LOCAL and
-    // ann_fetch_limit = max(N_LOCAL*4, N_LOCAL+32) = 35, the first round fetches
-    // 35 of the 53 total.  If ANN returns foreign-namespace entries first (which is
-    // likely when N_FOREIGN > ann_fetch_limit), visible-local survivors < N_LOCAL
-    // and the retry fires.  Round 2 doubles the limit to 70 > 53, exhausting the
-    // corpus and finding all locals.  The assertion must hold regardless of which
-    // round found them.
-    let wide_token = rt
-        .authorize_with_visibility(
-            Namespace::parse("local").expect("local ns"),
-            vec![Namespace::parse("foreign").expect("foreign ns")],
-        )
-        .expect("wide token");
+    (rt, registry, pack, local_ids)
+}
+
+// C1 main: with default retry rounds, local memories ARE found despite the foreign
+// cluster dominating the first over-fetch round.
+#[tokio::test]
+async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_cluster() {
+    use khive_runtime::PackRuntime;
+
+    let (rt, registry, pack, local_ids) = c1_setup().await;
+
+    // Local-only token: the production default. visible = {"local"}.
+    // The global ANN index spans {"local", "foreign"} — retry gate must fire.
+    let local_token = rt
+        .authorize(Namespace::parse("local").expect("local ns"))
+        .expect("authorize local");
 
     let result = pack
         .dispatch(
             "memory.recall",
-            json!({ "query": "local memory must be recalled", "limit": N_LOCAL }),
+            // candidate_limit=Some(8) → ann_fetch_limit=40. Query maps to [1,0,0,0]
+            // (same as foreign cluster). Round 1 returns 40 foreign hits, 0 local.
+            // Retry widens to 80>53, exhausting corpus and finding all 3 locals.
+            json!({
+                "query": "xforeign dominant cluster",
+                "limit": 3,
+                "config": { "candidate_limit": 8 }
+            }),
             &registry,
-            &wide_token,
+            &local_token,
         )
         .await
-        .expect("wide-token recall");
+        .expect("local-token recall");
 
     let hits: Vec<&str> = result
         .as_array()
@@ -3386,11 +3497,72 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
         .map(|h| h["id"].as_str().unwrap())
         .collect();
 
-    // All N_LOCAL local memories must appear in the result.
     for lid in &local_ids {
         assert!(
             hits.contains(&lid.as_str()),
-            "C1 retry regression: local memory {lid} must be in recall result; got: {hits:?}"
+            "C1 retry regression: local memory {lid} must be in recall result with retry; \
+             got: {hits:?}. If this fails with ANN_OVERFETCH_MAX_ROUNDS=1, that is expected."
+        );
+    }
+}
+
+// C1 stall: with ANN_OVERFETCH_MAX_ROUNDS=1, local memories are NOT found because the
+// retry loop is disabled. This test PASSES only when ANN_OVERFETCH_MAX_ROUNDS=1 is set.
+// It is skipped silently when the env var is absent or != "1".
+//
+// Run to confirm the gate matters:
+//   ANN_OVERFETCH_MAX_ROUNDS=1 cargo test -p khive-pack-memory \
+//       test_ann_overfetch_retry_stalls_without_widening -- --nocapture
+#[tokio::test]
+async fn test_ann_overfetch_retry_stalls_without_widening() {
+    use khive_runtime::PackRuntime;
+
+    // Only meaningful when ANN_OVERFETCH_MAX_ROUNDS=1 is set externally.
+    // When unset, the retry loop runs to default (3 rounds) and locals ARE found —
+    // which would make this test always pass trivially. Skip unless forced to 1.
+    let max_rounds = std::env::var("ANN_OVERFETCH_MAX_ROUNDS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(3);
+    if max_rounds != 1 {
+        // Not running with the stall condition — skip.
+        return;
+    }
+
+    let (rt, registry, pack, local_ids) = c1_setup().await;
+
+    let local_token = rt
+        .authorize(Namespace::parse("local").expect("local ns"))
+        .expect("authorize local");
+
+    let result = pack
+        .dispatch(
+            "memory.recall",
+            json!({
+                "query": "xforeign dominant cluster",
+                "limit": 3,
+                "config": { "candidate_limit": 8 }
+            }),
+            &registry,
+            &local_token,
+        )
+        .await
+        .expect("local-token recall (stall)");
+
+    let hits: Vec<&str> = result
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+
+    // With a single round, round 1 fetches 40 of 53 vectors — all foreign (near query).
+    // No retry fires, so local memories (far from query) are silently dropped.
+    for lid in &local_ids {
+        assert!(
+            !hits.contains(&lid.as_str()),
+            "C1 stall: local memory {lid} must NOT appear in single-round recall; \
+             if it does, the test corpus geometry is wrong. hits: {hits:?}"
         );
     }
 }

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3282,3 +3282,115 @@ async fn test_multi_namespace_recall_overfetch_filter() {
         );
     }
 }
+
+// C1 regression: ANN bounded retry — local memories must be found even when the
+// first over-fetch round is dominated by foreign-namespace hits.
+//
+// Stores N_FOREIGN "foreign" memories followed by N_LOCAL "local" memories in an
+// ANN index that spans both namespaces.  For a wide token (visible = local + foreign),
+// recall@N_LOCAL with `ann_fetch_limit` < total corpus is forced to widen and retry
+// until local candidates accumulate.
+//
+// The retry loop fires when: (a) `is_multi_ns` is true, (b) visible-local survivors
+// from round 1 < candidate_limit, and (c) corpus is not yet exhausted.  Round 2
+// doubles the fetch window; at most ANN_OVERFETCH_MAX_ROUNDS = 3 total rounds.
+//
+// Correctness assertion: ALL local memory IDs appear in the recall result set,
+// regardless of which round they were found in.
+#[tokio::test]
+async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_cluster() {
+    use khive_runtime::PackRuntime;
+
+    const MODEL: &str = "c1-retry-enc";
+    const DIMS: usize = 4;
+    const N_FOREIGN: usize = 50;
+    const N_LOCAL: usize = 3;
+
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("runtime");
+    rt.register_embedder(ConstVecProvider::new(MODEL, DIMS, 0.5));
+
+    let registry = make_registry(rt.clone());
+
+    // Insert N_FOREIGN memories in the "foreign" namespace.
+    for i in 0..N_FOREIGN {
+        registry
+            .dispatch(
+                "memory.remember",
+                json!({
+                    "content": format!("foreign memory {i} occupying ann slot"),
+                    "salience": 0.6,
+                    "namespace": "foreign"
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("foreign remember {i} failed: {e}"));
+    }
+
+    // Insert N_LOCAL memories in the "local" namespace AFTER foreign ones,
+    // so in insertion-order ANN they appear at the end.
+    let mut local_ids = Vec::new();
+    for i in 0..N_LOCAL {
+        let r = registry
+            .dispatch(
+                "memory.remember",
+                json!({
+                    "content": format!("local memory {i} that must be recalled"),
+                    "salience": 0.8,
+                    "namespace": "local"
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("local remember {i} failed: {e}"));
+        local_ids.push(r["id"].as_str().expect("note_id").to_string());
+    }
+
+    // Warm the ANN so all vectors are indexed.
+    let pack = MemoryPack::new(rt.clone());
+    pack.warm().await;
+
+    // Wide token: visible = [local, foreign].  The global ANN index spans all
+    // N_FOREIGN + N_LOCAL = 53 vectors.  With candidate_limit = N_LOCAL and
+    // ann_fetch_limit = max(N_LOCAL*4, N_LOCAL+32) = 35, the first round fetches
+    // 35 of the 53 total.  If ANN returns foreign-namespace entries first (which is
+    // likely when N_FOREIGN > ann_fetch_limit), visible-local survivors < N_LOCAL
+    // and the retry fires.  Round 2 doubles the limit to 70 > 53, exhausting the
+    // corpus and finding all locals.  The assertion must hold regardless of which
+    // round found them.
+    let wide_token = rt
+        .authorize_with_visibility(
+            Namespace::parse("local").expect("local ns"),
+            vec![Namespace::parse("foreign").expect("foreign ns")],
+        )
+        .expect("wide token");
+
+    let result = pack
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "local memory must be recalled", "limit": N_LOCAL }),
+            &registry,
+            &wide_token,
+        )
+        .await
+        .expect("wide-token recall");
+
+    let hits: Vec<&str> = result
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+
+    // All N_LOCAL local memories must appear in the result.
+    for lid in &local_ids {
+        assert!(
+            hits.contains(&lid.as_str()),
+            "C1 retry regression: local memory {lid} must be in recall result; got: {hits:?}"
+        );
+    }
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3117,3 +3117,168 @@ async fn test_recall_budget_truncation_preserves_rank_order() {
          its presence proves the old greedy retain was used instead of the prefix cut"
     );
 }
+
+// ── B2 — multi-namespace recall regression (ADR-062 §2 over-fetch + filter) ────
+
+/// B2: ANN over-fetch + namespace post-filter.
+///
+/// Stores memories in two namespaces (`local` and `other`).  The global ANN index
+/// spans both.  Asserts:
+///  1. Default recall (visible = [`local`]) excludes `other`-namespace memories.
+///  2. A wide token (visible = [`local`, `other`]) includes both namespaces.
+///  3. Recall@k is satisfied when ≥k local candidates exist (over-fetch is enough).
+///
+/// Uses a deterministic custom embedder (no lattice weights required).
+#[tokio::test]
+async fn test_multi_namespace_recall_overfetch_filter() {
+    use khive_runtime::PackRuntime;
+
+    const MODEL: &str = "ns-filter-enc";
+    const DIMS: usize = 8;
+
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        ..RuntimeConfig::default()
+    })
+    .expect("runtime");
+    rt.register_embedder(ConstVecProvider::new(MODEL, DIMS, 0.42));
+
+    let registry = make_registry(rt.clone());
+
+    // Store 3 memories in `local` namespace.
+    let mut local_ids = Vec::new();
+    for i in 0..3 {
+        let r = registry
+            .dispatch(
+                "memory.remember",
+                json!({
+                    "content": format!("local memory entry number {i} about graph databases"),
+                    "salience": 0.7,
+                    "namespace": "local"
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("local remember {i} failed: {e}"));
+        local_ids.push(r["id"].as_str().expect("note_id").to_string());
+    }
+
+    // Store 2 memories in `other` namespace.
+    let mut other_ids = Vec::new();
+    for i in 0..2 {
+        let r = registry
+            .dispatch(
+                "memory.remember",
+                json!({
+                    "content": format!("other namespace memory {i} about graph databases"),
+                    "salience": 0.7,
+                    "namespace": "other"
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("other remember {i} failed: {e}"));
+        other_ids.push(r["id"].as_str().expect("note_id").to_string());
+    }
+
+    // ── Assertion 1: default recall (local-only) excludes `other` memories ────
+    let default_recall = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "graph databases", "limit": 10 }),
+        )
+        .await
+        .expect("default recall");
+    let default_hits: Vec<&str> = default_recall
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+
+    for oid in &other_ids {
+        assert!(
+            !default_hits.contains(&oid.as_str()),
+            "default recall must exclude other-namespace memory {oid}; got: {default_hits:?}"
+        );
+    }
+    for lid in &local_ids {
+        assert!(
+            default_hits.contains(&lid.as_str()),
+            "default recall must include local memory {lid}; got: {default_hits:?}"
+        );
+    }
+
+    // ── Assertion 2: wide token includes both namespaces ──────────────────────
+    let pack = MemoryPack::new(rt.clone());
+    // Warm the ANN so vectors are indexed.
+    pack.warm().await;
+
+    let wide_token = rt
+        .authorize_with_visibility(
+            Namespace::parse("local").expect("local ns"),
+            vec![Namespace::parse("other").expect("other ns")],
+        )
+        .expect("wide token");
+
+    let wide_recall = pack
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "graph databases", "limit": 10 }),
+            &registry,
+            &wide_token,
+        )
+        .await
+        .expect("wide-token recall");
+
+    let wide_hits: Vec<&str> = wide_recall
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+
+    for lid in &local_ids {
+        assert!(
+            wide_hits.contains(&lid.as_str()),
+            "wide-token recall must include local memory {lid}; got: {wide_hits:?}"
+        );
+    }
+    for oid in &other_ids {
+        assert!(
+            wide_hits.contains(&oid.as_str()),
+            "wide-token recall must include other-namespace memory {oid}; got: {wide_hits:?}"
+        );
+    }
+
+    // ── Assertion 3: recall@3 satisfied with 3 local candidates even when ────
+    // the global ANN top results may include foreign-namespace hits.
+    let k3_recall = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "graph databases", "limit": 3 }),
+        )
+        .await
+        .expect("recall@3");
+    let k3_hits: Vec<&str> = k3_recall
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+
+    // All 3 local memories should be present — over-fetch ensures enough
+    // local candidates survive the post-filter even if the global NN top-k
+    // includes foreign-namespace hits.
+    assert_eq!(
+        k3_hits.len(),
+        3,
+        "recall@3 must return exactly 3 results when 3 local candidates exist; got: {k3_hits:?}"
+    );
+    for lid in &local_ids {
+        assert!(
+            k3_hits.contains(&lid.as_str()),
+            "recall@3 must include local memory {lid}; got: {k3_hits:?}"
+        );
+    }
+}

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3887,10 +3887,24 @@ async fn c1_setup() -> (
     (rt, registry, pack, local_ids)
 }
 
-// C1 main: with default retry rounds, local memories ARE found despite the foreign
-// cluster dominating the first over-fetch round.
+// C1 deterministic: asserts BOTH branches of the ANN over-fetch retry loop in a
+// single test with no env mutation. Both branches run every CI invocation.
+//
+// Corpus geometry (see c1_setup):
+//   - 50 foreign vectors [1,0,0,0] closest to query direction
+//   - 3 local  vectors [0.15,0.9887,0,0] farther from query (cosine=0.15)
+//   - candidate_limit=8 → ann_fetch_limit=40 < 53 total
+//
+// Branch (a): ann_overfetch_max_rounds=3 (≥2 rounds needed to widen to 80>53)
+//   → retry fires, corpus exhausted, all 3 locals surface.
+//
+// Branch (b): ann_overfetch_max_rounds=1 (single round only)
+//   → round 1 returns 40 foreign hits; no retry; locals silently absent.
+//
+// Both branches are exercised in-process via RecallConfig.ann_overfetch_max_rounds.
+// No env var mutation; no cross-test interference; no silent skips.
 #[tokio::test]
-async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_cluster() {
+async fn test_ann_overfetch_retry_both_branches_deterministic() {
     use khive_runtime::PackRuntime;
 
     let (rt, registry, pack, local_ids) = c1_setup().await;
@@ -3901,24 +3915,26 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
         .authorize(Namespace::parse("local").expect("local ns"))
         .expect("authorize local");
 
-    let result = pack
+    // Branch (a): with adequate rounds (3), the retry widens to 80>53 and
+    // exhausts the corpus, surfacing all 3 local memories.
+    let result_with_retry = pack
         .dispatch(
             "memory.recall",
-            // candidate_limit=Some(8) → ann_fetch_limit=40. Query maps to [1,0,0,0]
-            // (same as foreign cluster). Round 1 returns 40 foreign hits, 0 local.
-            // Retry widens to 80>53, exhausting corpus and finding all 3 locals.
             json!({
                 "query": "xforeign dominant cluster",
                 "limit": 3,
-                "config": { "candidate_limit": 8 }
+                "config": {
+                    "candidate_limit": 8,
+                    "ann_overfetch_max_rounds": 3
+                }
             }),
             &registry,
             &local_token,
         )
         .await
-        .expect("local-token recall");
+        .expect("recall with retry");
 
-    let hits: Vec<&str> = result
+    let hits_with_retry: Vec<&str> = result_with_retry
         .as_array()
         .expect("array")
         .iter()
@@ -3927,70 +3943,44 @@ async fn test_ann_overfetch_retry_finds_local_memories_in_foreign_dominated_clus
 
     for lid in &local_ids {
         assert!(
-            hits.contains(&lid.as_str()),
-            "C1 retry regression: local memory {lid} must be in recall result with retry; \
-             got: {hits:?}. If this fails with ANN_OVERFETCH_MAX_ROUNDS=1, that is expected."
+            hits_with_retry.contains(&lid.as_str()),
+            "C1 branch-a: local memory {lid} MUST appear when retry rounds=3; \
+             got: {hits_with_retry:?}"
         );
     }
-}
 
-// C1 stall: with ANN_OVERFETCH_MAX_ROUNDS=1, local memories are NOT found because the
-// retry loop is disabled. This test PASSES only when ANN_OVERFETCH_MAX_ROUNDS=1 is set.
-// It is skipped silently when the env var is absent or != "1".
-//
-// Run to confirm the gate matters:
-//   ANN_OVERFETCH_MAX_ROUNDS=1 cargo test -p khive-pack-memory \
-//       test_ann_overfetch_retry_stalls_without_widening -- --nocapture
-#[tokio::test]
-async fn test_ann_overfetch_retry_stalls_without_widening() {
-    use khive_runtime::PackRuntime;
-
-    // Only meaningful when ANN_OVERFETCH_MAX_ROUNDS=1 is set externally.
-    // When unset, the retry loop runs to default (3 rounds) and locals ARE found —
-    // which would make this test always pass trivially. Skip unless forced to 1.
-    let max_rounds = std::env::var("ANN_OVERFETCH_MAX_ROUNDS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(3);
-    if max_rounds != 1 {
-        // Not running with the stall condition — skip.
-        return;
-    }
-
-    let (rt, registry, pack, local_ids) = c1_setup().await;
-
-    let local_token = rt
-        .authorize(Namespace::parse("local").expect("local ns"))
-        .expect("authorize local");
-
-    let result = pack
+    // Branch (b): with a single round, round 1 fetches 40 of 53 vectors — all
+    // foreign (nearest to query direction). No retry fires so local memories
+    // (ranked 51-53 behind all 50 foreign) are absent from the result.
+    let result_no_retry = pack
         .dispatch(
             "memory.recall",
             json!({
                 "query": "xforeign dominant cluster",
                 "limit": 3,
-                "config": { "candidate_limit": 8 }
+                "config": {
+                    "candidate_limit": 8,
+                    "ann_overfetch_max_rounds": 1
+                }
             }),
             &registry,
             &local_token,
         )
         .await
-        .expect("local-token recall (stall)");
+        .expect("recall without retry");
 
-    let hits: Vec<&str> = result
+    let hits_no_retry: Vec<&str> = result_no_retry
         .as_array()
         .expect("array")
         .iter()
         .map(|h| h["id"].as_str().unwrap())
         .collect();
 
-    // With a single round, round 1 fetches 40 of 53 vectors — all foreign (near query).
-    // No retry fires, so local memories (far from query) are silently dropped.
     for lid in &local_ids {
         assert!(
-            !hits.contains(&lid.as_str()),
-            "C1 stall: local memory {lid} must NOT appear in single-round recall; \
-             if it does, the test corpus geometry is wrong. hits: {hits:?}"
+            !hits_no_retry.contains(&lid.as_str()),
+            "C1 branch-b: local memory {lid} must NOT appear when retry rounds=1 \
+             (corpus geometry broken if it does); got: {hits_no_retry:?}"
         );
     }
 }

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -294,11 +294,7 @@ impl KhiveRuntime {
             }
         }
         let ns = token.namespace().as_str().to_owned();
-        let sanitized_ns: String = ns
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect();
-        let fts_table = format!("fts_entities_{}", sanitized_ns);
+        let fts_table = "fts_entities".to_string();
         let vec_tables: Vec<String> = self
             .registered_embedding_model_names()
             .iter()
@@ -612,11 +608,7 @@ impl KhiveRuntime {
             ));
         }
         let ns = token.namespace().as_str().to_string();
-        let sanitized_ns: String = ns
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect();
-        let fts_table = format!("fts_notes_{}", sanitized_ns);
+        let fts_table = "fts_notes".to_string();
         let vec_tables: Vec<String> = self
             .registered_embedding_model_names()
             .iter()

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -292,22 +292,22 @@ impl KhiveRuntime {
         )?)
     }
 
-    /// Get a TextSearch index for the token's namespace entity corpus.
+    /// Get a TextSearch index for the entity corpus (single shared table).
     pub fn text(
         &self,
         token: &NamespaceToken,
     ) -> RuntimeResult<Arc<dyn khive_storage::TextSearch>> {
-        let key = format!("entities_{}", sanitize_key(token.namespace().as_str()));
-        Ok(self.backend.text(&key)?)
+        let _ = token;
+        Ok(self.backend.text("entities")?)
     }
 
-    /// Get a TextSearch index for the token's namespace notes corpus.
+    /// Get a TextSearch index for the notes corpus (single shared table).
     pub fn text_for_notes(
         &self,
         token: &NamespaceToken,
     ) -> RuntimeResult<Arc<dyn khive_storage::TextSearch>> {
-        let key = format!("notes_{}", sanitize_key(token.namespace().as_str()));
-        Ok(self.backend.text(&key)?)
+        let _ = token;
+        Ok(self.backend.text("notes")?)
     }
 
     /// Mint an authorization token for the given namespace.

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -2234,19 +2234,14 @@ async fn create_note_annotates_refuses_target_in_visible_only_namespace() {
 // Finding 5: hybrid_search cross-namespace Option B limitation documented + tested
 // =============================================================================
 
-/// Documents the Phase 1.5 limitation: `hybrid_search` is primary-namespace-only
-/// for both the FTS and vector legs (each namespace owns its own FTS table and
-/// ANN index; cross-namespace fanout is deferred to Phase 1.5).
+/// Verifies that `hybrid_search` with a visible-set token returns entities from
+/// ALL visible namespaces (not just the primary namespace).
 ///
-/// This test verifies the actual current behavior:
-/// - The primary-namespace entity appears in results.
-/// - The extra-namespace entity does NOT appear in results (its FTS data lives
-///   in `fts_entities_{extra-ns}`, a separate table not queried here).
-///
-/// A caller with a visible set can READ the extra-namespace entity directly via
-/// `get_entity`, but `hybrid_search` does not surface it today.
+/// After FTS+ANN consolidation, `fts_entities` is a single shared table with a
+/// `namespace` column. `hybrid_search` passes `visible_ns` as a `TextFilter`
+/// so entities from any visible namespace are surfaced in one query pass.
 #[tokio::test]
-async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
+async fn hybrid_search_surfaces_all_visible_namespaces() {
     let rt = rt();
 
     let ns_primary = Namespace::parse("hs-primary-ns").unwrap();
@@ -2289,7 +2284,7 @@ async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
         .unwrap();
 
     // Search: FTS-only (no embedding model in test runtime).
-    // Current behavior: only primary-namespace results surface.
+    // With consolidated fts_entities, both namespace entities should surface.
     let hits = rt
         .hybrid_search(&vis_tok, "stellar", None, 20, None, None)
         .await
@@ -2305,18 +2300,16 @@ async fn hybrid_search_is_primary_namespace_only_phase1_5_limitation() {
         entity_in_primary.id,
     );
 
-    // Extra-namespace entity does NOT surface — Phase 1.5 limitation.
-    // Each namespace has its own FTS table; cross-namespace FTS fanout is deferred.
+    // Extra-namespace entity must also surface (Phase-1.5 limitation lifted).
+    // The consolidated fts_entities table + namespace column filter enables cross-namespace FTS.
     assert!(
-        !hit_ids.contains(&entity_in_extra.id),
-        "hybrid_search must NOT return entity from extra (visible-only) namespace \
-         until Phase 1.5 cross-namespace fanout ships; \
-         entity_id={} unexpectedly appeared in: {hit_ids:?}",
+        hit_ids.contains(&entity_in_extra.id),
+        "hybrid_search must return entity from visible extra namespace; \
+         entity_id={} missing from: {hit_ids:?}",
         entity_in_extra.id,
     );
 
-    // Direct read of the extra-namespace entity via get_entity must still work
-    // (this proves the visible set wiring is correct — only search is primary-scoped).
+    // Direct read of the extra-namespace entity via get_entity must still work.
     let fetched = rt
         .get_entity(&vis_tok, entity_in_extra.id)
         .await

--- a/crates/khive-storage/src/vectors.rs
+++ b/crates/khive-storage/src/vectors.rs
@@ -160,4 +160,24 @@ pub trait VectorStore: Send + Sync + 'static {
             message: "this backend does not support batch existence checks".into(),
         })
     }
+
+    /// Delete all rows for the given subject IDs, regardless of their stored namespace.
+    ///
+    /// This is a namespace-agnostic sweep — it removes every vector row whose
+    /// `subject_id` matches, no matter which namespace the row was written under.
+    /// Required when the vec table's PRIMARY KEY is `subject_id` alone (not
+    /// `(subject_id, namespace)`): a row from a prior namespace would collide on
+    /// re-insert after a relabel, so the pre-insert drop must target by subject
+    /// only. Returns the number of rows deleted across all chunks.
+    ///
+    /// Default returns [`StorageError::Unsupported`]; backends that store vectors
+    /// in a per-subject keyed table should override this method.
+    async fn delete_subjects(&self, ids: &[Uuid]) -> StorageResult<u64> {
+        let _ = ids;
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Vectors,
+            operation: "delete_subjects".into(),
+            message: "this backend does not support namespace-agnostic subject deletion".into(),
+        })
+    }
 }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -41,6 +41,8 @@ toml = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 serial_test = { workspace = true }
+async-trait = { workspace = true }
+lattice-embed = { workspace = true }
 
 [[bin]]
 name = "kkernel"

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -578,6 +578,17 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         if let Err(e) = invalidate_vamana_snapshots(&rt, &ns_str).await {
             tracing::warn!(error = %e, "failed to invalidate Vamana snapshots after reindex");
         }
+
+        // Purge stale per-namespace memory Vamana snapshot rows (legacy key format
+        // `{ns}::memory_vamana::*`). After FTS+ANN consolidation the unified key is
+        // `global::memory_vamana::*`; old per-ns rows are orphaned and waste space.
+        purge_stale_memory_vamana_snapshots(&rt).await;
+
+        // Drop per-namespace FTS partition tables that survived the V4 migration
+        // (tables created by the runtime before the migration ran, or on databases
+        // that were migrated but not swept). Safe to run on any V4+ database;
+        // a no-op on fresh databases.
+        sweep_stale_fts_partitions(&rt).await;
     } // end if do_graph
 
     // ── knowledge corpus ───────────────────────────────────────────────────────
@@ -724,6 +735,118 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
                 Ok(())
             } else {
                 Err(anyhow::anyhow!("{e}"))
+            }
+        }
+    }
+}
+
+/// Remove per-namespace memory Vamana snapshot rows (legacy `{ns}::memory_vamana::*` format).
+/// After FTS+ANN consolidation the active key is `global::memory_vamana::*`; old per-ns rows
+/// are orphaned. Best-effort — missing table or SQL failure is logged and ignored.
+async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
+    use khive_storage::types::SqlStatement;
+    let sql = rt.sql();
+    let Ok(mut writer) = sql.writer().await else {
+        return;
+    };
+    match writer
+        .execute(SqlStatement {
+            sql: "DELETE FROM retrieval_snapshots \
+                  WHERE index_type = 'memory_vamana' AND namespace != 'global'"
+                .into(),
+            params: vec![],
+            label: Some("purge_stale_memory_vamana_snapshots".into()),
+        })
+        .await
+    {
+        Ok(deleted) => {
+            if deleted > 0 {
+                tracing::info!(deleted, "purged stale per-ns memory Vamana snapshot rows");
+            }
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if !msg.contains("no such table") {
+                tracing::warn!(error = %e, "failed to purge stale memory Vamana snapshots");
+            }
+        }
+    }
+}
+
+/// Drop per-namespace FTS5 partition tables (`fts_entities_*`, `fts_notes_*`) that
+/// may exist in databases that were not yet migrated or were created before V4.
+/// Canonical tables (`fts_entities`, `fts_notes`, `fts_knowledge`, `fts_sections`)
+/// and their FTS5 shadow tables are never dropped.
+/// Safe to run repeatedly; a no-op on fresh databases.
+async fn sweep_stale_fts_partitions(rt: &KhiveRuntime) {
+    use khive_storage::types::{SqlStatement, SqlValue};
+
+    // Canonical base names that must never be dropped.
+    let canonical: &[&str] = &["fts_entities", "fts_notes", "fts_knowledge", "fts_sections"];
+
+    // FTS5 shadow table suffixes that must never be dropped (the extension drops
+    // them automatically when the virtual table itself is dropped; we only drop
+    // the virtual table, so these patterns must be excluded from discovery).
+    let shadow_suffixes: &[&str] = &["_data", "_idx", "_docsize", "_config", "_content"];
+
+    let sql = rt.sql();
+    let Ok(mut reader) = sql.reader().await else {
+        return;
+    };
+
+    // Find candidate tables: type='table', name starts with `fts_entities_` or `fts_notes_`.
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT name FROM sqlite_master \
+                  WHERE type IN ('table', 'shadow') \
+                    AND (name LIKE 'fts_entities_%' OR name LIKE 'fts_notes_%')"
+                .into(),
+            params: vec![],
+            label: Some("sweep_stale_fts_partitions_discover".into()),
+        })
+        .await;
+
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to discover stale FTS partition tables");
+            return;
+        }
+    };
+
+    let mut to_drop: Vec<String> = Vec::new();
+    for row in &rows {
+        let name = match row.get("name") {
+            Some(SqlValue::Text(s)) => s.clone(),
+            _ => continue,
+        };
+        // Skip canonical tables.
+        if canonical.contains(&name.as_str()) {
+            continue;
+        }
+        // Skip FTS5 shadow tables (they are dropped automatically with the virtual table).
+        if shadow_suffixes.iter().any(|suf| name.ends_with(suf)) {
+            continue;
+        }
+        to_drop.push(name);
+    }
+    drop(reader);
+
+    if to_drop.is_empty() {
+        return;
+    }
+
+    let Ok(mut writer) = sql.writer().await else {
+        return;
+    };
+    for table in &to_drop {
+        let ddl = format!("DROP TABLE IF EXISTS \"{table}\"");
+        match writer.execute_script(ddl).await {
+            Ok(_) => {
+                tracing::info!(table, "dropped stale FTS partition table");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, table, "failed to drop stale FTS partition table");
             }
         }
     }

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1506,6 +1506,89 @@ mod tests {
         assert_eq!(after, 0, "row must be deleted by drop_vectors_for_subjects");
     }
 
+    // C3 alias regression: drop_vectors_for_subjects via a lattice ALIAS must target
+    // the SAME canonical table as the insert path that used the full canonical name.
+    //
+    // Previously the old hand-sanitized path would diverge on aliases like "paraphrase"
+    // (→ "paraphrase-multilingual-minilm-l12-v2" canonical, table
+    // "vec_paraphrase_multilingual_minilm_l12_v2"). Both the insert path and the drop
+    // path go through rt.vectors_for_model() which resolves the alias to the same
+    // canonical VectorStore — the bug cannot happen with the current implementation.
+    //
+    // This test registers a stub under the canonical name, inserts via the canonical
+    // name, drops via the short alias "paraphrase", and asserts the row is gone.
+    // It FAILS if either path hand-derives the table name from the raw string instead
+    // of routing through vectors_for_model().
+    #[tokio::test]
+    async fn drop_vectors_for_subjects_paraphrase_alias_targets_same_table_as_insert() {
+        use khive_runtime::RuntimeConfig;
+        use khive_storage::types::VectorRecord;
+        use khive_types::SubstrateKind;
+        use lattice_embed::EmbeddingModel;
+
+        // "paraphrase" is a short alias for the built-in lattice model.
+        // vectors_for_model resolves both the alias and the canonical name to the
+        // same physical table (key = sanitize_key(CANONICAL), dims = 384).
+        //
+        // We register the model in RuntimeConfig so vectors_for_model(CANONICAL)
+        // can resolve it without an Unknown model error.  We write raw VectorRecords
+        // directly — the embedder is never called — so DIMS must equal the lattice
+        // model's declared output dimension.
+        const CANONICAL: &str = "paraphrase-multilingual-minilm-l12-v2";
+        const ALIAS: &str = "paraphrase";
+        // Must equal EmbeddingModel::ParaphraseMultilingualMiniLmL12V2::dimensions().
+        const DIMS: usize = 384;
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        // The paraphrase model is now in the registry under its canonical name.
+        // vectors_for_model("paraphrase") and vectors_for_model(CANONICAL) must
+        // both resolve to the same table — that is what this test verifies.
+
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        // Insert via the canonical name (same as the normal embed-and-store path).
+        let store_canonical = rt
+            .vectors_for_model(&token, CANONICAL)
+            .expect("canonical store");
+        let subject_id = Uuid::new_v4();
+        store_canonical
+            .insert_batch(vec![VectorRecord {
+                subject_id,
+                kind: SubstrateKind::Note,
+                namespace: "local".to_string(),
+                field: "content".to_string(),
+                embedding_model: Some(CANONICAL.to_string()),
+                vectors: vec![vec![0.1_f32; DIMS]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("insert_batch via canonical name");
+
+        let before = store_canonical.count().await.expect("count before");
+        assert_eq!(before, 1, "row must exist before alias-drop");
+
+        // Drop via the ALIAS "paraphrase".  vectors_for_model resolves alias →
+        // EmbeddingModel::ParaphraseMultilingualMiniLmL12V2 → same canonical table.
+        // If the implementation ever diverges (hand-sanitizes the raw alias string),
+        // the delete targets a different table and `after` stays 1 → test fails.
+        drop_vectors_for_subjects(&rt, &token, ALIAS, &[subject_id]).await;
+
+        let after = store_canonical.count().await.expect("count after");
+        assert_eq!(
+            after, 0,
+            "alias-routed drop must delete from the same canonical table as insert; \
+             after={after} (expected 0). \
+             Failure means alias 'paraphrase' resolved to a different table than CANONICAL."
+        );
+    }
+
     #[test]
     fn has_failures_flags_notes_fts_failed() {
         let report = ReindexReport {

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -235,14 +235,71 @@ impl ReindexReport {
     }
 }
 
+/// Drop ALL existing vector rows for `subject_ids` in the given model table,
+/// regardless of their stored namespace. This is required before re-embedding
+/// because the vec table's PRIMARY KEY is `(subject_id)` — not `(subject_id,
+/// namespace)` — so a row written by a different namespace would collide on
+/// re-insert. By deleting on subject_id alone we ensure the subsequent INSERT
+/// lands cleanly with the base row's current namespace.
+///
+/// Only called when `drop_existing` (i.e. NOT `--keep-existing`). Best-effort:
+/// a deletion failure is logged but does not abort; the subsequent INSERT will
+/// either collide (and be counted as an error) or succeed.
+async fn drop_vectors_for_subjects(rt: &KhiveRuntime, model_name: &str, ids: &[Uuid]) {
+    use khive_storage::types::{SqlStatement, SqlValue};
+    if ids.is_empty() {
+        return;
+    }
+    // Compute the table name the same way SqliteVecStore does.
+    let model_key: String = model_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let table = format!("vec_{model_key}");
+    let sql = rt.sql();
+
+    // Batch into ≤400 IDs per statement to stay within SQLite's variable limit.
+    for chunk in ids.chunks(400) {
+        let placeholders: String = (1..=chunk.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let statement = format!("DELETE FROM {table} WHERE subject_id IN ({placeholders})");
+        let params: Vec<SqlValue> = chunk
+            .iter()
+            .map(|id| SqlValue::Text(id.to_string()))
+            .collect();
+        let Ok(mut writer) = sql.writer().await else {
+            tracing::warn!(
+                table,
+                "failed to open writer for subject-scoped vector drop"
+            );
+            return;
+        };
+        if let Err(e) = writer
+            .execute(SqlStatement {
+                sql: statement,
+                params,
+                label: Some("drop_vectors_for_subjects".into()),
+            })
+            .await
+        {
+            tracing::warn!(error = %e, table, "subject-scoped vector drop failed (continuing)");
+        }
+    }
+}
+
 /// Embed `staged` with every model in `model_names` and store one vector record
 /// per model — mirroring the multi-model write path in the runtime. Returns the
 /// number of vector inserts that failed.
 ///
-/// With `drop_existing`, all staged ids are (re)embedded — existing vectors are
-/// atomically replaced by `SqliteVecStore::insert`'s internal DELETE+INSERT
-/// transaction (no-worse-than-stale on failure). Otherwise (`--keep-existing`),
-/// ids already embedded in a given model are skipped for that model only.
+/// With `drop_existing`, all staged ids are (re)embedded. Before inserting, a
+/// subject-scoped delete removes ANY existing row for each `subject_id` in the
+/// model table, regardless of its stored namespace. This prevents UNIQUE
+/// constraint violations when the database was relabeled and vec rows from a
+/// prior namespace survive. The subsequent INSERT writes the current base-row
+/// namespace. With `--keep-existing`, existing vectors are preserved and ids
+/// already embedded are skipped.
 // REASON: each argument is a distinct embed dimension (runtime, token, models,
 // namespace, batch, substrate kind, field, drop flag); a struct would add
 // indirection without grouping anything cohesive.
@@ -258,6 +315,20 @@ async fn embed_and_store_batch(
     drop_existing: bool,
 ) -> u64 {
     let mut errors: u64 = 0;
+
+    // Subject-scoped drop: remove ANY existing vec rows for these subject_ids
+    // in each model table, regardless of stored namespace. This ensures the
+    // re-insert never hits a UNIQUE collision when vec rows from a prior
+    // namespace survive a relabel operation. Done once per model here; the
+    // SqliteVecStore::insert DELETE is namespace-scoped and would miss rows
+    // stored under a different namespace.
+    if drop_existing && !staged.is_empty() {
+        let subject_ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
+        for model_name in model_names {
+            drop_vectors_for_subjects(rt, model_name, &subject_ids).await;
+        }
+    }
+
     for model_name in model_names {
         let vectors = match rt.vectors_for_model(token, model_name) {
             Ok(v) => v,
@@ -586,9 +657,13 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
 
         // Drop per-namespace FTS partition tables that survived the V4 migration
         // (tables created by the runtime before the migration ran, or on databases
-        // that were migrated but not swept). Safe to run on any V4+ database;
-        // a no-op on fresh databases.
-        sweep_stale_fts_partitions(&rt).await;
+        // that were migrated but not swept). The sweep is guarded: it only runs
+        // when this reindex pass covered every distinct namespace in the base
+        // entities/notes tables. If any namespace is uncovered, sweeping would
+        // orphan those rows (they were dropped from the old partition and never
+        // written to the new unified table). On a single-namespace (post-relabel)
+        // db the guard always passes and the sweep runs normally.
+        sweep_stale_fts_partitions(&rt, &ns_str).await;
     } // end if do_graph
 
     // ── knowledge corpus ───────────────────────────────────────────────────────
@@ -773,13 +848,76 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
     }
 }
 
+/// Return the set of distinct namespaces present in base `entities` and `notes`
+/// (non-deleted rows only). Used by the FTS sweep guard.
+async fn distinct_base_namespaces(rt: &KhiveRuntime) -> HashSet<String> {
+    use khive_storage::types::SqlStatement;
+    let sql = rt.sql();
+    let Ok(mut reader) = sql.reader().await else {
+        return HashSet::new();
+    };
+    // Union of entity and note namespaces; soft-deleted rows are excluded so
+    // we only guard against losing rows that are still live in the base table.
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT DISTINCT namespace FROM entities WHERE deleted_at IS NULL \
+                  UNION \
+                  SELECT DISTINCT namespace FROM notes WHERE deleted_at IS NULL"
+                .into(),
+            params: vec![],
+            label: Some("distinct_base_namespaces".into()),
+        })
+        .await
+        .unwrap_or_default();
+    rows.into_iter()
+        .filter_map(|row| {
+            row.get("namespace").and_then(|v| {
+                if let khive_storage::types::SqlValue::Text(s) = v {
+                    Some(s.clone())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
 /// Drop per-namespace FTS5 partition tables (`fts_entities_*`, `fts_notes_*`) that
 /// may exist in databases that were not yet migrated or were created before V4.
 /// Canonical tables (`fts_entities`, `fts_notes`, `fts_knowledge`, `fts_sections`)
 /// and their FTS5 shadow tables are never dropped.
 /// Safe to run repeatedly; a no-op on fresh databases.
-async fn sweep_stale_fts_partitions(rt: &KhiveRuntime) {
+///
+/// **Sweep guard**: only drops partition tables when every distinct namespace
+/// present in the base `entities`/`notes` tables was covered by this reindex
+/// pass (i.e. the operating namespace `covered_ns` is the only namespace in the
+/// base). If uncovered namespaces exist, the sweep is skipped and a warning is
+/// emitted so operators know a manual or multi-namespace reindex is needed.
+async fn sweep_stale_fts_partitions(rt: &KhiveRuntime, covered_ns: &str) {
     use khive_storage::types::{SqlStatement, SqlValue};
+
+    // Guard: only sweep when every distinct namespace present in base
+    // entities/notes was covered by this reindex pass. A single-namespace
+    // (post-relabel) db has exactly {covered_ns} and passes immediately. A
+    // multi-namespace db would be partially swept — rows in other namespaces
+    // were dropped from old partitions but never carried to the unified table —
+    // so we skip and warn instead.
+    let base_namespaces = distinct_base_namespaces(rt).await;
+    let uncovered: Vec<&str> = base_namespaces
+        .iter()
+        .filter(|ns| ns.as_str() != covered_ns)
+        .map(String::as_str)
+        .collect();
+    if !uncovered.is_empty() {
+        tracing::warn!(
+            covered = covered_ns,
+            uncovered = ?uncovered,
+            "skipping stale FTS partition sweep: base tables contain namespaces not \
+             covered by this reindex pass; run reindex for each namespace first, \
+             or normalize all rows to one namespace before sweeping"
+        );
+        return;
+    }
 
     // Canonical base names that must never be dropped.
     let canonical: &[&str] = &["fts_entities", "fts_notes", "fts_knowledge", "fts_sections"];

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -235,57 +235,36 @@ impl ReindexReport {
     }
 }
 
-/// Drop ALL existing vector rows for `subject_ids` in the given model table,
+/// Drop ALL existing vector rows for `subject_ids` in the model's canonical table,
 /// regardless of their stored namespace. This is required before re-embedding
 /// because the vec table's PRIMARY KEY is `(subject_id)` — not `(subject_id,
 /// namespace)` — so a row written by a different namespace would collide on
 /// re-insert. By deleting on subject_id alone we ensure the subsequent INSERT
 /// lands cleanly with the base row's current namespace.
 ///
-/// Only called when `drop_existing` (i.e. NOT `--keep-existing`). Best-effort:
-/// a deletion failure is logged but does not abort; the subsequent INSERT will
-/// either collide (and be counted as an error) or succeed.
-async fn drop_vectors_for_subjects(rt: &KhiveRuntime, model_name: &str, ids: &[Uuid]) {
-    use khive_storage::types::{SqlStatement, SqlValue};
+/// Resolves the store via `rt.vectors_for_model(token, model_name)` — the SAME
+/// call the insert path uses — so alias resolution (`paraphrase` → canonical table
+/// name) is handled identically in both directions. Best-effort: a failure to
+/// resolve the store or delete is logged but does not abort; the subsequent INSERT
+/// will either collide (counted as an error) or succeed.
+async fn drop_vectors_for_subjects(
+    rt: &KhiveRuntime,
+    token: &khive_runtime::NamespaceToken,
+    model_name: &str,
+    ids: &[Uuid],
+) {
     if ids.is_empty() {
         return;
     }
-    // Compute the table name the same way SqliteVecStore does.
-    let model_key: String = model_name
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    let table = format!("vec_{model_key}");
-    let sql = rt.sql();
-
-    // Batch into ≤400 IDs per statement to stay within SQLite's variable limit.
-    for chunk in ids.chunks(400) {
-        let placeholders: String = (1..=chunk.len())
-            .map(|i| format!("?{i}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let statement = format!("DELETE FROM {table} WHERE subject_id IN ({placeholders})");
-        let params: Vec<SqlValue> = chunk
-            .iter()
-            .map(|id| SqlValue::Text(id.to_string()))
-            .collect();
-        let Ok(mut writer) = sql.writer().await else {
-            tracing::warn!(
-                table,
-                "failed to open writer for subject-scoped vector drop"
-            );
+    let store = match rt.vectors_for_model(token, model_name) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(model = %model_name, error = %e, "drop_vectors_for_subjects: could not resolve store; skipping delete");
             return;
-        };
-        if let Err(e) = writer
-            .execute(SqlStatement {
-                sql: statement,
-                params,
-                label: Some("drop_vectors_for_subjects".into()),
-            })
-            .await
-        {
-            tracing::warn!(error = %e, table, "subject-scoped vector drop failed (continuing)");
         }
+    };
+    if let Err(e) = store.delete_subjects(ids).await {
+        tracing::warn!(model = %model_name, error = %e, "subject-scoped vector drop failed (continuing)");
     }
 }
 
@@ -325,7 +304,7 @@ async fn embed_and_store_batch(
     if drop_existing && !staged.is_empty() {
         let subject_ids: Vec<Uuid> = staged.iter().map(|(id, _)| *id).collect();
         for model_name in model_names {
-            drop_vectors_for_subjects(rt, model_name, &subject_ids).await;
+            drop_vectors_for_subjects(rt, token, model_name, &subject_ids).await;
         }
     }
 
@@ -1416,6 +1395,115 @@ mod tests {
             args.namespace.is_none(),
             "omitted --namespace must be None (not a String default)"
         );
+    }
+
+    // C3 regression: drop_vectors_for_subjects must target the SAME table as the insert path.
+    //
+    // The old code hand-sanitized model_name to derive the table name, which diverged from
+    // the insert path when the model is registered under a canonical name (e.g.
+    // "all-minilm-l6-v2" → table "vec_all_minilm_l6_v2" but a different sanitization of the
+    // raw env-var alias would yield a different key). The fix routes both drop and insert
+    // through rt.vectors_for_model() — the same Arc<dyn VectorStore> — so the table is
+    // always consistent.
+    //
+    // This test inserts a vector via vectors_for_model, calls drop_vectors_for_subjects with
+    // the same model name, and asserts the row is gone.
+    #[tokio::test]
+    async fn drop_vectors_for_subjects_targets_same_table_as_insert() {
+        use async_trait::async_trait;
+        use khive_runtime::{EmbedderProvider, RuntimeConfig, RuntimeError};
+        use khive_storage::types::VectorRecord;
+        use khive_types::SubstrateKind;
+        use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+        use std::sync::Arc;
+
+        struct StubService;
+
+        #[async_trait]
+        impl EmbeddingService for StubService {
+            async fn embed(
+                &self,
+                _texts: &[String],
+                _model: EmbeddingModel,
+            ) -> Result<Vec<Vec<f32>>, EmbedError> {
+                panic!("StubService::embed must not be called in this test")
+            }
+
+            fn supports_model(&self, _model: EmbeddingModel) -> bool {
+                true
+            }
+
+            fn name(&self) -> &'static str {
+                "stub-c3"
+            }
+        }
+
+        struct StubProvider {
+            model_name: &'static str,
+            dims: usize,
+        }
+
+        #[async_trait]
+        impl EmbedderProvider for StubProvider {
+            fn name(&self) -> &str {
+                self.model_name
+            }
+
+            fn dimensions(&self) -> usize {
+                self.dims
+            }
+
+            async fn build(&self) -> Result<Arc<dyn EmbeddingService>, RuntimeError> {
+                Ok(Arc::new(StubService))
+            }
+        }
+
+        const MODEL: &str = "stub-model-c3";
+        const DIMS: usize = 4;
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(StubProvider {
+            model_name: MODEL,
+            dims: DIMS,
+        });
+
+        let ns = khive_runtime::Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        // Obtain the store via the same path as the insert path uses.
+        let store = rt.vectors_for_model(&token, MODEL).expect("store");
+
+        // Insert one vector record.
+        let subject_id = Uuid::new_v4();
+        store
+            .insert_batch(vec![VectorRecord {
+                subject_id,
+                kind: SubstrateKind::Note,
+                namespace: "local".to_string(),
+                field: "content".to_string(),
+                embedding_model: Some(MODEL.to_string()),
+                vectors: vec![vec![0.1_f32; DIMS]],
+                updated_at: chrono::Utc::now(),
+            }])
+            .await
+            .expect("insert_batch");
+
+        // Confirm the row exists.
+        let before = store.count().await.expect("count before");
+        assert_eq!(before, 1, "row must exist before drop");
+
+        // Drop via drop_vectors_for_subjects — uses the same vectors_for_model path.
+        drop_vectors_for_subjects(&rt, &token, MODEL, &[subject_id]).await;
+
+        // Row must be gone.
+        let after = store.count().await.expect("count after");
+        assert_eq!(after, 0, "row must be deleted by drop_vectors_for_subjects");
     }
 
     #[test]


### PR DESCRIPTION
## What

Lands the ADR-062 FTS + ANN consolidation (schema **V4**) plus the namespace-agnostic memory fixes that came out of the khive-studio collaboration:

- **V4 migration** (`sql/004-fts-consolidation.sql`): consolidated `fts_entities` + `fts_notes` tables, replacing per-namespace FTS fanout with a single shared FTS table.
- **ANN single global index** with a stale-partition sweep, replacing per-namespace ANN fanout.
- **Namespace-agnostic subject-scoped vector drop** + alias-safe vec drop (C3), and a **bounded ANN over-fetch retry** gate with regression coverage (C1).

## Why now

Studio boots against the canonical live `~/.khive/khive.db`. The running `kkernel` daemon (built from this branch) has already migrated that DB to schema V4. The working-tree `khive-runtime` on `main` stops at V3, so `run_migrations` trips the schema-ahead guard (`current(4) > latest_known(3)`) and studio crashes at boot before any window. `main` is behind deployed reality, not ahead. Landing V4 realigns them and unblocks studio.

## Testing

921 tests pass across khive-db, khive-pack-memory, khive-runtime, khive-storage, kkernel. Build and clippy clean. The C1/C3 fixes ship with a genuine regression test and a multi-namespace integration suite (`+449` in `pack-memory/tests/integration.rs`).

## Notes for review

- This branch is the V4 merge state (`31c33580`), which matches the deployed `kkernel 0.2.11` reality, not the older pre-reconciliation `feat/fts-ann-consolidation` tip.
- No `boot.rs` namespace change ships here. Per the namespace consult, `boot.rs` stays `..Default::default()` (default_namespace = local) pending a decision on the studio attribution-actor question.
- The perf-gate PR (#170) is independent: it was rebased onto pre-V4 `origin/main`, so the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

