### PR TITLE
perf(knowledge): O(N) keyset pagination for section reindex + unify embed batch

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -7,7 +7,9 @@ use khive_storage::types::{SqlStatement, SqlValue};
 use khive_types::SubstrateKind;
 
 use super::schema::{Atom, IndexParams};
-use super::util::{atom_embed_text, atom_from_row, deser, sql_err, EMBED_BATCH, MAX_EMBED_BYTES};
+use super::util::{
+    atom_embed_text, atom_from_row, deser, sql_err, DEFAULT_EMBED_BATCH, MAX_EMBED_BYTES,
+};
 use super::vamana;
 use super::KnowledgeHandlers;
 
@@ -30,7 +32,7 @@ impl KnowledgeHandlers {
         }
 
         let sql = runtime.sql();
-        let batch_size = p.batch_size.unwrap_or(500).clamp(1, 1000);
+        let batch_size = p.batch_size.unwrap_or(DEFAULT_EMBED_BATCH).clamp(1, 1000);
         // insert_only is accepted for API compatibility but no longer drives a
         // pre-delete loop: SqliteVecStore::insert atomically replaces via its own
         // transacted DELETE+INSERT regardless of this flag.
@@ -98,7 +100,7 @@ impl KnowledgeHandlers {
         let mut ann_ids: Vec<uuid::Uuid> = Vec::new();
         let mut ann_dim: usize = 0;
 
-        for chunk in atoms.chunks(EMBED_BATCH) {
+        for chunk in atoms.chunks(batch_size) {
             let mut staged: Vec<(uuid::Uuid, String)> = Vec::with_capacity(chunk.len());
             for atom in chunk {
                 let text = atom_embed_text(atom);

--- a/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/sections_index.rs
@@ -8,7 +8,7 @@
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
-use super::util::{now_us, row_str, sql_err, EMBED_BATCH, MAX_EMBED_BYTES};
+use super::util::{now_us, row_str, sql_err, MAX_EMBED_BYTES};
 
 fn unit_normalize(v: &mut [f32]) {
     let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -109,56 +109,45 @@ pub(crate) async fn embed_sections(
     let mut indexed = 0usize;
     let mut skipped = 0usize;
     let mut failed = 0usize;
-    let mut offset = 0i64;
+    let mut last_id: Option<String> = None;
 
     loop {
-        let skipped_before = skipped;
-        let failed_before = failed;
-        // When keeping existing vectors we filter on `embedding IS NULL`. Embedded
-        // rows leave the set; rows that fail or are skipped stay NULL, so we must
-        // advance the offset past THEM each pass (see the offset update below) —
-        // otherwise a full page of persistent failures would re-select forever.
-        // A full re-embed has a stable result set, so we paginate by row count.
+        // Keyset pagination on the `id` PRIMARY KEY: each page selects rows with
+        // `id > last_id` in id order, then advances `last_id` to the page's max id.
+        // Cost is O(N) total (one forward walk of the id B-tree) instead of the
+        // O(N^2) deep-OFFSET re-scan. Works for both modes: a full re-embed walks
+        // every row once; keep-existing walks once and the `embedding IS NULL`
+        // filter skips already-embedded rows inline. Advancing past EVERY page row
+        // (embedded, skipped, or failed) guarantees each row is attempted at most
+        // once and the loop terminates.
         let null_filter = if drop_existing {
             ""
         } else {
             " AND s.embedding IS NULL"
         };
-        // atom_filter uses ?2 when present; pagination params follow at ?2/?3 or ?3/?4.
-        let (query, page_params) = if let Some(id) = atom_id {
-            (
-                format!(
-                    "SELECT s.id AS id, s.heading AS heading, s.content AS content, \
-                            a.name AS atom_name \
-                     FROM knowledge_sections s \
-                     JOIN knowledge_atoms a ON a.id = s.atom_id \
-                     WHERE s.namespace = ?1 AND s.atom_id = ?2{null_filter} \
-                     ORDER BY s.id LIMIT ?3 OFFSET ?4"
-                ),
-                vec![
-                    SqlValue::Text(ns.clone()),
-                    SqlValue::Text(id.to_owned()),
-                    SqlValue::Integer(page),
-                    SqlValue::Integer(offset),
-                ],
-            )
+        let mut page_params = vec![SqlValue::Text(ns.clone())];
+        let atom_clause = if let Some(id) = atom_id {
+            page_params.push(SqlValue::Text(id.to_owned()));
+            format!(" AND s.atom_id = ?{}", page_params.len())
         } else {
-            (
-                format!(
-                    "SELECT s.id AS id, s.heading AS heading, s.content AS content, \
-                            a.name AS atom_name \
-                     FROM knowledge_sections s \
-                     JOIN knowledge_atoms a ON a.id = s.atom_id \
-                     WHERE s.namespace = ?1{null_filter} \
-                     ORDER BY s.id LIMIT ?2 OFFSET ?3"
-                ),
-                vec![
-                    SqlValue::Text(ns.clone()),
-                    SqlValue::Integer(page),
-                    SqlValue::Integer(offset),
-                ],
-            )
+            String::new()
         };
+        let keyset_clause = if let Some(ref last) = last_id {
+            page_params.push(SqlValue::Text(last.clone()));
+            format!(" AND s.id > ?{}", page_params.len())
+        } else {
+            String::new()
+        };
+        page_params.push(SqlValue::Integer(page));
+        let limit_pos = page_params.len();
+        let query = format!(
+            "SELECT s.id AS id, s.heading AS heading, s.content AS content, \
+                    a.name AS atom_name \
+             FROM knowledge_sections s \
+             JOIN knowledge_atoms a ON a.id = s.atom_id \
+             WHERE s.namespace = ?1{atom_clause}{null_filter}{keyset_clause} \
+             ORDER BY s.id LIMIT ?{limit_pos}"
+        );
         let mut reader = sql
             .reader()
             .await
@@ -192,49 +181,52 @@ pub(crate) async fn embed_sections(
             staged.push((id, text));
         }
 
-        for chunk in staged.chunks(EMBED_BATCH) {
-            let texts: Vec<String> = chunk.iter().map(|(_, t)| truncate_bytes(t)).collect();
-            let embeddings = match runtime.embed_document_batch(&texts).await {
-                Ok(e) if e.len() == chunk.len() => e,
+        // One embed call per page: the page (LIMIT = batch_size) IS the embed
+        // batch, so there is no inner re-chunk. `staged` holds the non-empty rows
+        // of this page (≤ batch_size).
+        if !staged.is_empty() {
+            let texts: Vec<String> = staged.iter().map(|(_, t)| truncate_bytes(t)).collect();
+            match runtime.embed_document_batch(&texts).await {
+                Ok(embeddings) if embeddings.len() == staged.len() => {
+                    let mut writer = sql
+                        .writer()
+                        .await
+                        .map_err(|e| sql_err("section index writer", e))?;
+                    let now = now_us();
+                    for ((id, _), mut emb) in staged.iter().zip(embeddings.into_iter()) {
+                        unit_normalize(&mut emb);
+                        if let Err(e) = writer
+                            .execute(SqlStatement {
+                                sql:
+                                    "UPDATE knowledge_sections SET embedding = ?1, updated_at = ?2 \
+                                      WHERE id = ?3"
+                                        .into(),
+                                params: vec![
+                                    SqlValue::Blob(f32_to_le_bytes(&emb)),
+                                    SqlValue::Integer(now),
+                                    SqlValue::Text(id.clone()),
+                                ],
+                                label: None,
+                            })
+                            .await
+                        {
+                            tracing::warn!(id = %id, error = %e, "section embedding UPDATE failed; counting as failed");
+                            failed += 1;
+                        } else {
+                            indexed += 1;
+                        }
+                    }
+                }
                 Ok(_) => {
                     tracing::warn!(
-                        batch = chunk.len(),
+                        batch = staged.len(),
                         "section embed_batch returned wrong vector count; counting as failed"
                     );
-                    failed += chunk.len();
-                    continue;
+                    failed += staged.len();
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, batch = chunk.len(), "section embed_batch failed; counting as failed");
-                    failed += chunk.len();
-                    continue;
-                }
-            };
-            let mut writer = sql
-                .writer()
-                .await
-                .map_err(|e| sql_err("section index writer", e))?;
-            let now = now_us();
-            for ((id, _), mut emb) in chunk.iter().zip(embeddings.into_iter()) {
-                unit_normalize(&mut emb);
-                if let Err(e) = writer
-                    .execute(SqlStatement {
-                        sql: "UPDATE knowledge_sections SET embedding = ?1, updated_at = ?2 \
-                              WHERE id = ?3"
-                            .into(),
-                        params: vec![
-                            SqlValue::Blob(f32_to_le_bytes(&emb)),
-                            SqlValue::Integer(now),
-                            SqlValue::Text(id.clone()),
-                        ],
-                        label: None,
-                    })
-                    .await
-                {
-                    tracing::warn!(id = %id, error = %e, "section embedding UPDATE failed; counting as failed");
-                    failed += 1;
-                } else {
-                    indexed += 1;
+                    tracing::warn!(error = %e, batch = staged.len(), "section embed_batch failed; counting as failed");
+                    failed += staged.len();
                 }
             }
         }
@@ -246,16 +238,13 @@ pub(crate) async fn embed_sections(
         if n < page as usize {
             break;
         }
-        // drop_existing: stable result set → paginate by full page.
-        // keep-existing: embedded rows leave the `embedding IS NULL` set, so only
-        // the rows still NULL after this pass (failed + skipped) need to be
-        // stepped over; advancing by exactly that count attempts each row once
-        // and guarantees termination.
-        offset += if drop_existing {
-            n as i64
-        } else {
-            (skipped - skipped_before + failed - failed_before) as i64
-        };
+        // Advance the cursor past the whole page. Rows are id-ordered, so the last
+        // row holds the page's max id; this steps over embedded, skipped, and
+        // failed rows alike so none is re-selected and the loop terminates.
+        match rows.last().and_then(|r| row_str(r, "id")) {
+            Some(id) => last_id = Some(id),
+            None => break,
+        }
     }
 
     Ok((indexed, skipped, failed))

--- a/crates/khive-pack-knowledge/src/knowledge/util.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/util.rs
@@ -22,7 +22,11 @@ pub(super) const D_W_BIGRAM: f32 = 2.0;
 
 pub(super) const CANDIDATE_POOL: usize = 2000;
 pub(super) const MIN_TERM_LEN: usize = 3;
-pub(super) const EMBED_BATCH: usize = 32;
+/// Default embed/write batch when the caller does not pass `batch_size`. This is
+/// the number of records embedded per `embed_document_batch` call (and written
+/// per batch) — NOT a separate DB-pagination unit. The reindex `--batch-size`
+/// flag overrides it; pagination uses the same value.
+pub(crate) const DEFAULT_EMBED_BATCH: usize = 128;
 pub(super) const MAX_EMBED_BYTES: usize = 32_768;
 
 pub(super) static STOP_WORDS: &[&str] = &[

--- a/crates/khive-pack-knowledge/src/lib.rs
+++ b/crates/khive-pack-knowledge/src/lib.rs
@@ -73,7 +73,10 @@ pub async fn reindex_knowledge(
     let mut sections_indexed = 0u64;
     let mut sections_failed = 0u64;
     if opts.sections {
-        let batch = opts.batch_size.unwrap_or(500) as usize;
+        let batch = opts
+            .batch_size
+            .map(|b| b as usize)
+            .unwrap_or(knowledge::util::DEFAULT_EMBED_BATCH);
         let (indexed, _skipped, sec_failed) = knowledge::sections_index::embed_sections(
             runtime,
             token,

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -150,8 +150,9 @@ pub struct ReindexArgs {
     #[arg(long)]
     pub model: Option<String>,
 
-    /// Records per embedding batch (default 100, max 500).
-    #[arg(long, default_value = "100")]
+    /// Records embedded per batch — also the DB page and write batch (default
+    /// 128, max 500). One `embed_document_batch` call processes this many records.
+    #[arg(long, default_value = "128")]
     pub batch_size: u32,
 
     /// Keep existing vectors instead of dropping before re-embedding.


### PR DESCRIPTION
## What

Two coupled fixes to the knowledge reindex path (`kkernel reindex`), driven by the observation that section-embedding backfill was slow (sections ~19/s vs atoms ~217/s). Cut cleanly on top of current `main` (post ADR-062 schema V4).

### 1. O(N) keyset pagination (the speed fix)

The section embedding pass paged with `LIMIT ? OFFSET ?` over a `knowledge_sections ⋈ knowledge_atoms` JOIN. Deep-offset pages re-scan the JOIN from the top each time → **O(N²)** total — the slow long tail of a full re-embed.

Replaced with **keyset pagination** on the `id` PRIMARY KEY:

```sql
... WHERE s.namespace = ?1 [atom] [null] AND s.id > :last_id ORDER BY s.id LIMIT :n
```

One forward walk of the `id` B-tree → **O(N) total**. The cursor advances past *every* page row (embedded, skipped-blank, or failed), so each row is attempted at most once and the loop terminates in **both** `drop_existing` and `--keep-existing` modes.

### 2. Unify the embed batch (the "misleading flag" fix)

`--batch-size` previously only controlled DB pagination; the actual embed batch was a hardcoded re-chunk (`EMBED_BATCH = 32`). Now `--batch-size` **is** the embed batch — one `embed_document_batch` call per page — for sections *and* atoms, matching the entity/note path.

- Default raised `32 → 128` (`DEFAULT_EMBED_BATCH`).
- `kkernel reindex --batch-size` default moves `100 → 128`; help text clarified.

## Scope

- No schema change, no ADR change. `id TEXT PRIMARY KEY` (BINARY collation); UUIDs are lowercase-hex so `id >` matches `ORDER BY id`.
- Atom ANN rebuild path unchanged (`rebuild_ann` stays independent of `--keep-existing`).

## Verification (against current main, ADR-062 V4 in tree)

- Verification: termination both modes, no-skip completeness, param numbering, whole-page embed failure paths, collation confirmed.
- `cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `khive-pack-knowledge` + `kkernel` suites: **277 tests, 0 failed** — incl. regression `section_keep_existing_failures_terminate_and_report` and the full `reindex::tests` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
