### PR TITLE
feat(memory): ADR-007 Rev 6 — per-actor episodic memory namespace

### DIFF
--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -134,6 +134,11 @@ pub(super) struct RememberParams {
     pub(super) tags: Option<Vec<String>>,
     #[serde(default)]
     pub(super) embedding_model: Option<String>,
+    /// Optional write-namespace override. When absent, episodic memories land in
+    /// the actor's namespace and semantic memories land in "local" (the shared pool).
+    /// When present, overrides both routing rules and stamps the note in this namespace.
+    #[serde(default)]
+    pub(super) namespace: Option<String>,
 }
 
 /// Tag filter mode: `any` = OR, `all` = AND.

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -3,7 +3,7 @@
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{micros_to_iso, NamespaceToken, RuntimeError};
+use khive_runtime::{micros_to_iso, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{Direction, NeighborQuery};
 use khive_storage::EdgeRelation;
 
@@ -30,6 +30,31 @@ impl MemoryPack {
 
         let memory_type = p.memory_type.as_deref().unwrap_or("episodic");
         validate_memory_type(memory_type)?;
+
+        // Resolve the write namespace (ADR-007 Rev 6 carve-out):
+        //   1. Explicit override (`namespace=` param) → use that.
+        //   2. Episodic memory → stamp with the caller's actor id.
+        //      ActorRef::anonymous() has id="local", so unconfigured actors produce no change.
+        //   3. Semantic memory → unchanged (shared "local" pool).
+        // Defense-in-depth for direct (non-dispatch) callers; dispatch pre-mints override ns via Rule-3 escape (pack.rs:~886).
+        let write_token_owned: Option<NamespaceToken> = if let Some(ns_str) = p.namespace.as_deref()
+        {
+            let ns = Namespace::parse(ns_str).map_err(|e| {
+                RuntimeError::InvalidInput(format!("invalid namespace {ns_str:?}: {e}"))
+            })?;
+            Some(token.with_namespace(ns))
+        } else if memory_type == "episodic" {
+            let actor_id = token.actor().id.as_str();
+            let ns = Namespace::parse(actor_id).map_err(|e| {
+                RuntimeError::InvalidInput(format!(
+                    "actor id {actor_id:?} is not a valid namespace: {e}"
+                ))
+            })?;
+            Some(token.with_namespace(ns))
+        } else {
+            None
+        };
+        let write_token: &NamespaceToken = write_token_owned.as_ref().unwrap_or(token);
 
         let salience = match p.salience {
             Some(v) if !(0.0..=1.0).contains(&v) => {
@@ -98,7 +123,7 @@ impl MemoryPack {
         let note = self
             .runtime
             .create_note_with_decay_for_embedding_model(
-                token,
+                write_token,
                 "memory",
                 None,
                 &p.content,
@@ -111,14 +136,14 @@ impl MemoryPack {
             .await?;
 
         {
-            let ns = token.namespace().as_str().to_owned();
+            let ns = write_token.namespace().as_str().to_owned();
             ann::invalidate_namespace(&self.runtime, &self.ann, &ns).await;
             let affected_models: Vec<String> = match p.embedding_model.as_deref() {
                 Some(model) => vec![model.to_owned()],
                 None => self.runtime.registered_embedding_model_names(),
             };
             for model in affected_models {
-                ann::ensure_ann_background(&self.runtime, token, &self.ann, &model).await;
+                ann::ensure_ann_background(&self.runtime, write_token, &self.ann, &model).await;
             }
         }
 

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -127,6 +127,12 @@ static MEMORY_HANDLERS: [HandlerDef; 8] = [
                 required: false,
                 description: "Tag values to filter by. Matched against properties.tags on stored memories.",
             },
+            ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: false,
+                description: "Write namespace override. When absent: episodic memories land in the actor's namespace; semantic memories land in \"local\". When present, overrides both routing rules.",
+            },
         ],
     },
     // Commissive: explicit feedback on a recalled memory — updates recall-domain posteriors

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -3984,3 +3984,281 @@ async fn test_ann_overfetch_retry_both_branches_deterministic() {
         );
     }
 }
+
+// ── ADR-007 Rev 6: episodic actor-namespace routing ─────────────────────────────────
+
+/// Build a registry whose dispatch tokens carry the given actor_id.
+///
+/// This is the test seam for ADR-007 Rev 6: `VerbRegistryBuilder::with_actor_id`
+/// configures the actor that `dispatch()` uses when minting the NamespaceToken
+/// passed to each handler. `mint_authorized` is `pub(crate)` to khive-runtime, so
+/// tests in other crates must go through this builder path.
+fn make_registry_with_actor(rt: KhiveRuntime, actor_id: &str) -> khive_runtime::VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_actor_id(Some(actor_id.to_string()));
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt));
+    builder.build().expect("registry with actor builds")
+}
+
+/// ADR-007 Rev 6: episodic memory → stamped with actor namespace.
+///
+/// A registry configured with actor_id="alice" writes an episodic memory.
+/// The note's stored namespace must be "alice".
+#[tokio::test]
+async fn test_episodic_remember_stamps_actor_namespace() {
+    let rt = make_runtime();
+    let registry = make_registry_with_actor(rt.clone(), "alice");
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "alice episodic event for namespace routing test",
+                "memory_type": "episodic",
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let note_id = result["id"].as_str().expect("response has id").to_owned();
+
+    // Fetch the note by ID (by-ID get is namespace-agnostic per PR-A1).
+    let got = registry
+        .dispatch("get", json!({ "id": note_id }))
+        .await
+        .expect("get by UUID must succeed");
+
+    let stored_ns = got["namespace"].as_str().expect("note has namespace field");
+    assert_eq!(
+        stored_ns, "alice",
+        "ADR-007 Rev 6: episodic memory with actor_id=alice must be stamped in namespace 'alice'; \
+         got: {stored_ns:?}"
+    );
+}
+
+/// ADR-007 Rev 6: semantic memory → remains in "local" (shared pool).
+///
+/// Even with actor_id="alice", a semantic memory must land in "local".
+#[tokio::test]
+async fn test_semantic_remember_stamps_local_namespace() {
+    let rt = make_runtime();
+    let registry = make_registry_with_actor(rt.clone(), "alice");
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "alice semantic fact for namespace routing test",
+                "memory_type": "semantic",
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let note_id = result["id"].as_str().expect("response has id").to_owned();
+
+    let got = registry
+        .dispatch("get", json!({ "id": note_id }))
+        .await
+        .expect("get by UUID must succeed");
+
+    let stored_ns = got["namespace"].as_str().expect("note has namespace field");
+    assert_eq!(
+        stored_ns, "local",
+        "ADR-007 Rev 6: semantic memory must always land in 'local' regardless of actor; \
+         got: {stored_ns:?}"
+    );
+}
+
+/// ADR-007 Rev 6: explicit namespace= override takes precedence over routing rules.
+///
+/// Passing `namespace="override-ns"` with an episodic memory for actor "alice"
+/// must stamp the note in "override-ns", not "alice".
+///
+/// Note: override correctness is provided at the dispatch layer — the Rule-3 escape
+/// in pack.rs (~line 886) mints the override namespace into the token BEFORE the
+/// handler runs. This test confirms the end-to-end override behavior as seen by
+/// callers, not the handler's own override branch in isolation.
+#[tokio::test]
+async fn test_remember_namespace_override_takes_precedence() {
+    let rt = make_runtime();
+    let registry = make_registry_with_actor(rt.clone(), "alice");
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "explicit override namespace test",
+                "memory_type": "episodic",
+                "namespace": "override-ns",
+            }),
+        )
+        .await
+        .expect("memory.remember with explicit namespace must succeed");
+
+    let note_id = result["id"].as_str().expect("response has id").to_owned();
+
+    let got = registry
+        .dispatch("get", json!({ "id": note_id }))
+        .await
+        .expect("get by UUID must succeed");
+
+    let stored_ns = got["namespace"].as_str().expect("note has namespace field");
+    assert_eq!(
+        stored_ns, "override-ns",
+        "ADR-007 Rev 6: explicit namespace= must override actor routing; \
+         got: {stored_ns:?}"
+    );
+}
+
+/// ADR-007 Rev 6: anonymous actor (actor_id="local") episodic → namespace "local".
+///
+/// When no actor is configured (`ActorRef::anonymous()` has id="local"), episodic
+/// memories must land in "local" — backward-compatible with pre-Rev-6 behavior.
+#[tokio::test]
+async fn test_episodic_anonymous_actor_uses_local() {
+    // make_registry uses the default builder (no actor_id) → ActorRef::anonymous() → id="local".
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "anonymous episodic memory backward-compat test",
+                "memory_type": "episodic",
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let note_id = result["id"].as_str().expect("response has id").to_owned();
+
+    let got = registry
+        .dispatch("get", json!({ "id": note_id }))
+        .await
+        .expect("get by UUID must succeed");
+
+    let stored_ns = got["namespace"].as_str().expect("note has namespace field");
+    assert_eq!(
+        stored_ns, "local",
+        "ADR-007 Rev 6: anonymous actor (id='local') episodic memory must land in 'local' \
+         (backward-compat no-op); got: {stored_ns:?}"
+    );
+}
+
+/// ADR-007 Rev 6 (R1): cross-actor isolation — episodic write lands in actor ns AND is
+/// invisible to a principal whose visible set excludes that actor namespace.
+///
+/// This is the discriminating test for the Rev-6 carve-out:
+///   (a) Alice's episodic memory writes to the "alice" namespace and is recallable by alice.
+///   (b) A `{local}`-only principal (anonymous make_registry) CANNOT recall alice's memory.
+///
+/// The vector leg is seeded with a ConstVecProvider but — because all stored
+/// memories share the same constant embedding vector — it cannot discriminate
+/// between alice's memory and any other.  The genuine cross-actor gate is the FTS
+/// namespace fanout; the vector leg is structurally present but not the discriminating
+/// signal (noted honestly here per the brief).  The FTS isolation IS the RED→GREEN
+/// discriminator validated by the red-run procedure.
+///
+/// Note: recall as alice requires alice's registry to have `with_visible_namespaces([alice_ns])`
+/// because pack.rs dispatch (default path) fans reads over {local} ∪ visible_namespaces only.
+#[tokio::test]
+async fn adr007_rev6_episodic_cross_actor_isolation() {
+    const MODEL_A: &str = "rev6-isolation-enc";
+    const DIMS: usize = 4;
+
+    // Build a runtime. Both alice and the anonymous observer share the same in-memory DB,
+    // which is the only way to verify cross-actor isolation within a single test.
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        visible_namespaces: vec![Namespace::parse("alice").unwrap()],
+        ..RuntimeConfig::default()
+    })
+    .expect("in-memory runtime");
+    // Register a ConstVecProvider so the vector leg is structurally live.
+    // NOTE: ConstVecProvider returns the same constant vector for every input, so the
+    // vector leg cannot discriminate between principals — the cross-actor isolation
+    // enforced here is via the FTS namespace fanout.  The vector leg is present but
+    // not a meaningful signal for this test.
+    rt.register_embedder(ConstVecProvider::new(MODEL_A, DIMS, 0.9));
+
+    // Alice's registry: actor_id="alice" + alice in visible_namespaces so recall fans out there.
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_actor_id(Some("alice".to_string()));
+    builder.with_visible_namespaces(vec![Namespace::parse("alice").unwrap()]);
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let alice_registry = builder.build().expect("alice registry builds");
+
+    // Anonymous (bob-equivalent) registry: no actor_id, no alice in visible set →
+    // only {local} is in scope for reads.
+    let anon_registry = make_registry(rt.clone());
+
+    // Step (a): alice writes an episodic memory (no explicit namespace= arg).
+    let result = alice_registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "alice private episodic cross-actor isolation marker",
+                "memory_type": "episodic",
+            }),
+        )
+        .await
+        .expect("memory.remember as alice must succeed");
+    let note_id = result["id"].as_str().expect("note id present").to_owned();
+    assert!(!note_id.is_empty());
+
+    // Confirm the write landed in the "alice" namespace (not "local").
+    let got = alice_registry
+        .dispatch("get", json!({ "id": note_id }))
+        .await
+        .expect("get by UUID must succeed");
+    let stored_ns = got["namespace"].as_str().expect("note has namespace field");
+    assert_eq!(
+        stored_ns, "alice",
+        "ADR-007 Rev 6: episodic memory must land in actor namespace 'alice'; got: {stored_ns:?}"
+    );
+
+    // Step (a-recall): alice can recall her own episodic memory.
+    let alice_recall = alice_registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "alice private episodic cross-actor isolation marker" }),
+        )
+        .await
+        .expect("memory.recall as alice must succeed");
+    let alice_hits = alice_recall.as_array().expect("recall returns array");
+    let alice_ids: Vec<&str> = alice_hits
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        alice_ids.contains(&note_id.as_str()),
+        "ADR-007 Rev 6: alice must recall her own episodic memory; got: {alice_ids:?}"
+    );
+
+    // Step (b): the anonymous (local-only) principal MUST NOT recall alice's episodic memory.
+    // This is the cross-actor isolation guarantee — the "alice" namespace is outside the
+    // anonymous visible set {local}, so the memory must be absent from recall results.
+    let anon_recall = anon_registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "alice private episodic cross-actor isolation marker" }),
+        )
+        .await
+        .expect("memory.recall as anonymous must succeed");
+    let anon_hits = anon_recall.as_array().expect("recall returns array");
+    let anon_ids: Vec<&str> = anon_hits
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        !anon_ids.contains(&note_id.as_str()),
+        "ADR-007 Rev 6: anonymous principal (visible={{local}}) must NOT see alice's episodic \
+         memory (in namespace 'alice'); isolation FAILED — got: {anon_ids:?}"
+    );
+}

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -873,6 +873,17 @@ id = "lambda:"
             "actor.id must NOT become default_namespace (ADR-007 Rev 4 Rule 0); \
              writes stay pinned to local"
         );
+        // Also assert the fold-in: actor.id MUST appear in visible_namespaces so that
+        // default reads widen to {local} ∪ {actor namespace} (ADR-007 Rev 4 Rule 3b,
+        // config.rs:~444). This is the load-bearing side-effect of the actor id config.
+        assert!(
+            result
+                .visible_namespaces
+                .contains(&Namespace::parse("lambda:test-actor").unwrap()),
+            "actor.id must be folded into visible_namespaces (ADR-007 Rev 4 Rule 3b fold-in); \
+             got: {:?}",
+            result.visible_namespaces
+        );
     }
 
     // 19. runtime_config_from_khive_config with no actor preserves base namespace.

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -1,13 +1,33 @@
-# ADR-007 Rev 4: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility
+# ADR-007 Rev 6: Namespace as Attribution-Only Open String — Dumb Storage, Single Gate, Operator-Configured Read Visibility, Per-Actor Episodic Memory
 
-**Status**: Accepted/Ratified (2026-06-18)
-**Date**: 2026-06-17
+**Status**: Accepted/Ratified (2026-06-19)
+**Date**: 2026-06-19
 **Authors**: lambda:khive, alpha:architect
-**Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, and Rev 3 read-scope clause)
+**Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, Rev 3 read-scope clause; Rev 6 amends the Rev 4 Rule 0 write-default for episodic memory)
 **Supersedes (partial)**: ADR-050 §"Decision"; ADR-059 §"Decision" and §"Visibility tiers"
 **Superseded-by-none**: ADR-053 (ActorStore, SessionStore, cloud-tier actor threading) survives in full
 **ADR chain**: ADR-018 (Gate trait, single dispatch site) | ADR-014 (curation, merge semantics)
-| ADR-002 (edge cascade, no dangling refs)
+| ADR-002 (edge cascade, no dangling refs) | ADR-021 (memory pack, episodic vs semantic routing)
+
+**Rev 6 summary (2026-06-19)**: Carves one exception out of the Rule 0 write default. Through
+Rev 4, every write pinned `namespace = 'local'` by default (the actor identity contributed only
+to the read visible-set, never to the write namespace). Rev 6 amends that default for a single
+write path: an episodic memory write (`memory.remember` with `memory_type = episodic`) stamps
+`namespace = the caller's actor id` (`token.actor().id`) by default, rather than the shared
+`'local'` pool. Semantic memory writes are unchanged: they continue to stamp `token.namespace()`
+(the shared pool, `'local'` by default). An explicit `namespace=` request parameter continues to
+override the write namespace for both memory types, exactly as in Rule 3. This carve-out is
+attribution plus view-layer visibility, not a storage boundary: the store performs no
+`record.namespace == caller_namespace` check (the prior-v1 pattern PR-A1 removed, which must not
+return), by-ID ops stay namespace-agnostic (Rule 2), and the actor-stamped episodic memory
+becomes visible purely through the existing Rev-4 read visible-set fanout
+(`{local} ∪ {actor.id} ∪ {actor.visible_namespaces}`). It is backward-compatible: an anonymous
+actor has id `'local'` (`ActorRef::anonymous`), so with no `[actor]` configured the episodic
+write namespace resolves to `'local'`, byte-identical to pre-Rev-6 behavior. The carve-out takes
+effect only once a real actor is configured and threaded into `token.actor()`. Recall needs no
+change: the Rev-4 fanout already returns actor.id-stamped memories on both the FTS path and the
+ANN post-filter path. The Gate (ADR-018) remains the single trust seam. All other Rev 4 / Rev 3
+rules are retained verbatim. See the Rev 6 amendment to Rule 0 below and Rule 3 (memory routing).
 
 **Rev 4 summary (2026-06-17)**: Generalizes the Rev 3 default read scope. Rev 3 fixed the
 default multi-record read scope at exactly `['local']`, with an explicit `namespace=` request
@@ -88,6 +108,52 @@ deployment is configured as must not route storage on its own.
 Source: CLAUDE.md "The local system is a single shared brain: one namespace (`local`), and
 every lambda / agent / subagent reads and writes it."
 
+**Rev 6 amendment to Rule 0 (episodic memory writes stamp the actor id by default).** Rule 0
+continues to hold for every write path EXCEPT one: an episodic memory write
+(`memory.remember` with `memory_type = episodic`, or the equivalent
+`create(kind="memory", properties={"memory_type": "episodic"})`) stamps
+`namespace = token.actor().id` by default, rather than the shared `'local'` pool. This is the
+single carve-out from the prior "writes always pin `'local'`" default. It is bounded as follows:
+
+- Scope is episodic memory only. Semantic memory writes (`memory_type = semantic`) are
+  unchanged: they stamp `token.namespace()` (the shared pool, `'local'` by default). All
+  non-memory writes (KG entities, edges, notes, tasks, comm, schedule, brain) are unchanged and
+  continue to pin `'local'` by default per the unamended Rule 0.
+- An explicit `namespace=` request parameter overrides the write namespace for both memory
+  types, identical to the Rule 3 escape. `memory.remember(..., namespace="ns-x")` writes to
+  exactly `ns-x` regardless of `memory_type`. The actor-id default applies only when no explicit
+  `namespace=` is supplied.
+- This is attribution plus view-layer visibility, not a storage boundary. The store performs no
+  `record.namespace == caller_namespace` check at any layer (the prior-v1 pattern PR-A1 removed
+  must not return). By-ID ops remain namespace-agnostic (Rule 2): an episodic memory written
+  under `lambda:leo` is fetchable, updatable, and deletable by UUID with no namespace check. The
+  actor-stamped episodic memory becomes _visible_ to a default recall purely through the existing
+  Rev-4 read visible-set fanout (`{local} ∪ {actor.id} ∪ {actor.visible_namespaces}`, Rule 3b),
+  not through any storage partition.
+- Backward-compatible. An anonymous actor has id `'local'` (`ActorRef::anonymous` returns
+  `kind = "anonymous"`, `id = "local"`). With no `[actor]` configured, the caller is the
+  anonymous actor, so the episodic write namespace resolves to `'local'`, byte-identical to
+  pre-Rev-6 behavior. The carve-out takes effect only once a real actor id is configured and
+  threaded onto the request token via `token.actor()` (the actor-identity threading from
+  ADR-053). Until a non-`'local'` actor is configured, this amendment is inert.
+
+Rationale: an episodic memory is a specific actor's lived experience. Attributing it to that
+actor, and keeping it private to that actor's default recall view, matches what episodic memory
+is. A semantic memory is distilled, shareable knowledge and belongs in the common pool. Per-actor
+episodic plus shared semantic is the intended model. The prior Rule 0 text ("writes always pin
+`'local'`") predates this episodic/semantic distinction; it stamped both memory types into the
+shared pool, which conflated one actor's experience with the common knowledge base. Rev 6 closes
+that gap for the episodic path while leaving the semantic path, and every other write path,
+unchanged.
+
+This is not the actor-as-namespace isolation Rev 3 rejected. The rejected model derived the
+storage namespace from actor identity for ALL writes and confined ALL reads to a per-actor
+partition, coupling identity to storage, hiding records, and breaking the shared brain and by-ID
+resolution. Rev 6 changes only the episodic-memory write default, leaves every other write path
+on `'local'`, never confines a read to a partition, never hides records behind a namespace check,
+and keeps by-ID ops global. Visibility is restored additively by the Rule 3b read fanout, which
+only ever shows MORE, never less.
+
 ### Rule 1 — Storage is dumb
 
 Stores (khive-db, khive-storage traits) are unscoped database connections. Namespace is a
@@ -157,10 +223,15 @@ partitions:
 - Comm: actor addressing uses `from_actor`/`to_actor` in message `properties` (ADR-057,
   implemented). Both copies of a comm.send stay in the caller's namespace ("local"). Actor
   label is attribution only; namespace carry is NO.
-- Memory: filter by `actor_id` attribution column when an owner-scoped view is needed; the
-  underlying pool is shared and cross-lambda recall operates over it. Namespace carry is NO.
-  The `actor_id` attribution column is deferred to ADR-053; interim attribution is via
-  `properties`.
+- Memory: recall reads operate over the caller's read visible-set
+  (`{local} ∪ {actor.id} ∪ {actor.visible_namespaces}`, Rule 3b); cross-lambda recall over the
+  shared pool is the intended behavior for the namespaces in that set. Per-actor read distinction
+  is also available as a view-layer filter on the `actor_id` attribution column when an
+  owner-scoped view is needed. The `actor_id` attribution column is deferred to ADR-053; interim
+  attribution is via `properties`. Write routing is per-`memory_type` (Rev 6): a semantic write
+  stamps `'local'` (namespace carry is NO, unchanged), while an episodic write stamps the
+  caller's actor id by default (the single Rev 6 carve-out from the Rule 0 write default). An
+  explicit `namespace=` overrides both. See the Rev 6 amendment to Rule 0 and ADR-021 §10.
 - Brain: profile resolution is its own scoping mechanism (brain.resolve, profile bindings),
   independent of namespace. Namespace carry is NO.
 - Schedule: attribution columns carry the scheduling actor; namespace is "local". Namespace
@@ -432,6 +503,35 @@ Negative:
   `namespace=` precise escape (Rule 3). The distinction (set-union default vs single-namespace
   override) must be documented at the call site to avoid surprise.
 
+### Rev 6 deltas
+
+Positive:
+
+- Episodic memory is attributed to the actor that lived it and is private to that actor's
+  default recall view, while semantic memory stays in the shared pool. This realizes the
+  per-actor-episodic plus shared-semantic model that the prior "all memory pins `'local'`"
+  default prevented.
+- The change is confined to one write default. By-ID ops, the read fanout, the Gate seam, and
+  every non-episodic write path are untouched. No `record.namespace == caller_namespace` check is
+  introduced; visibility is restored by the existing Rule 3b read fanout, not by a storage
+  partition.
+- Backward-compatible with zero behavior change for unconfigured deployments: the anonymous actor
+  id is `'local'`, so episodic writes resolve to `'local'` until a real actor is configured.
+- Recall requires no code change. The Rev-4 visible-set fanout already returns actor.id-stamped
+  memories on both the FTS and ANN paths.
+
+Negative:
+
+- Episodic and semantic writes now resolve to different default namespaces. A caller that wants
+  an episodic memory in the shared pool must pass `namespace="local"` explicitly. The
+  `memory_type`-conditioned default must be documented at the `memory.remember` call site (done
+  in ADR-021 §10) to avoid surprise.
+- Once a real actor is configured, episodic memories written by one actor are not in another
+  actor's default recall view unless that actor's `visible_namespaces` includes the writer's id
+  (Rule 3b). This is the intended privacy boundary, but it is a behavior change for multi-actor
+  deployments relative to the all-`'local'` default. It is a view-scope effect, not a storage
+  partition: the records remain reachable by UUID and by an explicit `namespace=` read.
+
 ### Neutral
 
 - Namespace::parse structural validation survives.
@@ -453,3 +553,7 @@ Negative:
 - ADR-018 — Gate trait, single dispatch site, AllowAllGate.
 - ADR-002 — edge cascade, no dangling refs.
 - ADR-053 — ActorStore, SessionStore, cloud-tier actor threading (survives).
+- ADR-021 §10, memory pack `memory_type` to namespace routing and the `namespace=` override
+  (the consumer-side statement of the Rev 6 carve-out).
+- `ActorRef::anonymous`, the anonymous caller (`kind = "anonymous"`, `id = "local"`) that makes
+  the Rev 6 carve-out a no-op for unconfigured deployments.

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -3,6 +3,10 @@
 **Status**: accepted
 **Date**: 2026-05-23
 **Authors**: Ocean, lambda:khive
+**Amended**: 2026-06-19, added §10 (`memory_type` to namespace routing) recording the
+[ADR-007](ADR-007-namespace.md) Rev 6 carve-out: episodic memory writes stamp the caller's actor
+id by default, semantic memory writes stamp the shared pool, and an explicit `namespace=`
+overrides both.
 
 ## Context
 
@@ -121,6 +125,11 @@ Semantically equivalent to:
 The handler validates: (a) `content` non-empty, (b) `memory_type ∈ {episodic, semantic}`
 if provided, (c) `salience ∈ [0, 1]`, (d) `decay_factor >= 0`, (e) `source_id` is a
 valid UUID present in the namespace.
+
+The write `namespace` is resolved per `memory_type` (ADR-007 Rev 6, full contract in §10): when
+no explicit `namespace=` argument is supplied, a semantic write stamps `token.namespace()` (the
+shared pool, `'local'` by default) and an episodic write stamps `token.actor().id` (the caller's
+actor id). An explicit `namespace=` argument overrides this for both types.
 
 Agents that prefer explicit CRUD are not blocked:
 `create(kind="memory", salience=0.7, decay_factor=0.01, properties={"memory_type":"semantic"}, ...)`
@@ -255,6 +264,59 @@ runtime:
     memory:
       primary_write_instance: memory-hot
 ```
+
+### 10. `memory_type` → namespace routing (ADR-007 Rev 6)
+
+The write namespace of a memory note is resolved from its `memory_type`, per the Rev 6 carve-out
+in [ADR-007](ADR-007-namespace.md) Rule 0. This is the single place in the system where the write
+namespace depends on the kind of record being written; every other write path pins `'local'` by
+default.
+
+| `memory_type` | Default write namespace (no `namespace=` argument)      | With explicit `namespace=X` |
+| ------------- | ------------------------------------------------------- | --------------------------- |
+| `semantic`    | `token.namespace()` (shared pool, `'local'` by default) | `X`                         |
+| `episodic`    | `token.actor().id` (the caller's actor id)              | `X`                         |
+
+Resolution rules:
+
+- The explicit `namespace=` argument on `memory.remember` (and on the equivalent
+  `create(kind="memory", ...)`) overrides the default for BOTH memory types. It is the precise
+  escape: `memory.remember(content="...", memory_type="episodic", namespace="local")` writes the
+  episodic memory into the shared pool, and `memory.remember(content="...",
+  memory_type="semantic", namespace="ns-x")` writes the semantic memory into `ns-x`.
+- The episodic default uses `token.actor().id`, the actor identity threaded onto the request token
+  (ADR-053). An anonymous caller has actor id `'local'` (`ActorRef::anonymous`), so when no
+  `[actor]` is configured the episodic default resolves to `'local'`, identical to the semantic
+  default and to pre-Rev-6 behavior. The per-actor episodic namespace takes effect only once a
+  real actor is configured.
+- The default `memory_type` is `episodic` (§1). A `memory.remember` call that supplies neither
+  `memory_type` nor `namespace=` therefore writes under the caller's actor id, which is `'local'`
+  for an anonymous caller and the configured actor id otherwise.
+
+Why episodic is per-actor and semantic is shared: an episodic memory is a specific actor's lived
+experience, so it is attributed to that actor and private to that actor's default recall view. A
+semantic memory is distilled, shareable knowledge, so it belongs in the common pool. This is the
+per-actor-episodic plus shared-semantic model. The prior contract stamped both memory types into
+`'local'`, which conflated one actor's experience with the shared knowledge base.
+
+This is attribution plus view-layer visibility, not storage isolation:
+
+- The store performs no `record.namespace == caller_namespace` check (ADR-007 Rule 2). By-ID ops
+  on a memory note (`get`, `update`, `delete`, `merge` by UUID) are namespace-agnostic regardless
+  of which actor wrote the memory. `delete(id=<memory_uuid>)` (§6) works across actors.
+- Recall reads operate over the caller's read visible-set,
+  `{local} ∪ {actor.id} ∪ {actor.visible_namespaces}` (ADR-007 Rule 3b). An actor's own episodic
+  memories are visible to its default recall because the set always includes `{actor.id}`. Another
+  actor sees them only if its configured `visible_namespaces` includes the writer's id. This is
+  the intended privacy boundary, realized as a read-scope (view) decision, not a storage
+  partition.
+- `memory.recall` requires no change for the Rev 6 routing. The visible-set fanout already
+  returns actor-id-stamped memories on both the FTS candidate path and the ANN post-filter path;
+  episodic memories written under the caller's actor id are in scope by construction.
+
+The `memory_type` post-filter on recall (§5) is orthogonal to namespace routing: it filters the
+candidate set by the stored `properties.memory_type` after candidate scoping, independent of
+which namespace a candidate was written to.
 
 ## Rationale
 
@@ -458,6 +520,10 @@ The pack's `StorageProfile` (from [ADR-003](ADR-003-system-architecture.md) /
 
 ## References
 
+- [ADR-007](ADR-007-namespace.md): Namespace as attribution-only. Rev 6 episodic-memory
+  write carve-out (Rule 0 amendment) and the read visible-set fanout (Rule 3b) that makes
+  per-actor episodic memory visible to its own default recall. §10 here is the consumer-side
+  statement of that carve-out.
 - [ADR-002](ADR-002-edge-ontology.md): Edge ontology — `annotates` as the universal note →
   any-substrate relation
 - [ADR-012](ADR-012-retrieval-composition.md): Retrieval composition — RRF hybrid score


### PR DESCRIPTION
## ADR-007 Rev 6 — per-actor episodic memory namespace

> **Stacked on #174** (`fix/issue-75-actor-identity`). Base is that branch, so the diff shown here is the **Rev-6-only** delta. Merge order: **#174 → this**. GitHub auto-retargets this PR to `main` when #174 merges.

### What this does

`memory.remember` now routes the **write namespace** by `memory_type`:

| `memory_type` | write namespace | rationale |
| --- | --- | --- |
| `episodic` (default) | `token.actor().id` | per-actor recall — each actor's lived experience is theirs |
| `semantic` | `local` (unchanged) | shared knowledge pool — visible to all |
| any, with explicit `namespace=` | the override | escape hatch, overrides both rules |

This is the carve-out specified: *episodic by actor id (unless explicitly overridden), semantic shared.* ADR-007 was not promptly updated when actor identity landed; this PR amends it (Rev 6) alongside the code.

### Attribution, not isolation

Consistent with ADR-007 Rev 3 (PR-A1):

- **No store-level namespace check.** Stamping `actor.id` into the write namespace is a write-stamp, not an access boundary.
- **By-ID ops stay namespace-agnostic** (Rule 2) — `get`/`update`/`delete`/`merge` of an actor-stamped memory via a `local` token still work. The read-side handlers keep the original `token`, not the write token.
- **Recall is unchanged.** The Rev-4 visible-set fanout (`{local} ∪ {actor.id} ∪ visible`) already returns actor-stamped memories on both the FTS and ANN legs; no recall code changed.
- **Authorization stays at the Gate** (Rule 4). Storage is ID-only.

### Backward-compatible

`ActorRef::anonymous()` has `id = "local"`, so an unconfigured actor routes episodic → `local` — a no-op until a real actor is configured (which #174 provides). Existing single-actor deployments see no behavior change.

### Implementation

- `handlers/remember.rs` — three-branch `write_token` routing before `create_note_*`; read-side ops (`resolve_prefix`, `neighbors_with_query`) keep the original token. `Namespace::parse` errors map to `InvalidInput`, never panic.
- `handlers/common.rs` — `namespace: Option<String>` on `RememberParams`.
- `pack.rs` — `namespace` `ParamDef` on `memory.remember` (undeclared params are stripped by the VerbRegistry; without this the override would be silently dropped).

### Tests (reviewed — all findings landed)

- `adr007_rev6_episodic_cross_actor_isolation` — **end-to-end RED→GREEN**: alice writes episodic (no `namespace=`) → stored namespace is `alice` (not `local`) → alice recalls it → an anonymous `{local}`-only principal does **not**. On reverted code the episodic memory lands in `local` and the `{local}` principal sees it (the leak this fixes).
- `test_runtime_config_actor_id_does_not_override_namespace` — added a positive assertion that `actor.id` folds into `visible_namespaces` (the load-bearing config side-effect).
- `test_remember_namespace_override_takes_precedence` — relabeled: override correctness is provided at the dispatch-layer Rule-3 escape; the handler branch is defense-in-depth for direct callers (documented inline).
- Plus the existing episodic/semantic/anonymous routing guards.

`cargo test -p khive-pack-memory -p khive-runtime`, `clippy -D warnings`, `fmt --check` all green.

### Docs

- `docs/adr/ADR-007-namespace.md` → Rev 6 (amends Rule 0, episodic path only; Rules 1–7 retained verbatim).
- `docs/adr/ADR-021-memory-pack.md` → new §10 (memory_type → namespace routing).

### Rebase caveat

This branch's ADR-007 is authored against **Rev 4** (the base it stacks on predates main's **Rev 5** Rule-8 backend carve-out). On rebase onto `main`, the Rev 6 amendment will be re-seated on top of Rev 5, preserving Rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

