### PR TITLE
fix(knowledge): restore green CI on main (actor_id merge-skew)

### DIFF
--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -3353,6 +3353,7 @@ mod ann_type_filter_regression {
             brain_profile: None,
             visible_namespaces: vec![],
             allowed_outbound_namespaces: vec![],
+            actor_id: None,
         })
         .expect("runtime");
         rt.register_embedder(CorrectDimProvider);


### PR DESCRIPTION
## Restore green CI on `main` — merge-skew compile break

`main` currently fails `cargo test --workspace` and `cargo clippy --workspace --all-targets` (the `khive-pack-knowledge` `fixes` test target does not compile). `cargo check --workspace` passes, which is why it slipped through — plain `check` does not build test targets.

### Root cause — stale-base merge skew

Two independently-green changes collided:

- The **knowledge fixes** added the `rt_with_embedder()` test helper, which builds a `RuntimeConfig { .. }` struct literal.
- **#174** (`fix/issue-75-actor-identity`) added a new **required** field `RuntimeConfig.actor_id: Option<String>` and updated every literal it could see.

#174's branch predated the `rt_with_embedder` helper, so its merge could not update that literal. Both PRs were green on their own bases; the merged result was never re-compiled with test targets, so `main` landed red.

### Fix

One line — add the missing field with its documented default:

```rust
actor_id: None,
```

`None` is the field's documented default (anonymous actor → `"local"` behavior) and matches the convention already used by the crate's bench literals (`benches/knowledge_bench.rs`, `benches/search_latency.rs`).

### Verification

```
cargo clippy -p khive-pack-knowledge --all-targets -- -D warnings   # green
cargo test  -p khive-pack-knowledge --test fixes                    # 59 passed; 0 failed
cargo fmt --all --check                                             # green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
