### PR TITLE
feat(knowledge): slim knowledge.compose default output; full telemetry behind explain=true

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -285,6 +285,8 @@ pub(crate) struct ComposeParams {
     pub auto_limit: Option<usize>,
     #[serde(default)]
     pub max_tokens: Option<usize>,
+    #[serde(default)]
+    pub explain: Option<bool>,
 }
 
 // ── edit ─────────────────────────────────────────────────────────────────────

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -834,6 +834,7 @@ fn format_section_compose_markdown(
     domains: &[Domain],
     atoms: &[Atom],
     sections: &[super::compose::ComposeSectionResult],
+    explain: bool,
 ) -> String {
     let mut out = String::from("# Knowledge Briefing\n\n");
     out.push_str(&format!("Query: {query}\n"));
@@ -849,7 +850,11 @@ fn format_section_compose_markdown(
             out.push_str(&format!("\n## {}\n\n", atom.name));
             out.push_str(&format!("Source: {}\n", atom.slug));
             for s in secs {
-                out.push_str(&format!("\n### {} (score: {:.4})\n\n", s.heading, s.score));
+                if explain {
+                    out.push_str(&format!("\n### {} (score: {:.4})\n\n", s.heading, s.score));
+                } else {
+                    out.push_str(&format!("\n### {}\n\n", s.heading));
+                }
                 if !s.content.is_empty() {
                     out.push_str(&s.content);
                     out.push('\n');
@@ -866,13 +871,20 @@ fn format_section_compose_markdown(
     out
 }
 
-fn format_compose_markdown(query: &str, domains: &[Domain], atoms: &[(&Atom, f32)]) -> String {
+fn format_compose_markdown(
+    query: &str,
+    domains: &[Domain],
+    atoms: &[(&Atom, f32)],
+    explain: bool,
+) -> String {
     let mut out = String::from("# Knowledge Briefing\n\n");
     out.push_str(&format!("Query: {query}\n"));
     for (atom, score) in atoms {
         out.push_str(&format!("\n## {}\n\n", atom.name));
         out.push_str(&format!("Source: {}\n", atom.slug));
-        out.push_str(&format!("Score: {:.4}\n", score));
+        if explain {
+            out.push_str(&format!("Score: {:.4}\n", score));
+        }
         if !atom.content.is_empty() {
             out.push('\n');
             out.push_str(&atom.content);
@@ -1150,6 +1162,7 @@ impl KnowledgeHandlers {
         if raw_query.is_empty() {
             return Err(RuntimeError::InvalidInput("query must not be empty".into()));
         }
+        let explain = p.explain.unwrap_or(false);
 
         let mut domain_ids: Vec<String> = p
             .domain_ids
@@ -1369,26 +1382,31 @@ impl KnowledgeHandlers {
                 &resolved_domains,
                 &ordered_atoms,
                 &section_results,
+                explain,
             );
-            let sj: Vec<Value> = section_results
-                .iter()
-                .map(|s| {
-                    json!({
-                        "section_id": s.section_id,
-                        "atom_id": s.atom_id,
-                        "section_type": s.section_type,
-                        "heading": s.heading,
-                        "score": (s.score * 10000.0).round() / 10000.0,
-                        "breakdown": {
-                            "section_cosine": (s.score_breakdown.section_cosine * 10000.0).round() / 10000.0,
-                            "section_bm25": (s.score_breakdown.section_bm25 * 10000.0).round() / 10000.0,
-                            "atom_cosine": (s.score_breakdown.atom_cosine * 10000.0).round() / 10000.0,
-                            "domain_score": (s.score_breakdown.domain_score * 10000.0).round() / 10000.0,
-                            "type_weight": (s.score_breakdown.type_weight * 10000.0).round() / 10000.0,
-                        },
+            let sj: Vec<Value> = if explain {
+                section_results
+                    .iter()
+                    .map(|s| {
+                        json!({
+                            "section_id": s.section_id,
+                            "atom_id": s.atom_id,
+                            "section_type": s.section_type,
+                            "heading": s.heading,
+                            "score": (s.score * 10000.0).round() / 10000.0,
+                            "breakdown": {
+                                "section_cosine": (s.score_breakdown.section_cosine * 10000.0).round() / 10000.0,
+                                "section_bm25": (s.score_breakdown.section_bm25 * 10000.0).round() / 10000.0,
+                                "atom_cosine": (s.score_breakdown.atom_cosine * 10000.0).round() / 10000.0,
+                                "domain_score": (s.score_breakdown.domain_score * 10000.0).round() / 10000.0,
+                                "type_weight": (s.score_breakdown.type_weight * 10000.0).round() / 10000.0,
+                            },
+                        })
                     })
-                })
-                .collect();
+                    .collect()
+            } else {
+                Vec::new()
+            };
             (md, sj)
         } else {
             let mut used = 0usize;
@@ -1410,7 +1428,7 @@ impl KnowledgeHandlers {
                 })
                 .collect();
             (
-                format_compose_markdown(&raw_query, &resolved_domains, &sorted_atoms),
+                format_compose_markdown(&raw_query, &resolved_domains, &sorted_atoms, explain),
                 Vec::new(),
             )
         };
@@ -1422,7 +1440,7 @@ impl KnowledgeHandlers {
                     "id": item.id,
                     "slug": item.slug,
                     "name": item.name,
-                    "score": item.score,
+                    "score": (item.score * 10000.0).round() / 10000.0,
                 })
             })
             .collect();
@@ -1441,7 +1459,7 @@ impl KnowledgeHandlers {
             "atoms": atom_json,
             "count": count,
         });
-        if !section_json.is_empty() {
+        if explain && !section_json.is_empty() {
             data["sections"] = json!(section_json);
             data["section_count"] = json!(section_json.len());
         }

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -3672,3 +3672,205 @@ mod ann_type_filter_regression {
         }
     }
 }
+
+// ── compose explain=true section path ────────────────────────────────────────
+//
+// The test in integration.rs (`compose_explain_true_atom_path_includes_score_in_markdown`)
+// exercises only the no-embedder atom path because `KhiveRuntime::memory()` has
+// no registered embedder, so `embed_query` always returns None and section_results
+// stays empty.  The section path in `search.rs` — the `if let Some(qe) = q_emb`
+// branch that fills section_results, the `if explain && !section_json.is_empty()`
+// gate at line 1462, and the `breakdown` object serialisation — requires a real
+// embedder.  This module provides one and asserts that path UNCONDITIONALLY.
+
+mod compose_explain_sections {
+    use super::*;
+    use async_trait::async_trait;
+    use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
+    use khive_types::Namespace;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use std::sync::Arc;
+
+    const MODEL_KEY: &str = "all-minilm-l6-v2";
+    // Must match AllMiniLmL6V2.native_dimensions() so vector inserts succeed.
+    const DIM: usize = 384;
+
+    struct UnitVecService;
+
+    #[async_trait]
+    impl EmbeddingService for UnitVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            // Distinct unit vectors per position so each text gets a real non-zero vector.
+            Ok(texts
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    let v = (i + 1) as f32;
+                    let norm = (DIM as f32 * v * v).sqrt();
+                    vec![v / norm; DIM]
+                })
+                .collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "explain-section-service"
+        }
+    }
+
+    struct UnitVecProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for UnitVecProvider {
+        fn name(&self) -> &str {
+            MODEL_KEY
+        }
+
+        fn dimensions(&self) -> usize {
+            DIM
+        }
+
+        async fn build(
+            &self,
+        ) -> std::result::Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(UnitVecService))
+        }
+    }
+
+    fn rt_with_embedder() -> KhiveRuntime {
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("runtime");
+        rt.register_embedder(UnitVecProvider);
+        rt
+    }
+
+    /// Verify that compose(explain=true) actually exercises the section path:
+    /// sections[] is present and non-empty, every entry carries a breakdown with
+    /// all 5 sub-keys, section_count matches sections.len(), and the markdown
+    /// contains "(score:".
+    ///
+    /// Setup: embedder-backed runtime → upsert_atoms → knowledge.edit (which
+    /// embeds sections inline via embed_sections) → compose(explain=true).
+    /// With a live embedder, embed_query() returns Some(qe), score_sections runs,
+    /// section_results is non-empty, and the gating block at search.rs:1462 fires.
+    #[tokio::test]
+    async fn compose_explain_true_section_path_is_exercised() {
+        let rt = rt_with_embedder();
+        let f = pack(rt);
+
+        // Create the atom.
+        f.dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "explain-sec-atom",
+                    "name": "Explain Section Atom",
+                    "content": "retrieval augmented generation combines dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+        // Attach a section via knowledge.edit. With an embedder registered, edit
+        // calls embed_sections inline so the row gets a non-NULL embedding
+        // immediately — no separate knowledge.index call required.
+        f.dispatch(
+            "knowledge.edit",
+            json!({
+                "id": "explain-sec-atom",
+                "sections": [{
+                    "section_type": "overview",
+                    "content": "retrieval augmented generation combines dense and sparse retrieval with generative models for grounded output synthesis covering dense sparse retrieval corpus benchmark search latency gradient descent transformer attention"
+                }]
+            }),
+        )
+        .await
+        .expect("edit atom with section");
+
+        let resp = f
+            .dispatch(
+                "knowledge.compose",
+                json!({
+                    "atom_ids": ["explain-sec-atom"],
+                    "query": "retrieval augmented generation dense sparse",
+                    "explain": true
+                }),
+            )
+            .await
+            .expect("compose explain ok");
+
+        let data = &resp["data"];
+        let md = data["markdown"].as_str().expect("markdown present");
+
+        // Unconditional assertions — these must all pass. If any gate in
+        // search.rs (embed_query, section_results non-empty check, explain guard)
+        // is broken, the test will fail here, not silently skip.
+        let sections = data["sections"]
+            .as_array()
+            .expect("sections key must be present when explain=true and sections are embedded");
+        assert!(
+            !sections.is_empty(),
+            "sections array must be non-empty: {data:?}"
+        );
+
+        let sec = &sections[0];
+        let bd = sec
+            .get("breakdown")
+            .expect("each section must carry a breakdown object in explain mode");
+
+        assert!(
+            bd.get("section_cosine").is_some(),
+            "breakdown must have section_cosine: {bd:?}"
+        );
+        assert!(
+            bd.get("section_bm25").is_some(),
+            "breakdown must have section_bm25: {bd:?}"
+        );
+        assert!(
+            bd.get("atom_cosine").is_some(),
+            "breakdown must have atom_cosine: {bd:?}"
+        );
+        assert!(
+            bd.get("domain_score").is_some(),
+            "breakdown must have domain_score: {bd:?}"
+        );
+        assert!(
+            bd.get("type_weight").is_some(),
+            "breakdown must have type_weight: {bd:?}"
+        );
+
+        let section_count = data["section_count"]
+            .as_u64()
+            .expect("section_count must be present in explain mode");
+        assert_eq!(
+            section_count as usize,
+            sections.len(),
+            "section_count must equal sections.len()"
+        );
+
+        assert!(
+            md.contains("(score:"),
+            "section-path markdown must contain '(score:' when explain=true, got: {md}"
+        );
+    }
+}

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1726,6 +1726,149 @@ async fn compose_accepts_mix_of_domain_ids_and_atom_ids() {
     assert_eq!(count, 2);
 }
 
+// ── compose slim output (explain flag) ───────────────────────────────────────
+
+#[tokio::test]
+async fn compose_default_omits_sections_and_score_annotations() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                {
+                    "slug": "slim-atom-a",
+                    "name": "Slim Atom A",
+                    "content": "retrieval augmented generation dense sparse corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+                }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom");
+
+    let resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "atom_ids": ["slim-atom-a"],
+                "query": "retrieval augmented generation"
+            }),
+        )
+        .await
+        .expect("compose default ok");
+
+    let data = &resp["data"];
+    assert!(
+        data.get("sections").is_none(),
+        "sections must be absent in default mode"
+    );
+    assert!(
+        data.get("section_count").is_none(),
+        "section_count must be absent in default mode"
+    );
+
+    let md = data["markdown"].as_str().expect("markdown");
+    assert!(
+        !md.contains("(score:"),
+        "markdown must not contain (score: in default mode"
+    );
+    assert!(
+        !md.contains("Score:"),
+        "markdown must not contain Score: in default mode"
+    );
+
+    let atoms = data["atoms"].as_array().expect("atoms array");
+    assert!(!atoms.is_empty(), "atoms must be present");
+    let score_val = atoms[0]["score"].as_f64().expect("score is a number");
+    let rendered = format!("{}", atoms[0]["score"]);
+    let decimal_len = rendered
+        .find('.')
+        .map(|dot| rendered.len() - dot - 1)
+        .unwrap_or(0);
+    assert!(
+        decimal_len <= 4,
+        "atom score must serialize with at most 4 decimal places, got: {rendered}"
+    );
+    let _ = score_val;
+}
+
+#[tokio::test]
+async fn compose_explain_true_includes_sections_and_score_annotations() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                {
+                    "slug": "explain-atom-b",
+                    "name": "Explain Atom B",
+                    "content": "retrieval augmented generation combines dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+                    "body": [
+                        {
+                            "section_type": "summary",
+                            "content": "retrieval augmented generation combines dense and sparse retrieval with generative models for grounded output synthesis"
+                        }
+                    ]
+                }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom with sections");
+
+    let resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "atom_ids": ["explain-atom-b"],
+                "query": "retrieval augmented generation dense sparse",
+                "explain": true
+            }),
+        )
+        .await
+        .expect("compose explain ok");
+
+    let data = &resp["data"];
+    let md = data["markdown"].as_str().expect("markdown");
+
+    if data.get("sections").is_some() {
+        let sections = data["sections"].as_array().expect("sections array");
+        assert!(
+            !sections.is_empty(),
+            "sections array must not be empty when present"
+        );
+        let sec = &sections[0];
+        assert!(
+            sec.get("breakdown").is_some(),
+            "section must have breakdown in explain mode"
+        );
+        let bd = &sec["breakdown"];
+        assert!(
+            bd.get("section_cosine").is_some(),
+            "breakdown.section_cosine"
+        );
+        assert!(bd.get("section_bm25").is_some(), "breakdown.section_bm25");
+        assert!(bd.get("atom_cosine").is_some(), "breakdown.atom_cosine");
+        assert!(bd.get("domain_score").is_some(), "breakdown.domain_score");
+        assert!(bd.get("type_weight").is_some(), "breakdown.type_weight");
+        assert!(
+            data.get("section_count").is_some(),
+            "section_count must be present in explain mode"
+        );
+        assert!(
+            md.contains("(score:"),
+            "markdown must contain (score: in explain mode"
+        );
+    } else {
+        assert!(
+            md.contains("Score:"),
+            "atom-path markdown must contain Score: in explain mode when no sections"
+        );
+    }
+}
+
 // ── KPK-002: DomainInput deny_unknown_fields + domain-mirror content-word minimum ──
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1794,7 +1794,14 @@ async fn compose_default_omits_sections_and_score_annotations() {
 }
 
 #[tokio::test]
-async fn compose_explain_true_includes_sections_and_score_annotations() {
+async fn compose_explain_true_atom_path_includes_score_in_markdown() {
+    // This test uses a no-embedder runtime (rt()). Without an embedder,
+    // embed_query() returns None, so section_results is always empty and
+    // compose falls through to the atom-path markdown branch. The sole
+    // assertion here is that explain=true causes "Score:" to appear in the
+    // atom-path output. The section path (sections[] + breakdown + section_count
+    // + "(score:") is exercised by the embedder-backed test in fixes.rs:
+    // compose_explain_sections::compose_explain_true_section_path_is_exercised.
     let f = pack(rt());
 
     f.dispatch(
@@ -1804,19 +1811,13 @@ async fn compose_explain_true_includes_sections_and_score_annotations() {
                 {
                     "slug": "explain-atom-b",
                     "name": "Explain Atom B",
-                    "content": "retrieval augmented generation combines dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
-                    "body": [
-                        {
-                            "section_type": "summary",
-                            "content": "retrieval augmented generation combines dense and sparse retrieval with generative models for grounded output synthesis"
-                        }
-                    ]
+                    "content": "retrieval augmented generation combines dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
                 }
             ]
         }),
     )
     .await
-    .expect("upsert atom with sections");
+    .expect("upsert atom");
 
     let resp = f
         .dispatch(
@@ -1833,40 +1834,16 @@ async fn compose_explain_true_includes_sections_and_score_annotations() {
     let data = &resp["data"];
     let md = data["markdown"].as_str().expect("markdown");
 
-    if data.get("sections").is_some() {
-        let sections = data["sections"].as_array().expect("sections array");
-        assert!(
-            !sections.is_empty(),
-            "sections array must not be empty when present"
-        );
-        let sec = &sections[0];
-        assert!(
-            sec.get("breakdown").is_some(),
-            "section must have breakdown in explain mode"
-        );
-        let bd = &sec["breakdown"];
-        assert!(
-            bd.get("section_cosine").is_some(),
-            "breakdown.section_cosine"
-        );
-        assert!(bd.get("section_bm25").is_some(), "breakdown.section_bm25");
-        assert!(bd.get("atom_cosine").is_some(), "breakdown.atom_cosine");
-        assert!(bd.get("domain_score").is_some(), "breakdown.domain_score");
-        assert!(bd.get("type_weight").is_some(), "breakdown.type_weight");
-        assert!(
-            data.get("section_count").is_some(),
-            "section_count must be present in explain mode"
-        );
-        assert!(
-            md.contains("(score:"),
-            "markdown must contain (score: in explain mode"
-        );
-    } else {
-        assert!(
-            md.contains("Score:"),
-            "atom-path markdown must contain Score: in explain mode when no sections"
-        );
-    }
+    // Without an embedder, sections are never emitted — the atom-path branch
+    // runs and renders "Score: X.XXXX" per atom when explain=true.
+    assert!(
+        data.get("sections").is_none(),
+        "no-embedder runtime must not emit sections key"
+    );
+    assert!(
+        md.contains("Score:"),
+        "atom-path markdown must contain 'Score:' when explain=true, got: {md}"
+    );
 }
 
 // ── KPK-002: DomainInput deny_unknown_fields + domain-mirror content-word minimum ──


### PR DESCRIPTION
## knowledge.compose — slim default output, full telemetry behind `explain=true`

Addresses the verbosity in `knowledge.compose`: the default response carried three overlapping representations of the same ranking (`atoms[]`, `sections[]`, `markdown`) plus a per-section `breakdown{}` of five raw scoring sub-scores. For an agent consumer the `markdown` briefing is the payload; the rest is scoring telemetry.

### What changed

**Default response is now slim:** `query`, `markdown` (clean — no inline `(score:)`), `atoms[]` (rounded score), `domains[]`, `count`. The `sections[]` array, `section_count`, and all per-section `breakdown` telemetry are **no longer emitted by default**.

**`explain=true` restores the full prior shape** for ranker tuning/debugging: `sections[]` with `breakdown{section_cosine, section_bm25, atom_cosine, domain_score, type_weight}`, `section_count`, and inline `(score:)`/`Score:` in the markdown. New optional param; defaults to `false`.

**`atoms[].score` is now rounded** to 4 decimals via the crate's existing convention (`(x*10000).round()/10000`), matching how section scores were already rounded — kills the full-precision `0.7851999998092651` noise.

### Why this is the right cut

The existing 8K-token budget (`search.rs:1350`) only bounds the **markdown** (it trims which sections/atoms get composed into prose). The `sections[]` + `breakdown` block rode on top, **uncounted** — which is why a budgeted-8K compose returned ~61KB. Slimming the default removes that unbudgeted overhead: roughly a **40–45% payload cut with zero loss of usable content** (the markdown briefing is unchanged in substance).

### Safety

Regression hunt across the whole repo: **no internal consumer** reads `sections`/`section_count`/`breakdown` from compose output without `explain=true`. The only compose consumer in-repo reads `atoms` only; npm/cli clients don't touch these fields; the ADR-048 section-manifest hook that would read them is documented as not-yet-wired (it will simply need to pass `explain=true` when implemented).

### Tests

- `compose_default_omits_sections_and_score_annotations` — default response has no `sections`/`section_count`, no inline score in markdown, rounded atom score.
- `compose_explain_true_atom_path_includes_score_in_markdown` (integration.rs, no-embedder path) — `explain=true` renders `Score:` in the atom-path markdown.
- `compose_explain_true_section_path_is_exercised` (fixes.rs, embedder-backed) — drives the real section path (upsert → `knowledge.edit` embeds sections inline → `compose(explain=true)`) and asserts **unconditionally**: `sections[]` present and non-empty, every entry has a `breakdown` with all 5 sub-keys, `section_count == sections.len()`, markdown contains `(score:`. Verified via panic-probe that the section assertions actually execute (an earlier version guarded them behind `if sections.is_some()` and silently no-opped — that false-green is removed).

Gates from `crates/`: `cargo fmt --all -- --check` green; `cargo clippy -p khive-pack-knowledge --all-targets -- -D warnings` green; `cargo test -p khive-pack-knowledge` 72 passed.

### Follow-up (separate doc PR)

`marketplace/knowledge/README.md` compose param table should list the new `explain` flag, and ADR-048 should note the section manifest is now opt-in. Kept out of this PR per the code/docs split convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

