### PR TITLE
test(mcp): assert multi-backend physical isolation across backend files

### DIFF
--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -49,3 +49,4 @@ async-trait = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }
 khive-pack-knowledge = { version = "0.2.11", path = "../khive-pack-knowledge" }
+rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1264,4 +1264,161 @@ brain_profile = "project-profile"
              both produced: {id_a}"
         );
     }
+
+    /// Physical isolation guard: a record written through a pack pinned to backend B's
+    /// SQLite file MUST NOT appear in backend A's file, and vice versa.
+    ///
+    /// This is the "billing data must not mix with agent memory" guarantee.
+    /// The test opens each file independently with rusqlite after the server is
+    /// dropped to confirm cross-file absence in both directions.
+    ///
+    /// Schema facts discovered from crates/khive-db/sql/:
+    ///   entities table — column `name` holds the entity name (entities-ddl.sql)
+    ///   notes table    — column `content` holds the message body; `kind` = "message"
+    ///                    for comm.send output (notes-ddl.sql + comm handlers.rs)
+    #[tokio::test]
+    #[serial]
+    async fn multi_backend_isolates_pack_data_to_separate_files() {
+        use crate::tools::request::RequestParams;
+        use khive_runtime::PackConfig;
+        use rusqlite::Connection;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let main_path = dir.path().join("main.db");
+        let second_path = dir.path().join("second.db");
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                BackendConfig {
+                    name: "main".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(main_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                BackendConfig {
+                    name: "second".to_string(),
+                    kind: BackendKind::Sqlite,
+                    path: Some(second_path.clone()),
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            packs: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "second".to_string(),
+                    },
+                );
+                m
+            },
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let server = build_server_multi_backend(base_cfg, &khive_cfg)
+            .expect("multi-backend boot must succeed");
+
+        let dispatch = |ops: String| {
+            let server = &server;
+            async move {
+                server
+                    .dispatch_request_local(RequestParams {
+                        ops,
+                        presentation: None,
+                        presentation_per_op: None,
+                    })
+                    .await
+                    .expect("dispatch must not error")
+            }
+        };
+
+        // kg → main.db: create an entity
+        let kg_resp =
+            dispatch(r#"create(kind="concept", name="MainOnlyEntity")"#.to_string()).await;
+        let kg_json: serde_json::Value =
+            serde_json::from_str(&kg_resp).expect("kg response is valid JSON");
+        assert_eq!(
+            kg_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "kg create must succeed; response: {kg_resp}"
+        );
+
+        // comm → second.db: send a message
+        let comm_resp =
+            dispatch(r#"comm.send(to="local", content="SecondOnlyMsg")"#.to_string()).await;
+        let comm_json: serde_json::Value =
+            serde_json::from_str(&comm_resp).expect("comm response is valid JSON");
+        assert_eq!(
+            comm_json["results"][0]["ok"].as_bool(),
+            Some(true),
+            "comm.send must succeed; response: {comm_resp}"
+        );
+
+        // Drop the server so WAL is checkpointed and files are fully flushed
+        // before we open them with rusqlite.
+        drop(server);
+
+        // --- Verify main.db ---
+        let main_conn = Connection::open(&main_path).expect("open main.db");
+
+        let main_entity_count: i64 = main_conn
+            .query_row(
+                "SELECT COUNT(*) FROM entities WHERE name = 'MainOnlyEntity' AND deleted_at IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query entities in main.db");
+        assert_eq!(
+            main_entity_count, 1,
+            "main.db MUST contain MainOnlyEntity (written via kg pack); got count={main_entity_count}"
+        );
+
+        let main_msg_count: i64 = main_conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE kind = 'message'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query notes in main.db");
+        assert_eq!(
+            main_msg_count, 0,
+            "main.db MUST NOT contain any message notes (comm is pinned to second.db); \
+             got count={main_msg_count}"
+        );
+
+        // --- Verify second.db ---
+        let second_conn = Connection::open(&second_path).expect("open second.db");
+
+        let second_msg_count: i64 = second_conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE kind = 'message' AND content = 'SecondOnlyMsg'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query notes in second.db");
+        assert_eq!(
+            second_msg_count, 2,
+            "second.db MUST contain SecondOnlyMsg (dual-write: 1 outbound + 1 inbound copy); \
+             got count={second_msg_count}"
+        );
+
+        let second_entity_count: i64 = second_conn
+            .query_row(
+                "SELECT COUNT(*) FROM entities WHERE name = 'MainOnlyEntity'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query entities in second.db");
+        assert_eq!(
+            second_entity_count, 0,
+            "second.db MUST NOT contain MainOnlyEntity (kg is pinned to main.db); \
+             got count={second_entity_count}"
+        );
+    }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1276,6 +1276,12 @@ brain_profile = "project-profile"
     ///   entities table — column `name` holds the entity name (entities-ddl.sql)
     ///   notes table    — column `content` holds the message body; `kind` = "message"
     ///                    for comm.send output (notes-ddl.sql + comm handlers.rs)
+    ///
+    /// Relies on `base_runtime_config_for_multi_backend` leaving `embedding_model`
+    /// unset: no embedder means no `vec0` virtual table is created, so the plain
+    /// `rusqlite::Connection::open` below (which does not load the vec0 extension)
+    /// can read both files. If an embedder is ever added to that helper, this test
+    /// must load the extension or query through a runtime instead.
     #[tokio::test]
     #[serial]
     async fn multi_backend_isolates_pack_data_to_separate_files() {


### PR DESCRIPTION
## What

Adds a regression test proving the ADR-028/029 multi-backend mechanism **physically** isolates pack data across separate SQLite files. This is the guarantee studio depends on: billing/operational data must never land in the agent-memory file.

## Why

The existing multi-backend tests (`multi_backend_boots_ok_with_two_memory_backends`, `multi_backend_preserves_actor_filtering`, etc.) prove the server boots with multiple backends and that actor filtering holds. **None of them asserted physical isolation** — that a pack pinned to backend A leaves zero rows in backend B's file.

## The test

`multi_backend_isolates_pack_data_to_separate_files` (`crates/khive-mcp/src/serve.rs`):

1. Two on-disk SQLite backends (`main.db`, `second.db`); comm pinned to `second`.
2. Dispatch `create(kind="concept", ...)` (routes to `main`) and `comm.send(...)` (routes to `second`).
3. Drop the server (WAL checkpoint), then open each file with raw rusqlite and assert:
   - `main.db`: the entity present, **zero** message notes
   - `second.db`: the messages present (dual-write = 2), **zero** entities

Falsified during development: re-pointing comm at `main` makes the isolation assert fail, so the test genuinely bites.

## Verification

- `cargo test -p khive-mcp` — 6/6 multi-backend tests green
- `cargo fmt --check`, `cargo clippy` — clean (pre-commit)
- Triple-confirmed end-to-end: also proven live against a fresh `kkernel` binary over stdio

## Notes

- Adds `rusqlite { workspace = true, features = ["bundled"] }` to `khive-mcp` **dev-dependencies** only.
- The test relies on `base_runtime_config_for_multi_backend` leaving `embedding_model` unset (no embedder → no `vec0` table) so the plain rusqlite connection can read both files; documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)