### PR TITLE
docs(verbs): fix stale insert_only + verb-surface help text (#133, #160)

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -89,7 +89,9 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
                 name: "id",
                 param_type: "uuid",
                 required: true,
-                description: "UUID of the entity, note, edge, event, or proposal to fetch.",
+                description: "UUID of the entity, note, edge, event, or proposal to fetch. \
+                               Short hex prefix accepted (minimum 8 hex characters); \
+                               shorter prefixes are not resolved and will be treated as a name lookup.",
             },
             ParamDef {
                 name: "include_deleted",
@@ -340,7 +342,8 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
     // Declaration: declares two entities identical
     HandlerDef {
         name: "merge",
-        description: "Deduplicate two entities",
+        description: "Deduplicate two entities. Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned, content_appended, dry_run}; \
+                       chain with $prev.kept_id (not $prev.id — merge does not return a top-level id field).",
         visibility: Visibility::Verb,
         category: VerbCategory::Declaration,
         params: &[
@@ -544,7 +547,11 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
     // Commissive: commits a proposal to the namespace event log
     HandlerDef {
         name: "propose",
-        description: "Create an event-sourced change proposal",
+        description: "Create an event-sourced change proposal. Returns {id, status, proposer, title}; \
+                       chain with $prev.id (not $prev.proposal_id). \
+                       Note: the changeset field contains nested objects and cannot be expressed in \
+                       function-call DSL form — use JSON form instead: \
+                       request(ops=\"[{\\\"tool\\\":\\\"propose\\\",\\\"args\\\":{...}}]\").",
         visibility: Visibility::Verb,
         category: VerbCategory::Commissive,
         params: &[

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -123,7 +123,7 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 name: "insert_only",
                 param_type: "boolean",
                 required: false,
-                description: "Skip delete-then-insert (faster for fresh corpus backfill)",
+                description: "Deprecated no-op. Accepted for API compatibility but no longer drives any pre-delete behavior; SqliteVecStore::insert atomically replaces regardless of this flag.",
             },
             ParamDef {
                 name: "rebuild_ann",
@@ -326,7 +326,9 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
                 name: "sections",
                 param_type: "array<object>",
                 required: true,
-                description: "Sections to upsert: [{section_type, content, heading?, sort_order?}]",
+                description: "Sections to upsert: [{section_type, content, heading?, sort_order?}]. \
+                    section_type is a closed enum — valid values: overview | core_model | boundary_conditions | formalism | operational_guidance | examples | failure_modes | expert_lens | references | other. \
+                    content must be ≥80 characters.",
             },
         ],
     },


### PR DESCRIPTION
## Summary

- Closes #133 — `knowledge.index` `insert_only` param description updated from stale "Skip delete-then-insert" to "Deprecated no-op. Accepted for API compatibility but no longer drives any pre-delete behavior."
- Addresses #160 — five doc/help-text sub-items fixed across `khive-pack-kg` and `khive-pack-knowledge`

## Changes

### #133 — `crates/khive-pack-knowledge/src/vocab.rs:123-127`

`insert_only` description was `"Skip delete-then-insert (faster for fresh corpus backfill)"` — describes removed behavior. Now marks it as a deprecated no-op with accurate explanation of actual semantics.

### #160 checklist — fixed vs deferred

**Fixed (doc/help-text only, zero behavior change):**

- [x] **Item 1 — `propose` changeset requires JSON form**: Added to `propose` description: "the changeset field contains nested objects and cannot be expressed in function-call DSL form — use JSON form instead." (`crates/khive-pack-kg/src/handler_defs.rs`)
- [x] **Item 4 — `get` min-prefix undocumented**: Added to `get` `id` param description: "Short hex prefix accepted (minimum 8 hex characters); shorter prefixes are not resolved and will be treated as a name lookup."
- [x] **Item 5 — `propose` returns `id` not `proposal_id`**: Added to `propose` description: "Returns {id, status, proposer, title}; chain with `$prev.id` (not `$prev.proposal_id`)."
- [x] **Item 6 — `merge` returns `kept_id`/`removed_id` not `id`**: Added to `merge` description: "Returns {kept_id, removed_id, edges_rewired, ...}; chain with `$prev.kept_id` (not `$prev.id`)."
- [x] **Item 7 — `knowledge.edit` section_type undocumented**: Added to `sections` param description: closed 10-value enum listing + "content must be ≥80 characters." (`crates/khive-pack-knowledge/src/vocab.rs`)

**Closed as by-design (no fix needed):**

- **Item 2 — `gtd.transition` next→done**: Confirmed in `khive-pack-gtd/src/schema.rs:9` — next→done is explicitly allowed in the lifecycle DAG. Intended behavior.
- **Item 3 — `comm.read` errors on outbound**: Error message at `khive-pack-comm/src/handlers.rs:227` is already descriptive and intentional. No change warranted.

## Test plan

- [x] `cargo test -p khive-pack-knowledge -p khive-pack-kg` — 72 passed, 0 failed
- [x] `cargo clippy -p khive-pack-knowledge -p khive-pack-kg --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p khive-pack-knowledge -p khive-pack-kg -- --check` — clean
- [x] Pre-commit hooks: cargo fmt, cargo clippy, secret scan — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)