### PR TITLE
feat(memory): honor expires_at in recall; add memory.prune + memory.vacuum

### DIFF
--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -1031,12 +1031,16 @@ impl MemoryPack {
             .iter()
             .map(String::as_str)
             .collect();
+        let now_micros = chrono::Utc::now().timestamp_micros();
         for note in batch {
             // Post-filter: ANN over-fetch may include rows from outside the caller's
             // visible namespace set. Drop them here where the note row carries its namespace.
+            // Also exclude memories whose expires_at is in the past (view-layer expiry).
+            let expired = note.expires_at.map(|e| e <= now_micros).unwrap_or(false);
             if note.deleted_at.is_none()
                 && note.kind == "memory"
                 && visible_set.contains(note.namespace.as_str())
+                && !expired
             {
                 memory_ids.insert(note.id);
                 notes_by_id.insert(note.id, note);

--- a/crates/khive-pack-memory/src/handlers/mod.rs
+++ b/crates/khive-pack-memory/src/handlers/mod.rs
@@ -2,6 +2,7 @@
 
 mod common;
 mod feedback;
+mod prune;
 mod recall;
 mod remember;
 mod sub_handlers;

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -1,0 +1,160 @@
+//! Handlers for `memory.prune` and `memory.vacuum`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use khive_runtime::{NamespaceToken, RuntimeError};
+use khive_storage::types::{DeleteMode, SqlStatement, SqlValue};
+
+use crate::MemoryPack;
+
+// ── Params ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PruneParams {
+    /// Soft-delete memories whose salience is strictly below this value.
+    /// `None` means no salience filter.
+    pub min_salience: Option<f64>,
+    /// Soft-delete memories whose `expires_at` is at or before this timestamp
+    /// (Unix microseconds). When omitted, defaults to `now`.
+    /// Pass `0` to skip the expiry filter entirely.
+    pub before: Option<i64>,
+    /// Namespace to prune. Defaults to `"local"`.
+    pub namespace: Option<String>,
+    /// Dry-run mode: count candidates without deleting. Default false.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct VacuumParams {
+    // No parameters — VACUUM takes no arguments.
+}
+
+// ── Implementations ───────────────────────────────────────────────────────────
+
+impl MemoryPack {
+    pub(crate) async fn handle_prune(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        let p: PruneParams = serde_json::from_value(params).map_err(|e| {
+            RuntimeError::InvalidInput(format!("memory.prune: invalid params: {e}"))
+        })?;
+
+        let namespace = p.namespace.as_deref().unwrap_or("local").to_string();
+
+        let now_micros = chrono::Utc::now().timestamp_micros();
+
+        // Collect IDs to prune: memories matching either criterion.
+        // We query via SqlAccess to avoid a full note-store scan.
+        let sql = self.runtime.sql();
+        let mut reader = sql.reader().await?;
+
+        // Build candidate query: kind='memory', not deleted, in namespace.
+        // We'll apply Python-side salience and expires_at filters below.
+        // For large datasets a dedicated SQL WHERE is better, but the note
+        // set is bounded by namespace and kind, so row-level filtering is safe.
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT id, salience, expires_at \
+                      FROM notes \
+                      WHERE kind = 'memory' \
+                        AND namespace = ? \
+                        AND deleted_at IS NULL"
+                    .to_string(),
+                params: vec![SqlValue::Text(namespace.clone())],
+                label: Some("memory.prune.candidates".to_string()),
+            })
+            .await?;
+
+        let mut to_delete: Vec<uuid::Uuid> = Vec::new();
+
+        for row in rows {
+            let id_str = match row.get("id") {
+                Some(SqlValue::Text(s)) => s.clone(),
+                _ => continue,
+            };
+            let id: uuid::Uuid = match id_str.parse() {
+                Ok(u) => u,
+                Err(_) => continue,
+            };
+
+            // Check salience threshold.
+            if let Some(min_sal) = p.min_salience {
+                let sal = match row.get("salience") {
+                    Some(SqlValue::Float(f)) => *f,
+                    Some(SqlValue::Integer(i)) => *i as f64,
+                    _ => 0.0, // treat missing salience as 0
+                };
+                if sal < min_sal {
+                    to_delete.push(id);
+                    continue;
+                }
+            }
+
+            // Check expiry. `before = Some(0)` skips expiry filter.
+            let cutoff = match p.before {
+                Some(0) => None, // explicit zero = skip expiry filter
+                Some(ts) => Some(ts),
+                None => Some(now_micros), // default = now
+            };
+            if let Some(cutoff_ts) = cutoff {
+                let exp = match row.get("expires_at") {
+                    Some(SqlValue::Integer(i)) => Some(*i),
+                    _ => None,
+                };
+                if let Some(e) = exp {
+                    if e <= cutoff_ts {
+                        to_delete.push(id);
+                    }
+                }
+            }
+        }
+
+        let count = to_delete.len();
+
+        if p.dry_run {
+            return Ok(json!({
+                "pruned": 0,
+                "dry_run": true,
+                "would_prune": count,
+                "namespace": namespace,
+            }));
+        }
+
+        // Soft-delete each candidate via NoteStore.
+        let note_store = self.runtime.notes(token)?;
+        let mut pruned = 0usize;
+        for id in to_delete {
+            if note_store.delete_note(id, DeleteMode::Soft).await? {
+                pruned += 1;
+            }
+        }
+
+        Ok(json!({
+            "pruned": pruned,
+            "dry_run": false,
+            "namespace": namespace,
+        }))
+    }
+
+    pub(crate) async fn handle_vacuum(&self, params: Value) -> Result<Value, RuntimeError> {
+        // Validate params — must be empty object or omitted.
+        let _: VacuumParams = serde_json::from_value(params).map_err(|e| {
+            RuntimeError::InvalidInput(format!("memory.vacuum: invalid params: {e}"))
+        })?;
+
+        // VACUUM must run outside an open transaction. A plain writer connection
+        // via execute_script (which calls execute_batch internally) satisfies
+        // SQLite's requirement that VACUUM is issued at the top level.
+        let sql = self.runtime.sql();
+        let mut writer = sql.writer().await?;
+        writer.execute_script("VACUUM;".to_string()).await?;
+
+        Ok(json!({ "ok": true }))
+    }
+}

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -77,7 +77,7 @@ impl Pack for MemoryPack {
 // Illocutionary classification (Searle 1976):
 //   Commissive — commits caller to a persistent change
 //   Assertive  — retrieves/presents state of affairs
-static MEMORY_HANDLERS: [HandlerDef; 8] = [
+static MEMORY_HANDLERS: [HandlerDef; 10] = [
     // Commissive: commits a memory to the namespace
     HandlerDef {
         name: "memory.remember",
@@ -290,6 +290,47 @@ static MEMORY_HANDLERS: [HandlerDef; 8] = [
         category: VerbCategory::Assertive,
         params: &[],
     },
+    // Commissive: curation prune of low-salience or expired memories
+    HandlerDef {
+        name: "memory.prune",
+        description: "Soft-delete memories below a salience threshold and/or past expires_at. Curation-layer operation per ADR-014.",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Commissive,
+        params: &[
+            ParamDef {
+                name: "min_salience",
+                param_type: "number",
+                required: false,
+                description: "Soft-delete memories with salience strictly below this value.",
+            },
+            ParamDef {
+                name: "before",
+                param_type: "integer",
+                required: false,
+                description: "Soft-delete memories expired at or before this Unix microsecond timestamp. Defaults to now. Pass 0 to skip expiry filter.",
+            },
+            ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: false,
+                description: "Namespace to prune. Defaults to \"local\".",
+            },
+            ParamDef {
+                name: "dry_run",
+                param_type: "boolean",
+                required: false,
+                description: "When true, count candidates without deleting. Default false.",
+            },
+        ],
+    },
+    // Commissive: reclaim disk space freed by soft-deleted rows
+    HandlerDef {
+        name: "memory.vacuum",
+        description: "Run SQLite VACUUM to reclaim space freed by soft-deleted rows.",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Commissive,
+        params: &[],
+    },
 ];
 
 // ── Inventory self-registration ───────────────────────────────────────────────
@@ -355,6 +396,8 @@ impl PackRuntime for MemoryPack {
             "memory.recall_fuse" => self.handle_recall_fuse(token, params, registry).await,
             "memory.recall_rerank" => self.handle_recall_rerank(params).await,
             "memory.recall_score" => self.handle_recall_score(params).await,
+            "memory.prune" => self.handle_prune(token, params).await,
+            "memory.vacuum" => self.handle_vacuum(params).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "memory pack does not handle verb {verb:?}"
             ))),

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -4262,3 +4262,292 @@ async fn adr007_rev6_episodic_cross_actor_isolation() {
          memory (in namespace 'alice'); isolation FAILED — got: {anon_ids:?}"
     );
 }
+
+// ── expires_at recall filter ──────────────────────────────────────────────────
+
+/// Expired memories (expires_at <= now) must be excluded from recall results.
+#[tokio::test]
+async fn test_expires_at_excluded_from_recall() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    // Store a memory.
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "this memory should expire and vanish from recall",
+                "memory_type": "semantic",
+                "salience": 0.9,
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed");
+
+    let note_id_str = result["id"].as_str().expect("note id present").to_owned();
+    let note_id: Uuid = note_id_str.parse().expect("valid UUID");
+
+    // Confirm it is recalled while fresh.
+    let fresh_recall = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "memory should expire and vanish from recall" }),
+        )
+        .await
+        .expect("recall must succeed");
+    let fresh_hits = fresh_recall.as_array().expect("array");
+    let fresh_ids: Vec<&str> = fresh_hits
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        fresh_ids.contains(&note_id_str.as_str()),
+        "memory must appear in recall before expiry; got: {fresh_ids:?}"
+    );
+
+    // Backdate expires_at to a point in the past.
+    let past_micros = chrono::Utc::now().timestamp_micros() - 1_000_000; // 1 second ago
+    let tok = rt.authorize(Namespace::local()).expect("authorize local");
+    let note_store = rt.notes(&tok).expect("notes store");
+    let mut note = note_store
+        .get_note(note_id)
+        .await
+        .expect("get must succeed")
+        .expect("note must exist");
+    note.expires_at = Some(past_micros);
+    note_store
+        .upsert_note(note)
+        .await
+        .expect("upsert must succeed");
+
+    // Now recall must NOT include the expired memory.
+    let expired_recall = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "memory should expire and vanish from recall" }),
+        )
+        .await
+        .expect("recall after expiry must succeed");
+    let expired_hits = expired_recall.as_array().expect("array");
+    let expired_ids: Vec<&str> = expired_hits
+        .iter()
+        .map(|h| h["id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        !expired_ids.contains(&note_id_str.as_str()),
+        "expired memory (expires_at <= now) must be excluded from recall; got: {expired_ids:?}"
+    );
+}
+
+// ── memory.prune ─────────────────────────────────────────────────────────────
+
+/// memory.prune with min_salience soft-deletes low-salience memories.
+#[tokio::test]
+async fn test_prune_by_salience() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    // High-salience memory — must survive prune.
+    let high = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "high salience memory that should survive prune",
+                "memory_type": "semantic",
+                "salience": 0.9,
+            }),
+        )
+        .await
+        .expect("remember high");
+    let high_id = high["id"].as_str().expect("id").to_owned();
+
+    // Low-salience memory — must be pruned.
+    let low = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "low salience memory that should be pruned",
+                "memory_type": "semantic",
+                "salience": 0.1,
+            }),
+        )
+        .await
+        .expect("remember low");
+    let low_id = low["id"].as_str().expect("id").to_owned();
+
+    // Prune min_salience=0.5: low must go, high must remain.
+    let prune_result = registry
+        .dispatch("memory.prune", json!({ "min_salience": 0.5, "before": 0 }))
+        .await
+        .expect("memory.prune must succeed");
+
+    assert_eq!(
+        prune_result["dry_run"].as_bool(),
+        Some(false),
+        "dry_run must be false"
+    );
+    assert!(
+        prune_result["pruned"].as_u64().unwrap_or(0) >= 1,
+        "at least 1 memory pruned; got: {prune_result:?}"
+    );
+
+    // Verify via NoteStore that low-salience note is soft-deleted.
+    let tok = rt.authorize(Namespace::local()).expect("authorize local");
+    let low_uuid: Uuid = low_id.parse().expect("valid uuid");
+    let low_note = rt
+        .get_note_including_deleted(&tok, low_uuid)
+        .await
+        .expect("get must succeed")
+        .expect("row must exist");
+    assert!(
+        low_note.deleted_at.is_some(),
+        "low-salience memory must be soft-deleted after prune; deleted_at={:?}",
+        low_note.deleted_at
+    );
+
+    // High-salience note must NOT be deleted.
+    let high_uuid: Uuid = high_id.parse().expect("valid uuid");
+    let high_note = rt
+        .get_note_including_deleted(&tok, high_uuid)
+        .await
+        .expect("get must succeed")
+        .expect("row must exist");
+    assert!(
+        high_note.deleted_at.is_none(),
+        "high-salience memory must NOT be deleted by prune; deleted_at={:?}",
+        high_note.deleted_at
+    );
+}
+
+/// memory.prune with no explicit `before` value (defaults to now) prunes expired memories.
+#[tokio::test]
+async fn test_prune_expired_by_default_cutoff() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    // Store a memory.
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "will be expired and then pruned",
+                "memory_type": "semantic",
+                "salience": 0.8,
+            }),
+        )
+        .await
+        .expect("remember");
+    let note_id_str = result["id"].as_str().expect("id").to_owned();
+    let note_id: Uuid = note_id_str.parse().expect("valid uuid");
+
+    // Set expires_at to the past.
+    let past_micros = chrono::Utc::now().timestamp_micros() - 1_000_000;
+    let tok = rt.authorize(Namespace::local()).expect("authorize local");
+    let note_store = rt.notes(&tok).expect("notes");
+    let mut note = note_store
+        .get_note(note_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    note.expires_at = Some(past_micros);
+    note_store.upsert_note(note).await.expect("upsert");
+
+    // Prune with no salience filter, default cutoff = now.
+    let prune_result = registry
+        .dispatch("memory.prune", json!({}))
+        .await
+        .expect("memory.prune must succeed");
+
+    assert!(
+        prune_result["pruned"].as_u64().unwrap_or(0) >= 1,
+        "expired memory must be pruned; got: {prune_result:?}"
+    );
+
+    let pruned_note = rt
+        .get_note_including_deleted(&tok, note_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(
+        pruned_note.deleted_at.is_some(),
+        "expired memory must be soft-deleted after prune"
+    );
+}
+
+/// memory.prune dry_run=true counts without deleting.
+#[tokio::test]
+async fn test_prune_dry_run() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "dry run target memory",
+                "memory_type": "semantic",
+                "salience": 0.05,
+            }),
+        )
+        .await
+        .expect("remember");
+    let note_id_str = result["id"].as_str().expect("id").to_owned();
+    let note_id: Uuid = note_id_str.parse().expect("valid uuid");
+
+    // Dry run — should report would_prune >= 1 but not delete.
+    let dry_result = registry
+        .dispatch(
+            "memory.prune",
+            json!({ "min_salience": 0.5, "before": 0, "dry_run": true }),
+        )
+        .await
+        .expect("memory.prune dry_run must succeed");
+
+    assert_eq!(
+        dry_result["dry_run"].as_bool(),
+        Some(true),
+        "dry_run field must be true"
+    );
+    assert!(
+        dry_result["would_prune"].as_u64().unwrap_or(0) >= 1,
+        "dry_run must report >= 1 would_prune; got: {dry_result:?}"
+    );
+    assert_eq!(
+        dry_result["pruned"].as_u64(),
+        Some(0),
+        "dry_run must not delete (pruned must be 0)"
+    );
+
+    // Verify note is NOT deleted.
+    let tok = rt.authorize(Namespace::local()).expect("authorize local");
+    let note = rt
+        .get_note_including_deleted(&tok, note_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(
+        note.deleted_at.is_none(),
+        "dry_run must not soft-delete notes; deleted_at={:?}",
+        note.deleted_at
+    );
+}
+
+// ── memory.vacuum ─────────────────────────────────────────────────────────────
+
+/// memory.vacuum must succeed and return ok=true.
+#[tokio::test]
+async fn test_vacuum_succeeds() {
+    let rt = make_runtime();
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch("memory.vacuum", json!({}))
+        .await
+        .expect("memory.vacuum must succeed");
+
+    assert_eq!(
+        result["ok"].as_bool(),
+        Some(true),
+        "vacuum must return ok=true; got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- **expires_at recall filter**: Expired memories (`expires_at <= now`) are now excluded from `memory.recall` results as a view-layer filter in `load_memory_candidate_notes`. No data is deleted — this is purely a visibility gate.
- **memory.prune verb**: New curation verb (ADR-014) that soft-deletes memories below a salience threshold (`min_salience`) and/or past `expires_at`. Accepts `dry_run=true` to count candidates without deleting, and a `namespace` param (default `"local"`). Pass `before=0` to skip the expiry filter and use only salience.
- **memory.vacuum verb**: New verb that runs `SQLite VACUUM` to reclaim disk space freed by soft-deleted rows.
- Both new verbs are registered in `MEMORY_HANDLERS` (size 8 → 10) and wired into `dispatch()`.

## Files changed

- `crates/khive-pack-memory/src/handlers/prune.rs` — new file, prune + vacuum handlers
- `crates/khive-pack-memory/src/handlers/common.rs` — expires_at view-filter in `load_memory_candidate_notes`
- `crates/khive-pack-memory/src/handlers/mod.rs` — `mod prune;` declaration
- `crates/khive-pack-memory/src/pack.rs` — 2 new `HandlerDef` entries + 2 dispatch arms
- `crates/khive-pack-memory/tests/integration.rs` — 5 new integration tests

## Test plan

- [x] `test_expires_at_excluded_from_recall` — memory backdated to past `expires_at` vanishes from recall
- [x] `test_prune_by_salience` — `memory.prune(min_salience=0.5)` soft-deletes low-salience, keeps high-salience
- [x] `test_prune_expired_by_default_cutoff` — `memory.prune({})` prunes memories whose `expires_at` is past
- [x] `test_prune_dry_run` — `dry_run=true` reports `would_prune` without deleting
- [x] `test_vacuum_succeeds` — `memory.vacuum({})` returns `ok: true`
- [x] Full suite: `cargo test -p khive-pack-memory` → 81/81 pass
- [x] `cargo clippy -p khive-pack-memory --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [x] All pre-commit hooks passed

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)