### PR TITLE
feat(comm): surface from/subject/preview in inbox; warn on unattributed actor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 | `comm.reply`  | Reply to a message (threading linkage) | Respond in-thread                        |
 | `comm.thread` | Retrieve full conversation thread      | Read the whole conversation              |
 
+**Inbox shape (ADR-057).** `comm.inbox` is scannable: each entry carries top-level `from`, `to`,
+`subject`, `read`, `direction`, and a derived `preview` (whitespace-collapsed, truncated to 80
+chars) — triage without a `get` per message. Delivery is actor-addressed: `comm.send(to="lambda:x")`
+stamps `from_actor` from the server's configured actor and lands in `x`'s inbox, and `comm.inbox`
+returns only messages addressed to you. Set that actor via `--actor` / `KHIVE_ACTOR`; an unset actor
+sends and reads as the shared `"local"` party line.
+
 ### Schedule pack — 4 verbs (`schedule.` prefix)
 
 | Verb                | What it does                     | When to use                                    |

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -187,6 +187,17 @@ pub fn build_registry_for_multi_backend(
         }
     }
 
+    if should_warn_unattributed(
+        default_runtime.config().actor_id.as_deref(),
+        &default_runtime.config().packs,
+    ) {
+        tracing::warn!(
+            "actor identity resolved to \"local\": comm sends will be stamped from \
+             \"local\" (unattributed) and comm.inbox will be unscoped (party-line). \
+             Set KHIVE_ACTOR or --actor to this lambda's id."
+        );
+    }
+
     let gate = default_runtime.config().gate.clone();
     let default_namespace = default_runtime.config().default_namespace.clone();
     let config_id = crate::server::compute_config_id(default_runtime.config(), Some(khive_cfg));
@@ -246,6 +257,19 @@ pub fn build_registry_for_multi_backend(
     })
 }
 
+/// Return true when the actor identity will produce unattributed comm sends and
+/// a party-line inbox.
+///
+/// Fires when:
+/// - `actor_id` is `None` (not configured) or `"local"` (the default fallback), AND
+/// - the loaded pack list includes `"comm"`.
+///
+/// Pure predicate — no I/O, no logging. Callers emit the warning.
+pub(crate) fn should_warn_unattributed(actor_id: Option<&str>, loaded_packs: &[String]) -> bool {
+    let is_local = actor_id.map(|id| id == "local").unwrap_or(true);
+    is_local && loaded_packs.iter().any(|p| p == "comm")
+}
+
 /// Build a fully-configured server from parsed args (without serving).
 pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
     let (cli_namespace_explicit, cli_namespace) =
@@ -280,6 +304,16 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
             for name in runtime.registered_embedding_model_names() {
                 runtime.register_embedder(crate::bench_embedder::FeatureHashProvider::new(name));
             }
+        }
+        if should_warn_unattributed(
+            runtime.config().actor_id.as_deref(),
+            &runtime.config().packs,
+        ) {
+            tracing::warn!(
+                "actor identity resolved to \"local\": comm sends will be stamped from \
+                 \"local\" (unattributed) and comm.inbox will be unscoped (party-line). \
+                 Set KHIVE_ACTOR or --actor to this lambda's id."
+            );
         }
         return KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"));
     }
@@ -415,6 +449,17 @@ fn build_server_multi_backend(
             default_runtime
                 .register_embedder(crate::bench_embedder::FeatureHashProvider::new(name));
         }
+    }
+
+    if should_warn_unattributed(
+        default_runtime.config().actor_id.as_deref(),
+        &default_runtime.config().packs,
+    ) {
+        tracing::warn!(
+            "actor identity resolved to \"local\": comm sends will be stamped from \
+             \"local\" (unattributed) and comm.inbox will be unscoped (party-line). \
+             Set KHIVE_ACTOR or --actor to this lambda's id."
+        );
     }
 
     // Build the VerbRegistry using per-pack runtimes.
@@ -1430,5 +1475,42 @@ brain_profile = "project-profile"
             "second.db MUST NOT contain MainOnlyEntity (kg is pinned to main.db); \
              got count={second_entity_count}"
         );
+    }
+
+    // --- should_warn_unattributed predicate ---
+
+    fn packs(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn warn_when_actor_is_none_and_comm_loaded() {
+        assert!(should_warn_unattributed(None, &packs(&["kg", "comm"])));
+    }
+
+    #[test]
+    fn warn_when_actor_is_local_and_comm_loaded() {
+        assert!(should_warn_unattributed(
+            Some("local"),
+            &packs(&["kg", "comm"])
+        ));
+    }
+
+    #[test]
+    fn no_warn_when_actor_is_configured() {
+        assert!(!should_warn_unattributed(
+            Some("lambda:khive"),
+            &packs(&["kg", "comm"])
+        ));
+    }
+
+    #[test]
+    fn no_warn_when_comm_not_loaded() {
+        assert!(!should_warn_unattributed(Some("local"), &packs(&["kg"])));
+    }
+
+    #[test]
+    fn no_warn_when_actor_none_and_no_comm() {
+        assert!(!should_warn_unattributed(None, &packs(&["kg", "memory"])));
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -640,6 +640,24 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
         resolve_config(inputs.config, base_config)?
     };
 
+    // ADR-057: the `--actor` / `--namespace` CLI flag must populate `actor_id`
+    // (token attribution), matching how the `KHIVE_ACTOR` env already does via
+    // RuntimeConfig::default(). Without this, `--actor lambda:x` alone — no env,
+    // no config-file `[actor] id` — leaves actor_id None, so the request token
+    // carries ActorRef::anonymous(): ADR-057 actor-addressed delivery degrades to
+    // the party line and the unattributed-comm startup warning fires despite an
+    // actor having been set. Fill only when still None so the env (base spread) and
+    // a config-file `[actor] id` keep precedence; the `"local"` guard leaves the
+    // default namespace anonymous (consistent with should_warn_unattributed).
+    let resolved = {
+        let mut resolved = resolved;
+        let ns = resolved.default_namespace.as_str().to_string();
+        if resolved.actor_id.is_none() && inputs.namespace_explicit && ns != "local" {
+            resolved.actor_id = Some(ns);
+        }
+        resolved
+    };
+
     // Tier-3 env fallback: KHIVE_BRAIN_PROFILE is applied AFTER CLI (tier-1) and
     // config-file (tier-2) so that a project or global TOML always wins over the env var.
     Ok(apply_env_brain_profile(resolved))
@@ -910,6 +928,63 @@ brain_profile = "project-profile"
             resolved.brain_profile.as_deref(),
             Some("cli-profile"),
             "CLI --brain-profile must win over both TOML and KHIVE_BRAIN_PROFILE env var"
+        );
+    }
+
+    /// Regression for code-review Finding 1 (#203): the `--actor` / `--namespace`
+    /// CLI flag must set `actor_id`, not just `default_namespace`. Before the fix,
+    /// `--actor lambda:x` with no `KHIVE_ACTOR` env and no config-file `[actor] id`
+    /// left actor_id None → anonymous token → degraded ADR-057 comm + false warning.
+    #[test]
+    #[serial]
+    fn cli_actor_flag_populates_actor_id() {
+        std::env::remove_var("KHIVE_ACTOR");
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: None,
+            namespace: Namespace::parse("lambda:agent-x").expect("ns"),
+            namespace_explicit: true,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        assert_eq!(
+            resolved.actor_id.as_deref(),
+            Some("lambda:agent-x"),
+            "--actor flag must populate actor_id (flag==env parity), not just default_namespace"
+        );
+        assert_eq!(
+            resolved.default_namespace.as_str(),
+            "lambda:agent-x",
+            "the flag still sets the write namespace"
+        );
+    }
+
+    /// The `"local"` default namespace must stay anonymous (actor_id None) even when
+    /// passed explicitly, so `should_warn_unattributed` still flags an unset actor.
+    #[test]
+    #[serial]
+    fn cli_actor_flag_local_stays_anonymous() {
+        std::env::remove_var("KHIVE_ACTOR");
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: true,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        assert_eq!(
+            resolved.actor_id, None,
+            "explicit --actor local must remain anonymous (no actor_id) so the \
+             unattributed-comm warning still fires"
         );
     }
 

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -37,16 +37,63 @@ pub(crate) async fn resolve_id(
 }
 
 pub(crate) fn note_to_message_json(note: &Note) -> Value {
+    let props = note.properties.as_ref();
+
+    let from = props
+        .and_then(|p| p.get("from_actor"))
+        .and_then(Value::as_str)
+        .map(|s| Value::String(s.to_string()))
+        .unwrap_or_else(|| Value::String(note.namespace.clone()));
+
+    let to = props
+        .and_then(|p| p.get("to_actor"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let subject = props
+        .and_then(|p| p.get("subject"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let read = props
+        .and_then(|p| p.get("read"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let direction = props
+        .and_then(|p| p.get("direction"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let preview = build_preview(&note.content);
+
     json!({
         "id": short_id(note.id),
         "full_id": note.id.as_hyphenated().to_string(),
         "kind": "message",
+        "from": from,
+        "to": to,
+        "subject": subject,
+        "read": read,
+        "direction": direction,
+        "preview": preview,
         "content": note.content,
         "namespace": note.namespace,
         "properties": note.properties,
         "created_at": micros_to_iso(note.created_at),
         "updated_at": micros_to_iso(note.updated_at),
     })
+}
+
+fn build_preview(content: &str) -> String {
+    const MAX_CHARS: usize = 80;
+    let collapsed: String = content.split_whitespace().collect::<Vec<&str>>().join(" ");
+    if collapsed.chars().count() > MAX_CHARS {
+        let truncated: String = collapsed.chars().take(MAX_CHARS).collect();
+        format!("{truncated}\u{2026}")
+    } else {
+        collapsed
+    }
 }
 
 /// Write an outbound copy (caller namespace) and an inbound copy (recipient namespace),
@@ -235,4 +282,109 @@ pub(crate) async fn dual_write_message(
     }
 
     Ok(outbound_note)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use khive_storage::note::Note;
+    use serde_json::json;
+
+    fn make_note(namespace: &str, content: &str, props: Option<Value>) -> Note {
+        let mut n = Note::new(namespace, "message", content);
+        n.properties = props;
+        n
+    }
+
+    #[test]
+    fn promotes_from_to_subject_when_present() {
+        let note = make_note(
+            "local",
+            "hello",
+            Some(json!({
+                "from_actor": "lambda:khive",
+                "to_actor": "lambda:leo",
+                "subject": "Status update",
+                "direction": "inbound",
+                "read": false,
+            })),
+        );
+        let v = note_to_message_json(&note);
+        assert_eq!(v["from"], json!("lambda:khive"));
+        assert_eq!(v["to"], json!("lambda:leo"));
+        assert_eq!(v["subject"], json!("Status update"));
+        assert_eq!(v["direction"], json!("inbound"));
+        assert_eq!(v["read"], json!(false));
+        assert!(v["content"].is_string());
+        assert!(v["properties"].is_object());
+    }
+
+    #[test]
+    fn from_falls_back_to_namespace_when_from_actor_absent() {
+        let note = make_note(
+            "legacy-ns",
+            "old message",
+            Some(json!({ "to_actor": "lambda:leo" })),
+        );
+        let v = note_to_message_json(&note);
+        assert_eq!(v["from"], json!("legacy-ns"));
+    }
+
+    #[test]
+    fn preview_is_single_line_and_truncated_for_long_content() {
+        let long_body = "word ".repeat(40);
+        let note = make_note("local", long_body.trim(), None);
+        let v = note_to_message_json(&note);
+        let preview = v["preview"].as_str().expect("preview is a string");
+        assert!(!preview.contains('\n'), "preview must be single-line");
+        assert!(
+            preview.ends_with('\u{2026}'),
+            "long preview must end with ellipsis"
+        );
+        let without_ellipsis: &str = &preview[..preview.len() - '\u{2026}'.len_utf8()];
+        assert!(
+            without_ellipsis.chars().count() <= 80,
+            "preview body must not exceed 80 chars before ellipsis"
+        );
+    }
+
+    #[test]
+    fn preview_not_truncated_for_short_content() {
+        let note = make_note("local", "short message", None);
+        let v = note_to_message_json(&note);
+        let preview = v["preview"].as_str().expect("preview is a string");
+        assert_eq!(preview, "short message");
+        assert!(!preview.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn preview_collapses_whitespace_and_newlines() {
+        let note = make_note("local", "line one\n  line two\n\nline three", None);
+        let v = note_to_message_json(&note);
+        let preview = v["preview"].as_str().expect("preview is a string");
+        assert_eq!(preview, "line one line two line three");
+    }
+
+    #[test]
+    fn properties_and_content_still_present() {
+        let note = make_note(
+            "local",
+            "body text",
+            Some(json!({ "from_actor": "x", "custom": 42 })),
+        );
+        let v = note_to_message_json(&note);
+        assert_eq!(v["content"], json!("body text"));
+        assert_eq!(v["properties"]["custom"], json!(42));
+    }
+
+    #[test]
+    fn null_defaults_when_no_properties() {
+        let note = make_note("local", "no props", None);
+        let v = note_to_message_json(&note);
+        assert_eq!(v["to"], Value::Null);
+        assert_eq!(v["subject"], Value::Null);
+        assert_eq!(v["direction"], Value::Null);
+        assert_eq!(v["read"], json!(false));
+        assert_eq!(v["from"], json!("local"));
+    }
 }

--- a/docs/adr/ADR-057-comm-actor-addressed-delivery.md
+++ b/docs/adr/ADR-057-comm-actor-addressed-delivery.md
@@ -155,14 +155,14 @@ are JSON properties, not columns.
 object for scannability. The canonical values remain stored in `properties`; these fields are
 extracted at view time and are additive (no existing keys are removed or renamed).
 
-| Field       | Source                                                                               | Default when absent |
-| ----------- | ------------------------------------------------------------------------------------ | ------------------- |
-| `from`      | `properties.from_actor`, fallback to `namespace`                                     | `namespace` value   |
-| `to`        | `properties.to_actor`                                                                | null                |
-| `subject`   | `properties.subject`                                                                 | null                |
-| `read`      | `properties.read`                                                                    | false               |
-| `direction` | `properties.direction`                                                               | null                |
-| `preview`   | derived: whitespace-collapsed, truncated to 80 chars with `...` appended when longer | (always present)    |
+| Field       | Source                                                                             | Default when absent |
+| ----------- | ---------------------------------------------------------------------------------- | ------------------- |
+| `from`      | `properties.from_actor`, fallback to `namespace`                                   | `namespace` value   |
+| `to`        | `properties.to_actor`                                                              | null                |
+| `subject`   | `properties.subject`                                                               | null                |
+| `read`      | `properties.read`                                                                  | false               |
+| `direction` | `properties.direction`                                                             | null                |
+| `preview`   | derived: whitespace-collapsed, truncated to 80 chars with `…` appended when longer | (always present)    |
 
 The `preview` field is computed from `content` in the view layer. Stored content is never
 mutated. When `subject` is null, `preview` provides a fallback scan line for the inbox.

--- a/docs/adr/ADR-057-comm-actor-addressed-delivery.md
+++ b/docs/adr/ADR-057-comm-actor-addressed-delivery.md
@@ -149,6 +149,24 @@ Existing messages that lack these fields are treated as if `from_actor == namesp
 `to_actor == "local"` (the single-actor fallback). No database migration is required; these
 are JSON properties, not columns.
 
+### `comm.inbox` response shape
+
+`comm.inbox` surfaces the following top-level convenience fields on each returned message
+object for scannability. The canonical values remain stored in `properties`; these fields are
+extracted at view time and are additive (no existing keys are removed or renamed).
+
+| Field       | Source                                                                               | Default when absent |
+| ----------- | ------------------------------------------------------------------------------------ | ------------------- |
+| `from`      | `properties.from_actor`, fallback to `namespace`                                     | `namespace` value   |
+| `to`        | `properties.to_actor`                                                                | null                |
+| `subject`   | `properties.subject`                                                                 | null                |
+| `read`      | `properties.read`                                                                    | false               |
+| `direction` | `properties.direction`                                                               | null                |
+| `preview`   | derived: whitespace-collapsed, truncated to 80 chars with `...` appended when longer | (always present)    |
+
+The `preview` field is computed from `content` in the view layer. Stored content is never
+mutated. When `subject` is null, `preview` provides a fallback scan line for the inbox.
+
 ### `comm.send` behavior change
 
 The `to` parameter is reinterpreted. When `to` does not start with a recognized remote


### PR DESCRIPTION
## What

Surfaces the fields agents need to triage `comm.inbox` at the top level of each
message, and warns at startup when the actor is unattributed.

- `note_to_message_json` (khive-pack-comm) emits top-level `from` (falls back to
  `namespace` when `from_actor` is absent), `to`, `subject`, `read`, `direction`,
  and a derived `preview` (whitespace-collapsed, truncated to 80 chars).
- `should_warn_unattributed` (khive-mcp/serve.rs): when the actor resolves to
  `"local"` and the `comm` pack is loaded, the server logs a startup warning —
  an unset `KHIVE_ACTOR` means unattributed sends and an unscoped inbox.
- ADR-057 documents the `comm.inbox` response shape.

## Why

Callers previously had to dig into `properties` to find who sent a message or
what it was about, and an unset actor silently defaulted to `"local"` with no
signal. Both were real frictions surfaced in dogfooding.

## Testing

- `cargo test -p khive-pack-comm` — 14 unit + 65 integration green
- `cargo test -p khive-mcp` — 57 unit + 102 integration green
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- +6 message-shape unit tests, +5 warn-logic unit tests

## Gate

DRAFT — not for merge until review + explicit approval.
