### PR TITLE
ci: add gitleaks secret-scan gate before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,20 @@ jobs:
       - name: Scan whole tree for corpus files
         run: bash scripts/check-json-data.sh --all
 
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | tar -xz -C /usr/local/bin gitleaks
+      - name: Scan git history for credentials
+        run: gitleaks detect --source . --redact --no-banner
+
   docs:
     name: Docs lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `secret-scan` CI job (gitleaks) so every PR is scanned for credentials before it can be merged.

## Why

`gitleaks` already runs in the **local** pre-commit hook (`.pre-commit-config.yaml`, v8.21.2) — but there was **no CI counterpart**. A commit made without pre-commit installed, or with the hook bypassed, could reach a PR with a live credential and nothing would block the merge. The existing `data-leak-guard` job only catches JSON/JSONL **corpus** files (the bulk-data leak vector), not secrets.

This is the gap behind the repo's prior history; a server-side gate that does not depend on every contributor's local setup closes it.

## How

- **Same scanner, same version** as the local hook (gitleaks **v8.21.2**), run as the release binary so CI and pre-commit give identical results.
- **Token-free.** `ohdearquant/khive` is a personal, public repo, so no gitleaks license is required; running the binary directly also sidesteps the `gitleaks-action` org-license path entirely. **No repo secret needed.**
- `--redact` keeps any detected secret value out of the public CI log.
- `fetch-depth: 0` scans full commit history, not just the working tree.

## Verification

`gitleaks detect` over current history is **clean — 428 commits scanned, no leaks found** (1.5s). The gate is green-on-arrival and does not block existing PRs.

## To make it actually block merges

This job **runs** on every PR, but blocking a merge requires adding **`Secret scan (gitleaks)`** as a *required status check* in branch-protection for `main`. That's a repo-settings change — your call, or I can set it via `gh api` if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)