### PR TITLE
docs: align contributor docs with shipped surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,10 @@ cases). Scores are normalized to [0,1] when `rerank` is active (default).
 Pass `kind=` (`"atom"` or `"domain"`) to filter by result type; `type=` is accepted as a legacy
 alias. `knowledge.list` accepts the same `kind=`/`type=` discriminant.
 
+`knowledge.compose` accepts `explain=true` to include the section manifest (`sections[]` and
+per-source `breakdown`) in the response; the default omits them and returns only the formatted
+briefing.
+
 ### How to call a verb
 
 Wrap the verb call in `request(ops="…")`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ Use `create(kind="note", note_kind="observation", ...)` for notes.
 
 ---
 
-## The 9 entity kinds (closed set — [ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-resource-entity-kind.md))
+## The 9 entity kinds (closed set — [ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-knowledge-section-profiles.md))
 
 | Kind       | What it represents                                                         |
 | ---------- | -------------------------------------------------------------------------- |
@@ -353,7 +353,7 @@ These are the KG pack verbs. Other packs are documented in their verb tables abo
 | `traverse`  | **roots** (UUID list); max_depth, direction, relations, include_roots                                                                                                                                                                            | `{"roots":["<uuid>"],"max_depth":2}`                         |
 | `query`     | **query** (GQL or SPARQL string) — **read-only**: write-shaped input (SPARQL `INSERT`/`DELETE`/`LOAD`, GQL/Cypher `CREATE`/`DELETE`/`SET`/`MERGE`) is rejected; use `create`, `update`, `link`, `merge`, `delete` to mutate                      | `{"query":"MATCH (a:concept)-[:extends]->(b) RETURN a"}`     |
 | `propose`   | **kind** (entity\|note\|edge), fields for the proposed change                                                                                                                                                                                    | `{"kind":"entity","entity_kind":"concept","name":"X"}`       |
-| `review`    | **id** (proposal UUID), **verdict** (approve\|reject); comment                                                                                                                                                                                   | `{"id":"<uuid>","verdict":"approve"}`                        |
+| `review`    | **id** (proposal UUID), **decision** (approve\|reject\|comment\|request_changes); comment                                                                                                                                                        | `{"id":"<uuid>","decision":"approve"}`                       |
 | `withdraw`  | **id** (proposal UUID)                                                                                                                                                                                                                           | `{"id":"<uuid>"}`                                            |
 
 ### When to use which retrieval verb
@@ -530,13 +530,13 @@ If you are an AI agent authoring PRs, issues, or comments via someone's CLI:
 
 ## Daemon and warm startup
 
-khive-mcp auto-spawns a background daemon (`khive-mcp --daemon`) on the first request. The daemon
-keeps the ANN index and embedding model warm so `knowledge.search` and `memory.recall` are fast on
-subsequent calls. Users do not need to configure or manage the daemon — it starts automatically and
-cleans up on exit.
+The `kkernel` binary auto-spawns a background daemon (`kkernel mcp --daemon`) on the first request.
+The daemon keeps the ANN index and embedding model warm so `knowledge.search` and `memory.recall`
+are fast on subsequent calls. Users do not need to configure or manage the daemon — it starts
+automatically and cleans up on exit.
 
 The daemon communicates over a Unix socket (`khived.sock`). If you see stale-process errors after a
-rebuild, kill zombie processes: `pkill -f khive-mcp` then reconnect.
+rebuild, kill zombie processes: `pkill -f kkernel` then reconnect.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ not shipped.
 
 ## Closed taxonomies (DO NOT extend without an ADR)
 
-### 9 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-resource-entity-kind.md))
+### 9 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-knowledge-section-profiles.md))
 
 `concept` | `document` | `dataset` | `project` | `person` | `org` | `artifact` | `service` | `resource`
 
@@ -207,15 +207,17 @@ Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 | `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                       |
 | `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation  |
 
-### Memory pack verbs (3 — ADR-021, optional)
+### Memory pack verbs (5 — ADR-021, optional)
 
 Load with `KHIVE_PACKS=kg,memory` or `--pack memory`. Adds the `memory` note kind.
 
-| Verb              | Args                                                                  | What it does                                                              |
-| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source |
-| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking        |
-| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors    |
+| Verb              | Args                                                                  | What it does                                                                                   |
+| ----------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source                      |
+| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking                             |
+| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors                         |
+| `memory.prune`    | `min_salience?`, `before?`, `namespace?`, `dry_run?`                  | Soft-delete memories below a salience floor and/or past `expires_at` (curation-layer, ADR-014) |
+| `memory.vacuum`   | —                                                                     | Run SQLite `VACUUM` to reclaim space freed by soft-deleted rows                                |
 
 `get`/`update`/`delete`/`merge` are UUID-only — no `kind` needed, the handler resolves
 the substrate from the UUID. `create`/`list`/`search` require `kind`.
@@ -272,7 +274,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
   `request`. **Per-verb validation failure** (unknown kind, bad UUID, etc.) returns a per-op
   `{ok: false, error: "..."}` entry — the batch does not abort.
 
-### Namespace (attribution-only — ADR-007 Rev 3, 2026-06-17)
+### Namespace (attribution-only — ADR-007 Rev 6, 2026-06-19)
 
 - **Namespace is attribution, not isolation.** It is a write-stamp on records, queryable and
   filterable, available to the Gate as policy input. It is never a storage boundary.
@@ -284,6 +286,9 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
   Gate is the trust boundary.
 - **Multi-record ops default to `WHERE namespace='local'`**; the only escape is an explicit
   `namespace=` parameter from the caller.
+- **Episodic memory writes are the Rev 6 write-default exception**: `memory.remember` with
+  `memory_type=episodic` stamps the caller's actor-id namespace by default; semantic and all
+  other writes still default to `'local'`, and an explicit `namespace=` overrides either way.
 
 ### Edge cascade
 
@@ -387,7 +392,7 @@ Full index: [docs/adr/README.md](docs/adr/README.md).
 - **Don't silently coerce invalid input.** Invalid entity kinds, note kinds, and edge relations
   must return errors with the valid values listed. Never `unwrap_or_default()`.
 - **Don't add namespace checks to by-ID ops.** By-ID methods (get, update, delete, merge)
-  are namespace-agnostic by design (ADR-007 Rev 3). Authorization is at the Gate. Adding
+  are namespace-agnostic by design (ADR-007 Rev 6). Authorization is at the Gate. Adding
   `record.namespace == caller_namespace` post-fetch checks is the prior v1 bug pattern; it
   was removed by PR-A1 and must not return.
 - **Don't edit V1 migrations.** Append a new version. V1 is immutable on existing databases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
 
 ### MCP tool changes
 
-- The MCP server exposes exactly one tool: `request` (ADR-027). There are no per-verb tool
+- The MCP server exposes exactly one tool: `request` (ADR-016). There are no per-verb tool
   files — the only schema in `crates/khive-mcp/src/tools/` is `request.rs` (the `RequestParams`
   struct).
 - DSL parsing lives in the `khive-request` crate (ADR-028). Edits to the parser go there,
@@ -267,7 +267,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
 - MCP server (`crates/khive-mcp/src/server.rs`) is a thin dispatch shell — calls
   `khive_request::parse_request`, then routes each parsed op through the registry. No
   business logic.
-- **Verb handler logic lives in the pack** (`crates/khive-pack-kg/src/handlers.rs`).
+- **Verb handler logic lives in the pack** (`crates/khive-pack-kg/src/handlers/`).
 - Runtime methods live in `crates/khive-runtime/src/operations.rs` (or `curation.rs`,
   `retrieval.rs`, `graph_traversal.rs`).
 - **Invalid DSL** (parse/lex failure) returns RPC-level `McpError::invalid_params` from
@@ -367,20 +367,20 @@ Full index: [docs/adr/README.md](docs/adr/README.md).
 
 ## What lives where
 
-| Want to do...                                               | Edit this                                                                                                                             |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Add a new verb                                              | Pack handler in `crates/khive-pack-kg/src/handlers.rs` (or your pack); the MCP surface is `request` — no per-verb tool file to author |
-| Change DSL syntax                                           | `crates/khive-request/src/lib.rs` + unit tests (ADR-016)                                                                              |
-| Change MCP surface shape                                    | `crates/khive-mcp/src/server.rs` (ADR-016 — `request` is the only tool)                                                               |
-| Add a runtime operation                                     | `crates/khive-runtime/src/operations.rs`                                                                                              |
-| Change DB schema                                            | New `crates/khive-db/sql/NNN-<name>.sql` file + register it as a new `VersionedMigration` in `crates/khive-db/src/migrations.rs`      |
-| Add a new entity kind                                       | `crates/khive-pack-kg/src/vocab.rs` + ADR-001 amendment                                                                               |
-| Add a new edge relation                                     | **STOP** — ADR change ([ADR-002](docs/adr/ADR-002-edge-ontology.md))                                                                  |
-| Allow a new edge endpoint pair (e.g. note-kind→entity-kind) | Pack's `EDGE_RULES` const ([ADR-017](docs/adr/ADR-017-pack-standard.md) §"Pack-extensible edge endpoints"); additive only             |
-| Add a new note kind                                         | `crates/khive-pack-kg/src/vocab.rs` + ADR-013 amendment                                                                               |
-| Add a new pack                                              | New crate implementing `Pack` + `PackRuntime` ([ADR-017](docs/adr/ADR-017-pack-standard.md))                                          |
-| Fix a query parser bug                                      | `crates/khive-query/src/parsers/` + add regression test                                                                               |
-| Fix a storage bug                                           | `crates/khive-db/src/stores/` + test                                                                                                  |
+| Want to do...                                               | Edit this                                                                                                                           |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Add a new verb                                              | Pack handler in `crates/khive-pack-kg/src/handlers/` (or your pack); the MCP surface is `request` — no per-verb tool file to author |
+| Change DSL syntax                                           | `crates/khive-request/src/lib.rs` + unit tests (ADR-016)                                                                            |
+| Change MCP surface shape                                    | `crates/khive-mcp/src/server.rs` (ADR-016 — `request` is the only tool)                                                             |
+| Add a runtime operation                                     | `crates/khive-runtime/src/operations.rs`                                                                                            |
+| Change DB schema                                            | New `crates/khive-db/sql/NNN-<name>.sql` file + register it as a new `VersionedMigration` in `crates/khive-db/src/migrations.rs`    |
+| Add a new entity kind                                       | `crates/khive-pack-kg/src/vocab.rs` + ADR-001 amendment                                                                             |
+| Add a new edge relation                                     | **STOP** — ADR change ([ADR-002](docs/adr/ADR-002-edge-ontology.md))                                                                |
+| Allow a new edge endpoint pair (e.g. note-kind→entity-kind) | Pack's `EDGE_RULES` const ([ADR-017](docs/adr/ADR-017-pack-standard.md) §"Pack-extensible edge endpoints"); additive only           |
+| Add a new note kind                                         | `crates/khive-pack-kg/src/vocab.rs` + ADR-013 amendment                                                                             |
+| Add a new pack                                              | New crate implementing `Pack` + `PackRuntime` ([ADR-017](docs/adr/ADR-017-pack-standard.md))                                        |
+| Fix a query parser bug                                      | `crates/khive-query/src/parsers/` + add regression test                                                                             |
+| Fix a storage bug                                           | `crates/khive-db/src/stores/` + test                                                                                                |
 
 ---
 

--- a/docs/adr/ADR-048-knowledge-section-profiles.md
+++ b/docs/adr/ADR-048-knowledge-section-profiles.md
@@ -42,6 +42,11 @@ section headings into section rows. For a section-only document (an empty or sho
 pre-section body), import synthesizes the atom's `content` from its section bodies so the
 atom satisfies the content minimum and remains searchable at the atom level.
 
+The `knowledge.compose` section manifest is **opt-in**: callers pass `explain=true` to receive
+`sections[]` and per-source `breakdown` in the response; the default compose response returns only
+the formatted briefing and omits them. Consumers that depend on the manifest (for example
+PostToolUse hooks) must set `explain=true` explicitly.
+
 ### Atom and section content constraints
 
 The `knowledge_atoms` table stores atom body text in a single `content` column. There is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,23 +6,23 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## Foundation
 
-| #                                               | Title                                                        |
-| ----------------------------------------------- | ------------------------------------------------------------ |
-| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                         |
-| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                         |
-| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                          |
-| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                        |
-| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                    |
-| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                        |
-| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 2 — attribution-only, all-local, single Gate) |
-| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                       |
-| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                         |
-| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                       |
-| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                         |
-| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                        |
-| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                           |
-| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                          |
-| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                            |
+| #                                               | Title                                                                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------- |
+| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                                        |
+| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                                        |
+| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                                         |
+| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                                       |
+| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                                   |
+| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                                       |
+| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 6 — attribution-only, by-ID namespace-agnostic, single Gate) |
+| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                                      |
+| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                                        |
+| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                                      |
+| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                                        |
+| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                                       |
+| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                                          |
+| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                                         |
+| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                                           |
 
 ## MCP / Pack Surface
 
@@ -84,7 +84,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-049](ADR-049-khived-daemon.md)                      | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
 | [ADR-050](ADR-050-kg-token-namespace-contract.md)        | KG Token Namespace Contract (Proposed)                                                                          |
 | [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)  | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
-| [ADR-052](ADR-052-ann-production-lifecycle.md)           | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Proposed) |
+| [ADR-052](ADR-052-ann-production-lifecycle.md)           | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
 | [ADR-053](ADR-053-authorization-gate.md)                 | Authorization Gate — ActorStore, SessionStore, and Cloud-Tier Caller Propagation (Proposed)                     |
 | [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)  | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
 | [ADR-055](ADR-055-epistemic-edge-relations.md)           | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |


### PR DESCRIPTION
## What

Doc-alignment sweep: contributor-facing docs (CLAUDE.md, AGENTS.md, ADR index, ADR-048) reconciled with the **currently shipped** code surface. Every change verified against the live verb schema (`verbs()`, per-verb `help`) and ADR file headers — not assumed.

## Changes (all verified)
- **CLAUDE.md**: ADR-048 link basename fixed (`resource-entity-kind` 404 → `knowledge-section-profiles`); memory pack documented as 5 verbs (added `prune`/`vacuum` with schema-accurate args); ADR-007 namespace section Rev 3 → **Rev 6** + one-line note on the Rev 6 episodic-write carve-out.
- **AGENTS.md + ADR-048**: documented `knowledge.compose explain=true` manifest opt-in (default omits `sections[]`/`breakdown`).
- **docs/adr/README.md**: ADR-007 Rev 6 descriptor; ADR-052 index status Proposed → **Accepted** (file header confirms `accepted (2026-06-14)`). The Foundation-table re-pad is deno-fmt-canonical.

## Deliberately deferred (surfaced separately, not this PR)
- **Version posture**: CLAUDE.md `v0.2.8`, README `v0.2.3`, Cargo workspace `0.2.11` — left untouched pending a call on whether docs track last-published or dev-HEAD (and whether 0.2.11 is released).
- **Aggregate verb-count convention**: "63"/"65"/"76" disagree by counting convention (user-facing vs internal dispatch arms). Needs a convention decision first.
- **Full README release-refresh**: README is a coherent `v0.2.3` snapshot; piecemeal edits would make it incoherent. Holistic refresh depends on the version-posture decision.

## Status
**HELD (draft)** — not for merge until reviewed. Docs-only, no code paths touched.
