### PR TITLE
tech-debt(khive-db): gate failpoint arming helpers on feature="vectors" (#202)

### DIFF
--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -43,8 +43,18 @@ mod failpoint {
         pub(super) static CURRENT: RefCell<Option<Arc<AtomicBool>>> = const { RefCell::new(None) };
     }
 
+    // The arming mechanism (`arm`/`disarm`/`FailpointGuard`) is used only by the
+    // SAVEPOINT/ROLLBACK sentinel tests, which need the sqlite-vec store and so
+    // live in the `cfg(all(test, feature = "vectors"))` module below.  Gating
+    // these items on `feature = "vectors"` keeps them out of the no-feature test
+    // build, where they would otherwise have no caller and trip
+    // `clippy --all-targets -D warnings` (which runs without `--features vectors`).
+    // `CURRENT`/`take` stay plain `cfg(test)`: they are read by the failpoint hooks
+    // in `insert_batch`/`update`, which are `cfg(test)` and compile in every test build.
+
     /// Create a fresh `Arc<AtomicBool>` set to `true` and register it in the
     /// thread-local so the write closure can capture it before spawn_blocking.
+    #[cfg(feature = "vectors")]
     pub(super) fn arm() {
         let flag = Arc::new(AtomicBool::new(true));
         CURRENT.with(|c| *c.borrow_mut() = Some(flag));
@@ -52,6 +62,7 @@ mod failpoint {
 
     /// Disarm: clear the thread-local (the Arc may live on in the closure
     /// a moment longer, but the flag is already spent after one `take()`).
+    #[cfg(feature = "vectors")]
     pub(super) fn disarm() {
         CURRENT.with(|c| *c.borrow_mut() = None);
     }
@@ -66,8 +77,10 @@ mod failpoint {
     /// RAII guard: arms the failpoint on construction and disarms on drop.
     /// The Arc is stored in the thread-local and captured by the write closure
     /// directly; the guard's only job is to ensure `disarm()` runs on drop.
+    #[cfg(feature = "vectors")]
     pub(super) struct FailpointGuard;
 
+    #[cfg(feature = "vectors")]
     impl FailpointGuard {
         pub(super) fn new() -> Self {
             arm();
@@ -75,6 +88,7 @@ mod failpoint {
         }
     }
 
+    #[cfg(feature = "vectors")]
     impl Drop for FailpointGuard {
         fn drop(&mut self) {
             disarm();


### PR DESCRIPTION
Closes #202 (part 1 — the dead-code; part 2 deferred, see below).

## Root cause (refined from the issue)

The issue framed this as "wire the failpoint harness into a test." It isn't unwired — the tests exist. It's a **cfg mismatch**:

- The `#[cfg(test)] mod failpoint` arming helpers — `arm`, `disarm`, `FailpointGuard`, `FailpointGuard::new` — are compiled in **every** test build.
- Their only callers are the SAVEPOINT/ROLLBACK sentinel tests (`*_rollback_restores_deleted_stale_*`), which need the sqlite-vec store and so live in the `#[cfg(all(test, feature = "vectors"))]` module.
- `cargo clippy --workspace --all-targets -- -D warnings` runs **without** `--features vectors`, so it compiles the helpers but not their callers → `arm`/`disarm`/`FailpointGuard`/`new` are dead-code.
- `make clippy` omits `--all-targets`, so the class shipped green.

(`CURRENT`/`take` were *not* flagged: their consumption sites — the failpoint hooks in `insert_batch`/`update` — are plain `#[cfg(test)]` and compile in any test build.)

## Fix

Gate the four arming items on `feature = "vectors"`, matching their only callers. `CURRENT`/`take` stay `#[cfg(test)]`. **No behavior change** — the failpoint apparatus is unchanged when the feature is on; it's simply absent from the build where it had no caller.

## Verification

| Check | Result |
|---|---|
| `cargo clippy -p khive-db --all-targets -- -D warnings` (no feature) | ✅ clean (was 4 dead-code errors) |
| `cargo clippy -p khive-db --all-targets --features vectors -- -D warnings` | ✅ clean |
| `cargo test -p khive-db --features vectors rollback` | ✅ 4 passed (sentinel tests intact) |
| `cargo fmt -p khive-db -- --check` | ✅ clean |

## Part 2 (the gate gap) — deliberately deferred

Adding `--all-targets` to `make clippy` would prevent recurrence but widens the lint surface across all workspace test/bench targets and may surface more latent warnings. That's a separate CI-policy decision with workspace-wide blast radius — not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)