### PR TITLE
perf(khive-db): WAL checkpoint discipline + PoolConfig env overrides

### DIFF
--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -37,6 +37,7 @@ khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
+serial_test = { workspace = true }
 
 [[bench]]
 name = "db_hot_path"

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1,17 +1,24 @@
 //! Periodic WAL checkpoint task for the connection pool.
 //!
-//! Issues `PRAGMA wal_checkpoint(PASSIVE)` on a configurable interval and
-//! escalates to `PRAGMA wal_checkpoint(TRUNCATE)` when the WAL page count
-//! exceeds a high-water mark.
+//! Issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick — including when the
+//! WAL page count exceeds the high-water mark. PASSIVE is the only mode the
+//! periodic task ever uses.
 //!
 //! Non-contending design: `checkpoint_once` uses `try_writer_nowait` (zero-wait
 //! `try_lock`) so a tick is skipped immediately when any writer holds the mutex,
 //! rather than blocking for up to `checkout_timeout`. The checkpoint task must
 //! never stall active write traffic — a skipped tick is always preferable.
 //!
-//! PASSIVE: yields if any reader holds a WAL snapshot — never blocks.
-//! TRUNCATE: resets the WAL to zero length after checkpointing; degrades to
-//! PASSIVE behavior when readers are present, so it is safe to call unconditionally.
+//! Why TRUNCATE is excluded from the periodic path: TRUNCATE inherits RESTART
+//! semantics — it waits for active readers to release their WAL snapshots and
+//! invokes the busy handler before acquiring the exclusive lock needed to reset
+//! the WAL file. With PoolConfig's 30 s busy_timeout, the task could sit inside
+//! SQLite holding the sole writer connection for up to 30 s, stalling all normal
+//! write traffic. PASSIVE never waits for readers; it checkpoints as many frames
+//! as currently possible and returns promptly. When WAL pressure is sustained
+//! (high_water_pages exceeded), the task emits a WARNING so an operator or
+//! scheduler can perform a blocking TRUNCATE at a safe moment outside normal
+//! traffic.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -36,7 +43,12 @@ pub struct CheckpointConfig {
     /// Default: 2000 pages (~8 MB at 4 KiB page size).
     pub warn_pages: u64,
 
-    /// WAL page count above which the task escalates from PASSIVE to TRUNCATE.
+    /// WAL page count above which a high-pressure WARNING is logged.
+    ///
+    /// The periodic task always runs PASSIVE regardless; this threshold signals
+    /// that a long-lived reader may be pinning an old WAL snapshot that PASSIVE
+    /// cannot reclaim. An operator can then schedule a blocking TRUNCATE at a
+    /// safe moment outside normal write traffic.
     ///
     /// Overridable via `KHIVE_WAL_HIGH_WATER_PAGES`.
     /// Default: 6000 pages (~24 MB at 4 KiB page size).
@@ -94,9 +106,10 @@ impl CheckpointConfig {
 /// `tokio::spawn`. It loops until the pool is dropped (the `Arc` count
 /// falls to one, meaning this task holds the last reference).
 ///
-/// The task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick. When the
-/// WAL page count exceeds `config.high_water_pages` it upgrades to
-/// `PRAGMA wal_checkpoint(TRUNCATE)` to reclaim disk space.
+/// The task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick. PASSIVE is
+/// the only checkpoint mode used; see the module-level doc for why TRUNCATE is
+/// excluded. When the WAL page count exceeds `config.high_water_pages` a
+/// WARNING is logged to signal sustained WAL pressure.
 ///
 /// Uses `try_writer_nowait` (zero-wait try-lock) so a busy writer causes the
 /// current tick to be skipped rather than stalling write traffic.
@@ -132,29 +145,29 @@ pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
     };
 
     let wal_pages = query_wal_pages(writer.conn());
-    let mode = if wal_pages >= config.high_water_pages {
+
+    if wal_pages >= config.high_water_pages {
         tracing::warn!(
             wal_pages,
             high_water = config.high_water_pages,
-            "WAL high-water mark exceeded; escalating to TRUNCATE checkpoint"
+            "WAL high-water mark exceeded; sustained WAL pressure — \
+             a long-lived reader may be pinning an old snapshot that PASSIVE cannot reclaim"
         );
-        "TRUNCATE"
-    } else {
-        if wal_pages >= config.warn_pages {
-            tracing::warn!(
-                wal_pages,
-                warn_threshold = config.warn_pages,
-                "WAL page count approaching checkpoint threshold"
-            );
-        }
-        "PASSIVE"
-    };
+    } else if wal_pages >= config.warn_pages {
+        tracing::warn!(
+            wal_pages,
+            warn_threshold = config.warn_pages,
+            "WAL page count approaching checkpoint threshold"
+        );
+    }
 
-    let sql = format!("PRAGMA wal_checkpoint({mode})");
-    if let Err(e) = writer.conn().execute_batch(&sql) {
-        tracing::warn!(error = %e, mode, "WAL checkpoint failed");
+    if let Err(e) = writer
+        .conn()
+        .execute_batch("PRAGMA wal_checkpoint(PASSIVE)")
+    {
+        tracing::warn!(error = %e, "WAL checkpoint failed");
     } else {
-        tracing::debug!(mode, wal_pages, "WAL checkpoint issued");
+        tracing::debug!(wal_pages, "WAL checkpoint issued");
     }
 }
 
@@ -162,11 +175,11 @@ pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
 ///
 /// The pragma returns a 3-column row `(busy, log, checkpointed)`, where `log`
 /// (column index 1) is the number of frames currently in the WAL file — the
-/// backlog the high-water escalation keys off. (Column 2 is `checkpointed`, the
+/// backlog the high-water threshold keys off. (Column 2 is `checkpointed`, the
 /// frames moved *by this call*, which is not the WAL size.) The no-arg pragma
 /// also performs a PASSIVE checkpoint as a side effect; the subsequent explicit
-/// checkpoint in `checkpoint_once` is therefore a deliberate second pass that
-/// can escalate to TRUNCATE.
+/// `PRAGMA wal_checkpoint(PASSIVE)` in `checkpoint_once` is a deliberate second
+/// pass that can checkpoint any frames written between the two calls.
 ///
 /// Returns 0 on any error (e.g. in-memory DB where WAL is not active, which
 /// reports `log = -1`).
@@ -289,6 +302,55 @@ mod tests {
         assert_eq!(cfg.interval, default.interval);
         assert_eq!(cfg.warn_pages, default.warn_pages);
         assert_eq!(cfg.high_water_pages, default.high_water_pages);
+    }
+
+    /// Regression: a high-water tick must not block behind an active reader.
+    ///
+    /// Opens a read connection and holds it for the duration, then triggers a
+    /// `checkpoint_once` with `high_water_pages = 1` so the high-water path
+    /// is taken. Asserts the call returns within 200 ms — proving PASSIVE
+    /// semantics (no reader wait). A TRUNCATE at this point would block for up
+    /// to `PoolConfig::busy_timeout` (30 s default).
+    #[test]
+    fn checkpoint_high_water_does_not_block_behind_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("high_water_test.db");
+        let pool = file_pool(&path);
+
+        // Write some data so the WAL is non-trivial.
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS t (x INTEGER); INSERT INTO t VALUES (1);",
+                )
+                .unwrap();
+        }
+
+        // Hold an open read connection for the duration of the checkpoint call.
+        let reader = pool.reader().expect("reader");
+
+        // high_water_pages = 1 ensures the high-water branch is taken for any
+        // non-trivial WAL (even after the table write above).
+        let config = CheckpointConfig {
+            high_water_pages: 1,
+            ..Default::default()
+        };
+
+        let start = std::time::Instant::now();
+        checkpoint_once(&pool, &config);
+        let elapsed = start.elapsed();
+
+        drop(reader);
+
+        // PASSIVE returns immediately regardless of readers.
+        // TRUNCATE would block for up to busy_timeout (30 s) here.
+        assert!(
+            elapsed < std::time::Duration::from_millis(200),
+            "checkpoint_once with active reader took {:?}; expected <200ms (PASSIVE must not block)",
+            elapsed
+        );
     }
 
     #[test]

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -108,14 +108,16 @@ impl CheckpointConfig {
 ///
 /// The task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick. PASSIVE is
 /// the only checkpoint mode used; see the module-level doc for why TRUNCATE is
-/// excluded. When the WAL page count exceeds `config.high_water_pages` a
-/// WARNING is logged to signal sustained WAL pressure.
+/// excluded. A WARNING is emitted once on threshold crossing (wal_pages
+/// transitions from below `high_water_pages` to at/above) rather than on every
+/// tick, preventing log spam when a long-lived reader pins a WAL snapshot.
 ///
 /// Uses `try_writer_nowait` (zero-wait try-lock) so a busy writer causes the
 /// current tick to be skipped rather than stalling write traffic.
 pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointConfig) {
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut was_above_high_water = false;
 
     loop {
         interval.tick().await;
@@ -126,34 +128,39 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
             break;
         }
 
-        checkpoint_once(&pool, &config);
+        let wal_pages = checkpoint_once(&pool, &config);
+        let above = wal_pages >= config.high_water_pages;
+        if above && !was_above_high_water {
+            tracing::warn!(
+                wal_pages,
+                high_water = config.high_water_pages,
+                "WAL high-water mark exceeded; sustained WAL pressure — \
+                 a long-lived reader may be pinning an old snapshot that PASSIVE cannot reclaim"
+            );
+        }
+        was_above_high_water = above;
     }
 }
 
 /// Issue one checkpoint cycle against the writer connection.
 ///
-/// Returns without error: all failures are logged at warn level and skipped.
-/// This is intentional — a failed checkpoint is non-fatal and will be retried
-/// on the next tick.
+/// Returns the observed WAL page count (0 when the writer mutex was busy and
+/// the tick was skipped, or when the pool is in-memory). All checkpoint errors
+/// are logged at warn level and treated as non-fatal; the next tick retries.
 ///
 /// Uses `try_writer_nowait` so that a busy active writer causes this tick to
 /// be skipped immediately rather than stalling for up to `checkout_timeout`.
-pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
+/// The caller (`run_checkpoint_task`) owns threshold-crossing WARN logging so
+/// that high-water warnings fire at most once per crossing, not every tick.
+pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) -> u64 {
     let writer = match pool.try_writer_nowait() {
         Ok(w) => w,
-        Err(_) => return,
+        Err(_) => return 0,
     };
 
     let wal_pages = query_wal_pages(writer.conn());
 
-    if wal_pages >= config.high_water_pages {
-        tracing::warn!(
-            wal_pages,
-            high_water = config.high_water_pages,
-            "WAL high-water mark exceeded; sustained WAL pressure — \
-             a long-lived reader may be pinning an old snapshot that PASSIVE cannot reclaim"
-        );
-    } else if wal_pages >= config.warn_pages {
+    if wal_pages >= config.warn_pages && wal_pages < config.high_water_pages {
         tracing::warn!(
             wal_pages,
             warn_threshold = config.warn_pages,
@@ -169,6 +176,8 @@ pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
     } else {
         tracing::debug!(wal_pages, "WAL checkpoint issued");
     }
+
+    wal_pages
 }
 
 /// Query the current WAL frame count via `PRAGMA wal_checkpoint`.
@@ -304,20 +313,35 @@ mod tests {
         assert_eq!(cfg.high_water_pages, default.high_water_pages);
     }
 
-    /// Regression: a high-water tick must not block behind an active reader.
+    /// Regression: a high-water tick must NOT block behind an active read transaction.
     ///
-    /// Opens a read connection and holds it for the duration, then triggers a
-    /// `checkpoint_once` with `high_water_pages = 1` so the high-water path
-    /// is taken. Asserts the call returns within 200 ms — proving PASSIVE
-    /// semantics (no reader wait). A TRUNCATE at this point would block for up
-    /// to `PoolConfig::busy_timeout` (30 s default).
+    /// Isomorphism guarantee: this test FAILS if `checkpoint_once` regresses to
+    /// `PRAGMA wal_checkpoint(TRUNCATE)`. Confirmed by reasoning: TRUNCATE inherits
+    /// RESTART semantics and will invoke the busy handler (sleeping up to
+    /// `busy_timeout`) while waiting for the open reader snapshot to release.
+    /// With `busy_timeout = 200ms` a TRUNCATE regression causes the call to take
+    /// ~200ms, blowing the <50ms assertion. PASSIVE returns in <1ms even with an
+    /// open reader, because PASSIVE never waits for readers.
+    ///
+    /// Why `busy_timeout = 200ms`: the test pool uses a small busy_timeout so a
+    /// TRUNCATE regression fails fast (~200ms), not after the 30s production default.
     #[test]
     fn checkpoint_high_water_does_not_block_behind_reader() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("high_water_test.db");
-        let pool = file_pool(&path);
 
-        // Write some data so the WAL is non-trivial.
+        // Use a small busy_timeout so a TRUNCATE regression fails fast (~200ms)
+        // rather than hanging the test suite for the 30s production default.
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path.clone()),
+                busy_timeout: Duration::from_millis(200),
+                ..PoolConfig::default()
+            })
+            .expect("pool open"),
+        );
+
+        // Write data so the WAL has frames to checkpoint.
         {
             let writer = pool.try_writer().unwrap();
             writer
@@ -328,11 +352,26 @@ mod tests {
                 .unwrap();
         }
 
-        // Hold an open read connection for the duration of the checkpoint call.
+        // Open a reader and start a real read transaction so it holds a WAL
+        // snapshot. An idle connection (no BEGIN) does NOT pin frames and would
+        // not cause TRUNCATE to wait — the transaction is required for isomorphism.
         let reader = pool.reader().expect("reader");
+        reader
+            .execute_batch("BEGIN DEFERRED; SELECT * FROM t;")
+            .expect("begin read tx");
 
-        // high_water_pages = 1 ensures the high-water branch is taken for any
-        // non-trivial WAL (even after the table write above).
+        // Write another row AFTER the snapshot is established. These new WAL
+        // frames are now pinned by the open reader snapshot — TRUNCATE cannot
+        // reclaim them without waiting; PASSIVE skips them and returns immediately.
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("INSERT INTO t VALUES (2);")
+                .unwrap();
+        }
+
+        // high_water_pages = 1 forces the high-water code path for any non-empty WAL.
         let config = CheckpointConfig {
             high_water_pages: 1,
             ..Default::default()
@@ -342,13 +381,16 @@ mod tests {
         checkpoint_once(&pool, &config);
         let elapsed = start.elapsed();
 
+        // Commit and release the read snapshot only after checkpoint_once returns.
+        reader.execute_batch("COMMIT;").ok();
         drop(reader);
 
-        // PASSIVE returns immediately regardless of readers.
-        // TRUNCATE would block for up to busy_timeout (30 s) here.
+        // PASSIVE returns in <1ms even with an open reader snapshot.
+        // A TRUNCATE regression would block ~busy_timeout (200ms) and fail here.
         assert!(
-            elapsed < std::time::Duration::from_millis(200),
-            "checkpoint_once with active reader took {:?}; expected <200ms (PASSIVE must not block)",
+            elapsed < std::time::Duration::from_millis(50),
+            "checkpoint_once with active reader snapshot took {:?}; \
+             expected <50ms (PASSIVE must not block on readers)",
             elapsed
         );
     }

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -2,14 +2,16 @@
 //!
 //! Issues `PRAGMA wal_checkpoint(PASSIVE)` on a configurable interval and
 //! escalates to `PRAGMA wal_checkpoint(TRUNCATE)` when the WAL page count
-//! exceeds a high-water mark. Both operations are submitted through the pool's
-//! writer connection so they are serialized with active writers and never
-//! contend with reads in flight.
+//! exceeds a high-water mark.
+//!
+//! Non-contending design: `checkpoint_once` uses `try_writer_nowait` (zero-wait
+//! `try_lock`) so a tick is skipped immediately when any writer holds the mutex,
+//! rather than blocking for up to `checkout_timeout`. The checkpoint task must
+//! never stall active write traffic — a skipped tick is always preferable.
 //!
 //! PASSIVE: yields if any reader holds a WAL snapshot — never blocks.
-//! TRUNCATE: resets the WAL to zero length after checkpointing; only safe when
-//! no reader is active, but `wal_checkpoint(TRUNCATE)` in SQLite degrades to
-//! PASSIVE if readers are present, so it is safe to call unconditionally.
+//! TRUNCATE: resets the WAL to zero length after checkpointing; degrades to
+//! PASSIVE behavior when readers are present, so it is safe to call unconditionally.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -68,13 +70,17 @@ impl CheckpointConfig {
 
         if let Ok(v) = std::env::var("KHIVE_WAL_WARN_PAGES") {
             if let Ok(n) = v.parse::<u64>() {
-                cfg.warn_pages = n;
+                if n > 0 {
+                    cfg.warn_pages = n;
+                }
             }
         }
 
         if let Ok(v) = std::env::var("KHIVE_WAL_HIGH_WATER_PAGES") {
             if let Ok(n) = v.parse::<u64>() {
-                cfg.high_water_pages = n;
+                if n > 0 {
+                    cfg.high_water_pages = n;
+                }
             }
         }
 
@@ -92,9 +98,8 @@ impl CheckpointConfig {
 /// WAL page count exceeds `config.high_water_pages` it upgrades to
 /// `PRAGMA wal_checkpoint(TRUNCATE)` to reclaim disk space.
 ///
-/// All pragma calls go through `pool.try_writer()` so they are serialized
-/// with active write transactions. If the writer is busy the call is skipped
-/// and retried on the next tick.
+/// Uses `try_writer_nowait` (zero-wait try-lock) so a busy writer causes the
+/// current tick to be skipped rather than stalling write traffic.
 pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointConfig) {
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -117,8 +122,11 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
 /// Returns without error: all failures are logged at warn level and skipped.
 /// This is intentional — a failed checkpoint is non-fatal and will be retried
 /// on the next tick.
+///
+/// Uses `try_writer_nowait` so that a busy active writer causes this tick to
+/// be skipped immediately rather than stalling for up to `checkout_timeout`.
 pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
-    let writer = match pool.try_writer() {
+    let writer = match pool.try_writer_nowait() {
         Ok(w) => w,
         Err(_) => return,
     };
@@ -172,6 +180,7 @@ fn query_wal_pages(conn: &rusqlite::Connection) -> u64 {
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
+    use serial_test::serial;
 
     fn file_pool(path: &std::path::Path) -> Arc<ConnectionPool> {
         let cfg = PoolConfig {
@@ -245,6 +254,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn checkpoint_config_env_override() {
         std::env::set_var("KHIVE_CHECKPOINT_INTERVAL_MS", "250");
         std::env::set_var("KHIVE_WAL_WARN_PAGES", "1500");
@@ -262,6 +272,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn checkpoint_config_defaults_on_invalid_env() {
         let default = CheckpointConfig::default();
 
@@ -277,5 +288,34 @@ mod tests {
 
         assert_eq!(cfg.interval, default.interval);
         assert_eq!(cfg.warn_pages, default.warn_pages);
+        assert_eq!(cfg.high_water_pages, default.high_water_pages);
+    }
+
+    #[test]
+    #[serial]
+    fn checkpoint_config_rejects_zero_for_all_fields() {
+        let default = CheckpointConfig::default();
+        std::env::set_var("KHIVE_CHECKPOINT_INTERVAL_MS", "0");
+        std::env::set_var("KHIVE_WAL_WARN_PAGES", "0");
+        std::env::set_var("KHIVE_WAL_HIGH_WATER_PAGES", "0");
+
+        let cfg = CheckpointConfig::from_env();
+
+        std::env::remove_var("KHIVE_CHECKPOINT_INTERVAL_MS");
+        std::env::remove_var("KHIVE_WAL_WARN_PAGES");
+        std::env::remove_var("KHIVE_WAL_HIGH_WATER_PAGES");
+
+        assert_eq!(
+            cfg.interval, default.interval,
+            "zero interval must fall back to default"
+        );
+        assert_eq!(
+            cfg.warn_pages, default.warn_pages,
+            "zero warn_pages must fall back to default"
+        );
+        assert_eq!(
+            cfg.high_water_pages, default.high_water_pages,
+            "zero high_water_pages must fall back to default"
+        );
     }
 }

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -1,0 +1,281 @@
+//! Periodic WAL checkpoint task for the connection pool.
+//!
+//! Issues `PRAGMA wal_checkpoint(PASSIVE)` on a configurable interval and
+//! escalates to `PRAGMA wal_checkpoint(TRUNCATE)` when the WAL page count
+//! exceeds a high-water mark. Both operations are submitted through the pool's
+//! writer connection so they are serialized with active writers and never
+//! contend with reads in flight.
+//!
+//! PASSIVE: yields if any reader holds a WAL snapshot — never blocks.
+//! TRUNCATE: resets the WAL to zero length after checkpointing; only safe when
+//! no reader is active, but `wal_checkpoint(TRUNCATE)` in SQLite degrades to
+//! PASSIVE if readers are present, so it is safe to call unconditionally.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::pool::ConnectionPool;
+
+/// Configuration for the WAL checkpoint background task.
+///
+/// All fields default to conservative production values. Override via the
+/// environment variables documented on each field.
+#[derive(Clone, Debug)]
+pub struct CheckpointConfig {
+    /// How often to run a passive checkpoint when there is no active write.
+    ///
+    /// Overridable via `KHIVE_CHECKPOINT_INTERVAL_MS` (milliseconds).
+    /// Default: 500 ms.
+    pub interval: Duration,
+
+    /// WAL page count above which a warning is logged.
+    ///
+    /// Overridable via `KHIVE_WAL_WARN_PAGES`.
+    /// Default: 2000 pages (~8 MB at 4 KiB page size).
+    pub warn_pages: u64,
+
+    /// WAL page count above which the task escalates from PASSIVE to TRUNCATE.
+    ///
+    /// Overridable via `KHIVE_WAL_HIGH_WATER_PAGES`.
+    /// Default: 6000 pages (~24 MB at 4 KiB page size).
+    pub high_water_pages: u64,
+}
+
+impl Default for CheckpointConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_millis(500),
+            warn_pages: 2000,
+            high_water_pages: 6000,
+        }
+    }
+}
+
+impl CheckpointConfig {
+    /// Build a `CheckpointConfig` from the environment.
+    ///
+    /// Unset or unparseable variables fall back to the compiled-in defaults.
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+
+        if let Ok(ms) = std::env::var("KHIVE_CHECKPOINT_INTERVAL_MS") {
+            if let Ok(v) = ms.parse::<u64>() {
+                if v > 0 {
+                    cfg.interval = Duration::from_millis(v);
+                }
+            }
+        }
+
+        if let Ok(v) = std::env::var("KHIVE_WAL_WARN_PAGES") {
+            if let Ok(n) = v.parse::<u64>() {
+                cfg.warn_pages = n;
+            }
+        }
+
+        if let Ok(v) = std::env::var("KHIVE_WAL_HIGH_WATER_PAGES") {
+            if let Ok(n) = v.parse::<u64>() {
+                cfg.high_water_pages = n;
+            }
+        }
+
+        cfg
+    }
+}
+
+/// Run the WAL checkpoint background task.
+///
+/// This is a long-running async task that should be spawned with
+/// `tokio::spawn`. It loops until the pool is dropped (the `Arc` count
+/// falls to one, meaning this task holds the last reference).
+///
+/// The task issues `PRAGMA wal_checkpoint(PASSIVE)` on every tick. When the
+/// WAL page count exceeds `config.high_water_pages` it upgrades to
+/// `PRAGMA wal_checkpoint(TRUNCATE)` to reclaim disk space.
+///
+/// All pragma calls go through `pool.try_writer()` so they are serialized
+/// with active write transactions. If the writer is busy the call is skipped
+/// and retried on the next tick.
+pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointConfig) {
+    let mut interval = tokio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+
+        // Stop looping when this task is the sole Arc holder — the daemon is
+        // shutting down and the pool will be dropped imminently.
+        if Arc::strong_count(&pool) <= 1 {
+            break;
+        }
+
+        checkpoint_once(&pool, &config);
+    }
+}
+
+/// Issue one checkpoint cycle against the writer connection.
+///
+/// Returns without error: all failures are logged at warn level and skipped.
+/// This is intentional — a failed checkpoint is non-fatal and will be retried
+/// on the next tick.
+pub fn checkpoint_once(pool: &ConnectionPool, config: &CheckpointConfig) {
+    let writer = match pool.try_writer() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+
+    let wal_pages = query_wal_pages(writer.conn());
+    let mode = if wal_pages >= config.high_water_pages {
+        tracing::warn!(
+            wal_pages,
+            high_water = config.high_water_pages,
+            "WAL high-water mark exceeded; escalating to TRUNCATE checkpoint"
+        );
+        "TRUNCATE"
+    } else {
+        if wal_pages >= config.warn_pages {
+            tracing::warn!(
+                wal_pages,
+                warn_threshold = config.warn_pages,
+                "WAL page count approaching checkpoint threshold"
+            );
+        }
+        "PASSIVE"
+    };
+
+    let sql = format!("PRAGMA wal_checkpoint({mode})");
+    if let Err(e) = writer.conn().execute_batch(&sql) {
+        tracing::warn!(error = %e, mode, "WAL checkpoint failed");
+    } else {
+        tracing::debug!(mode, wal_pages, "WAL checkpoint issued");
+    }
+}
+
+/// Query the current WAL frame count via `PRAGMA wal_checkpoint`.
+///
+/// The pragma returns a 3-column row `(busy, log, checkpointed)`, where `log`
+/// (column index 1) is the number of frames currently in the WAL file — the
+/// backlog the high-water escalation keys off. (Column 2 is `checkpointed`, the
+/// frames moved *by this call*, which is not the WAL size.) The no-arg pragma
+/// also performs a PASSIVE checkpoint as a side effect; the subsequent explicit
+/// checkpoint in `checkpoint_once` is therefore a deliberate second pass that
+/// can escalate to TRUNCATE.
+///
+/// Returns 0 on any error (e.g. in-memory DB where WAL is not active, which
+/// reports `log = -1`).
+fn query_wal_pages(conn: &rusqlite::Connection) -> u64 {
+    conn.query_row("PRAGMA wal_checkpoint", [], |row| row.get::<_, i64>(1))
+        .unwrap_or(0)
+        .max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::PoolConfig;
+
+    fn file_pool(path: &std::path::Path) -> Arc<ConnectionPool> {
+        let cfg = PoolConfig {
+            path: Some(path.to_path_buf()),
+            ..PoolConfig::default()
+        };
+        Arc::new(ConnectionPool::new(cfg).expect("pool open"))
+    }
+
+    #[test]
+    fn checkpoint_once_succeeds_on_file_backed_pool() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal_test.db");
+        let pool = file_pool(&path);
+
+        // Create a table so the DB is not completely empty.
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE IF NOT EXISTS t (x INTEGER);")
+                .unwrap();
+            writer
+                .conn()
+                .execute_batch("INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+
+        let config = CheckpointConfig::default();
+        checkpoint_once(&pool, &config);
+    }
+
+    #[test]
+    fn checkpoint_once_is_noop_on_in_memory_pool() {
+        // In-memory databases do not use WAL; checkpoint_once must not panic.
+        let cfg = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(cfg).expect("in-memory pool"));
+        let config = CheckpointConfig::default();
+        checkpoint_once(&pool, &config);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_task_exits_when_pool_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wal_task_drop.db");
+        let pool = file_pool(&path);
+
+        // Use a very short interval so the task ticks quickly in the test.
+        let cfg = CheckpointConfig {
+            interval: Duration::from_millis(10),
+            ..Default::default()
+        };
+
+        let weak = Arc::downgrade(&pool);
+        let task_pool = Arc::clone(&pool);
+        let handle = tokio::spawn(run_checkpoint_task(task_pool, cfg));
+
+        // Drop our copy — only the task holds the Arc now.
+        drop(pool);
+
+        // The task detects strong_count == 1 on its next tick and exits.
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("checkpoint task should exit within 1s")
+            .expect("checkpoint task panicked");
+
+        assert!(weak.upgrade().is_none(), "pool should be fully dropped");
+    }
+
+    #[test]
+    fn checkpoint_config_env_override() {
+        std::env::set_var("KHIVE_CHECKPOINT_INTERVAL_MS", "250");
+        std::env::set_var("KHIVE_WAL_WARN_PAGES", "1500");
+        std::env::set_var("KHIVE_WAL_HIGH_WATER_PAGES", "8000");
+
+        let cfg = CheckpointConfig::from_env();
+
+        std::env::remove_var("KHIVE_CHECKPOINT_INTERVAL_MS");
+        std::env::remove_var("KHIVE_WAL_WARN_PAGES");
+        std::env::remove_var("KHIVE_WAL_HIGH_WATER_PAGES");
+
+        assert_eq!(cfg.interval, Duration::from_millis(250));
+        assert_eq!(cfg.warn_pages, 1500);
+        assert_eq!(cfg.high_water_pages, 8000);
+    }
+
+    #[test]
+    fn checkpoint_config_defaults_on_invalid_env() {
+        let default = CheckpointConfig::default();
+
+        std::env::set_var("KHIVE_CHECKPOINT_INTERVAL_MS", "not_a_number");
+        std::env::set_var("KHIVE_WAL_WARN_PAGES", "");
+        std::env::set_var("KHIVE_WAL_HIGH_WATER_PAGES", "0");
+
+        let cfg = CheckpointConfig::from_env();
+
+        std::env::remove_var("KHIVE_CHECKPOINT_INTERVAL_MS");
+        std::env::remove_var("KHIVE_WAL_WARN_PAGES");
+        std::env::remove_var("KHIVE_WAL_HIGH_WATER_PAGES");
+
+        assert_eq!(cfg.interval, default.interval);
+        assert_eq!(cfg.warn_pages, default.warn_pages);
+    }
+}

--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -5,6 +5,8 @@
 
 /// Concrete storage backend providing capability-trait factories.
 pub mod backend;
+/// Periodic WAL checkpoint task.
+pub mod checkpoint;
 /// Error types for the SQLite layer.
 pub mod error;
 /// SQLite extension registration (sqlite-vec auto-extension).
@@ -19,6 +21,7 @@ pub mod sql_bridge;
 pub mod stores;
 
 pub use backend::StorageBackend;
+pub use checkpoint::{checkpoint_once, run_checkpoint_task, CheckpointConfig};
 pub use error::SqliteError;
 pub use migrations::{
     inspect_schema_version, query_embedding_models, read_schema_version, run_migrations,

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -317,6 +317,23 @@ impl ConnectionPool {
         self.writer()
     }
 
+    /// Zero-wait writer checkout for background tasks.
+    ///
+    /// Uses `try_lock()` (no timeout, no spin) — returns `Err` immediately when
+    /// any other caller holds the writer Mutex. Background tasks (e.g. the WAL
+    /// checkpoint task) MUST use this instead of `try_writer` so that a busy
+    /// writer causes the background task to skip its current tick rather than
+    /// stalling for up to `checkout_timeout` (default 5s) while write traffic
+    /// is in progress.
+    pub fn try_writer_nowait(&self) -> Result<WriterGuard<'_>, SqliteError> {
+        let guard = self.writer.try_lock().ok_or_else(|| {
+            SqliteError::InvalidData(
+                "writer connection busy (checkpoint skipped this tick)".to_string(),
+            )
+        })?;
+        Ok(WriterGuard { guard })
+    }
+
     /// Get the current number of available reader connections.
     pub fn available_readers(&self) -> usize {
         self.readers.len()
@@ -504,6 +521,7 @@ fn pool_exhausted_error(timeout: Duration, max_readers: usize) -> SqliteError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn pool_config_default_values_match_constants() {
@@ -522,6 +540,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_config_env_override_wal_autocheckpoint() {
         std::env::set_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES", "8000");
         let cfg = PoolConfig::default();
@@ -530,6 +549,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_config_env_override_journal_size_limit() {
         std::env::set_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES", "134217728");
         let cfg = PoolConfig::default();
@@ -538,6 +558,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_config_env_override_busy_timeout() {
         std::env::set_var("KHIVE_BUSY_TIMEOUT_SECS", "60");
         let cfg = PoolConfig::default();
@@ -546,6 +567,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_config_env_override_checkout_timeout() {
         std::env::set_var("KHIVE_CHECKOUT_TIMEOUT_SECS", "10");
         let cfg = PoolConfig::default();
@@ -554,6 +576,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_config_env_invalid_falls_back_to_default() {
         std::env::set_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES", "not_a_number");
         std::env::set_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES", "");

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -12,9 +12,10 @@ use crate::error::SqliteError;
 
 const CACHE_SIZE_KIB: &str = "-65536";
 const MMAP_SIZE_BYTES: &str = "1073741824";
-const WAL_AUTOCHECKPOINT_PAGES: &str = "4000";
-const JOURNAL_SIZE_LIMIT_BYTES: &str = "67108864";
 const DEFAULT_READER_CAP: usize = 8;
+
+const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: u32 = 4000;
+const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
 
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
@@ -26,9 +27,26 @@ pub struct PoolConfig {
     /// WAL mode (must be true for pooling to work; default: true).
     pub wal_mode: bool,
     /// Busy timeout per connection (default: 30s).
+    ///
+    /// Overridable via `KHIVE_BUSY_TIMEOUT_SECS`.
     pub busy_timeout: Duration,
     /// Time to wait for a reader connection before returning an error (default: 5s).
+    ///
+    /// Overridable via `KHIVE_CHECKOUT_TIMEOUT_SECS`.
     pub checkout_timeout: Duration,
+    /// Number of WAL pages that triggers an automatic checkpoint.
+    ///
+    /// Maps to `PRAGMA wal_autocheckpoint`. The default (4000 pages, ~16 MiB
+    /// at SQLite's default 4 KiB page size) matches the pre-config behaviour.
+    ///
+    /// Overridable via `KHIVE_WAL_AUTOCHECKPOINT_PAGES`.
+    pub wal_autocheckpoint_pages: u32,
+    /// Maximum WAL journal size in bytes before SQLite resets the WAL.
+    ///
+    /// Maps to `PRAGMA journal_size_limit`. Default: 64 MiB.
+    ///
+    /// Overridable via `KHIVE_JOURNAL_SIZE_LIMIT_BYTES`.
+    pub journal_size_limit_bytes: i64,
 }
 
 impl Default for PoolConfig {
@@ -40,8 +58,26 @@ impl Default for PoolConfig {
                 .unwrap_or(1)
                 .clamp(1, DEFAULT_READER_CAP),
             wal_mode: true,
-            busy_timeout: Duration::from_secs(30),
-            checkout_timeout: Duration::from_secs(5),
+            busy_timeout: Duration::from_secs(
+                std::env::var("KHIVE_BUSY_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(30),
+            ),
+            checkout_timeout: Duration::from_secs(
+                std::env::var("KHIVE_CHECKOUT_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(5),
+            ),
+            wal_autocheckpoint_pages: std::env::var("KHIVE_WAL_AUTOCHECKPOINT_PAGES")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(DEFAULT_WAL_AUTOCHECKPOINT_PAGES),
+            journal_size_limit_bytes: std::env::var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES")
+                .ok()
+                .and_then(|v| v.parse::<i64>().ok())
+                .unwrap_or(DEFAULT_JOURNAL_SIZE_LIMIT_BYTES),
         }
     }
 }
@@ -388,8 +424,8 @@ fn configure_writer_connection(
     let wal_enabled = wants_wal && current_journal_mode(conn)?.eq_ignore_ascii_case("wal");
 
     if wal_enabled {
-        conn.pragma_update(None, "wal_autocheckpoint", WAL_AUTOCHECKPOINT_PAGES)?;
-        conn.pragma_update(None, "journal_size_limit", JOURNAL_SIZE_LIMIT_BYTES)?;
+        conn.pragma_update(None, "wal_autocheckpoint", config.wal_autocheckpoint_pages)?;
+        conn.pragma_update(None, "journal_size_limit", config.journal_size_limit_bytes)?;
     }
 
     Ok(wal_enabled)
@@ -463,4 +499,113 @@ fn pool_exhausted_error(timeout: Duration, max_readers: usize) -> SqliteError {
         )),
     )
     .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_config_default_values_match_constants() {
+        // Ensure defaults are not accidentally changed.
+        let cfg = PoolConfig::default();
+        assert_eq!(
+            cfg.wal_autocheckpoint_pages,
+            DEFAULT_WAL_AUTOCHECKPOINT_PAGES
+        );
+        assert_eq!(
+            cfg.journal_size_limit_bytes,
+            DEFAULT_JOURNAL_SIZE_LIMIT_BYTES
+        );
+        assert_eq!(cfg.busy_timeout, Duration::from_secs(30));
+        assert_eq!(cfg.checkout_timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn pool_config_env_override_wal_autocheckpoint() {
+        std::env::set_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES", "8000");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES");
+        assert_eq!(cfg.wal_autocheckpoint_pages, 8000);
+    }
+
+    #[test]
+    fn pool_config_env_override_journal_size_limit() {
+        std::env::set_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES", "134217728");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES");
+        assert_eq!(cfg.journal_size_limit_bytes, 134_217_728);
+    }
+
+    #[test]
+    fn pool_config_env_override_busy_timeout() {
+        std::env::set_var("KHIVE_BUSY_TIMEOUT_SECS", "60");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_BUSY_TIMEOUT_SECS");
+        assert_eq!(cfg.busy_timeout, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn pool_config_env_override_checkout_timeout() {
+        std::env::set_var("KHIVE_CHECKOUT_TIMEOUT_SECS", "10");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_CHECKOUT_TIMEOUT_SECS");
+        assert_eq!(cfg.checkout_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn pool_config_env_invalid_falls_back_to_default() {
+        std::env::set_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES", "not_a_number");
+        std::env::set_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES", "");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WAL_AUTOCHECKPOINT_PAGES");
+        std::env::remove_var("KHIVE_JOURNAL_SIZE_LIMIT_BYTES");
+        assert_eq!(
+            cfg.wal_autocheckpoint_pages,
+            DEFAULT_WAL_AUTOCHECKPOINT_PAGES
+        );
+        assert_eq!(
+            cfg.journal_size_limit_bytes,
+            DEFAULT_JOURNAL_SIZE_LIMIT_BYTES
+        );
+    }
+
+    #[test]
+    fn file_backed_pool_opens_successfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test_pool.db");
+        let cfg = PoolConfig {
+            path: Some(path.clone()),
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
+        assert!(path.exists());
+        assert!(pool.max_readers() > 0);
+    }
+
+    #[test]
+    fn in_memory_pool_degrades_to_single_connection() {
+        let cfg = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).expect("in-memory pool should open");
+        assert_eq!(pool.max_readers(), 0);
+    }
+
+    #[test]
+    fn writer_checkout_and_release_works() {
+        let cfg = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        {
+            let _writer = pool.writer().expect("writer checkout should succeed");
+        }
+        // After drop, writer should be re-acquirable.
+        let _writer2 = pool
+            .writer()
+            .expect("second writer checkout should succeed");
+    }
 }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
+khive-db = { version = "0.2.11", path = "../khive-db" }
 khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
 khive-storage = { version = "0.2.11", path = "../khive-storage" }
 khive-request = { version = "0.2.11", path = "../khive-request" }

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -92,6 +92,10 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
     fn config_id(&self) -> &str {
         crate::server::KhiveMcpServer::config_id(self)
     }
+
+    fn pool_for_checkpoint(&self) -> Option<std::sync::Arc<khive_db::ConnectionPool>> {
+        self.pool()
+    }
 }
 
 // ── client ────────────────────────────────────────────────────────────────────

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use khive_runtime::{
     config_from_env, run_migrations, runtime_config_from_khive_config, BackendConfig, BackendId,
-    BackendKind, KhiveConfig, KhiveRuntime, PackRegistry, RuntimeConfig, StorageBackend,
-    VerbRegistryBuilder,
+    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, PackRegistry, RuntimeConfig,
+    StorageBackend, VerbRegistryBuilder,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -514,11 +514,23 @@ fn build_server_multi_backend(
         .apply_schema_plans_with_map(&backend_for_pack, main_ref)
         .map_err(|e| anyhow::anyhow!("pack schema boot failure: {e}"))?;
 
-    Ok(KhiveMcpServer::from_registry_with_meta(
-        registry,
-        default_namespace.as_str(),
-        &config_id,
-    ))
+    // Wire the main backend's pool for background WAL checkpointing. The pool is
+    // only present for file-backed databases; in-memory backends return None here
+    // so that checkpoint_once never runs on a non-WAL connection.
+    let pool: Option<Arc<ConnectionPool>> = if main_backend.is_file_backed() {
+        Some(main_backend.pool_arc())
+    } else {
+        None
+    };
+
+    let server =
+        KhiveMcpServer::from_registry_with_meta(registry, default_namespace.as_str(), &config_id);
+
+    Ok(if let Some(p) = pool {
+        server.with_pool(p)
+    } else {
+        server
+    })
 }
 
 /// Open a `StorageBackend` from a `BackendConfig`.

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -20,6 +20,7 @@ use rmcp::{
 };
 use serde_json::{json, Value};
 
+use khive_db::ConnectionPool;
 use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
 use khive_runtime::{
     present, KhiveRuntime, Namespace, PackLoadError, PackRegistry, PresentationMode, RuntimeConfig,
@@ -194,6 +195,9 @@ pub struct KhiveMcpServer {
     /// deployments. `None` in single-backend mode — all dispatch goes through the
     /// `VerbRegistry` unchanged (zero-change invariant).
     coordinator: Option<Arc<dyn CoordinatorService>>,
+    /// Pool arc for the WAL checkpoint background task. `None` for in-memory
+    /// or registry-only servers that have no persistent database.
+    pool: Option<Arc<ConnectionPool>>,
 }
 
 /// Failure reason inside a [`PackRegError`].
@@ -311,11 +315,19 @@ impl KhiveMcpServer {
         // present before any handler runs. Errors are logged but not propagated
         // so a single pack's schema failure cannot abort startup.
         registry.apply_schema_plans(runtime.backend());
+        // Capture the pool arc for the WAL checkpoint task. Only available for
+        // file-backed databases; in-memory backends return None here.
+        let pool = if runtime.backend().is_file_backed() {
+            Some(runtime.backend().pool_arc())
+        } else {
+            None
+        };
         Ok(Self {
             registry,
             default_namespace: default_namespace.as_str().to_string(),
             config_id,
             coordinator: None,
+            pool,
         })
     }
 
@@ -334,6 +346,7 @@ impl KhiveMcpServer {
             // dispatch locally rather than forward.
             config_id: "registry-only".to_string(),
             coordinator: None,
+            pool: None,
         }
     }
 
@@ -351,6 +364,7 @@ impl KhiveMcpServer {
             default_namespace: default_namespace.to_string(),
             config_id: config_id.to_string(),
             coordinator: None,
+            pool: None,
         }
     }
 
@@ -397,6 +411,13 @@ impl KhiveMcpServer {
     /// Fingerprint of the runtime config this server's registry was built for.
     pub fn config_id(&self) -> &str {
         &self.config_id
+    }
+
+    /// The connection pool to use for background WAL checkpointing, if any.
+    ///
+    /// Returns `None` for in-memory or registry-only servers.
+    pub fn pool(&self) -> Option<Arc<ConnectionPool>> {
+        self.pool.clone()
     }
 
     /// Warm every pack's in-memory state. Called by the daemon in a background

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -378,6 +378,16 @@ impl KhiveMcpServer {
         self
     }
 
+    /// Attach a connection pool for the WAL checkpoint background task.
+    ///
+    /// Used by the multi-backend boot path to wire the main backend's pool into a
+    /// server built via `from_registry_with_meta` (which cannot carry a pool itself
+    /// because registry-only construction has no access to the backend layer).
+    pub fn with_pool(mut self, pool: Arc<ConnectionPool>) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
     /// Route a `link` or `search` verb through the coordinator when in multi-backend mode.
     ///
     /// Returns `Some(result)` when the coordinator handled the op (caller should skip

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
+use khive_db::{run_checkpoint_task, CheckpointConfig, ConnectionPool};
+
 /// Maximum frame size accepted in either direction.
 pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 
@@ -244,6 +246,17 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// config differs, so a restricted client cannot dispatch through a broader
     /// daemon.
     fn config_id(&self) -> &str;
+
+    /// Return the pool to use for background WAL checkpointing, if available.
+    ///
+    /// Implementors backed by a file-based SQLite database should return
+    /// `Some(pool_arc)`. In-memory or test dispatchers that have no pool
+    /// return `None` and the checkpoint task is not spawned.
+    ///
+    /// The default implementation returns `None`.
+    fn pool_for_checkpoint(&self) -> Option<Arc<ConnectionPool>> {
+        None
+    }
 }
 
 // ── server ────────────────────────────────────────────────────────────────────
@@ -442,6 +455,12 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
         tokio::spawn(async move {
             warm.warm_all().await;
         });
+    }
+
+    if let Some(pool) = dispatcher.pool_for_checkpoint() {
+        let cfg = CheckpointConfig::from_env();
+        tokio::spawn(run_checkpoint_task(pool, cfg));
+        tracing::info!("WAL checkpoint task started");
     }
 
     let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -39,7 +39,10 @@ pub use engine_config::{
 pub use error::{RuntimeError, RuntimeResult};
 pub use fusion::FusionStrategy;
 pub use graph_traversal::PathNode;
-pub use khive_db::{run_migrations, StorageBackend};
+pub use khive_db::{
+    checkpoint_once, run_checkpoint_task, run_migrations, CheckpointConfig, ConnectionPool,
+    StorageBackend,
+};
 pub use khive_gate::{
     ActorRef, AllowAllGate, AuditDecision, AuditEvent, Gate, GateContext, GateDecision, GateError,
     GateRef, GateRequest, Obligation,


### PR DESCRIPTION
## What

**Cluster-1 Slice-1** (no ADR required). Reduces the WAL-wedge probability immediately while ADR-067's (#219) write-owner-daemon redesign is under review.

- Extracts `WAL_AUTOCHECKPOINT_PAGES` + `JOURNAL_SIZE_LIMIT_BYTES` from `pool.rs` constants into `PoolConfig` with env overrides (`KHIVE_WAL_AUTOCHECKPOINT_PAGES`, `KHIVE_JOURNAL_SIZE_LIMIT_BYTES`, `KHIVE_BUSY_TIMEOUT_SECS`, `KHIVE_CHECKOUT_TIMEOUT_SECS`).
- Adds `crates/khive-db/src/checkpoint.rs`: a periodic **PASSIVE** checkpoint task (`KHIVE_CHECKPOINT_INTERVAL_MS`, default 500ms) escalating to **TRUNCATE** at a high-water mark (`KHIVE_WAL_HIGH_WATER_PAGES`, default 6000); warns at `KHIVE_WAL_WARN_PAGES` (default 2000).
- Spawned in `run_daemon` after `warm_all`, gated on a file-backed pool (in-memory → `None`, no task), exits when it becomes the sole `Arc` holder.
- All pragmas go through `pool.try_writer()` (non-blocking) so they never contend with reads.

## Why

Pre-cloud Cluster-1 (concurrency / write-path). Per ADR-068, per-tenant SQLite files mean each tenant gets an independent WAL checkpoint thread — this lands that discipline. First-landable piece; the full write-owner redesign follows in ADR-067 (#219).

## Note

`query_wal_pages` reads the WAL `log` frame count (`PRAGMA wal_checkpoint` column **1**, not the `checkpointed` count at column 2) so the high-water escalation keys off the real backlog. (Caught and fixed during review.)

## Tests

`cargo test -p khive-db` (137) + `-p khive-mcp` (102) green; `cargo clippy --workspace --all-targets -D warnings` + `cargo fmt --check` clean. 14 new tests (checkpoint config/task/once + pool config env overrides).