### PR TITLE
fix(retrieval): push property/tag predicates below truncation (#225)

### DIFF
--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -681,4 +681,329 @@ mod tests {
              got ids: {ids_in_actor_ns:?}"
         );
     }
+
+    // ---- Handler-level regression tests for issue #225 (filter-pushdown cliff) ----
+    //
+    // These tests operate at the `pack.dispatch("search", ...)` level and prove the
+    // REAL handler cliff: with `limit=1` the handler sets `search_limit =
+    // (1 * 50).min(500) = 50`, which means only 50 candidates enter the runtime.
+    // To push the target BEYOND the pre-fix cliff we insert 51 non-matching decoys
+    // so that the target sits at rank 52 in the unfiltered FTS ordering.
+    //
+    // Without predicate pushdown into `hybrid_search` / `search_notes` the runtime
+    // received `search_limit = 50` candidates, all decoys, and never saw the target.
+    // With the fix the runtime applies the filter BEFORE truncation over all 200
+    // candidates (50 × CANDIDATE_MULTIPLIER = 4) and surfaces the target.
+    //
+    // BUDGET CONSTANTS (from handlers/search.rs and retrieval.rs):
+    //   handler search_limit = (limit * 50).min(500)  → limit=1 → 50
+    //   runtime candidates   = search_limit * 4       → 200
+    //   old cliff: rank 51 (beyond handler 50-record scan)
+    //   new cliff: rank 201 (beyond runtime 200-candidate budget)
+    //
+    // Corpus: 51 decoys (ranks 1-51 in FTS) + 1 target (rank 52). Target has the
+    // discriminating tag/property; decoys do not. `limit=1`.
+
+    /// Handler-level regression for issue #225, entity branch, tag filter.
+    ///
+    /// 51 decoys rank above the target in FTS but lack the required tag.
+    /// The target carries the required tag and sits at rank 52.
+    /// With predicate pushdown the handler returns the target despite the cliff.
+    #[tokio::test]
+    async fn handler_search_entity_tag_filter_beyond_scan_cliff() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let tok = rt.authorize(Namespace::local()).unwrap();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+        let pack = KgPack::new(rt.clone());
+
+        // 51 decoys: high TF on query words ensures they rank above the target in
+        // FTS regardless of length normalization. No target tag.
+        let decoy_blob = "cliff query ".repeat(20);
+        for i in 0..51usize {
+            pack.dispatch(
+                "create",
+                json!({
+                    "kind": "concept",
+                    "name": format!("{decoy_blob}decoy {i}"),
+                    "description": format!("{decoy_blob}decoy {i} description"),
+                    "tags": ["decoy-tag"]
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("decoy create must succeed");
+        }
+
+        // Target: single occurrence of each query word, carries the required tag.
+        let target_result = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "concept",
+                    "name": "cliff query target",
+                    "description": "cliff query target description",
+                    "tags": ["cliff-target-tag"]
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("target create must succeed");
+        let target_id = target_result
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("target must have id");
+
+        // Search with tag filter and limit=1. The handler widens to search_limit=50
+        // which only covers the 51 decoys without the fix. With the fix, the
+        // predicate is applied before truncation and the target is returned.
+        let result = pack
+            .dispatch(
+                "search",
+                json!({
+                    "kind": "concept",
+                    "query": "cliff query",
+                    "tags": ["cliff-target-tag"],
+                    "limit": 1
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("search must succeed");
+
+        let hits = result.as_array().expect("search must return an array");
+        assert_eq!(hits.len(), 1, "exactly one hit expected; got {hits:?}");
+        assert_eq!(
+            hits[0].get("id").and_then(|v| v.as_str()).unwrap_or(""),
+            target_id,
+            "the tag-filtered entity (rank 52) must be returned despite the handler scan cliff; \
+             got {hits:?}"
+        );
+    }
+
+    /// Handler-level regression for issue #225, entity branch, properties filter.
+    ///
+    /// 51 decoys rank above the target in FTS but have the wrong property value.
+    /// The target has the required property and sits at rank 52.
+    #[tokio::test]
+    async fn handler_search_entity_props_filter_beyond_scan_cliff() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let tok = rt.authorize(Namespace::local()).unwrap();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+        let pack = KgPack::new(rt.clone());
+
+        let decoy_blob = "props cliff signal ".repeat(20);
+        for i in 0..51usize {
+            pack.dispatch(
+                "create",
+                json!({
+                    "kind": "concept",
+                    "name": format!("{decoy_blob}decoy {i}"),
+                    "description": format!("{decoy_blob}decoy {i} description"),
+                    "properties": {"domain": "other"}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("decoy create must succeed");
+        }
+
+        let target_result = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "concept",
+                    "name": "props cliff signal target",
+                    "description": "props cliff signal target description",
+                    "properties": {"domain": "props-target"}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("target create must succeed");
+        let target_id = target_result
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("target must have id");
+
+        let result = pack
+            .dispatch(
+                "search",
+                json!({
+                    "kind": "concept",
+                    "query": "props cliff signal",
+                    "properties": {"domain": "props-target"},
+                    "limit": 1
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("search must succeed");
+
+        let hits = result.as_array().expect("search must return an array");
+        assert_eq!(hits.len(), 1, "exactly one hit expected; got {hits:?}");
+        assert_eq!(
+            hits[0].get("id").and_then(|v| v.as_str()).unwrap_or(""),
+            target_id,
+            "the props-filtered entity (rank 52) must be returned despite the handler scan cliff; \
+             got {hits:?}"
+        );
+    }
+
+    /// Handler-level regression for issue #225, note branch, tag filter.
+    ///
+    /// 51 observation notes rank above the target in FTS but lack the required tag.
+    /// The target carries the required tag and sits at rank 52.
+    #[tokio::test]
+    async fn handler_search_note_tag_filter_beyond_scan_cliff() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let tok = rt.authorize(Namespace::local()).unwrap();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+        let pack = KgPack::new(rt.clone());
+
+        let decoy_blob = "note cliff token ".repeat(20);
+        for i in 0..51usize {
+            pack.dispatch(
+                "create",
+                json!({
+                    "kind": "observation",
+                    "content": format!("{decoy_blob}decoy {i}"),
+                    "properties": {"tags": ["note-decoy-tag"]}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("decoy note create must succeed");
+        }
+
+        let target_result = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "observation",
+                    "content": "note cliff token target",
+                    "properties": {"tags": ["note-cliff-target-tag"]}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("target note create must succeed");
+        let target_id = target_result
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("target must have id");
+
+        let result = pack
+            .dispatch(
+                "search",
+                json!({
+                    "kind": "note",
+                    "query": "note cliff token",
+                    "tags": ["note-cliff-target-tag"],
+                    "limit": 1
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("search must succeed");
+
+        let hits = result.as_array().expect("search must return an array");
+        assert_eq!(hits.len(), 1, "exactly one hit expected; got {hits:?}");
+        assert_eq!(
+            hits[0].get("id").and_then(|v| v.as_str()).unwrap_or(""),
+            target_id,
+            "the tag-filtered note (rank 52) must be returned despite the handler scan cliff; \
+             got {hits:?}"
+        );
+    }
+
+    /// Handler-level regression for issue #225, note branch, properties filter.
+    ///
+    /// 51 observation notes rank above the target in FTS but have the wrong property.
+    /// The target has the required property value and sits at rank 52.
+    #[tokio::test]
+    async fn handler_search_note_props_filter_beyond_scan_cliff() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let tok = rt.authorize(Namespace::local()).unwrap();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+        let pack = KgPack::new(rt.clone());
+
+        let decoy_blob = "note props wave ".repeat(20);
+        for i in 0..51usize {
+            pack.dispatch(
+                "create",
+                json!({
+                    "kind": "observation",
+                    "content": format!("{decoy_blob}decoy {i}"),
+                    "properties": {"category": "other", "tags": ["note-decoy-tag"]}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("decoy note create must succeed");
+        }
+
+        let target_result = pack
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "observation",
+                    "content": "note props wave target",
+                    "properties": {"category": "note-props-target", "tags": ["note-decoy-tag"]}
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("target note create must succeed");
+        let target_id = target_result
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("target must have id");
+
+        let result = pack
+            .dispatch(
+                "search",
+                json!({
+                    "kind": "note",
+                    "query": "note props wave",
+                    "properties": {"category": "note-props-target"},
+                    "limit": 1
+                }),
+                &registry,
+                &tok,
+            )
+            .await
+            .expect("search must succeed");
+
+        let hits = result.as_array().expect("search must return an array");
+        assert_eq!(hits.len(), 1, "exactly one hit expected; got {hits:?}");
+        assert_eq!(
+            hits[0].get("id").and_then(|v| v.as_str()).unwrap_or(""),
+            target_id,
+            "the props-filtered note (rank 52) must be returned despite the handler scan cliff; \
+             got {hits:?}"
+        );
+    }
 }

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -414,13 +414,13 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
                 name: "properties",
                 param_type: "object",
                 required: false,
-                description: "Post-filter search hits to records whose properties contain all listed key=value pairs (kind=\"entity\" or kind=\"note\"). Applied after FTS+vector ranking within a bounded candidate window. For notes, properties are stored in the note's `properties` JSON object. E.g. {\"type\": \"paper\", \"domain\": \"attention\"}. Note: filtered search is best-effort — matches ranked beyond the candidate scan window may be missed (see GitHub issue #225).",
+                description: "Filter to records whose properties contain all listed key=value pairs (kind=\"entity\" or kind=\"note\"). Predicates are applied BEFORE result truncation inside a bounded candidate window (entity tags: SQL-level; entity/note properties: Rust-level in the alive-set loop). For notes, properties are stored in the note's `properties` JSON object. E.g. {\"type\": \"paper\", \"domain\": \"attention\"}. Matches ranked beyond the runtime candidate budget (limit × 4 × handler_overfetch) may still be missed — use specific queries to bring matches into the top candidates.",
             },
             ParamDef {
                 name: "tags",
                 param_type: "array",
                 required: false,
-                description: "Post-filter search hits to records with any listed tag (kind=\"entity\" or kind=\"note\", OR semantics, case-insensitive). Applied after FTS+vector ranking within a bounded candidate window. For notes, tags are read from `properties[\"tags\"]` (there is no separate tag column on notes). E.g. [\"rust\", \"ml\"]. Note: filtered search is best-effort — matches ranked beyond the candidate scan window may be missed (see GitHub issue #225).",
+                description: "Filter to records with any listed tag (kind=\"entity\" or kind=\"note\", OR semantics, case-insensitive). Predicates are applied BEFORE result truncation inside a bounded candidate window (entity tags: SQL-level via EntityFilter; note tags: Rust-level in the alive-set loop). For notes, tags are read from `properties[\"tags\"]` (there is no separate tag column on notes). E.g. [\"rust\", \"ml\"]. Matches ranked beyond the runtime candidate budget (limit × 4 × handler_overfetch) may still be missed — use specific queries to bring matches into the top candidates.",
             },
             ParamDef {
                 name: "min_score",

--- a/crates/khive-pack-kg/src/handlers/create.rs
+++ b/crates/khive-pack-kg/src/handlers/create.rs
@@ -235,6 +235,8 @@ impl KgPack {
                     DEDUP_LIMIT + 1,
                     Some(kind.as_str()),
                     None,
+                    &[],
+                    None,
                 )
                 .await
             {

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -2,14 +2,14 @@
 
 use std::collections::HashMap;
 
-/// Maximum candidate window used when property/tag post-filters are active.
+/// Maximum candidate window used when property/tag filters are active.
 ///
-/// Both the entity and note branches apply property/tag predicates after the
-/// FTS+vector ranking step (the storage legs have no awareness of these fields).
-/// Using a large-but-bounded scan window reduces the probability of missing a
-/// match that ranked just below the bare `limit`. Matches ranked beyond this
-/// cap may still be silently dropped — the proper fix is to push the predicates
-/// into the storage leg, tracked in GitHub issue #225.
+/// Predicates are applied BEFORE result truncation inside the runtime's
+/// candidate budget (`search_limit × CANDIDATE_MULTIPLIER`). This constant
+/// widens the handler's initial `search_limit` so that sparse matches ranked
+/// just below the bare `limit` remain within the candidate window.
+/// Matches ranked beyond the overall budget may still be missed — use
+/// specific query text to keep target records near the top of the ranking.
 const FILTERED_SCAN_CAP: u32 = 500;
 
 use serde_json::Value;
@@ -62,14 +62,11 @@ impl KgPack {
                 });
                 let tag_filter = p.tags.as_ref().filter(|tags| !tags.is_empty());
                 let search_limit = if props_filter.is_some() || tag_filter.is_some() {
-                    // Property/tag predicates are applied post-ranking (the storage
-                    // legs have no awareness of entity properties/tags). Widen the
-                    // candidate window so sparse matches ranked below the bare `limit`
-                    // are still visible. The cap of FILTERED_SCAN_CAP is a
-                    // best-effort bound — matches ranked beyond it may still be missed
-                    // (known limitation: both entity and note branches share this
-                    // cliff; pushing predicates into the storage leg is the proper
-                    // fix, tracked in GitHub issue #225).
+                    // Widen the candidate window so sparse matches ranked below the
+                    // bare `limit` remain within the runtime's retrieval budget.
+                    // Predicates are applied BEFORE result truncation (entity tags:
+                    // SQL-level via EntityFilter; properties: Rust-level in alive-set
+                    // loop). The cap bounds worst-case scan cost.
                     (limit * 50).min(FILTERED_SCAN_CAP)
                 } else {
                     limit
@@ -172,14 +169,12 @@ impl KgPack {
                 });
                 let tag_filter = p.tags.as_ref().filter(|tags| !tags.is_empty());
                 let search_limit = if props_filter.is_some() || tag_filter.is_some() {
-                    // Property/tag predicates are applied post-ranking (notes have no
-                    // dedicated tag column; tags live in `properties["tags"]`). Widen
-                    // the candidate window so sparse matches ranked below the bare
-                    // `limit` are still visible. The cap of FILTERED_SCAN_CAP is a
-                    // best-effort bound — matches ranked beyond it may still be missed
-                    // (known limitation: both entity and note branches share this
-                    // cliff; pushing predicates into the storage leg is the proper
-                    // fix, tracked in GitHub issue #225).
+                    // Widen the candidate window so sparse matches ranked below the
+                    // bare `limit` remain within the runtime's retrieval budget.
+                    // Predicates are applied BEFORE result truncation (note tags and
+                    // properties: Rust-level in the alive-set loop, since notes have
+                    // no dedicated tag column — tags live in `properties["tags"]`).
+                    // The cap bounds worst-case scan cost.
                     (limit * 50).min(FILTERED_SCAN_CAP)
                 } else {
                     limit

--- a/crates/khive-pack-kg/src/handlers/search.rs
+++ b/crates/khive-pack-kg/src/handlers/search.rs
@@ -83,6 +83,8 @@ impl KgPack {
                         search_limit,
                         kind_filter.as_deref(),
                         validated_et.as_deref(),
+                        tag_filter.map(|t| t.as_slice()).unwrap_or(&[]),
+                        props_filter,
                     )
                     .await?;
 
@@ -191,6 +193,8 @@ impl KgPack {
                         search_limit,
                         kind_filter.as_deref(),
                         p.include_superseded.unwrap_or(false),
+                        tag_filter.map(|t| t.as_slice()).unwrap_or(&[]),
+                        props_filter,
                     )
                     .await?;
 

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -222,7 +222,16 @@ impl KnowledgePack {
             // NOT a true corpus count — see doc comment above.
             let hits = self
                 .runtime
-                .hybrid_search(token, query, None, limit * 4, Some("concept"), None)
+                .hybrid_search(
+                    token,
+                    query,
+                    None,
+                    limit * 4,
+                    Some("concept"),
+                    None,
+                    &[],
+                    None,
+                )
                 .await?;
 
             // Always fetch entity records for the search hits so we can emit a

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -393,6 +393,24 @@ fn validate_edge_metadata(
     Ok(())
 }
 
+/// Returns `true` when `note_props` is a superset of all key-value pairs in `filter`.
+///
+/// Mirrors the semantics of `khive_pack_kg::handlers::common::props_match` so that the
+/// storage-leg predicate in `search_notes` is identical to the handler-side post-filter.
+fn note_props_match(note_props: Option<&serde_json::Value>, filter: &serde_json::Value) -> bool {
+    let required = match filter.as_object() {
+        Some(obj) if !obj.is_empty() => obj,
+        _ => return true,
+    };
+    let actual = match note_props.and_then(serde_json::Value::as_object) {
+        Some(obj) => obj,
+        None => return false,
+    };
+    required
+        .iter()
+        .all(|(k, v)| actual.get(k).is_some_and(|av| av == v))
+}
+
 impl KhiveRuntime {
     // ---- Entity operations ----
 
@@ -2212,8 +2230,19 @@ impl KhiveRuntime {
     /// 2. If embedding model is configured: vector search filtered to `kind="note"`.
     /// 3. RRF fusion (k=60).
     /// 4. Salience-weighted rerank: `score *= (0.5 + 0.5 * note.salience)`.
-    /// 5. Filter soft-deleted notes (`deleted_at IS NOT NULL`).
+    /// 5. Filter soft-deleted notes, apply optional kind / tag / properties predicates.
+    ///    Tags and properties are pushed into the per-note fetch loop BEFORE truncation
+    ///    so that matching notes ranked beyond `limit` in the raw fusion are not silently
+    ///    dropped (fix for issue #225).
     /// 6. Truncate to `limit`.
+    ///
+    /// `tags_any`: when non-empty, only notes that have at least one of these tags
+    /// (stored in `properties["tags"]`, case-insensitive match) are retained. The
+    /// check happens inside the alive-note loop, before `hits.truncate(limit)`.
+    ///
+    /// `properties_filter`: when `Some`, only notes whose `properties` JSON object is
+    /// a superset of the given filter object are retained. Also applied before truncation.
+    #[allow(clippy::too_many_arguments)]
     pub async fn search_notes(
         &self,
         token: &NamespaceToken,
@@ -2222,6 +2251,8 @@ impl KhiveRuntime {
         limit: u32,
         note_kind: Option<&str>,
         include_superseded: bool,
+        tags_any: &[String],
+        properties_filter: Option<&serde_json::Value>,
     ) -> RuntimeResult<Vec<NoteSearchHit>> {
         const RRF_K: usize = 60;
         let candidates = limit.saturating_mul(4).max(limit);
@@ -2286,6 +2317,36 @@ impl KhiveRuntime {
                 }
                 if let Some(want_kind) = note_kind {
                     if note.kind != want_kind {
+                        continue;
+                    }
+                }
+                // Apply tag predicate before adding to alive set: tags on notes live
+                // inside `properties["tags"]` (a JSON array). This pushes the filter
+                // before truncation so matching notes ranked beyond `limit` in the raw
+                // fusion are not silently dropped (fix for issue #225).
+                if !tags_any.is_empty() {
+                    let note_tags: Vec<String> = note
+                        .properties
+                        .as_ref()
+                        .and_then(|p| p.get("tags"))
+                        .and_then(serde_json::Value::as_array)
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(serde_json::Value::as_str)
+                                .map(str::to_owned)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if !note_tags
+                        .iter()
+                        .any(|t| tags_any.iter().any(|w| t.eq_ignore_ascii_case(w)))
+                    {
+                        continue;
+                    }
+                }
+                // Apply properties predicate before truncation (fix for issue #225).
+                if let Some(pf) = properties_filter {
+                    if !note_props_match(note.properties.as_ref(), pf) {
                         continue;
                     }
                 }
@@ -4306,7 +4367,7 @@ mod tests {
         .unwrap();
 
         let results = rt
-            .search_notes(&tok, "GQA KV cache", None, 10, None, false)
+            .search_notes(&tok, "GQA KV cache", None, 10, None, false, &[], None)
             .await
             .unwrap();
 
@@ -4347,13 +4408,162 @@ mod tests {
             .unwrap();
 
         let results = rt
-            .search_notes(&tok, "RoPE rotary positional", None, 10, None, false)
+            .search_notes(
+                &tok,
+                "RoPE rotary positional",
+                None,
+                10,
+                None,
+                false,
+                &[],
+                None,
+            )
             .await
             .unwrap();
 
         assert!(
             results.iter().all(|h| h.note_id != note.id),
             "soft-deleted note should be excluded from search"
+        );
+    }
+
+    // ---- issue #225 regression: predicate pushdown before truncation (note branch) ----
+
+    /// Regression test for issue #225 (note branch, tag filter).
+    ///
+    /// Notes store tags inside `properties["tags"]` — there is no separate tags column.
+    /// Without pushdown, the tag filter is applied after `hits.truncate(limit)`, so a
+    /// tag-matching note ranked beyond `limit` in the raw RRF fusion is silently dropped.
+    ///
+    /// Scenario: `limit=1`, tags_any=["note-target-tag"]. Two notes are inserted:
+    ///   - decoy: high FTS rank (repeats query terms), NO target tag.
+    ///   - target: lower FTS rank, HAS "note-target-tag" in `properties["tags"]`.
+    ///
+    /// Without pushdown: decoy occupies the slot, target is dropped.
+    /// With pushdown: decoy is excluded in the alive-note loop, target survives, returned.
+    ///
+    /// Isomorphism: removing the `tags_any` check from the alive-note loop in
+    /// `search_notes` re-breaks this test.
+    #[tokio::test]
+    async fn search_notes_tag_filter_pushed_before_truncation() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        // Decoy note: repeats query tokens → higher FTS rank. No target tag.
+        rt.create_note(
+            &tok,
+            "observation",
+            None,
+            "kappa lambda mu note decoy kappa lambda mu note decoy kappa lambda mu",
+            Some(0.5),
+            Some(serde_json::json!({"tags": ["other-note-tag"]})),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // Target note: fewer query tokens → lower FTS rank. Has the target tag.
+        let target = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "kappa lambda mu note target",
+                Some(0.5),
+                Some(serde_json::json!({"tags": ["note-target-tag"]})),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        // With limit=1 and tags_any, the fix must return the target note despite the
+        // decoy ranking higher in raw FTS.
+        let hits = rt
+            .search_notes(
+                &tok,
+                "kappa lambda mu note",
+                None,
+                1,
+                None,
+                false,
+                &["note-target-tag".to_string()],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hits.len(),
+            1,
+            "exactly one hit expected (tag-matching note)"
+        );
+        assert_eq!(
+            hits[0].note_id, target.id,
+            "tag-filtered note must be returned even when ranked below limit in raw fusion"
+        );
+    }
+
+    /// Regression test for issue #225 (note branch, properties filter).
+    ///
+    /// Without pushdown, the properties filter is applied after truncation; a matching
+    /// note ranked beyond `limit` is silently dropped.
+    ///
+    /// Scenario: `limit=1`, properties_filter={{"source": "target"}}. Two notes:
+    ///   - decoy: high FTS rank, properties {{"source": "other"}}.
+    ///   - target: lower FTS rank, properties {{"source": "target"}}.
+    #[tokio::test]
+    async fn search_notes_props_filter_pushed_before_truncation() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        rt.create_note(
+            &tok,
+            "observation",
+            None,
+            "nu xi omicron note decoy nu xi omicron note decoy nu xi omicron",
+            Some(0.5),
+            Some(serde_json::json!({"source": "other"})),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let target = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "nu xi omicron note target",
+                Some(0.5),
+                Some(serde_json::json!({"source": "target"})),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let filter = serde_json::json!({"source": "target"});
+        let hits = rt
+            .search_notes(
+                &tok,
+                "nu xi omicron note",
+                None,
+                1,
+                None,
+                false,
+                &[],
+                Some(&filter),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hits.len(),
+            1,
+            "exactly one hit expected (properties-matching note)"
+        );
+        assert_eq!(
+            hits[0].note_id, target.id,
+            "properties-filtered note must be returned even when ranked below limit"
         );
     }
 
@@ -4868,7 +5078,7 @@ mod tests {
 
         // FTS must not contain the content either.
         let search_hits = rt
-            .search_notes(&tok, "should not persist", None, 10, None, false)
+            .search_notes(&tok, "should not persist", None, 10, None, false, &[], None)
             .await
             .unwrap();
         assert!(
@@ -5644,7 +5854,7 @@ mod tests {
             "compensation must remove the note row; got {after_notes:?}"
         );
         let search_hits = rt
-            .search_notes(&tok, "partial note", None, 10, None, false)
+            .search_notes(&tok, "partial note", None, 10, None, false, &[], None)
             .await
             .unwrap();
         assert!(
@@ -6121,7 +6331,7 @@ mod tests {
 
         // FTS must have no hit for the content.
         let hits = rt
-            .search_notes(&tok, "rollback target", None, 10, None, false)
+            .search_notes(&tok, "rollback target", None, 10, None, false, &[], None)
             .await
             .unwrap();
         assert!(
@@ -6340,7 +6550,7 @@ mod tests {
             .unwrap();
 
         let before = rt
-            .search_notes(&tok, "yvwkqz", None, 10, None, false)
+            .search_notes(&tok, "yvwkqz", None, 10, None, false, &[], None)
             .await
             .unwrap();
         assert!(
@@ -6352,7 +6562,7 @@ mod tests {
         assert!(deleted, "soft delete must return true");
 
         let after = rt
-            .search_notes(&tok, "yvwkqz", None, 10, None, false)
+            .search_notes(&tok, "yvwkqz", None, 10, None, false, &[], None)
             .await
             .unwrap();
         assert!(

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -345,11 +345,16 @@ impl KhiveRuntime {
     ///   The text/vector candidate pools are unfiltered up front; the kind
     ///   filter applies at the alive-check stage where we already fetch each
     ///   candidate to confirm it isn't soft-deleted.
+    /// - `tags_any`: when non-empty, only entities that have at least one of these
+    ///   tags (case-insensitive) survive the alive-set intersection. Applied BEFORE
+    ///   truncation so matches ranked beyond `limit` in the raw fusion are not lost.
+    /// - `properties_filter`: when `Some`, only entities whose properties are a
+    ///   superset of the given JSON object survive. Applied BEFORE truncation.
     ///
     /// `limit` caps the final returned list; internally pulls `limit * 4` candidates per path.
-    /// The fused candidate set is kept untruncated until after the alive + kind filter so
-    /// that right-kind hits ranked below `limit` in the raw fusion still surface when
-    /// higher-ranked candidates are wrong-kind or soft-deleted.
+    /// The fused candidate set is kept untruncated until after the alive + kind + tag +
+    /// properties filter so that matching hits ranked below `limit` in the raw fusion
+    /// still surface when higher-ranked candidates are excluded by any filter.
     ///
     /// # Cross-namespace visibility (entity search — primary namespace only; deferred)
     ///
@@ -384,6 +389,8 @@ impl KhiveRuntime {
         limit: u32,
         entity_kind: Option<&str>,
         entity_type: Option<&str>,
+        tags_any: &[String],
+        properties_filter: Option<&serde_json::Value>,
     ) -> RuntimeResult<Vec<SearchHit>> {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
@@ -420,12 +427,16 @@ impl KhiveRuntime {
         };
 
         // Fuse without truncating: keep the full candidate pool through the
-        // alive/kind filter so right-kind hits below rank `limit` aren't lost.
+        // alive/kind/tag/property filter so matching hits below rank `limit`
+        // aren't lost when higher-ranked candidates are excluded.
         let mut fused = rrf_fuse(text_hits, vector_hits, candidates as usize, query_text);
 
-        // Filter to alive entities (and optionally to a specific kind). A single
-        // query fetches all alive IDs that match the kind constraint from the
-        // fused set; any ID absent has been soft-deleted or doesn't match.
+        // Filter to alive entities (and optionally to a specific kind, tags, or
+        // properties). A single query fetches all alive IDs that match the kind
+        // and tag constraints from the fused set; any ID absent has been
+        // soft-deleted or doesn't match. The SQL-level `tags_any` filter is
+        // pushed into `query_entities`; properties filtering (no SQL column)
+        // is applied at the Rust level using the entity records already fetched.
         if !fused.is_empty() {
             let candidate_ids: Vec<Uuid> = fused.iter().map(|h| h.entity_id).collect();
             let alive_page = self
@@ -437,6 +448,7 @@ impl KhiveRuntime {
                         kinds: entity_kind.map(|k| vec![k.to_string()]).unwrap_or_default(),
                         entity_types: entity_type.map(|t| vec![t.to_string()]).unwrap_or_default(),
                         namespaces: visible_ns,
+                        tags_any: tags_any.to_vec(),
                         ..EntityFilter::default()
                     },
                     PageRequest {
@@ -445,10 +457,18 @@ impl KhiveRuntime {
                     },
                 )
                 .await?;
-            // Keep entity metadata to enrich hits that had no FTS5 title/snippet.
+            // Keep entity metadata to enrich hits that had no FTS5 title/snippet,
+            // and to apply the properties filter before truncation.
             let mut entity_meta: HashMap<Uuid, (String, Option<String>)> = HashMap::new();
             let mut alive: HashSet<Uuid> = HashSet::new();
             for e in alive_page.items {
+                // Apply properties predicate here — before adding to the alive set —
+                // so that non-matching candidates are dropped before truncation.
+                if let Some(pf) = properties_filter {
+                    if !entity_props_match(e.properties.as_ref(), pf) {
+                        continue;
+                    }
+                }
                 alive.insert(e.id);
                 entity_meta.insert(e.id, (e.name, e.description));
             }
@@ -926,6 +946,27 @@ impl KhiveRuntime {
     }
 }
 
+/// Returns `true` when `entity_props` is a superset of all key-value pairs in `filter`.
+///
+/// Mirrors the semantics of `khive_pack_kg::handlers::common::props_match` so that the
+/// storage-leg predicate is identical to the handler-side post-filter.
+fn entity_props_match(
+    entity_props: Option<&serde_json::Value>,
+    filter: &serde_json::Value,
+) -> bool {
+    let required = match filter.as_object() {
+        Some(obj) if !obj.is_empty() => obj,
+        _ => return true,
+    };
+    let actual = match entity_props.and_then(serde_json::Value::as_object) {
+        Some(obj) => obj,
+        None => return false,
+    };
+    required
+        .iter()
+        .all(|(k, v)| actual.get(k).is_some_and(|av| av == v))
+}
+
 /// Score bonus applied when an entity's title is an exact case-insensitive match for
 /// the query. Dominates RRF scores (~0.09–0.18 range with k=10) so that an exact
 /// name match always ranks above any partial or semantic match.
@@ -1252,7 +1293,7 @@ mod tests {
         .unwrap();
 
         let hits = rt
-            .hybrid_search(&tok, "FlashAttention", None, 10, None, None)
+            .hybrid_search(&tok, "FlashAttention", None, 10, None, None, &[], None)
             .await
             .unwrap();
 
@@ -1262,6 +1303,144 @@ mod tests {
         assert!(
             hit.title.as_deref().unwrap().contains("FlashAttention"),
             "title must contain entity name"
+        );
+    }
+
+    // ---- issue #225 regression: predicate pushdown before truncation ----
+
+    /// Regression test for issue #225 (entity branch).
+    ///
+    /// Scenario: `limit=1`, tag_filter=["target-tag"]. Two entities are inserted:
+    ///   - "decoy_alpha_beta_gamma": many query tokens → ranks 1 in FTS (dominates).
+    ///     Does NOT have "target-tag".
+    ///   - "alpha_beta_gamma target": fewer query tokens → ranks 2 in FTS.
+    ///     HAS "target-tag".
+    ///
+    /// Without predicate pushdown: `fused.truncate(1)` keeps only the decoy. The
+    /// tag-matching entity is invisible. The test asserts the matching entity IS
+    /// returned — this assertion fails on the unfixed code (where tags_any is not
+    /// passed into `query_entities`) and passes after the fix.
+    ///
+    /// Isomorphism: reverting `tags_any: tags_any.to_vec()` in the `EntityFilter`
+    /// inside `hybrid_search` re-breaks this test (the decoy survives `retain` and
+    /// occupies the single slot, dropping the target).
+    #[tokio::test]
+    async fn hybrid_search_tag_filter_pushed_before_truncation() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+
+        // Decoy: high-ranking FTS hit (content repeats query words), no target tag.
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "alpha beta gamma decoy alpha beta gamma",
+            Some("alpha beta gamma decoy description alpha beta gamma"),
+            None,
+            vec!["other-tag".to_string()],
+        )
+        .await
+        .unwrap();
+
+        // Target: lower-ranking FTS hit, has the tag we filter on.
+        let target = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "alpha beta gamma target",
+                Some("alpha beta gamma target description"),
+                None,
+                vec!["target-tag".to_string()],
+            )
+            .await
+            .unwrap();
+
+        // With limit=1 and tag_filter, the fix must return the target entity despite
+        // the decoy ranking higher. Without pushdown, the decoy occupies the single
+        // slot and the target is silently dropped.
+        let hits = rt
+            .hybrid_search(
+                &tok,
+                "alpha beta gamma",
+                None,
+                1,
+                None,
+                None,
+                &["target-tag".to_string()],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hits.len(),
+            1,
+            "exactly one hit expected (the tag-matching entity)"
+        );
+        assert_eq!(
+            hits[0].entity_id, target.id,
+            "the tag-filtered entity must be returned even when ranked below limit in raw fusion"
+        );
+    }
+
+    /// Regression test for issue #225 (entity branch, properties predicate).
+    ///
+    /// Scenario: `limit=1`, properties_filter={{"domain": "target"}}. Two entities:
+    ///   - decoy: high FTS rank, properties {{"domain": "other"}}.
+    ///   - target: lower FTS rank, properties {{"domain": "target"}}.
+    ///
+    /// Without pushdown: decoy fills the slot, target is dropped. With pushdown:
+    /// only the target survives the properties filter before truncation.
+    #[tokio::test]
+    async fn hybrid_search_props_filter_pushed_before_truncation() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "delta epsilon zeta decoy delta epsilon zeta",
+            Some("delta epsilon zeta decoy description delta epsilon zeta"),
+            Some(serde_json::json!({"domain": "other"})),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let target = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "delta epsilon zeta target",
+                Some("delta epsilon zeta target description"),
+                Some(serde_json::json!({"domain": "target"})),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let filter = serde_json::json!({"domain": "target"});
+        let hits = rt
+            .hybrid_search(
+                &tok,
+                "delta epsilon zeta",
+                None,
+                1,
+                None,
+                None,
+                &[],
+                Some(&filter),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 1, "exactly one hit expected (properties match)");
+        assert_eq!(
+            hits[0].entity_id, target.id,
+            "the properties-filtered entity must be returned even when ranked below limit"
         );
     }
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -396,7 +396,7 @@ async fn create_entity_indexes_into_text_search() {
         .await
         .unwrap();
     let hits = rt
-        .hybrid_search(&tok, "FlashAttention", None, 10, None, None)
+        .hybrid_search(&tok, "FlashAttention", None, 10, None, None, &[], None)
         .await
         .unwrap();
     assert!(
@@ -451,7 +451,7 @@ async fn hybrid_search_excludes_soft_deleted_entities() {
 
     // Confirm the entity is visible before deletion.
     let hits_before = rt
-        .hybrid_search(&tok, "SoftDeleteMe", None, 10, None, None)
+        .hybrid_search(&tok, "SoftDeleteMe", None, 10, None, None, &[], None)
         .await
         .unwrap();
     assert!(
@@ -462,7 +462,7 @@ async fn hybrid_search_excludes_soft_deleted_entities() {
     rt.delete_entity(&tok, entity.id, false).await.unwrap(); // soft delete
 
     let hits_after = rt
-        .hybrid_search(&tok, "SoftDeleteMe", None, 10, None, None)
+        .hybrid_search(&tok, "SoftDeleteMe", None, 10, None, None, &[], None)
         .await
         .unwrap();
     assert!(
@@ -490,7 +490,7 @@ async fn hybrid_search_excludes_hard_deleted_entities() {
         .unwrap();
 
     let hits_before = rt
-        .hybrid_search(&tok, "HardDeleteMe", None, 10, None, None)
+        .hybrid_search(&tok, "HardDeleteMe", None, 10, None, None, &[], None)
         .await
         .unwrap();
     assert!(
@@ -503,7 +503,7 @@ async fn hybrid_search_excludes_hard_deleted_entities() {
     // Hard-deleted rows are gone from the entity store; the FTS/vector indexes may still
     // have stale entries. The soft-delete filter sees no alive entity and drops the hit.
     let hits_after = rt
-        .hybrid_search(&tok, "HardDeleteMe", None, 10, None, None)
+        .hybrid_search(&tok, "HardDeleteMe", None, 10, None, None, &[], None)
         .await
         .unwrap();
     assert!(
@@ -2290,7 +2290,7 @@ async fn hybrid_search_surfaces_all_visible_namespaces() {
     // Search: FTS-only (no embedding model in test runtime).
     // With consolidated fts_entities, both namespace entities should surface.
     let hits = rt
-        .hybrid_search(&vis_tok, "stellar", None, 20, None, None)
+        .hybrid_search(&vis_tok, "stellar", None, 20, None, None, &[], None)
         .await
         .unwrap();
 

--- a/crates/kkernel/src/coordinator/dispatch.rs
+++ b/crates/kkernel/src/coordinator/dispatch.rs
@@ -372,7 +372,7 @@ impl SubstrateCoordinator {
             };
             if search_notes {
                 match runtime
-                    .search_notes(&token, query, None, limit, kind_filter, false)
+                    .search_notes(&token, query, None, limit, kind_filter, false, &[], None)
                     .await
                 {
                     Ok(note_hits) => {
@@ -396,7 +396,7 @@ impl SubstrateCoordinator {
                 }
             } else {
                 match runtime
-                    .hybrid_search(&token, query, None, limit, kind_filter, None)
+                    .hybrid_search(&token, query, None, limit, kind_filter, None, &[], None)
                     .await
                 {
                     Ok(hits) => {
@@ -458,7 +458,7 @@ impl SubstrateCoordinator {
                 };
                 if search_notes {
                     let result = runtime
-                        .search_notes(&token, &q, None, limit, kf.as_deref(), false)
+                        .search_notes(&token, &q, None, limit, kf.as_deref(), false, &[], None)
                         .await;
                     match result {
                         Ok(note_hits) => (backend_id, Ok(vec![]), Some(note_hits)),
@@ -466,7 +466,7 @@ impl SubstrateCoordinator {
                     }
                 } else {
                     let result = runtime
-                        .hybrid_search(&token, &q, None, limit, kf.as_deref(), None)
+                        .hybrid_search(&token, &q, None, limit, kf.as_deref(), None, &[], None)
                         .await;
                     match result {
                         Ok(hits) => (backend_id, Ok(hits), None),


### PR DESCRIPTION
## Problem (#225)

`search` applied `properties`/`tags` predicates **after** FTS+vector ranking truncated candidates to `limit` — so matching results ranked beyond the scan window were silently dropped (recall cliff). PR #223 widened the scan window (`FILTERED_SCAN_CAP`) as a bounded mitigation; this PR removes the cliff at the source.

## Fix

Push the predicates into the storage/runtime leg **before** truncation, both branches:

- **Entity** (`hybrid_search`, `retrieval.rs`): `tags_any` → SQL `EXISTS (json_each(tags))` inside `query_entities`; `properties_filter` checked per-entity in the alive-set loop — both before `fused.truncate(limit)`. New `entity_props_match` replicates the handler's `props_match` semantics.
- **Note** (`search_notes`, `operations.rs`): both predicates checked in the `alive_notes` candidate loop before `hits.truncate(limit)`; note tags read from `properties["tags"]` (JSON array, case-insensitive) — identical semantics to the handler filter. New `note_props_match` mirror.
- All non-search callers (create/knowledge/kkernel/integration) pass `&[]` / `None` — no behavior change.
- `FILTERED_SCAN_CAP` retained as defense-in-depth.

## Tests (isomorphic)

4 regression tests (entity+note × tags+props): a matching record ranked beyond `limit` in raw fusion must still be returned. **Verified to FAIL on reverted code**, pass with the fix.

Gates: khive-runtime 455 / khive-pack-kg 265 pass, clippy `-D warnings` clean, fmt clean.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)