### PR TITLE
fix(runtime): thread configured actor into gate request (drop hardcoded anonymous)

### DIFF
--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -849,7 +849,14 @@ impl VerbRegistry {
             .unwrap_or_else(|| self.default_namespace.clone());
         let ns = Namespace::parse(&ns_str)
             .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
-        let gate_req = GateRequest::new(ActorRef::anonymous(), ns, verb, params.clone());
+        // ADR-057: thread the configured actor identity into the gate request so
+        // the gate can distinguish human vs agent callers at the dispatch seam.
+        // Mirrors the actor resolution used by the token-minting path below.
+        let gate_actor = match self.actor_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
+            _ => ActorRef::anonymous(),
+        };
+        let gate_req = GateRequest::new(gate_actor, ns, verb, params.clone());
 
         // Consult the gate.
         //
@@ -2230,6 +2237,71 @@ mod tests {
         assert_eq!(ev.namespace, "tenant-q");
         assert_eq!(ev.verb, "list");
         assert_eq!(ev.actor.kind, "anonymous");
+    }
+
+    // ---- Actor attribution threading into gate request (ADR-057) ----
+
+    /// A gate spy that captures the raw `GateRequest` it receives.
+    #[derive(Default, Debug)]
+    struct ActorCapturingGate {
+        requests: std::sync::Mutex<Vec<GateRequest>>,
+    }
+
+    impl Gate for ActorCapturingGate {
+        fn check(&self, req: &GateRequest) -> Result<GateDecision, GateError> {
+            self.requests.lock().unwrap().push(req.clone());
+            Ok(GateDecision::allow())
+        }
+    }
+
+    /// When `actor_id` is configured, the gate request carries that actor, not
+    /// anonymous. This exercises the ADR-057 attribution fix: the gate can
+    /// distinguish an agent caller from an unauthenticated caller.
+    #[tokio::test]
+    async fn gate_request_carries_configured_actor_when_actor_id_is_set() {
+        let gate = Arc::new(ActorCapturingGate::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate.clone());
+        builder.with_actor_id(Some("team-abc:implementer".to_string()));
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("list", Value::Null).await.unwrap();
+
+        let reqs = gate.requests.lock().unwrap();
+        assert_eq!(reqs.len(), 1);
+        let req = &reqs[0];
+        assert_eq!(
+            req.actor.kind, "actor",
+            "gate request must carry kind='actor' when actor_id is configured"
+        );
+        assert_eq!(
+            req.actor.id, "team-abc:implementer",
+            "gate request must carry the configured actor id"
+        );
+    }
+
+    /// When no `actor_id` is configured, the gate request still receives the
+    /// anonymous actor (no regression to the party-line default).
+    #[tokio::test]
+    async fn gate_request_carries_anonymous_when_no_actor_id_configured() {
+        let gate = Arc::new(ActorCapturingGate::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_gate(gate.clone());
+        // actor_id left at default (None).
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("list", Value::Null).await.unwrap();
+
+        let reqs = gate.requests.lock().unwrap();
+        assert_eq!(reqs.len(), 1);
+        let req = &reqs[0];
+        assert_eq!(
+            req.actor.kind, "anonymous",
+            "gate request must carry anonymous actor when no actor_id is configured"
+        );
+        assert_eq!(req.actor.id, "local");
     }
 
     // ---- Rego gate: fail-closed end-to-end (issue #30) ----


### PR DESCRIPTION
## Bug

`VerbRegistry::dispatch` built the `GateRequest` with a hardcoded `ActorRef::anonymous()` at `pack.rs:852`, even when `self.actor_id` was set (ADR-057 dual-write attribution). The token-minting path further down (lines 940-942) already resolved the configured actor correctly — but that resolution happened *after* the gate check, so the gate always saw `anonymous` and could not distinguish a human caller from an agent caller at the dispatch seam.

`GateRequest` already carries an `actor` field and `RegoGate` already evaluates `input.actor.kind`. The actor simply wasn't being threaded in.

## Fix

Resolve the configured actor using the same `match self.actor_id.as_deref()` pattern as the token-minting path, immediately before constructing the `GateRequest`, and pass it in place of `ActorRef::anonymous()`. The token-minting code is left exactly as-is — this is the minimal change.

**Diff in `pack.rs`:**
```
-        let gate_req = GateRequest::new(ActorRef::anonymous(), ns, verb, params.clone());
+        // ADR-057: thread the configured actor identity into the gate request so
+        // the gate can distinguish human vs agent callers at the dispatch seam.
+        // Mirrors the actor resolution used by the token-minting path below.
+        let gate_actor = match self.actor_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
+            _ => ActorRef::anonymous(),
+        };
+        let gate_req = GateRequest::new(gate_actor, ns, verb, params.clone());
```

## Tests added

Two regression tests using a new `ActorCapturingGate` spy that captures the raw `GateRequest` and asserts on `req.actor`:

- `gate_request_carries_configured_actor_when_actor_id_is_set` — verifies that when `actor_id` is configured, the gate sees `kind="actor"` and the exact configured id
- `gate_request_carries_anonymous_when_no_actor_id_configured` — verifies no regression: without `actor_id`, the gate still sees `kind="anonymous"`, `id="local"`

## Gate results

| Leg | RC |
|-----|----|
| `cargo test -p khive-runtime gate --all-features` | 0 (96 tests) |
| `cargo test -p khive-runtime --all-features` | 0 (461 tests) |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p khive-runtime -- -D warnings` | 0 |

## Out of scope

The fail-open posture (`Err(_)` branch at the gate check) is intentionally not touched here — that is a separate, decision-gated task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)