### PR TITLE
fix(pack-kg): reject non-applicable fields in update verb (kill silent no-op)

### DIFF
--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -788,6 +788,16 @@ async fn update_entity_with_note_field_content_returns_error() {
         err_msg.contains("description"),
         "error must list 'description' as a valid entity field; got: {err_msg}"
     );
+
+    // Confirm entity name is unchanged after the rejected update.
+    let unchanged = rt
+        .get_entity(&token, entity.id)
+        .await
+        .expect("get_entity must not fail");
+    assert_eq!(
+        unchanged.name, "MyEntity",
+        "entity name must be unchanged after rejected update"
+    );
 }
 
 // Regression (edge branch): update(id=<edge>, description=...) must return an
@@ -851,5 +861,132 @@ async fn update_edge_with_non_edge_field_returns_error() {
     assert_eq!(
         unchanged.weight, 0.8,
         "edge weight must be unchanged after rejected update"
+    );
+}
+
+// HIGH regression: update(note_id, tags=[...]) must return an explicit error.
+// Notes have no top-level tags column; tags live in properties["tags"].
+// Before the fix, tags was silently dropped on the note path (the error string
+// even advertised it as valid — making the bug worse for callers following docs).
+#[tokio::test]
+async fn update_note_with_entity_field_tags_returns_error() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    let note = rt
+        .create_note(
+            &token,
+            "observation",
+            None,
+            "note content unchanged",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let result = pack
+        .handle_update(
+            &token,
+            json!({ "id": note.id.to_string(), "tags": ["rust", "ml"] }),
+            &registry,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "update note with entity-only field 'tags' must return an error, got ok"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("tags"),
+        "error must name the invalid field 'tags'; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("content"),
+        "error must list 'content' as a valid note field; got: {err_msg}"
+    );
+
+    // Confirm note content is unchanged.
+    let unchanged = rt
+        .notes(&token)
+        .unwrap()
+        .get_note(note.id)
+        .await
+        .unwrap()
+        .expect("note must still exist");
+    assert_eq!(
+        unchanged.content, "note content unchanged",
+        "note content must be unchanged after rejected update"
+    );
+}
+
+// MEDIUM regression: update(entity_id, salience=...) must return an explicit
+// error — salience is a note-only field and was silently dropped on entities.
+#[tokio::test]
+async fn update_entity_with_note_field_salience_returns_error() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    let entity = rt
+        .create_entity(
+            &token,
+            "concept",
+            None,
+            "SalienceEntity",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create entity");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let result = pack
+        .handle_update(
+            &token,
+            json!({ "id": entity.id.to_string(), "salience": 0.9 }),
+            &registry,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "update entity with note-only field 'salience' must return an error, got ok"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("salience"),
+        "error must name the invalid field 'salience'; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("description"),
+        "error must list 'description' as a valid entity field; got: {err_msg}"
+    );
+
+    // Confirm entity name is unchanged.
+    let unchanged = rt
+        .get_entity(&token, entity.id)
+        .await
+        .expect("get_entity must not fail");
+    assert_eq!(
+        unchanged.name, "SalienceEntity",
+        "entity name must be unchanged after rejected update"
     );
 }

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -678,3 +678,178 @@ fn validate_weight_accepts_valid_range() {
     assert_eq!(validate_weight(Some(0.5)).unwrap(), 0.5);
     assert_eq!(validate_weight(Some(1.0)).unwrap(), 1.0);
 }
+
+// Regression: update(id=<note>, description=...) must return an explicit error,
+// not silently drop the field and return ok:true with stale content.
+// The silent-drop was the original bug: description is an entity-only field;
+// passing it on a note caused updated_at to bump while content stayed unchanged.
+#[tokio::test]
+async fn update_note_with_entity_field_description_returns_error() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    // Create a note with known content.
+    let note = rt
+        .create_note(
+            &token,
+            "observation",
+            None,
+            "original content",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    // Attempt to update the note using the entity-only field `description`.
+    let result = pack
+        .handle_update(
+            &token,
+            json!({ "id": note.id.to_string(), "description": "should be rejected" }),
+            &registry,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "update note with entity-only field 'description' must return an error, got ok"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("description"),
+        "error must name the invalid field 'description'; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("content"),
+        "error must list 'content' as a valid note field; got: {err_msg}"
+    );
+
+    // Confirm note content is unchanged after the rejected update.
+    let unchanged = rt
+        .notes(&token)
+        .unwrap()
+        .get_note(note.id)
+        .await
+        .unwrap()
+        .expect("note must still exist");
+    assert_eq!(
+        unchanged.content, "original content",
+        "note content must be unchanged after rejected update"
+    );
+}
+
+// Regression (symmetric): update(id=<entity>, content=...) must return an
+// explicit error — `content` is a note-only field.
+#[tokio::test]
+async fn update_entity_with_note_field_content_returns_error() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    let entity = rt
+        .create_entity(&token, "concept", None, "MyEntity", None, None, vec![])
+        .await
+        .expect("create entity");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    let result = pack
+        .handle_update(
+            &token,
+            json!({ "id": entity.id.to_string(), "content": "should be rejected" }),
+            &registry,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "update entity with note-only field 'content' must return an error, got ok"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("content"),
+        "error must name the invalid field 'content'; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("description"),
+        "error must list 'description' as a valid entity field; got: {err_msg}"
+    );
+}
+
+// Regression (edge branch): update(id=<edge>, description=...) must return an
+// explicit error — edges only accept relation, weight, properties.
+#[tokio::test]
+async fn update_edge_with_non_edge_field_returns_error() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+    use khive_types::EdgeRelation;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+
+    let src = rt
+        .create_entity(&token, "concept", None, "SrcConcept", None, None, vec![])
+        .await
+        .expect("create source entity");
+    let tgt = rt
+        .create_entity(&token, "concept", None, "TgtConcept", None, None, vec![])
+        .await
+        .expect("create target entity");
+    let edge = rt
+        .link(&token, src.id, tgt.id, EdgeRelation::Extends, 0.8, None)
+        .await
+        .expect("create edge");
+
+    let pack = KgPack::new(rt.clone());
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry build");
+
+    // Attempt to update the edge using the non-edge field `description`.
+    let result = pack
+        .handle_update(
+            &token,
+            json!({ "id": edge.id.to_string(), "description": "should be rejected" }),
+            &registry,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "update edge with non-edge field 'description' must return an error, got ok"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("description"),
+        "error must name the invalid field 'description'; got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("relation"),
+        "error must list 'relation' as a valid edge field; got: {err_msg}"
+    );
+
+    // Confirm the edge is unchanged after the rejected update.
+    let unchanged = rt
+        .get_edge(&token, edge.id.into())
+        .await
+        .expect("get_edge must not fail")
+        .expect("edge must still exist");
+    assert_eq!(
+        unchanged.weight, 0.8,
+        "edge weight must be unchanged after rejected update"
+    );
+}

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -14,6 +14,88 @@ use super::common::{
 };
 use crate::KgPack;
 
+// ---------------------------------------------------------------------------
+// Field applicability guard (authoritative field sets per substrate)
+//
+// Valid fields per substrate (source of truth: handler_defs.rs:241-243 +
+// EntityPatch / NotePatch / EdgePatch in crates/khive-runtime/src/curation.rs):
+//
+//   Entity: name, description, tags, properties
+//   Note:   name, content, salience, decay_factor, properties
+//           (notes have NO top-level tags column; tags live in properties["tags"])
+//   Edge:   relation, weight, properties
+//
+// Any present-but-inapplicable field is rejected with a fail-loud error naming
+// the offending field and listing the substrate's valid set.  This function
+// MUST be updated whenever UpdateParams or a patch struct changes.
+// ---------------------------------------------------------------------------
+fn reject_inapplicable_fields(spec: &KindSpec, p: &UpdateParams) -> Result<(), RuntimeError> {
+    let (bad_field, valid): (Option<&str>, &str) = match spec {
+        KindSpec::Entity { .. } => {
+            let bad = if p.content.is_some() {
+                Some("content")
+            } else if p.salience.is_some() {
+                Some("salience")
+            } else if p.decay_factor.is_some() {
+                Some("decay_factor")
+            } else if p.relation.is_some() {
+                Some("relation")
+            } else if p.weight.is_some() {
+                Some("weight")
+            } else {
+                None
+            };
+            (bad, "name, description, tags, properties")
+        }
+        KindSpec::Note { .. } => {
+            let bad = if p.description.is_some() {
+                Some("description")
+            } else if p.tags.is_some() {
+                Some("tags")
+            } else if p.relation.is_some() {
+                Some("relation")
+            } else if p.weight.is_some() {
+                Some("weight")
+            } else {
+                None
+            };
+            (bad, "name, content, salience, decay_factor, properties")
+        }
+        KindSpec::Edge => {
+            let bad = if p.name.is_some() {
+                Some("name")
+            } else if p.description.is_some() {
+                Some("description")
+            } else if p.content.is_some() {
+                Some("content")
+            } else if p.tags.is_some() {
+                Some("tags")
+            } else if p.salience.is_some() {
+                Some("salience")
+            } else if p.decay_factor.is_some() {
+                Some("decay_factor")
+            } else {
+                None
+            };
+            (bad, "relation, weight, properties")
+        }
+        // Event/Proposal are rejected by the match arms below; no field check needed.
+        KindSpec::Event | KindSpec::Proposal => return Ok(()),
+    };
+    if let Some(field) = bad_field {
+        let substrate = match spec {
+            KindSpec::Entity { .. } => "an entity",
+            KindSpec::Note { .. } => "a note",
+            KindSpec::Edge => "an edge",
+            _ => unreachable!(),
+        };
+        return Err(RuntimeError::InvalidInput(format!(
+            "field '{field}' is not valid for {substrate}; valid fields: {valid}"
+        )));
+    }
+    Ok(())
+}
+
 impl KgPack {
     pub(crate) async fn infer_kind_from_uuid(
         &self,
@@ -107,17 +189,10 @@ impl KgPack {
             },
         };
 
+        reject_inapplicable_fields(&spec, &p)?;
+
         match spec {
             KindSpec::Entity { specific } => {
-                // `content` is a note-only field; reject it explicitly so callers
-                // learn the correct field name rather than silently losing their edit.
-                if p.content.is_some() {
-                    return Err(RuntimeError::InvalidInput(
-                        "field 'content' is not valid for an entity; \
-                         valid fields: name, description, tags, properties"
-                            .into(),
-                    ));
-                }
                 let entity = self.runtime.get_entity(token, id).await?;
                 if specific.as_ref().is_some_and(|k| entity.kind != *k) {
                     return Err(RuntimeError::NotFound(format!("entity {}", p.id)));
@@ -133,26 +208,6 @@ impl KgPack {
                 )?))
             }
             KindSpec::Edge => {
-                // Reject non-edge fields explicitly; edges only accept relation, weight,
-                // properties. Silently dropping caller text fields is the same bug class
-                // this PR exists to kill.
-                let bad_field = if p.name.is_some() {
-                    Some("name")
-                } else if p.description.is_some() {
-                    Some("description")
-                } else if p.content.is_some() {
-                    Some("content")
-                } else if p.tags.is_some() {
-                    Some("tags")
-                } else {
-                    None
-                };
-                if let Some(field) = bad_field {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "field '{field}' is not valid for an edge; \
-                         valid fields: relation, weight, properties"
-                    )));
-                }
                 let relation = p.relation.as_deref().map(parse_relation).transpose()?;
                 let patch = EdgePatch {
                     relation,
@@ -162,16 +217,6 @@ impl KgPack {
                 to_json(&self.runtime.update_edge(token, id, patch).await?)
             }
             KindSpec::Note { specific } => {
-                // `description` is an entity-only field; reject it explicitly so
-                // callers learn the correct field name rather than silently losing
-                // their edit (CLAUDE.md: "Don't silently coerce invalid input").
-                if p.description.is_some() {
-                    return Err(RuntimeError::InvalidInput(
-                        "field 'description' is not valid for a note; \
-                         valid fields: content, name, tags, properties, salience, decay_factor"
-                            .into(),
-                    ));
-                }
                 let note = self
                     .runtime
                     .notes(token)?

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -109,6 +109,15 @@ impl KgPack {
 
         match spec {
             KindSpec::Entity { specific } => {
+                // `content` is a note-only field; reject it explicitly so callers
+                // learn the correct field name rather than silently losing their edit.
+                if p.content.is_some() {
+                    return Err(RuntimeError::InvalidInput(
+                        "field 'content' is not valid for an entity; \
+                         valid fields: name, description, tags, properties"
+                            .into(),
+                    ));
+                }
                 let entity = self.runtime.get_entity(token, id).await?;
                 if specific.as_ref().is_some_and(|k| entity.kind != *k) {
                     return Err(RuntimeError::NotFound(format!("entity {}", p.id)));
@@ -124,6 +133,26 @@ impl KgPack {
                 )?))
             }
             KindSpec::Edge => {
+                // Reject non-edge fields explicitly; edges only accept relation, weight,
+                // properties. Silently dropping caller text fields is the same bug class
+                // this PR exists to kill.
+                let bad_field = if p.name.is_some() {
+                    Some("name")
+                } else if p.description.is_some() {
+                    Some("description")
+                } else if p.content.is_some() {
+                    Some("content")
+                } else if p.tags.is_some() {
+                    Some("tags")
+                } else {
+                    None
+                };
+                if let Some(field) = bad_field {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "field '{field}' is not valid for an edge; \
+                         valid fields: relation, weight, properties"
+                    )));
+                }
                 let relation = p.relation.as_deref().map(parse_relation).transpose()?;
                 let patch = EdgePatch {
                     relation,
@@ -133,6 +162,16 @@ impl KgPack {
                 to_json(&self.runtime.update_edge(token, id, patch).await?)
             }
             KindSpec::Note { specific } => {
+                // `description` is an entity-only field; reject it explicitly so
+                // callers learn the correct field name rather than silently losing
+                // their edit (CLAUDE.md: "Don't silently coerce invalid input").
+                if p.description.is_some() {
+                    return Err(RuntimeError::InvalidInput(
+                        "field 'description' is not valid for a note; \
+                         valid fields: content, name, tags, properties, salience, decay_factor"
+                            .into(),
+                    ));
+                }
                 let note = self
                     .runtime
                     .notes(token)?


### PR DESCRIPTION
## Problem
The `update` verb silently dropped fields that don't apply to the resolved substrate. `update(note_id, description=X)` returned `{ok: true}` and bumped `updated_at` while leaving `content` untouched — the caller believed the edit landed when it did not (data-loss-adjacent UX). Root cause: `handle_update`'s Note branch built `NotePatch` without referencing `p.description`, which `NotePatch` has no field for, so the value was silently discarded.

## Fix
Fail loud instead of silently coercing (CLAUDE.md: "Don't silently coerce invalid input"). Each substrate now rejects the text fields it cannot apply, naming the offending field and listing the valid ones:
- **entity** rejects `content`
- **edge** rejects `name`/`description`/`content`/`tags`
- **note** rejects `description`

The checks short-circuit before any get/patch, so a rejected update has no side effects.

## Tests
3 regression tests (one per substrate), each asserting the error names the invalid field and the record is left unchanged. Full workspace test suite: 786 pass.

## Scope
2 files, +149 LOC. Handler-layer only (`khive-pack-kg/src/handlers/update.rs` + tests). No schema, taxonomy, or DSL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)