### PR TITLE
docs: correct version/verb drift, document merge/propose shapes, index ADR-067/068

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ khive gives your agent:
 8. **Knowledge corpus** — atom/domain CRUD, FTS + embedding search, compose briefings
 9. **Brain** — Bayesian profile tuning from feedback signals
 
-All 7 packs load by default. **65 public verbs** across the packs.
+All 7 packs load by default. **67 public verbs** across the packs.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 
@@ -64,13 +64,15 @@ or edge. `create`, `list`, `search` require `kind=entity|note` (or `kind=edge` f
 
 `gtd.assign` accepts `context_entity_id` to anchor a task to a KG entity.
 
-### Memory pack — 3 verbs (`memory.` prefix, [ADR-021](docs/adr/ADR-021-memory-pack.md))
+### Memory pack — 5 verbs (`memory.` prefix, [ADR-021](docs/adr/ADR-021-memory-pack.md))
 
-| Verb              | What it does                                           | When to use                                 |
-| ----------------- | ------------------------------------------------------ | ------------------------------------------- |
-| `memory.remember` | Store a memory with salience and decay                 | Cross-session context, agent state          |
-| `memory.recall`   | Hybrid FTS + vector recall with decay-weighted ranking | Retrieve what you stored in prior sessions  |
-| `memory.feedback` | Emit explicit feedback on a recalled memory            | Signal useful/not_useful to tune posteriors |
+| Verb              | What it does                                           | When to use                                         |
+| ----------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `memory.remember` | Store a memory with salience and decay                 | Cross-session context, agent state                  |
+| `memory.recall`   | Hybrid FTS + vector recall with decay-weighted ranking | Retrieve what you stored in prior sessions          |
+| `memory.feedback` | Emit explicit feedback on a recalled memory            | Signal useful/not_useful to tune posteriors         |
+| `memory.prune`    | Soft-delete memories below a salience threshold        | Trim low-value memories to prevent unbounded growth |
+| `memory.vacuum`   | Hard-delete soft-deleted memories and reclaim storage  | Periodic maintenance after heavy prune runs         |
 
 `memory.recall` supports `tags` and `tag_mode` ("any"|"all") for tag-based post-filtering.
 Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
@@ -147,6 +149,12 @@ sends and reads as the shared `"local"` party line.
 cases). Scores are normalized to [0,1] when `rerank` is active (default).
 Pass `kind=` (`"atom"` or `"domain"`) to filter by result type; `type=` is accepted as a legacy
 alias. `knowledge.list` accepts the same `kind=`/`type=` discriminant.
+
+`knowledge.edit` takes `sections=[{section_type, content, heading?, sort_order?}]`. `section_type`
+is a **closed enum** — valid values: `overview` | `core_model` | `boundary_conditions` |
+`formalism` | `operational_guidance` | `examples` | `failure_modes` | `expert_lens` |
+`references` | `other`. Content must be **at least 80 characters**. Shorter content or an
+unrecognized `section_type` returns a validation error listing the valid values.
 
 ### How to call a verb
 
@@ -342,13 +350,13 @@ These are the KG pack verbs. Other packs are documented in their verb tables abo
 | `list`      | **kind** (entity\|edge\|note\|event\|proposal); entity_kind, entity_type, note_kind, tags, source_id, target_id, relations, min_weight, max_weight, limit, offset; event: event_kind, event_kinds; message: thread_id, direction, from, to, read | `{"kind":"entity","entity_kind":"concept","tags":["ml"]}`    |
 | `update`    | **id** (UUID); name, description, properties, tags (entity), relation, weight (edge)                                                                                                                                                             | `{"id":"<uuid>","description":"Updated desc"}`               |
 | `delete`    | **id** (UUID); hard (default: false)                                                                                                                                                                                                             | `{"id":"<uuid>","hard":true}`                                |
-| `merge`     | **into_id**, **from_id**; strategy (prefer_into\|prefer_from\|union)                                                                                                                                                                             | `{"into_id":"<uuid>","from_id":"<uuid>"}`                    |
+| `merge`     | **into_id**, **from_id**; strategy (prefer_into\|prefer_from\|union). Returns `{kept_id, removed_id, edges_rewired, …}` — no top-level `id` field. Chain as `merge(...) \| link(source_id=$prev.kept_id, …)`, **not** `$prev.id`.                | `{"into_id":"<uuid>","from_id":"<uuid>"}`                    |
 | `search`    | **kind** (entity\|note), **query** (text); entity_kind, entity_type, note_kind, tags, include_superseded (note), properties (entity post-filter), min_score, limit                                                                               | `{"kind":"entity","query":"attention mechanism"}`            |
 | `link`      | **source_id**, **target_id**, **relation**; weight (0.0–1.0)                                                                                                                                                                                     | `{"source_id":"<A>","target_id":"<B>","relation":"extends"}` |
 | `neighbors` | **node_id**; direction (out\|in\|both), relations, min_weight, limit                                                                                                                                                                             | `{"node_id":"<uuid>","direction":"both"}`                    |
 | `traverse`  | **roots** (UUID list); max_depth, direction, relations, include_roots                                                                                                                                                                            | `{"roots":["<uuid>"],"max_depth":2}`                         |
 | `query`     | **query** (GQL or SPARQL string) — **read-only**: write-shaped input (SPARQL `INSERT`/`DELETE`/`LOAD`, GQL/Cypher `CREATE`/`DELETE`/`SET`/`MERGE`) is rejected; use `create`, `update`, `link`, `merge`, `delete` to mutate                      | `{"query":"MATCH (a:concept)-[:extends]->(b) RETURN a"}`     |
-| `propose`   | **kind** (entity\|note\|edge), fields for the proposed change                                                                                                                                                                                    | `{"kind":"entity","entity_kind":"concept","name":"X"}`       |
+| `propose`   | **kind** (entity\|note\|edge), fields for the proposed change. Returns `{id, status, proposer, title}`. Chain as `propose(...) \| review(id=$prev.id, …)`, **not** `$prev.proposal_id`. Use JSON form for nested `changeset` objects.            | `{"kind":"entity","entity_kind":"concept","name":"X"}`       |
 | `review`    | **id** (proposal UUID), **verdict** (approve\|reject); comment                                                                                                                                                                                   | `{"id":"<uuid>","verdict":"approve"}`                        |
 | `withdraw`  | **id** (proposal UUID)                                                                                                                                                                                                                           | `{"id":"<uuid>"}`                                            |
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ No Neo4j. No SPARQL endpoint to deploy. SQLite on disk, MCP over stdio, `cargo t
 
 | Capability                  | How                                                                                                                      |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **63 verbs, 7 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge — all load by default                                                  |
+| **67 verbs, 7 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge — all load by default                                                  |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                            |
 | **Typed edges**             | 15 closed relations in 8 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation) |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                      |
@@ -58,17 +58,17 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 7 packs load by default — **63 verbs** out of the box:
+All 7 packs load by default — **67 verbs** out of the box:
 
 | Pack          | Prefix       | Verbs | What it does                                     |
 | ------------- | ------------ | ----- | ------------------------------------------------ |
-| **kg**        | _(bare)_     | 11    | Entities, edges, notes, graph queries            |
+| **kg**        | _(bare)_     | 16    | Entities, edges, notes, graph queries            |
 | **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)    |
-| **memory**    | `memory.`    | 2     | Salience-weighted remember / decay-ranked recall |
+| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall |
 | **brain**     | `brain.`     | 13    | Bayesian user profiles + feedback loop           |
 | **comm**      | `comm.`      | 5     | Threaded messaging                               |
 | **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution           |
-| **knowledge** | `knowledge.` | 14    | Atom-based KB with embedding rerank search       |
+| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search       |
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only — they auto-detect the record type.
@@ -90,13 +90,13 @@ No language SDK to learn.
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch
 ┌──────────────────────────────────────────────────────────────┐
-│  khive-pack-kg         — KG vocabulary + 11 verb handlers    │
+│  khive-pack-kg         — KG vocabulary + 16 verb handlers    │
 │  khive-pack-gtd        — task lifecycle (5 verbs)            │
-│  khive-pack-memory     — salience + decay recall (2 verbs)   │
+│  khive-pack-memory     — salience + decay recall (5 verbs)   │
 │  khive-pack-brain      — Bayesian profiles (13 verbs)        │
 │  khive-pack-comm       — threaded messaging (5 verbs)        │
 │  khive-pack-schedule   — reminders + scheduled ops (4 verbs) │
-│  khive-pack-knowledge  — atom KB + embedding rerank (14 verbs)│
+│  khive-pack-knowledge  — atom KB + embedding rerank (19 verbs)│
 └──────────────────────────────────────────────────────────────┘
                             ↕ in-process
 ┌──────────────────────────────────────────────────────────────┐
@@ -167,7 +167,7 @@ global):
 ```
 
 **That's it.** All 7 packs load by default, a background daemon auto-spawns to keep the runtime
-warm, and Claude Code discovers the `request` tool with the full 63-verb catalog.
+warm, and Claude Code discovers the `request` tool with the full 67-verb catalog.
 
 ### Alternative: install via Cargo
 
@@ -260,8 +260,8 @@ Deno 2.x (for the TypeScript CLI layer — optional)
 
 ## Status
 
-**v0.2.3 — published on [crates.io](https://crates.io/crates/khive-mcp).** 63 verbs across 7
-packs, 9 entity kinds, 15 edge relations, daemon warm startup (ADR-049), knowledge search with
+**v0.2.11 — published on [crates.io](https://crates.io/crates/khive-mcp).** 67 verbs across 7
+packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,6 +94,8 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-059](ADR-059-namespace-write-tiers.md)              | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
 | [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)   | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)          | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
+| [ADR-067](ADR-067-write-owner-daemon.md)                 | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
+| [ADR-068](ADR-068-cloud-multitenancy-topology.md)        | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Three docs-only fixes targeting seed-readiness (items S1, S2, S7 from the review shortlist). No Rust code changed.

### S1 — README version + verb-count drift (README.md)

| Location | Before | After | Source |
|----------|--------|-------|--------|
| Version string | v0.2.3 | v0.2.11 | `crates/Cargo.toml:2` (`workspace.package.version`) |
| Total verb count (4 occurrences) | 63 | 67 | `HandlerDef` arrays, `Visibility::Verb` entries per pack |
| kg verbs (table + arch block) | 11 | 16 | `crates/khive-pack-kg/src/handler_defs.rs:17` (`[HandlerDef; 16]`) |
| memory verbs (table + arch block) | 2 | 5 | `crates/khive-pack-memory/src/pack.rs` (5 `Visibility::Verb` entries) |
| knowledge verbs (table + arch block) | 14 | 19 | `crates/khive-pack-knowledge/src/vocab.rs:5` (`[HandlerDef; 19]`) |
| Edge relations in status line | 15 | 17 | ADR-055 adds `supports` + `refutes` |

Verb count methodology: counted only `Visibility::Verb` entries per pack (subhandlers excluded). Per-pack breakdown: kg=16, gtd=5, memory=5, brain=13, comm=5, schedule=4, knowledge=19. Total: 67.

### S2 — AGENTS.md issue #160 chain-key docs (AGENTS.md only)

- **`merge` result shape**: Row now documents `{kept_id, removed_id, edges_rewired, …}` with explicit warning that `$prev.id` fails — use `$prev.kept_id`. Source: `crates/khive-pack-kg/src/handler_defs.rs:344-346`.
- **`propose` result shape**: Row now documents `{id, status, proposer, title}` with explicit warning against `$prev.proposal_id`. Source: `handler_defs.rs:549-551`.
- **`knowledge.edit` section_type**: Added paragraph after the knowledge verb table documenting the 10-value closed enum and the ≥80-char content minimum. Source: `crates/khive-pack-knowledge/src/vocab.rs:329-331` and `crates/khive-brain-core/src/section_type.rs:39-48`.
- **`memory.prune` / `memory.vacuum`**: Added two missing rows to the memory pack table (was 3, now 5 — matching the heading). Source: `crates/khive-pack-memory/src/pack.rs` `Visibility::Verb` entries.

### S7 — ADR README index missing ADR-067/068 (docs/adr/README.md)

Appended two rows in numeric order after ADR-066, matching the existing table column format:
- ADR-067: Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed). Source: `docs/adr/ADR-067-write-owner-daemon.md` header.
- ADR-068: Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed). Source: `docs/adr/ADR-068-cloud-multitenancy-topology.md` header.

## Test plan

- [ ] `grep "v0.2.11\|67 verb\|67-verb\|67 public" README.md` — all four verb-count occurrences match
- [ ] `grep "kept_id\|proposal_id" AGENTS.md` — merge/propose chain-key warnings present
- [ ] `grep "section_type\|closed enum\|80 char" AGENTS.md` — knowledge.edit constraints documented
- [ ] `grep "memory.prune\|memory.vacuum" AGENTS.md` — two new memory rows present
- [ ] `grep "ADR-067\|ADR-068" docs/adr/README.md` — two new index rows present
- [ ] No `63 verb`, `v0.2.3`, `kg=11`, `knowledge=14`, `65 public` remain in edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
