### PR TITLE
fix(bm25): recover poisoned lock instead of collapsing IDF cache to empty

### DIFF
--- a/crates/khive-bm25/src/index/core.rs
+++ b/crates/khive-bm25/src/index/core.rs
@@ -133,8 +133,8 @@ impl Clone for Bm25Index {
         let block_max_clone = self
             .block_max_state
             .read()
-            .map(|state| state.clone())
-            .unwrap_or_default();
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
 
         Self {
             inverted_index: self.inverted_index.clone(),
@@ -745,6 +745,83 @@ mod regression_tests {
         assert!(
             result.is_err(),
             "posting list with unsorted doc_ids must be rejected"
+        );
+    }
+
+    #[test]
+    fn bm25_index_clone_recovers_idf_cache_from_poisoned_lock() {
+        let mut index = Bm25Index::default();
+        // Index enough documents so the IDF cache gets populated.
+        for i in 0..5 {
+            index
+                .index_document(format!("doc{i}"), "rust systems programming")
+                .unwrap();
+        }
+        // Warm the IDF cache by running a search.
+        let _ = index.search("rust", 10);
+        assert!(
+            !index.is_idf_cache_empty(),
+            "IDF cache must be populated before poisoning"
+        );
+
+        // Poison the IDF cache lock by panicking inside its write-lock scope.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = index.idf_cache.by_df.write().unwrap();
+            panic!("intentional idf cache poison");
+        });
+        assert!(
+            index.idf_cache.by_df.read().is_err(),
+            "IDF cache lock must be poisoned"
+        );
+
+        // Clone must preserve populated IDF cache, not collapse to empty.
+        let cloned = index.clone();
+        assert!(
+            !cloned.is_idf_cache_empty(),
+            "cloned index must retain non-empty IDF cache after lock was poisoned"
+        );
+
+        // Search results must be non-empty (scores non-zero) — not silently zeroed.
+        let results = cloned.search("rust", 10);
+        assert_eq!(
+            results.len(),
+            5,
+            "all documents must be found in clone of poisoned index"
+        );
+        assert!(
+            results.iter().all(|(_id, score)| score.to_f64() > 0.0),
+            "BM25 scores must be non-zero; a collapsed IDF cache would produce score=0"
+        );
+    }
+
+    #[test]
+    fn bm25_index_clone_recovers_block_max_state_from_poisoned_lock() {
+        let mut index = Bm25Index::default();
+        for i in 0..4 {
+            index
+                .index_document(format!("doc{i}"), "search engine indexing")
+                .unwrap();
+        }
+        // Force block-max metadata to be built.
+        index.ensure_block_max_metadata();
+
+        // Poison the block_max_state lock.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = index.block_max_state.write().unwrap();
+            panic!("intentional block_max poison");
+        });
+        assert!(
+            index.block_max_state.read().is_err(),
+            "block_max_state lock must be poisoned"
+        );
+
+        // Clone must succeed and the clone must be searchable.
+        let cloned = index.clone();
+        let results = cloned.search("search", 10);
+        assert_eq!(
+            results.len(),
+            4,
+            "all documents must be found in clone after block_max_state lock was poisoned"
         );
     }
 }

--- a/crates/khive-bm25/src/index/scoring.rs
+++ b/crates/khive-bm25/src/index/scoring.rs
@@ -17,7 +17,11 @@ pub(crate) struct IdfCache {
 
 impl Clone for IdfCache {
     fn clone(&self) -> Self {
-        let map_clone = self.by_df.read().map(|m| m.clone()).unwrap_or_default();
+        let map_clone = self
+            .by_df
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
         Self {
             cached_doc_count: AtomicUsize::new(self.cached_doc_count.load(AtomicOrdering::Relaxed)),
             by_df: RwLock::new(map_clone),
@@ -185,4 +189,51 @@ pub struct Bm25Stats {
     pub avg_doc_length: f64,
     /// Number of unique terms in the index.
     pub unique_terms: usize,
+}
+
+#[cfg(test)]
+mod poison_tests {
+    use super::IdfCache;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn idf_cache_clone_recovers_data_from_poisoned_lock() {
+        let cache = IdfCache::default();
+        cache.cached_doc_count.store(10, Ordering::Relaxed);
+
+        // Populate the cache before poisoning.
+        {
+            let mut guard = cache.by_df.write().unwrap();
+            guard.insert(1, 2.5);
+            guard.insert(3, 1.1);
+        }
+
+        // Poison the lock by panicking inside a write-lock scope.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = cache.by_df.write().unwrap();
+            panic!("intentional poison");
+        });
+
+        // The lock is now poisoned — verify that.
+        assert!(cache.by_df.read().is_err(), "lock must be poisoned");
+
+        // Clone must recover the populated data, not produce an empty map.
+        let cloned = cache.clone();
+
+        let guard = cloned.by_df.read().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(
+            guard.len(),
+            2,
+            "cloned IdfCache must preserve all entries from a poisoned lock"
+        );
+        assert!(
+            (*guard.get(&1).unwrap() - 2.5).abs() < f64::EPSILON,
+            "IDF value for df=1 must survive poison-clone"
+        );
+        assert_eq!(
+            cloned.cached_doc_count.load(Ordering::Relaxed),
+            10,
+            "doc_count must be preserved across poison-clone"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Silent score-collapse bug**: `IdfCache::clone()` and `Bm25Index::clone()` called `unwrap_or_default()` on a poisoned `RwLock` read guard. When any thread panicked while holding the write lock, subsequent `clone()` calls silently produced an empty IDF cache (`HashMap::default()`) and empty `BlockMaxState`. This caused every BM25 relevance score to collapse to `0.0` with no error surfaced — a total retrieval-quality failure that is invisible to callers.
- **Root cause**: A poisoned `RwLock` in Rust records that a thread panicked while the lock was held, but the guarded data is still valid. `unwrap_or_default()` discarded the data; the correct recovery idiom is `unwrap_or_else(|poisoned| poisoned.into_inner())`, which extracts the still-valid inner value from the poisoned guard.
- **Fix applied in two places**: `IdfCache::clone()` in `crates/khive-bm25/src/index/scoring.rs` and `Bm25Index::clone()` in `crates/khive-bm25/src/index/core.rs`.

## Regression tests added

Three new tests in `crates/khive-bm25/src/index/`:

1. `scoring::poison_tests::idf_cache_clone_recovers_data_from_poisoned_lock` — directly poisons the `IdfCache.by_df` lock, clones the cache, and asserts all pre-poison entries are present (non-empty map, correct values). This test would **fail** against the old `unwrap_or_default()` path.

2. `core::regression_tests::bm25_index_clone_recovers_idf_cache_from_poisoned_lock` — populates a real index, warms the IDF cache via a search, poisons the IDF lock, clones the index, then asserts search returns all 5 documents with non-zero BM25 scores. The old path would produce `score=0.0` for every hit.

3. `core::regression_tests::bm25_index_clone_recovers_block_max_state_from_poisoned_lock` — poisons the `block_max_state` lock after building metadata, clones the index, and asserts all 4 documents are still found by search.

## Gate results

```
cargo test -p khive-bm25              RC=0  (122 tests, 0 failed)
cargo clippy -p khive-bm25 --all-targets -- -D warnings   RC=0  (0 warnings)
cargo fmt --all -- --check            RC=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)