### PR TITLE
docs(quant): fix phantom ADR-107 refs -> ADR-052 (lib.rs)

### DIFF
--- a/crates/khive-quant/src/lib.rs
+++ b/crates/khive-quant/src/lib.rs
@@ -16,7 +16,7 @@
 //! L2² in code space: `gs² × Σ (a_i - b_i)²` — algebraically exact (offsets cancel,
 //! one scalar factorizes out). No residual pass needed, no gate, no silent fallback.
 //! Small-range dims contribute proportionally fewer codes and proportionally less
-//! L2 signal — an honest trade-off documented in ADR-107.
+//! L2 signal — an honest trade-off documented in ADR-052.
 //!
 //! # Hot-loop NEON helpers (`u8_dot_u32`, `u8_l2sq_u32`)
 //!
@@ -421,7 +421,7 @@ impl Sq8Codec {
 /// anisotropy gate (ratio ≤ 4.0) to achieve the integer-only hot path. The gate was
 /// calibrated on an LCG corpus that gave ratio ≈ 4.0; real transformer embeddings
 /// have rogue dimensions (ratio 10–32) that silently fell back to the full residual
-/// path, defeating the purpose. Global-scale eliminates the gate entirely — see ADR-107.
+/// path, defeating the purpose. Global-scale eliminates the gate entirely — see ADR-052.
 #[derive(Debug, Clone)]
 pub struct GsSq8Codec {
     /// Per-dimension minimum values.


### PR DESCRIPTION
## Summary

- Two doc-comments in `crates/khive-quant/src/lib.rs` referenced `ADR-107`, a khivedb-namespace ADR number that does not exist in this repo.
- Replaced both with the correct `ADR-052` (ANN Production Lifecycle -- SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence), which specifies `khive-quant`, `GsSq8Codec`, and the global-scale quantization trade-off described by the surrounding text.

## Changed lines

- `lib.rs:19`: `...honest trade-off documented in ADR-107.` → `ADR-052`
- `lib.rs:424`: `...Global-scale eliminates the gate entirely — see ADR-107.` → `ADR-052`

## Verification

- ADR-107: confirmed absent (`ls docs/adr/ | grep -i 107` → empty)
- ADR-052: confirmed correct target (title + SQ8/global-scale/khive-quant content match)

## Test plan

- [x] `cargo test -p khive-quant` → TEST_RC=0 (14 passed)
- [x] `cargo clippy -p khive-quant --all-targets -- -D warnings` → CLIPPY_RC=0
- [x] `cargo fmt --all -- --check` → FMT_RC=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)