### PR TITLE
fix(khive-db): de-flake checkpoint-vs-reader timing assertion (CI runner jitter)

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -364,23 +364,27 @@ mod tests {
     /// `PRAGMA wal_checkpoint(TRUNCATE)`. Confirmed by reasoning: TRUNCATE inherits
     /// RESTART semantics and will invoke the busy handler (sleeping up to
     /// `busy_timeout`) while waiting for the open reader snapshot to release.
-    /// With `busy_timeout = 200ms` a TRUNCATE regression causes the call to take
-    /// ~200ms, blowing the <50ms assertion. PASSIVE returns in <1ms even with an
+    /// With `busy_timeout = 2000ms` a TRUNCATE regression causes the call to take
+    /// ~2000ms, blowing the <500ms assertion. PASSIVE returns in <1ms even with an
     /// open reader, because PASSIVE never waits for readers.
     ///
-    /// Why `busy_timeout = 200ms`: the test pool uses a small busy_timeout so a
-    /// TRUNCATE regression fails fast (~200ms), not after the 30s production default.
+    /// Why `busy_timeout = 2000ms` and threshold `< 500ms`: the original 200ms
+    /// busy_timeout / 50ms threshold was too tight for contended CI runners where
+    /// PASSIVE legitimately takes 50-200ms under parallel-test load. Raising the
+    /// busy_timeout to 2000ms keeps the PASSIVE path well below 500ms while a
+    /// TRUNCATE regression blocks for ~2000ms — a 4x safety margin on both sides.
     #[test]
     fn checkpoint_high_water_does_not_block_behind_reader() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("high_water_test.db");
 
-        // Use a small busy_timeout so a TRUNCATE regression fails fast (~200ms)
-        // rather than hanging the test suite for the 30s production default.
+        // busy_timeout = 2000ms: a TRUNCATE regression blocks ~2s (clearly caught by
+        // the <500ms assertion below), but PASSIVE returns well within 500ms even on
+        // a heavily loaded CI runner. 4x margin on both sides vs. the old 200ms/50ms.
         let pool = Arc::new(
             ConnectionPool::new(PoolConfig {
                 path: Some(path.clone()),
-                busy_timeout: Duration::from_millis(200),
+                busy_timeout: Duration::from_millis(2000),
                 ..PoolConfig::default()
             })
             .expect("pool open"),
@@ -425,11 +429,13 @@ mod tests {
         drop(reader);
 
         // PASSIVE returns in <1ms even with an open reader snapshot.
-        // A TRUNCATE regression would block ~busy_timeout (200ms) and fail here.
+        // A TRUNCATE regression would block ~busy_timeout (2000ms) and fail here.
+        // 500ms threshold is generous for CI jitter while staying well below 2000ms.
         assert!(
-            elapsed < std::time::Duration::from_millis(50),
+            elapsed < std::time::Duration::from_millis(500),
             "checkpoint_once with active reader snapshot took {:?}; \
-             expected <50ms (PASSIVE must not block on readers)",
+             expected <500ms (PASSIVE must not block on readers; \
+             a TRUNCATE regression would block ~2000ms)",
             elapsed
         );
     }


### PR DESCRIPTION
## Summary

The 50ms wall-clock assertion in `checkpoint_high_water_does_not_block_behind_reader` was too tight for contended GitHub CI runners, where a PASSIVE checkpoint legitimately takes 50–200ms under parallel-test load. `main` CI went RED on every push after #237 merged even though the checkpoint blocking behaviour is unchanged — #237 only touched WARN-log rate-limiting via a `CheckpointTick` enum.

## What changed

**Single file**: `crates/khive-db/src/checkpoint.rs` — test-only, no production behaviour modified.

**Approach (a)**: Widen the timing separation rather than just relaxing the magic number.

| | Before | After |
|---|---|---|
| `busy_timeout` on test pool | 200 ms | 2000 ms |
| Assertion threshold | `< 50 ms` | `< 500 ms` |
| TRUNCATE regression blocks for | ~200 ms | ~2000 ms |
| Safety margin | 4× (200 / 50) | **4×** (2000 / 500) |

A TRUNCATE regression still fails the assertion unambiguously (~2000 ms >> 500 ms). PASSIVE under CI load stays comfortably within 500 ms. Regression detection intent is fully preserved.

## Gates (all captured without pipe-masking)

- `cargo test -p khive-db` → `TEST_RC=0`; `checkpoint_high_water_does_not_block_behind_reader ... ok`; `grep -c 'test result: FAILED'` → `0`
- `cargo clippy -p khive-db --all-targets -- -D warnings` → `CLIPPY_RC=0`
- `cargo fmt --all -- --check` → `FMT_RC=0`
- Pre-commit hooks (cargo fmt, cargo clippy, secret scan) → all Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)