### PR TITLE
fix(retrieval): push property/tag predicates below truncation (#176)

### DIFF
--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -335,6 +335,57 @@ pub(crate) mod tests {
         );
     }
 
+    /// T6d: A multi-backend search with a malformed `tags` value must return a
+    /// per-op error (`ok: false`) rather than silently returning unfiltered results.
+    ///
+    /// Single-backend rejects malformed tags via `SearchParams` deserialisation
+    /// (RuntimeError::InvalidInput → `ok: false`).  Multi-backend must match that
+    /// contract: the server must reject before reaching the coordinator, not silently
+    /// collapse the filter to an empty Vec.
+    ///
+    /// This test FAILS against the old `filter_map(as_str)` code (which would call
+    /// the coordinator with an empty tags Vec and return `ok: true, result: []`),
+    /// and PASSES after the strict `serde_json::from_value::<Vec<String>>` fix.
+    #[tokio::test]
+    async fn t6d_malformed_tags_return_per_op_error_in_multi_backend() {
+        let (registry, _runtime) = make_registry();
+        let coord = MockCoordinator::multi_backend();
+        let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+            .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+        // Pass a non-string entry in the tags array; the strict parser must reject this.
+        let raw = server
+            .dispatch_request_local(RequestParams {
+                ops: r#"search(kind="entity", query="anything", tags=[42])"#.to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+            })
+            .await
+            .expect("T6d: dispatch must not return an MCP-level error");
+
+        let result_val: serde_json::Value =
+            serde_json::from_str(&raw).expect("T6d: response must be valid JSON");
+        let first = result_val
+            .get("results")
+            .and_then(|r| r.as_array())
+            .and_then(|a| a.first())
+            .expect("T6d: results array must be non-empty");
+        assert_eq!(
+            first.get("ok").and_then(serde_json::Value::as_bool),
+            Some(false),
+            "T6d: malformed tags must produce ok=false; got {:?}",
+            first
+        );
+        // The coordinator must NOT have been called — rejection happens before dispatch.
+        assert!(
+            !coord
+                .search_called
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "T6d: coordinator must not be reached when tags validation fails"
+        );
+    }
+
     /// T6c: A single-backend server must NOT route through the coordinator.
     ///
     /// When the coordinator reports `is_single_backend() == true`, the zero-change

--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -133,8 +133,15 @@ pub trait CoordinatorService: Send + Sync {
     /// (`entity_kind` for entity substrate, `note_kind` for note substrate).
     /// Pass `None` for substrate-level (`kind="entity"` or `kind="note"`) searches.
     ///
+    /// `props_filter` and `tags` are entity-substrate filters forwarded to each
+    /// backend's `hybrid_search`. When either is active the per-backend candidate
+    /// window is widened so that sparse matches ranked below the bare `limit` are
+    /// not cut off before filtering (mirrors the single-backend handler).
+    /// Both are ignored for note-substrate searches.
+    ///
     /// Granular kinds that cannot be resolved to a substrate fall through to the
     /// registry (single-backend path); the coordinator does not silently drop results.
+    #[allow(clippy::too_many_arguments)]
     async fn fan_out_search(
         &self,
         kind: &str,
@@ -142,6 +149,8 @@ pub trait CoordinatorService: Send + Sync {
         namespace: &Namespace,
         limit: u32,
         kind_filter: Option<&str>,
+        props_filter: Option<&serde_json::Value>,
+        tags: &[String],
     ) -> CoordSearchResult;
 
     /// True when only one backend is registered (zero-change invariant check).
@@ -211,6 +220,8 @@ pub(crate) mod tests {
             _namespace: &Namespace,
             _limit: u32,
             _kind_filter: Option<&str>,
+            _props_filter: Option<&serde_json::Value>,
+            _tags: &[String],
         ) -> CoordSearchResult {
             self.search_called
                 .store(true, std::sync::atomic::Ordering::SeqCst);

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -961,8 +961,39 @@ async fn dispatch_via_coordinator_inner(
                 other => Some(other),
             };
 
+            // Extract entity-substrate filters and forward them to each backend.
+            // When either is active the coordinator widens the per-backend candidate
+            // window so that sparse matches ranked below the bare limit are not cut
+            // off before filtering (before-truncation parity with the single-backend
+            // handler in search.rs).
+            let props_filter: Option<&serde_json::Value> =
+                args_value.get("properties").and_then(|v| {
+                    if v.as_object().is_some_and(|m| !m.is_empty()) {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                });
+            let tags_owned: Vec<String> = args_value
+                .get("tags")
+                .and_then(serde_json::Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             let coord_result = coord
-                .fan_out_search(kind, query, &namespace, limit, kind_filter)
+                .fan_out_search(
+                    kind,
+                    query,
+                    &namespace,
+                    limit,
+                    kind_filter,
+                    props_filter,
+                    &tags_owned,
+                )
                 .await;
 
             // Shape result to match the kg search handler's output fields exactly.
@@ -971,10 +1002,6 @@ async fn dispatch_via_coordinator_inner(
             //   - score: RRF-merged, subject to min_score floor
             // Note hits:   [{id, note_kind, score, title, snippet}]
             //   - note_kind: real kind string fetched from the owning backend
-            //
-            // NOTE: props/tags filters are not applied here (deferred).
-            // All other parity gaps (kind filter, min_score, real kinds) are closed.
-            // TODO(ADR-029): apply props/tags entity filters in fan-out path — khive#176
             let result_val = if !coord_result.note_hits.is_empty()
                 || (coord_result.entity_hits.is_empty() && coord_result.note_hits.is_empty())
             {

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -974,15 +974,25 @@ async fn dispatch_via_coordinator_inner(
                         None
                     }
                 });
-            let tags_owned: Vec<String> = args_value
-                .get("tags")
-                .and_then(serde_json::Value::as_array)
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(str::to_string))
-                        .collect()
-                })
-                .unwrap_or_default();
+            // Parse tags strictly: absent/null → no filter (empty Vec); present and
+            // valid Vec<String> → use as-is (including empty array → no filter);
+            // present but not a Vec<String> → reject with a per-op error so the
+            // multi-backend path matches single-backend behaviour, which rejects
+            // malformed tags via SearchParams deserialisation (RuntimeError::InvalidInput).
+            // filter_map(as_str) would silently drop non-string entries and produce
+            // an empty Vec, bypassing the filter and returning unfiltered results.
+            let tags_owned: Vec<String> = match args_value.get("tags") {
+                None | Some(Value::Null) => vec![],
+                Some(v) => match serde_json::from_value::<Vec<String>>(v.clone()) {
+                    Ok(t) => t,
+                    Err(_) => {
+                        return Some(Err((
+                            "search".to_string(),
+                            json!("tags must be an array of strings"),
+                        )));
+                    }
+                },
+            };
 
             let coord_result = coord
                 .fan_out_search(

--- a/crates/kkernel/src/coordinator/dispatch.rs
+++ b/crates/kkernel/src/coordinator/dispatch.rs
@@ -333,10 +333,17 @@ impl SubstrateCoordinator {
     /// - entity substrate: `entity_kind` parameter of `hybrid_search`
     /// - note substrate: `note_kind` parameter of `search_notes`
     ///
-    /// Pass `None` for substrate-level searches (`kind="entity"` or `kind="note"`).
+    /// `props_filter` and `tags` are forwarded to each backend's `hybrid_search` when
+    /// `search_notes` is false. When either is active the per-backend candidate window is
+    /// widened (up to 500) so that sparse matches ranked below the bare `limit` are not
+    /// cut off before the filter is applied inside `hybrid_search`. Both parameters are
+    /// ignored for note-substrate searches.
+    ///
+    /// Pass `None`/`&[]` for substrate-level searches without filters.
     ///
     /// Per-backend errors are captured in [`BackendSearchResult::error`] — a single
     /// failing backend does NOT abort the fan-out.
+    #[allow(clippy::too_many_arguments)]
     pub async fn fan_out_search(
         &self,
         query: &str,
@@ -344,7 +351,21 @@ impl SubstrateCoordinator {
         limit: u32,
         search_notes: bool,
         kind_filter: Option<&str>,
+        props_filter: Option<&serde_json::Value>,
+        tags: &[String],
     ) -> (Vec<SearchHit>, Vec<NoteSearchHit>, Vec<BackendSearchResult>) {
+        // Widen the per-backend candidate window when entity filters are active so
+        // that sparse matches ranked below the bare `limit` survive inside each
+        // backend's hybrid_search before being filtered (mirrors search.rs behaviour).
+        let search_limit = if !search_notes && (props_filter.is_some() || !tags.is_empty()) {
+            limit.saturating_mul(50).min(500)
+        } else {
+            limit
+        };
+
+        let props_filter_owned: Option<serde_json::Value> = props_filter.cloned();
+        let tags_owned: Vec<String> = tags.to_vec();
+
         let entries: Vec<(BackendId, Arc<KhiveRuntime>)> = self
             .registry
             .iter()
@@ -396,10 +417,20 @@ impl SubstrateCoordinator {
                 }
             } else {
                 match runtime
-                    .hybrid_search(&token, query, None, limit, kind_filter, None, &[], None)
+                    .hybrid_search(
+                        &token,
+                        query,
+                        None,
+                        search_limit,
+                        kind_filter,
+                        None,
+                        &tags_owned,
+                        props_filter_owned.as_ref(),
+                    )
                     .await
                 {
                     Ok(hits) => {
+                        let hits: Vec<SearchHit> = hits.into_iter().take(limit as usize).collect();
                         let backend_result = BackendSearchResult {
                             backend_id: backend_id.clone(),
                             hits: hits.clone(),
@@ -435,6 +466,10 @@ impl SubstrateCoordinator {
             let q = query.clone();
             let ns = ns.clone();
             let kf = kind_filter_owned.clone();
+            let pf = props_filter_owned.clone();
+            let tg = tags_owned.clone();
+            let sl = search_limit;
+            let lim = limit;
             let should_fail = fail_id
                 .as_deref()
                 .map(|id| id == backend_id.as_str())
@@ -458,7 +493,7 @@ impl SubstrateCoordinator {
                 };
                 if search_notes {
                     let result = runtime
-                        .search_notes(&token, &q, None, limit, kf.as_deref(), false, &[], None)
+                        .search_notes(&token, &q, None, lim, kf.as_deref(), false, &[], None)
                         .await;
                     match result {
                         Ok(note_hits) => (backend_id, Ok(vec![]), Some(note_hits)),
@@ -466,10 +501,17 @@ impl SubstrateCoordinator {
                     }
                 } else {
                     let result = runtime
-                        .hybrid_search(&token, &q, None, limit, kf.as_deref(), None, &[], None)
+                        .hybrid_search(&token, &q, None, sl, kf.as_deref(), None, &tg, pf.as_ref())
                         .await;
                     match result {
-                        Ok(hits) => (backend_id, Ok(hits), None),
+                        Ok(hits) => {
+                            // Truncate to the user limit after filtering so each
+                            // backend contributes at most `limit` ranked hits to
+                            // the RRF merge (not the widened search_limit).
+                            let hits: Vec<SearchHit> =
+                                hits.into_iter().take(lim as usize).collect();
+                            (backend_id, Ok(hits), None)
+                        }
                         Err(e) => (backend_id, Err(e), None),
                     }
                 }

--- a/crates/kkernel/src/coordinator/service.rs
+++ b/crates/kkernel/src/coordinator/service.rs
@@ -98,11 +98,21 @@ impl CoordinatorService for SubstrateCoordinatorService {
         namespace: &Namespace,
         limit: u32,
         kind_filter: Option<&str>,
+        props_filter: Option<&serde_json::Value>,
+        tags: &[String],
     ) -> CoordSearchResult {
         let search_notes = is_note_substrate(kind);
         let (entity_hits, note_hits, per_backend) = self
             .inner
-            .fan_out_search(query, namespace, limit, search_notes, kind_filter)
+            .fan_out_search(
+                query,
+                namespace,
+                limit,
+                search_notes,
+                kind_filter,
+                props_filter,
+                tags,
+            )
             .await;
 
         let partial = per_backend.iter().any(|r| r.error.is_some());

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -184,7 +184,7 @@ async fn fan_out_search_single_backend_returns_hits() {
         .expect("create entity");
 
     let (hits, _note_hits, per_backend) = coord
-        .fan_out_search("FlashAttention", &ns, 10, false, None)
+        .fan_out_search("FlashAttention", &ns, 10, false, None, None, &[])
         .await;
 
     assert!(!hits.is_empty(), "should find the entity");
@@ -232,8 +232,9 @@ async fn fan_out_search_two_backends_merged() {
         .expect("create on lore");
 
     // Fan-out search for "LoRA" — both backends should contribute.
-    let (merged_hits, _note_hits, per_backend) =
-        coord.fan_out_search("LoRA", &ns, 10, false, None).await;
+    let (merged_hits, _note_hits, per_backend) = coord
+        .fan_out_search("LoRA", &ns, 10, false, None, None, &[])
+        .await;
 
     assert_eq!(per_backend.len(), 2, "both backends in report");
     // Merged set should contain at least one hit from the combined results.
@@ -247,8 +248,9 @@ async fn fan_out_search_two_backends_merged() {
 async fn fan_out_search_empty_registry_returns_empty() {
     let coord = SubstrateCoordinator::new(BackendRegistry::new());
     let ns = Namespace::local();
-    let (hits, note_hits, per_backend) =
-        coord.fan_out_search("anything", &ns, 10, false, None).await;
+    let (hits, note_hits, per_backend) = coord
+        .fan_out_search("anything", &ns, 10, false, None, None, &[])
+        .await;
     assert!(hits.is_empty());
     assert!(note_hits.is_empty());
     assert!(per_backend.is_empty());
@@ -289,7 +291,7 @@ async fn fan_out_partial_failure_preserves_working_backend_hits() {
     let coord = SubstrateCoordinator::new(registry).with_failing_backend("main");
 
     let (merged_hits, _note_hits, per_backend) = coord
-        .fan_out_search("PartialFailureProbe", &ns, 10, false, None)
+        .fan_out_search("PartialFailureProbe", &ns, 10, false, None, None, &[])
         .await;
 
     // Both backends must be reported.
@@ -461,8 +463,9 @@ async fn t1_single_backend_zero_change_invariant() {
     );
 
     // fan_out_search returns results equivalent to a single runtime search.
-    let (hits, _note_hits, per_backend) =
-        coord.fan_out_search("T1Entity", &ns, 10, false, None).await;
+    let (hits, _note_hits, per_backend) = coord
+        .fan_out_search("T1Entity", &ns, 10, false, None, None, &[])
+        .await;
     assert!(
         !hits.is_empty(),
         "T1: fan-out on single backend must return hits"
@@ -582,8 +585,9 @@ async fn t3_fan_out_search_merged_from_two_backends() {
     .expect("T3: create on beta");
 
     // Search "Entity" — should match both AlphaEntity and BetaEntity.
-    let (merged, _note_hits, per_backend) =
-        coord.fan_out_search("Entity", &ns, 20, false, None).await;
+    let (merged, _note_hits, per_backend) = coord
+        .fan_out_search("Entity", &ns, 20, false, None, None, &[])
+        .await;
 
     assert_eq!(per_backend.len(), 2, "T3: both backends in report");
     assert!(
@@ -715,7 +719,7 @@ async fn fan_out_note_search_two_backends() {
 
     // Note fan-out (search_notes=true).
     let (_entity_hits, note_hits, per_backend) = coord
-        .fan_out_search("observation", &ns, 10, true, None)
+        .fan_out_search("observation", &ns, 10, true, None, None, &[])
         .await;
 
     assert_eq!(per_backend.len(), 2, "both backends in report");
@@ -724,6 +728,207 @@ async fn fan_out_note_search_two_backends() {
     assert!(
         !note_hits.is_empty(),
         "note fan-out must return hits, got 0"
+    );
+}
+
+// ---- props/tags filter regression (ADR-029 residual, khive#176) ----
+
+/// Entity on the non-primary backend whose properties match the filter must
+/// survive the fan-out; a sibling entity without the matching property must
+/// not appear in the results.
+///
+/// Query token "propsfiltertest" is embedded in both descriptions so FTS
+/// returns both candidates before the property predicate is applied.
+/// sanitize_fts5_query strips hyphens by removal rather than replacement, so
+/// all tokens here are plain lowercase ASCII with no punctuation.
+#[tokio::test]
+async fn fan_out_search_props_filter_drops_non_matching() {
+    let rt_main = memory_runtime();
+    let rt_lore = memory_runtime();
+
+    let ns = Namespace::local();
+
+    // Entity on "main" — does NOT have the target property.
+    let tok_main = rt_main.authorize(ns.clone()).unwrap();
+    rt_main
+        .create_entity(
+            &tok_main,
+            "concept",
+            None,
+            "PropsFanDecoy",
+            Some("propsfiltertest decoy entity without the matching property"),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create decoy on main");
+
+    // Entity on "lore" — has the target property.
+    let tok_lore = rt_lore.authorize(ns.clone()).unwrap();
+    let target = rt_lore
+        .create_entity(
+            &tok_lore,
+            "concept",
+            None,
+            "PropsFanTarget",
+            Some("propsfiltertest target entity with the matching property"),
+            Some(serde_json::json!({"status": "keep"})),
+            vec![],
+        )
+        .await
+        .expect("create target on lore");
+
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("main"), rt_main);
+    registry.register(BackendId::new("lore"), rt_lore);
+    let coord = SubstrateCoordinator::new(registry);
+
+    let props = serde_json::json!({"status": "keep"});
+    let (hits, _note_hits, _per_backend) = coord
+        .fan_out_search("propsfiltertest", &ns, 10, false, None, Some(&props), &[])
+        .await;
+
+    let hit_ids: Vec<uuid::Uuid> = hits.iter().map(|h| h.entity_id).collect();
+    assert!(
+        hit_ids.contains(&target.id),
+        "entity with matching property must be in results; got {:?}",
+        hit_ids
+    );
+    assert!(
+        hit_ids.iter().all(|id| *id == target.id),
+        "only the matching entity should be returned; got {:?}",
+        hit_ids
+    );
+}
+
+/// With `limit=1` and the matching entity ranked below the decoy in raw text
+/// score, the matching entity must still be returned because the per-backend
+/// candidate window is widened when filters are active (before-truncation
+/// semantics parity with the single-backend handler).
+///
+/// Query token "truncsemtest" appears in both descriptions; sanitize_fts5_query
+/// passes it unchanged (no hyphens or special characters).
+#[tokio::test]
+async fn fan_out_search_props_filter_before_truncation_semantics() {
+    let rt = memory_runtime();
+    let ns = Namespace::local();
+    let tok = rt.authorize(ns.clone()).unwrap();
+
+    // Both entities contain the search token so FTS returns both as candidates.
+    // With widening (search_limit = min(1*50, 500) = 50) the full candidate set
+    // is fetched, the decoy is filtered by the property predicate, and the target
+    // survives. Without widening at limit=1 the decoy could crowd out the target.
+    rt.create_entity(
+        &tok,
+        "concept",
+        None,
+        "TruncSemAlpha",
+        Some("truncsemtest decoy entity without the filter property"),
+        None,
+        vec![],
+    )
+    .await
+    .expect("create decoy");
+
+    let target = rt
+        .create_entity(
+            &tok,
+            "concept",
+            None,
+            "TruncSemBeta",
+            Some("truncsemtest target entity with the filter property"),
+            Some(serde_json::json!({"keep": true})),
+            vec![],
+        )
+        .await
+        .expect("create target");
+
+    let coord = SubstrateCoordinator::single(rt);
+
+    let props = serde_json::json!({"keep": true});
+    let (hits, _note_hits, _per_backend) = coord
+        .fan_out_search("truncsemtest", &ns, 1, false, None, Some(&props), &[])
+        .await;
+
+    let hit_ids: Vec<uuid::Uuid> = hits.iter().map(|h| h.entity_id).collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one hit expected with limit=1; got {:?}",
+        hit_ids
+    );
+    assert_eq!(
+        hits[0].entity_id, target.id,
+        "the matching entity must be returned even at limit=1; got {:?}",
+        hit_ids
+    );
+}
+
+/// Tags filter: entity with matching tag survives; entity without it is dropped.
+///
+/// Query token "tagsfiltertest" is embedded in both descriptions so FTS returns
+/// both candidates before the tag predicate is applied inside hybrid_search.
+#[tokio::test]
+async fn fan_out_search_tags_filter_drops_non_matching() {
+    let rt_main = memory_runtime();
+    let rt_lore = memory_runtime();
+    let ns = Namespace::local();
+
+    let tok_main = rt_main.authorize(ns.clone()).unwrap();
+    rt_main
+        .create_entity(
+            &tok_main,
+            "concept",
+            None,
+            "TagsFanDecoy",
+            Some("tagsfiltertest decoy entity without the target tag"),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create untagged on main");
+
+    let tok_lore = rt_lore.authorize(ns.clone()).unwrap();
+    let tagged = rt_lore
+        .create_entity(
+            &tok_lore,
+            "concept",
+            None,
+            "TagsFanMarked",
+            Some("tagsfiltertest target entity with the target tag"),
+            None,
+            vec!["target-tag".to_string()],
+        )
+        .await
+        .expect("create tagged on lore");
+
+    let mut registry = BackendRegistry::new();
+    registry.register(BackendId::new("main"), rt_main);
+    registry.register(BackendId::new("lore"), rt_lore);
+    let coord = SubstrateCoordinator::new(registry);
+
+    let (hits, _note_hits, _per_backend) = coord
+        .fan_out_search(
+            "tagsfiltertest",
+            &ns,
+            10,
+            false,
+            None,
+            None,
+            &["target-tag".to_string()],
+        )
+        .await;
+
+    let hit_ids: Vec<uuid::Uuid> = hits.iter().map(|h| h.entity_id).collect();
+    assert!(
+        hit_ids.contains(&tagged.id),
+        "tagged entity must be in results; got {:?}",
+        hit_ids
+    );
+    assert!(
+        hit_ids.iter().all(|id| *id == tagged.id),
+        "only the tagged entity should be returned; got {:?}",
+        hit_ids
     );
 }
 


### PR DESCRIPTION
## Summary

- Extends the `fan_out_search` coordinator seam (`CoordinatorService` trait in `khive-mcp`, `SubstrateCoordinator` in `kkernel`) with two new parameters: `props_filter` and `tags`
- Forwards both filters into each backend's `hybrid_search` call, which already applies them correctly with before-truncation semantics via an internal `CANDIDATE_MULTIPLIER`
- Widens the per-backend candidate window to `min(limit * 50, 500)` when either filter is active, matching the single-backend handler's behavior so sparse matches ranked below the bare `limit` are not cut off before filtering
- Removes the ADR-029 deferral TODO/NOTE from `server.rs`
- Updates all existing `fan_out_search` call sites in tests with the new `None`/`&[]` defaults
- Adds three regression tests in `kkernel/coordinator/tests.rs`: props filter drops non-matching entity across backends, before-truncation semantics at `limit=1`, tags filter drops non-matching entity across backends

## Test plan

- [ ] `cargo test -p khive-mcp -p khive-pack-kg -p khive-runtime --all-features` passes (1003 tests, 0 failed)
- [ ] `cargo test -p kkernel --all-features` passes (154 tests including 3 new regression tests, 0 failed)
- [ ] `cargo clippy -p khive-mcp -p khive-pack-kg -p khive-runtime -p kkernel --all-features -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)