### PR TITLE
test(contract): refresh drifted taxonomy/verb sets + degreen importance guard (#256 #257 #258 #259)

### DIFF
--- a/tests/khive-contract/khive_contract/fixtures.py
+++ b/tests/khive-contract/khive_contract/fixtures.py
@@ -1,62 +1,80 @@
 """Canonical constants and closed sets for khive contract tests.
 
 These are facts derived from the ADRs — not generated at runtime.
+Test modules import from here so there is one source of truth.
 """
 
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Entity kind taxonomy (ADR-001)
+# Entity kind taxonomy (ADR-001 + ADR-048)
+# 8 base kinds + resource (ADR-048) = 9 total
+# Source of truth: crates/khive-pack-kg/src/vocab.rs EntityKind::NAMES
 # ---------------------------------------------------------------------------
 
 ENTITY_KINDS: frozenset[str] = frozenset(
     {
         "concept",
-        "person",
-        "project",
-        "tool",
         "document",
-        "event",
-        "location",
-        "organization",
+        "dataset",
+        "project",
+        "person",
+        "org",
+        "artifact",
+        "service",
         "resource",
-        "tag",
     }
 )
 
 # ---------------------------------------------------------------------------
 # Note kind taxonomy (ADR-013)
+# 5 canonical kinds — no aliases accepted
+# Source of truth: crates/khive-pack-kg/src/vocab.rs NoteKind::NAMES
 # ---------------------------------------------------------------------------
 
 NOTE_KINDS: frozenset[str] = frozenset(
     {
         "observation",
+        "insight",
         "question",
-        "hypothesis",
-        "conclusion",
+        "decision",
         "reference",
     }
 )
 
 # ---------------------------------------------------------------------------
-# Edge relation ontology (ADR-002)
+# Edge relation ontology (ADR-002 base 15 + ADR-055 epistemic 2 = 17 total)
+# Source of truth: crates/khive-types/src/edge.rs EdgeRelation::VALID_NAMES
 # ---------------------------------------------------------------------------
 
 EDGE_RELATIONS: frozenset[str] = frozenset(
     {
-        "extends",
-        "implements",
-        "depends_on",
-        "uses",
-        "produces",
-        "relates_to",
-        "contradicts",
-        "supersedes",
-        "annotates",
+        # Structure
         "contains",
         "part_of",
+        "instance_of",
+        # Derivation
+        "extends",
+        "variant_of",
+        "introduced_by",
+        "supersedes",
+        # Provenance
+        "derived_from",
+        # Temporal
+        "precedes",
+        # Dependency
+        "depends_on",
         "enables",
-        "blocks",
+        # Implementation
+        "implements",
+        # Lateral
+        "competes_with",
+        "composed_with",
+        # Annotation
+        "annotates",
+        # Epistemic (ADR-055)
+        "supports",
+        "refutes",
     }
 )
 
@@ -65,6 +83,8 @@ ANNOTATES_SOURCE_MUST_BE_NOTE = True
 
 # ---------------------------------------------------------------------------
 # Product verb manifest (ADR-023 / ADR-025 / ADR-027)
+# KG pack ships 16 verbs; bare names (no pack prefix).
+# Source of truth: crates/khive-pack-kg/src/handler_defs.rs KG_HANDLERS
 # ---------------------------------------------------------------------------
 
 KG_VERBS: frozenset[str] = frozenset(
@@ -80,6 +100,11 @@ KG_VERBS: frozenset[str] = frozenset(
         "neighbors",
         "traverse",
         "query",
+        "stats",
+        "propose",
+        "review",
+        "withdraw",
+        "verbs",
     }
 )
 
@@ -102,8 +127,9 @@ MEMORY_VERBS: frozenset[str] = frozenset(
 
 DISCOVERABLE_PRODUCT_VERBS: frozenset[str] = KG_VERBS | GTD_VERBS | MEMORY_VERBS
 
-# The play spec says "15 product verbs"; the baseline exposes 18.
-# DISCOVERABLE_PRODUCT_VERBS (18) subsumes the stated minimum (15).
+# The play spec says "15 product verbs"; the baseline exposes 23
+# (KG:16 + GTD:5 + memory:2). DISCOVERABLE_PRODUCT_VERBS (23) subsumes
+# the stated minimum (15).
 PLAY_SPEC_MINIMUM_VERB_COUNT = 15
 
 # ---------------------------------------------------------------------------

--- a/tests/khive-contract/tests/test_adr_001_entity_kind.py
+++ b/tests/khive-contract/tests/test_adr_001_entity_kind.py
@@ -1,7 +1,7 @@
 """Entity kind taxonomy contract tests.
 
 ADR: ADR-001
-section: Entity kinds closed-set registry; MCP verb resolution; Registry contract
+section: 9 entity kinds closed-set registry; MCP verb resolution; Registry contract
 """
 
 from __future__ import annotations
@@ -9,11 +9,13 @@ from __future__ import annotations
 import pytest
 
 from khive_contract.client import KhiveMcpSession, KhiveOperationError
+from khive_contract.fixtures import ENTITY_KINDS
 
 VERBS_UNDER_TEST = {"create", "list", "get"}
 
-# Runtime-confirmed entity kinds (6 legacy kinds; ADR-001 spec adds artifact/service as drift)
-RUNTIME_ENTITY_KINDS = ("concept", "document", "project", "dataset", "person", "org")
+# All 9 entity kinds confirmed in the runtime (ADR-001 base 8 + ADR-048 resource).
+# Imported from fixtures.py — single source of truth.
+RUNTIME_ENTITY_KINDS = tuple(sorted(ENTITY_KINDS))
 
 
 @pytest.mark.adr_001
@@ -28,7 +30,7 @@ def test_create_list_get_each_entity_kind(
     """Create, list-filtered, and get each runtime entity kind.
 
     ADR: ADR-001
-    section: 8 entity kinds / MCP verb resolution
+    section: 9 entity kinds / MCP verb resolution
 
     Each create returns an id and name; list filtered by that entity_kind contains
     the returned id; get returns a kind=="entity" wrapper with matching data.
@@ -79,7 +81,7 @@ def test_invalid_entity_kind_reports_closed_set(
     section: Registry contract
 
     The error must name 'galaxy' and list all valid entity kinds so agents
-    can self-correct.  Currently the runtime exposes 6 legacy kinds.
+    can self-correct.  The runtime exposes all 9 entity kinds.
     """
     envelope = khive_session.request_batch([
         {"tool": "create", "args": {

--- a/tests/khive-contract/tests/test_adr_002_edge_ontology.py
+++ b/tests/khive-contract/tests/test_adr_002_edge_ontology.py
@@ -1,7 +1,7 @@
 """Edge ontology contract tests.
 
 ADR: ADR-002
-section: 13 canonical relations; Base endpoint contract; Cascade behavior;
+section: 17 canonical relations; Base endpoint contract; Cascade behavior;
          Annotation relation; Endpoint validation
 """
 
@@ -10,12 +10,14 @@ from __future__ import annotations
 import pytest
 
 from khive_contract.client import KhiveMcpSession, KhiveOperationError
+from khive_contract.fixtures import EDGE_RELATIONS
 
 VERBS_UNDER_TEST = {"create", "link", "get", "list", "neighbors", "delete"}
 
 # Relations confirmed to work concept-to-concept in the runtime base allowlist.
-# introduced_by and implements require EDGE_RULES pack (specific endpoint types).
+# introduced_by and implements require specific non-concept endpoint types.
 # competes_with and composed_with are symmetric: runtime may canonicalize endpoint order.
+# supports and refutes (ADR-055 epistemic) also permit concept→concept.
 CONCEPT_CONCEPT_RELATIONS = (
     "extends",
     "enables",
@@ -26,14 +28,13 @@ CONCEPT_CONCEPT_RELATIONS = (
     "supersedes",
     "competes_with",
     "composed_with",
+    "supports",
+    "refutes",
 )
 
-# All 13 canonical relations (runtime-confirmed)
-ALL_CANONICAL_RELATIONS = (
-    "contains", "part_of", "instance_of", "extends", "variant_of",
-    "introduced_by", "supersedes", "depends_on", "enables",
-    "implements", "competes_with", "composed_with", "annotates",
-)
+# All 17 canonical relations (ADR-002 base 15 + ADR-055 epistemic 2).
+# Imported from fixtures.py — single source of truth.
+ALL_CANONICAL_RELATIONS = tuple(sorted(EDGE_RELATIONS))
 
 
 @pytest.mark.adr_002
@@ -85,7 +86,7 @@ def test_invalid_relation_reports_closed_relation_set(
     temp_namespace: str,
     sample_entity,
 ) -> None:
-    """link with invalid relation returns per-op error listing all 13 canonical relations.
+    """link with invalid relation returns per-op error listing all 17 canonical relations.
 
     ADR: ADR-002
     section: Rules; Closed-set taxonomy
@@ -109,7 +110,7 @@ def test_invalid_relation_reports_closed_relation_set(
     assert err, "Error message must be non-empty"
     assert "invented_by" in err, f"Error must name offending relation 'invented_by': {err!r}"
 
-    # All 13 canonical relations must be listed
+    # All 17 canonical relations must be listed
     for rel in ALL_CANONICAL_RELATIONS:
         assert rel in err, (
             f"Canonical relation '{rel}' missing from error message: {err!r}"

--- a/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
+++ b/tests/khive-contract/tests/test_adr_023_verb_taxonomy.py
@@ -9,22 +9,26 @@ from __future__ import annotations
 import pytest
 
 from khive_contract.client import KhiveMcpSession
+from khive_contract.fixtures import KG_VERBS as _KG_VERBS
 
-# All 18 baseline product verbs
+# KG verbs imported from fixtures.py — single source of truth (16 verbs).
+KG_VERBS = tuple(sorted(_KG_VERBS))
+
+GTD_VERBS = ("gtd.assign", "gtd.next", "gtd.complete", "gtd.tasks", "gtd.transition")
+MEMORY_VERBS = ("memory.remember", "memory.recall")
+
+# All 23 baseline product verbs (KG:16 + GTD:5 + memory:2).
+# Written as a set literal so the manifest AST-introspector can parse it.
 VERBS_UNDER_TEST = {
-    # KG substrate (11) — bare names; no pack prefix
+    # KG substrate (16) — bare names; no pack prefix
     "create", "get", "list", "update", "delete", "merge",
     "search", "link", "neighbors", "traverse", "query",
+    "stats", "propose", "review", "withdraw", "verbs",
     # GTD (5) — dotted pack.verb form
     "gtd.assign", "gtd.next", "gtd.complete", "gtd.tasks", "gtd.transition",
     # Memory (2) — dotted pack.verb form
     "memory.remember", "memory.recall",
 }
-
-KG_VERBS = ("create", "get", "list", "update", "delete", "merge",
-            "search", "link", "neighbors", "traverse", "query")
-GTD_VERBS = ("gtd.assign", "gtd.next", "gtd.complete", "gtd.tasks", "gtd.transition")
-MEMORY_VERBS = ("memory.remember", "memory.recall")
 
 
 @pytest.mark.adr_023

--- a/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
+++ b/tests/khive-contract/tests/test_adr_027_single_tool_mcp.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import pytest
 
 from khive_contract.client import KhiveMcpSession, KhiveRpcError
+from khive_contract.fixtures import KG_VERBS as _KG_VERBS
 
 VERBS_UNDER_TEST = {"create"}
 
-KG_VERBS = ("create", "get", "list", "update", "delete", "merge",
-            "search", "link", "neighbors", "traverse", "query")
+# KG verbs imported from fixtures.py — single source of truth (16 verbs).
+KG_VERBS = tuple(sorted(_KG_VERBS))
 GTD_VERBS = ("gtd.assign", "gtd.next", "gtd.complete", "gtd.tasks", "gtd.transition")
 MEMORY_VERBS = ("memory.remember", "memory.recall")
 

--- a/tests/khive-contract/tests/test_no_importance_in_manifest.py
+++ b/tests/khive-contract/tests/test_no_importance_in_manifest.py
@@ -175,6 +175,8 @@ def _is_allowed(line: str) -> bool:
         "earlier draft aliased `importance`",  # ADR-021 historical note
         "Separate `importance` column", # ADR-021 alternatives table
         "relative importance during",  # engine_config.rs English prose (not a param name)
+        "the memory's importance, decayed",  # docs/guide/memory.md prose explaining salience
+        "weigh the importance of different words",  # khive-text bench sample text (Transformer prose)
     ):
         if allowed in line:
             return True


### PR DESCRIPTION
## What

Refreshes the Python contract-test suite's drifted closed-set constants to match the shipped
source-of-truth, consolidates them into `fixtures.py` as a single source of truth, and degreens
the `importance` sweep guard for two English-prose false positives.

The suite under `tests/khive-contract/` had drifted because each test module redefined its own
local copy of the taxonomy/verb tuples, so the closed sets fell behind the runtime independently.

## Changes

| Issue | Set | Was → Now | Source of truth |
|-------|-----|-----------|-----------------|
| #256 | entity kinds | 6 → **9** (adds `artifact`, `service`, `resource`) | `crates/khive-pack-kg/src/vocab.rs` `EntityKind::NAMES` |
| #257 | edge relations | 13 → **17** (adds `derived_from`, `precedes`, + epistemic `supports`/`refutes`) | `crates/khive-types/src/edge.rs` `EdgeRelation::VALID_NAMES` |
| #257 | concept→concept legal | adds `supports`, `refutes` (ADR-055) | `crates/khive-pack-kg/src/handlers/common.rs` |
| #258 | KG verbs | 11 → **16** (adds `stats`, `propose`, `review`, `withdraw`, `verbs`) | `crates/khive-pack-kg/src/handler_defs.rs` |
| #259 | dead fixtures | `fixtures.py` `ENTITY_KINDS`/`NOTE_KINDS`/`EDGE_RELATIONS`/`KG_VERBS` corrected; test modules now **import** from fixtures instead of redefining local tuples | — |

Plus: the `importance` sweep guard (`test_no_importance_in_manifest.py`) flagged two plain-prose
occurrences (`docs/guide/memory.md` explaining salience; a Transformer sample sentence in
`khive-text`'s bench). Neither is the eliminated `importance` parameter — added to the existing
prose allowlist, consistent with `importance sampling` / `relative importance during`.

## Verification

Every corrected value was confirmed against the cited Rust source before writing. The four
refreshed taxonomy/verb modules and the `importance` guard pass.

## Scope / follow-ups

- **Out of scope:** #260 (new coverage for recently-added surface).
- **Deferred (blocks CI wiring):** `test_namespace_isolation.py` asserts removed by-ID
  namespace isolation; tracked in #262. The suite cannot be wired into CI green until that lands,
  so #261's CI-wiring step is intentionally not included here.

Closes #256, #257, #258, #259.
