### PR TITLE
test(contract): align namespace-isolation test with ADR-007 Rev 6 Rule 2 (#262)

### DIFF
--- a/tests/khive-contract/tests/test_namespace_isolation.py
+++ b/tests/khive-contract/tests/test_namespace_isolation.py
@@ -1,7 +1,8 @@
-"""Namespace isolation contract tests.
+"""Namespace contract tests (ADR-007 Rev 6).
 
-ADR: ADR-003
-section: Namespace isolation; Cross-namespace access; Write path isolation
+ADR: ADR-007
+section: By-ID namespace-agnostic access (Rule 2); Multi-record namespace scoping (Rule 3);
+         Link endpoint resolution (namespace-scoped write path)
 """
 
 from __future__ import annotations
@@ -13,21 +14,29 @@ from khive_contract.client import KhiveMcpSession
 VERBS_UNDER_TEST = {"create", "get", "list", "search", "link"}
 
 
-@pytest.mark.adr_003
+@pytest.mark.adr_007
 @pytest.mark.slow
 def test_read_isolation_between_namespaces(
     khive_session: KhiveMcpSession,
     temp_namespace: str,
     sample_entity,
 ) -> None:
-    """Entity created in alpha namespace is invisible via get/list/search from beta namespace.
+    """By-ID ops are namespace-agnostic; multi-record ops remain namespace-scoped.
 
-    ADR: ADR-003
-    section: Namespace isolation
+    ADR: ADR-007
+    section: By-ID namespace-agnostic access (Rule 2); Namespace scoping (Rule 3)
 
-    Ports test_namespace_isolation from contract_test.py.
-    Entity in alpha: get(beta) → not found; list(beta) → absent; search(beta) → absent.
-    Entity in alpha: get(alpha) → succeeds.
+    ADR-007 Rev 6 Rule 2 (SHIPPED, PR-A1 commit 2607e263): get/update/delete resolve by UUID
+    with WHERE id = ? only — no namespace equality check at any layer (store, runtime, handler).
+
+    Contract verified here:
+    - get(id, namespace=beta) where entity lives in alpha: SUCCEEDS — full-UUID by-ID is
+      namespace-agnostic (ADR-007 Rev 6 Rule 2, SHIPPED PR-A1 commit 2607e263).
+    - 8-char prefix get from beta: FAILS with not-found — prefix expansion is a namespace-scoped
+      lookup, distinct from the full-UUID by-ID path; ADR-007 Rule 2 covers "by UUID" only.
+    - list(namespace=beta): alpha entity ABSENT — multi-record namespace scoping survives.
+    - search(namespace=beta): alpha entity ABSENT — multi-record namespace scoping survives.
+    - get(id, namespace=alpha): SUCCEEDS — control path confirming same-namespace access.
     """
     ns_alpha = f"{temp_namespace}_alpha"
     ns_beta = f"{temp_namespace}_beta"
@@ -42,20 +51,25 @@ def test_read_isolation_between_namespaces(
     })
     full_id = entity["id"]
 
-    # get from beta must fail
+    # By-ID get from beta: must SUCCEED (ADR-007 Rev 6 Rule 2 — namespace-agnostic)
     envelope_get = khive_session.request_batch([{
         "tool": "get",
         "args": {"id": full_id, "namespace": ns_beta},
     }])
     first_get = envelope_get["results"][0]
-    assert not first_get.get("ok", False), (
-        "get from beta namespace must not find alpha entity"
+    assert first_get.get("ok", False), (
+        "get by UUID from beta namespace must succeed: by-ID ops are namespace-agnostic "
+        "(ADR-007 Rev 6 Rule 2, SHIPPED PR-A1 commit 2607e263)"
     )
-    assert "not found" in first_get.get("error", "").lower(), (
-        f"Expected not-found error from beta get, got: {first_get.get('error')!r}"
+    cross_ns_result = first_get.get("result", {})
+    assert cross_ns_result.get("kind") == "concept", (
+        f"get from beta must return kind=concept, got: {first_get}"
+    )
+    assert cross_ns_result.get("name") == "AlphaEntity", (
+        f"get from beta must return AlphaEntity, got: {first_get}"
     )
 
-    # list from beta must not include the alpha entity
+    # list from beta must not include the alpha entity (multi-record namespace scoping survives)
     entities_beta = khive_session.verb("list", {
         "kind": "entity",
         "entity_kind": "concept",
@@ -63,10 +77,10 @@ def test_read_isolation_between_namespaces(
     })
     ids_beta = [e["id"] for e in entities_beta]
     assert full_id not in ids_beta, (
-        f"AlphaEntity appeared in beta namespace list: {ids_beta}"
+        f"AlphaEntity must not appear in beta namespace list (multi-record scoping): {ids_beta}"
     )
 
-    # search from beta must not find the alpha entity
+    # search from beta must not find the alpha entity (multi-record namespace scoping survives)
     hits_beta = khive_session.verb("search", {
         "kind": "entity",
         "query": "AlphaEntity",
@@ -74,11 +88,12 @@ def test_read_isolation_between_namespaces(
     })
     hit_ids_beta = [h.get("id", h.get("entity_id", "")) for h in hits_beta]
     assert full_id not in hit_ids_beta, (
-        f"AlphaEntity appeared in beta namespace search: {hit_ids_beta}"
+        f"AlphaEntity must not appear in beta namespace search (multi-record scoping): "
+        f"{hit_ids_beta}"
     )
 
     # Per P-H2 (ADR-045): get returns flat object with granular kind — no {data: ...} wrapper.
-    # get from alpha must succeed
+    # get from alpha: control path — same namespace as creator, must succeed.
     fetched = khive_session.verb("get", {"id": full_id, "namespace": ns_alpha})
     assert fetched.get("kind") == "concept", (
         f"get from alpha must return kind=concept, got: {fetched}"
@@ -87,7 +102,9 @@ def test_read_isolation_between_namespaces(
         f"Entity name mismatch: {fetched}"
     )
 
-    # 8-char prefix from beta must not resolve to the alpha entity
+    # 8-char prefix get from beta: prefix expansion is namespace-scoped (distinct from full-UUID
+    # by-ID path). ADR-007 Rule 2 covers "by UUID" only; prefix resolution expands via a
+    # namespace-scoped query and correctly returns not-found for a cross-namespace prefix.
     prefix8 = full_id[:8]
     envelope_prefix = khive_session.request_batch([{
         "tool": "get",
@@ -95,7 +112,8 @@ def test_read_isolation_between_namespaces(
     }])
     first_prefix = envelope_prefix["results"][0]
     assert not first_prefix.get("ok", False), (
-        "8-char prefix should not resolve alpha entity from beta namespace"
+        "8-char prefix get from beta namespace must not resolve alpha entity: "
+        "prefix expansion is namespace-scoped (not the full-UUID by-ID path of ADR-007 Rule 2)"
     )
     err_prefix = first_prefix.get("error", "").lower()
     assert "not found" in err_prefix or "no record" in err_prefix, (
@@ -103,19 +121,25 @@ def test_read_isolation_between_namespaces(
     )
 
 
-@pytest.mark.adr_003
+@pytest.mark.adr_007
 @pytest.mark.slow
 def test_write_isolation_cross_namespace_link_fails(
     khive_session: KhiveMcpSession,
     temp_namespace: str,
     sample_entity,
 ) -> None:
-    """link from beta using alpha entity UUID must fail — write path enforces namespace isolation.
+    """link endpoint resolution is namespace-scoped — cross-namespace links are rejected.
 
-    ADR: ADR-003
-    section: Write path isolation; Cross-namespace access
+    ADR: ADR-007
+    section: Link endpoint resolution; Multi-record namespace scoping (Rule 3)
 
-    Ports the link-write portion of test_namespace_isolation from contract_test.py.
+    link is not a by-ID op: endpoint resolution looks up source and target entities within the
+    caller-supplied namespace. A link that references an entity from a different namespace fails
+    with not-found because the endpoint is invisible to the scoped lookup — consistent with
+    Rule 3 (multi-record namespace scoping) even though the UUID itself is globally unique.
+
+    This test is distinct from the by-ID get contract (Rule 2): link does NOT use WHERE id = ?
+    unconditionally; it uses a namespace-scoped entity fetch for endpoint validation.
     """
     ns_alpha = f"{temp_namespace}_alpha"
     ns_beta = f"{temp_namespace}_beta"


### PR DESCRIPTION
## What

Aligns `tests/khive-contract/tests/test_namespace_isolation.py` with the ratified namespace
contract. The module was anchored to ADR-003 and asserted that a cross-namespace by-ID `get`
returns not-found — the **removed v1 behavior**. ADR-007 Rev 6 Rule 2 (SHIPPED via PR-A1,
commit `2607e263`) makes `get`/`update`/`delete`/`merge` resolve by UUID with `WHERE id = ?`
only, with no namespace equality check at any layer.

## Changes (test-only — zero runtime change)

- **Full-UUID `get(id, namespace=beta)`** for an entity created in alpha: assertion **flipped**
  to expect success (returns `kind=concept`, `name=AlphaEntity`) — verifies Rule 2 is active.
- **8-char prefix `get` from beta**: unchanged (still not-found). Prefix expansion is a
  namespace-scoped scan, distinct from the full-UUID by-ID path; Rule 2 covers "by UUID" only.
- **`list(beta)` / `search(beta)`**: unchanged (alpha entity absent) — multi-record namespace
  scoping (Rule 3) survives.
- **`test_write_isolation_cross_namespace_link_fails`**: unchanged (still passes). Link endpoint
  resolution is namespace-scoped, not a by-ID op.
- Re-anchored docstrings ADR-003 → ADR-007 Rev 6; markers `adr_003` → `adr_007` (both already
  registered under `--strict-markers`).

## Sibling sweep

Grepped the full `tests/khive-contract/` suite for other stale cross-namespace by-ID isolation
assertions. The `not found` asserts in `test_adr_002_edge_ontology.py` and `test_adr_014_curation.py`
concern genuinely deleted/merged records within one namespace, not cross-namespace by-ID ops.
None found.

## Verification

Full suite: **93 passed, 2 xfailed** (the xfails are pre-existing `golden/`/`baselines/` stubs,
unrelated).

Closes #262.
