### PR TITLE
docs: correct edge-relation count (17/9) + ADR-021 memory verb list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ No Neo4j. No SPARQL endpoint to deploy. SQLite on disk, MCP over stdio, `cargo t
 
 ## What you get
 
-| Capability                  | How                                                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **67 verbs, 7 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge — all load by default                                                  |
-| **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                            |
-| **Typed edges**             | 15 closed relations in 8 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation) |
-| **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                      |
-| **Hybrid retrieval**        | FTS5 + vector RRF with embedding rerank; shipped BM25, HNSW, Vamana, and fusion crates for pack-specific retrieval paths |
-| **Graph traversal**         | BFS with depth/direction/relation filters, bidirectional shortest path                                                   |
-| **GQL + SPARQL queries**    | Parse to SQL, run against the same SQLite backend                                                                        |
-| **Salience-weighted notes** | Notes carry salience scores; search ranks by semantic relevance × salience                                               |
-| **Cross-substrate links**   | Notes annotate entities (and vice versa) via the same edge system                                                        |
-| **Soft delete + supersede** | History-preserving: old records stay, newer ones supersede via graph edges                                               |
-| **Namespace attribution**   | Every record stamped with a namespace; one shared store in OSS, tenant isolation enforced at the Gate in cloud           |
+| Capability                  | How                                                                                                                                 |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **67 verbs, 7 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge — all load by default                                                             |
+| **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                       |
+| **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic) |
+| **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                 |
+| **Hybrid retrieval**        | FTS5 + vector RRF with embedding rerank; shipped BM25, HNSW, Vamana, and fusion crates for pack-specific retrieval paths            |
+| **Graph traversal**         | BFS with depth/direction/relation filters, bidirectional shortest path                                                              |
+| **GQL + SPARQL queries**    | Parse to SQL, run against the same SQLite backend                                                                                   |
+| **Salience-weighted notes** | Notes carry salience scores; search ranks by semantic relevance × salience                                                          |
+| **Cross-substrate links**   | Notes annotate entities (and vice versa) via the same edge system                                                                   |
+| **Soft delete + supersede** | History-preserving: old records stay, newer ones supersede via graph edges                                                          |
+| **Namespace attribution**   | Every record stamped with a namespace; one shared store in OSS, tenant isolation enforced at the Gate in cloud                      |
 
 ---
 

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -196,7 +196,7 @@ The memory pack is a thin pack over the notes substrate. It declares:
 - **Vocabulary**: one note kind (`memory`); no entity kinds; no new edge endpoint rules
   (the existing `annotates` rule from the kg pack accepts any note→any-substrate target,
   which covers `memory→entity` and `memory→note` provenance edges)
-- **Verbs**: `remember`, `recall`
+- **Verbs**: `remember`, `recall`, `feedback`, `prune`, `vacuum`
 - **Storage profile**: hot tier (same as kg/gtd packs); `default_backend="main"`
 - **Requires**: `kg` (memory pack delegates CRUD to kg-pack note handlers)
 


### PR DESCRIPTION
## Summary

- **README.md**: corrects the typed-edges row from "15 closed relations in 8 categories" to "17 closed relations in 9 categories". The two additional relations (`supports`, `refutes`) and the ninth category (epistemic) were added by ADR-055 and have been in the shipped binary since that ADR landed; the README was never updated to match.
- **ADR-021**: corrects the pack composition section's verb list from `remember, recall` to `remember, recall, feedback, prune, vacuum`. The `feedback`, `prune`, and `vacuum` verbs are registered with `Visibility::Verb` in `crates/khive-pack-memory/src/pack.rs` and are callable from `request`; the ADR text was never amended after they shipped.

Both changes correct drift between the public-facing documentation and the shipped binary surface. Source verification: `crates/khive-types/src/edge.rs` declares `EdgeRelation::ALL` as `[Self; 17]` with 9 `EdgeCategory` variants; `crates/khive-pack-memory/src/pack.rs` lists exactly 5 handlers with `Visibility::Verb`.

This PR does not overlap the files touched by PR #206 (AGENTS.md, docs/adr/README.md).

## Test plan

- [ ] Verify README.md line 25 now reads "17 closed relations in 9 categories (..., epistemic)"
- [ ] Verify ADR-021 line 199 now lists `remember`, `recall`, `feedback`, `prune`, `vacuum`
- [ ] CI passes (doc-only, no Rust changes)