### PR TITLE
test(contract): formal-pack EntityOfType + create_many coverage (#260)

### DIFF
--- a/tests/khive-contract/conftest.py
+++ b/tests/khive-contract/conftest.py
@@ -60,6 +60,23 @@ def khive_memory_session() -> Iterator[KhiveMcpSession]:
         yield session
 
 
+@pytest.fixture(scope="session")
+def khive_formal_session() -> Iterator[KhiveMcpSession]:
+    """KG + formal-math ontology MCP session.
+
+    ADR: ADR-017 (pack standard, edge endpoint rules)
+    Spawn config: packs=("kg", "formal"), db=":memory:", no_embed=True, log="error".
+
+    The formal pack (crates/khive-pack-formal) registers 21 EntityOfType edge
+    endpoint rules for six concept subtypes (theorem, definition, structure,
+    instance, axiom, goal) — no verbs, pure ontology extension.
+    """
+    with KhiveMcpSession(
+        packs=("kg", "formal"), db=":memory:", no_embed=True, log="error"
+    ) as session:
+        yield session
+
+
 # ---------------------------------------------------------------------------
 # Function fixtures — unique per test, never shared.
 # ---------------------------------------------------------------------------

--- a/tests/khive-contract/pytest.ini
+++ b/tests/khive-contract/pytest.ini
@@ -27,3 +27,5 @@ markers =
     manifest: package self-audit tests
     xfail_pending_adr: executable spec for accepted ADR behavior not yet implemented
     search_filters: property and tag predicate filters for the search verb (#225, #260)
+    formal_pack: EntityOfType edge endpoint rules in khive-pack-formal (#231, #260)
+    create_many: bulk entity creation semantics for create(items=[...]) (#232, #260)

--- a/tests/khive-contract/tests/test_create_many.py
+++ b/tests/khive-contract/tests/test_create_many.py
@@ -1,0 +1,340 @@
+"""Contract tests: create(items=[...]) bulk entity creation semantics.
+
+ADR: ADR-017 (pack standard)
+section: bulk entity creation; atomic vs non-atomic path; spec-building failure semantics
+Issue: #260 (formal-pack + create_many coverage), surface: PR #232
+
+Source of truth for all asserted semantics:
+  crates/khive-pack-kg/src/handlers/create.rs — handle_create, bulk path lines 68-203
+
+The create verb's bulk path activates when the top-level `items` key is present.
+
+--- atomic=true (default, create.rs lines 97-164) ---
+
+  specs built for all items (one-shot), then self.runtime.create_many(token, specs)
+  called once.  Any runtime failure propagates via `?`, failing the whole batch.
+  Response shape: { attempted, created, skipped: 0, failed: 0 }
+  When verbose=true: adds "entities" array of created entity objects.
+  "entities" key is ABSENT when verbose=false (the default).
+
+--- atomic=false (create.rs lines 165-201) ---
+
+  Each spec calls self.runtime.create_many(token, vec![spec]) individually.
+  Per-item errors are collected; successful items are counted in "created".
+  Response always includes "errors" key (even if the list is empty).
+  Response shape: { attempted, created, skipped: 0, failed, errors: [...] }
+  When verbose=true: adds "entities" array of the successful entity objects.
+
+--- Spec-building errors (create.rs lines 109-148) ---
+
+  The for loop that builds EntityCreateSpec values uses `?` for each item.
+  If any item triggers an error during spec building, the handler returns Err
+  immediately, before reaching the atomic/non-atomic split.
+  Items carrying a note kind (e.g., "observation") hit the `_ =>` branch at
+  create.rs lines 130-136:
+    return Err(RuntimeError::InvalidInput(format!(
+        "items[{idx}]: bulk create only supports entity kinds; got {:?}",
+        entry.kind
+    )))
+  This failure is NOT per-item in the non-atomic sense — it aborts the batch
+  regardless of the atomic flag.
+
+--- Limit guard (create.rs lines 92-95) ---
+
+  More than 1000 items returns Err("bulk create limited to 1000 entries per request").
+
+--- BulkCreateEntry schema (create.rs/params.rs lines 16-26) ---
+
+  #[serde(deny_unknown_fields)]
+  Fields: kind (String), name (String), entity_kind?, entity_type?,
+          description?, properties?, tags?
+  Note: "content" is not a field; passing it would fail serde deserialization.
+  Bulk create supports ENTITY kinds only (kind must resolve to KindSpec::Entity).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khive_contract.client import KhiveOperationError, KhiveMcpSession
+
+VERBS_UNDER_TEST = {"create"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _item(name: str, *, kind: str = "concept", **kwargs: object) -> dict:
+    entry: dict = {"kind": kind, "name": name}
+    entry.update(kwargs)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# atomic=true (default) — basic batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_basic(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """create(items=[...]) with 3 valid concepts returns attempted=3 created=3.
+
+    Source: create.rs lines 151-164 (atomic=true default path, verbose=false).
+    Response must have keys attempted/created/skipped/failed.
+    "entities" key must be ABSENT when verbose is not passed (default false).
+    """
+    ns = temp_namespace
+    items = [
+        _item(f"cm_basic_{i}_{ns[-6:]}", description=f"batch item {i}")
+        for i in range(3)
+    ]
+
+    result = khive_session.verb("create", {"items": items, "namespace": ns})
+
+    assert isinstance(result, dict), f"bulk create must return a dict; got {type(result)}"
+    assert result.get("attempted") == 3, (
+        f"attempted must equal the number of submitted items (3); got {result}"
+    )
+    assert result.get("created") == 3, (
+        f"created must equal 3 when all items succeed; got {result}"
+    )
+    assert result.get("failed") == 0, (
+        f"failed must be 0 when all items succeed; got {result}"
+    )
+    assert result.get("skipped") == 0, (
+        f"skipped must be 0; got {result}"
+    )
+    # verbose=false (default): "entities" key must not be present
+    assert "entities" not in result, (
+        "atomic=true + verbose=false must NOT include 'entities' key; "
+        f"got keys: {list(result.keys())}"
+    )
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_verbose(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """create(items=[...], verbose=true) adds 'entities' array with created objects.
+
+    Source: create.rs lines 160-162 (atomic path, verbose=true branch).
+    The entities array must have length == created count.
+    Each element must carry an "id" field (the new entity's UUID).
+    """
+    ns = temp_namespace
+    n = 3
+    items = [_item(f"cm_verbose_{i}_{ns[-6:]}") for i in range(n)]
+
+    result = khive_session.verb("create", {
+        "items": items,
+        "verbose": True,
+        "namespace": ns,
+    })
+
+    assert result.get("created") == n, (
+        f"created must be {n}; got {result}"
+    )
+    assert "entities" in result, (
+        "atomic=true + verbose=true must include 'entities' key; "
+        f"got keys: {list(result.keys())}"
+    )
+    entities = result["entities"]
+    assert isinstance(entities, list), (
+        f"'entities' must be a list; got {type(entities)}"
+    )
+    assert len(entities) == n, (
+        f"entities list length ({len(entities)}) must equal created count ({n})"
+    )
+    for ent in entities:
+        assert "id" in ent, (
+            f"each entity in 'entities' must have an 'id' field; got {ent}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# atomic=false — non-atomic batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_atomic_false_all_valid(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """create(items=[...], atomic=false) with all valid items: errors key always present.
+
+    Source: create.rs lines 165-201 (non-atomic path).
+    Unlike the atomic path, the non-atomic response always carries "errors" even
+    when it is an empty list.  The atomic path does NOT include "errors" at all.
+    This difference in response shape is the canonical distinction.
+    """
+    ns = temp_namespace
+    n = 3
+    items = [_item(f"cm_nonatomic_{i}_{ns[-6:]}") for i in range(n)]
+
+    result = khive_session.verb("create", {
+        "items": items,
+        "atomic": False,
+        "namespace": ns,
+    })
+
+    assert isinstance(result, dict), f"non-atomic bulk create must return a dict; got {type(result)}"
+    assert result.get("attempted") == n, (
+        f"attempted must equal {n}; got {result}"
+    )
+    assert result.get("created") == n, (
+        f"created must equal {n} when all items succeed; got {result}"
+    )
+    assert result.get("failed") == 0, (
+        f"failed must be 0 when all items succeed; got {result}"
+    )
+    # Non-atomic path: "errors" key is ALWAYS present (create.rs line 189).
+    assert "errors" in result, (
+        "atomic=false response must always include 'errors' key (even when empty); "
+        f"got keys: {list(result.keys())}"
+    )
+    assert result["errors"] == [], (
+        f"errors must be empty when all items succeed; got {result['errors']}"
+    )
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_atomic_true_has_no_errors_key(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """atomic=true (default) response does NOT include 'errors' key.
+
+    Source: create.rs lines 154-163 (atomic response JSON).
+    The serde_json::json! literal for the atomic path does not include 'errors'.
+    This is the shape distinction between atomic and non-atomic responses.
+    """
+    ns = temp_namespace
+    items = [_item(f"cm_noerr_{i}_{ns[-6:]}") for i in range(2)]
+
+    result = khive_session.verb("create", {"items": items, "namespace": ns})
+
+    assert "errors" not in result, (
+        "atomic=true response must NOT include 'errors' key; "
+        f"got keys: {list(result.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec-building failures — affect the whole batch before atomic split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_note_kind_in_items_rejected(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """items containing a note kind triggers a whole-batch failure before atomic/non-atomic split.
+
+    Source: create.rs lines 111-136 (spec-building loop, _ => branch):
+      match &item_kind_spec {
+          KindSpec::Entity { .. } => { ... }
+          _ => {
+              return Err(RuntimeError::InvalidInput(format!(
+                  "items[{idx}]: bulk create only supports entity kinds; got {:?}",
+                  entry.kind
+              )));
+          }
+      }
+    This return Err is inside the for loop before the atomic check at line 151.
+    The error propagates immediately regardless of the atomic flag.
+    Note: "content" is not a BulkCreateEntry field (deny_unknown_fields).
+          Use name= to avoid a serde deserialization error.
+    """
+    ns = temp_namespace
+    items = [
+        _item(f"cm_noterej_concept_{ns[-6:]}"),  # valid entity item
+        {"kind": "observation", "name": f"cm_noterej_note_{ns[-6:]}"},  # note kind
+    ]
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_session.verb("create", {
+            "items": items,
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    # Error from create.rs line 134: "bulk create only supports entity kinds"
+    assert "entity" in error_msg or "bulk" in error_msg or "kind" in error_msg, (
+        "note-kind rejection must mention entity/bulk/kind in the error; "
+        f"got: {exc_info.value.message!r}"
+    )
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_note_kind_rejected_with_atomic_false(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """Note kind in items is rejected even when atomic=false.
+
+    The spec-building loop failure happens before the atomic split
+    (create.rs lines 109-148 vs lines 151/165).  atomic=false does not
+    provide per-item tolerance for spec-building errors — only runtime
+    errors in the non-atomic loop at line 170 are collected per-item.
+    """
+    ns = temp_namespace
+    items = [{"kind": "observation", "name": f"cm_noterej2_{ns[-6:]}"}]
+
+    with pytest.raises(KhiveOperationError):
+        khive_session.verb("create", {
+            "items": items,
+            "atomic": False,
+            "namespace": ns,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Limit guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.create_many
+@pytest.mark.slow
+def test_create_many_limit_exceeded(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """create(items=[...]) with > 1000 items is rejected before any creation.
+
+    Source: create.rs lines 92-95:
+      if attempted > 1000 {
+          return Err(RuntimeError::InvalidInput(
+              "bulk create limited to 1000 entries per request".into(),
+          ));
+      }
+    This guard fires before spec building and before the atomic split.
+    """
+    ns = temp_namespace
+    # 1001 items — one over the 1000-item limit.
+    items = [_item(f"cm_limit_{i}") for i in range(1001)]
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_session.verb("create", {
+            "items": items,
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    assert "1000" in error_msg or "limit" in error_msg or "bulk" in error_msg, (
+        "1001-item batch must be rejected with a limit-exceeded error; "
+        f"got: {exc_info.value.message!r}"
+    )

--- a/tests/khive-contract/tests/test_formal_pack.py
+++ b/tests/khive-contract/tests/test_formal_pack.py
@@ -1,0 +1,348 @@
+"""Contract tests: khive-pack-formal EntityOfType edge endpoint rules.
+
+ADR: ADR-017
+section: EntityOfType edge endpoint rules; formal-math ontology pack; depends_on
+Issue: #260 (formal-pack + create_many coverage), surface: PR #231
+
+Source of truth for all asserted rules:
+  crates/khive-pack-formal/src/vocab.rs — FORMAL_EDGE_RULES (21 entries)
+
+The formal-math pack extends the closed edge ontology with 21 EntityOfType
+rules for six concept subtypes registered in BUILTIN_DEFS:
+  theorem, definition, structure, instance, axiom, goal
+  (crates/khive-pack-kg/src/entity_type_registry.rs, lines ~90-125)
+
+All six subtypes use kind="concept" at the endpoint level (vocab.rs, macro
+formal_ep! line 14-21).  Relations covered by the pack:
+  depends_on  — 14 rules (vocab.rs lines 29-98)
+  instance_of — 1 rule  (vocab.rs lines 100-104)
+  extends     — 2 rules (vocab.rs lines 106-116)
+  variant_of  — 4 rules (vocab.rs lines 118-136)
+
+Why depends_on is the canonical test surface:
+  The base allowlist (crates/khive-runtime/src/operations.rs, function
+  base_entity_rule_allows, lines 266-335) has NO concept->concept entry for
+  depends_on.  Only the formal pack grants these permissions.  In contrast,
+  extends/variant_of/instance_of already have base c->c or *->c entries that
+  permit concept->concept regardless of the pack.
+
+Endpoint validation flow (operations.rs lines 1163-1229):
+  1. pack_rule_allows() — if any pack rule matches, return Ok immediately.
+  2. base_entity_rule_allows() — fallback for kinds without a pack rule.
+  For depends_on + concept->concept: step 1 decides the outcome entirely.
+
+Positive tests: formal pack loaded; legal depends_on type pairs succeed.
+Negative tests (illegal type pair): formal pack loaded; rejected.
+Baseline test: no formal pack; any concept depends_on is rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khive_contract.client import KhiveOperationError, KhiveMcpSession
+
+VERBS_UNDER_TEST = {"create", "link"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_formal_concept(
+    session: KhiveMcpSession,
+    namespace: str,
+    entity_type: str,
+    suffix: str,
+) -> str:
+    """Create a concept entity with the given formal entity_type; return its id."""
+    result = session.verb("create", {
+        "kind": "concept",
+        "name": f"fp_{entity_type}_{suffix}",
+        "entity_type": entity_type,
+        "namespace": namespace,
+    })
+    return result["id"]
+
+
+# ---------------------------------------------------------------------------
+# Positive: legal depends_on pairs (formal pack required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_theorem_to_definition(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on theorem->definition is legal under the formal pack.
+
+    Source: vocab.rs lines 35-39 — FORMAL_EDGE_RULES entry
+      EdgeEndpointRule { relation: DependsOn, source: formal_ep!("theorem"),
+                         target: formal_ep!("definition") }
+
+    Without the formal pack this link would be rejected because the base
+    allowlist has no concept->concept entry for depends_on.
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "theorem", "thm_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "definition", "def_tgt")
+
+    result = khive_formal_session.verb("link", {
+        "source_id": src_id,
+        "target_id": tgt_id,
+        "relation": "depends_on",
+        "namespace": ns,
+    })
+
+    assert result is not None, (
+        "link(theorem->definition, depends_on) must succeed with formal pack loaded; "
+        f"got None"
+    )
+    assert result.get("source_id") == src_id or result.get("id") is not None, (
+        f"link result must reference the created edge; got {result}"
+    )
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_goal_to_axiom(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on goal->axiom is legal under the formal pack.
+
+    Source: vocab.rs lines 89-98 — FORMAL_EDGE_RULES entry
+      EdgeEndpointRule { relation: DependsOn, source: formal_ep!("goal"),
+                         target: formal_ep!("axiom") }
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "goal", "goal_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "axiom", "axm_tgt")
+
+    result = khive_formal_session.verb("link", {
+        "source_id": src_id,
+        "target_id": tgt_id,
+        "relation": "depends_on",
+        "namespace": ns,
+    })
+
+    assert result is not None, (
+        "link(goal->axiom, depends_on) must succeed with formal pack loaded"
+    )
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_instance_to_structure(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on instance->structure is legal under the formal pack.
+
+    Source: vocab.rs lines 69-72 — FORMAL_EDGE_RULES entry
+      EdgeEndpointRule { relation: DependsOn, source: formal_ep!("instance"),
+                         target: formal_ep!("structure") }
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "instance", "inst_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "structure", "str_tgt")
+
+    result = khive_formal_session.verb("link", {
+        "source_id": src_id,
+        "target_id": tgt_id,
+        "relation": "depends_on",
+        "namespace": ns,
+    })
+
+    assert result is not None, (
+        "link(instance->structure, depends_on) must succeed with formal pack loaded"
+    )
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_definition_to_theorem(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on definition->theorem is legal under the formal pack.
+
+    Source: vocab.rs lines 58-62 — FORMAL_EDGE_RULES entry
+      EdgeEndpointRule { relation: DependsOn, source: formal_ep!("definition"),
+                         target: formal_ep!("theorem") }
+
+    Confirms bidirectional reachability in the theorem<->definition pair.
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "definition", "def_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "theorem", "thm_tgt")
+
+    result = khive_formal_session.verb("link", {
+        "source_id": src_id,
+        "target_id": tgt_id,
+        "relation": "depends_on",
+        "namespace": ns,
+    })
+
+    assert result is not None, (
+        "link(definition->theorem, depends_on) must succeed with formal pack loaded"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative: illegal depends_on type pairs (formal pack loaded; still rejected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_axiom_as_source_rejected(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on axiom->theorem is rejected even with the formal pack loaded.
+
+    axiom does NOT appear as a depends_on source in FORMAL_EDGE_RULES.
+    vocab.rs search: no entry with source=formal_ep!("axiom") under DependsOn.
+    The base allowlist also has no concept->concept depends_on entry
+    (operations.rs base_entity_rule_allows lines 298-304 — project/service/artifact only).
+    Both checks fail, so the link must be rejected.
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "axiom", "axm_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "theorem", "thm_tgt")
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_formal_session.verb("link", {
+            "source_id": src_id,
+            "target_id": tgt_id,
+            "relation": "depends_on",
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    assert "valid relations" in error_msg or "invalid relation" in error_msg or "allowlist" in error_msg, (
+        "error must indicate a relation/endpoint rule violation "
+        "(expected 'Valid relations:' or 'Invalid relation' or 'allowlist'); "
+        f"got: {exc_info.value.message!r}"
+    )
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_structure_as_source_rejected(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on structure->definition is rejected even with the formal pack loaded.
+
+    structure does NOT appear as a depends_on source in FORMAL_EDGE_RULES.
+    vocab.rs search: no entry with source=formal_ep!("structure") under DependsOn.
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "structure", "str_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "definition", "def_tgt")
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_formal_session.verb("link", {
+            "source_id": src_id,
+            "target_id": tgt_id,
+            "relation": "depends_on",
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    assert "valid relations" in error_msg or "invalid relation" in error_msg or "allowlist" in error_msg, (
+        "error must indicate a relation/endpoint rule violation "
+        "(expected 'Valid relations:' or 'Invalid relation' or 'allowlist'); "
+        f"got: {exc_info.value.message!r}"
+    )
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_formal_depends_on_theorem_to_instance_rejected(
+    khive_formal_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """depends_on theorem->instance is rejected: instance is not a valid depends_on target for theorem.
+
+    vocab.rs lines 29-48 list the four legal theorem depends_on targets:
+      formal_ep!("theorem"), formal_ep!("definition"),
+      formal_ep!("structure"), formal_ep!("axiom")
+    formal_ep!("instance") is absent from that list.
+    """
+    ns = temp_namespace
+    src_id = _make_formal_concept(khive_formal_session, ns, "theorem", "thm_src")
+    tgt_id = _make_formal_concept(khive_formal_session, ns, "instance", "inst_tgt")
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_formal_session.verb("link", {
+            "source_id": src_id,
+            "target_id": tgt_id,
+            "relation": "depends_on",
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    assert "valid relations" in error_msg or "invalid relation" in error_msg or "allowlist" in error_msg, (
+        "error must indicate a relation/endpoint rule violation "
+        "(expected 'Valid relations:' or 'Invalid relation' or 'allowlist'); "
+        f"got: {exc_info.value.message!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Baseline: formal pack is required — no pack means no concept depends_on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.formal_pack
+@pytest.mark.slow
+def test_no_formal_pack_concept_depends_on_rejected(
+    khive_session: KhiveMcpSession,
+    temp_namespace: str,
+) -> None:
+    """Without the formal pack, all concept->concept depends_on links are rejected.
+
+    This test uses khive_session (packs=("kg",) only).  The base allowlist has
+    no concept->concept entry for depends_on (operations.rs lines 298-304).
+    Without formal pack rules, pack_rule_allows returns false, and the link falls
+    through to base_entity_rule_allows which also returns false.
+
+    This proves the formal pack is not vacuous: it is the sole source of
+    permission for theorem->definition depends_on.
+    """
+    ns = temp_namespace
+
+    # Create concept entities using the KG-only session (entity_type still accepted
+    # because it is registered in BUILTIN_DEFS, not in formal pack).
+    src_result = khive_session.verb("create", {
+        "kind": "concept",
+        "name": f"fp_baseline_theorem_{ns[-6:]}",
+        "entity_type": "theorem",
+        "namespace": ns,
+    })
+    tgt_result = khive_session.verb("create", {
+        "kind": "concept",
+        "name": f"fp_baseline_definition_{ns[-6:]}",
+        "entity_type": "definition",
+        "namespace": ns,
+    })
+
+    with pytest.raises(KhiveOperationError) as exc_info:
+        khive_session.verb("link", {
+            "source_id": src_result["id"],
+            "target_id": tgt_result["id"],
+            "relation": "depends_on",
+            "namespace": ns,
+        })
+
+    error_msg = exc_info.value.message.lower()
+    assert "valid relations" in error_msg or "invalid relation" in error_msg or "allowlist" in error_msg, (
+        "without formal pack, concept depends_on must fail with an endpoint rule error; "
+        f"got: {exc_info.value.message!r}"
+    )

--- a/tests/khive-contract/tests/test_search_filters.py
+++ b/tests/khive-contract/tests/test_search_filters.py
@@ -28,9 +28,9 @@ Note on note tags: entity tags live in the top-level `tags` column; note
 tags live in `properties["tags"]` (notes have no dedicated tag column).
 The `search(tags=[...])` filter checks the correct field for each substrate.
 
-Out of scope (gated on unmerged work — do NOT add here):
-  - create_many bulk verb (#232, unmerged PR)
-  - khive-pack-formal / EntityOfType (#231, unmerged PR in codex review)
+Out of scope for this file (covered elsewhere in the suite):
+  - create_many bulk verb (#232) — see tests/test_create_many.py
+  - khive-pack-formal / EntityOfType (#231) — see tests/test_formal_pack.py
   - True N-physical-backend fan-out routing (storage-pluggability unmerged)
 """
 


### PR DESCRIPTION
## Surfaces covered

**PR #231 — khive-pack-formal EntityOfType edge endpoint rules**
Reads `crates/khive-pack-formal/src/vocab.rs` and encodes the exact FORMAL_EDGE_RULES (21 rules for 6 concept subtypes).

**PR #232 — create_many batch semantics**
Grounded in `crates/khive-pack-kg/src/handlers/create.rs` lines 68-203.

## New tests: 15 total (103 baseline → 118 passed)

### test_formal_pack.py (8 tests, marker: `formal_pack`)

**Positive (4)** — legal depends_on pairs; formal pack is the sole source of permission since `base_entity_rule_allows` has no concept→concept entry for depends_on:
- theorem→definition (vocab.rs rule 1)
- goal→axiom (vocab.rs rule 14)
- instance→structure (vocab.rs rule 9)
- definition→theorem (vocab.rs rule 5)

**Negative with formal pack (3)** — not in FORMAL_EDGE_RULES, so rejected:
- axiom→theorem (axiom has no depends_on outgoing rules)
- structure→definition (structure has no depends_on outgoing rules)
- theorem→instance (instance is not a legal target for theorem depends_on)

**Baseline (1)** — concept→concept depends_on rejected without formal pack (uses `khive_session`, not `khive_formal_session`). Confirms the formal pack is the sole source of the permission.

Error assertion grounded in `crates/khive-pack-kg/src/handlers/common.rs:481-483` (`enrich_allowlist_error`): checks for `"invalid relation"` or `"valid relations"` in the error message.

### test_create_many.py (7 tests, marker: `create_many`)

| Test | create.rs anchor | What is asserted |
|------|-----------------|-----------------|
| basic | lines 151-164 | attempted=3 created=3 skipped=0 failed=0; no `"entities"` key when verbose omitted |
| verbose | lines 160-162 | `"entities"` array present with len=3, each entry has `"id"` |
| atomic_false_all_valid | lines 165-201 | `"errors"` key always present in non-atomic response (even when empty) |
| atomic_true_has_no_errors_key | lines 154-163 | `"errors"` key absent from atomic response |
| note_kind_in_items_rejected | lines 109-136 (`?` propagation) | note kind aborts whole batch via `return Err(...)` before atomic split |
| note_kind_rejected_with_atomic_false | same | atomic=false provides no per-item tolerance for spec-building errors |
| limit_exceeded | lines 92-95 | 1001 items → rejected before spec building |

## Support changes

- `conftest.py`: `khive_formal_session` fixture (packs=`["kg","formal"]`, session-scoped)
- `pytest.ini`: registered `formal_pack` and `create_many` markers (`--strict-markers` is ON)
- `test_search_filters.py`: updated stale "out of scope" comment to point at the new files

## Closes / partially closes

Closes #231 contract gap, closes #232 contract gap, partial #260.