### PR TITLE
test: harden taxonomy + smoke pack-section gates

### DIFF
--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3619,7 +3619,8 @@ allowed_outbound_namespaces = ["lambda:khive", "lambda:atlas"]
 //     tenants when actor_id IS configured.
 //   - #224 (gate actor identity gap): the GateRequest.actor must carry the
 //     configured actor identity, not ActorRef::anonymous(), so a cloud TenantGate
-//     can act on it. This assertion FAILS today — see the #[ignore] test below.
+//     can act on it. Fixed in PR #271, which removed the #[ignore] attribute.
+//     The test now passes unconditionally.
 
 /// When two registries share the same storage backend but carry distinct
 /// configured actor identities, `comm.inbox` must isolate each actor's view:

--- a/tests/contract_test.py
+++ b/tests/contract_test.py
@@ -600,7 +600,7 @@ def test_closed_taxonomy_errors(proc: subprocess.Popen) -> None:
     # ---- Invalid entity_kind ----
     err_ek = _expect_rpc_error(proc, "create", {
         "kind": "entity",
-        "entity_kind": "galaxy",   # not in the 6-element closed set
+        "entity_kind": "galaxy",   # not in the 9-element closed set
         "name": "StarSystem",
     })
     assert err_ek, "Expected non-empty error for invalid entity_kind"
@@ -608,7 +608,8 @@ def test_closed_taxonomy_errors(proc: subprocess.Popen) -> None:
         f"Error should name the offending kind 'galaxy': {err_ek!r}"
     )
     # The full closed set must be listed so agents can self-correct.
-    for kind in ("concept", "document", "project", "dataset", "person", "org"):
+    for kind in ("concept", "document", "project", "dataset", "person", "org",
+                 "artifact", "service", "resource"):
         assert kind in err_ek, (
             f"Valid entity_kind '{kind}' missing from error message: {err_ek!r}"
         )

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -894,29 +894,41 @@ def epistemic_smoke():
 
 
 if __name__ == "__main__":
+    failed_sections: list[str] = []
+
     code = main()
-    if code == 0 and os.environ.get("KHIVE_SMOKE_GTD", "1") != "0":
+    if code != 0:
+        failed_sections.append("kg")
+
+    if os.environ.get("KHIVE_SMOKE_GTD", "1") != "0":
         try:
             gtd_smoke()
         except Exception as e:
             print(f"  [gtd FAIL] {e}")
-            code = 2
-    if code == 0 and os.environ.get("KHIVE_SMOKE_MEMORY", "1") != "0":
+            failed_sections.append("gtd")
+
+    if os.environ.get("KHIVE_SMOKE_MEMORY", "1") != "0":
         try:
             memory_smoke()
         except Exception as e:
             print(f"  [memory FAIL] {e}")
-            code = 3
-    if code == 0 and os.environ.get("KHIVE_SMOKE_FORMAL", "1") != "0":
+            failed_sections.append("memory")
+
+    if os.environ.get("KHIVE_SMOKE_FORMAL", "1") != "0":
         try:
             formal_smoke()
         except Exception as e:
             print(f"  [formal FAIL] {e}")
-            code = 5
-    if code == 0 and os.environ.get("KHIVE_SMOKE_EPISTEMIC", "1") != "0":
+            failed_sections.append("formal")
+
+    if os.environ.get("KHIVE_SMOKE_EPISTEMIC", "1") != "0":
         try:
             epistemic_smoke()
         except Exception as e:
             print(f"  [epistemic FAIL] {e}")
-            code = 4
-    sys.exit(code)
+            failed_sections.append("epistemic")
+
+    if failed_sections:
+        print(f"\nFAILED sections: {', '.join(failed_sections)}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
## Summary

- **A1 — Full entity-kind taxonomy in contract test**: `test_closed_taxonomy_errors` in `tests/contract_test.py` iterated only 6 of the 9 closed entity kinds when asserting that invalid-kind error messages list all valid options. Added the missing three (`artifact`, `service`, `resource`) and updated the inline comment from \"6-element\" to \"9-element\". The error message must list all 9 so callers can self-correct without consulting external docs.

- **A2 — Unconditional smoke section execution**: The `__main__` block in `tests/smoke_test.py` used a short-circuit chain (`if code == 0 and ...`) that caused the gtd, memory, formal, and epistemic sections to silently skip when an earlier section failed. A simultaneous regression in two sections would appear as a single failure, hiding the full blast radius. Refactored to run every enabled section unconditionally, collect section names into a `failed_sections` list, and report them all before exiting nonzero.

- **A3 — Stale ignore-marker comment in comm integration tests**: A block comment in `crates/khive-pack-comm/tests/integration.rs` (the Cluster-2 isolation section header) still described the `#224` gate-actor test as failing and marked with `#[ignore]`. That attribute was removed and the test passes. Updated the comment to reflect the current state.

## Test plan

- [ ] `uv run python -m py_compile tests/contract_test.py tests/smoke_test.py` passes (verified locally before push)
- [ ] CI ubuntu/macos legs build kkernel and run the contract + smoke test suites against a live binary
- [ ] `cargo clippy --workspace` passes (pre-commit hook verified)