### PR TITLE
refactor(pack-kg,runtime): fix misleading dead_code allow + dedupe EdgeRow

### DIFF
--- a/crates/khive-pack-kg/src/vocab.rs
+++ b/crates/khive-pack-kg/src/vocab.rs
@@ -44,7 +44,6 @@ impl EntityKind {
         "resource",
     ];
 
-    #[allow(dead_code)]
     pub(crate) const fn name(self) -> &'static str {
         match self {
             Self::Concept => "concept",

--- a/crates/khive-pack-kg/src/vocab.rs
+++ b/crates/khive-pack-kg/src/vocab.rs
@@ -23,7 +23,7 @@ pub(crate) enum EntityKind {
 }
 
 impl EntityKind {
-    // REASON: ALL and NAMES are used exclusively in the test module below.
+    // REASON: ALL is used exclusively in the test module below.
     // Suppressed here because pub(crate) items in non-test code still trigger
     // dead_code if they have no callers outside cfg(test).
     #[allow(dead_code)]
@@ -39,7 +39,6 @@ impl EntityKind {
         Self::Resource,
     ];
 
-    #[allow(dead_code)]
     pub(crate) const NAMES: &'static [&'static str] = &[
         "concept", "document", "dataset", "project", "person", "org", "artifact", "service",
         "resource",

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -163,6 +163,27 @@ impl From<EdgeListFilter> for EdgeFilter {
 }
 
 // ---------------------------------------------------------------------------
+// Private types
+// ---------------------------------------------------------------------------
+
+// REASON: EdgeRow fields are populated via rusqlite row mapping. The struct is fully
+// constructed even when not all fields are read back after construction. The complete
+// field mapping guards against column-order bugs when the schema changes.
+#[allow(dead_code)]
+struct EdgeRow {
+    id: Uuid,
+    source_id: Uuid,
+    target_id: Uuid,
+    relation: String,
+    weight: f64,
+    created_at: i64,
+    updated_at: i64,
+    deleted_at: Option<i64>,
+    target_backend: Option<String>,
+    metadata: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
 
@@ -866,23 +887,6 @@ fn merge_entity_sql(
     let from_entity = read_merge_entity(conn, from_id, &namespace)?;
 
     // --- Collect edges incident to from_id ---
-    // REASON: EdgeRow fields are populated via rusqlite row mapping; the struct is fully
-    // constructed even though not all fields are read back after construction — the
-    // complete mapping guards against column-order bugs when the schema changes.
-    #[allow(dead_code)]
-    struct EdgeRow {
-        id: Uuid,
-        source_id: Uuid,
-        target_id: Uuid,
-        relation: String,
-        weight: f64,
-        created_at: i64,
-        updated_at: i64,
-        deleted_at: Option<i64>,
-        target_backend: Option<String>,
-        metadata: Option<String>,
-    }
-
     let parse_id =
         |s: String| Uuid::parse_str(&s).map_err(|e| SqliteError::InvalidData(e.to_string()));
 
@@ -1318,20 +1322,6 @@ fn merge_note_sql(
     let from_str = from_id.to_string();
 
     // Collect edges incident to from_id.
-    // REASON: same as merge_entity_sql — full field mapping prevents column-order bugs.
-    #[allow(dead_code)]
-    struct EdgeRow {
-        id: Uuid,
-        source_id: Uuid,
-        target_id: Uuid,
-        relation: String,
-        weight: f64,
-        created_at: i64,
-        updated_at: i64,
-        deleted_at: Option<i64>,
-        target_backend: Option<String>,
-        metadata: Option<String>,
-    }
     let parse_id =
         |s: String| Uuid::parse_str(&s).map_err(|e| SqliteError::InvalidData(e.to_string()));
 


### PR DESCRIPTION
## Changes

### khive-pack-kg: correct dead_code allow on `EntityKind::NAMES`

`EntityKind::NAMES` was annotated with `#[allow(dead_code)]` and a reason
comment claiming it is test-only. It is not: `NAMES` is passed to
`UnknownVariant::new` inside the production `FromStr` impl, which runs on
every parse of an entity kind string. The allow and the incorrect portion
of the reason comment have been removed. `ALL` retains its allow (it is
genuinely used only in tests).

### khive-runtime: hoist duplicate `EdgeRow` to module level

`EdgeRow` was defined with identical fields inside two separate function
scopes: `merge_entity_sql` and `merge_note_sql`. Both definitions had the
same 10 fields (`id`, `source_id`, `target_id`, `relation`, `weight`,
`created_at`, `updated_at`, `deleted_at`, `target_backend`, `metadata`),
the same types, and no derives. One definition is now at module level; the
two local copies are removed.

## Verification

- `cargo check -p khive-pack-kg -p khive-runtime`: rc=0
- `cargo clippy -p khive-pack-kg -p khive-runtime --all-targets -- -D warnings`: rc=0
- `cargo test -p khive-pack-kg -p khive-runtime`: rc=0 (59 tests passed)
- `cargo fmt --all -- --check`: rc=0