### PR TITLE
chore(perf,packaging): fix measure.sh binary, npm metadata, homepage links, bench-runs dir

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -47,7 +47,7 @@ edition = "2021"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/ohdearquant/khive"
-homepage = "https://github.com/ohdearquant"
+homepage = "https://github.com/ohdearquant/khive"
 keywords = ["knowledge-graph", "semantic-search", "mcp", "ai-tools", "graph-database"]
 categories = ["database", "command-line-utilities"]
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,19 +1,18 @@
 {
   "name": "khive",
-  "version": "0.2.8",
-  "description": "Research knowledge graph CLI — git-native KG versioning",
+  "version": "0.2.11",
+  "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ohdearquant/khive"
   },
-  "homepage": "https://github.com/ohdearquant",
+  "homepage": "https://github.com/ohdearquant/khive",
   "keywords": [
     "knowledge-graph",
     "research",
-    "git",
-    "ndjson",
-    "cli"
+    "mcp",
+    "research-agents"
   ],
   "bin": {
     "khive": "bin/khive",
@@ -36,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.2.8",
-    "@khive-ai/kernel-darwin-x64": "0.2.8",
-    "@khive-ai/kernel-linux-x64-gnu": "0.2.8",
-    "@khive-ai/kernel-linux-x64-musl": "0.2.8",
-    "@khive-ai/kernel-linux-arm64": "0.2.8",
-    "@khive-ai/kernel-win32-x64": "0.2.8"
+    "@khive-ai/kernel-darwin-arm64": "0.2.11",
+    "@khive-ai/kernel-darwin-x64": "0.2.11",
+    "@khive-ai/kernel-linux-x64-gnu": "0.2.11",
+    "@khive-ai/kernel-linux-x64-musl": "0.2.11",
+    "@khive-ai/kernel-linux-arm64": "0.2.11",
+    "@khive-ai/kernel-win32-x64": "0.2.11"
   }
 }

--- a/perf/README.md
+++ b/perf/README.md
@@ -124,6 +124,22 @@ not a competitive benchmark. PR #153 explicitly notes: "Do not lead with 341x."
 
 ---
 
+## Obtaining the SIFT-1M dataset
+
+The bench harness reads `sift_base.fvecs` and `sift_query.fvecs` from `$SIFT_DIR`.
+The dataset is published by IRISA at `http://corpus-texmex.irisa.fr/`.
+
+```bash
+mkdir -p "$SIFT_DIR"
+wget http://corpus-texmex.irisa.fr/sift.tar.gz -O /tmp/sift.tar.gz
+tar -xzf /tmp/sift.tar.gz -C "$SIFT_DIR" --strip-components=1
+```
+
+The archive is approximately 160 MB. After extraction, `$SIFT_DIR` should contain
+`sift_base.fvecs` (1 000 000 vectors) and `sift_query.fvecs` (10 000 query vectors).
+
+---
+
 ## Reproducing the banked run
 
 ```bash

--- a/scripts/perf/measure.sh
+++ b/scripts/perf/measure.sh
@@ -33,7 +33,7 @@ WORKTREE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CRATES_DIR="${KHIVE_CRATES_DIR:-$WORKTREE_ROOT/crates}"
 PERF_DIR="${KHIVE_PERF_DIR:-/tmp/khive-perf}"
 OUT_DIR="${OUT_DIR:-$PERF_DIR}"
-BINARY="$CRATES_DIR/target/release/khive-mcp"
+BINARY="$CRATES_DIR/target/release/kkernel"
 SKIP_BUILD=0
 
 for arg in "$@"; do
@@ -109,7 +109,7 @@ db_path = sys.argv[2]
 extra = sys.argv[3:]
 
 env = {**os.environ, "KHIVE_NO_DAEMON": "1"}
-args = [binary, "--db", db_path, "--no-embed", "--log", "error"] + extra
+args = [binary, "mcp", "--db", db_path, "--no-embed", "--log", "error"] + extra
 
 start = time.perf_counter()
 proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,


### PR DESCRIPTION
## What this changes

Four independent packaging and harness fixes:

**perf harness binary name (`scripts/perf/measure.sh`)**
The script referenced `khive-mcp` as the target binary. `crates/khive-mcp` is a library crate
with no `main.rs`; the actual binary is `kkernel` (declared in `crates/kkernel/Cargo.toml`).
Updated `BINARY` on line 36 and inserted the required `mcp` subcommand into the cold-start
probe arg list (`kkernel mcp --db ...`).

**Missing `perf/bench-runs/` directory**
`perf/README.md` lists `bench-runs/` in its directory contents table but the directory did
not exist in the repo. Added `perf/bench-runs/.gitkeep` so the claim and the tree agree.

**SIFT-1M download instructions (`perf/README.md`)**
The reproducing section set `SIFT_DIR` without explaining where to obtain the dataset.
Added a short download stanza (wget + tar) pointing at the IRISA corpus site before the
reproducing section.

**Homepage links and npm metadata**
`crates/Cargo.toml` `[workspace.package]` and `npm/package.json` both had
`homepage = "https://github.com/ohdearquant"` (profile page). Changed both to
`https://github.com/ohdearquant/khive` (the repo).

`npm/package.json` version and all six `optionalDependencies` entries were pinned at
`0.2.8` while the Cargo workspace is at `0.2.11`. Bumped all to `0.2.11`.
Updated `description` and `keywords` to reflect the actual product (MCP stdio runtime,
not a git CLI). `npm publish` and `cargo publish` are intentionally not performed here;
that remains an owner-gated step.

## Gates

- `bash -n scripts/perf/measure.sh` RC=0
- `python3 -c "import json,sys; json.load(open('npm/package.json'))"` RC=0
- `cargo metadata --no-deps --format-version 1` RC=0
- `perf/bench-runs/.gitkeep` present and staged