### PR TITLE
test(ci): run brain/comm/knowledge/schedule smoke suites in CI

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -50,6 +50,10 @@ echo "=== Deno Tests ==="
 
 echo "=== Smoke Test ==="
 python3 "$SCRIPT_DIR/../tests/smoke_test.py"
+python3 "$SCRIPT_DIR/../tests/smoke_brain.py"
+python3 "$SCRIPT_DIR/../tests/smoke_comm.py"
+python3 "$SCRIPT_DIR/../tests/smoke_knowledge.py"
+python3 "$SCRIPT_DIR/../tests/smoke_schedule.py"
 
 echo "=== Contract Suite (khive-contract) ==="
 (cd "$SCRIPT_DIR/../tests/khive-contract" && uv run pytest -q)

--- a/tests/smoke_comm.py
+++ b/tests/smoke_comm.py
@@ -285,17 +285,24 @@ def test_read_outbound_rejection(proc):
     print("  [ok] read outbound rejection: error mentions outbound/direction")
 
 
-def test_cross_namespace_denial(proc):
-    """send with to='other-ns' → error containing 'cross' or 'namespace'."""
-    err = call_verb_expect_error(proc, "comm.send", {
+def test_actor_addressed_send(proc):
+    """send with to='other-ns' succeeds as actor-addressed delivery (ADR-057).
+
+    ADR-057 reinterpreted the `to` field as an actor label within the caller's
+    namespace. Cross-namespace denial was removed: both copies land in the
+    caller's namespace and the actor label is stored in `to_actor`. Sends to
+    any non-empty actor label must succeed.
+    """
+    result = call_verb(proc, "comm.send", {
         "to": "other-ns",
-        "content": "should be denied",
+        "content": "actor-addressed message",
     })
-    assert err, "expected a non-empty error message"
-    assert "cross" in err.lower() or "namespace" in err.lower(), (
-        f"error must mention 'cross' or 'namespace': {err!r}"
+    assert result.get("id"), f"send must return id: {result}"
+    assert result.get("full_id"), f"send must return full_id: {result}"
+    assert result.get("to") == "other-ns", (
+        f"to field must preserve the actor label: {result}"
     )
-    print("  [ok] cross-namespace denial: error mentions cross/namespace")
+    print("  [ok] actor-addressed send: to='other-ns' accepted (ADR-057)")
 
 
 def test_inbox_status_filter(proc):
@@ -417,7 +424,7 @@ def main():
         test_empty_content_rejection,
         test_empty_to_rejection,
         test_read_outbound_rejection,
-        test_cross_namespace_denial,
+        test_actor_addressed_send,
         test_inbox_status_filter,
         test_reply_to_non_message_note,
         test_thread_nonexistent_id,

--- a/tests/smoke_knowledge.py
+++ b/tests/smoke_knowledge.py
@@ -305,7 +305,7 @@ def test_topic_list_all(proc):
         call_verb(proc, "knowledge.learn", {"name": name})
 
     result = call_verb(proc, "knowledge.topic", {})
-    items = result["items"]
+    items = result["results"]
     assert isinstance(items, list), f"expected list, got: {type(items)}"
     assert len(items) >= 3, f"expected at least 3 concepts, got {len(items)}: {items}"
     total = result["total"]
@@ -320,7 +320,7 @@ def test_topic_domain_filter(proc):
     call_verb(proc, "knowledge.learn", {"name": "KVCache", "domain": "inference"})
 
     result = call_verb(proc, "knowledge.topic", {"domain": "attention"})
-    items = result["items"]
+    items = result["results"]
     names = [i["name"] for i in items]
     assert len(items) == 2, f"expected 2 attention concepts, got {len(items)}: {names}"
     assert "MHA" in names, f"MHA missing: {names}"
@@ -334,7 +334,7 @@ def test_topic_domain_case_insensitive(proc):
     call_verb(proc, "knowledge.learn", {"name": "PagedAttention", "domain": "Attention"})
 
     result = call_verb(proc, "knowledge.topic", {"domain": "ATTENTION"})
-    items = result["items"]
+    items = result["results"]
     names = [i["name"] for i in items]
     assert any("PagedAttention" == n for n in names), (
         f"case-insensitive match must find PagedAttention: {names}"
@@ -354,7 +354,7 @@ def test_topic_with_query_fts(proc):
     })
 
     result = call_verb(proc, "knowledge.topic", {"query": "SpeculativeDecodingXYZ"})
-    items = result["items"]
+    items = result["results"]
     names = [i["name"] for i in items]
     assert any("SpeculativeDecodingXYZ" == n for n in names), (
         f"FTS query must find exact name match: {names}"
@@ -371,7 +371,7 @@ def test_topic_limit(proc):
         call_verb(proc, "knowledge.learn", {"name": f"LimitConcept{i}"})
 
     result = call_verb(proc, "knowledge.topic", {"limit": 2})
-    items = result["items"]
+    items = result["results"]
     total = result["total"]
     assert len(items) <= 2, f"limit=2 must return at most 2 items, got {len(items)}"
     assert total >= 5, (


### PR DESCRIPTION
Four smoke test files (smoke_brain.py, smoke_comm.py, smoke_knowledge.py,
smoke_schedule.py) existed in the tests/ directory but were never invoked by
scripts/ci.sh, leaving the brain, comm, knowledge, and schedule pack verbs
with no CI coverage. This PR wires them in immediately after the existing
smoke_test.py line, matching its invocation style.

Two test correctness fixes were required before wiring: smoke_comm.py had a
test that expected comm.send to non-local actor labels to be denied, but
ADR-057 intentionally removed that denial (actor-addressed delivery now
succeeds within the caller's namespace); smoke_knowledge.py had five topic
verb tests that accessed result["items"] but knowledge.topic returns
result["results"]. Both were corrected to match the current implementation.

Each file was verified to exit 0 against a freshly built release binary before
being added to ci.sh.