### PR TITLE
docs: align AGENTS.md/CLAUDE.md with shipped verb surface and binary name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ These are the KG pack verbs. Other packs are documented in their verb tables abo
 | `traverse`  | **roots** (UUID list); max_depth, direction, relations, include_roots                                                                                                                                                                            | `{"roots":["<uuid>"],"max_depth":2}`                         |
 | `query`     | **query** (GQL or SPARQL string) — **read-only**: write-shaped input (SPARQL `INSERT`/`DELETE`/`LOAD`, GQL/Cypher `CREATE`/`DELETE`/`SET`/`MERGE`) is rejected; use `create`, `update`, `link`, `merge`, `delete` to mutate                      | `{"query":"MATCH (a:concept)-[:extends]->(b) RETURN a"}`     |
 | `propose`   | **kind** (entity\|note\|edge), fields for the proposed change. Returns `{id, status, proposer, title}`. Chain as `propose(...) \| review(id=$prev.id, …)`, **not** `$prev.proposal_id`. Use JSON form for nested `changeset` objects.            | `{"kind":"entity","entity_kind":"concept","name":"X"}`       |
-| `review`    | **id** (proposal UUID), **verdict** (approve\|reject); comment                                                                                                                                                                                   | `{"id":"<uuid>","verdict":"approve"}`                        |
+| `review`    | **id** (proposal UUID), **decision** (approve\|reject\|comment\|request_changes); comment                                                                                                                                                        | `{"id":"<uuid>","decision":"approve"}`                       |
 | `withdraw`  | **id** (proposal UUID)                                                                                                                                                                                                                           | `{"id":"<uuid>"}`                                            |
 
 ### When to use which retrieval verb
@@ -534,13 +534,13 @@ If you are an AI agent authoring PRs, issues, or comments via someone's CLI:
 
 ## Daemon and warm startup
 
-khive-mcp auto-spawns a background daemon (`khive-mcp --daemon`) on the first request. The daemon
+The `kkernel` binary auto-spawns a background daemon (`kkernel mcp --daemon`) on the first request. The daemon
 keeps the ANN index and embedding model warm so `knowledge.search` and `memory.recall` are fast on
 subsequent calls. Users do not need to configure or manage the daemon — it starts automatically and
 cleans up on exit.
 
 The daemon communicates over a Unix socket (`khived.sock`). If you see stale-process errors after a
-rebuild, kill zombie processes: `pkill -f khive-mcp` then reconnect.
+rebuild, kill zombie processes: `pkill -f kkernel` then reconnect.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ behavior isn't written there, it is an unspecified design decision → escalate,
 │  khive-mcp      — stdio MCP server + persistent daemon       │
 │  1 tool: `request` (ADR-016) — parses DSL,                   │
 │  dispatches verb ops through the VerbRegistry                │
-│  Auto-spawns `khive-mcp --daemon` for warm ANN/embedder      │
+│  Auto-spawns `kkernel mcp --daemon` for warm ANN/embedder    │
 │  state (ADR-049). Daemon keeps indexes hot across sessions.  │
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch
@@ -114,7 +114,7 @@ not shipped.
 
 ## Closed taxonomies (DO NOT extend without an ADR)
 
-### 9 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-resource-entity-kind.md))
+### 9 entity kinds ([ADR-001](docs/adr/ADR-001-entity-kind-taxonomy.md), [ADR-048](docs/adr/ADR-048-knowledge-section-profiles.md))
 
 `concept` | `document` | `dataset` | `project` | `person` | `org` | `artifact` | `service` | `resource`
 
@@ -207,15 +207,17 @@ Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 | `gtd.tasks`      | `status?`, `assignee?`, `priority?`, `limit?`, `offset?`                     | Filtered task listing                                       |
 | `gtd.transition` | `id`, `status`, `note?`                                                      | Explicit lifecycle change with `can_transition` validation  |
 
-### Memory pack verbs (3 — ADR-021, optional)
+### Memory pack verbs (5 — ADR-021, optional)
 
 Load with `KHIVE_PACKS=kg,memory` or `--pack memory`. Adds the `memory` note kind.
 
-| Verb              | Args                                                                  | What it does                                                              |
-| ----------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source |
-| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking        |
-| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors    |
+| Verb              | Args                                                                  | What it does                                                                                   |
+| ----------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source                      |
+| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking                             |
+| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors                         |
+| `memory.prune`    | `min_salience?`, `before?`, `namespace?`, `dry_run?`                  | Soft-delete memories below a salience floor and/or past `expires_at` (curation-layer, ADR-014) |
+| `memory.vacuum`   | —                                                                     | Run SQLite `VACUUM` to reclaim space freed by soft-deleted rows                                |
 
 `get`/`update`/`delete`/`merge` are UUID-only — no `kind` needed, the handler resolves
 the substrate from the UUID. `create`/`list`/`search` require `kind`.
@@ -257,7 +259,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
 
 ### MCP tool changes
 
-- The MCP server exposes exactly one tool: `request` (ADR-027). There are no per-verb tool
+- The MCP server exposes exactly one tool: `request` (ADR-016). There are no per-verb tool
   files — the only schema in `crates/khive-mcp/src/tools/` is `request.rs` (the `RequestParams`
   struct).
 - DSL parsing lives in the `khive-request` crate (ADR-028). Edits to the parser go there,
@@ -265,7 +267,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
 - MCP server (`crates/khive-mcp/src/server.rs`) is a thin dispatch shell — calls
   `khive_request::parse_request`, then routes each parsed op through the registry. No
   business logic.
-- **Verb handler logic lives in the pack** (`crates/khive-pack-kg/src/handlers.rs`).
+- **Verb handler logic lives in the pack** (`crates/khive-pack-kg/src/handlers/`).
 - Runtime methods live in `crates/khive-runtime/src/operations.rs` (or `curation.rs`,
   `retrieval.rs`, `graph_traversal.rs`).
 - **Invalid DSL** (parse/lex failure) returns RPC-level `McpError::invalid_params` from
@@ -362,20 +364,20 @@ Full index: [docs/adr/README.md](docs/adr/README.md).
 
 ## What lives where
 
-| Want to do...                                               | Edit this                                                                                                                             |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Add a new verb                                              | Pack handler in `crates/khive-pack-kg/src/handlers.rs` (or your pack); the MCP surface is `request` — no per-verb tool file to author |
-| Change DSL syntax                                           | `crates/khive-request/src/lib.rs` + unit tests (ADR-016)                                                                              |
-| Change MCP surface shape                                    | `crates/khive-mcp/src/server.rs` (ADR-016 — `request` is the only tool)                                                               |
-| Add a runtime operation                                     | `crates/khive-runtime/src/operations.rs`                                                                                              |
-| Change DB schema                                            | New `crates/khive-db/sql/NNN-<name>.sql` file + register it as a new `VersionedMigration` in `crates/khive-db/src/migrations.rs`      |
-| Add a new entity kind                                       | `crates/khive-pack-kg/src/vocab.rs` + ADR-001 amendment                                                                               |
-| Add a new edge relation                                     | **STOP** — ADR change ([ADR-002](docs/adr/ADR-002-edge-ontology.md))                                                                  |
-| Allow a new edge endpoint pair (e.g. note-kind→entity-kind) | Pack's `EDGE_RULES` const ([ADR-017](docs/adr/ADR-017-pack-standard.md) §"Pack-extensible edge endpoints"); additive only             |
-| Add a new note kind                                         | `crates/khive-pack-kg/src/vocab.rs` + ADR-013 amendment                                                                               |
-| Add a new pack                                              | New crate implementing `Pack` + `PackRuntime` ([ADR-017](docs/adr/ADR-017-pack-standard.md))                                          |
-| Fix a query parser bug                                      | `crates/khive-query/src/parsers/` + add regression test                                                                               |
-| Fix a storage bug                                           | `crates/khive-db/src/stores/` + test                                                                                                  |
+| Want to do...                                               | Edit this                                                                                                                           |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Add a new verb                                              | Pack handler in `crates/khive-pack-kg/src/handlers/` (or your pack); the MCP surface is `request` — no per-verb tool file to author |
+| Change DSL syntax                                           | `crates/khive-request/src/lib.rs` + unit tests (ADR-016)                                                                            |
+| Change MCP surface shape                                    | `crates/khive-mcp/src/server.rs` (ADR-016 — `request` is the only tool)                                                             |
+| Add a runtime operation                                     | `crates/khive-runtime/src/operations.rs`                                                                                            |
+| Change DB schema                                            | New `crates/khive-db/sql/NNN-<name>.sql` file + register it as a new `VersionedMigration` in `crates/khive-db/src/migrations.rs`    |
+| Add a new entity kind                                       | `crates/khive-pack-kg/src/vocab.rs` + ADR-001 amendment                                                                             |
+| Add a new edge relation                                     | **STOP** — ADR change ([ADR-002](docs/adr/ADR-002-edge-ontology.md))                                                                |
+| Allow a new edge endpoint pair (e.g. note-kind→entity-kind) | Pack's `EDGE_RULES` const ([ADR-017](docs/adr/ADR-017-pack-standard.md) §"Pack-extensible edge endpoints"); additive only           |
+| Add a new note kind                                         | `crates/khive-pack-kg/src/vocab.rs` + ADR-013 amendment                                                                             |
+| Add a new pack                                              | New crate implementing `Pack` + `PackRuntime` ([ADR-017](docs/adr/ADR-017-pack-standard.md))                                        |
+| Fix a query parser bug                                      | `crates/khive-query/src/parsers/` + add regression test                                                                             |
+| Fix a storage bug                                           | `crates/khive-db/src/stores/` + test                                                                                                |
 
 ---
 


### PR DESCRIPTION
Aligns the contributor and agent-facing docs with the runtime that ships on `main`:

- `review` verb argument is `decision` (`approve|reject|comment|request_changes`), not `verdict` — fixed in the AGENTS.md KG verb table. An agent calling `review(verdict=…)` gets a silent `{ok:false}` for the missing required `decision`.
- Memory pack now documents all 5 verbs: adds `memory.prune` and `memory.vacuum`; section count 3 → 5 (CLAUDE.md). AGENTS.md already listed 5.
- Daemon auto-spawn command is `kkernel mcp --daemon`, and the stale-process kill command references `kkernel` (AGENTS.md daemon section + CLAUDE.md architecture box).
- KG pack handler path is the directory `crates/khive-pack-kg/src/handlers/`, not `handlers.rs` (CLAUDE.md, 2 references).
- Single-`request`-tool decision attributed to ADR-016 (was ADR-027) in CLAUDE.md, matching the section header.
- ADR-048 link points to `ADR-048-knowledge-section-profiles.md` (CLAUDE.md; AGENTS.md was already corrected).

Docs-only, `deno fmt` clean. Supersedes the stale #206 branch (48 commits behind `main`).
