### PR TITLE
docs: sync ADR index, namespace rev, and directory map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,7 +544,7 @@ rebuild, kill zombie processes: `pkill -f kkernel` then reconnect.
 
 ---
 
-## Namespace (attribution-only — ADR-007 Rev 3)
+## Namespace (attribution-only — ADR-007 Rev 6)
 
 Namespace is a write-stamp on records. In OSS, every record is stored under namespace `"local"` by
 default. It is attribution, not isolation: queryable and filterable as a data column, but never a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,30 +85,31 @@ not shipped.
 
 ## Directory map
 
-| Path                       | Purpose                                                                                                                |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `crates/khive-types`       | Domain types: Entity, Note, Event, EntityKind, EdgeRelation, Pack trait                                                |
-| `crates/khive-score`       | Deterministic i64 fixed-point scoring + RRF                                                                            |
-| `crates/khive-storage`     | Trait-only: SqlAccess, GraphStore, VectorStore, TextSearch                                                             |
-| `crates/khive-db`          | SQLite backend; FTS5 trigram TextSearch; current sqlite-vec VectorStore compatibility                                  |
-| `crates/khive-retrieval`   | Hybrid retrieval primitives over dense, lexical, graph, and fusion signals                                             |
-| `crates/khive-fusion`      | RRF, weighted, union, vector-only, and keyword-only fusion strategies                                                  |
-| `crates/khive-bm25`        | BM25 keyword index                                                                                                     |
-| `crates/khive-hnsw`        | HNSW vector index                                                                                                      |
-| `crates/khive-vamana`      | Vamana ANN index used by knowledge search                                                                              |
-| `crates/khive-query`       | GQL + SPARQL parsers, AST validation, SQL compiler                                                                     |
-| `crates/khive-runtime`     | Service API + VerbRegistry + PackRuntime trait                                                                         |
-| `crates/khive-request`     | Request DSL parser (function-call + JSON; pipe/LNDL planned)                                                           |
-| `crates/khive-pack-kg`     | KG pack: vocabulary, 16 verb handlers, kind validation                                                                 |
-| `crates/khive-pack-gtd`    | GTD pack: 5 verbs over notes (assign / next / complete / tasks / transition)                                           |
-| `crates/khive-pack-memory` | Memory pack: `remember`/`recall`/`feedback` verbs, decay-weighted recall ([ADR-021](docs/adr/ADR-021-memory-pack.md))  |
-| `crates/khive-vcs`         | KG versioning: content-addressed snapshots, branch pointers, push/pull ([ADR-010](docs/adr/ADR-010-kg-versioning.md))  |
-| `crates/khive-merge`       | KG merge: three-way merge with LCA walk, conflict enum, strategy shortcuts ([ADR-039](docs/adr/ADR-039-note-merge.md)) |
-| `crates/khive-mcp`         | Stdio MCP binary — single `request` tool over VerbRegistry; auto-spawns daemon                                         |
-| `docs/adr/`                | Architecture Decision Records (the design contract)                                                                    |
-| `marketplace/`             | The `khive` umbrella Claude Code plugin (one skill per pack + kg agents) — install via `/plugin install`               |
-| `tests/smoke_test.py`      | End-to-end binary smoke test (drives every verb via the `request` DSL)                                                 |
-| `scripts/publish.sh`       | Publish all crates to crates.io in dependency order                                                                    |
+| Path                       | Purpose                                                                                                                                                                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `crates/khive-types`       | Domain types: Entity, Note, Event, EntityKind, EdgeRelation, Pack trait                                                                                                                                                                          |
+| `crates/khive-score`       | Deterministic i64 fixed-point scoring + RRF                                                                                                                                                                                                      |
+| `crates/khive-storage`     | Trait-only: SqlAccess, GraphStore, VectorStore, TextSearch                                                                                                                                                                                       |
+| `crates/khive-db`          | SQLite backend; FTS5 trigram TextSearch; current sqlite-vec VectorStore compatibility                                                                                                                                                            |
+| `crates/khive-retrieval`   | Hybrid retrieval primitives over dense, lexical, graph, and fusion signals                                                                                                                                                                       |
+| `crates/khive-fusion`      | RRF, weighted, union, vector-only, and keyword-only fusion strategies                                                                                                                                                                            |
+| `crates/khive-bm25`        | BM25 keyword index                                                                                                                                                                                                                               |
+| `crates/khive-hnsw`        | HNSW vector index                                                                                                                                                                                                                                |
+| `crates/khive-vamana`      | Vamana ANN index used by knowledge search                                                                                                                                                                                                        |
+| `crates/khive-query`       | GQL + SPARQL parsers, AST validation, SQL compiler                                                                                                                                                                                               |
+| `crates/khive-runtime`     | Service API + VerbRegistry + PackRuntime trait                                                                                                                                                                                                   |
+| `crates/khive-request`     | Request DSL parser (function-call + JSON; pipe/LNDL planned)                                                                                                                                                                                     |
+| `crates/khive-pack-kg`     | KG pack: vocabulary, 16 verb handlers, kind validation                                                                                                                                                                                           |
+| `crates/khive-pack-gtd`    | GTD pack: 5 verbs over notes (assign / next / complete / tasks / transition)                                                                                                                                                                     |
+| `crates/khive-pack-memory` | Memory pack: `remember`/`recall`/`feedback` verbs, decay-weighted recall ([ADR-021](docs/adr/ADR-021-memory-pack.md))                                                                                                                            |
+| `crates/khive-pack-formal` | Formal-methods pack: typed edge endpoint rules for six formal-math concept subtypes (theorem, definition, structure, instance, axiom, goal); pure ontology, no verbs ([ADR-069](docs/adr/ADR-069-subject-model.md)); not in the default pack set |
+| `crates/khive-vcs`         | KG versioning: content-addressed snapshots, branch pointers, push/pull ([ADR-010](docs/adr/ADR-010-kg-versioning.md))                                                                                                                            |
+| `crates/khive-merge`       | KG merge: three-way merge with LCA walk, conflict enum, strategy shortcuts ([ADR-039](docs/adr/ADR-039-note-merge.md))                                                                                                                           |
+| `crates/khive-mcp`         | Stdio MCP binary — single `request` tool over VerbRegistry; auto-spawns daemon                                                                                                                                                                   |
+| `docs/adr/`                | Architecture Decision Records (the design contract)                                                                                                                                                                                              |
+| `marketplace/`             | The `khive` umbrella Claude Code plugin (one skill per pack + kg agents) — install via `/plugin install`                                                                                                                                         |
+| `tests/smoke_test.py`      | End-to-end binary smoke test (drives every verb via the `request` DSL)                                                                                                                                                                           |
+| `scripts/publish.sh`       | Publish all crates to crates.io in dependency order                                                                                                                                                                                              |
 
 ---
 
@@ -274,7 +275,7 @@ NOT abort the batch — each entry has its own ok/error. The aggregate response 
   `request`. **Per-verb validation failure** (unknown kind, bad UUID, etc.) returns a per-op
   `{ok: false, error: "..."}` entry — the batch does not abort.
 
-### Namespace (attribution-only — ADR-007 Rev 3, 2026-06-17)
+### Namespace (attribution-only — ADR-007 Rev 6, 2026-06-19)
 
 - **Namespace is attribution, not isolation.** It is a write-stamp on records, queryable and
   filterable, available to the Gate as policy input. It is never a storage boundary.
@@ -389,7 +390,7 @@ Full index: [docs/adr/README.md](docs/adr/README.md).
 - **Don't silently coerce invalid input.** Invalid entity kinds, note kinds, and edge relations
   must return errors with the valid values listed. Never `unwrap_or_default()`.
 - **Don't add namespace checks to by-ID ops.** By-ID methods (get, update, delete, merge)
-  are namespace-agnostic by design (ADR-007 Rev 3). Authorization is at the Gate. Adding
+  are namespace-agnostic by design (ADR-007 Rev 6). Authorization is at the Gate. Adding
   `record.namespace == caller_namespace` post-fetch checks is the prior v1 bug pattern; it
   was removed by PR-A1 and must not return.
 - **Don't edit V1 migrations.** Append a new version. V1 is immutable on existing databases.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,23 +6,23 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## Foundation
 
-| #                                               | Title                                                        |
-| ----------------------------------------------- | ------------------------------------------------------------ |
-| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                         |
-| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                         |
-| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                          |
-| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                        |
-| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                    |
-| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                        |
-| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 2 — attribution-only, all-local, single Gate) |
-| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                       |
-| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                         |
-| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                       |
-| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                         |
-| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                        |
-| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                           |
-| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                          |
-| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                            |
+| #                                               | Title                                                                                     |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [ADR-001](ADR-001-entity-kind-taxonomy.md)      | Entity Kind Taxonomy                                                                      |
+| [ADR-002](ADR-002-edge-ontology.md)             | Closed Edge Ontology                                                                      |
+| [ADR-003](ADR-003-system-architecture.md)       | System Architecture                                                                       |
+| [ADR-004](ADR-004-substrate-observables.md)     | Substrate Observables                                                                     |
+| [ADR-005](ADR-005-storage-capability-traits.md) | Storage Capability Traits                                                                 |
+| [ADR-006](ADR-006-deterministic-scoring.md)     | Deterministic Scoring                                                                     |
+| [ADR-007](ADR-007-namespace.md)                 | Namespace (Rev 6 — attribution-only, dumb storage, single Gate, per-actor episodic write) |
+| [ADR-008](ADR-008-query-layer-separation.md)    | Query Layer Separation                                                                    |
+| [ADR-009](ADR-009-backend-architecture.md)      | Backend Architecture                                                                      |
+| [ADR-010](ADR-010-kg-versioning.md)             | KG Versioning Strategy                                                                    |
+| [ADR-011](ADR-011-embedding-and-inference.md)   | Embedding and Inference Architecture                                                      |
+| [ADR-012](ADR-012-retrieval-composition.md)     | Retrieval Composition                                                                     |
+| [ADR-013](ADR-013-note-kind-taxonomy.md)        | Note Kind Taxonomy                                                                        |
+| [ADR-014](ADR-014-curation-operations.md)       | Curation Operations                                                                       |
+| [ADR-015](ADR-015-schema-migrations.md)         | Schema Migrations                                                                         |
 
 ## MCP / Pack Surface
 
@@ -84,7 +84,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-049](ADR-049-khived-daemon.md)                      | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
 | [ADR-050](ADR-050-kg-token-namespace-contract.md)        | KG Token Namespace Contract (Proposed)                                                                          |
 | [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)  | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
-| [ADR-052](ADR-052-ann-production-lifecycle.md)           | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Proposed) |
+| [ADR-052](ADR-052-ann-production-lifecycle.md)           | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
 | [ADR-053](ADR-053-authorization-gate.md)                 | Authorization Gate — ActorStore, SessionStore, and Cloud-Tier Caller Propagation (Proposed)                     |
 | [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)  | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
 | [ADR-055](ADR-055-epistemic-edge-relations.md)           | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |
@@ -97,6 +97,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)          | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
 | [ADR-067](ADR-067-write-owner-daemon.md)                 | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
 | [ADR-068](ADR-068-cloud-multitenancy-topology.md)        | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
+| [ADR-073](ADR-073-pack-core-backend-accessor.md)         | Pack Core-Backend Accessor (Proposed)                                                                           |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Documentation-only sync pass. Three files changed; no code, no ADR content altered.

## Changes with source citations

### `docs/adr/README.md`

1. **ADR-073 added** to the "New v1 Surfaces" index table after ADR-068.
   - Source: `docs/adr/ADR-073-pack-core-backend-accessor.md` line 1 — title "ADR-073: Pack Core-Backend Accessor"; line 3 — "**Status**: Proposed"; line 4 — "**Date**: 2026-06-25".

2. **ADR-007 row updated** from "Rev 2" to "Rev 6".
   - Source: `docs/adr/ADR-007-namespace.md` line 1 — "# ADR-007 Rev 6: Namespace as Attribution-Only Open String …"; line 3 — "**Status**: Accepted/Ratified (2026-06-19)".
   - Old: `Namespace (Rev 2 — attribution-only, all-local, single Gate)`
   - New: `Namespace (Rev 6 — attribution-only, dumb storage, single Gate, per-actor episodic write)`

3. **ADR-052 status updated** from "(Proposed)" to "(Accepted)".
   - Source: `docs/adr/ADR-052-ann-production-lifecycle.md` line 3 — "**Status**: accepted (2026-06-14)".

### `CLAUDE.md`

4. **Namespace section heading** updated from "ADR-007 Rev 3, 2026-06-17" to "ADR-007 Rev 6, 2026-06-19".
   - Source: same ADR-007 header as above.

5. **Anti-pattern bullet** ("don't add namespace checks to by-ID ops") updated from "ADR-007 Rev 3" to "ADR-007 Rev 6".
   - Source: same ADR-007 header as above.

6. **`crates/khive-pack-formal` row added** to the directory map table.
   - Source: `crates/khive-pack-formal/src/lib.rs` lines 1-4 — "formal-math ontology pack … Registers typed edge endpoint rules for six formal-math concept subtypes (theorem, definition, structure, instance, axiom, goal). Pure ontology: no verbs."
   - "Not in default pack set" verified against `crates/khive-mcp/src/args.rs` doc comment — default set listed as `kg,gtd,memory,brain,comm,schedule,knowledge`; `formal` is absent.

### `AGENTS.md`

7. **Namespace section heading** updated from "ADR-007 Rev 3" to "ADR-007 Rev 6".
   - Source: same ADR-007 header as above.

## Skipped items

- **`knowledge.compose` `explain` param** (item 4): grepped all `crates/khive-pack-*/src/*.rs` for `compose` + `explain` — no results. The param does not exist in the shipped source. Skipped to avoid inventing a non-existent API.
- **Formal pack entity subtypes in AGENTS.md** (explicitly excluded): `khive-pack-formal` is not in the default pack set; adding its vocabulary to AGENTS.md would mislead agents about the default surface.
- **ADR-059 "superseded by ADR-007 Rev 2" note**: this is a historical record of which revision superseded ADR-059 at the time; it is not a stale reference to the current revision and was left unchanged.

## Test plan

- [ ] CI "Docs lint" (`deno fmt --check`) passes — verified locally before push (all 3 files clean)
- [ ] No code files changed
- [ ] No ADR file content changed