### PR TITLE
perf(db,query): fix recursive CTE join order — 17,000x traverse speedup

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1052,15 +1052,9 @@ impl GraphStore for SqlGraphStore {
             if let Some(min_w) = opts.min_weight {
                 extra_params.push(Box::new(min_w));
                 weight_cond = format!(" AND e.weight >= ?{extra_param_idx}");
-                extra_param_idx += 1;
+                // extra_param_idx would advance here if more params followed;
+                // limit is now applied in Rust (see below), so no SQL param needed.
             }
-
-            let limit_clause = if let Some(lim) = opts.limit {
-                extra_params.push(Box::new(lim as i64));
-                format!(" LIMIT ?{extra_param_idx}")
-            } else {
-                String::new()
-            };
 
             // Seed rows: one per root, each referencing its own param 3× (root_id,
             // node_id, and the initial path string all carry the same UUID).
@@ -1092,7 +1086,7 @@ impl GraphStore for SqlGraphStore {
                  ) \
                  SELECT root_id, node_id, edge_id, depth, total_weight \
                  FROM traversal WHERE depth > 0 \
-                 ORDER BY root_id, depth{limit}",
+                 ORDER BY root_id, depth",
                 seeds = seeds,
                 next_node = next_node,
                 join_condition = join_condition,
@@ -1100,7 +1094,6 @@ impl GraphStore for SqlGraphStore {
                 depth = depth_param,
                 rel_cond = relation_cond,
                 wt_cond = weight_cond,
-                limit = limit_clause,
             );
 
             // Build the flat param list matching the layout above.
@@ -1125,22 +1118,28 @@ impl GraphStore for SqlGraphStore {
                 Ok((root_str, node_str, edge_str, depth, total_weight))
             })?;
 
-            // Accumulate per-root state: (nodes, max_weight, seen_set).
-            let mut root_data: HashMap<Uuid, (Vec<PathNode>, f64, HashSet<Uuid>)> =
+            // Accumulate per-root state: (nodes_with_path_weight, seen_set).
+            // Each entry carries the PathNode and its cumulative path weight from
+            // the SQL row, so the Rust-level per-root limit truncation can compute
+            // an accurate max_weight over the kept nodes.
+            let mut root_data: HashMap<Uuid, (Vec<(PathNode, f64)>, HashSet<Uuid>)> =
                 HashMap::with_capacity(n_roots);
 
             // Pre-seed with root nodes when include_roots is set.
             for root_id in &roots {
-                let (nodes, _, seen) = root_data.entry(*root_id).or_default();
+                let (nodes, seen) = root_data.entry(*root_id).or_default();
                 if include_roots {
                     seen.insert(*root_id);
-                    nodes.push(PathNode {
-                        node_id: *root_id,
-                        via_edge: None,
-                        depth: 0,
-                        name: None,
-                        kind: None,
-                    });
+                    nodes.push((
+                        PathNode {
+                            node_id: *root_id,
+                            via_edge: None,
+                            depth: 0,
+                            name: None,
+                            kind: None,
+                        },
+                        0.0,
+                    ));
                 }
             }
 
@@ -1152,34 +1151,45 @@ impl GraphStore for SqlGraphStore {
                 let root_id = parse_uuid(&root_str)?;
                 let node_id = parse_uuid(&node_str)?;
 
-                let (nodes, max_weight, seen) = root_data.entry(root_id).or_default();
+                let (nodes, seen) = root_data.entry(root_id).or_default();
                 if !seen.insert(node_id) {
                     continue;
                 }
                 let via_edge = edge_str.map(|s| parse_uuid(&s)).transpose()?;
-                nodes.push(PathNode {
-                    node_id,
-                    via_edge,
-                    depth: depth as usize,
-                    name: None,
-                    kind: None,
-                });
-                if total_weight > *max_weight {
-                    *max_weight = total_weight;
-                }
+                nodes.push((
+                    PathNode {
+                        node_id,
+                        via_edge,
+                        depth: depth as usize,
+                        name: None,
+                        kind: None,
+                    },
+                    total_weight,
+                ));
             }
 
             // Reconstruct Vec<GraphPath> in original root order.
+            // Per-root limit: counts only non-root nodes against the cap, matching
+            // the original per-root-CTE semantics where the SQL LIMIT applied only
+            // to depth > 0 rows.  Truncation is on the post-dedup list (BFS order),
+            // so the shallowest `limit` reachable nodes are kept per root.
             let mut all_paths: Vec<GraphPath> = Vec::with_capacity(n_roots);
             for root_id in &roots {
-                if let Some((nodes, max_weight, _)) = root_data.remove(root_id) {
-                    if !nodes.is_empty() {
-                        all_paths.push(GraphPath {
-                            root_id: *root_id,
-                            nodes,
-                            total_weight: max_weight,
-                        });
+                if let Some((mut nw, _)) = root_data.remove(root_id) {
+                    if nw.is_empty() {
+                        continue;
                     }
+                    if let Some(lim) = opts.limit {
+                        let root_count = usize::from(include_roots);
+                        nw.truncate(root_count + lim as usize);
+                    }
+                    let max_weight = nw.iter().map(|(_, w)| *w).fold(0.0_f64, f64::max);
+                    let nodes: Vec<PathNode> = nw.into_iter().map(|(n, _)| n).collect();
+                    all_paths.push(GraphPath {
+                        root_id: *root_id,
+                        nodes,
+                        total_weight: max_weight,
+                    });
                 }
             }
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -994,6 +994,8 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn traverse(&self, request: TraversalRequest) -> Result<Vec<GraphPath>, StorageError> {
+        use std::collections::{HashMap, HashSet};
+
         use khive_storage::types::Direction;
 
         if request.roots.is_empty() {
@@ -1006,107 +1008,130 @@ impl GraphStore for SqlGraphStore {
         let namespace = self.namespace.clone();
 
         self.with_reader("traverse", move |conn| {
-            let mut all_paths: Vec<GraphPath> = Vec::new();
+            let n_roots = roots.len();
 
+            // Determine join direction and the expression for the "next" node in
+            // the expansion step.
+            let (join_condition, next_node) = match opts.direction {
+                Direction::Out => ("e.source_id = t.node_id", "e.target_id"),
+                Direction::In => ("e.target_id = t.node_id", "e.source_id"),
+                Direction::Both => (
+                    "(e.source_id = t.node_id OR e.target_id = t.node_id)",
+                    "CASE WHEN e.source_id = t.node_id THEN e.target_id ELSE e.source_id END",
+                ),
+            };
+
+            // Param layout:
+            //   ?1 .. ?{n_roots}     — root UUID strings (each used 3× in their seed row)
+            //   ?{n_roots + 1}       — namespace
+            //   ?{n_roots + 2}       — max_depth
+            //   ?{n_roots + 3} ..    — optional relation / weight / limit params
+            let ns_param = n_roots + 1;
+            let depth_param = n_roots + 2;
+            let mut extra_param_idx = n_roots + 3;
+
+            let mut relation_cond = String::new();
+            let mut extra_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+            if let Some(ref rels) = opts.relations {
+                if !rels.is_empty() {
+                    let placeholders: Vec<String> = rels
+                        .iter()
+                        .map(|r| {
+                            extra_params.push(Box::new(r.to_string()));
+                            let p = format!("?{extra_param_idx}");
+                            extra_param_idx += 1;
+                            p
+                        })
+                        .collect();
+                    relation_cond = format!(" AND e.relation IN ({})", placeholders.join(","));
+                }
+            }
+
+            let mut weight_cond = String::new();
+            if let Some(min_w) = opts.min_weight {
+                extra_params.push(Box::new(min_w));
+                weight_cond = format!(" AND e.weight >= ?{extra_param_idx}");
+                extra_param_idx += 1;
+            }
+
+            let limit_clause = if let Some(lim) = opts.limit {
+                extra_params.push(Box::new(lim as i64));
+                format!(" LIMIT ?{extra_param_idx}")
+            } else {
+                String::new()
+            };
+
+            // Seed rows: one per root, each referencing its own param 3× (root_id,
+            // node_id, and the initial path string all carry the same UUID).
+            let seed_rows: Vec<String> = (1..=n_roots)
+                .map(|i| format!("(?{i}, ?{i}, NULL, 0, ?{i}, 0.0)"))
+                .collect();
+            let seeds = seed_rows.join(", ");
+
+            // Single CTE covering all roots.  CROSS JOIN forces SQLite to put the
+            // frontier (t) as the outer loop and seek graph_edges by source/target
+            // (ns, source_id) index, avoiding the O(edges × frontier) plan that
+            // the plain INNER JOIN produces (#250, #251).
+            let cte_sql = format!(
+                "WITH RECURSIVE traversal(\
+                     root_id, node_id, edge_id, depth, path, total_weight\
+                 ) AS (\
+                     VALUES {seeds} \
+                     UNION ALL \
+                     SELECT t.root_id, {next_node}, e.id, t.depth + 1, \
+                            t.path || ',' || {next_node}, \
+                            t.total_weight + e.weight \
+                     FROM traversal t CROSS JOIN graph_edges e \
+                         ON {join_condition} \
+                     WHERE e.namespace = ?{ns} \
+                       AND e.deleted_at IS NULL \
+                       AND t.depth < ?{depth} \
+                       AND (',' || t.path || ',') NOT LIKE '%,' || {next_node} || ',%'\
+                       {rel_cond}{wt_cond} \
+                 ) \
+                 SELECT root_id, node_id, edge_id, depth, total_weight \
+                 FROM traversal WHERE depth > 0 \
+                 ORDER BY root_id, depth{limit}",
+                seeds = seeds,
+                next_node = next_node,
+                join_condition = join_condition,
+                ns = ns_param,
+                depth = depth_param,
+                rel_cond = relation_cond,
+                wt_cond = weight_cond,
+                limit = limit_clause,
+            );
+
+            // Build the flat param list matching the layout above.
+            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
             for root_id in &roots {
-                let root_str = root_id.to_string();
+                all_params.push(Box::new(root_id.to_string()));
+            }
+            all_params.push(Box::new(namespace.clone()));
+            all_params.push(Box::new(opts.max_depth as i64));
+            all_params.extend(extra_params);
 
-                let (join_condition, next_node) = match opts.direction {
-                    Direction::Out => ("e.source_id = t.node_id", "e.target_id"),
-                    Direction::In => ("e.target_id = t.node_id", "e.source_id"),
-                    Direction::Both => (
-                        "(e.source_id = t.node_id OR e.target_id = t.node_id)",
-                        "CASE WHEN e.source_id = t.node_id THEN e.target_id ELSE e.source_id END",
-                    ),
-                };
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                all_params.iter().map(|p| p.as_ref()).collect();
 
-                let mut relation_cond = String::new();
-                let mut relation_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-                let mut param_idx = 4;
+            let mut stmt = conn.prepare(&cte_sql)?;
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                let root_str: String = row.get(0)?;
+                let node_str: String = row.get(1)?;
+                let edge_str: Option<String> = row.get(2)?;
+                let depth: i64 = row.get(3)?;
+                let total_weight: f64 = row.get(4)?;
+                Ok((root_str, node_str, edge_str, depth, total_weight))
+            })?;
 
-                if let Some(ref rels) = opts.relations {
-                    if !rels.is_empty() {
-                        let placeholders: Vec<String> = rels
-                            .iter()
-                            .map(|r| {
-                                relation_params.push(Box::new(r.to_string()));
-                                let p = format!("?{}", param_idx);
-                                param_idx += 1;
-                                p
-                            })
-                            .collect();
-                        relation_cond =
-                            format!(" AND e.relation IN ({})", placeholders.join(","));
-                    }
-                }
+            // Accumulate per-root state: (nodes, max_weight, seen_set).
+            let mut root_data: HashMap<Uuid, (Vec<PathNode>, f64, HashSet<Uuid>)> =
+                HashMap::with_capacity(n_roots);
 
-                let mut weight_cond = String::new();
-                if let Some(min_w) = opts.min_weight {
-                    relation_params.push(Box::new(min_w));
-                    weight_cond = format!(" AND e.weight >= ?{}", param_idx);
-                    param_idx += 1;
-                }
-
-                let limit_clause = if let Some(lim) = opts.limit {
-                    relation_params.push(Box::new(lim as i64));
-                    format!(" LIMIT ?{}", param_idx)
-                } else {
-                    String::new()
-                };
-
-                let cte_sql = format!(
-                    "WITH RECURSIVE traversal(node_id, edge_id, depth, path, total_weight) AS (\
-                         SELECT ?2, NULL, 0, ?2, 0.0 \
-                         UNION ALL \
-                         SELECT {next_node}, e.id, t.depth + 1, \
-                                t.path || ',' || {next_node}, \
-                                t.total_weight + e.weight \
-                         FROM graph_edges e \
-                         JOIN traversal t ON {join_condition} \
-                         WHERE e.namespace = ?1 \
-                           AND e.deleted_at IS NULL \
-                           AND t.depth < ?3 \
-                           AND (',' || t.path || ',') NOT LIKE '%,' || {next_node} || ',%'{rel_cond}{wt_cond} \
-                     ) \
-                     SELECT node_id, edge_id, depth, path, total_weight \
-                     FROM traversal WHERE depth > 0 \
-                     ORDER BY depth{limit}",
-                    next_node = next_node,
-                    join_condition = join_condition,
-                    rel_cond = relation_cond,
-                    wt_cond = weight_cond,
-                    limit = limit_clause,
-                );
-
-                let mut stmt = conn.prepare(&cte_sql)?;
-
-                let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-                all_params.push(Box::new(namespace.clone()));
-                all_params.push(Box::new(root_str.clone()));
-                all_params.push(Box::new(opts.max_depth as i64));
-                all_params.extend(relation_params);
-
-                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                    all_params.iter().map(|p| p.as_ref()).collect();
-
-                let rows = stmt.query_map(param_refs.as_slice(), |row| {
-                    let node_str: String = row.get(0)?;
-                    let edge_str: Option<String> = row.get(1)?;
-                    let depth: i64 = row.get(2)?;
-                    let _path: String = row.get(3)?;
-                    let total_weight: f64 = row.get(4)?;
-                    Ok((node_str, edge_str, depth, total_weight))
-                })?;
-
-                let mut nodes = Vec::new();
-                let mut max_weight = 0.0f64;
-                // Track visited node IDs to deduplicate multi-path reachability
-                // (#285). Rows are ordered by depth (shallowest first), so the
-                // first occurrence is the BFS-order first-visit — that is the
-                // one we keep.
-                let mut seen: std::collections::HashSet<Uuid> =
-                    std::collections::HashSet::new();
-
+            // Pre-seed with root nodes when include_roots is set.
+            for root_id in &roots {
+                let (nodes, _, seen) = root_data.entry(*root_id).or_default();
                 if include_roots {
                     seen.insert(*root_id);
                     nodes.push(PathNode {
@@ -1117,33 +1142,44 @@ impl GraphStore for SqlGraphStore {
                         kind: None,
                     });
                 }
+            }
 
-                for row in rows {
-                    let (node_str, edge_str, depth, total_weight) = row?;
-                    let node_id = parse_uuid(&node_str)?;
-                    // Skip nodes already seen via an earlier (shallower) path.
-                    if !seen.insert(node_id) {
-                        continue;
-                    }
-                    let via_edge = edge_str.map(|s| parse_uuid(&s)).transpose()?;
-                    nodes.push(PathNode {
-                        node_id,
-                        via_edge,
-                        depth: depth as usize,
-                        name: None,
-                        kind: None,
-                    });
-                    if total_weight > max_weight {
-                        max_weight = total_weight;
-                    }
+            // The CTE is ordered by (root_id, depth), so the first occurrence of
+            // each (root_id, node_id) pair is the shallowest-depth path — that is
+            // the one we keep (BFS first-visit semantics, matching #285).
+            for row in rows {
+                let (root_str, node_str, edge_str, depth, total_weight) = row?;
+                let root_id = parse_uuid(&root_str)?;
+                let node_id = parse_uuid(&node_str)?;
+
+                let (nodes, max_weight, seen) = root_data.entry(root_id).or_default();
+                if !seen.insert(node_id) {
+                    continue;
                 }
+                let via_edge = edge_str.map(|s| parse_uuid(&s)).transpose()?;
+                nodes.push(PathNode {
+                    node_id,
+                    via_edge,
+                    depth: depth as usize,
+                    name: None,
+                    kind: None,
+                });
+                if total_weight > *max_weight {
+                    *max_weight = total_weight;
+                }
+            }
 
-                if nodes.len() > if include_roots { 1 } else { 0 } || include_roots {
-                    all_paths.push(GraphPath {
-                        root_id: *root_id,
-                        nodes,
-                        total_weight: max_weight,
-                    });
+            // Reconstruct Vec<GraphPath> in original root order.
+            let mut all_paths: Vec<GraphPath> = Vec::with_capacity(n_roots);
+            for root_id in &roots {
+                if let Some((nodes, max_weight, _)) = root_data.remove(root_id) {
+                    if !nodes.is_empty() {
+                        all_paths.push(GraphPath {
+                            root_id: *root_id,
+                            nodes,
+                            total_weight: max_weight,
+                        });
+                    }
                 }
             }
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1183,6 +1183,11 @@ impl GraphStore for SqlGraphStore {
                         let root_count = usize::from(include_roots);
                         nw.truncate(root_count + lim as usize);
                     }
+                    // Post-truncation guard: a limit=0 + include_roots=false call
+                    // truncates to zero nodes; there is nothing to emit.
+                    if nw.is_empty() {
+                        continue;
+                    }
                     let max_weight = nw.iter().map(|(_, w)| *w).fold(0.0_f64, f64::max);
                     let nodes: Vec<PathNode> = nw.into_iter().map(|(n, _)| n).collect();
                     all_paths.push(GraphPath {

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -299,6 +299,145 @@ async fn test_traverse_preserves_first_path_metadata() {
     assert_eq!(d_nodes[0].depth, 2, "D lives at depth 2");
 }
 
+/// Multi-root batched traversal: two independent chains A→B→C and D→E→F.
+/// Each root must produce its own GraphPath with the correct node set.
+#[tokio::test]
+async fn test_traverse_multi_root_independent_chains() {
+    let store = setup_memory_store();
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    let d = Uuid::new_v4();
+    let e = Uuid::new_v4();
+    let f = Uuid::new_v4();
+
+    for (src, tgt) in [(a, b), (b, c), (d, e), (e, f)] {
+        store
+            .upsert_edge(make_edge(src, tgt, EdgeRelation::Extends, 1.0))
+            .await
+            .unwrap();
+    }
+
+    let request = TraversalRequest {
+        roots: vec![a, d],
+        options: TraversalOptions::new(2).with_direction(Direction::Out),
+        include_roots: true,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+    assert_eq!(paths.len(), 2, "one GraphPath per root");
+
+    // Locate paths by root_id.
+    let path_a = paths
+        .iter()
+        .find(|p| p.root_id == a)
+        .expect("path for root A");
+    let path_d = paths
+        .iter()
+        .find(|p| p.root_id == d)
+        .expect("path for root D");
+
+    let ids_a: HashSet<Uuid> = path_a.nodes.iter().map(|n| n.node_id).collect();
+    assert!(ids_a.contains(&a), "root A in its own path");
+    assert!(ids_a.contains(&b), "depth-1 B in A's path");
+    assert!(ids_a.contains(&c), "depth-2 C in A's path");
+    assert!(!ids_a.contains(&d), "root D must not appear in A's path");
+
+    let ids_d: HashSet<Uuid> = path_d.nodes.iter().map(|n| n.node_id).collect();
+    assert!(ids_d.contains(&d), "root D in its own path");
+    assert!(ids_d.contains(&e), "depth-1 E in D's path");
+    assert!(ids_d.contains(&f), "depth-2 F in D's path");
+    assert!(!ids_d.contains(&a), "root A must not appear in D's path");
+}
+
+/// Multi-root with a shared neighbor: A→C and B→C.  C must appear in BOTH
+/// A's path and B's path (per-root isolation, not global dedup).
+#[tokio::test]
+async fn test_traverse_multi_root_shared_neighbor_appears_in_both() {
+    let store = setup_memory_store();
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4(); // shared neighbor
+
+    for (src, tgt) in [(a, c), (b, c)] {
+        store
+            .upsert_edge(make_edge(src, tgt, EdgeRelation::Extends, 1.0))
+            .await
+            .unwrap();
+    }
+
+    let request = TraversalRequest {
+        roots: vec![a, b],
+        options: TraversalOptions::new(1).with_direction(Direction::Out),
+        include_roots: false,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+    assert_eq!(paths.len(), 2, "one GraphPath per root");
+
+    for path in &paths {
+        let node_ids: HashSet<Uuid> = path.nodes.iter().map(|n| n.node_id).collect();
+        assert!(
+            node_ids.contains(&c),
+            "shared node C must appear in each root's path; root={:?}",
+            path.root_id
+        );
+    }
+}
+
+/// Query-count regression: a 15-node binary tree at max_depth=3 must be
+/// traversed in a single CTE execution (one conn.prepare call), not N CTEs.
+/// This test asserts the node-count result is correct, which would fail if
+/// the batched CTE produced duplicates or missed nodes.
+#[tokio::test]
+async fn test_traverse_binary_tree_result_count() {
+    let store = setup_memory_store();
+
+    // Build a complete binary tree of depth 3: root + 2 + 4 + 8 = 15 nodes.
+    let nodes: Vec<Uuid> = (0..15).map(|_| Uuid::new_v4()).collect();
+    for i in 0..7usize {
+        let left = 2 * i + 1;
+        let right = 2 * i + 2;
+        store
+            .upsert_edge(make_edge(nodes[i], nodes[left], EdgeRelation::Extends, 1.0))
+            .await
+            .unwrap();
+        store
+            .upsert_edge(make_edge(
+                nodes[i],
+                nodes[right],
+                EdgeRelation::Extends,
+                1.0,
+            ))
+            .await
+            .unwrap();
+    }
+
+    let request = TraversalRequest {
+        roots: vec![nodes[0]],
+        options: TraversalOptions::new(3).with_direction(Direction::Out),
+        include_roots: true,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+    assert_eq!(paths.len(), 1);
+    // root + depth-1 (2) + depth-2 (4) + depth-3 (8) = 15
+    assert_eq!(
+        paths[0].nodes.len(),
+        15,
+        "binary tree depth-3 must yield exactly 15 nodes"
+    );
+    // Every depth-3 node must have a via_edge.
+    for node in paths[0].nodes.iter().filter(|n| n.depth == 3) {
+        assert!(
+            node.via_edge.is_some(),
+            "depth-3 nodes must carry a via_edge"
+        );
+    }
+}
+
 #[tokio::test]
 async fn test_metadata_roundtrip() {
     let store = setup_memory_store();

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1254,23 +1254,38 @@ async fn test_traverse_per_root_limit_capped_independently() {
 // ---- batch == per-root decomposition equivalence tests ----
 
 /// Equivalence fixture: for a small deterministic graph, batched
-/// `traverse([A, E])` must produce the same per-root results as running
-/// `traverse([A])` and `traverse([E])` independently.
+/// `traverse([R0, R1])` must produce the same per-root results as running
+/// `traverse([R0])` and `traverse([R1])` independently, across four sections:
 ///
-/// The fixture exercises a matrix of parameters:
-///   include_roots ∈ {true, false}
-///   with and without a relation filter
-///   with and without min_weight
-///   with a finite limit  ← catches the Major per-root-limit bug class
+/// **Section A** – linear chains, Direction::Out, 6-case parameter matrix
+///   (include_roots, relation filter, min_weight, finite limit):
+///   A → B (w=0.9, Extends) → C (w=0.8) → D (w=0.7)
+///   E → F (w=0.6, Extends) → G (w=0.5)
 ///
-/// Graph (two independent linear chains — no diamond — so via_edge is
-/// unambiguous and the comparison is exact field-by-field):
-///   A → B (w=0.9) → C (w=0.8) → D (w=0.7)   [relation: Extends]
-///   E → F (w=0.6) → G (w=0.5)                [relation: Extends]
+/// **Section B** – diamond with shortcut, Direction::Out (depth/via_edge drift):
+///   H → VI (w=1.0, Extends) → K (w=1.0, Extends)
+///   H → K  (w=0.5, PartOf)  ← shortcut; K is at depth 1 from H via H→K,
+///                                          NOT depth 2 via H→VI→K.
+///   Batched CTE must attribute K's first visit to depth=1, via_edge=H→K edge.
+///
+/// **Section C** – same diamond, Direction::In (bidirectional traversal):
+///   roots [K, N].  K has two distinct incoming edges (H→K and VI→K); the
+///   batched CTE must assign each one its own via_edge independently.
+///
+/// **Section D** – same diamond + chain, Direction::Both:
+///   roots [VI, N].  VI has both in-edges (H→VI) and out-edges (VI→K).
+///
+/// M → N (w=1.0, Extends) — independent parallel chain used as the second
+///   root in Sections B/C/D.
+///
+/// Same-depth node ordering is resolved by sorting PathNodes by (depth, node_id)
+/// before the per-node comparison — no new ordering contract is introduced in
+/// production code.
 #[tokio::test]
 async fn test_traverse_batch_equals_per_root_decomposition() {
     let store = setup_memory_store();
 
+    // Section A nodes
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();
     let c = Uuid::new_v4();
@@ -1279,6 +1294,14 @@ async fn test_traverse_batch_equals_per_root_decomposition() {
     let f = Uuid::new_v4();
     let g = Uuid::new_v4();
 
+    // Section B/C/D nodes
+    let h = Uuid::new_v4(); // diamond source
+    let vi = Uuid::new_v4(); // diamond intermediate
+    let k = Uuid::new_v4(); // convergent node (reachable from h directly AND via vi)
+    let m = Uuid::new_v4(); // independent parallel root
+    let n = Uuid::new_v4(); // child of m
+
+    // Section A edges
     for (src, tgt, w) in [
         (a, b, 0.9_f64),
         (b, c, 0.8),
@@ -1292,14 +1315,35 @@ async fn test_traverse_batch_equals_per_root_decomposition() {
             .unwrap();
     }
 
-    // Sort PathNode by (depth, node_id) so the comparison is stable even
-    // if SQLite returns same-depth nodes in different orders between calls.
+    // Section B/C/D edges
+    store
+        .upsert_edge(make_edge(h, vi, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(vi, k, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    // Shortcut: K is reachable from H in one hop; the depth-2 path via VI→K must
+    // be suppressed by BFS first-visit in both batched and single-root traversals.
+    store
+        .upsert_edge(make_edge(h, k, EdgeRelation::PartOf, 0.5))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(m, n, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    // Sort PathNodes by (depth, node_id) for a stable comparison even when
+    // same-depth nodes appear in different orders between CTE executions.
+    // This resolves depth-1 tie-breaking without requiring a new ordering
+    // contract in production code.
     let sort_nodes = |nodes: &mut Vec<khive_storage::types::PathNode>| {
         nodes.sort_by_key(|n| (n.depth, n.node_id));
     };
 
-    // (include_roots, direction, relation_filter, min_weight, limit)
-    // Direction is Clone but not Copy, so we build TraversalOptions per iteration.
+    // Direction is Clone but not Copy; TraversalOptions is built per case.
     struct Case {
         include_roots: bool,
         direction: Direction,
@@ -1307,151 +1351,293 @@ async fn test_traverse_batch_equals_per_root_decomposition() {
         min_weight: Option<f64>,
         limit: Option<u32>,
     }
-    let cases = [
-        Case {
-            include_roots: false,
-            direction: Direction::Out,
-            relation_filter: None,
-            min_weight: None,
-            limit: None,
-        },
-        Case {
-            include_roots: true,
-            direction: Direction::Out,
-            relation_filter: None,
-            min_weight: None,
-            limit: None,
-        },
-        Case {
-            include_roots: false,
-            direction: Direction::Out,
-            relation_filter: None,
-            min_weight: None,
-            limit: Some(1),
-        },
-        Case {
-            include_roots: false,
-            direction: Direction::Out,
-            relation_filter: None,
-            min_weight: None,
-            limit: Some(2),
-        },
-        Case {
-            include_roots: false,
-            direction: Direction::Out,
-            relation_filter: Some(EdgeRelation::Extends),
-            min_weight: None,
-            limit: None,
-        },
-        Case {
-            include_roots: false,
-            direction: Direction::Out,
-            relation_filter: None,
-            min_weight: Some(0.65),
-            limit: None,
-        },
-    ];
 
-    for case in &cases {
-        let opts = TraversalOptions {
-            max_depth: 4,
-            direction: case.direction.clone(),
-            relations: case.relation_filter.map(|r| vec![r]),
-            min_weight: case.min_weight,
-            limit: case.limit,
-        };
+    // run_cases: for each case, assert batched([r0, r1]) == decomposed([r0]) + ([r1]).
+    // Takes roots by value so it can be called for each section.
+    async fn run_cases(
+        store: &SqlGraphStore,
+        root0: Uuid,
+        root1: Uuid,
+        cases: &[Case],
+        sort_nodes: &dyn Fn(&mut Vec<khive_storage::types::PathNode>),
+    ) {
+        for case in cases {
+            let opts = TraversalOptions {
+                max_depth: 4,
+                direction: case.direction.clone(),
+                relations: case.relation_filter.map(|r| vec![r]),
+                min_weight: case.min_weight,
+                limit: case.limit,
+            };
 
-        let batched = store
-            .traverse(TraversalRequest {
-                roots: vec![a, e],
-                options: opts.clone(),
-                include_roots: case.include_roots,
-            })
-            .await
-            .unwrap();
-        let single_a = store
-            .traverse(TraversalRequest {
-                roots: vec![a],
-                options: opts.clone(),
-                include_roots: case.include_roots,
-            })
-            .await
-            .unwrap();
-        let single_e = store
-            .traverse(TraversalRequest {
-                roots: vec![e],
-                options: opts,
-                include_roots: case.include_roots,
-            })
-            .await
-            .unwrap();
+            let batched = store
+                .traverse(TraversalRequest {
+                    roots: vec![root0, root1],
+                    options: opts.clone(),
+                    include_roots: case.include_roots,
+                })
+                .await
+                .unwrap();
+            let single_0 = store
+                .traverse(TraversalRequest {
+                    roots: vec![root0],
+                    options: opts.clone(),
+                    include_roots: case.include_roots,
+                })
+                .await
+                .unwrap();
+            let single_1 = store
+                .traverse(TraversalRequest {
+                    roots: vec![root1],
+                    options: opts,
+                    include_roots: case.include_roots,
+                })
+                .await
+                .unwrap();
 
-        for (root_id, single_result) in [(a, &single_a), (e, &single_e)] {
-            let batch_path = batched.iter().find(|p| p.root_id == root_id);
-            let single_path = single_result.first();
+            for (root_id, single_result) in [(root0, &single_0), (root1, &single_1)] {
+                let batch_path = batched.iter().find(|p| p.root_id == root_id);
+                let single_path = single_result.first();
 
-            let label = format!(
-                "root={root_id:?} params=(include_roots={},dir={:?},rel={:?},\
-                 min_w={:?},limit={:?})",
-                case.include_roots,
-                case.direction,
-                case.relation_filter,
-                case.min_weight,
-                case.limit,
-            );
+                let label = format!(
+                    "root={root_id:?} params=(include_roots={},dir={:?},rel={:?},\
+                     min_w={:?},limit={:?})",
+                    case.include_roots,
+                    case.direction,
+                    case.relation_filter,
+                    case.min_weight,
+                    case.limit,
+                );
 
-            match (batch_path, single_path) {
-                (None, None) => {}
-                (Some(bp), Some(sp)) => {
-                    let mut bn = bp.nodes.clone();
-                    let mut sn = sp.nodes.clone();
-                    sort_nodes(&mut bn);
-                    sort_nodes(&mut sn);
+                match (batch_path, single_path) {
+                    (None, None) => {}
+                    (Some(bp), Some(sp)) => {
+                        let mut bn = bp.nodes.clone();
+                        let mut sn = sp.nodes.clone();
+                        sort_nodes(&mut bn);
+                        sort_nodes(&mut sn);
 
-                    assert_eq!(
-                        bn.len(),
-                        sn.len(),
-                        "{label}: node count mismatch batch={} single={}",
-                        bn.len(),
-                        sn.len()
-                    );
-                    for (bi, si) in bn.iter().zip(sn.iter()) {
                         assert_eq!(
-                            bi.node_id, si.node_id,
-                            "{label}: node_id mismatch at depth {}",
-                            bi.depth
+                            bn.len(),
+                            sn.len(),
+                            "{label}: node count mismatch batch={} single={}",
+                            bn.len(),
+                            sn.len()
                         );
-                        assert_eq!(
-                            bi.depth, si.depth,
-                            "{label}: depth mismatch for node {}",
-                            bi.node_id
-                        );
-                        assert_eq!(
-                            bi.via_edge, si.via_edge,
-                            "{label}: via_edge mismatch for node {}",
-                            bi.node_id
+                        for (bi, si) in bn.iter().zip(sn.iter()) {
+                            assert_eq!(
+                                bi.node_id, si.node_id,
+                                "{label}: node_id mismatch at depth {}",
+                                bi.depth
+                            );
+                            assert_eq!(
+                                bi.depth, si.depth,
+                                "{label}: depth mismatch for node {}",
+                                bi.node_id
+                            );
+                            assert_eq!(
+                                bi.via_edge, si.via_edge,
+                                "{label}: via_edge mismatch for node {}",
+                                bi.node_id
+                            );
+                        }
+                        assert!(
+                            (bp.total_weight - sp.total_weight).abs() < 1e-9,
+                            "{label}: total_weight mismatch batch={} single={}",
+                            bp.total_weight,
+                            sp.total_weight
                         );
                     }
-                    assert!(
-                        (bp.total_weight - sp.total_weight).abs() < 1e-9,
-                        "{label}: total_weight mismatch batch={} single={}",
-                        bp.total_weight,
-                        sp.total_weight
-                    );
-                }
-                (None, Some(sp)) => {
-                    panic!(
-                        "{label}: batch missing path that single found ({} nodes)",
-                        sp.nodes.len()
-                    );
-                }
-                (Some(bp), None) => {
-                    panic!(
-                        "{label}: batch has path ({} nodes) that single didn't produce",
-                        bp.nodes.len()
-                    );
+                    (None, Some(sp)) => {
+                        panic!(
+                            "{label}: batch missing path that single found ({} nodes)",
+                            sp.nodes.len()
+                        );
+                    }
+                    (Some(bp), None) => {
+                        panic!(
+                            "{label}: batch has path ({} nodes) that single didn't produce",
+                            bp.nodes.len()
+                        );
+                    }
                 }
             }
         }
     }
+
+    // ── Section A: linear chains, Direction::Out ──────────────────────────────
+    run_cases(
+        &store,
+        a,
+        e,
+        &[
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: true,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: Some(1),
+            },
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: Some(2),
+            },
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: Some(EdgeRelation::Extends),
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: Some(0.65),
+                limit: None,
+            },
+        ],
+        &sort_nodes,
+    )
+    .await;
+
+    // ── Section B: diamond, Direction::Out ────────────────────────────────────
+    // K must appear at depth=1 via the H→K shortcut edge, NOT at depth=2 via
+    // H→VI→K.  A bug in the batched CTE's per-root seen-set tracking would
+    // produce the wrong depth or via_edge for K.
+    run_cases(
+        &store,
+        h,
+        m,
+        &[
+            Case {
+                include_roots: false,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: true,
+                direction: Direction::Out,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+        ],
+        &sort_nodes,
+    )
+    .await;
+
+    // ── Section C: converging node, Direction::In ─────────────────────────────
+    // K has two distinct incoming edges (H→K via PartOf and VI→K via Extends).
+    // Both must appear independently in K's path; neither must bleed into N's path.
+    run_cases(
+        &store,
+        k,
+        n,
+        &[
+            Case {
+                include_roots: false,
+                direction: Direction::In,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: true,
+                direction: Direction::In,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+        ],
+        &sort_nodes,
+    )
+    .await;
+
+    // ── Section D: middle node, Direction::Both ───────────────────────────────
+    // VI has H→VI incoming and VI→K outgoing.  Direction::Both must walk both
+    // sides and produce identical results for the batched and single-root cases.
+    run_cases(
+        &store,
+        vi,
+        n,
+        &[
+            Case {
+                include_roots: false,
+                direction: Direction::Both,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+            Case {
+                include_roots: true,
+                direction: Direction::Both,
+                relation_filter: None,
+                min_weight: None,
+                limit: None,
+            },
+        ],
+        &sort_nodes,
+    )
+    .await;
+}
+
+/// Regression: `limit=0` with `include_roots=false` must emit NO path for that
+/// root, not an empty `GraphPath`.  Pre-fix, the Rust-level truncation reduced
+/// the node list to zero but still pushed a `GraphPath { nodes: [] }`.
+///
+/// This test must FAIL on the commit that introduced the per-root Rust truncation
+/// but BEFORE the post-truncation empty guard was added, and PASS after.
+#[tokio::test]
+async fn test_traverse_limit_zero_include_roots_false_emits_no_path() {
+    let store = setup_memory_store();
+
+    let root = Uuid::new_v4();
+    let child = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(root, child, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let paths = store
+        .traverse(TraversalRequest {
+            roots: vec![root],
+            options: TraversalOptions {
+                max_depth: 2,
+                direction: Direction::Out,
+                relations: None,
+                min_weight: None,
+                limit: Some(0),
+            },
+            include_roots: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        paths.len(),
+        0,
+        "limit=0 + include_roots=false: root has reachable children but no nodes \
+         qualify under the cap, so no GraphPath should be emitted at all"
+    );
 }

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1180,3 +1180,278 @@ async fn batch_neighbors_both_chunk_boundary() {
         "Both chunk-boundary with limit=1: must return exactly 1 hit per source"
     );
 }
+
+// ---- per-root limit regression (codex-mandated) ----
+
+/// Regression guard for the per-root `limit` regression introduced when N
+/// roots were batched into a single CTE with one global SQL LIMIT.
+///
+/// Graph: A→B and C→D (two independent chains).  With `limit=1` and
+/// `include_roots=false`, EVERY root must receive its own capped result —
+/// not just the lexicographically-first root_id.
+///
+/// This test FAILs on the pre-fix code (global LIMIT returns 1 row total,
+/// so only one root gets a path) and PASSes after the fix (Rust-level
+/// per-root truncation after SQL returns all rows).
+#[tokio::test]
+async fn test_traverse_per_root_limit_capped_independently() {
+    let store = setup_memory_store();
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    let d = Uuid::new_v4();
+
+    // Two independent one-hop chains: A→B and C→D.
+    store
+        .upsert_edge(make_edge(a, b, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(c, d, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let request = TraversalRequest {
+        roots: vec![a, c],
+        options: TraversalOptions {
+            max_depth: 2,
+            direction: Direction::Out,
+            relations: None,
+            min_weight: None,
+            limit: Some(1),
+        },
+        include_roots: false,
+    };
+
+    let paths = store.traverse(request).await.unwrap();
+
+    // Both roots must produce a path — global SQL LIMIT would drop one.
+    assert_eq!(
+        paths.len(),
+        2,
+        "both roots must produce a path even with limit=1 \
+         (per-root cap, not global cap)"
+    );
+
+    // Each root gets exactly one node.
+    for path in &paths {
+        assert_eq!(
+            path.nodes.len(),
+            1,
+            "root {:?}: limit=1 must cap to exactly one non-root node",
+            path.root_id
+        );
+    }
+
+    // Correct child per root.
+    let path_a = paths.iter().find(|p| p.root_id == a).expect("path for A");
+    let path_c = paths.iter().find(|p| p.root_id == c).expect("path for C");
+    assert_eq!(path_a.nodes[0].node_id, b, "root A must reach child B");
+    assert_eq!(path_c.nodes[0].node_id, d, "root C must reach child D");
+}
+
+// ---- batch == per-root decomposition equivalence tests ----
+
+/// Equivalence fixture: for a small deterministic graph, batched
+/// `traverse([A, E])` must produce the same per-root results as running
+/// `traverse([A])` and `traverse([E])` independently.
+///
+/// The fixture exercises a matrix of parameters:
+///   include_roots ∈ {true, false}
+///   with and without a relation filter
+///   with and without min_weight
+///   with a finite limit  ← catches the Major per-root-limit bug class
+///
+/// Graph (two independent linear chains — no diamond — so via_edge is
+/// unambiguous and the comparison is exact field-by-field):
+///   A → B (w=0.9) → C (w=0.8) → D (w=0.7)   [relation: Extends]
+///   E → F (w=0.6) → G (w=0.5)                [relation: Extends]
+#[tokio::test]
+async fn test_traverse_batch_equals_per_root_decomposition() {
+    let store = setup_memory_store();
+
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    let d = Uuid::new_v4();
+    let e = Uuid::new_v4();
+    let f = Uuid::new_v4();
+    let g = Uuid::new_v4();
+
+    for (src, tgt, w) in [
+        (a, b, 0.9_f64),
+        (b, c, 0.8),
+        (c, d, 0.7),
+        (e, f, 0.6),
+        (f, g, 0.5),
+    ] {
+        store
+            .upsert_edge(make_edge(src, tgt, EdgeRelation::Extends, w))
+            .await
+            .unwrap();
+    }
+
+    // Sort PathNode by (depth, node_id) so the comparison is stable even
+    // if SQLite returns same-depth nodes in different orders between calls.
+    let sort_nodes = |nodes: &mut Vec<khive_storage::types::PathNode>| {
+        nodes.sort_by_key(|n| (n.depth, n.node_id));
+    };
+
+    // (include_roots, direction, relation_filter, min_weight, limit)
+    // Direction is Clone but not Copy, so we build TraversalOptions per iteration.
+    struct Case {
+        include_roots: bool,
+        direction: Direction,
+        relation_filter: Option<EdgeRelation>,
+        min_weight: Option<f64>,
+        limit: Option<u32>,
+    }
+    let cases = [
+        Case {
+            include_roots: false,
+            direction: Direction::Out,
+            relation_filter: None,
+            min_weight: None,
+            limit: None,
+        },
+        Case {
+            include_roots: true,
+            direction: Direction::Out,
+            relation_filter: None,
+            min_weight: None,
+            limit: None,
+        },
+        Case {
+            include_roots: false,
+            direction: Direction::Out,
+            relation_filter: None,
+            min_weight: None,
+            limit: Some(1),
+        },
+        Case {
+            include_roots: false,
+            direction: Direction::Out,
+            relation_filter: None,
+            min_weight: None,
+            limit: Some(2),
+        },
+        Case {
+            include_roots: false,
+            direction: Direction::Out,
+            relation_filter: Some(EdgeRelation::Extends),
+            min_weight: None,
+            limit: None,
+        },
+        Case {
+            include_roots: false,
+            direction: Direction::Out,
+            relation_filter: None,
+            min_weight: Some(0.65),
+            limit: None,
+        },
+    ];
+
+    for case in &cases {
+        let opts = TraversalOptions {
+            max_depth: 4,
+            direction: case.direction.clone(),
+            relations: case.relation_filter.map(|r| vec![r]),
+            min_weight: case.min_weight,
+            limit: case.limit,
+        };
+
+        let batched = store
+            .traverse(TraversalRequest {
+                roots: vec![a, e],
+                options: opts.clone(),
+                include_roots: case.include_roots,
+            })
+            .await
+            .unwrap();
+        let single_a = store
+            .traverse(TraversalRequest {
+                roots: vec![a],
+                options: opts.clone(),
+                include_roots: case.include_roots,
+            })
+            .await
+            .unwrap();
+        let single_e = store
+            .traverse(TraversalRequest {
+                roots: vec![e],
+                options: opts,
+                include_roots: case.include_roots,
+            })
+            .await
+            .unwrap();
+
+        for (root_id, single_result) in [(a, &single_a), (e, &single_e)] {
+            let batch_path = batched.iter().find(|p| p.root_id == root_id);
+            let single_path = single_result.first();
+
+            let label = format!(
+                "root={root_id:?} params=(include_roots={},dir={:?},rel={:?},\
+                 min_w={:?},limit={:?})",
+                case.include_roots,
+                case.direction,
+                case.relation_filter,
+                case.min_weight,
+                case.limit,
+            );
+
+            match (batch_path, single_path) {
+                (None, None) => {}
+                (Some(bp), Some(sp)) => {
+                    let mut bn = bp.nodes.clone();
+                    let mut sn = sp.nodes.clone();
+                    sort_nodes(&mut bn);
+                    sort_nodes(&mut sn);
+
+                    assert_eq!(
+                        bn.len(),
+                        sn.len(),
+                        "{label}: node count mismatch batch={} single={}",
+                        bn.len(),
+                        sn.len()
+                    );
+                    for (bi, si) in bn.iter().zip(sn.iter()) {
+                        assert_eq!(
+                            bi.node_id, si.node_id,
+                            "{label}: node_id mismatch at depth {}",
+                            bi.depth
+                        );
+                        assert_eq!(
+                            bi.depth, si.depth,
+                            "{label}: depth mismatch for node {}",
+                            bi.node_id
+                        );
+                        assert_eq!(
+                            bi.via_edge, si.via_edge,
+                            "{label}: via_edge mismatch for node {}",
+                            bi.node_id
+                        );
+                    }
+                    assert!(
+                        (bp.total_weight - sp.total_weight).abs() < 1e-9,
+                        "{label}: total_weight mismatch batch={} single={}",
+                        bp.total_weight,
+                        sp.total_weight
+                    );
+                }
+                (None, Some(sp)) => {
+                    panic!(
+                        "{label}: batch missing path that single found ({} nodes)",
+                        sp.nodes.len()
+                    );
+                }
+                (Some(bp), None) => {
+                    panic!(
+                        "{label}: batch has path ({} nodes) that single didn't produce",
+                        bp.nodes.len()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -1212,8 +1212,8 @@ fn compile_variable_length(
                     t.path || ',' || {recurse_next}, \
                     t.total_weight + e.weight, \
                     e.id, e.relation, e.weight \
-             FROM traverse t \
-             JOIN graph_edges e ON {recurse_join} AND e.deleted_at IS NULL{e_ns_filter}{relation_condition} \
+             FROM traverse t CROSS JOIN graph_edges e \
+                 ON {recurse_join} AND e.deleted_at IS NULL{e_ns_filter}{relation_condition} \
              JOIN entities next_node ON next_node.id = ({recurse_next}) \
                     AND next_node.deleted_at IS NULL{next_node_ns_and} \
              WHERE t.depth < ?{depth_param} \


### PR DESCRIPTION
## Problem

The `GraphStore::traverse()` implementation in `crates/khive-db/src/stores/graph.rs` had a
join-order bug in its recursive CTE. SQLite does not reorder the outer/inner loop in
recursive CTEs, so:

```sql
-- Old: edges as outer loop
FROM graph_edges e
JOIN traversal t ON e.source_id = t.node_id
```

scanned all 786K edges at every depth step (O(edges × frontier) per step). On a 62K-node
/ 786K-edge graph, a single-root depth-1 traversal took **97.6 seconds**.

The same bug existed in the GQL var-length path compiler
(`crates/khive-query/src/compilers/sql.rs`), causing GQL depth-2 traversals to take 89s.

## Fix

Replace `JOIN` with `CROSS JOIN` to force the frontier as the outer loop:

```sql
-- Fixed: frontier as outer loop → index seek on inner
FROM traversal t CROSS JOIN graph_edges e ON e.source_id = t.node_id
```

This allows SQLite to use `idx_graph_edges_unique_triple(namespace, source_id)` as an
inner seek, reducing cost to O(frontier × avg_degree) per step.

Additionally, replace the per-root CTE loop with a single batched CTE using a `VALUES`
seed carrying a `root_id` tracking column, so N roots share one CTE compilation and one
traversal pass. The `limit` option is applied **per-root** in Rust after BFS dedup,
matching the original contract: each root independently caps to its shallowest `limit`
reachable nodes.

## Results

Benchmarked on a 62,038-node / 786,649-edge SQLite graph (all `depends_on` edges):

| Scenario | Before | After | Speedup |
|---|---|---|---|
| 1 root, depth 1 | 97,600ms | ~1ms | ~97,000× |
| 1 root, depth 2 | >97,600ms (est.) | 5.4ms | >18,000× |
| 1 root, depth 3 | >97,600ms (est.) | 5.7ms | >17,000× |
| 5 roots, depth 3 | >488,000ms (est.) | 31.4ms | >15,500× |

Post-fix re-bench (balanced tree, 121 nodes / 120 edges):

| Probe | Median |
|---|---|
| depth=2 single-root | 14.6ms |
| depth=3 single-root | 14.7ms |
| depth=4 single-root | 15.9ms |
| depth=3 5-root batch | 17.2ms |

## Changes

- `crates/khive-db/src/stores/graph.rs` — `traverse()` rewritten: batch-roots CTE,
  `CROSS JOIN`, `root_id` tracking column, `HashMap`-based result assembly. `limit` is
  now applied per-root in Rust (post-dedup BFS truncation) rather than as a global SQL
  `LIMIT` over the concatenated multi-root output.
- `crates/khive-db/src/stores/graph_tests.rs` — 5 regression/equivalence tests:
  multi-root independent chains, shared-neighbor isolation, binary-tree node count,
  per-root limit independence, and batch-equals-decomposed equivalence matrix.
- `crates/khive-query/src/compilers/sql.rs` — same `CROSS JOIN` fix in GQL
  recursive CTE compiler

`GraphStore::traverse` contract (ADR-005) is unchanged: same `TraversalRequest` input,
same `Vec<GraphPath>` output, same BFS first-visit semantics (shallowest depth per root),
`limit` caps per-root (not globally).

Closes #250, closes #251

## Test plan

- [x] `cargo test -p khive-db` — 31 tests passed
- [x] `cargo test -p khive-query` — passed
- [x] `cargo test -p khive-runtime` — passed
- [x] `cargo clippy ... -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `test_traverse_per_root_limit_capped_independently` — fails before fix, passes after
- [x] `test_traverse_batch_equals_per_root_decomposition` — 6-case matrix, all pass
- [x] Post-fix latency: depth=2/3/4 single-root = 14.6/14.7/15.9ms; 5-root depth=3 = 17.2ms