### PR TITLE
fix(knowledge): warn when ignored chunk_size/cascade params are supplied

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -24,6 +24,12 @@ impl KnowledgeHandlers {
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let p: UpsertAtomsParams = deser(params)?;
+        if p.chunk_size.is_some() {
+            tracing::warn!(
+                "upsert_atoms: chunk_size is accepted but not yet implemented; \
+                 server-side chunking is not performed"
+            );
+        }
         if p.atoms.is_empty() {
             return Err(RuntimeError::InvalidInput(
                 "atoms list must not be empty".into(),
@@ -551,6 +557,12 @@ impl KnowledgeHandlers {
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let p: DeleteAtomsParams = deser(params)?;
+        if p.cascade.is_some() {
+            tracing::warn!(
+                "delete_atoms: cascade is accepted but not yet implemented; \
+                 sections are not cascade-deleted when atoms are soft-deleted"
+            );
+        }
         if p.ids.is_empty() {
             return Err(RuntimeError::InvalidInput("ids must not be empty".into()));
         }
@@ -766,6 +778,38 @@ mod tests {
             check(name).is_ok(),
             "normal atom name must pass; fired: {:?}",
             check(name).err()
+        );
+    }
+
+    // Ignored-param warning coverage: verify that chunk_size and cascade are still
+    // accepted by the param structs (no deserialization error) and that the fields
+    // are Some when supplied, confirming the warning branch is reachable.
+
+    #[test]
+    fn upsert_atoms_chunk_size_accepted_and_detectable() {
+        use crate::knowledge::schema::UpsertAtomsParams;
+        let p: UpsertAtomsParams = serde_json::from_value(serde_json::json!({
+            "atoms": [{"slug": "s", "name": "n", "content": "placeholder content for test"}],
+            "chunk_size": 100,
+        }))
+        .expect("upsert_atoms params with chunk_size must deserialize without error");
+        assert!(
+            p.chunk_size.is_some(),
+            "chunk_size must be Some when supplied so the warning branch fires"
+        );
+    }
+
+    #[test]
+    fn delete_atoms_cascade_accepted_and_detectable() {
+        use crate::knowledge::schema::DeleteAtomsParams;
+        let p: DeleteAtomsParams = serde_json::from_value(serde_json::json!({
+            "ids": ["some-atom-id"],
+            "cascade": true,
+        }))
+        .expect("delete_atoms params with cascade must deserialize without error");
+        assert!(
+            p.cascade.is_some(),
+            "cascade must be Some when supplied so the warning branch fires"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -26,6 +26,7 @@ impl KnowledgeHandlers {
         let p: UpsertAtomsParams = deser(params)?;
         if p.chunk_size.is_some() {
             tracing::warn!(
+                chunk_size = ?p.chunk_size,
                 "upsert_atoms: chunk_size is accepted but not yet implemented; \
                  server-side chunking is not performed"
             );
@@ -559,6 +560,7 @@ impl KnowledgeHandlers {
         let p: DeleteAtomsParams = deser(params)?;
         if p.cascade.is_some() {
             tracing::warn!(
+                cascade = ?p.cascade,
                 "delete_atoms: cascade is accepted but not yet implemented; \
                  sections are not cascade-deleted when atoms are soft-deleted"
             );
@@ -783,7 +785,7 @@ mod tests {
 
     // Ignored-param warning coverage: verify that chunk_size and cascade are still
     // accepted by the param structs (no deserialization error) and that the fields
-    // are Some when supplied, confirming the warning branch is reachable.
+    // are Some when supplied, confirming the warning branch precondition is satisfiable.
 
     #[test]
     fn upsert_atoms_chunk_size_accepted_and_detectable() {
@@ -795,7 +797,7 @@ mod tests {
         .expect("upsert_atoms params with chunk_size must deserialize without error");
         assert!(
             p.chunk_size.is_some(),
-            "chunk_size must be Some when supplied so the warning branch fires"
+            "chunk_size must be Some when supplied so the warning branch precondition is satisfiable"
         );
     }
 
@@ -809,7 +811,7 @@ mod tests {
         .expect("delete_atoms params with cascade must deserialize without error");
         assert!(
             p.cascade.is_some(),
-            "cascade must be Some when supplied so the warning branch fires"
+            "cascade must be Some when supplied so the warning branch precondition is satisfiable"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/schema.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/schema.rs
@@ -107,7 +107,6 @@ pub(crate) struct UpsertAtomsParams {
     // REASON: chunk_size is accepted from callers as a hint for client-side pagination;
     // server-side chunking is not yet implemented but the field must be deserialized
     // so callers that send it don't receive unexpected errors.
-    #[allow(dead_code)]
     pub chunk_size: Option<usize>,
 }
 
@@ -166,7 +165,6 @@ pub(crate) struct DeleteAtomsParams {
     #[serde(default)]
     // REASON: cascade is accepted from callers for API forward-compatibility; cascading
     // delete behavior is not yet implemented (atoms are soft-deleted without affecting sections).
-    #[allow(dead_code)]
     pub cascade: Option<bool>,
 }
 


### PR DESCRIPTION
## Summary

Two params in `khive-pack-knowledge` were accepted by the handler but silently
discarded, leaving callers with no feedback:

- `chunk_size` in `upsert_atoms` — accepted as a client-side pagination hint;
  server-side chunking is not implemented.
- `cascade` in `delete_atoms` — accepted for API forward-compatibility; cascading
  section deletion is not implemented.

Both have `#[allow(dead_code)]` on the field and explanatory comments describing
the forward-compat intent.

## What changed

`crates/khive-pack-knowledge/src/knowledge/crud.rs`

- After deserializing `UpsertAtomsParams`, emit `tracing::warn!` when `chunk_size`
  is `Some`, naming the param and stating it is not yet implemented.
- After deserializing `DeleteAtomsParams`, emit `tracing::warn!` when `cascade` is
  `Some`, naming the param and stating it is not yet implemented.

`crates/khive-pack-knowledge/src/knowledge/schema.rs`

- Removed `#[allow(dead_code)]` from both fields; they are now read (via `.is_some()`)
  so the attribute was no longer accurate.

The accepted param surface is unchanged — `chunk_size` and `cascade` remain in the
structs and are still deserialized without error.

## Tests added

Two unit tests in `crud.rs`:
- `upsert_atoms_chunk_size_accepted_and_detectable` — confirms `chunk_size` deserializes
  without error and is `Some` when supplied (warning branch reachable).
- `delete_atoms_cascade_accepted_and_detectable` — confirms `cascade` deserializes
  without error and is `Some` when supplied (warning branch reachable).

## Gate results

```
test rc=0
clippy rc=0
fmt rc=0
```