### PR TITLE
feat(db): implement orphan_sweep in SqliteVecStore (ADR-044 §5)

### DIFF
--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -9,10 +9,11 @@ use uuid::Uuid;
 use khive_score::DeterministicScore;
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteSummary, IndexRebuildScope, VectorIndexKind, VectorRecord, VectorSearchHit,
-    VectorSearchRequest, VectorStoreCapabilities, VectorStoreInfo,
+    BatchWriteSummary, IndexRebuildScope, OrphanSweepConfig, OrphanSweepResult, VectorIndexKind,
+    VectorRecord, VectorSearchHit, VectorSearchRequest, VectorStoreCapabilities, VectorStoreInfo,
 };
 use khive_storage::StorageCapability;
+use khive_storage::StorageResult;
 use khive_storage::VectorStore;
 use khive_types::SubstrateKind;
 
@@ -787,6 +788,144 @@ impl VectorStore for SqliteVecStore {
         .await
     }
 
+    async fn orphan_sweep(&self, config: &OrphanSweepConfig) -> StorageResult<OrphanSweepResult> {
+        let table = self.table_name.clone();
+
+        // Serialize filter lists as JSON arrays for json_each() usage inside SQL.
+        // An empty list becomes None, which binds as NULL; the IS NULL guard then
+        // short-circuits to true, passing all rows through (= no filtering).
+        let ns_json: Option<String> = if config.namespaces.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&config.namespaces).ok()
+        };
+
+        let kind_json: Option<String> = if config.substrate_kinds.is_empty() {
+            None
+        } else {
+            let strs: Vec<String> = config
+                .substrate_kinds
+                .iter()
+                .map(|k| k.to_string())
+                .collect();
+            serde_json::to_string(&strs).ok()
+        };
+
+        // None = all rows eligible; Some(ids) = only those IDs may be swept.
+        let allow_json: Option<String> = config.subject_id_allowlist.as_ref().map(|ids| {
+            let strs: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+            serde_json::to_string(&strs).unwrap_or_default()
+        });
+
+        let max_delete = config.max_delete as i64;
+        let dry_run = config.dry_run;
+
+        self.with_writer("orphan_sweep", move |conn| {
+            // Acquire a write lock for the entire sweep to eliminate the TOCTOU
+            // window between counting orphans and deleting them (ADR-044 §5).
+            conn.execute_batch("BEGIN IMMEDIATE")?;
+
+            // Optional-filter clause shared across all three queries.
+            // Each ?N appears twice (IS NULL guard + json_each call); SQLite
+            // reuses the same bound value for every occurrence of the same ?N.
+            //   ?1 = namespace JSON or NULL   ?2 = kind JSON or NULL
+            //   ?3 = allowlist JSON or NULL
+            let filter_pred = "(?1 IS NULL OR namespace IN (SELECT value FROM json_each(?1))) \
+                               AND (?2 IS NULL OR kind IN (SELECT value FROM json_each(?2))) \
+                               AND (?3 IS NULL OR subject_id IN (SELECT value FROM json_each(?3)))";
+
+            // Live-subjects subquery used in the orphan anti-join.
+            //
+            // Policy-critical: `deleted_at IS NULL` means a soft-deleted substrate
+            // row is NOT considered live, so its vector is swept.
+            // To preserve vectors for soft-deleted subjects, remove the
+            // `deleted_at IS NULL` filter from both lines below (one-line change per
+            // table).  The `memories` table referenced in ADR-044 §5 does not exist;
+            // memory notes live in the `notes` table with kind = 'memory'.
+            let live_subq = "SELECT id FROM entities WHERE deleted_at IS NULL \
+                             UNION ALL \
+                             SELECT id FROM notes    WHERE deleted_at IS NULL";
+
+            let orphan_pred = format!(
+                "subject_id NOT IN ({live}) AND {f}",
+                live = live_subq,
+                f = filter_pred,
+            );
+
+            // 1. Scanned: rows matching the caller's filters (before orphan check).
+            let scan_sql = format!(
+                "SELECT COUNT(*) FROM {t} WHERE {f}",
+                t = table,
+                f = filter_pred
+            );
+            let scanned: i64 = conn.query_row(
+                &scan_sql,
+                rusqlite::params![
+                    ns_json.as_deref(),
+                    kind_json.as_deref(),
+                    allow_json.as_deref()
+                ],
+                |row| row.get(0),
+            )?;
+
+            // 2. Would-delete: orphaned rows among the scanned set.
+            let count_sql = format!(
+                "SELECT COUNT(*) FROM {t} WHERE {p}",
+                t = table,
+                p = orphan_pred,
+            );
+            let would_delete: i64 = conn.query_row(
+                &count_sql,
+                rusqlite::params![
+                    ns_json.as_deref(),
+                    kind_json.as_deref(),
+                    allow_json.as_deref()
+                ],
+                |row| row.get(0),
+            )?;
+
+            let max_delete_hit = would_delete > max_delete;
+
+            // 3. Delete — skipped in dry-run mode.
+            //
+            // `DELETE … LIMIT N` requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which
+            // rusqlite's bundled SQLite does not enable.  Portable alternative:
+            // delete subject_ids returned by a capped SELECT subquery.  SQLite
+            // materialises the inner SELECT before running the outer DELETE, so there
+            // is no self-referential conflict.
+            let deleted: i64 = if dry_run {
+                0
+            } else {
+                let del_sql = format!(
+                    "DELETE FROM {t} WHERE subject_id IN (\
+                     SELECT subject_id FROM {t} WHERE {p} LIMIT ?4\
+                     )",
+                    t = table,
+                    p = orphan_pred,
+                );
+                conn.execute(
+                    &del_sql,
+                    rusqlite::params![
+                        ns_json.as_deref(),
+                        kind_json.as_deref(),
+                        allow_json.as_deref(),
+                        max_delete
+                    ],
+                )? as i64
+            };
+
+            conn.execute_batch("COMMIT")?;
+
+            Ok(OrphanSweepResult {
+                scanned: scanned as u64,
+                would_delete: would_delete as u64,
+                deleted: deleted as u64,
+                max_delete_hit,
+            })
+        })
+        .await
+    }
+
     fn capabilities(&self) -> &'static VectorStoreCapabilities {
         static SQLITE_VEC_CAPABILITIES: OnceLock<VectorStoreCapabilities> = OnceLock::new();
         SQLITE_VEC_CAPABILITIES.get_or_init(|| VectorStoreCapabilities {
@@ -794,7 +933,7 @@ impl VectorStore for SqliteVecStore {
             supports_batch_search: false,
             supports_quantization: false,
             supports_update: false,
-            supports_orphan_sweep: false,
+            supports_orphan_sweep: true,
             // sqlite-vec uses subject_id as PRIMARY KEY — only one vector per
             // subject per namespace is stored. Callers must use a single canonical
             // field (e.g. "content") and are not permitted to store both
@@ -1179,8 +1318,8 @@ mod capabilities_tests {
             "sqlite-vec does not support in-place update"
         );
         assert!(
-            !caps.supports_orphan_sweep,
-            "sqlite-vec does not support orphan sweep"
+            caps.supports_orphan_sweep,
+            "SqliteVecStore must advertise supports_orphan_sweep = true"
         );
         // sqlite-vec 0.1.9: SQLITE_VEC_VEC0_MAX_DIMENSIONS = 8192.
         assert_eq!(caps.max_dimensions, Some(8192));
@@ -2002,5 +2141,493 @@ mod atomic_replace_tests {
             "similarity to vec1 must be ~1.0 (got {sim:.6}); \
              a lower value means the stale embedding was not restored — transaction rollback failed"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orphan sweep tests
+// ---------------------------------------------------------------------------
+// Require the `vectors` feature because the sweep queries the vec0 virtual
+// table, which only exists when the sqlite-vec extension is loaded.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "vectors"))]
+mod orphan_sweep_tests {
+    use std::sync::Arc;
+
+    use khive_storage::types::{OrphanSweepConfig, OrphanSweepResult};
+    use khive_storage::VectorStore;
+    use khive_types::SubstrateKind;
+    use uuid::Uuid;
+
+    use super::*;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn make_pool() -> Arc<crate::pool::ConnectionPool> {
+        use crate::pool::{ConnectionPool, PoolConfig};
+        crate::extension::ensure_extensions_loaded();
+        Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: None,
+                ..PoolConfig::default()
+            })
+            .expect("in-memory pool"),
+        )
+    }
+
+    /// Create minimal substrate tables (id + deleted_at only — enough for the anti-join).
+    fn create_substrate_tables(pool: &Arc<crate::pool::ConnectionPool>) {
+        pool.try_writer()
+            .expect("writer")
+            .conn()
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS entities \
+                     (id TEXT PRIMARY KEY, deleted_at INTEGER); \
+                 CREATE TABLE IF NOT EXISTS notes \
+                     (id TEXT PRIMARY KEY, deleted_at INTEGER);",
+            )
+            .expect("create substrate tables");
+    }
+
+    fn create_vec_table(pool: &Arc<crate::pool::ConnectionPool>, model_key: &str, dims: usize) {
+        let ddl = format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+             subject_id TEXT PRIMARY KEY, \
+             namespace TEXT NOT NULL, \
+             kind TEXT NOT NULL, \
+             field TEXT NOT NULL, \
+             embedding_model TEXT NOT NULL, \
+             embedding float[{}] distance_metric=cosine)",
+            model_key, dims
+        );
+        pool.try_writer()
+            .expect("writer")
+            .conn()
+            .execute_batch(&ddl)
+            .expect("create vec table");
+    }
+
+    fn make_store(
+        pool: Arc<crate::pool::ConnectionPool>,
+        model_key: &str,
+        dims: usize,
+        ns: &str,
+    ) -> SqliteVecStore {
+        SqliteVecStore::new(
+            pool,
+            false,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            ns.to_string(),
+        )
+        .expect("SqliteVecStore::new")
+    }
+
+    /// Insert a substrate row into `entities`.  `deleted_at = None` → live; `Some(ts)` → soft-deleted.
+    fn insert_entity(pool: &Arc<crate::pool::ConnectionPool>, id: Uuid, deleted_at: Option<i64>) {
+        let id_str = id.to_string();
+        pool.try_writer()
+            .expect("writer")
+            .conn()
+            .execute(
+                "INSERT INTO entities (id, deleted_at) VALUES (?1, ?2)",
+                rusqlite::params![id_str, deleted_at],
+            )
+            .expect("insert entity");
+    }
+
+    fn vec4(a: f32, b: f32, c: f32, d: f32) -> Vec<f32> {
+        vec![a, b, c, d]
+    }
+
+    fn sweep_all(max_delete: u32, dry_run: bool) -> OrphanSweepConfig {
+        OrphanSweepConfig {
+            subject_id_allowlist: None,
+            namespaces: vec![],
+            substrate_kinds: vec![],
+            max_delete,
+            dry_run,
+        }
+    }
+
+    // ── test 1: live subject → vector kept ───────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_keeps_live_subject() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_live", 4);
+        let store = make_store(Arc::clone(&pool), "sw_live", 4, "ns:sw");
+        let ns = "ns:sw";
+
+        let id = Uuid::new_v4();
+        insert_entity(&pool, id, None); // live
+
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r: OrphanSweepResult = store
+            .orphan_sweep(&sweep_all(100, false))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1, "one vec row exists");
+        assert_eq!(r.would_delete, 0, "live subject is not an orphan");
+        assert_eq!(r.deleted, 0);
+        assert!(!r.max_delete_hit);
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(present.contains(&id), "live subject's vec must survive");
+    }
+
+    // ── test 2: soft-deleted subject → vector swept ──────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_sweeps_soft_deleted_subject() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_soft", 4);
+        let store = make_store(Arc::clone(&pool), "sw_soft", 4, "ns:soft");
+        let ns = "ns:soft";
+
+        let id = Uuid::new_v4();
+        insert_entity(&pool, id, Some(1_000_000)); // soft-deleted
+
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.5, 0.5, 0.5, 0.5)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r = store
+            .orphan_sweep(&sweep_all(100, false))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1);
+        assert_eq!(r.would_delete, 1, "soft-deleted subject counts as orphan");
+        assert_eq!(r.deleted, 1);
+        assert!(!r.max_delete_hit);
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(
+            !present.contains(&id),
+            "soft-deleted subject's vec must be swept"
+        );
+    }
+
+    // ── test 3: absent subject → vector swept ────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_sweeps_absent_subject() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_absent", 4);
+        let store = make_store(Arc::clone(&pool), "sw_absent", 4, "ns:absent");
+        let ns = "ns:absent";
+
+        let id = Uuid::new_v4(); // no substrate row at all
+
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r = store
+            .orphan_sweep(&sweep_all(100, false))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1);
+        assert_eq!(r.would_delete, 1, "absent subject counts as orphan");
+        assert_eq!(r.deleted, 1);
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(!present.contains(&id), "absent subject's vec must be swept");
+    }
+
+    // ── test 4: dry_run → nothing deleted, would_delete populated ────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_dry_run_does_not_delete() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_dry", 4);
+        let store = make_store(Arc::clone(&pool), "sw_dry", 4, "ns:dry");
+        let ns = "ns:dry";
+
+        let id = Uuid::new_v4(); // absent subject → orphan
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r = store
+            .orphan_sweep(&sweep_all(100, true))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.would_delete, 1, "dry-run must still count the orphan");
+        assert_eq!(r.deleted, 0, "dry-run must not delete anything");
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(present.contains(&id), "dry-run must not remove the vec");
+    }
+
+    // ── test 5: max_delete cap ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_max_delete_caps_deletion() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_cap", 4);
+        let store = make_store(Arc::clone(&pool), "sw_cap", 4, "ns:cap");
+        let ns = "ns:cap";
+
+        // Insert 5 orphaned vecs (no substrate rows).
+        let ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+        for (i, &id) in ids.iter().enumerate() {
+            let v = i as f32 / 10.0;
+            store
+                .insert(
+                    id,
+                    SubstrateKind::Entity,
+                    ns,
+                    "body",
+                    vec![vec![v, v + 0.1, v + 0.2, v + 0.3]],
+                )
+                .await
+                .expect("insert vec");
+        }
+
+        let r = store
+            .orphan_sweep(&OrphanSweepConfig {
+                subject_id_allowlist: None,
+                namespaces: vec![],
+                substrate_kinds: vec![],
+                max_delete: 2,
+                dry_run: false,
+            })
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 5);
+        assert_eq!(r.would_delete, 5);
+        assert_eq!(r.deleted, 2, "cap must stop at max_delete");
+        assert!(
+            r.max_delete_hit,
+            "max_delete_hit must be true when cap triggered"
+        );
+
+        // Verify exactly 3 vecs survive.
+        let mut surviving = 0usize;
+        for &id in &ids {
+            if store
+                .batch_exists(&[id], ns)
+                .await
+                .expect("exists")
+                .contains(&id)
+            {
+                surviving += 1;
+            }
+        }
+        assert_eq!(surviving, 3, "3 orphans must survive after cap");
+    }
+
+    // ── test 6: namespace filter ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_namespace_filter_scopes_sweep() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_ns", 4);
+        let store = make_store(Arc::clone(&pool), "sw_ns", 4, "ns:a");
+
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+
+        store
+            .insert(
+                id_a,
+                SubstrateKind::Entity,
+                "ns:a",
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert ns:a");
+        store
+            .insert(
+                id_b,
+                SubstrateKind::Entity,
+                "ns:b",
+                "body",
+                vec![vec4(0.5, 0.6, 0.7, 0.8)],
+            )
+            .await
+            .expect("insert ns:b");
+
+        // Both are orphans (no substrate rows); sweep scoped to ns:a only.
+        let r = store
+            .orphan_sweep(&OrphanSweepConfig {
+                subject_id_allowlist: None,
+                namespaces: vec!["ns:a".to_string()],
+                substrate_kinds: vec![],
+                max_delete: 100,
+                dry_run: false,
+            })
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1, "only ns:a row visible to scoped sweep");
+        assert_eq!(r.deleted, 1);
+
+        let exists_a = store.batch_exists(&[id_a], "ns:a").await.expect("exists a");
+        let exists_b = store.batch_exists(&[id_b], "ns:b").await.expect("exists b");
+        assert!(!exists_a.contains(&id_a), "ns:a orphan must be swept");
+        assert!(exists_b.contains(&id_b), "ns:b vec must be untouched");
+    }
+
+    // ── test 7: substrate_kinds filter ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_substrate_kinds_filter_scopes_sweep() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_kind", 4);
+        let store = make_store(Arc::clone(&pool), "sw_kind", 4, "ns:kind");
+        let ns = "ns:kind";
+
+        let id_ent = Uuid::new_v4();
+        let id_note = Uuid::new_v4();
+
+        // Both orphaned; one entity-kind vec, one note-kind vec.
+        store
+            .insert(
+                id_ent,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert entity vec");
+        store
+            .insert(
+                id_note,
+                SubstrateKind::Note,
+                ns,
+                "body",
+                vec![vec4(0.5, 0.6, 0.7, 0.8)],
+            )
+            .await
+            .expect("insert note vec");
+
+        // Sweep only entity-kind vecs.
+        let r = store
+            .orphan_sweep(&OrphanSweepConfig {
+                subject_id_allowlist: None,
+                namespaces: vec![],
+                substrate_kinds: vec![SubstrateKind::Entity],
+                max_delete: 100,
+                dry_run: false,
+            })
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1, "kind filter restricts scanned count");
+        assert_eq!(r.deleted, 1, "only entity-kind orphan is swept");
+
+        let ent_exists = store.batch_exists(&[id_ent], ns).await.expect("ent exists");
+        let note_exists = store
+            .batch_exists(&[id_note], ns)
+            .await
+            .expect("note exists");
+        assert!(
+            !ent_exists.contains(&id_ent),
+            "entity-kind orphan must be swept"
+        );
+        assert!(
+            note_exists.contains(&id_note),
+            "note-kind vec must be untouched"
+        );
+    }
+
+    // ── test 8: subject_id_allowlist filter ──────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_allowlist_restricts_eligible_rows() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_allow", 4);
+        let store = make_store(Arc::clone(&pool), "sw_allow", 4, "ns:allow");
+        let ns = "ns:allow";
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let id3 = Uuid::new_v4(); // not in allowlist
+
+        for (i, &id) in [id1, id2, id3].iter().enumerate() {
+            let v = i as f32 * 0.1 + 0.1;
+            store
+                .insert(
+                    id,
+                    SubstrateKind::Entity,
+                    ns,
+                    "body",
+                    vec![vec![v, v, v, v]],
+                )
+                .await
+                .expect("insert vec");
+        }
+
+        // All are orphans; allowlist only allows id1 and id2 to be swept.
+        let r = store
+            .orphan_sweep(&OrphanSweepConfig {
+                subject_id_allowlist: Some(vec![id1, id2]),
+                namespaces: vec![],
+                substrate_kinds: vec![],
+                max_delete: 100,
+                dry_run: false,
+            })
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 2, "allowlist restricts scanned to 2");
+        assert_eq!(r.would_delete, 2);
+        assert_eq!(r.deleted, 2, "both allowlisted orphans deleted");
+
+        let e1 = store.batch_exists(&[id1], ns).await.expect("e1");
+        let e2 = store.batch_exists(&[id2], ns).await.expect("e2");
+        let e3 = store.batch_exists(&[id3], ns).await.expect("e3");
+        assert!(!e1.contains(&id1), "id1 must be swept");
+        assert!(!e2.contains(&id2), "id2 must be swept");
+        assert!(e3.contains(&id3), "id3 not in allowlist must survive");
     }
 }

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -821,9 +821,37 @@ impl VectorStore for SqliteVecStore {
         let dry_run = config.dry_run;
 
         self.with_writer("orphan_sweep", move |conn| {
-            // Acquire a write lock for the entire sweep to eliminate the TOCTOU
-            // window between counting orphans and deleting them (ADR-044 §5).
-            conn.execute_batch("BEGIN IMMEDIATE")?;
+            // RAII transaction guard: acquires BEGIN IMMEDIATE on construction and
+            // issues ROLLBACK on drop if commit() was never called.  This prevents
+            // the connection from being left with an open transaction when any of
+            // the inner `?`-propagated errors fire (scan COUNT, would-delete COUNT,
+            // or DELETE), which would poison the pooled writer for subsequent callers.
+            struct ImmediateTx<'a> {
+                conn: &'a rusqlite::Connection,
+                done: bool,
+            }
+            impl<'a> ImmediateTx<'a> {
+                fn begin(conn: &'a rusqlite::Connection) -> rusqlite::Result<Self> {
+                    conn.execute_batch("BEGIN IMMEDIATE")?;
+                    Ok(ImmediateTx { conn, done: false })
+                }
+                fn commit(mut self) -> rusqlite::Result<()> {
+                    // Set done BEFORE executing so that if COMMIT fails and this
+                    // struct is dropped by the `?` propagation, Drop does not issue
+                    // a redundant ROLLBACK (SQLite auto-rolls-back on COMMIT failure).
+                    self.done = true;
+                    self.conn.execute_batch("COMMIT")
+                }
+            }
+            impl Drop for ImmediateTx<'_> {
+                fn drop(&mut self) {
+                    if !self.done {
+                        let _ = self.conn.execute_batch("ROLLBACK");
+                    }
+                }
+            }
+
+            let tx = ImmediateTx::begin(conn)?;
 
             // Optional-filter clause shared across all three queries.
             // Each ?N appears twice (IS NULL guard + json_each call); SQLite
@@ -914,7 +942,7 @@ impl VectorStore for SqliteVecStore {
                 )? as i64
             };
 
-            conn.execute_batch("COMMIT")?;
+            tx.commit()?;
 
             Ok(OrphanSweepResult {
                 scanned: scanned as u64,
@@ -2629,5 +2657,144 @@ mod orphan_sweep_tests {
         assert!(!e1.contains(&id1), "id1 must be swept");
         assert!(!e2.contains(&id2), "id2 must be swept");
         assert!(e3.contains(&id3), "id3 not in allowlist must survive");
+    }
+
+    // ── helpers for note substrate rows ─────────────────────────────────────
+
+    fn insert_note(pool: &Arc<crate::pool::ConnectionPool>, id: Uuid, deleted_at: Option<i64>) {
+        let id_str = id.to_string();
+        pool.try_writer()
+            .expect("writer")
+            .conn()
+            .execute(
+                "INSERT INTO notes (id, deleted_at) VALUES (?1, ?2)",
+                rusqlite::params![id_str, deleted_at],
+            )
+            .expect("insert note");
+    }
+
+    // ── test 9: live note → vector kept ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_keeps_live_note() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_note_live", 4);
+        let store = make_store(Arc::clone(&pool), "sw_note_live", 4, "ns:nlive");
+        let ns = "ns:nlive";
+
+        let id = Uuid::new_v4();
+        insert_note(&pool, id, None); // live note row
+
+        store
+            .insert(
+                id,
+                SubstrateKind::Note,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r = store
+            .orphan_sweep(&sweep_all(100, false))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1);
+        assert_eq!(r.would_delete, 0, "live note is not an orphan");
+        assert_eq!(r.deleted, 0);
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(present.contains(&id), "live note's vec must survive");
+    }
+
+    // ── test 10: soft-deleted note → vector swept ─────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_sweep_sweeps_soft_deleted_note() {
+        let pool = make_pool();
+        create_substrate_tables(&pool);
+        create_vec_table(&pool, "sw_note_soft", 4);
+        let store = make_store(Arc::clone(&pool), "sw_note_soft", 4, "ns:nsoft");
+        let ns = "ns:nsoft";
+
+        let id = Uuid::new_v4();
+        insert_note(&pool, id, Some(1_000_000)); // soft-deleted note row
+
+        store
+            .insert(
+                id,
+                SubstrateKind::Note,
+                ns,
+                "body",
+                vec![vec4(0.5, 0.5, 0.5, 0.5)],
+            )
+            .await
+            .expect("insert vec");
+
+        let r = store
+            .orphan_sweep(&sweep_all(100, false))
+            .await
+            .expect("sweep");
+
+        assert_eq!(r.scanned, 1);
+        assert_eq!(r.would_delete, 1, "soft-deleted note counts as orphan");
+        assert_eq!(r.deleted, 1);
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(
+            !present.contains(&id),
+            "soft-deleted note's vec must be swept"
+        );
+    }
+
+    // ── test 11: mid-transaction error must NOT poison the pooled connection ──
+    //
+    // Regression for the transaction-leak bug: if orphan_sweep errors after
+    // BEGIN IMMEDIATE but before COMMIT, the pooled writer must NOT be left
+    // with an open transaction.  Without the RAII guard, the next writer
+    // call fails with "cannot start a transaction within a transaction".
+    //
+    // Deterministic injection: we create the vec table but deliberately omit
+    // the substrate tables.  The anti-join queries reference `entities` and
+    // `notes`, so the first scan COUNT fails with "no such table: entities".
+    // After the error, we immediately perform a normal vector insert on the
+    // same store and assert it succeeds — proving the connection is clean.
+
+    #[tokio::test]
+    async fn orphan_sweep_error_does_not_poison_connection() {
+        let pool = make_pool();
+        // Note: create_substrate_tables is intentionally NOT called here.
+        create_vec_table(&pool, "sw_poison", 4);
+        let store = make_store(Arc::clone(&pool), "sw_poison", 4, "ns:poison");
+        let ns = "ns:poison";
+
+        // orphan_sweep must fail because `entities` / `notes` do not exist.
+        let sweep_result = store.orphan_sweep(&sweep_all(100, false)).await;
+        assert!(
+            sweep_result.is_err(),
+            "sweep must fail when substrate tables are absent"
+        );
+
+        // The connection must not be poisoned: a normal vector insert must succeed.
+        let id = Uuid::new_v4();
+        store
+            .insert(
+                id,
+                SubstrateKind::Entity,
+                ns,
+                "body",
+                vec![vec4(0.1, 0.2, 0.3, 0.4)],
+            )
+            .await
+            .expect("insert after failed sweep must succeed (connection not poisoned)");
+
+        let present = store.batch_exists(&[id], ns).await.expect("exists");
+        assert!(
+            present.contains(&id),
+            "vector inserted after failed sweep must be present"
+        );
     }
 }

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -821,37 +821,22 @@ impl VectorStore for SqliteVecStore {
         let dry_run = config.dry_run;
 
         self.with_writer("orphan_sweep", move |conn| {
-            // RAII transaction guard: acquires BEGIN IMMEDIATE on construction and
-            // issues ROLLBACK on drop if commit() was never called.  This prevents
-            // the connection from being left with an open transaction when any of
-            // the inner `?`-propagated errors fire (scan COUNT, would-delete COUNT,
-            // or DELETE), which would poison the pooled writer for subsequent callers.
-            struct ImmediateTx<'a> {
-                conn: &'a rusqlite::Connection,
-                done: bool,
-            }
-            impl<'a> ImmediateTx<'a> {
-                fn begin(conn: &'a rusqlite::Connection) -> rusqlite::Result<Self> {
-                    conn.execute_batch("BEGIN IMMEDIATE")?;
-                    Ok(ImmediateTx { conn, done: false })
-                }
-                fn commit(mut self) -> rusqlite::Result<()> {
-                    // Set done BEFORE executing so that if COMMIT fails and this
-                    // struct is dropped by the `?` propagation, Drop does not issue
-                    // a redundant ROLLBACK (SQLite auto-rolls-back on COMMIT failure).
-                    self.done = true;
-                    self.conn.execute_batch("COMMIT")
-                }
-            }
-            impl Drop for ImmediateTx<'_> {
-                fn drop(&mut self) {
-                    if !self.done {
-                        let _ = self.conn.execute_batch("ROLLBACK");
-                    }
-                }
-            }
-
-            let tx = ImmediateTx::begin(conn)?;
+            // `Transaction::new_unchecked` issues `BEGIN IMMEDIATE` and RAII-manages
+            // rollback via its Drop impl: it checks `conn.is_autocommit()` and issues
+            // ROLLBACK when the connection still has an open transaction — covering both
+            // early-`?` errors AND a COMMIT that fails with SQLITE_BUSY (BUSY leaves
+            // the transaction open, so autocommit is false, and Drop rolls back).
+            // The hand-rolled guard used previously set `done = true` before COMMIT,
+            // which would have skipped the Drop-ROLLBACK on a BUSY COMMIT and re-poisoned
+            // the pool.  Using the native primitive avoids that class of bug entirely.
+            //
+            // `with_writer` serialises all callers through the pool mutex — at most one
+            // writer closure executes on this connection at a time, so no nested
+            // transactions can exist when this line runs.
+            let tx = rusqlite::Transaction::new_unchecked(
+                conn,
+                rusqlite::TransactionBehavior::Immediate,
+            )?;
 
             // Optional-filter clause shared across all three queries.
             // Each ?N appears twice (IS NULL guard + json_each call); SQLite

--- a/docs/adr/ADR-044-vector-store-extensions.md
+++ b/docs/adr/ADR-044-vector-store-extensions.md
@@ -331,7 +331,7 @@ pub struct OrphanSweepResult {
     pub deleted: u64,
     /// Rows that would be deleted (populated even when `dry_run = false`).
     pub would_delete: u64,
-    /// Whether `max_delete` was reached before the full scan completed.
+    /// Whether `would_delete` exceeded `max_delete`, meaning deletion was capped after full counting.
     pub max_delete_hit: bool,
 }
 ```

--- a/docs/adr/ADR-044-vector-store-extensions.md
+++ b/docs/adr/ADR-044-vector-store-extensions.md
@@ -342,8 +342,9 @@ pub struct OrphanSweepResult {
 /// substrate (entities / notes / memories with `deleted_at IS NULL`).
 ///
 /// A vector is orphaned when its subject_id is either absent from all substrate
-/// tables, or present with `deleted_at IS NOT NULL`. Soft-deleted records are NOT
-/// orphaned — the vector stays as long as the substrate row exists.
+/// tables, or present with `deleted_at IS NOT NULL`. Soft-deleted substrate rows
+/// (`deleted_at IS NOT NULL`) do not protect their vectors -- only rows with
+/// `deleted_at IS NULL` are treated as live.
 ///
 /// The anti-join + DELETE execute in one statement under the writer lock,
 /// preventing TOCTOU between the scan and the delete.
@@ -371,16 +372,15 @@ WHERE subject_id NOT IN (
     SELECT id FROM entities  WHERE deleted_at IS NULL
     UNION ALL
     SELECT id FROM notes     WHERE deleted_at IS NULL
-    UNION ALL
-    SELECT id FROM memories  WHERE deleted_at IS NULL
 )
 -- namespace filter:
-AND  (? IS NULL OR namespace IN (SELECT value FROM json_each(?)))
+AND  (?1 IS NULL OR namespace IN (SELECT value FROM json_each(?1)))
 -- substrate_kinds filter:
-AND  (? IS NULL OR kind IN (SELECT value FROM json_each(?)))
+AND  (?2 IS NULL OR kind IN (SELECT value FROM json_each(?2)))
 -- allowlist filter:
-AND  (? IS NULL OR subject_id IN (SELECT value FROM json_each(?)))
-LIMIT :max_delete
+AND  (?3 IS NULL OR subject_id IN (SELECT value FROM json_each(?3)))
+-- portable capped delete (SQLITE_ENABLE_UPDATE_DELETE_LIMIT not compiled in bundled rusqlite):
+-- wrap as: DELETE FROM t WHERE subject_id IN (SELECT subject_id FROM t WHERE [above] LIMIT :max_delete)
 ```
 
 The anti-join and `DELETE` are one statement under a `BEGIN IMMEDIATE` transaction,

--- a/docs/adr/ADR-044-vector-store-extensions.md
+++ b/docs/adr/ADR-044-vector-store-extensions.md
@@ -385,10 +385,18 @@ AND  (?3 IS NULL OR subject_id IN (SELECT value FROM json_each(?3)))
 -- wrap as: DELETE FROM t WHERE subject_id IN (SELECT subject_id FROM t WHERE [above] LIMIT :max_delete)
 ```
 
-The anti-join and `DELETE` are one statement under a `BEGIN IMMEDIATE` transaction,
-held for the duration of the sweep. This eliminates the TOCTOU window between
-"find orphans" and "delete orphans." The `LIMIT` ensures the writer lock is not held
-for an unbounded time on large tables.
+The sweep runs three SQL operations under one `BEGIN IMMEDIATE` transaction: a
+filtered `COUNT` for `scanned`, an anti-join `COUNT` for `would_delete`, and the
+capped `DELETE`. This eliminates the TOCTOU window between counting orphans and
+deleting them.
+
+`max_delete` bounds the number of rows **deleted** in a single run — it is a
+blast-radius and safety cap, not a scan or lock-hold duration limit. The
+`scanned` and `would_delete` counts require a full filtered table scan and an
+anti-join against the substrate tables, so the writer lock is held for a duration
+proportional to the filtered table size regardless of `max_delete`. This is
+acceptable because `orphan_sweep` is a CLI-only maintenance operation run by an
+operator, not a hot-path call.
 
 **Naming:** `subject_id_allowlist` (this ADR) replaces `include_subjects` (original
 draft). The rename makes the polarity explicit: allowlist means "only these are eligible

--- a/docs/adr/ADR-044-vector-store-extensions.md
+++ b/docs/adr/ADR-044-vector-store-extensions.md
@@ -339,7 +339,9 @@ pub struct OrphanSweepResult {
 ```rust
 // On VectorStore trait:
 /// Find vector rows whose subject_id has no corresponding live record in the SQL
-/// substrate (entities / notes / memories with `deleted_at IS NULL`).
+/// substrate (`entities` / `notes` with `deleted_at IS NULL`). Memory records
+/// are stored as notes with `kind = 'memory'`, so a memory vector is protected
+/// only by its row in `notes` -- there is no separate `memories` table.
 ///
 /// A vector is orphaned when its subject_id is either absent from all substrate
 /// tables, or present with `deleted_at IS NOT NULL`. Soft-deleted substrate rows


### PR DESCRIPTION
## Summary

Implements the `orphan_sweep` method on `SqliteVecStore`, replacing the
`StorageError::Unsupported` default from the `VectorStore` trait. Flips
`supports_orphan_sweep` from `false` to `true` in the capabilities static.

## What changed

**`crates/khive-db/src/stores/vectors.rs`**

- Adds `StorageResult` to the import block.
- Implements `SqliteVecStore::orphan_sweep`. A vector row is orphaned
  when its `subject_id` has no live row (`deleted_at IS NULL`) in
  `entities` or `notes`. Soft-deleted substrate rows are treated as
  orphaned, matching the primary definition in ADR-044 §5.
- The method runs inside `BEGIN IMMEDIATE` / `COMMIT` to hold the writer
  lock across the count query and the delete, preventing TOCTOU.
- Capped delete uses `DELETE ... WHERE subject_id IN (SELECT subject_id
  ... LIMIT N)` because `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` is not
  compiled into the bundled rusqlite build.
- Namespace, `substrate_kinds`, and `subject_id_allowlist` filters are
  serialized to JSON and matched via `json_each(?N)` with `IS NULL`
  guards so absent filters are true no-ops.
- Sets `supports_orphan_sweep: true` in the capabilities static.
- Updates the capabilities test assertion to match the new value.
- Adds 8 integration tests under `#[cfg(all(test, feature = "vectors"))]`
  covering: live subject kept, soft-deleted swept, absent subject swept,
  `dry_run` no-op, `max_delete` cap with `max_delete_hit`, namespace
  filter, `substrate_kinds` filter, `subject_id_allowlist` filter.

**`docs/adr/ADR-044-vector-store-extensions.md`**

- Removes the `memories` table from the anti-join SQL (no such table
  exists in the schema; memory notes live in `notes`).
- Corrects one contradicting sentence that claimed soft-deleted rows
  protect their vectors (the primary definition and anti-join SQL both
  treat them as orphaned).
- Updates numbered params to match the implementation (`?1`/`?2`/`?3`).
- Adds a note on the portable capped-delete form.

## Test plan

- `cargo test -p khive-db --features vectors` -- 178 tests pass (8 new
  orphan sweep tests, all others unchanged).
- `cargo clippy -p khive-db --all-targets -- -D warnings` -- clean.
- `cargo fmt --all -- --check` -- clean.