### PR TITLE
ci: bump actions to Node24 runtimes

### DIFF
--- a/.github/workflows/bench-1m.yml
+++ b/.github/workflows/bench-1m.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.94.1
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload synthetic ledger artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-synthetic-ledger
           path: perf/ci-synthetic-ledger.csv
@@ -135,7 +135,7 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.94.1
 

--- a/.github/workflows/bench-pipeline.yml
+++ b/.github/workflows/bench-pipeline.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: crates
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload pipeline ledger
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-ledger
           path: perf/pipeline-ledger.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: crates
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
@@ -40,7 +40,7 @@ jobs:
     name: Supply-chain (cargo-deny)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: crates/Cargo.toml
@@ -70,7 +70,7 @@ jobs:
     name: JSON/JSONL data-leak guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Scan whole tree for corpus files
         run: bash scripts/check-json-data.sh --all
 
@@ -78,7 +78,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -92,7 +92,7 @@ jobs:
     name: Docs lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -103,8 +103,8 @@ jobs:
     name: Marketplace example validator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Validate marketplace SKILL/agent verb examples
@@ -117,7 +117,7 @@ jobs:
       run:
         working-directory: crates
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
         with:
@@ -138,7 +138,7 @@ jobs:
     # graph between the base and head commits.  Skip on push to main/integration.
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Dependency review
         uses: actions/dependency-review-action@v4
         with:
@@ -172,7 +172,7 @@ jobs:
     # under that model the bot is not a ruleset bypass actor, so the push would be
     # rejected and fail the job on every merge.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: llvm-tools-preview


### PR DESCRIPTION
Replaces Node20-runtime action references with their current stable Node24 majors to eliminate the deprecation warnings GitHub Actions emits for Node20 runners.

## Changes

| File | Action | Before | After |
|------|--------|--------|-------|
| `ci.yml` (9 occurrences) | `actions/checkout` | `@v4` | `@v7` |
| `ci.yml` | `actions/setup-python` | `@v5` | `@v6` |
| `bench-pipeline.yml` | `actions/checkout` | `@v4` | `@v7` |
| `bench-pipeline.yml` | `actions/upload-artifact` | `@v4` | `@v7` |
| `bench-1m.yml` (2 occurrences) | `actions/checkout` | `@v4` | `@v7` |
| `bench-1m.yml` | `actions/upload-artifact` | `@v4` | `@v7` |

## Left unchanged

- **`release.yml`**: excluded from this change; contains `checkout@v4`, `upload-artifact@v4`, `setup-node@v4`, and `download-artifact@v4`. These are release-path-sensitive and handled separately.
- **`dtolnay/rust-toolchain@1.94.1`**: intentional Rust toolchain version pin, not a Node runtime reference.
- **`actions/dependency-review-action@v4`** (`ci.yml`): out of scope for this PR; current stable is v5.
- **`astral-sh/setup-uv`**: not part of the Node20-runtime sweep; left at existing `@v4` / `@v5` references.

## Version verification

All target majors confirmed via `gh api repos/actions/*/releases/latest` before editing:

- `actions/checkout` v7.0.0 — only behavioral change affecting our usage: security hardening for `pull_request_target` and `workflow_run` events (none of our workflows use those triggers).
- `actions/setup-python` v6.3.0 — breaking change is the Node24 runtime itself; requires Actions runner >= 2.327.1, which all GitHub-hosted runners satisfy.
- `actions/upload-artifact` v7.0.1 — v4 was still Node20; v7 adds optional `archive` parameter but existing `name` / `path` / `if-no-files-found` usage is unaffected.

YAML parse validated on all three files post-edit.