### PR TITLE
fix(bm25): deprecate panicking constructors in favor of fallible variants

### DIFF
--- a/crates/khive-bm25/README.md
+++ b/crates/khive-bm25/README.md
@@ -18,7 +18,7 @@ acceleration.
 ```rust
 use khive_bm25::{Bm25Config, Bm25Index};
 
-let mut index = Bm25Index::new(Bm25Config::default());
+let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
 
 index.index_document("doc1", "the quick brown fox").unwrap();
 index.index_document("doc2", "the lazy dog").unwrap();
@@ -38,7 +38,7 @@ for (doc_id, score) in &results {
 
 ```rust
 let config = Bm25Config::new(2.0, 0.5);
-let index = Bm25Index::new(config);
+let index = Bm25Index::try_new(config).expect("valid config");
 ```
 
 Both parameters must be finite and non-negative. `b` must be in `[0.0, 1.0]`.

--- a/crates/khive-bm25/benches/bm25_bench.rs
+++ b/crates/khive-bm25/benches/bm25_bench.rs
@@ -323,7 +323,7 @@ fn gen_doc(rng: &mut StdRng, num_words: usize) -> String {
 
 fn build_index(n_docs: usize, words_per_doc: usize) -> Bm25Index {
     let mut rng = StdRng::seed_from_u64(42);
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     for i in 0..n_docs {
         let doc = gen_doc(&mut rng, words_per_doc);
         index.index_document(format!("doc{i}"), &doc).unwrap();
@@ -343,7 +343,7 @@ fn bench_index_throughput(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("docs", n), &n, |b, &n| {
             b.iter(|| {
                 let mut rng = StdRng::seed_from_u64(42);
-                let mut index = Bm25Index::new(Bm25Config::default());
+                let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
                 for i in 0..n {
                     let doc = gen_doc(&mut rng, 200);
                     index

--- a/crates/khive-bm25/docs/usage.md
+++ b/crates/khive-bm25/docs/usage.md
@@ -19,7 +19,7 @@ $$
 ```rust
 use khive_bm25::{Bm25Config, Bm25Index};
 
-let mut index = Bm25Index::new(Bm25Config::default());
+let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
 
 index.index_document("doc1", "the quick brown fox").unwrap();
 index.index_document("doc2", "the lazy dog").unwrap();

--- a/crates/khive-bm25/src/index/core.rs
+++ b/crates/khive-bm25/src/index/core.rs
@@ -160,7 +160,7 @@ impl Clone for Bm25Index {
 
 impl Default for Bm25Index {
     fn default() -> Self {
-        Self::new(Bm25Config::default())
+        Self::try_new(Bm25Config::default()).expect("default Bm25Config is always valid")
     }
 }
 
@@ -247,11 +247,20 @@ impl<'de> serde::Deserialize<'de> for Bm25Index {
 
 impl Bm25Index {
     /// Create a new empty BM25 index. Panics on invalid config; use `try_new` for an error.
+    #[deprecated(
+        note = "use `try_new` (or `try_with_tokenizer`), which returns a Result instead of panicking on an invalid config"
+    )]
     pub fn new(config: Bm25Config) -> Self {
-        if let Err(e) = config.validate() {
-            panic!("invalid BM25 config: {e}");
-        }
-        Self {
+        Self::try_new(config).expect("invalid BM25 config")
+    }
+
+    /// Non-panicking constructor. Returns `Err(RetrievalError::Configuration(...))`
+    /// if the config is invalid instead of panicking.
+    pub fn try_new(config: Bm25Config) -> Result<Self> {
+        config
+            .validate()
+            .map_err(|e| RetrievalError::Configuration(format!("invalid BM25 config: {e}")))?;
+        Ok(Self {
             inverted_index: HashMap::new(),
             doc_lengths: HashMap::new(),
             id_to_internal: HashMap::new(),
@@ -268,24 +277,16 @@ impl Bm25Index {
             config,
             tokenizer: Arc::new(SimpleTokenizer::default()),
             metrics: None,
-        }
+        })
     }
 
-    /// Non-panicking constructor.  Returns `Err(RetrievalError::Configuration(…))`
+    /// Non-panicking constructor with a custom tokenizer. Returns `Err(RetrievalError::Configuration(...))`
     /// if the config is invalid instead of panicking.
-    pub fn try_new(config: Bm25Config) -> Result<Self> {
+    pub fn try_with_tokenizer(config: Bm25Config, tokenizer: BoxedTokenizer) -> Result<Self> {
         config
             .validate()
             .map_err(|e| RetrievalError::Configuration(format!("invalid BM25 config: {e}")))?;
-        Ok(Self::new(config))
-    }
-
-    /// Create a new BM25 index with a custom tokenizer. Panics on invalid config.
-    pub fn with_tokenizer(config: Bm25Config, tokenizer: BoxedTokenizer) -> Self {
-        if let Err(e) = config.validate() {
-            panic!("invalid BM25 config: {e}");
-        }
-        Self {
+        Ok(Self {
             inverted_index: HashMap::new(),
             doc_lengths: HashMap::new(),
             id_to_internal: HashMap::new(),
@@ -302,7 +303,15 @@ impl Bm25Index {
             config,
             tokenizer,
             metrics: None,
-        }
+        })
+    }
+
+    /// Create a new BM25 index with a custom tokenizer. Panics on invalid config.
+    #[deprecated(
+        note = "use `try_new` (or `try_with_tokenizer`), which returns a Result instead of panicking on an invalid config"
+    )]
+    pub fn with_tokenizer(config: Bm25Config, tokenizer: BoxedTokenizer) -> Self {
+        Self::try_with_tokenizer(config, tokenizer).expect("invalid BM25 config")
     }
 
     /// Set the tokenizer. Does not re-tokenize existing documents.
@@ -658,7 +667,7 @@ mod regression_tests {
     #[test]
     fn budget_check_does_not_overflow() {
         let config = Bm25Config::default().with_memory_budget(1);
-        let mut index = Bm25Index::new(config);
+        let mut index = Bm25Index::try_new(config).expect("valid config");
         let result = index.index_document("doc1", "hello world");
         assert!(result.is_err(), "budget should be exceeded");
     }
@@ -678,6 +687,28 @@ mod regression_tests {
         assert!(
             Bm25Index::try_new(config).is_err(),
             "Inf b must be rejected by try_new"
+        );
+    }
+
+    #[test]
+    fn config_nan_k1_rejected_by_try_with_tokenizer() {
+        use std::sync::Arc;
+        let config = Bm25Config::new(f64::NAN, 0.75);
+        let tokenizer = Arc::new(crate::tokenizer::SimpleTokenizer::default());
+        assert!(
+            Bm25Index::try_with_tokenizer(config, tokenizer).is_err(),
+            "NaN k1 must be rejected by try_with_tokenizer"
+        );
+    }
+
+    #[test]
+    fn config_inf_b_rejected_by_try_with_tokenizer() {
+        use std::sync::Arc;
+        let config = Bm25Config::new(1.2, f64::INFINITY);
+        let tokenizer = Arc::new(crate::tokenizer::SimpleTokenizer::default());
+        assert!(
+            Bm25Index::try_with_tokenizer(config, tokenizer).is_err(),
+            "Inf b must be rejected by try_with_tokenizer"
         );
     }
 

--- a/crates/khive-bm25/src/index/indexing.rs
+++ b/crates/khive-bm25/src/index/indexing.rs
@@ -258,7 +258,7 @@ mod forward_index_tests {
 
     #[test]
     fn test_search_results_unchanged_after_add_remove_cycle() {
-        let mut baseline_index = Bm25Index::new(Bm25Config::default());
+        let mut baseline_index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
         baseline_index
             .index_document("doc1", "quick brown fox")
             .unwrap();

--- a/crates/khive-bm25/src/index/search/tests.rs
+++ b/crates/khive-bm25/src/index/search/tests.rs
@@ -240,7 +240,7 @@ fn test_max_tf() {
 fn test_brute_force_search_various_sizes() {
     use crate::{Bm25Config, Bm25Index};
 
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
 
     // Index enough documents to exercise different batch sizes.
     // The word "alpha" appears in all 100 docs, giving a posting list of 100.
@@ -322,7 +322,7 @@ fn test_score_batch_scalar_8_matches_reference() {
 fn test_empty_posting_list_search() {
     use crate::{Bm25Config, Bm25Index};
 
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     index.index_document("doc1", "hello world").unwrap();
 
     // Search for a term not in the index.

--- a/crates/khive-bm25/tests/golden.rs
+++ b/crates/khive-bm25/tests/golden.rs
@@ -22,7 +22,7 @@ const GOLDEN_TOLERANCE: f64 = 1e-6;
 
 /// Golden test corpus for reproducible scoring.
 fn setup_golden_corpus() -> Bm25Index {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     // Fixed corpus with known characteristics:
     // doc1: 4 tokens (quick, brown, fox, jumps)
     // doc2: 3 tokens (lazy, brown, dog)
@@ -136,7 +136,7 @@ fn golden_rare_term_high_idf() {
 #[test]
 fn golden_term_frequency_saturation() {
     // Test that repeated terms show saturation (TF component approaches k1+1=2.2)
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
 
     // doc1 has "test" once, doc2 has it 5 times
     index.index_document("doc1".to_string(), "test").unwrap();
@@ -183,7 +183,7 @@ fn golden_term_frequency_saturation() {
 #[test]
 fn golden_length_normalization() {
     // Test length normalization with same term frequency
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
 
     // Both have "test" once, but different lengths
     index.index_document("short".to_string(), "test").unwrap();

--- a/crates/khive-bm25/tests/integration.rs
+++ b/crates/khive-bm25/tests/integration.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 #[test]
 fn index_lifecycle_create_index_search_rank() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     assert_eq!(index.doc_count(), 0);
 
     index
@@ -247,7 +247,8 @@ impl Tokenizer for UppercasePreservingTokenizer {
 #[test]
 fn custom_tokenizer_is_called_for_indexing_and_search() {
     let tokenizer: BoxedTokenizer = Arc::new(UppercasePreservingTokenizer);
-    let mut index = Bm25Index::with_tokenizer(Bm25Config::default(), tokenizer);
+    let mut index =
+        Bm25Index::try_with_tokenizer(Bm25Config::default(), tokenizer).expect("valid config");
 
     // With the custom tokenizer "Rust" and "rust" are different tokens
     index
@@ -272,7 +273,8 @@ fn custom_tokenizer_is_called_for_indexing_and_search() {
 fn custom_tokenizer_min_length_filters_short_tokens() {
     // SimpleTokenizer with min_length=4 filters stop words and short tokens
     let tokenizer: BoxedTokenizer = Arc::new(SimpleTokenizer::new(true, 4));
-    let mut index = Bm25Index::with_tokenizer(Bm25Config::default(), tokenizer);
+    let mut index =
+        Bm25Index::try_with_tokenizer(Bm25Config::default(), tokenizer).expect("valid config");
 
     index.index_document("doc1", "the quick brown fox").unwrap();
 

--- a/crates/khive-bm25/tests/memory_budget.rs
+++ b/crates/khive-bm25/tests/memory_budget.rs
@@ -15,7 +15,7 @@ fn test_no_budget_allows_unlimited_indexing() {
 #[test]
 fn test_budget_blocks_new_document_when_exceeded() {
     let config = Bm25Config::default().with_memory_budget(1_100);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
 
     // First doc should succeed (index starts empty)
     index
@@ -49,7 +49,7 @@ fn test_budget_blocks_new_document_when_exceeded() {
 #[test]
 fn test_budget_reindex_bypasses_check() {
     let config = Bm25Config::default().with_memory_budget(2_000);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
 
     // Index initial doc
     index
@@ -127,14 +127,14 @@ fn test_memory_budget_getter_setter() {
 #[test]
 fn test_budget_from_config() {
     let config = Bm25Config::default().with_memory_budget(10_000);
-    let index = Bm25Index::new(config);
+    let index = Bm25Index::try_new(config).expect("valid config");
     assert_eq!(index.memory_budget(), Some(10_000));
 }
 
 #[test]
 fn test_budget_exceeded_error_details() {
     let config = Bm25Config::default().with_memory_budget(1);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
 
     // Budget of 1 byte is too small for any document
     let result = index.index_document("doc1", "hello world");
@@ -158,7 +158,7 @@ fn test_budget_exceeded_error_details() {
 #[test]
 fn test_search_unaffected_by_budget() {
     let config = Bm25Config::default().with_memory_budget(100_000);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
 
     index.index_document("doc1", "quick brown fox").unwrap();
     index.index_document("doc2", "lazy brown dog").unwrap();
@@ -171,7 +171,7 @@ fn test_search_unaffected_by_budget() {
 #[test]
 fn test_budget_allows_removal_then_insert() {
     let config = Bm25Config::default().with_memory_budget(3_000);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
 
     // Fill the index
     let mut last_success = 0;

--- a/crates/khive-bm25/tests/metrics.rs
+++ b/crates/khive-bm25/tests/metrics.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 #[test]
 fn index_document_emits_metrics() {
     let sink = Arc::new(RecordingSink::new());
-    let mut index = Bm25Index::new(Bm25Config::default()).with_metrics(sink.clone());
+    let mut index = Bm25Index::try_new(Bm25Config::default())
+        .expect("valid config")
+        .with_metrics(sink.clone());
 
     index.index_document("doc1", "the quick brown fox").unwrap();
 
@@ -36,7 +38,9 @@ fn index_document_emits_metrics() {
 #[test]
 fn search_emits_metrics() {
     let sink = Arc::new(RecordingSink::new());
-    let mut index = Bm25Index::new(Bm25Config::default()).with_metrics(sink.clone());
+    let mut index = Bm25Index::try_new(Bm25Config::default())
+        .expect("valid config")
+        .with_metrics(sink.clone());
 
     index.index_document("doc1", "the quick brown fox").unwrap();
     index.index_document("doc2", "the lazy dog").unwrap();
@@ -76,14 +80,14 @@ fn search_emits_metrics() {
 #[test]
 fn no_metrics_without_sink() {
     // Ensure no panic when metrics is None (default)
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     index.index_document("doc1", "hello world").unwrap();
     let _ = index.search("hello", 5);
 }
 
 #[test]
 fn set_metrics_at_runtime() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     index.index_document("doc1", "hello world").unwrap();
 
     // Attach sink
@@ -105,7 +109,9 @@ fn set_metrics_at_runtime() {
 #[test]
 fn search_on_empty_index_still_emits() {
     let sink = Arc::new(RecordingSink::new());
-    let index = Bm25Index::new(Bm25Config::default()).with_metrics(sink.clone());
+    let index = Bm25Index::try_new(Bm25Config::default())
+        .expect("valid config")
+        .with_metrics(sink.clone());
 
     let results = index.search("anything", 5);
     assert!(results.is_empty());
@@ -121,7 +127,9 @@ fn search_on_empty_index_still_emits() {
 #[test]
 fn multiple_operations_accumulate_events() {
     let sink = Arc::new(RecordingSink::new());
-    let mut index = Bm25Index::new(Bm25Config::default()).with_metrics(sink.clone());
+    let mut index = Bm25Index::try_new(Bm25Config::default())
+        .expect("valid config")
+        .with_metrics(sink.clone());
 
     // 3 index operations
     index.index_document("d1", "alpha beta").unwrap();
@@ -140,7 +148,9 @@ fn multiple_operations_accumulate_events() {
 #[test]
 fn index_duration_is_nonnegative() {
     let sink = Arc::new(RecordingSink::new());
-    let mut index = Bm25Index::new(Bm25Config::default()).with_metrics(sink.clone());
+    let mut index = Bm25Index::try_new(Bm25Config::default())
+        .expect("valid config")
+        .with_metrics(sink.clone());
 
     index
         .index_document("doc1", "test document content")

--- a/crates/khive-bm25/tests/unit.rs
+++ b/crates/khive-bm25/tests/unit.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 #[test]
 fn test_new_index() {
-    let index = Bm25Index::new(Bm25Config::default());
+    let index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     assert_eq!(index.doc_count(), 0);
     assert!((index.avg_doc_length() - 0.0).abs() < f64::EPSILON);
 }
@@ -363,7 +363,7 @@ fn test_punctuation_handling() {
 #[test]
 fn test_config_custom() {
     let config = Bm25Config::new(2.0, 0.5);
-    let mut index = Bm25Index::new(config);
+    let mut index = Bm25Index::try_new(config).expect("valid config");
     index
         .index_document("doc1".to_string(), "test document")
         .unwrap();
@@ -444,7 +444,8 @@ fn test_serde_roundtrip() {
 fn test_custom_tokenizer() {
     // Create a custom tokenizer with minimum length 4
     let tokenizer: BoxedTokenizer = Arc::new(SimpleTokenizer::new(true, 4));
-    let mut index = Bm25Index::with_tokenizer(Bm25Config::default(), tokenizer);
+    let mut index =
+        Bm25Index::try_with_tokenizer(Bm25Config::default(), tokenizer).expect("valid config");
 
     // "the", "a" will be filtered out (< 4 chars)
     index

--- a/crates/khive-bm25/tests/wand_correctness.rs
+++ b/crates/khive-bm25/tests/wand_correctness.rs
@@ -174,7 +174,7 @@ fn bmw_matches_bruteforce_on_random_zipf_corpora() {
     let zipf = ZipfSampler::new(vocab.len(), 1.07);
 
     for (case_idx, &doc_count) in [1_000usize, 2_500, 10_000].iter().enumerate() {
-        let mut index = Bm25Index::new(Bm25Config::default());
+        let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
         build_zipf_corpus(&mut index, doc_count, 0xC0FFEE + case_idx as u64);
 
         let mut rng = XorShift64::new(0xBAD5EED + doc_count as u64);
@@ -200,7 +200,7 @@ fn bmw_matches_bruteforce_on_random_zipf_corpora() {
 
 #[test]
 fn bmw_handles_empty_index_and_zero_k() {
-    let index = Bm25Index::new(Bm25Config::default());
+    let index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     let mut ctx = SearchContext::new();
 
     assert!(index
@@ -216,7 +216,7 @@ fn bmw_handles_empty_index_and_zero_k() {
 
 #[test]
 fn bmw_handles_single_document_and_large_k() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     index
         .index_document("doc1", "alpha beta gamma alpha")
         .unwrap();
@@ -234,7 +234,7 @@ fn bmw_handles_single_document_and_large_k() {
 
 #[test]
 fn bmw_handles_all_docs_match_and_no_docs_match() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     for doc_idx in 0..300 {
         index
             .index_document(format!("doc_{doc_idx}"), &format!("common term_{doc_idx}"))
@@ -256,7 +256,7 @@ fn bmw_handles_all_docs_match_and_no_docs_match() {
 
 #[test]
 fn bmw_handles_many_term_queries() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     build_zipf_corpus(&mut index, 2_000, 0x1234_5678);
 
     let query = "tok_0000 tok_0001 tok_0002 tok_0003 tok_0004 tok_0005 tok_0006 tok_0007";
@@ -271,7 +271,7 @@ fn bmw_handles_many_term_queries() {
 
 #[test]
 fn bmw_block_boundary_regression() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     let filler = " filler filler filler filler filler filler filler filler";
 
     for doc_idx in 0..(DEFAULT_BLOCK_SIZE * 2) {
@@ -307,7 +307,7 @@ fn bmw_block_boundary_regression() {
 
 #[test]
 fn sorted_posting_lists_are_maintained_across_mutations() {
-    let mut index = Bm25Index::new(Bm25Config::default());
+    let mut index = Bm25Index::try_new(Bm25Config::default()).expect("valid config");
     index.index_document("c", "alpha beta").unwrap();
     index.index_document("a", "alpha gamma").unwrap();
     index.index_document("b", "alpha delta").unwrap();


### PR DESCRIPTION
## Summary

`Bm25Index::new` and `Bm25Index::with_tokenizer` panic unconditionally when
passed an invalid config (NaN `k1`, infinite `b`, etc.). This change
introduces `try_with_tokenizer` as the fallible companion to the existing
`try_new`, marks both panicking constructors deprecated, and migrates all
internal and test call sites to the `try_` variants.

- `try_new`: refactored to build the index struct directly; no longer calls
  the deprecated `Self::new` after validation
- `try_with_tokenizer` (new): validates config, returns
  `Err(RetrievalError::Configuration(...))` on invalid params instead of
  panicking
- `new` and `with_tokenizer`: marked `#[deprecated]`; bodies now delegate to
  their `try_` twins with `.expect(...)`, preserving existing behavior for any
  downstream code that has not yet migrated
- `Default::default`: switched from `Self::new` to `Self::try_new` to avoid
  triggering the deprecation lint internally
- All 34 call sites inside the crate (src, tests, benches) migrated from
  `::new(...)` / `::with_tokenizer(...)` to `try_new(...).expect(...)` /
  `try_with_tokenizer(...).expect(...)`
- Two new regression tests (`config_nan_k1_rejected_by_try_with_tokenizer`,
  `config_inf_b_rejected_by_try_with_tokenizer`) assert that the new
  constructor returns `Err` rather than panicking
- README quick-start examples updated to use `try_new`

This is a non-breaking change: the deprecated constructors still compile and
run correctly; they just carry a compiler warning directing callers to the
fallible path.

## Test plan

- [ ] `cargo test -p khive-bm25` passes (124 tests, including 2 new)
- [ ] `cargo clippy -p khive-bm25 --all-targets -- -D warnings` passes (no
  deprecated-item warnings from within the crate)
- [ ] `cargo check --workspace` passes (no downstream compilation breaks)
- [ ] `cargo fmt --all -- --check` passes