### PR TITLE
docs: close verb-surface contract-accuracy findings (issue #160)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,11 @@ defined in [ADR-023](docs/adr/ADR-023-declarative-pack-format.md).
 | `withdraw`  | Cancel an open proposal                          | Abandoning a staged change                               |
 | `verbs`     | List all registered verbs on this server         | Discovery — see what's available                         |
 
-`get`, `update`, `delete` are UUID-only — they auto-detect whether the record is an entity, note,
-or edge. `create`, `list`, `search` require `kind=entity|note` (or `kind=edge` for `list`;
-`kind=event` for audit events per [ADR-022](docs/adr/ADR-022-events-query-surface.md)).
+`get`, `update`, `delete` are by-ID — they auto-detect whether the record is an entity, note, or
+edge. The `id` parameter accepts either a full UUID or a short hex prefix of at least 8 hex
+characters; shorter strings fall through to a name lookup. `create`, `list`, `search` require
+`kind=entity|note` (or `kind=edge` for `list`; `kind=event` for audit events per
+[ADR-022](docs/adr/ADR-022-events-query-surface.md)).
 
 ### GTD pack — 5 verbs (`gtd.` prefix, [ADR-019](docs/adr/ADR-019-gtd-pack.md))
 
@@ -63,6 +65,13 @@ or edge. `create`, `list`, `search` require `kind=entity|note` (or `kind=edge` f
 | `gtd.transition` | Explicit lifecycle change (inbox→next→active→done)      | Moving a task through its lifecycle      |
 
 `gtd.assign` accepts `context_entity_id` to anchor a task to a KG entity.
+
+Full `gtd.transition` allowed transitions:
+`inbox` → next | waiting | someday | active | done | cancelled;
+`next` → active | waiting | someday | done | cancelled (skipping `active` with `next -> done` is valid);
+`active` → next | waiting | done | cancelled;
+`waiting` | `someday` → next | active | done | cancelled;
+`done` and `cancelled` are terminal.
 
 ### Memory pack — 5 verbs (`memory.` prefix, [ADR-021](docs/adr/ADR-021-memory-pack.md))
 
@@ -346,7 +355,7 @@ These are the KG pack verbs. Other packs are documented in their verb tables abo
 | Tool        | Fields                                                                                                                                                                                                                                           | Example                                                      |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
 | `create`    | **kind** (entity\|note), **name** + **entity_kind** for entity, **content** + note_kind for note; entity_type, description, properties, tags, salience, annotates                                                                                | `{"kind":"entity","entity_kind":"concept","name":"LoRA"}`    |
-| `get`       | **id** (UUID)                                                                                                                                                                                                                                    | `{"id":"<uuid>"}`                                            |
+| `get`       | **id** — full UUID or short hex prefix (minimum 8 hex characters)                                                                                                                                                                                | `{"id":"<uuid>"}`                                            |
 | `list`      | **kind** (entity\|edge\|note\|event\|proposal); entity_kind, entity_type, note_kind, tags, source_id, target_id, relations, min_weight, max_weight, limit, offset; event: event_kind, event_kinds; message: thread_id, direction, from, to, read | `{"kind":"entity","entity_kind":"concept","tags":["ml"]}`    |
 | `update`    | **id** (UUID); name, description, properties, tags (entity), relation, weight (edge)                                                                                                                                                             | `{"id":"<uuid>","description":"Updated desc"}`               |
 | `delete`    | **id** (UUID); hard (default: false)                                                                                                                                                                                                             | `{"id":"<uuid>","hard":true}`                                |

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -246,8 +246,7 @@ pub(crate) async fn handle_read(
         .unwrap_or("");
     if direction == "outbound" {
         return Err(RuntimeError::InvalidInput(format!(
-            "read: cannot mark outbound message {id} as read (direction=outbound); \
-             read() is a recipient action for inbound messages only"
+            "read: message {id} is outbound; only received (inbound) messages can be marked as read"
         )));
     }
 


### PR DESCRIPTION
## Summary

Closes contract-accuracy findings from issue #160. All changes are
documentation and error message only; no verb semantics, DSL grammar, or
closed taxonomies are changed.

**Finding #4 — `get` min-prefix policy (AGENTS.md)**

`get`, `update`, and `delete` accept a short hex prefix (minimum 8
characters) in addition to a full UUID, but the documentation said
"UUID-only". Updated the prose note and the `get` verb table row to
reflect the actual behavior documented in the handler and verified in
`resolve_uuid_async` (common.rs line 249).

**Finding #7 — `gtd.transition next -> done` (AGENTS.md)**

The skip from `next` directly to `done` is intentional per ADR-019 and
`allowed_transitions()` in schema.rs, but was not documented for callers.
Added a full allowed-transition reference block after the GTD verb table.

**Finding #5 — `comm.read` outbound error message (handlers.rs)**

Replaced the redundant "(direction=outbound)" annotation with a tighter
phrasing that tells the caller what they can do instead:

```
Before: "read: cannot mark outbound message {id} as read (direction=outbound); read() is a recipient action for inbound messages only"
After:  "read: message {id} is outbound; only received (inbound) messages can be marked as read"
```

**Findings #1, #2, #3, #6 — already resolved**

- `propose` result field (`id`, not `proposal_id`) — correct in AGENTS.md line 359 and handler_defs.rs.
- `merge` result fields (`kept_id`, `removed_id`) — correct in AGENTS.md line 353 and handler_defs.rs.
- `knowledge.edit` section_type enum + 80-char minimum — documented in AGENTS.md lines 153-157 and vocab.rs.
- DSL nested-object args — already noted in the `propose` handler description and AGENTS.md.

## Test plan

- [x] `cargo test -p khive-pack-comm` — 71 passed, 0 failed
- [x] `cargo clippy -p khive-pack-comm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — no changes needed
- [x] `cargo check --workspace` — clean
- [x] Pre-commit hooks (deno fmt, cargo fmt, cargo clippy) — all passed