### PR TITLE
docs: correct taxonomy counts (9 kinds/17 relations) and ADR index status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,13 +212,13 @@ Load with `KHIVE_PACKS=kg,gtd` or `--pack gtd`. Adds the `task` note kind.
 
 Load with `KHIVE_PACKS=kg,memory` or `--pack memory`. Adds the `memory` note kind.
 
-| Verb              | Args                                                                  | What it does                                                                                   |
-| ----------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?` | Create a memory note with salience + decay; optionally annotates a source                      |
-| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`      | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking                             |
-| `memory.feedback` | `target_id`, `signal`                                                 | Emit explicit feedback on a recalled entity; updates recall posteriors                         |
-| `memory.prune`    | `min_salience?`, `before?`, `namespace?`, `dry_run?`                  | Soft-delete memories below a salience floor and/or past `expires_at` (curation-layer, ADR-014) |
-| `memory.vacuum`   | —                                                                     | Run SQLite `VACUUM` to reclaim space freed by soft-deleted rows                                |
+| Verb              | Args                                                                                   | What it does                                                                                   |
+| ----------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `memory.remember` | `content`, `salience?`, `decay_factor?`, `memory_type?`, `source_id?`                  | Create a memory note with salience + decay; optionally annotates a source                      |
+| `memory.recall`   | `query`, `limit?`, `min_score?`, `min_salience?`, `memory_type?`, `tags?`, `tag_mode?` | Hybrid FTS + vector recall with RRF fusion, decay-weighted ranking                             |
+| `memory.feedback` | `target_id`, `signal`                                                                  | Emit explicit feedback on a recalled entity; updates recall posteriors                         |
+| `memory.prune`    | `min_salience?`, `before?`, `namespace?`, `dry_run?`                                   | Soft-delete memories below a salience floor and/or past `expires_at` (curation-layer, ADR-014) |
+| `memory.vacuum`   | —                                                                                      | Run SQLite `VACUUM` to reclaim space freed by soft-deleted rows                                |
 
 `get`/`update`/`delete`/`merge` are UUID-only — no `kind` needed, the handler resolves
 the substrate from the UUID. `create`/`list`/`search` require `kind`.

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -2,7 +2,7 @@
 
 ## ADR Compliance
 
-### ADR-002: Edge Ontology (15 edge relations — closed set)
+### ADR-002: Edge Ontology (17 edge relations — closed set; 15 base + 2 epistemic via ADR-055)
 
 - The GTD pack does NOT add new edge relation variants; `depends_on` is already in the base set.
 - The pack additively extends the _endpoint contract_ to allow `depends_on` between two `task`

--- a/crates/khive-pack-kg/docs/design.md
+++ b/crates/khive-pack-kg/docs/design.md
@@ -14,7 +14,7 @@ the khive binary.
 | ADR                                                                | What it governs                                   | Status      |
 | ------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
 | [ADR-001](../../../docs/adr/ADR-001-entity-kind-taxonomy.md)       | 9 entity kinds (8 base + resource per ADR-048)    | Implemented |
-| [ADR-002](../../../docs/adr/ADR-002-edge-ontology.md)              | 15 edge relations, closed set                     | Implemented |
+| [ADR-002](../../../docs/adr/ADR-002-edge-ontology.md)              | 17 edge relations, closed set (15 base + 2 epistemic via ADR-055) | Implemented |
 | [ADR-007](../../../docs/adr/ADR-007-namespace.md)                  | KG uses shared `local` namespace                  | Implemented |
 | [ADR-013](../../../docs/adr/ADR-013-note-kind-taxonomy.md)         | 5 base note kinds                                 | Implemented |
 | [ADR-014](../../../docs/adr/ADR-014-curation-operations.md)        | UUID-only get/update/delete                       | Implemented |

--- a/crates/khive-types/docs/design.md
+++ b/crates/khive-types/docs/design.md
@@ -86,13 +86,14 @@ types for proposals, events, and namespace isolation.
 
 ### ADR-002: Edge Ontology
 
-- `EdgeRelation` is a closed enum with exactly 15 canonical relations.
+- `EdgeRelation` is a closed enum with exactly 17 canonical relations (15 base
+  per ADR-002 + 2 epistemic `supports`/`refutes` added by ADR-055).
 - `EdgeRelation::ALL` lists them in ontology-table order.
 - Wire format is snake_case (e.g., `"part_of"`, `"introduced_by"`).
 - `FromStr` accepts canonical snake_case names, hyphen variants, and squashed
   forms (e.g., `"partof"`, `"derivedfrom"`) for ergonomic DSL entry. Squashed
   forms are not stored on the wire.
-- `EdgeCategory` groups the 15 relations into 8 structural categories for query
+- `EdgeCategory` groups the 17 relations into 9 structural categories for query
   planners and UI rendering.
 - Symmetric relations (`competes_with`, `composed_with`) are identified via
   `is_symmetric()`.

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -527,7 +527,7 @@ never specify `substrate` directly.
 ## References
 
 - ADR-001: Entity Kind Taxonomy — entity_type validation via EntityTypeRegistry.
-- ADR-002: Edge Ontology — 15 relations, endpoint legality.
+- ADR-002: Edge Ontology — 15 base relations, endpoint legality. (Amended by ADR-055: current total is 17.)
 - ADR-004: Substrate Observables — Note kind_status lifecycle validation.
 - ADR-005: Storage Capability Traits — `EntityStore`, `GraphStore`, `NoteStore`,
   `EventStore`, `VectorStore`, `TextSearch` are the primitives curation composes.

--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -4,6 +4,10 @@
 **Date**: 2026-05-23\
 **Authors**: Ocean, lambda:khive
 
+> **Amended ([ADR-055](ADR-055-epistemic-edge-relations.md))**: ADR-055 added 2
+> epistemic relations (`supports`, `refutes`), expanding the closed set from 15 to 17.
+> Occurrences of "15 edge relations" in this document reflect the original base set.
+
 ## Context
 
 khive's foundational substrate (ADR-001 through ADR-016) is closed and stable. Six

--- a/docs/adr/ADR-029-substrate-coordinator.md
+++ b/docs/adr/ADR-029-substrate-coordinator.md
@@ -665,7 +665,7 @@ write queue. `link()` and ordinary writes still hard-fail on partition (see D6).
 ### Neutral
 
 - **ADR-002's 15 edge relations** (closed taxonomy) — `target_backend` is row metadata,
-  not a relation.
+  not a relation. (Amended by ADR-055: current total is 17 edge relations.)
 - **ADR-013 cross-substrate search contract preserved** — D4 fulfills it for
   multi-backend.
 - **MCP wire format unchanged** — clients see the same verbs; backend assignment is

--- a/docs/adr/ADR-041-event-provenance-projection.md
+++ b/docs/adr/ADR-041-event-provenance-projection.md
@@ -47,6 +47,9 @@ ADR-022 §3b's append-only ordering invariant rests on events being a separate s
 from entities. Promoting events into the entity table to "make them queryable" would
 break replay determinism, cursor semantics, and PackEventConsumer atomicity (ADR-017).
 
+> **Amended ([ADR-055](ADR-055-epistemic-edge-relations.md))**: ADR-055 added 2
+> epistemic relations (`supports`, `refutes`); the current total is 17 edge relations.
+
 This ADR resolves the tension via a **hybrid** model: the event log stays canonical
 (append-only, ordered, cursor-anchored), and a **sibling projection table**
 `event_observations` records the structured references at write time. Synthetic graph

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -63,6 +63,10 @@ requires at minimum three steps: `create(kind="concept", ...)`, optionally
 `link(relation="introduced_by", ...)`, and `search(kind="concept", ...)` for retrieval.
 These three steps recur in every research-agent workflow.
 
+> **Amended**: ADR-048 added a 9th entity kind (`resource`); ADR-055 added 2 epistemic
+> relations (`supports`, `refutes`); the current totals are 9 entity kinds and 17 edge
+> relations.
+
 Agents that work exclusively with research concepts encounter two friction points:
 
 1. **Domain promotion is manual.** `create` accepts a `tags` list; callers must

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -23,7 +23,7 @@ the exact `request(ops="...")` syntax for every common operation.
 ## What khive is
 
 khive is a structured persistence layer for AI research agents. It provides a
-typed knowledge graph (8 entity kinds, 15 edge relations, 5 note kinds), hybrid
+typed knowledge graph (9 entity kinds, 17 edge relations, 5 note kinds), hybrid
 search (FTS5 + vector + RRF fusion), GQL/SPARQL queries, task management, agent
 memory with decay-weighted recall, inter-agent messaging, scheduling, and a
 knowledge corpus with reranking.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -92,9 +92,9 @@ batch of them), and khive dispatches it to the appropriate pack handler.
 
 ### 1. Create an entity
 
-Entities are the nodes in your knowledge graph. khive has 8 entity kinds:
+Entities are the nodes in your knowledge graph. khive has 9 entity kinds:
 `concept`, `document`, `dataset`, `project`, `person`, `org`, `artifact`,
-`service`.
+`service`, `resource`.
 
 ```
 request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"FlashAttention\", description=\"IO-aware exact attention algorithm\", properties={domain: \"attention\", year: 2022})")

--- a/docs/guide/knowledge-graph.md
+++ b/docs/guide/knowledge-graph.md
@@ -21,7 +21,7 @@ it is a note.
 
 ## Entity kinds
 
-khive has 8 entity kinds. This is a closed set — you cannot add new kinds
+khive has 9 entity kinds. This is a closed set — you cannot add new kinds
 without an ADR.
 
 ### concept
@@ -109,6 +109,18 @@ create(kind="entity", entity_kind="service", name="OpenAI API",
        properties={type: "api"})
 ```
 
+### resource
+
+Actionable knowledge resources: atoms, domain knowledge packs, skills. Governed
+by the KG pack (ADR-048). Use `resource` for reusable knowledge objects that are
+managed by the knowledge pack rather than authored as raw entities.
+
+```
+create(kind="entity", entity_kind="resource", name="retrieval-patterns",
+       description="Domain knowledge pack for hybrid retrieval patterns",
+       properties={type: "domain"})
+```
+
 ## Note kinds
 
 khive has 5 base note kinds (also a closed set):
@@ -129,7 +141,7 @@ through their respective pack verbs, not through `create(kind="note")`.
 
 ## Edge relations
 
-khive has 15 edge relations. This is a closed set enforced at compile time.
+khive has 17 edge relations (15 base + 2 epistemic via ADR-055). This is a closed set enforced at compile time.
 
 ### When to use each relation
 
@@ -188,6 +200,16 @@ khive has 15 edge relations. This is a closed set enforced at compile time.
 | ----------- | ---------------- | ----------------------------------------------------------- |
 | `annotates` | note to anything | An observation about a concept, a decision about a project. |
 
+**Epistemic** — evidence relationships (added by ADR-055):
+
+| Relation   | Direction         | When to use                                         |
+| ---------- | ----------------- | --------------------------------------------------- |
+| `supports` | evidence to claim | A paper or dataset supports a concept or finding.   |
+| `refutes`  | evidence to claim | A paper or experiment refutes a concept or finding. |
+
+`supports` and `refutes` are same-substrate: source and target must both be
+entities or both be notes. The source is the evidence; the target is the claim.
+
 ### Edge endpoint rules
 
 Not every `(source_kind, relation, target_kind)` triple is valid. The base
@@ -196,7 +218,8 @@ for each relation. Key rules:
 
 - `annotates` is the only cross-substrate relation. Source must be a note;
   target can be anything (entity, note, edge, event).
-- `supersedes` is same-substrate only: entity to entity, or note to note.
+- `supersedes`, `supports`, and `refutes` are same-substrate only: entity to
+  entity, or note to note.
 - All other 13 relations require entity-to-entity endpoints.
 - `competes_with` and `composed_with` are symmetric — the system canonicalizes
   direction internally.
@@ -209,7 +232,7 @@ KG pack adds person-to-org and org-to-org pairs. The GTD pack allows task-to-tas
 
 A sparse, fixed set of relations keeps the graph queryable. Ad-hoc relations
 like `uses`, `related_to`, or `loaded_by` fragment the graph and make traversal
-meaningless. If your relationship does not fit one of the 15, it is probably a
+meaningless. If your relationship does not fit one of the 17, it is probably a
 property on the entity rather than an edge.
 
 ## Modeling patterns


### PR DESCRIPTION
## Summary

Fixes stale taxonomy-count documentation across guide docs, crate design docs, and ADR bodies. No source, schema, or TOML files are touched.

### A2 — Guide/overview docs updated (8→9 entity kinds, 15→17 edge relations)

- `docs/guide/README.md`: one-line summary corrected.
- `docs/guide/getting-started.md`: entity kind count and inline list updated; `resource` added.
- `docs/guide/knowledge-graph.md`: count updated in two places; new `### resource` entity-kind section added; new **Epistemic** edge table added (`supports`, `refutes`); endpoint-rules bullet updated to include `supports`/`refutes` as same-substrate; "one of the 15" → "one of the 17".
- `crates/khive-pack-kg/docs/design.md`: ADR-002 compliance row updated to 17 (15 base + 2 epistemic via ADR-055).
- `crates/khive-types/docs/design.md`: EdgeRelation enum description and EdgeCategory group count updated.
- `crates/khive-pack-gtd/docs/design.md`: section heading updated.

### A4 — ADR body amendment notes added (original sentences preserved)

- `docs/adr/ADR-017-pack-standard.md`: blockquote amendment note added below header metadata.
- `docs/adr/ADR-041-event-provenance-projection.md`: blockquote amendment note added after the "15 edge relations" sentence.
- `docs/adr/ADR-047-knowledge-pack.md`: blockquote amendment note added after the Context paragraph (covers both the entity-kind count and edge-relation count changes from ADR-048 and ADR-055).
- `docs/adr/ADR-014-curation-operations.md`: inline note appended to the ADR-002 reference entry.
- `docs/adr/ADR-029-substrate-coordinator.md`: inline note appended to the ADR-002 bullet in the Neutral section.

### A5 — `memory.recall` params in CLAUDE.md

Verified `tags` and `tag_mode` exist in `crates/khive-pack-memory/src/handlers/common.rs` (`RecallParams` struct, fields `tags: Option<Vec<String>>` and `tag_mode: TagMode`). Added both params to the `memory.recall` row in the memory pack verb table.

### A6 — docs/adr/README.md ADR 066–073 status

Verified each existing ADR file (066, 067, 068, 069, 073) against its own status header. All five show `Status: Proposed` and the README already marks them `(Proposed)`. No changes needed. ADR-070, ADR-071, and ADR-072 have no corresponding files in the repository; nothing to add.

## Test plan

- [ ] `deno fmt --check docs/ CLAUDE.md` passes (pre-commit hook verified clean)
- [ ] Grep confirms no remaining bare "8 entity kinds" or "15 edge relations" in guide docs and crate design docs
- [ ] ADR bodies retain their original sentences; amendment notes are additive only