### PR TITLE
docs(adr): ADR-076 — relation-set calculability and system-role justification

### DIFF
--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -2,7 +2,10 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive
+**Authors**: Ocean, lambda:khive\
+**Amended by**: [ADR-076](ADR-076-relation-calculability-and-system-role.md) — `part_of` is a
+distinct relation, not the "inverse of `contains`"; the two coincide in some domains and diverge
+in others, and neither is derived from the other.
 
 ## Context
 
@@ -34,7 +37,7 @@ classification ambiguity.
 | Relation      | Direction          | When                                             |
 | ------------- | ------------------ | ------------------------------------------------ |
 | `contains`    | parent → child     | Crate contains module, system contains component |
-| `part_of`     | child → parent     | Inverse of `contains`                            |
+| `part_of`     | child → parent     | Member/constitution; distinct from `contains`    |
 | `instance_of` | specific → general | One is a case of the other (GPT-4 → Transformer) |
 
 ### Category 2: Derivation (intellectual lineage)
@@ -136,8 +139,10 @@ snapshot -[derived_from]-> project
 - Relations not in this list are forbidden.
 - If a relationship doesn't fit, it's either an entity property or it doesn't belong in
   the graph.
-- Inverse relations are NOT created automatically. Use `part_of` explicitly if you need the
-  inverse of `contains`. Query with `direction=in` for logical inverses.
+- Inverse relations are NOT created automatically. `part_of` is a distinct relation, not the
+  converse of `contains` (see [ADR-076](ADR-076-relation-calculability-and-system-role.md));
+  assert it explicitly when constitution holds. Query with `direction=in` for direction-aware
+  traversal of a single relation.
 - Edge weight: `1.0` = definitional, `0.7-0.9` = strong, `0.4-0.6` = plausible,
   `<0.4` = speculative.
 
@@ -316,7 +321,8 @@ These are additive — the base contract is unchanged. Semantics:
 - `Org depends_on Org` — one org depends on another (e.g. subsidiary dependency)
 - `Org enables Org` — one org enables another (e.g. incubator → startup)
 - `Org contains Org` — org hierarchy (e.g. parent company contains subsidiary)
-- `Org part_of Org` — inverse of contains; subsidiary is part of parent
+- `Org part_of Org` — subsidiary is part of parent (here it coincides with `contains`; the two
+  remain distinct relations, not converses — see ADR-076)
 - `Org precedes Org` — temporal ordering without replacement (predecessor org)
 
 ## Edge Metadata

--- a/docs/adr/ADR-076-relation-calculability-and-system-role.md
+++ b/docs/adr/ADR-076-relation-calculability-and-system-role.md
@@ -1,0 +1,235 @@
+# ADR-076: Relation-Set Calculability — System Role and the Non-Redundancy Certificate
+
+**Status**: proposed\
+**Date**: 2026-06-26\
+**Authors**: Ocean, lambda:khive\
+**Amends**: [ADR-002](ADR-002-edge-ontology.md) — corrects the `contains`/`part_of` "inverse"
+phrasing (the relations are distinct, not converses).\
+**Relates to**: [ADR-055](ADR-055-epistemic-edge-relations.md) (the `supports`/`refutes` case
+study), [ADR-001](ADR-001-entity-kind-taxonomy.md), [ADR-013](ADR-013-note-kind-taxonomy.md),
+[ADR-017](ADR-017-pack-standard.md).
+
+## Context
+
+khive ships a closed set of 17 edge relations (ADR-002 base 15, ADR-055 +2 epistemic), 9 entity
+kinds, and 5 note kinds. A recurring and fair challenge to any closed taxonomy is: the set looks
+hand-picked. Why exactly these relations and not others? If the answer is "they felt right," the
+taxonomy is ad-hoc, and ad-hoc closed sets accrete cruft and resist principled extension. The
+demand is for the set to be **calculable** rather than eyeballed: a mechanical account of why
+each relation belongs, and a mechanical gate that any proposed new relation must pass.
+
+This ADR answers that demand. It does so honestly, after validating every claim against a copy
+of the production graph rather than against theory. The honest answer has three parts, and the
+first thing to state is what calculability **is not**.
+
+**Calculability is not derivation.** There is no closed-form argument that yields "these 17
+relations are necessary" from first principles. Any such derivation would smuggle in the very
+modeling choices it claims to derive. A relation set is a design artifact answering a bounded
+list of query classes that the system's users actually run. The query classes are chosen, not
+deduced.
+
+**What is mechanical** is the justification of each relation and the falsification of redundancy:
+
+1. **System role** — each relation must name a concrete query, view, or policy that it uniquely
+   serves, witnessed by usage. This is the justifier.
+2. **A non-redundancy certificate** — a fixed family of redundancy hypotheses ("eliminators"),
+   each of which proposes encoding a relation as something cheaper. A relation is non-redundant
+   only if, for every eliminator, a concrete fixture exists where the cheaper encoding returns a
+   wrong answer that the standalone relation gets right. This is a falsification harness, not a
+   necessity proof.
+
+The two compose: the certificate is a tripwire that forces a redundancy question to be answered
+explicitly; the system-role declaration is the arbiter that decides the relation's fate. The
+certificate is **necessary but not sufficient**. A relation can fail the certificate (be formally
+redundant) and still be kept, when a declared system role demands it. The `supports`/`refutes`
+pair is exactly that case, and it is the proof that the arbiter, not the algebra, has the final
+word.
+
+### What is actually in the system today
+
+This ADR is grounded in the live graph (8381 edges, 2763 entities), not in the design loop's
+prior assumptions. The relevant facts:
+
+- 16 of 17 relations carry live edges; only `refutes` has none. The taxonomy is exercised, not
+  speculative. Each heavily-used relation answers a query class agents run.
+- khive performs pure breadth-first traversal with relation filters. There is **no**
+  composition engine, transitive-closure machinery, derived-edge materialization, or rollup
+  inference anywhere in the codebase.
+- Edge metadata is populated on 3.3% of edges, and the only keys ever used are `context`,
+  `dependency_kind`, `note`, `reason`. There is no `role` or `structural_role` field in use.
+- The `entity_type` subtype column (ADR-069) is null on every entity. Typed subtyping is
+  unexercised.
+- Live data violates the declared endpoint contracts in several places (for example
+  `contains` project→concept, `part_of` person→org). The contracts are partly aspirational.
+
+These facts decide the scope. The normative content of this ADR is the calculability account,
+the `supports`/`refutes` finding, and the `contains`/`part_of` correction. Everything that would
+require building new machinery (composition tables, rollup guards, materialized views, typed
+sub-relations, RDF/OWL export) is explicitly **out of normative scope** and recorded as future
+work with the empirical reason it is not built today. Building any of it now would be theory
+dictating architecture against the grain of how the system is actually used.
+
+## Decision
+
+### D1 — System role is the admission and retention standard
+
+A relation belongs in the closed set if and only if it has a declared **system role**: a
+specific query, view, or policy that the relation uniquely serves and that some other relation
+or attribute encoding would answer incorrectly. The role is recorded in prose in the governing
+ADR (ADR-002 and its amendments) and is witnessed by usage in the live graph.
+
+System role is the justifier of record. Usage corroborates it but does not replace it: a
+relation may be provisioned ahead of the workload it serves (see D3). The role declaration is
+what a future maintainer reads to understand why the relation exists.
+
+### D2 — The non-redundancy certificate is the regression gate on new relations
+
+Any proposal to add a relation to the closed set must pass a non-redundancy certificate. The
+certificate runs a fixed family of **eliminators**, each a hypothesis that the proposed relation
+R is redundant because it can be encoded more cheaply. R earns admission only if every eliminator
+is **defeated** by a fixture: a small concrete graph plus a query where the cheaper encoding
+returns a wrong answer and R-as-its-own-relation returns the right one.
+
+The eliminator families:
+
+| Family | Hypothesis: R is redundant because it is …                                    | Defeated by a fixture where …                                             |
+| ------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Cv     | the converse of an existing relation (use `direction=in`)                     | R and the converse disagree on some pair                                  |
+| Er     | an existing relation restricted to specific endpoint kinds                    | R holds for a pair the endpoint restriction would exclude, or vice versa  |
+| At     | an existing relation plus a metadata attribute value                          | the attribute encoding loses a query the standalone relation answers      |
+| Po     | an existing relation plus a polarity/sign attribute                           | a polarity-blind reader returns a wrong answer the signed relation avoids |
+| Ch     | a fixed composition (property chain) of existing relations, `R = S ∘ T`       | the chain admits a pair R rejects, or rejects a pair R admits             |
+| Mv     | a query-free materialized view (reachability) over existing relations         | the view and the asserted relation diverge on some pair                   |
+| Sr     | a sub-relation of a broader parent (model it as a typed sub-relation instead) | the parent cannot carry a distinction R needs at top level                |
+
+A relation that survives every eliminator is non-redundant and admissible. A relation for which
+some eliminator has **no** defeating fixture is formally redundant under that eliminator, and the
+default disposition is to encode it the cheaper way (demote to an attribute, a sub-relation, a
+direction-aware query, or a view) rather than mint a top-level relation.
+
+This is the operational meaning of "calculable": the gate is a mechanical, repeatable check that
+a build can run, not a matter of taste applied case by case. It is a **falsification harness**.
+It cannot prove a relation is necessary. It can only fail to refute its non-redundancy, which is
+the strongest mechanical statement available and the right discipline for a closed set.
+
+### D3 — `supports`/`refutes`: redundant under the certificate, kept by system role
+
+The `supports`/`refutes` pair (ADR-055) fails the Po eliminator. A single relation `assesses`
+carrying a polarity attribute (`polarity ∈ {supports, refutes}`) answers every query the pair
+answers, with provably identical results: every "what supports X" query becomes "what assesses X
+with polarity=supports." No fixture defeats the Po eliminator for this pair. By the D2 default,
+the pair would be demoted to one relation plus an attribute.
+
+The pair is kept as two top-level relations anyway. The justification is the declared system role
+in ADR-055: the epistemic layer khive is building toward requires polarity to be a first-class,
+relation-level distinction that planners, indexes, federation, and the public API can branch on
+directly, not a value buried in an open metadata blob that 3.3% of edges populate. That is a
+design decision about where the distinction must live, and it is the designer's to make.
+
+This is the load-bearing case for the whole ADR. The certificate did its job: it flagged the one
+pair in the set that is formally collapsible, and it forced the keep-or-demote question to be
+answered explicitly. The answer came from the system-role declaration, not from the algebra. The
+certificate is necessary and not sufficient; the declaration is the arbiter. The live data
+sharpens the point: `supports`=2 edges, `refutes`=0. The pair is both the algebra-flagged pair
+and the near-unused pair, kept purely on forward-looking design grounds. A taxonomy that admitted
+relations only by algebra would have dropped it; a taxonomy that admitted them only by usage
+would also have dropped it. It is kept because the design says the epistemic layer matters.
+
+### D4 — `contains` and `part_of` are distinct relations, not converses
+
+ADR-002 describes `part_of` as the "inverse of `contains`" in three places. That phrasing is
+incorrect and is struck by this ADR. `contains` denotes housing or scope; `part_of` denotes
+constitution or membership. The two **coincide** in some domains (an organization contains a
+subsidiary and the subsidiary is part of the parent) and **diverge** in others (an ocean
+contains fish, but a fish is not part of the ocean). Because they diverge, neither may be derived
+from the other.
+
+The live graph confirms this is the correct model. 70 pairs carry both `contains(a,b)` and
+`part_of(b,a)`. That co-occurrence is the fingerprint of a system that does **not** auto-infer
+the converse: agents assert both directions by hand exactly when both housing and constitution
+hold. If khive derived `part_of` from `contains`, those 70 doubles would not exist as asserted
+edges. The mechanical "no auto-inverse" rule (ADR-002 §"Why no auto-inverse?") is correct and is
+confirmed by code: no code couples the two relations. Only the **semantic** phrasing — calling
+one the inverse of the other — is wrong, and only that phrasing is corrected here.
+
+## Empirical grounding
+
+Validated on a disposable copy of the production graph. Full detail in the design workspace; the
+load-bearing numbers:
+
+- **Relation distribution** (live edges): introduced_by 1435, enables 1380, annotates 1269,
+  implements 896, composed_with 659, part_of 539, instance_of 519, extends 452, competes_with
+  446, depends_on 294, contains 285, precedes 120, variant_of 50, supersedes 25, derived_from 10,
+  supports 2, refutes 0. Evidence for D1 (system role witnessed by usage) and D3 (the flagged
+  pair is also the unused pair).
+- **`contains(a,b) ∧ part_of(b,a)`**: 70 pairs. Evidence for D4 (no auto-inverse, distinct
+  relations co-asserted where they coincide).
+- **Metadata population**: 3.3% of edges; keys `context, dependency_kind, note, reason` only.
+  Evidence that an attribute-encoded distinction (the At/Po default of D2) is cheap in schema but
+  expensive in practice, because agents rarely populate metadata. This is why D3 keeps polarity
+  at relation level.
+- **`entity_type` null on all entities**: typed subtyping is unexercised. Evidence that the Sr
+  eliminator's "model it as a typed sub-relation" alternative is forward-looking, not a reuse.
+- **Endpoint-contract violations**: the declared contracts do not fully match live data. The
+  certificate operates over the declared contracts, so its soundness is bounded by contract
+  fidelity. A reconciliation audit is recorded as future work.
+
+## Out of normative scope (future work)
+
+Each item below was considered and is **not** adopted. The empirical reason is recorded so the
+deferral is a decision, not an omission.
+
+- **Composition / rollup tables and a `structural_role` edge field.** A guard that decides when
+  `part_of` reachability rolls a functional fact up a hierarchy would need agents to mark each
+  edge's role. Metadata is populated on 3.3% of edges and no `role` field is in use, so such a
+  guard would be unreliable in exactly the cases it must cover. No rollup is computed today
+  (pure BFS), so there is nothing to guard. Revisit only if a workload begins computing closures
+  over `part_of` and the role signal is reliably populated.
+- **Materialized derived-edge views and pin-on-annotation.** No materialization machinery exists;
+  traversal is on-demand. Building a view catalog, derivation provenance, and invalidation before
+  any measured need is premature optimization. Revisit behind a measured reuse-and-pain threshold.
+- **Typed sub-relations (`proves ⊑ supports`) for opaque-label resolution (#293).** The subtype
+  column is unused, so this would be the first subtyping in the system, not a reuse. It is a
+  coherent forward direction for resolving overloaded relations (for example `extends` as both
+  subtype and "builds on"), to be specified when a pack needs it, under closed-world,
+  validator-enforced entailment.
+- **RDF / OWL / SHACL export of the relation set.** External-interop concern, tracked separately.
+  The relevant invariant for that work is that core relations must carry no `rdfs:domain` /
+  `rdfs:range` that would let a reasoner infer entity kinds from edges; this ADR's endpoint
+  contracts are validation rules, not logical axioms.
+- **Endpoint-contract reconciliation.** Declared contracts diverge from observed endpoint pairs.
+  A reconciliation audit (compare declared vs observed, then either tighten enforcement or widen
+  the contract per relation) is concrete future work and a precondition for the certificate's
+  soundness over real data.
+
+## Consequences
+
+**Changes now (documentation only).**
+
+- ADR-002's "inverse of `contains`" phrasing is struck in favor of the distinct-relations model
+  (D4). No code or schema changes; the no-auto-inverse behavior is already correct.
+- The non-redundancy certificate (D2) is the documented gate any future relation proposal must
+  pass. New-relation ADRs must include the eliminator fixtures or an explicit system-role
+  override for any undefeated eliminator, on the `supports`/`refutes` pattern.
+
+**Does not change.**
+
+- No relation is added or removed. The set stays at 17.
+- No schema change, no new edge field, no new machinery. khive continues to do pure BFS.
+- The closed enum stays closed and compile-time. The certificate governs proposals; it does not
+  open the set.
+
+**Trade-off accepted.** The certificate is a falsification harness, not a necessity proof. It
+cannot certify that the 17 relations are the uniquely correct set, only that each survives the
+registered eliminators or is kept by an explicit, recorded system-role override. This is the
+honest ceiling for a designed closed set, and it is stronger than the prior state, where the set
+was justified only by prose intuition.
+
+## References
+
+- [ADR-001](ADR-001-entity-kind-taxonomy.md) — entity kind taxonomy
+- [ADR-002](ADR-002-edge-ontology.md) — edge ontology (amended here)
+- [ADR-013](ADR-013-note-kind-taxonomy.md) — note kind taxonomy
+- [ADR-017](ADR-017-pack-standard.md) — pack standard, pack-extensible endpoints
+- [ADR-055](ADR-055-epistemic-edge-relations.md) — `supports`/`refutes` epistemic relations
+- [ADR-069](ADR-069-subject-model.md) — subject model, typed subtypes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,39 +70,40 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 
 ## New v1 Surfaces
 
-| #                                                         | Title                                                                                                           |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [ADR-040](ADR-040-communication-and-schedule-packs.md)    | Communication and Schedule Packs                                                                                |
-| [ADR-041](ADR-041-event-provenance-projection.md)         | Event Provenance Projection — Hybrid Log + Graph Edges                                                          |
-| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)  | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                                   |
-| [ADR-043](ADR-043-embedding-model-migration.md)           | Embedding Model Migration                                                                                       |
-| [ADR-044](ADR-044-vector-store-extensions.md)             | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep                   |
-| [ADR-045](ADR-045-verb-response-presentation.md)          | Verb Response Presentation Modes                                                                                |
-| [ADR-046](ADR-046-event-sourced-proposals.md)             | Event-Sourced Agent KG Proposals                                                                                |
-| [ADR-047](ADR-047-knowledge-pack.md)                      | Knowledge Pack — Concept Registration, Citation, and Topic Search                                               |
-| [ADR-048](ADR-048-knowledge-section-profiles.md)          | Knowledge Section Profiles                                                                                      |
-| [ADR-049](ADR-049-khived-daemon.md)                       | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
-| [ADR-050](ADR-050-kg-token-namespace-contract.md)         | KG Token Namespace Contract (Accepted -- partially superseded by ADR-007 Rev 3)                                 |
-| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)   | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
-| [ADR-052](ADR-052-ann-production-lifecycle.md)            | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
-| [ADR-053](ADR-053-authorization-gate.md)                  | Authorization Gate — ActorStore, SessionStore, and Cloud-Tier Caller Propagation (Proposed)                     |
-| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)   | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
-| [ADR-055](ADR-055-epistemic-edge-relations.md)            | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |
-| [ADR-056](ADR-056-channel-transport-layer.md)             | Channel Transport Layer — `khive-channel` and External Messaging Adapters (Proposed)                            |
-| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)       | Comm Actor-Addressed Delivery (Accepted)                                                                        |
-| [ADR-058](ADR-058-brain-posterior-read-path.md)           | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking (Proposed)                            |
-| [ADR-059](ADR-059-namespace-write-tiers.md)               | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
-| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)    | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
-| [ADR-062](ADR-062-fts-ann-consolidation.md)               | FTS and ANN Consolidation -- Unified Search Tables (Schema V4) (Accepted)                                       |
-| [ADR-066](ADR-066-autonomous-merge-pipeline.md)           | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
-| [ADR-067](ADR-067-write-owner-daemon.md)                  | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
-| [ADR-068](ADR-068-cloud-multitenancy-topology.md)         | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
-| [ADR-069](ADR-069-subject-model.md)                       | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
-| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)        | Subject OntologySpec as Runtime Data — Verbless Verticals and Pack Retirement (Proposed)                        |
-| [ADR-073](ADR-073-pack-core-backend-accessor.md)          | Pack Core-Backend Accessor (Accepted)                                                                           |
-| [ADR-074](ADR-074-graph-aware-recall.md)                  | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval (Proposed)                                      |
-| [ADR-075](ADR-075-owl-rdf-interoperability.md)            | OWL/RDF Interoperability — Publishing the khive Vocabulary and Aligning with External Ontologies (Draft)        |
-| [ADR-078](ADR-078-output-format-shape-aware-rendering.md) | Output Format and Shape-Aware Rendering (Proposed)                                                              |
+| #                                                            | Title                                                                                                           |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [ADR-040](ADR-040-communication-and-schedule-packs.md)       | Communication and Schedule Packs                                                                                |
+| [ADR-041](ADR-041-event-provenance-projection.md)            | Event Provenance Projection — Hybrid Log + Graph Edges                                                          |
+| [ADR-042](ADR-042-local-rerank-via-lattice-inference.md)     | Composable Rerank Pipeline (local cross-encoder + salience + graph-proximity)                                   |
+| [ADR-043](ADR-043-embedding-model-migration.md)              | Embedding Model Migration                                                                                       |
+| [ADR-044](ADR-044-vector-store-extensions.md)                | Vector Store Extensions — Capabilities, Metadata Filter, Batched Search, Update, Orphan Sweep                   |
+| [ADR-045](ADR-045-verb-response-presentation.md)             | Verb Response Presentation Modes                                                                                |
+| [ADR-046](ADR-046-event-sourced-proposals.md)                | Event-Sourced Agent KG Proposals                                                                                |
+| [ADR-047](ADR-047-knowledge-pack.md)                         | Knowledge Pack — Concept Registration, Citation, and Topic Search                                               |
+| [ADR-048](ADR-048-knowledge-section-profiles.md)             | Knowledge Section Profiles                                                                                      |
+| [ADR-049](ADR-049-khived-daemon.md)                          | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
+| [ADR-050](ADR-050-kg-token-namespace-contract.md)            | KG Token Namespace Contract (Accepted -- partially superseded by ADR-007 Rev 3)                                 |
+| [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)      | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
+| [ADR-052](ADR-052-ann-production-lifecycle.md)               | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
+| [ADR-053](ADR-053-authorization-gate.md)                     | Authorization Gate — ActorStore, SessionStore, and Cloud-Tier Caller Propagation (Proposed)                     |
+| [ADR-054](ADR-054-ann-build-strategy-scaling-limits.md)      | ANN Build Strategy and Scaling Limits (Proposed)                                                                |
+| [ADR-055](ADR-055-epistemic-edge-relations.md)               | Epistemic Edge Relations — `supports` and `refutes` (Accepted)                                                  |
+| [ADR-056](ADR-056-channel-transport-layer.md)                | Channel Transport Layer — `khive-channel` and External Messaging Adapters (Proposed)                            |
+| [ADR-057](ADR-057-comm-actor-addressed-delivery.md)          | Comm Actor-Addressed Delivery (Accepted)                                                                        |
+| [ADR-058](ADR-058-brain-posterior-read-path.md)              | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking (Proposed)                            |
+| [ADR-059](ADR-059-namespace-write-tiers.md)                  | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
+| [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)       | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
+| [ADR-062](ADR-062-fts-ann-consolidation.md)                  | FTS and ANN Consolidation -- Unified Search Tables (Schema V4) (Accepted)                                       |
+| [ADR-066](ADR-066-autonomous-merge-pipeline.md)              | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
+| [ADR-067](ADR-067-write-owner-daemon.md)                     | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
+| [ADR-068](ADR-068-cloud-multitenancy-topology.md)            | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
+| [ADR-069](ADR-069-subject-model.md)                          | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
+| [ADR-072](ADR-072-subject-ontologyspec-as-data.md)           | Subject OntologySpec as Runtime Data — Verbless Verticals and Pack Retirement (Proposed)                        |
+| [ADR-073](ADR-073-pack-core-backend-accessor.md)             | Pack Core-Backend Accessor (Accepted)                                                                           |
+| [ADR-074](ADR-074-graph-aware-recall.md)                     | Graph-Aware Recall — Graph-Proximity Signal in Memory Retrieval (Proposed)                                      |
+| [ADR-075](ADR-075-owl-rdf-interoperability.md)               | OWL/RDF Interoperability — Publishing the khive Vocabulary and Aligning with External Ontologies (Draft)        |
+| [ADR-076](ADR-076-relation-calculability-and-system-role.md) | Relation-Set Calculability — System Role and the Non-Redundancy Certificate (Proposed)                          |
+| [ADR-078](ADR-078-output-format-shape-aware-rendering.md)    | Output Format and Shape-Aware Rendering (Proposed)                                                              |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## What

Adds **ADR-076: Relation-Set Calculability — System Role and the Non-Redundancy Certificate**, and amends ADR-002's `contains`/`part_of` "inverse" phrasing. Docs-only; no code or schema changes.

## Why

A fair challenge to any closed taxonomy: the edge-relation set (17 relations) looks hand-picked. This ADR answers that demand honestly, after validating every claim against a copy of the live graph rather than against theory.

The honest answer is in three parts:

1. **System role is the admission standard.** Each relation must name a concrete query, view, or policy it uniquely serves, witnessed by usage. 16 of 17 relations carry live edges.
2. **A non-redundancy certificate is the regression gate on new relations.** A fixed family of redundancy eliminators (converse, endpoint-restriction, attribute/polarity-encoding, composition, materialized-view, sub-relation); a proposed relation is admissible only if a concrete fixture defeats every eliminator. This is the operational meaning of "calculable" — a mechanical, repeatable check — framed honestly as a **falsification harness**: necessary, not sufficient.
3. **`supports`/`refutes` is the load-bearing case.** It fails the polarity eliminator (formally collapsible to a single `assesses(polarity)` relation) yet is kept by declared system role (ADR-055). The certificate did its job — it flagged the one collapsible pair and forced the keep-or-demote question to be explicit. The answer came from the design declaration, not the algebra. The certificate is necessary and not sufficient; the declaration is the arbiter.

## ADR-002 correction

`part_of` is described as the "inverse of `contains`" in three places. That phrasing is struck. The relations are **distinct**: `contains` is housing/scope, `part_of` is constitution/membership. They coincide in some domains (an org contains a subsidiary and the subsidiary is part of the parent) and diverge in others (a room contains a table, but a table is not part of the room). Neither is derived from the other. The mechanical no-auto-inverse behavior is already correct and unchanged; only the semantic phrasing is fixed.

## Empirical grounding (live graph, 8381 edges)

- Relation distribution shows 16/17 relations exercised; `supports`=2, `refutes`=0 is both the algebra-flagged pair and the near-unused pair, kept purely on forward-looking design grounds.
- 70 pairs carry both `contains(a,b)` and `part_of(b,a)` — the fingerprint of a system that does not auto-infer the converse.
- Edge metadata populated on 3.3% of edges with no role field in use; `entity_type` unused. These facts decide scope: machinery that would depend on per-edge role annotation is out of normative scope.

## Out of normative scope (recorded as future work, with the empirical reason)

Composition/rollup tables and a `structural_role` field, materialized derived-edge views, typed sub-relations, and RDF/OWL export. None exist today (khive does pure BFS); building them now would run against how the system is actually used.

## Scope

- Docs-only: new `docs/adr/ADR-076-*.md`, `contains`/`part_of` phrasing fix in `docs/adr/ADR-002-*.md`, README index entry.
- No relation added or removed; the closed enum stays at 17.
- No code, no schema, no new machinery.

Status: **proposed** — pending review and maintainer approval.
