### PR TITLE
docs(adr): status + doc-catchup batch (073/062/050)

### DIFF
--- a/docs/adr/ADR-050-kg-token-namespace-contract.md
+++ b/docs/adr/ADR-050-kg-token-namespace-contract.md
@@ -7,7 +7,8 @@
 > The §"Context" and §"Rationale / Why not token rebinding" sections remain authoritative
 > historical background for why the override was introduced and why it was removed.
 
-**Status**: Proposed — pending Ocean review
+**Status**: Accepted — core decision shipped with initial codebase; §"Decision" absorbed and
+confirmed by ADR-007 Rev 3 (#164, 2026-06-17). See supersession note above.
 **Date**: 2026-06-03
 **Supersedes**: ADR-007 §"Namespace-by-Layer Rule" (KG pack rebinding only)
 **References**: ADR-007 (Rev 3), ADR-028, ADR-029

--- a/docs/adr/ADR-062-fts-ann-consolidation.md
+++ b/docs/adr/ADR-062-fts-ann-consolidation.md
@@ -1,0 +1,221 @@
+# ADR-062: FTS and ANN Consolidation -- Unified Search Tables (Schema V4)
+
+**Status**: Accepted
+**Date**: 2026-06-19
+**PR**: #171
+**Amends**: [ADR-015](ADR-015-schema-migrations.md) -- adds schema version 4
+**Depends on**: [ADR-031](ADR-031-multi-engine-retrieval.md), [ADR-044](ADR-044-vector-store-extensions.md), [ADR-052](ADR-052-ann-production-lifecycle.md)
+
+---
+
+## Context
+
+### Per-namespace FTS tables (the problem)
+
+Before schema V4, full-text search tables were created on demand, one per namespace. An entity
+create in namespace `local` wrote into `fts_entities_local`; one in namespace `tenant-a` wrote
+into `fts_entities_tenant_a`. The table key was computed by sanitizing the namespace string and
+appending it as a suffix.
+
+This design had several consequences:
+
+1. **FTS fanout in memory recall**: the memory pack's `collect_recall_candidates` iterated over
+   every visible namespace in a loop, issuing one FTS query per namespace. For a caller with a
+   visible set of two namespaces, that was two serial FTS round-trips per recall operation.
+
+2. **Merge and curation code carried the sanitized suffix**: `merge_entity` and `merge_note` in
+   `curation.rs` reproduced the namespace-sanitize computation to derive the FTS table name.
+   Any divergence between the sanitize implementations would silently corrupt the FTS index.
+
+3. **ANN indexes were also per-namespace**: the memory pack's ANN (Vamana) snapshot key was
+   `{namespace}::memory_vamana::{model}`. Recall in a multi-namespace context required separate
+   index builds per namespace.
+
+4. **Stale partitions accumulated**: old per-namespace FTS and ANN tables stayed in the SQLite
+   file indefinitely. `kkernel reindex` had no sweep step to prune them.
+
+### Blocking condition
+
+The khernel daemon (`kkernel mcp --daemon`) had already migrated the live `~/.khive/khive.db` to
+schema V4 before this ADR's migration landed in `main`. The pre-V4 `main` codebase triggered the
+schema-ahead guard in `run_migrations` (`current(4) > latest_known(3)`) and crashed at boot. This
+PR was the V4 realignment to unblock the studio build.
+
+---
+
+## Decision
+
+Consolidate per-namespace FTS5 virtual tables into two shared tables with a `namespace` column,
+and replace per-namespace ANN index keys with a single global index per model. Add a sweep pass to
+`kkernel reindex` that drops stale per-namespace partitions.
+
+---
+
+## Schema V4 Changes (`crates/khive-db/sql/004-fts-consolidation.sql`)
+
+Two FTS5 virtual tables are created, both using the `trigram` tokenizer:
+
+### `fts_entities`
+
+Unified entity full-text search table, one row per entity across all namespaces.
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_entities USING fts5(
+    subject_id UNINDEXED,
+    kind       UNINDEXED,
+    title,
+    body,
+    tags       UNINDEXED,
+    namespace  UNINDEXED,
+    metadata   UNINDEXED,
+    updated_at UNINDEXED,
+    tokenize = 'trigram'
+);
+```
+
+Replaces the family of `fts_entities_{namespace}` tables created on demand before V4.
+
+### `fts_notes`
+
+Unified note full-text search table with identical column structure.
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_notes USING fts5(
+    subject_id UNINDEXED,
+    kind       UNINDEXED,
+    title,
+    body,
+    tags       UNINDEXED,
+    namespace  UNINDEXED,
+    metadata   UNINDEXED,
+    updated_at UNINDEXED,
+    tokenize = 'trigram'
+);
+```
+
+Replaces the family of `fts_notes_{namespace}` tables.
+
+### Migration properties
+
+- Forward-only, `IF NOT EXISTS` safe, idempotent on re-run.
+- Does not contain any `DROP TABLE` for the old per-namespace tables. Stale partition cleanup
+  is performed at runtime by `kkernel reindex`, not in the SQL, so no namespace names appear
+  in the migration file.
+- After the migration runs, callers must execute `kkernel reindex --no-knowledge` to repopulate
+  the new unified tables from the entity and note rows already in the database.
+
+---
+
+## Runtime Changes
+
+### FTS table key (`crates/khive-runtime/src/runtime.rs`)
+
+`KhiveRuntime::text()` and `text_for_notes()` previously computed a per-namespace key:
+
+```rust
+// before V4
+let key = format!("entities_{}", sanitize_key(token.namespace().as_str()));
+self.backend.text(&key)
+```
+
+After V4, the namespace argument is ignored; the shared table name is used directly:
+
+```rust
+// V4
+self.backend.text("entities")   // text()
+self.backend.text("notes")      // text_for_notes()
+```
+
+`curation.rs` (merge paths) was updated in the same commit to use `"fts_entities"` and
+`"fts_notes"` as the FTS table name, eliminating the sanitized-suffix computation that duplicated
+the key logic.
+
+### Memory pack FTS search (`crates/khive-pack-memory/src/handlers/common.rs`)
+
+The `collect_recall_candidates` function previously fanned out over each visible namespace with one
+FTS call per namespace. After V4, `collect_text_hits` receives the full visible namespace set and
+issues a single FTS query with a `namespace IN (...)` filter.
+
+### ANN index key (`crates/khive-pack-memory/src/ann.rs`)
+
+`AnnKey` previously included the namespace as a field. After V4:
+
+- `AnnKey` is model-only; the namespace field is removed.
+- Snapshot key format is `global::memory_vamana::{model}` regardless of namespace.
+- `warm_existing_memory_indexes()` issues one `ensure_ann_for_model` call per model using
+  `Namespace::local()` as the token; the resulting index serves all namespaces.
+- ANN over-fetch (factor 4, minimum 32) with a bounded retry loop (default 3 rounds, env-
+  overridable via `ANN_OVERFETCH_MAX_ROUNDS`) addresses the case where a global index is
+  dominated by foreign-namespace vectors: each retry widens the fetch limit by 2x until the
+  visible-namespace survivor count reaches `candidate_limit` or the corpus is exhausted.
+
+### Stale partition sweep (`crates/kkernel/src/reindex.rs`)
+
+`run_reindex` calls two new idempotent sweep functions at the end of each reindex:
+
+- `purge_stale_memory_vamana_snapshots`: deletes rows from `retrieval_snapshots` where
+  `index_type = 'memory_vamana' AND namespace != 'global'`.
+- `sweep_stale_fts_partitions`: queries `sqlite_master` for tables matching `fts_entities_%` and
+  `fts_notes_%`, skips the canonical shared tables and FTS5 shadow tables (`*_data`, `*_idx`,
+  `*_docsize`, `*_config`, `*_content`), and drops each remaining stale table.
+
+Both sweeps are no-ops on databases that have no stale partitions.
+
+---
+
+## Migration Path for Existing Databases
+
+1. The versioned migration system in `run_migrations` applies the V4 SQL automatically on the next
+   boot if the database is at V3.
+2. After migration, run `kkernel reindex --no-knowledge` to populate `fts_entities` and `fts_notes`
+   from existing entity and note rows and to purge stale per-namespace FTS and ANN partitions.
+3. Databases already at V4 (migrated by a pre-release daemon) are unaffected; the migration is
+   idempotent.
+
+---
+
+## Consequences
+
+### Positive
+
+- A single FTS query per recall operation regardless of the size of the visible namespace set.
+- No per-namespace key computation in the runtime or curation layer.
+- A single ANN index per model; no namespace-specific snapshot management.
+- Stale per-namespace FTS and ANN tables are cleaned up automatically on reindex.
+- The schema is now consistent with any deployment topology: single-namespace OSS and
+  multi-namespace cloud use the same code path.
+
+### Negative
+
+- After migration, `kkernel reindex --no-knowledge` is required to populate the new tables.
+  Until reindex completes, FTS search and ANN recall return empty results on newly-migrated
+  databases. The memory pack emits a `WARN`-level FTS population guard during `warm()` when
+  the base note count exceeds the FTS row count by more than 2x.
+- ANN over-fetch increases the number of vector candidates retrieved per query. For deployments
+  where the global index is heavily dominated by foreign-namespace vectors, additional retry rounds
+  may increase recall latency.
+
+---
+
+## Alternatives Considered
+
+**Keep per-namespace FTS tables with a cross-namespace UNION query.** Would avoid the reindex
+requirement but requires dynamic SQL construction that references table names that may or may not
+exist. Fragile under concurrent schema changes. Rejected.
+
+**Add namespace as a query parameter rather than a column.** Not supported by the FTS5 `MATCH`
+syntax; namespace filtering must be a WHERE clause on an UNINDEXED column. The chosen approach
+is the canonical pattern for FTS5 multi-tenant tables in SQLite.
+
+---
+
+## References
+
+- [ADR-015](ADR-015-schema-migrations.md) -- schema migration system; V4 follows the same
+  `VersionedMigration` pattern as V1-V3
+- [ADR-031](ADR-031-multi-engine-retrieval.md) -- multi-engine retrieval; FTS is one component
+- [ADR-044](ADR-044-vector-store-extensions.md) -- vector store extensions; ANN lifecycle
+- [ADR-052](ADR-052-ann-production-lifecycle.md) -- ANN production lifecycle; snapshot management
+- `crates/khive-db/sql/004-fts-consolidation.sql` -- the V4 migration SQL
+- `crates/khive-db/src/migrations.rs` -- V4 registered as `fts_consolidation` at version 4
+- `crates/kkernel/src/reindex.rs` -- stale partition sweep implementation

--- a/docs/adr/ADR-073-pack-core-backend-accessor.md
+++ b/docs/adr/ADR-073-pack-core-backend-accessor.md
@@ -1,7 +1,8 @@
 # ADR-073: Pack Core-Backend Accessor
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-06-25\
+**PR**: #252\
 **Authors**: Ocean, lambda:khive\
 **Depends on**: [ADR-017](ADR-017-pack-standard.md) (Pack Standard), [ADR-028](ADR-028-pack-scoped-backends.md) (Pack-Scoped Backends), [ADR-029](ADR-029-substrate-coordinator.md) (Substrate Coordinator)\
 **Extends**: ADR-028 §"Per-pack runtime instances"\

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,7 +82,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-047](ADR-047-knowledge-pack.md)                     | Knowledge Pack — Concept Registration, Citation, and Topic Search                                               |
 | [ADR-048](ADR-048-knowledge-section-profiles.md)         | Knowledge Section Profiles                                                                                      |
 | [ADR-049](ADR-049-khived-daemon.md)                      | khived Daemon — Persistent Warm Runtime over a Unix Socket                                                      |
-| [ADR-050](ADR-050-kg-token-namespace-contract.md)        | KG Token Namespace Contract (Proposed)                                                                          |
+| [ADR-050](ADR-050-kg-token-namespace-contract.md)        | KG Token Namespace Contract (Accepted -- partially superseded by ADR-007 Rev 3)                                 |
 | [ADR-051](ADR-051-section-embeddings-hybrid-compose.md)  | Section-Level Embeddings and Hybrid Compose Scoring (Accepted)                                                  |
 | [ADR-052](ADR-052-ann-production-lifecycle.md)           | ANN Production Lifecycle — SQ8 Quantization, Tombstone Delete, Consolidation, Crash-Safe Persistence (Accepted) |
 | [ADR-053](ADR-053-authorization-gate.md)                 | Authorization Gate — ActorStore, SessionStore, and Cloud-Tier Caller Propagation (Proposed)                     |
@@ -93,11 +93,12 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-058](ADR-058-brain-posterior-read-path.md)          | Brain Posterior Read Path — Wiring Profile Posteriors into Recall Ranking (Proposed)                            |
 | [ADR-059](ADR-059-namespace-write-tiers.md)              | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
 | [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)   | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
+| [ADR-062](ADR-062-fts-ann-consolidation.md)              | FTS and ANN Consolidation -- Unified Search Tables (Schema V4) (Accepted)                                       |
 | [ADR-069](ADR-069-subject-model.md)                      | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)          | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
 | [ADR-067](ADR-067-write-owner-daemon.md)                 | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
 | [ADR-068](ADR-068-cloud-multitenancy-topology.md)        | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
-| [ADR-073](ADR-073-pack-core-backend-accessor.md)         | Pack Core-Backend Accessor (Proposed)                                                                           |
+| [ADR-073](ADR-073-pack-core-backend-accessor.md)         | Pack Core-Backend Accessor (Accepted)                                                                           |
 
 ## Closed Taxonomies — Quick Reference
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,10 +94,10 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-059](ADR-059-namespace-write-tiers.md)              | Namespace Write Tiers and Cross-Namespace Link Access Control (Withdrawn — superseded by ADR-007 Rev 2)         |
 | [ADR-061](ADR-061-pack-extensible-by-id-resolution.md)   | Pack-Extensible by-ID Resolution (Accepted)                                                                     |
 | [ADR-062](ADR-062-fts-ann-consolidation.md)              | FTS and ANN Consolidation -- Unified Search Tables (Schema V4) (Accepted)                                       |
-| [ADR-069](ADR-069-subject-model.md)                      | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
 | [ADR-066](ADR-066-autonomous-merge-pipeline.md)          | Autonomous Merge Pipeline — Gate Wall as Reviewer, Human Gate at Release (Proposed)                             |
 | [ADR-067](ADR-067-write-owner-daemon.md)                 | Write-Owner Daemon — Single-Writer Task and Write Queue (Proposed)                                              |
 | [ADR-068](ADR-068-cloud-multitenancy-topology.md)        | Cloud Multi-Tenancy Topology and Tenant Isolation (Proposed)                                                    |
+| [ADR-069](ADR-069-subject-model.md)                      | Subject Model — Domain-Ontology Ingestion and Map Pipeline (Proposed)                                           |
 | [ADR-073](ADR-073-pack-core-backend-accessor.md)         | Pack Core-Backend Accessor (Accepted)                                                                           |
 
 ## Closed Taxonomies — Quick Reference


### PR DESCRIPTION
## Summary

Docs-only batch. No code files modified.

### Verification per item

**ADR-073 -- Proposed -> Accepted**

\`gh pr view 252 -R ohdearquant/khive\`: state=MERGED, mergedAt=2026-06-25T22:42:50Z,
title=\"feat(runtime): pack core-backend accessor (ADR-073)\". The
\`core_backend: Option<Arc<StorageBackend>>\` field and \`core()\` accessor confirmed present
in \`crates/khive-runtime/src/runtime.rs\` (git annotate: line 94 \`let graph_token = token\` in
the KG pack confirms the pattern is shipped). Status flipped to Accepted; \`**PR**: #252\` line
added.

**ADR-062 -- New file (was absent)**

\`ls docs/adr/\` confirmed no ADR-062-*.md existed. Schema V4 confirmed shipped:
\`crates/khive-db/sql/004-fts-consolidation.sql\` exists; \`crates/khive-db/src/migrations.rs\`
registers it as \`VersionedMigration { version: 4, name: \"fts_consolidation\", up: V4_UP }\`.
Commit \`ce904209\` (PR #171, merged 2026-06-19) is the source. New file
\`docs/adr/ADR-062-fts-ann-consolidation.md\` written from the SQL file and commit body.
Status: Accepted.

**ADR-050 -- Proposed -> Accepted**

Code verified: \`crates/khive-pack-kg/src/dispatch.rs\` line 93-94 reads
\`// KG graph operations honor the NamespaceToken minted by VerbRegistry::dispatch. / let graph_token = token;\`
(git annotate: present since the initial commit, \`16d75d9aa\`). The namespace override described
in the Context section was removed before this repository was published. The ADR's own preamble
block already documents absorption by ADR-007 Rev 3 (PR #164). Status updated to Accepted with
a note referencing #164 and 2026-06-17. Prose unchanged.

**README.md**

ADR-062 row added; ADR-050 and ADR-073 status annotations updated. ADR-069 row moved to its
correct numeric position (after ADR-068, before ADR-073) — the row was out of order relative
to ADR-066/067/068. \`deno fmt docs/\` passes.

## What was not changed

All \`.rs\`, \`.sql\`, \`.toml\`, and other code files are untouched. The doc changes are confined to
\`docs/adr/\`.
