### PR TITLE
perf(bench): gitignore bench-run JSON outputs and update provenance docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ perf/pipeline-ledger.csv
 
 # Synthetic ANN regression gate ledger — written by --ci-synthetic, uploaded as CI artifact; not committed.
 perf/ci-synthetic-ledger.csv
+
+# Raw bench-run JSON files banked by bench_1m.sh / vec_bench --bank-run.
+# Named {YYYYMMDD}-{sha7}-{dataset}.json; kept out of the repo to avoid large
+# generated files in PRs. The perf/bench-runs/ directory is tracked via .gitkeep.
+perf/bench-runs/*.json

--- a/perf/README.md
+++ b/perf/README.md
@@ -62,8 +62,10 @@ unavailable (0). Both fields are populated by the bench binary at run time.
 ## bench-runs/ provenance JSON schema
 
 Each file in `bench-runs/` is the complete output JSON from one bench invocation,
-named `{YYYYMMDD}-{sha7}-{dataset}.json`. These files are committed to the
-repository and provide the authoritative provenance record for each banked row.
+named `{YYYYMMDD}-{sha7}-{dataset}.json`. These files are **gitignored** (see
+`.gitignore` entry for `perf/bench-runs/*.json`) to keep PRs code-only. They are
+written locally by `bench_1m.sh` and can be uploaded as CI artifacts if needed for
+auditing, but they are not committed to the repository.
 
 Top-level fields in each JSON:
 
@@ -127,9 +129,9 @@ These are **different runs with different configurations**, not measurement erro
    N = 1M, yielding roughly half the query latency (171 µs vs 334 µs).
 2. The PR #153 brute-force figure (58 330 µs back-derived) is arithmetically
    reconstructed and reflects the brute-force measurement from that run but
-   cannot be independently verified without a committed raw JSON. Future runs
-   commit raw JSON to `bench-runs/`, making the directly measured `bruteforce_p50_us`
-   auditable and the speedup ratio independently verifiable.
+   cannot be independently verified. Future runs write raw JSON to `bench-runs/`
+   (locally; gitignored), making the directly measured `bruteforce_p50_us`
+   available for local audit and uploadable as a CI artifact.
 3. The 34x figure (ADR-054) is the result for a higher-beam configuration and
    is NOT a contradiction of 341x; both are internally consistent for their
    respective run parameters.
@@ -137,8 +139,8 @@ These are **different runs with different configurations**, not measurement erro
 The actionable conclusion: the headline speedup figure depends materially on
 the iso-recall beam used. The 341x figure is valid for the iso-recall
 beam-optimal configuration at N = 1M. Future comparison runs should confirm
-`bruteforce_p50_us` from the committed `bench-runs/` JSON rather than the
-back-derived ledger value.
+`bruteforce_p50_us` from the `bench-runs/` JSON (written locally by the bench
+harness) rather than the back-derived ledger value.
 
 ---
 


### PR DESCRIPTION
## Summary

The bench harness (`vec_bench --bank-run`) writes raw provenance JSON files to
`perf/bench-runs/` named `{YYYYMMDD}-{sha7}-{dataset}.json`. These files were
not matched by the existing `*results.json` gitignore pattern (that pattern
only matches files ending literally in `results.json`). As a result, any local
bench run would leave untracked JSON files visible in `git status`, and a
contributor who ran the bench before opening a PR would need to manually exclude
them.

**Changes:**

- Add `perf/bench-runs/*.json` to `.gitignore` so generated outputs are
  suppressed. The `perf/bench-runs/` directory itself remains tracked via
  `.gitkeep`.
- Update `perf/README.md` to document that bench-run JSONs are gitignored
  (not committed), and that they can be uploaded as CI artifacts when needed
  for auditing.

## Grounding findings (pre-implementation audit)

All three provenance fields were already fully implemented before this PR:

| Field | Location | Status before this PR |
|-------|----------|-----------------------|
| `machine_model` | `vec_bench.rs:554-597` (`collect_machine_model`) | Real — `sysctl`/`/proc/cpuinfo`, no-panic fallback |
| `ram_bytes` | `vec_bench.rs:599-628` (`collect_ram_bytes`) | Real — `sysctl hw.memsize`/`/proc/meminfo`, fallback 0 |
| `bruteforce_p50_us` | `vec_bench.rs:388-408` (`measure_bruteforce_latency_us`) | Directly measured warm p50 of `exact_topk` |

The only gap was the gitignore coverage for the bank output directory.

## Sample provenance JSON (synthetic values)

```json
{
  "schema_version": "1.0",
  "produced_at": "2026-06-26T00:00:00Z",
  "git_sha": "f191f789...",
  "runner_os": "macos-arm64",
  "machine_model": "Apple M2 Max",
  "ram_bytes": 68719476736,
  "loadavg1": 1.23,
  "rows": [
    {
      "n": 1000,
      "bruteforce_p50_us": 4.2,
      "speedup_vs_brute_force": 18.5,
      "recall_at_10": 0.952,
      "query_warm_p50_us": 0.23
    }
  ]
}
```

Values above are illustrative (synthetic N=1000). The SIFT-1M re-bench is
deferred to a maintainer with access to the SIFT dataset (`$SIFT_DIR`).

## Test plan

- [x] `cargo test -p khive-vamana` — TEST_RC=0 (29 tests pass)
- [x] `cargo clippy -p khive-vamana --all-targets -- -D warnings` — CLIPPY_RC=0
- [x] `cargo fmt --all -- --check` — FMT_RC=0
- [x] Gitignore verified: writing a test JSON to `perf/bench-runs/` produces no
      untracked output in `git status`
- [ ] SIFT-1M re-bench deferred to maintainer (out of scope for this PR)