### PR TITLE
test(verbs): regression tests for propose/merge/knowledge.edit contracts (#160)

### DIFF
--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -970,4 +970,51 @@ mod tests {
             .expect("limit param must be documented in query handler metadata");
         assert!(!limit_param.required, "limit must be optional");
     }
+
+    // ── issue #160 return-shape regressions ──────────────────────────────────
+
+    /// propose returns {id, ...}; the correct chain key is $prev.id, not $prev.proposal_id (#160).
+    /// The description may mention $prev.proposal_id in a "not this" warning, which is fine.
+    #[test]
+    fn propose_description_documents_id_field_not_proposal_id() {
+        let h = find_handler("propose");
+        assert!(
+            h.description.contains("Returns {id"),
+            "propose description must name the 'id' return field"
+        );
+        assert!(
+            h.description.contains("$prev.id"),
+            "propose description must document chaining via $prev.id"
+        );
+        // The description warns callers off $prev.proposal_id by name; the critical
+        // check is that $prev.id appears first as the authoritative form.
+        let id_pos = h
+            .description
+            .find("$prev.id")
+            .expect("$prev.id must appear in propose description");
+        let proposal_id_pos = h.description.find("$prev.proposal_id");
+        if let Some(pid_pos) = proposal_id_pos {
+            // $prev.proposal_id is only acceptable when it appears AFTER $prev.id
+            // (i.e., as a negative example, not as the recommended form).
+            assert!(
+                id_pos < pid_pos,
+                "propose description must present $prev.id before $prev.proposal_id"
+            );
+        }
+    }
+
+    /// merge returns {kept_id, removed_id, ...}; no top-level 'id' field.
+    /// Chain with $prev.kept_id, not $prev.id (#160).
+    #[test]
+    fn merge_description_documents_kept_id_and_removed_id_return_fields() {
+        let h = find_handler("merge");
+        assert!(
+            h.description.contains("kept_id") && h.description.contains("removed_id"),
+            "merge description must name both kept_id and removed_id return fields"
+        );
+        assert!(
+            h.description.contains("$prev.kept_id"),
+            "merge description must document chaining via $prev.kept_id"
+        );
+    }
 }

--- a/crates/khive-pack-knowledge/src/vocab.rs
+++ b/crates/khive-pack-knowledge/src/vocab.rs
@@ -530,3 +530,46 @@ pub(crate) static KNOWLEDGE_HANDLERS: [HandlerDef; 19] = [
         ],
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn find_handler(name: &str) -> &'static HandlerDef {
+        KNOWLEDGE_HANDLERS
+            .iter()
+            .find(|h| h.name == name)
+            .unwrap_or_else(|| panic!("handler {name:?} not found in KNOWLEDGE_HANDLERS"))
+    }
+
+    /// knowledge.edit sections param must document the closed section_type enum (10 values) and
+    /// the 80-character content minimum (#160).
+    #[test]
+    fn knowledge_edit_sections_documents_enum_and_content_minimum() {
+        let h = find_handler("knowledge.edit");
+        let sections = h
+            .params
+            .iter()
+            .find(|p| p.name == "sections")
+            .expect("knowledge.edit must have a sections param");
+        assert!(
+            sections.description.contains("80"),
+            "knowledge.edit sections description must document the 80-character content minimum"
+        );
+        // Spot-check the first and last members of the closed enum.
+        assert!(
+            sections.description.contains("overview"),
+            "knowledge.edit sections description must list 'overview' as a valid section_type"
+        );
+        assert!(
+            sections.description.contains("other"),
+            "knowledge.edit sections description must list 'other' as a valid section_type"
+        );
+        // Verify the description calls out the closed-enum nature so callers know unrecognized
+        // values are rejected (not silently coerced).
+        assert!(
+            sections.description.contains("closed enum"),
+            "knowledge.edit sections description must state that section_type is a closed enum"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Issue #160 flagged three verb help-text accuracy items. This PR resolves them by:

1. Verifying each item against handler source (the authoritative truth).
2. Adding regression tests so the verified behavior cannot silently regress.

No behavior is changed. No help text strings are changed (all three were already correct).

---

## Item-by-item findings

### 1. `propose` return shape

**Claimed bug**: verb help and chain examples reference `$prev.proposal_id` but `propose` returns field `id`.

**Verified from source** (`crates/khive-pack-kg/src/handlers/proposal.rs`, `handle_propose`):

```rust
to_json(&serde_json::json!({
    "id": proposal_id.to_string(),
    "status": "open",
    "proposer": actor,
    "title": p.title,
}))
```

The returned field is `id`. The help text in `handler_defs.rs` already reads:

> Returns {id, status, proposer, title}; chain with $prev.id (not $prev.proposal_id).

**Finding: already correct.** Regression test added to lock it in.

---

### 2. `merge` return shape

**Claimed bug**: docs say `merge` returns `id`; it actually returns `kept_id`/`removed_id`.

**Verified from source** (`crates/khive-runtime/src/curation.rs`, `MergeSummary`):

```rust
pub struct MergeSummary {
    pub kept_id: Uuid,
    pub removed_id: Uuid,
    pub edges_rewired: usize,
    pub properties_merged: usize,
    pub tags_unioned: usize,
    pub content_appended: bool,
    pub dry_run: bool,
}
```

The help text in `handler_defs.rs` already reads:

> Returns {kept_id, removed_id, edges_rewired, properties_merged, tags_unioned,
> content_appended, dry_run}; chain with $prev.kept_id (not $prev.id -- merge
> does not return a top-level id field).

**Finding: already correct.** Regression test added to lock it in.

---

### 3. `knowledge.edit` section_type and content constraints

**Claimed gap**: `section_type` is a closed enum and content requires 80 chars,
but neither constraint was surfaced in the verb help.

**Verified from source**:

- `crates/khive-brain-core/src/section_type.rs`: `SectionType::NAMES` lists 10 values:
  `overview | core_model | boundary_conditions | formalism | operational_guidance |
  examples | failure_modes | expert_lens | references | other`.
- `crates/khive-pack-knowledge/src/knowledge/util.rs`: `MIN_SECTION_CONTENT_LEN = 80`,
  enforced by `validate_section_content`.

The `sections` param description in `vocab.rs` already reads:

> section_type is a closed enum -- valid values: overview | core_model |
> boundary_conditions | formalism | operational_guidance | examples |
> failure_modes | expert_lens | references | other. content must be >=80 characters.

**Finding: already correct.** Regression test added to lock it in.

---

## Test plan

- `cargo test -p khive-pack-kg -p khive-pack-knowledge`: all pass
- `cargo clippy -p khive-pack-kg -p khive-pack-knowledge --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean