### PR TITLE
docs: fix stale verb counts, bogus kg command, and ADR citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Entities are _things_. Notes are _what you think about things_. Events are _what
 
 ## The MCP verb surface
 
-One MCP tool: `request` (ADR-020 + ADR-027). Every verb is a parsed op inside it.
+One MCP tool: `request` (ADR-016 + ADR-027). Every verb is a parsed op inside it.
 
 ```
 request(ops="verb(arg=value, arg=value)")              # single op
@@ -85,7 +85,7 @@ No language SDK to learn.
 │  kkernel mcp      — stdio MCP server (the `kkernel` binary)   │
 │  khived           — persistent daemon (ADR-049): warm runtime │
 │                     auto-spawned on first request             │
-│  1 tool: `request` (ADR-020 + ADR-027) — parses DSL,         │
+│  1 tool: `request` (ADR-016 + ADR-027) — parses DSL,         │
 │  dispatches each op through the VerbRegistry                 │
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 63 verbs, 7 packs, one MCP tool.
+A research knowledge graph runtime — 67 verbs, 7 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -27,11 +27,11 @@ All 7 packs load by default. A background daemon auto-spawns to keep the runtime
 | ------------- | ----- | ------------------------------------------------ |
 | **kg**        | 16    | Entities, edges, notes, graph queries, proposals |
 | **gtd**       | 5     | Task lifecycle (inbox → next → active → done)    |
-| **memory**    | 2     | Salience-weighted remember / decay-ranked recall |
+| **memory**    | 5     | Salience-weighted remember / decay-ranked recall |
 | **brain**     | 13    | Bayesian user profiles + feedback loop           |
 | **comm**      | 5     | Threaded messaging                               |
 | **schedule**  | 4     | Reminders and scheduled verb execution           |
-| **knowledge** | 18    | Atom-based KB with embedding rerank search       |
+| **knowledge** | 19    | Atom-based KB with embedding rerank search       |
 
 ## Usage
 
@@ -39,7 +39,6 @@ All 7 packs load by default. A background daemon auto-spawns to keep the runtime
 khive mcp                   # Start MCP server (used by Claude Code)
 khive kg init               # Initialize .khive/kg/ in a git repo
 khive kg validate           # Check NDJSON files against schema
-khive kg commit -m "msg"    # Validate + stage + git commit
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

Three documentation accuracy fixes in `npm/README.md` and `README.md`. All
changes verified against actual source code before editing. No Rust, config,
or schema files were modified.

### Fix 1: `npm/README.md` -- non-existent command removed

Line 42 documented `khive kg commit -m "msg"` as a valid CLI command.
Verification: `KgCommand` enum in `crates/kkernel/src/kg/types.rs` has no
`commit` variant. Variants are: `Validate`, `Init`, `Fetch` (alias `sync`),
`Export`, `Import`, `Status`, `Hook`. The line was removed.

### Fix 2: `npm/README.md` -- stale verb counts corrected

Line 3 total: **63 -> 67**
Line 30 memory: **2 -> 5**
Line 34 knowledge: **18 -> 19**

Verified by counting `Visibility::Verb` entries in each pack:

| Pack | Source | Count |
| --- | --- | --- |
| kg | `crates/khive-pack-kg/` | 16 |
| gtd | `crates/khive-pack-gtd/` | 5 |
| memory | `crates/khive-pack-memory/src/pack.rs` | 5 |
| brain | `crates/khive-pack-brain/` | 13 |
| comm | `crates/khive-pack-comm/` | 5 |
| schedule | `crates/khive-pack-schedule/` | 4 |
| knowledge | `crates/khive-pack-knowledge/src/vocab.rs` | 19 |
| **Total** | | **67** |

### Fix 3: `README.md` -- wrong ADR cited for the `request` tool

Lines 53 and 88 cited `ADR-020 + ADR-027`. ADR-020 is the Git-Native KG
Implementation ADR, unrelated to the request tool. The correct ADR for the
request DSL is ADR-016 (`docs/adr/ADR-016-request-dsl.md`). Cross-checked
against `AGENTS.md:26-27`, which already cites `ADR-016 + ADR-027` correctly.
Both occurrences updated to `ADR-016 + ADR-027`.

## Format check

`deno fmt --check README.md npm/README.md` -- RC=0

Pre-commit `deno fmt (markdown + docs)` hook also passed at commit time.