### PR TITLE
feat(channel): email SMTP/IMAP channel adapter (ADR-056 §14, closes #114)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -32,6 +32,8 @@ members = [
     "khive-vcs-adapters",
     "kkernel",
     "khive-retrieval",
+    "khive-channel",
+    "khive-channel-email",
 ]
 exclude = ["khive-merge"]
 # khive-merge is forward-deployed v2 infrastructure (ADR-039), not removed or
@@ -56,7 +58,11 @@ inventory = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["rt", "compat"] }
+lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
+async-imap = "0.9"
+async-native-tls = "0.5"
+mail-parser = "0.9"
 rusqlite = { version = "0.33" }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "khive-channel-email"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
+
+[dependencies]
+khive-channel = { version = "0.2.11", path = "../khive-channel" }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"] }
+lettre = { workspace = true }
+async-imap = { workspace = true }
+async-native-tls = { workspace = true }
+mail-parser = { workspace = true }
+futures = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -49,27 +49,58 @@ impl EmailChannel {
         Self { config, smtp, imap }
     }
 
-    /// Validate that the sender address matches the configured maintainer.
+    /// Validate that the message sender is authorized.
     ///
-    /// Returns `Err(ChannelError::UnauthorizedSender)` when the addresses differ.
-    fn check_sender(&self, raw_from: &str) -> Result<(), ChannelError> {
-        let parsed = MailAddress::parse(raw_from).ok_or_else(|| {
-            ChannelError::InvalidEnvelope(format!("cannot parse sender address: {raw_from:?}"))
-        })?;
-        if parsed != self.config.maintainer_address {
+    /// Rules:
+    /// - `from_addrs` must contain exactly one entry (multi-From is rejected).
+    /// - That single From address must match the configured maintainer.
+    /// - If `sender_addr` is present, it must also match.
+    ///
+    /// Returns `Err(ChannelError::UnauthorizedSender)` on any violation.
+    /// Error messages intentionally omit the actual addresses to avoid leaking them to logs.
+    fn check_sender(
+        &self,
+        from_addrs: &[String],
+        sender_addr: Option<&str>,
+    ) -> Result<(), ChannelError> {
+        // Exactly one From address is required. Zero or more-than-one is an unauthorized state.
+        if from_addrs.len() != 1 {
             return Err(ChannelError::UnauthorizedSender(format!(
-                "message from {parsed} rejected; expected {}",
-                self.config.maintainer_address
+                "expected exactly 1 From address, got {}",
+                from_addrs.len()
             )));
+        }
+        let from = MailAddress::parse(&from_addrs[0]).ok_or_else(|| {
+            ChannelError::UnauthorizedSender("From field does not contain a valid addr-spec".into())
+        })?;
+        if from != self.config.maintainer_address {
+            return Err(ChannelError::UnauthorizedSender(
+                "From address is not the configured maintainer".into(),
+            ));
+        }
+        // Sender header, when present, must also match the maintainer.
+        if let Some(s) = sender_addr {
+            let sender = MailAddress::parse(s).ok_or_else(|| {
+                ChannelError::UnauthorizedSender(
+                    "Sender field does not contain a valid addr-spec".into(),
+                )
+            })?;
+            if sender != self.config.maintainer_address {
+                return Err(ChannelError::UnauthorizedSender(
+                    "Sender address is not the configured maintainer".into(),
+                ));
+            }
         }
         Ok(())
     }
 
     /// Convert a `RawEmail` to a `ChannelEnvelope`, validating the sender.
     fn to_envelope(&self, email: RawEmail) -> Result<ChannelEnvelope, ChannelError> {
-        self.check_sender(&email.from)?;
+        self.check_sender(&email.from_addrs, email.sender_addr.as_deref())?;
 
-        let from = format!("email:{}", email.from);
+        // Safe: check_sender verified exactly one entry.
+        let from_addr = &email.from_addrs[0];
+        let from = format!("email:{from_addr}");
         let to = email
             .to
             .first()
@@ -84,9 +115,9 @@ impl EmailChannel {
         if let Some(date) = email.date {
             env = env.with_sent_at(date);
         }
-        if let Some(mid) = &email.message_id {
-            env = env.with_external_id(mid.as_str());
-        }
+        // Always set external_id from the stable IMAP-based dedup key. Never derive it
+        // from Message-ID, which is optional and could be absent or absent-by-design.
+        env = env.with_external_id(&email.imap_external_id);
         if let Some(corr) = email.correlation() {
             env = env.with_correlation(corr);
         }
@@ -117,12 +148,13 @@ impl Channel for EmailChannel {
         let raw = self.imap.fetch_since(since, 50).await?;
         let mut envelopes = Vec::new();
         for email in raw {
+            let uid = email.uid;
             match self.to_envelope(email) {
                 Ok(env) => envelopes.push(env),
-                Err(ChannelError::UnauthorizedSender(msg)) => {
-                    warn!("skipping unauthorized message: {msg}");
+                Err(_) => {
+                    // Log only the IMAP UID -- never the sender address or any credentials.
+                    warn!(uid, "skipping message: validation failed");
                 }
-                Err(e) => return Err(e),
             }
         }
         Ok(envelopes)
@@ -189,11 +221,29 @@ mod tests {
         }
     }
 
-    fn make_email(from: &str, msg_id: &str) -> RawEmail {
+    /// Build a RawEmail with a single-address From and a stable IMAP external ID.
+    fn make_email(from_addr: &str, imap_id: &str) -> RawEmail {
         RawEmail {
             uid: 1,
-            message_id: Some(msg_id.to_string()),
-            from: from.to_string(),
+            imap_external_id: imap_id.to_string(),
+            from_addrs: vec![from_addr.to_string()],
+            sender_addr: None,
+            to: vec!["me@example.com".to_string()],
+            subject: "Hello".to_string(),
+            date: None,
+            body_text: Some("body text".to_string()),
+            body_html: None,
+            headers: HashMap::new(),
+        }
+    }
+
+    /// Build a RawEmail with an explicit From address list.
+    fn make_email_with_from_addrs(from_addrs: Vec<String>, imap_id: &str) -> RawEmail {
+        RawEmail {
+            uid: 1,
+            imap_external_id: imap_id.to_string(),
+            from_addrs,
+            sender_addr: None,
             to: vec!["me@example.com".to_string()],
             subject: "Hello".to_string(),
             date: None,
@@ -213,47 +263,145 @@ mod tests {
         EmailChannel::with_connectors(config, smtp, imap)
     }
 
+    // --- Basic trait ---
+
     #[test]
     fn kind_is_email() {
         let ch = build_channel("maintainer@example.com", vec![]);
         assert_eq!(ch.kind(), "email");
     }
 
+    // --- Authorization: authorized sender ---
+
     #[tokio::test]
     async fn authorized_sender_produces_envelope() {
         let ch = build_channel(
             "maintainer@example.com",
-            vec![make_email("maintainer@example.com", "<id1@example.com>")],
+            vec![make_email("maintainer@example.com", "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
-        assert_eq!(envs[0].external_id.as_deref(), Some("<id1@example.com>"));
+        // external_id is now always the stable IMAP key, not Message-ID.
+        assert_eq!(envs[0].external_id.as_deref(), Some("imap:test:0:1"));
         assert_eq!(envs[0].from, "email:maintainer@example.com");
     }
+
+    #[tokio::test]
+    async fn normalized_addr_spec_is_accepted() {
+        // IMAP parsing strips display names before channel.rs sees the address.
+        // from_addrs already contains the bare addr-spec.
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![make_email("maintainer@example.com", "imap:test:0:1")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1, "plain addr-spec must be accepted");
+    }
+
+    // --- Authorization: rejected senders (Fix 1) ---
 
     #[tokio::test]
     async fn unauthorized_sender_is_silently_skipped() {
         let ch = build_channel(
             "maintainer@example.com",
-            vec![make_email("attacker@example.com", "<evil@example.com>")],
+            vec![make_email("attacker@example.com", "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(envs.is_empty(), "unauthorized message must be dropped");
+        assert!(envs.is_empty(), "unauthorized From must be dropped");
     }
 
     #[tokio::test]
-    async fn display_name_sender_is_normalized() {
-        // "Alice Maintainer <maintainer@example.com>" should be accepted.
+    async fn multi_from_addresses_rejected() {
+        // RFC 5322 permits multiple From addresses; we treat it as unauthorized.
         let ch = build_channel(
             "maintainer@example.com",
-            vec![make_email(
-                "Alice Maintainer <maintainer@example.com>",
-                "<id2@example.com>",
+            vec![make_email_with_from_addrs(
+                vec![
+                    "maintainer@example.com".to_string(),
+                    "attacker@example.com".to_string(),
+                ],
+                "imap:test:0:1",
             )],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert_eq!(envs.len(), 1, "display-name format must be accepted");
+        assert!(envs.is_empty(), "multi-From message must be rejected");
     }
+
+    #[tokio::test]
+    async fn empty_from_list_rejected() {
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![make_email_with_from_addrs(vec![], "imap:test:0:1")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(
+            envs.is_empty(),
+            "message with no From address must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn sender_header_mismatch_rejected() {
+        let mut email = make_email("maintainer@example.com", "imap:test:0:1");
+        // Sender header claims a different mailbox -- reject.
+        email.sender_addr = Some("attacker@example.com".to_string());
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(envs.is_empty(), "Sender mismatch must be rejected");
+    }
+
+    #[tokio::test]
+    async fn sender_header_matching_maintainer_accepted() {
+        let mut email = make_email("maintainer@example.com", "imap:test:0:1");
+        email.sender_addr = Some("maintainer@example.com".to_string());
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1, "matching Sender header must be accepted");
+    }
+
+    #[tokio::test]
+    async fn reply_to_header_is_not_used_for_auth() {
+        // Reply-To is irrelevant for authorization; only From (and optionally Sender) matter.
+        let mut email = make_email("maintainer@example.com", "imap:test:0:1");
+        email
+            .headers
+            .insert("reply-to".to_string(), "attacker@evil.com".to_string());
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(
+            envs.len(),
+            1,
+            "Reply-To must not affect authorization; only From is checked"
+        );
+    }
+
+    // --- Batch isolation (Fix 3) ---
+
+    #[tokio::test]
+    async fn bad_message_in_batch_does_not_abort_poll() {
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![
+                // First message: unauthorized -- should be skipped.
+                make_email("attacker@example.com", "imap:test:0:1"),
+                // Second message: authorized -- must be returned.
+                make_email("maintainer@example.com", "imap:test:0:2"),
+            ],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(
+            envs.len(),
+            1,
+            "only the authorized message must be returned"
+        );
+        assert_eq!(
+            envs[0].external_id.as_deref(),
+            Some("imap:test:0:2"),
+            "the authorized message must be the one returned"
+        );
+    }
+
+    // --- SMTP send path ---
 
     #[tokio::test]
     async fn send_strips_email_prefix() {

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -1,0 +1,286 @@
+//! `EmailChannel` — implements the `Channel` trait for email transport.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use khive_channel::{Channel, ChannelEnvelope, ChannelError};
+use tracing::{debug, warn};
+
+use crate::config::EmailChannelConfig;
+use crate::connector::imap::ImapFetcher;
+use crate::connector::smtp::SmtpSender;
+use crate::connector::{MailAddress, RawEmail};
+
+/// Email channel adapter implementing `Channel` via SMTP + IMAP.
+///
+/// Configuration is provided at construction time via `EmailChannelConfig`.
+/// All credentials come from environment variables; see `EmailChannelConfig::from_env`.
+pub struct EmailChannel {
+    config: EmailChannelConfig,
+    smtp: SmtpSender,
+    imap: ImapFetcher,
+}
+
+impl EmailChannel {
+    /// Build from environment variables. Fails if any required env var is absent.
+    pub fn from_env() -> Result<Self, ChannelError> {
+        let config = EmailChannelConfig::from_env()?;
+        let smtp = SmtpSender::new(
+            &config.smtp_host,
+            config.smtp_port,
+            &config.username,
+            &config.password,
+        );
+        let imap = ImapFetcher::new(
+            &config.imap_host,
+            config.imap_port,
+            &config.username,
+            &config.password,
+        );
+        Ok(Self { config, smtp, imap })
+    }
+
+    /// Build from pre-constructed connectors (for testing).
+    #[cfg(test)]
+    pub(crate) fn with_connectors(
+        config: EmailChannelConfig,
+        smtp: SmtpSender,
+        imap: ImapFetcher,
+    ) -> Self {
+        Self { config, smtp, imap }
+    }
+
+    /// Validate that the sender address matches the configured maintainer.
+    ///
+    /// Returns `Err(ChannelError::UnauthorizedSender)` when the addresses differ.
+    fn check_sender(&self, raw_from: &str) -> Result<(), ChannelError> {
+        let parsed = MailAddress::parse(raw_from).ok_or_else(|| {
+            ChannelError::InvalidEnvelope(format!("cannot parse sender address: {raw_from:?}"))
+        })?;
+        if parsed != self.config.maintainer_address {
+            return Err(ChannelError::UnauthorizedSender(format!(
+                "message from {parsed} rejected; expected {}",
+                self.config.maintainer_address
+            )));
+        }
+        Ok(())
+    }
+
+    /// Convert a `RawEmail` to a `ChannelEnvelope`, validating the sender.
+    fn to_envelope(&self, email: RawEmail) -> Result<ChannelEnvelope, ChannelError> {
+        self.check_sender(&email.from)?;
+
+        let from = format!("email:{}", email.from);
+        let to = email
+            .to
+            .first()
+            .map(|a| format!("email:{a}"))
+            .unwrap_or_else(|| format!("email:{}", self.config.maintainer_address));
+
+        let mut env = ChannelEnvelope::new(from, to, email.best_body());
+
+        if !email.subject.is_empty() {
+            env = env.with_subject(&email.subject);
+        }
+        if let Some(date) = email.date {
+            env = env.with_sent_at(date);
+        }
+        if let Some(mid) = &email.message_id {
+            env = env.with_external_id(mid.as_str());
+        }
+        if let Some(corr) = email.correlation() {
+            env = env.with_correlation(corr);
+        }
+
+        Ok(env)
+    }
+}
+
+#[async_trait]
+impl Channel for EmailChannel {
+    fn kind(&self) -> &'static str {
+        "email"
+    }
+
+    async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+        let from = strip_kind_prefix(&envelope.from, "email");
+        let to = strip_kind_prefix(&envelope.to, "email");
+        let subject = envelope.subject.as_deref().unwrap_or("(no subject)");
+        let thread_id = envelope.correlation_external_id.as_deref();
+
+        debug!(from, to, subject, "email send");
+        self.smtp
+            .send(from, to, subject, &envelope.content, thread_id)
+            .await
+    }
+
+    async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+        let raw = self.imap.fetch_since(since, 50).await?;
+        let mut envelopes = Vec::new();
+        for email in raw {
+            match self.to_envelope(email) {
+                Ok(env) => envelopes.push(env),
+                Err(ChannelError::UnauthorizedSender(msg)) => {
+                    warn!("skipping unauthorized message: {msg}");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(envelopes)
+    }
+}
+
+/// Strip a `"kind:"` prefix from an address string.
+fn strip_kind_prefix<'a>(addr: &'a str, kind: &str) -> &'a str {
+    let prefix = format!("{kind}:");
+    addr.strip_prefix(prefix.as_str()).unwrap_or(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connector::imap::{ImapConnector, ImapFetcher};
+    use crate::connector::smtp::{SmtpConnector, SmtpSender};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn make_config(maintainer: &str) -> EmailChannelConfig {
+        EmailChannelConfig {
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            imap_host: "imap.example.com".to_string(),
+            imap_port: 993,
+            username: "user@example.com".to_string(),
+            password: "secret".to_string(),
+            maintainer_address: MailAddress::parse(maintainer).unwrap(),
+        }
+    }
+
+    struct RecordingSmtp {
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl SmtpConnector for RecordingSmtp {
+        async fn deliver(
+            &self,
+            from: &str,
+            to: &str,
+            _subject: &str,
+            _body: &str,
+            _tid: Option<&str>,
+        ) -> Result<(), ChannelError> {
+            self.calls.lock().unwrap().push(format!("{from}->{to}"));
+            Ok(())
+        }
+    }
+
+    struct FixedImap {
+        emails: Vec<RawEmail>,
+    }
+
+    #[async_trait]
+    impl ImapConnector for FixedImap {
+        async fn fetch_since(
+            &self,
+            _since: DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<RawEmail>, ChannelError> {
+            Ok(self.emails.clone())
+        }
+    }
+
+    fn make_email(from: &str, msg_id: &str) -> RawEmail {
+        RawEmail {
+            uid: 1,
+            message_id: Some(msg_id.to_string()),
+            from: from.to_string(),
+            to: vec!["me@example.com".to_string()],
+            subject: "Hello".to_string(),
+            date: None,
+            body_text: Some("body text".to_string()),
+            body_html: None,
+            headers: HashMap::new(),
+        }
+    }
+
+    fn build_channel(maintainer: &str, emails: Vec<RawEmail>) -> EmailChannel {
+        let config = make_config(maintainer);
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let smtp = SmtpSender::with_connector(RecordingSmtp {
+            calls: calls.clone(),
+        });
+        let imap = ImapFetcher::with_connector(FixedImap { emails });
+        EmailChannel::with_connectors(config, smtp, imap)
+    }
+
+    #[test]
+    fn kind_is_email() {
+        let ch = build_channel("maintainer@example.com", vec![]);
+        assert_eq!(ch.kind(), "email");
+    }
+
+    #[tokio::test]
+    async fn authorized_sender_produces_envelope() {
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![make_email("maintainer@example.com", "<id1@example.com>")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].external_id.as_deref(), Some("<id1@example.com>"));
+        assert_eq!(envs[0].from, "email:maintainer@example.com");
+    }
+
+    #[tokio::test]
+    async fn unauthorized_sender_is_silently_skipped() {
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![make_email("attacker@example.com", "<evil@example.com>")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(envs.is_empty(), "unauthorized message must be dropped");
+    }
+
+    #[tokio::test]
+    async fn display_name_sender_is_normalized() {
+        // "Alice Maintainer <maintainer@example.com>" should be accepted.
+        let ch = build_channel(
+            "maintainer@example.com",
+            vec![make_email(
+                "Alice Maintainer <maintainer@example.com>",
+                "<id2@example.com>",
+            )],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1, "display-name format must be accepted");
+    }
+
+    #[tokio::test]
+    async fn send_strips_email_prefix() {
+        let config = make_config("maintainer@example.com");
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let smtp = SmtpSender::with_connector(RecordingSmtp {
+            calls: calls.clone(),
+        });
+        let imap = ImapFetcher::with_connector(FixedImap { emails: vec![] });
+        let ch = EmailChannel::with_connectors(config, smtp, imap);
+
+        let env = ChannelEnvelope::new("email:from@example.com", "email:to@example.com", "hello");
+        ch.send(env).await.unwrap();
+
+        let recorded = calls.lock().unwrap();
+        assert_eq!(recorded[0], "from@example.com->to@example.com");
+    }
+
+    #[test]
+    fn strip_kind_prefix_removes_prefix() {
+        assert_eq!(
+            strip_kind_prefix("email:user@example.com", "email"),
+            "user@example.com"
+        );
+        assert_eq!(
+            strip_kind_prefix("user@example.com", "email"),
+            "user@example.com"
+        );
+    }
+}

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -11,7 +11,9 @@ use khive_channel::ChannelError;
 /// Build via [`EmailChannelConfig::from_env`]. All fields are sourced
 /// exclusively from environment variables; no defaults are provided for
 /// credentials or host names.
-#[derive(Clone, Debug)]
+///
+/// `Debug` output redacts the password field; see the manual `Debug` impl below.
+#[derive(Clone)]
 pub struct EmailChannelConfig {
     /// SMTP relay host (e.g. `smtp.example.com`).
     pub smtp_host: String,
@@ -28,6 +30,20 @@ pub struct EmailChannelConfig {
     /// The single authorized maintainer address. Inbound messages from any other
     /// sender are rejected before ingestion.
     pub maintainer_address: MailAddress,
+}
+
+impl std::fmt::Debug for EmailChannelConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmailChannelConfig")
+            .field("smtp_host", &self.smtp_host)
+            .field("smtp_port", &self.smtp_port)
+            .field("imap_host", &self.imap_host)
+            .field("imap_port", &self.imap_port)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .field("maintainer_address", &self.maintainer_address)
+            .finish()
+    }
 }
 
 impl EmailChannelConfig {
@@ -123,5 +139,28 @@ mod tests {
         let result = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST3", 587);
         assert!(result.is_err());
         std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST3");
+    }
+
+    #[test]
+    fn debug_output_does_not_expose_password() {
+        use crate::connector::MailAddress;
+        let config = EmailChannelConfig {
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            imap_host: "imap.example.com".to_string(),
+            imap_port: 993,
+            username: "user@example.com".to_string(),
+            password: "super-secret-credential-99".to_string(),
+            maintainer_address: MailAddress::parse("user@example.com").unwrap(),
+        };
+        let debug_output = format!("{config:?}");
+        assert!(
+            !debug_output.contains("super-secret-credential-99"),
+            "Debug output must not expose the password; got: {debug_output:?}"
+        );
+        assert!(
+            debug_output.contains("<redacted>"),
+            "Debug output must include the redaction marker; got: {debug_output:?}"
+        );
     }
 }

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -1,0 +1,127 @@
+//! Environment-only configuration for the email channel.
+//!
+//! All settings are read from environment variables. No filesystem config is
+//! loaded. Missing required variables produce an error at construction time.
+
+use crate::connector::MailAddress;
+use khive_channel::ChannelError;
+
+/// Configuration for the SMTP sender and IMAP fetcher.
+///
+/// Build via [`EmailChannelConfig::from_env`]. All fields are sourced
+/// exclusively from environment variables; no defaults are provided for
+/// credentials or host names.
+#[derive(Clone, Debug)]
+pub struct EmailChannelConfig {
+    /// SMTP relay host (e.g. `smtp.example.com`).
+    pub smtp_host: String,
+    /// SMTP port. Defaults to 587 (STARTTLS) when `KHIVE_EMAIL_SMTP_PORT` is unset.
+    pub smtp_port: u16,
+    /// IMAP server host (e.g. `imap.example.com`).
+    pub imap_host: String,
+    /// IMAP port. Defaults to 993 (TLS) when `KHIVE_EMAIL_IMAP_PORT` is unset.
+    pub imap_port: u16,
+    /// Login username for both SMTP and IMAP.
+    pub username: String,
+    /// Login password for both SMTP and IMAP. Never logged or stored.
+    pub password: String,
+    /// The single authorized maintainer address. Inbound messages from any other
+    /// sender are rejected before ingestion.
+    pub maintainer_address: MailAddress,
+}
+
+impl EmailChannelConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Required variables:
+    /// - `KHIVE_EMAIL_SMTP_HOST`
+    /// - `KHIVE_EMAIL_IMAP_HOST`
+    /// - `KHIVE_EMAIL_USERNAME`
+    /// - `KHIVE_EMAIL_PASSWORD`
+    /// - `KHIVE_EMAIL_MAINTAINER_ADDRESS`
+    ///
+    /// Optional variables with defaults:
+    /// - `KHIVE_EMAIL_SMTP_PORT` (default `587`)
+    /// - `KHIVE_EMAIL_IMAP_PORT` (default `993`)
+    pub fn from_env() -> Result<Self, ChannelError> {
+        let smtp_host = require_env("KHIVE_EMAIL_SMTP_HOST")?;
+        let smtp_port = optional_port("KHIVE_EMAIL_SMTP_PORT", 587)?;
+        let imap_host = require_env("KHIVE_EMAIL_IMAP_HOST")?;
+        let imap_port = optional_port("KHIVE_EMAIL_IMAP_PORT", 993)?;
+        let username = require_env("KHIVE_EMAIL_USERNAME")?;
+        let password = require_env("KHIVE_EMAIL_PASSWORD")?;
+        let maintainer_raw = require_env("KHIVE_EMAIL_MAINTAINER_ADDRESS")?;
+        let maintainer_address = MailAddress::parse(&maintainer_raw).ok_or_else(|| {
+            ChannelError::Config(format!(
+                "KHIVE_EMAIL_MAINTAINER_ADDRESS is not a valid RFC 5322 address: {maintainer_raw:?}"
+            ))
+        })?;
+
+        Ok(Self {
+            smtp_host,
+            smtp_port,
+            imap_host,
+            imap_port,
+            username,
+            password,
+            maintainer_address,
+        })
+    }
+}
+
+fn require_env(key: &str) -> Result<String, ChannelError> {
+    std::env::var(key).map_err(|_| {
+        ChannelError::Config(format!("required environment variable {key:?} is not set"))
+    })
+}
+
+fn optional_port(key: &str, default: u16) -> Result<u16, ChannelError> {
+    match std::env::var(key) {
+        Err(_) => Ok(default),
+        Ok(v) => v.parse::<u16>().map_err(|_| {
+            ChannelError::Config(format!(
+                "environment variable {key:?} must be a valid port number (1-65535), got: {v:?}"
+            ))
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_required_env_returns_error() {
+        // Ensure the key is absent (it may not be set in CI; use a unique key).
+        std::env::remove_var("KHIVE_EMAIL_SMTP_HOST_TEST_MISSING");
+        // from_env() will fail because KHIVE_EMAIL_SMTP_HOST is absent in a clean env.
+        // We test require_env directly to avoid environment pollution.
+        let result = require_env("KHIVE_EMAIL_SMTP_HOST_TEST_MISSING");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("KHIVE_EMAIL_SMTP_HOST_TEST_MISSING"));
+    }
+
+    #[test]
+    fn optional_port_uses_default_when_absent() {
+        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST");
+        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST", 587).unwrap();
+        assert_eq!(port, 587);
+    }
+
+    #[test]
+    fn optional_port_parses_set_value() {
+        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST2", "465");
+        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST2", 587).unwrap();
+        assert_eq!(port, 465);
+        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST2");
+    }
+
+    #[test]
+    fn optional_port_rejects_invalid_value() {
+        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST3", "notaport");
+        let result = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST3", 587);
+        assert!(result.is_err());
+        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST3");
+    }
+}

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -105,10 +105,13 @@ impl ImapConnector for LiveImap {
     ) -> Result<Vec<RawEmail>, ChannelError> {
         let mut session = self.connect().await?;
 
-        session
+        // SELECT returns the Mailbox struct; uid_validity is the UIDVALIDITY value needed
+        // for stable per-message dedup keys of the form `imap:{host}:{uidvalidity}:{uid}`.
+        let mailbox = session
             .select("INBOX")
             .await
             .map_err(|e| ChannelError::Transport(format!("IMAP SELECT INBOX failed: {e}")))?;
+        let uidvalidity = mailbox.uid_validity.unwrap_or(0);
 
         // Search for messages since the given date.
         let since_str = since.format("%d-%b-%Y").to_string();
@@ -156,7 +159,7 @@ impl ImapConnector for LiveImap {
 
         let mut result = Vec::new();
         for (uid, raw_bytes) in fetched_raw {
-            if let Some(email) = parse_raw_bytes(uid, &raw_bytes) {
+            if let Some(email) = parse_raw_bytes(uid, &raw_bytes, &self.host, uidvalidity) {
                 result.push(email);
             }
         }
@@ -165,16 +168,41 @@ impl ImapConnector for LiveImap {
 }
 
 /// Parse raw RFC 822 bytes into a `RawEmail`.
-pub(crate) fn parse_raw_bytes(uid: u32, raw: &[u8]) -> Option<RawEmail> {
+///
+/// `host` and `uidvalidity` are combined with `uid` to form the stable
+/// `imap_external_id` dedup key. This avoids relying on the `Message-ID`
+/// header, which is optional and could be absent or spoofed.
+pub(crate) fn parse_raw_bytes(
+    uid: u32,
+    raw: &[u8],
+    host: &str,
+    uidvalidity: u32,
+) -> Option<RawEmail> {
     let parser = MessageParser::default();
     let msg = parser.parse(raw)?;
 
-    let from = msg
+    // Stable dedup key: imap:{host}:{uidvalidity}:{uid}.
+    // Always set; never depends on Message-ID.
+    let imap_external_id = format!("imap:{host}:{uidvalidity}:{uid}");
+
+    // Collect all From addresses as addr-specs (display names stripped by mail_parser).
+    let from_addrs: Vec<String> = msg
         .from()
+        .map(|addrs| {
+            addrs
+                .iter()
+                .filter_map(|a| a.address())
+                .map(|s| s.to_lowercase())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Sender header (RFC 5322: single mailbox; first entry is the canonical one).
+    let sender_addr: Option<String> = msg
+        .sender()
         .and_then(|a| a.first())
         .and_then(|a| a.address())
-        .map(|s| s.to_lowercase())
-        .unwrap_or_default();
+        .map(|s| s.to_lowercase());
 
     let to: Vec<String> = msg
         .to()
@@ -193,8 +221,6 @@ pub(crate) fn parse_raw_bytes(uid: u32, raw: &[u8]) -> Option<RawEmail> {
         .date()
         .and_then(|d| DateTime::from_timestamp(d.to_timestamp(), 0));
 
-    let message_id = msg.message_id().map(|s| s.to_string());
-
     let body_text = msg.body_text(0).map(|s| s.to_string());
 
     let body_html = msg.body_html(0).map(|s| s.to_string());
@@ -212,8 +238,9 @@ pub(crate) fn parse_raw_bytes(uid: u32, raw: &[u8]) -> Option<RawEmail> {
 
     Some(RawEmail {
         uid,
-        message_id,
-        from,
+        imap_external_id,
+        from_addrs,
+        sender_addr,
         to,
         subject,
         date,
@@ -279,11 +306,12 @@ mod tests {
         }
     }
 
-    fn make_email(uid: u32, msg_id: &str, from: &str) -> RawEmail {
+    fn make_email(uid: u32, imap_id: &str, from_addr: &str) -> RawEmail {
         RawEmail {
             uid,
-            message_id: Some(msg_id.to_string()),
-            from: from.to_string(),
+            imap_external_id: imap_id.to_string(),
+            from_addrs: vec![from_addr.to_string()],
+            sender_addr: None,
             to: vec!["me@example.com".to_string()],
             subject: "Test".to_string(),
             date: None,
@@ -295,11 +323,16 @@ mod tests {
 
     #[tokio::test]
     async fn mock_imap_returns_emails() {
-        let emails = vec![make_email(1, "<id1@example.com>", "alice@example.com")];
+        let emails = vec![make_email(
+            1,
+            "imap:mail.example.com:12345:1",
+            "alice@example.com",
+        )];
         let fetcher = ImapFetcher::with_connector(MockImap::with_emails(emails));
         let result = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].message_id.as_deref(), Some("<id1@example.com>"));
+        assert_eq!(result[0].imap_external_id, "imap:mail.example.com:12345:1");
+        assert_eq!(result[0].from_addrs, vec!["alice@example.com"]);
     }
 
     #[tokio::test]
@@ -310,13 +343,54 @@ mod tests {
     }
 
     #[test]
+    fn parse_raw_bytes_extracts_all_from_addresses() {
+        // RFC 5322 allows multiple addresses in From.
+        let raw = b"From: alice@example.com, bob@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: Multi-From test\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(42, raw, "imap.example.com", 9999).unwrap();
+        assert_eq!(email.imap_external_id, "imap:imap.example.com:9999:42");
+        assert_eq!(email.from_addrs.len(), 2);
+        assert!(email.from_addrs.contains(&"alice@example.com".to_string()));
+        assert!(email.from_addrs.contains(&"bob@example.com".to_string()));
+    }
+
+    #[test]
+    fn parse_raw_bytes_extracts_sender_header() {
+        let raw = b"From: alice@example.com\r\n\
+                    Sender: sender@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: Sender test\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(7, raw, "imap.example.com", 1).unwrap();
+        assert_eq!(email.sender_addr.as_deref(), Some("sender@example.com"));
+    }
+
+    #[test]
+    fn parse_raw_bytes_stable_id_without_message_id() {
+        // Message has no Message-ID header; imap_external_id must still be set.
+        let raw = b"From: alice@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: No Message-ID\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(3, raw, "imap.example.com", 5555).unwrap();
+        assert_eq!(email.imap_external_id, "imap:imap.example.com:5555:3");
+        assert!(!email.imap_external_id.is_empty());
+    }
+
+    #[test]
     fn raw_email_khive_thread_id_header() {
         let mut headers = HashMap::new();
         headers.insert("x-khive-thread-id".to_string(), "some-uuid".to_string());
         let email = RawEmail {
             uid: 1,
-            message_id: None,
-            from: "a@example.com".to_string(),
+            imap_external_id: "imap:host:1:1".to_string(),
+            from_addrs: vec!["a@example.com".to_string()],
+            sender_addr: None,
             to: vec![],
             subject: String::new(),
             date: None,
@@ -334,8 +408,9 @@ mod tests {
         headers.insert("in-reply-to".to_string(), "<orig@example.com>".to_string());
         let email = RawEmail {
             uid: 2,
-            message_id: None,
-            from: "b@example.com".to_string(),
+            imap_external_id: "imap:host:1:2".to_string(),
+            from_addrs: vec!["b@example.com".to_string()],
+            sender_addr: None,
             to: vec![],
             subject: String::new(),
             date: None,

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -1,0 +1,350 @@
+//! IMAP inbound connector.
+//!
+//! Fetches new messages from the INBOX since a given timestamp. TLS is always
+//! required; plaintext IMAP connections are rejected. Credentials are supplied
+//! at construction time from environment variables.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
+use khive_channel::ChannelError;
+use mail_parser::MessageParser;
+use tokio_util::compat::TokioAsyncReadCompatExt;
+use tracing::instrument;
+
+use super::RawEmail;
+
+/// IMAP session type using TLS over a compat-wrapped tokio stream.
+type ImapSession = async_imap::Session<
+    async_native_tls::TlsStream<tokio_util::compat::Compat<tokio::net::TcpStream>>,
+>;
+
+/// Internal trait for IMAP fetch operations.
+///
+/// Allows unit tests to substitute a mock without a live IMAP server.
+#[async_trait]
+pub(crate) trait ImapConnector: Send + Sync + 'static {
+    async fn fetch_since(
+        &self,
+        since: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<RawEmail>, ChannelError>;
+}
+
+/// Production IMAP connector backed by `async-imap` with native TLS.
+pub(crate) struct LiveImap {
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+}
+
+impl LiveImap {
+    pub(crate) fn new(
+        host: impl Into<String>,
+        port: u16,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+
+    async fn connect(&self) -> Result<ImapSession, ChannelError> {
+        // TCP connect with 10s timeout.
+        let tcp = tokio::time::timeout(
+            Duration::from_secs(10),
+            tokio::net::TcpStream::connect((self.host.as_str(), self.port)),
+        )
+        .await
+        .map_err(|_| ChannelError::Transport("IMAP TCP connect timed out (10s)".into()))?
+        .map_err(|e| ChannelError::Transport(format!("IMAP TCP connect failed: {e}")))?;
+
+        // Wrap with compat layer so async-native-tls (which uses futures-io) can use the stream.
+        let tcp_compat = tcp.compat();
+
+        // TLS handshake with 15s timeout.
+        let tls_connector = async_native_tls::TlsConnector::new();
+        let tls_stream = tokio::time::timeout(
+            Duration::from_secs(15),
+            tls_connector.connect(&self.host, tcp_compat),
+        )
+        .await
+        .map_err(|_| ChannelError::Auth("IMAP TLS handshake timed out (15s)".into()))?
+        .map_err(|e| ChannelError::Auth(format!("IMAP TLS handshake failed: {e}")))?;
+
+        // IMAP login with 15s timeout.
+        let client = async_imap::Client::new(tls_stream);
+        let session: ImapSession = tokio::time::timeout(
+            Duration::from_secs(15),
+            client.login(&self.username, &self.password),
+        )
+        .await
+        .map_err(|_| ChannelError::Auth("IMAP login timed out (15s)".into()))?
+        .map_err(|(e, _)| ChannelError::Auth(format!("IMAP login failed: {e}")))?;
+
+        Ok(session)
+    }
+}
+
+#[async_trait]
+impl ImapConnector for LiveImap {
+    #[instrument(skip(self), fields(imap_host = %self.host))]
+    async fn fetch_since(
+        &self,
+        since: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<RawEmail>, ChannelError> {
+        let mut session = self.connect().await?;
+
+        session
+            .select("INBOX")
+            .await
+            .map_err(|e| ChannelError::Transport(format!("IMAP SELECT INBOX failed: {e}")))?;
+
+        // Search for messages since the given date.
+        let since_str = since.format("%d-%b-%Y").to_string();
+        let uid_set = session
+            .uid_search(format!("SINCE {since_str}"))
+            .await
+            .map_err(|e| ChannelError::Transport(format!("IMAP UID SEARCH SINCE failed: {e}")))?;
+
+        let mut uid_list: Vec<u32> = uid_set.into_iter().collect();
+        uid_list.truncate(limit);
+
+        if uid_list.is_empty() {
+            let _ = session.logout().await;
+            return Ok(vec![]);
+        }
+
+        let uid_str = uid_list
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        // Collect the fetch stream into owned bytes before releasing the session borrow.
+        let fetched_raw: Vec<(u32, Vec<u8>)> = {
+            let mut stream = session
+                .uid_fetch(&uid_str, "RFC822")
+                .await
+                .map_err(|e| ChannelError::Transport(format!("IMAP UID FETCH failed: {e}")))?;
+
+            let mut collected = Vec::new();
+            while let Some(msg) = stream
+                .try_next()
+                .await
+                .map_err(|e| ChannelError::Transport(format!("IMAP fetch stream error: {e}")))?
+            {
+                let uid = msg.uid.unwrap_or(0);
+                if let Some(body) = msg.body() {
+                    collected.push((uid, body.to_vec()));
+                }
+            }
+            collected
+        };
+
+        let _ = session.logout().await;
+
+        let mut result = Vec::new();
+        for (uid, raw_bytes) in fetched_raw {
+            if let Some(email) = parse_raw_bytes(uid, &raw_bytes) {
+                result.push(email);
+            }
+        }
+        Ok(result)
+    }
+}
+
+/// Parse raw RFC 822 bytes into a `RawEmail`.
+pub(crate) fn parse_raw_bytes(uid: u32, raw: &[u8]) -> Option<RawEmail> {
+    let parser = MessageParser::default();
+    let msg = parser.parse(raw)?;
+
+    let from = msg
+        .from()
+        .and_then(|a| a.first())
+        .and_then(|a| a.address())
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+
+    let to: Vec<String> = msg
+        .to()
+        .map(|addrs| {
+            addrs
+                .iter()
+                .filter_map(|a| a.address())
+                .map(|s| s.to_lowercase())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let subject = msg.subject().map(|s| s.to_string()).unwrap_or_default();
+
+    let date = msg
+        .date()
+        .and_then(|d| DateTime::from_timestamp(d.to_timestamp(), 0));
+
+    let message_id = msg.message_id().map(|s| s.to_string());
+
+    let body_text = msg.body_text(0).map(|s| s.to_string());
+
+    let body_html = msg.body_html(0).map(|s| s.to_string());
+
+    // Collect headers into a flat lowercase map (first occurrence wins).
+    let mut headers: HashMap<String, String> = HashMap::new();
+    for header in msg.headers() {
+        let key = header.name().to_lowercase();
+        if let std::collections::hash_map::Entry::Vacant(e) = headers.entry(key) {
+            if let mail_parser::HeaderValue::Text(v) = header.value() {
+                e.insert(v.to_string());
+            }
+        }
+    }
+
+    Some(RawEmail {
+        uid,
+        message_id,
+        from,
+        to,
+        subject,
+        date,
+        body_text,
+        body_html,
+        headers,
+    })
+}
+
+/// IMAP fetcher wrapping an `ImapConnector`.
+pub struct ImapFetcher {
+    pub(crate) inner: Arc<dyn ImapConnector>,
+}
+
+impl ImapFetcher {
+    /// Create a production fetcher backed by `async-imap`.
+    pub fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
+        Self {
+            inner: Arc::new(LiveImap::new(host, port, username, password)),
+        }
+    }
+
+    /// Create a fetcher wrapping a custom connector (for testing).
+    #[cfg(test)]
+    pub(crate) fn with_connector(connector: impl ImapConnector) -> Self {
+        Self {
+            inner: Arc::new(connector),
+        }
+    }
+
+    /// Fetch messages received since `since`, up to `limit` items.
+    pub async fn fetch_since(
+        &self,
+        since: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<RawEmail>, ChannelError> {
+        self.inner.fetch_since(since, limit).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockImap {
+        emails: Vec<RawEmail>,
+    }
+
+    impl MockImap {
+        fn with_emails(emails: Vec<RawEmail>) -> Self {
+            Self { emails }
+        }
+    }
+
+    #[async_trait]
+    impl ImapConnector for MockImap {
+        async fn fetch_since(
+            &self,
+            _since: DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<RawEmail>, ChannelError> {
+            Ok(self.emails.clone())
+        }
+    }
+
+    fn make_email(uid: u32, msg_id: &str, from: &str) -> RawEmail {
+        RawEmail {
+            uid,
+            message_id: Some(msg_id.to_string()),
+            from: from.to_string(),
+            to: vec!["me@example.com".to_string()],
+            subject: "Test".to_string(),
+            date: None,
+            body_text: Some("body".to_string()),
+            body_html: None,
+            headers: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_imap_returns_emails() {
+        let emails = vec![make_email(1, "<id1@example.com>", "alice@example.com")];
+        let fetcher = ImapFetcher::with_connector(MockImap::with_emails(emails));
+        let result = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].message_id.as_deref(), Some("<id1@example.com>"));
+    }
+
+    #[tokio::test]
+    async fn mock_imap_returns_empty_when_no_messages() {
+        let fetcher = ImapFetcher::with_connector(MockImap::with_emails(vec![]));
+        let result = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn raw_email_khive_thread_id_header() {
+        let mut headers = HashMap::new();
+        headers.insert("x-khive-thread-id".to_string(), "some-uuid".to_string());
+        let email = RawEmail {
+            uid: 1,
+            message_id: None,
+            from: "a@example.com".to_string(),
+            to: vec![],
+            subject: String::new(),
+            date: None,
+            body_text: None,
+            body_html: None,
+            headers,
+        };
+        assert_eq!(email.khive_thread_id(), Some("some-uuid"));
+        assert_eq!(email.correlation(), Some("some-uuid"));
+    }
+
+    #[test]
+    fn raw_email_in_reply_to_fallback() {
+        let mut headers = HashMap::new();
+        headers.insert("in-reply-to".to_string(), "<orig@example.com>".to_string());
+        let email = RawEmail {
+            uid: 2,
+            message_id: None,
+            from: "b@example.com".to_string(),
+            to: vec![],
+            subject: String::new(),
+            date: None,
+            body_text: Some("reply body".to_string()),
+            body_html: None,
+            headers,
+        };
+        assert_eq!(email.in_reply_to(), Some("<orig@example.com>"));
+        assert_eq!(email.correlation(), Some("<orig@example.com>"));
+        assert_eq!(email.best_body(), "reply body");
+    }
+}

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -111,7 +111,7 @@ impl ImapConnector for LiveImap {
             .select("INBOX")
             .await
             .map_err(|e| ChannelError::Transport(format!("IMAP SELECT INBOX failed: {e}")))?;
-        let uidvalidity = mailbox.uid_validity.unwrap_or(0);
+        let uid_validity = mailbox.uid_validity;
 
         // Search for messages since the given date.
         let since_str = since.format("%d-%b-%Y").to_string();
@@ -135,7 +135,9 @@ impl ImapConnector for LiveImap {
             .join(",");
 
         // Collect the fetch stream into owned bytes before releasing the session borrow.
-        let fetched_raw: Vec<(u32, Vec<u8>)> = {
+        // Each entry carries the raw UID as returned by the server (Option<u32>); zero
+        // and absent UIDs are validated inside process_mailbox_fetch.
+        let fetched_raw: Vec<(Option<u32>, Vec<u8>)> = {
             let mut stream = session
                 .uid_fetch(&uid_str, "RFC822")
                 .await
@@ -147,9 +149,8 @@ impl ImapConnector for LiveImap {
                 .await
                 .map_err(|e| ChannelError::Transport(format!("IMAP fetch stream error: {e}")))?
             {
-                let uid = msg.uid.unwrap_or(0);
                 if let Some(body) = msg.body() {
-                    collected.push((uid, body.to_vec()));
+                    collected.push((msg.uid, body.to_vec()));
                 }
             }
             collected
@@ -157,14 +158,57 @@ impl ImapConnector for LiveImap {
 
         let _ = session.logout().await;
 
-        let mut result = Vec::new();
-        for (uid, raw_bytes) in fetched_raw {
-            if let Some(email) = parse_raw_bytes(uid, &raw_bytes, &self.host, uidvalidity) {
-                result.push(email);
-            }
-        }
-        Ok(result)
+        process_mailbox_fetch(uid_validity, fetched_raw, &self.host)
     }
+}
+
+/// Validate UIDVALIDITY + per-message UIDs and build the `RawEmail` list.
+///
+/// `uid_validity` must be `Some(non-zero)`.  When it is `None` or `Some(0)` the
+/// whole batch is rejected as a transport error: UIDVALIDITY is required to form
+/// the stable `imap:{host}:{uidvalidity}:{uid}` dedup key, and without it we
+/// cannot safely identify or deduplicate messages.
+///
+/// Per-message UIDs that are `None` or `0` are skipped with a `warn!` log rather
+/// than failing the batch: one missing UID is a server quirk, not a reason to
+/// discard all other messages in the poll.
+///
+/// This function is extracted from `LiveImap::fetch_since` so the validation
+/// logic can be exercised without a live IMAP server.
+pub(crate) fn process_mailbox_fetch(
+    uid_validity: Option<u32>,
+    fetched_raw: Vec<(Option<u32>, Vec<u8>)>,
+    host: &str,
+) -> Result<Vec<RawEmail>, ChannelError> {
+    let uidvalidity = match uid_validity {
+        Some(v) if v != 0 => v,
+        _ => {
+            return Err(ChannelError::Transport(
+                "IMAP SELECT did not return a valid UIDVALIDITY; \
+                 cannot safely deduplicate messages — poll aborted"
+                    .to_string(),
+            ));
+        }
+    };
+
+    let mut result = Vec::new();
+    for (uid_opt, raw_bytes) in fetched_raw {
+        let uid = match uid_opt {
+            Some(u) if u != 0 => u,
+            _ => {
+                tracing::warn!(
+                    host = %host,
+                    uidvalidity = %uidvalidity,
+                    "skipping message with missing or zero UID; cannot form a stable dedup key"
+                );
+                continue;
+            }
+        };
+        if let Some(email) = parse_raw_bytes(uid, &raw_bytes, host, uidvalidity) {
+            result.push(email);
+        }
+    }
+    Ok(result)
 }
 
 /// Parse raw RFC 822 bytes into a `RawEmail`.
@@ -400,6 +444,82 @@ mod tests {
         };
         assert_eq!(email.khive_thread_id(), Some("some-uuid"));
         assert_eq!(email.correlation(), Some("some-uuid"));
+    }
+
+    // --- process_mailbox_fetch guard tests ---
+
+    fn minimal_rfc822(from: &str, subject: &str) -> Vec<u8> {
+        format!("From: {from}\r\nTo: me@example.com\r\nSubject: {subject}\r\n\r\nbody").into_bytes()
+    }
+
+    #[test]
+    fn process_mailbox_fetch_missing_uidvalidity_returns_error() {
+        let raw = minimal_rfc822("a@example.com", "test");
+        let result = process_mailbox_fetch(None, vec![(Some(1), raw)], "imap.example.com");
+        assert!(
+            result.is_err(),
+            "missing UIDVALIDITY must return a transport error"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("UIDVALIDITY"),
+            "error message should mention UIDVALIDITY; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn process_mailbox_fetch_zero_uidvalidity_returns_error() {
+        let raw = minimal_rfc822("a@example.com", "test");
+        let result = process_mailbox_fetch(Some(0), vec![(Some(1), raw)], "imap.example.com");
+        assert!(
+            result.is_err(),
+            "zero UIDVALIDITY must return a transport error"
+        );
+    }
+
+    #[test]
+    fn process_mailbox_fetch_missing_uid_skips_message() {
+        let raw = minimal_rfc822("a@example.com", "test");
+        let result =
+            process_mailbox_fetch(Some(999), vec![(None, raw)], "imap.example.com").unwrap();
+        assert!(
+            result.is_empty(),
+            "a message with missing UID must be skipped (not an error)"
+        );
+    }
+
+    #[test]
+    fn process_mailbox_fetch_zero_uid_skips_message() {
+        let raw = minimal_rfc822("a@example.com", "test");
+        let result =
+            process_mailbox_fetch(Some(999), vec![(Some(0), raw)], "imap.example.com").unwrap();
+        assert!(
+            result.is_empty(),
+            "a message with zero UID must be skipped (not an error)"
+        );
+    }
+
+    #[test]
+    fn process_mailbox_fetch_valid_inputs_produce_email() {
+        let raw = minimal_rfc822("alice@example.com", "hello");
+        let result =
+            process_mailbox_fetch(Some(1234), vec![(Some(7), raw)], "mail.example.com").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].imap_external_id, "imap:mail.example.com:1234:7");
+    }
+
+    #[test]
+    fn process_mailbox_fetch_skips_invalid_uid_continues_valid() {
+        let raw_bad = minimal_rfc822("bad@example.com", "bad");
+        let raw_good = minimal_rfc822("good@example.com", "good");
+        let result = process_mailbox_fetch(
+            Some(555),
+            vec![(Some(0), raw_bad), (Some(3), raw_good)],
+            "imap.example.com",
+        )
+        .unwrap();
+        assert_eq!(result.len(), 1, "only the valid message should be returned");
+        assert_eq!(result[0].imap_external_id, "imap:imap.example.com:555:3");
     }
 
     #[test]

--- a/crates/khive-channel-email/src/connector/mod.rs
+++ b/crates/khive-channel-email/src/connector/mod.rs
@@ -1,0 +1,99 @@
+//! Transport-level connector types for SMTP and IMAP.
+
+pub mod imap;
+pub mod smtp;
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+pub use imap::ImapFetcher;
+pub use smtp::SmtpSender;
+
+/// A parsed RFC 822 address (addr-spec only, display name stripped).
+///
+/// Stored in lowercase for case-insensitive comparison per RFC 5321.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MailAddress(String);
+
+impl MailAddress {
+    /// Parse a raw header value into a `MailAddress`.
+    ///
+    /// Strips display names and angle brackets; lowercases the result.
+    /// Returns `None` if no valid addr-spec can be extracted.
+    pub fn parse(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim();
+        // Handle "Display Name <addr@example.com>" form.
+        if let Some(start) = trimmed.rfind('<') {
+            if let Some(end) = trimmed[start..].find('>') {
+                let addr = trimmed[start + 1..start + end].trim().to_lowercase();
+                if addr.contains('@') {
+                    return Some(Self(addr));
+                }
+            }
+        }
+        // Plain addr-spec.
+        let lower = trimmed.to_lowercase();
+        if lower.contains('@') {
+            return Some(Self(lower));
+        }
+        None
+    }
+
+    /// Return the normalized addr-spec string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MailAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A raw email fetched from the IMAP server before enrichment.
+#[derive(Debug, Clone)]
+pub struct RawEmail {
+    /// IMAP UID (opaque; used for SEEN marking).
+    pub uid: u32,
+    /// RFC 822 Message-ID header value. Used as the dedup external_id.
+    pub message_id: Option<String>,
+    /// Parsed sender address (addr-spec, lowercase).
+    pub from: String,
+    /// All recipient addresses.
+    pub to: Vec<String>,
+    /// Subject header value.
+    pub subject: String,
+    /// Date header parsed to UTC.
+    pub date: Option<DateTime<Utc>>,
+    /// Plain-text body.
+    pub body_text: Option<String>,
+    /// HTML body (informational; not stored in the KG note).
+    pub body_html: Option<String>,
+    /// All headers as a flat map (lowercase key, first-occurrence value).
+    pub headers: HashMap<String, String>,
+}
+
+impl RawEmail {
+    /// Return the value of the `X-Khive-Thread-ID` header if present.
+    pub fn khive_thread_id(&self) -> Option<&str> {
+        self.headers.get("x-khive-thread-id").map(|s| s.as_str())
+    }
+
+    /// Return the `In-Reply-To` header value if present.
+    pub fn in_reply_to(&self) -> Option<&str> {
+        self.headers.get("in-reply-to").map(|s| s.as_str())
+    }
+
+    /// Resolve the best available correlation key: `X-Khive-Thread-ID` first,
+    /// then `In-Reply-To`.
+    pub fn correlation(&self) -> Option<&str> {
+        self.khive_thread_id().or_else(|| self.in_reply_to())
+    }
+
+    /// Return the best available body text.
+    pub fn best_body(&self) -> String {
+        self.body_text.clone().unwrap_or_default()
+    }
+}

--- a/crates/khive-channel-email/src/connector/mod.rs
+++ b/crates/khive-channel-email/src/connector/mod.rs
@@ -55,13 +55,25 @@ impl std::fmt::Display for MailAddress {
 /// A raw email fetched from the IMAP server before enrichment.
 #[derive(Debug, Clone)]
 pub struct RawEmail {
-    /// IMAP UID (opaque; used for SEEN marking).
+    /// IMAP UID (opaque; used for message identification).
     pub uid: u32,
-    /// RFC 822 Message-ID header value. Used as the dedup external_id.
-    pub message_id: Option<String>,
-    /// Parsed sender address (addr-spec, lowercase).
-    pub from: String,
-    /// All recipient addresses.
+    /// Stable dedup key: `imap:{host}:{uidvalidity}:{uid}`.
+    ///
+    /// Always set by the IMAP connector. Never empty. Used as the primary
+    /// `external_id` in `comm.ingest`; derived from UIDVALIDITY and UID so
+    /// dedup works even when a message has no `Message-ID` header.
+    pub imap_external_id: String,
+    /// All parsed sender addresses from the `From:` header (addr-spec, lowercase).
+    ///
+    /// The authorization check requires exactly one entry matching the configured
+    /// maintainer address. Zero entries or more than one cause the message to be
+    /// rejected as unauthorized before any note is written.
+    pub from_addrs: Vec<String>,
+    /// Parsed address from the `Sender:` header, if present (addr-spec, lowercase).
+    ///
+    /// When present, must also match the configured maintainer address.
+    pub sender_addr: Option<String>,
+    /// All recipient addresses from the `To:` header.
     pub to: Vec<String>,
     /// Subject header value.
     pub subject: String,

--- a/crates/khive-channel-email/src/connector/smtp.rs
+++ b/crates/khive-channel-email/src/connector/smtp.rs
@@ -1,0 +1,252 @@
+//! SMTP outbound connector.
+//!
+//! Delivers outbound messages via SMTP with mandatory TLS. Credentials are
+//! supplied at construction time from environment variables; they are never
+//! logged or embedded in source.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use khive_channel::ChannelError;
+use lettre::{
+    message::{header::ContentType, Mailbox},
+    transport::smtp::authentication::Credentials,
+    AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+};
+use tracing::instrument;
+
+/// Custom MIME header for khive thread correlation.
+///
+/// Attached to outbound messages so that replies can be linked back to the
+/// originating thread by the IMAP fetcher.
+#[derive(Clone)]
+struct XKhiveThreadId(String);
+
+impl lettre::message::header::Header for XKhiveThreadId {
+    fn name() -> lettre::message::header::HeaderName {
+        lettre::message::header::HeaderName::new_from_ascii_str("X-Khive-Thread-ID")
+    }
+
+    fn parse(s: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Self(s.trim().to_string()))
+    }
+
+    fn display(&self) -> lettre::message::header::HeaderValue {
+        lettre::message::header::HeaderValue::new(
+            lettre::message::header::HeaderName::new_from_ascii_str("X-Khive-Thread-ID"),
+            self.0.clone(),
+        )
+    }
+}
+
+/// Internal trait for the SMTP send operation.
+///
+/// Allows unit tests to swap in a mock without a live SMTP server.
+#[async_trait]
+pub(crate) trait SmtpConnector: Send + Sync + 'static {
+    async fn deliver(
+        &self,
+        from: &str,
+        to: &str,
+        subject: &str,
+        body: &str,
+        thread_id_header: Option<&str>,
+    ) -> Result<(), ChannelError>;
+}
+
+/// Production SMTP connector backed by `lettre`.
+pub(crate) struct LettreSmtp {
+    host: String,
+    port: u16,
+    creds: Credentials,
+}
+
+impl LettreSmtp {
+    pub(crate) fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            creds: Credentials::new(username.to_string(), password.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl SmtpConnector for LettreSmtp {
+    #[instrument(skip(self, body), fields(smtp_host = %self.host))]
+    async fn deliver(
+        &self,
+        from: &str,
+        to: &str,
+        subject: &str,
+        body: &str,
+        thread_id_header: Option<&str>,
+    ) -> Result<(), ChannelError> {
+        let from_mb: Mailbox = from.parse().map_err(|e| {
+            ChannelError::InvalidEnvelope(format!("invalid from address {from:?}: {e}"))
+        })?;
+        let to_mb: Mailbox = to.parse().map_err(|e| {
+            ChannelError::InvalidEnvelope(format!("invalid to address {to:?}: {e}"))
+        })?;
+
+        let mut builder = Message::builder()
+            .from(from_mb)
+            .to(to_mb)
+            .subject(subject)
+            .header(ContentType::TEXT_PLAIN);
+
+        if let Some(tid) = thread_id_header {
+            builder = builder.header(XKhiveThreadId(tid.to_string()));
+        }
+
+        let msg = builder
+            .body(body.to_string())
+            .map_err(|e| ChannelError::InvalidEnvelope(format!("failed to build message: {e}")))?;
+
+        let transport = AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
+            .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
+            .credentials(self.creds.clone())
+            .port(self.port)
+            .build();
+
+        transport
+            .send(msg)
+            .await
+            .map_err(|e| ChannelError::Transport(format!("SMTP send failed: {e}")))?;
+
+        Ok(())
+    }
+}
+
+/// SMTP sender wrapping a `SmtpConnector`.
+pub struct SmtpSender {
+    pub(crate) inner: Arc<dyn SmtpConnector>,
+}
+
+impl SmtpSender {
+    /// Create a production sender backed by lettre.
+    pub fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
+        Self {
+            inner: Arc::new(LettreSmtp::new(host, port, username, password)),
+        }
+    }
+
+    /// Create a sender wrapping a custom connector (for testing).
+    #[cfg(test)]
+    pub(crate) fn with_connector(connector: impl SmtpConnector) -> Self {
+        Self {
+            inner: Arc::new(connector),
+        }
+    }
+
+    /// Deliver an outbound message. `thread_id` is attached as `X-Khive-Thread-ID`.
+    pub async fn send(
+        &self,
+        from: &str,
+        to: &str,
+        subject: &str,
+        body: &str,
+        thread_id: Option<&str>,
+    ) -> Result<(), ChannelError> {
+        self.inner.deliver(from, to, subject, body, thread_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct MockSmtp {
+        calls: Arc<Mutex<Vec<(String, String, String)>>>,
+    }
+
+    impl MockSmtp {
+        fn new() -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SmtpConnector for MockSmtp {
+        async fn deliver(
+            &self,
+            from: &str,
+            to: &str,
+            subject: &str,
+            _body: &str,
+            _thread_id_header: Option<&str>,
+        ) -> Result<(), ChannelError> {
+            self.calls.lock().unwrap().push((
+                from.to_string(),
+                to.to_string(),
+                subject.to_string(),
+            ));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn smtp_sender_records_call() {
+        let mock = MockSmtp::new();
+        let calls = mock.calls.clone();
+        let sender = SmtpSender::with_connector(mock);
+
+        sender
+            .send(
+                "from@example.com",
+                "to@example.com",
+                "Hello",
+                "body text",
+                None,
+            )
+            .await
+            .expect("send ok");
+
+        let locked = calls.lock().unwrap();
+        assert_eq!(locked.len(), 1);
+        assert_eq!(locked[0].0, "from@example.com");
+        assert_eq!(locked[0].1, "to@example.com");
+        assert_eq!(locked[0].2, "Hello");
+    }
+
+    #[tokio::test]
+    async fn smtp_sender_passes_thread_id() {
+        struct CapturingSmtp {
+            headers: Arc<Mutex<Vec<Option<String>>>>,
+        }
+
+        #[async_trait]
+        impl SmtpConnector for CapturingSmtp {
+            async fn deliver(
+                &self,
+                _from: &str,
+                _to: &str,
+                _subject: &str,
+                _body: &str,
+                thread_id_header: Option<&str>,
+            ) -> Result<(), ChannelError> {
+                self.headers
+                    .lock()
+                    .unwrap()
+                    .push(thread_id_header.map(|s| s.to_string()));
+                Ok(())
+            }
+        }
+
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let sender = SmtpSender::with_connector(CapturingSmtp {
+            headers: headers.clone(),
+        });
+
+        sender
+            .send("a@example.com", "b@example.com", "s", "b", Some("tid-abc"))
+            .await
+            .unwrap();
+
+        let captured = headers.lock().unwrap();
+        assert_eq!(captured[0].as_deref(), Some("tid-abc"));
+    }
+}

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -1,0 +1,12 @@
+//! Email (SMTP/IMAP) channel adapter for khive (ADR-056).
+//!
+//! Provides `EmailChannel`, which implements the `Channel` trait from
+//! `khive-channel`. Configure exclusively via environment variables; no
+//! filesystem config is read.
+
+pub mod channel;
+pub mod config;
+pub mod connector;
+
+pub use channel::EmailChannel;
+pub use config::EmailChannelConfig;

--- a/crates/khive-channel/Cargo.toml
+++ b/crates/khive-channel/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "khive-channel"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Channel transport abstraction for outbound and inbound message delivery (ADR-056)"
+
+[dependencies]
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -1,0 +1,284 @@
+//! Channel transport abstraction (ADR-056).
+//!
+//! This crate defines the `Channel` trait, `ChannelEnvelope`, `ChannelRegistry`, and
+//! `ChannelError`. Concrete transport adapters (e.g. `khive-channel-email`) implement
+//! the `Channel` trait; the MCP server polls registered channels and ingests inbound
+//! messages via the `comm.ingest` subhandler verb.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A message envelope passed between the channel transport and the runtime.
+///
+/// Outbound envelopes are produced by the runtime and delivered by a `Channel`.
+/// Inbound envelopes are produced by a `Channel` and consumed by the polling loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelEnvelope {
+    /// Sender address in `channel-kind:address` form, e.g. `email:alice@example.com`.
+    pub from: String,
+    /// Recipient address in `channel-kind:address` form.
+    pub to: String,
+    /// Message body (plain text).
+    pub content: String,
+    /// Optional subject line (used by email and similar channels).
+    pub subject: Option<String>,
+    /// RFC 3339 timestamp of when the message was originally sent or received.
+    pub sent_at: Option<DateTime<Utc>>,
+    /// External deduplication key (e.g. RFC 822 Message-ID for email).
+    pub external_id: Option<String>,
+    /// External correlation key used to resolve the thread (e.g. X-Khive-Thread-ID header
+    /// or In-Reply-To header value for email). The handler resolves this to an internal UUID.
+    pub correlation_external_id: Option<String>,
+    /// Arbitrary transport-specific key-value metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+impl ChannelEnvelope {
+    /// Create a minimal outbound envelope.
+    pub fn new(from: impl Into<String>, to: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            content: content.into(),
+            subject: None,
+            sent_at: None,
+            external_id: None,
+            correlation_external_id: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Attach a subject line.
+    pub fn with_subject(mut self, subject: impl Into<String>) -> Self {
+        self.subject = Some(subject.into());
+        self
+    }
+
+    /// Attach a sent-at timestamp.
+    pub fn with_sent_at(mut self, ts: DateTime<Utc>) -> Self {
+        self.sent_at = Some(ts);
+        self
+    }
+
+    /// Attach an external deduplication key.
+    pub fn with_external_id(mut self, id: impl Into<String>) -> Self {
+        self.external_id = Some(id.into());
+        self
+    }
+
+    /// Attach a correlation key for thread resolution.
+    pub fn with_correlation(mut self, correlation: impl Into<String>) -> Self {
+        self.correlation_external_id = Some(correlation.into());
+        self
+    }
+}
+
+/// Errors produced by channel operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ChannelError {
+    /// Configuration is missing or invalid.
+    #[error("channel configuration error: {0}")]
+    Config(String),
+    /// Transport-level connection or I/O failure.
+    #[error("transport error: {0}")]
+    Transport(String),
+    /// Authentication failure (TLS, credentials, etc.).
+    #[error("authentication error: {0}")]
+    Auth(String),
+    /// Message was rejected because the sender is not authorized.
+    #[error("unauthorized sender: {0}")]
+    UnauthorizedSender(String),
+    /// The envelope is malformed or missing required fields.
+    #[error("invalid envelope: {0}")]
+    InvalidEnvelope(String),
+}
+
+/// A channel transport adapter.
+///
+/// Implementors handle outbound delivery (`send`) and inbound polling (`poll`).
+/// Each adapter is identified by a stable kind string (e.g. `"email"`).
+#[async_trait]
+pub trait Channel: Send + Sync + 'static {
+    /// Short stable identifier for this transport (e.g. `"email"`, `"telegram"`).
+    fn kind(&self) -> &'static str;
+
+    /// Send a single outbound message.
+    async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError>;
+
+    /// Poll for new inbound messages since `since`.
+    ///
+    /// Returns envelopes ready to be ingested. Callers are responsible for
+    /// deduplication via `external_id`; adapters should apply a best-effort
+    /// server-side filter on `since` to avoid fetching large backlogs.
+    async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError>;
+}
+
+/// Registry of named channel adapters.
+///
+/// The MCP server holds an `Arc<ChannelRegistry>` and polls all registered
+/// channels in a background loop, ingesting results via `comm.ingest`.
+#[derive(Default)]
+pub struct ChannelRegistry {
+    channels: HashMap<String, Arc<dyn Channel>>,
+}
+
+impl ChannelRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a channel adapter. Replaces any previous adapter with the same `kind`.
+    pub fn register(&mut self, channel: Arc<dyn Channel>) {
+        self.channels.insert(channel.kind().to_string(), channel);
+    }
+
+    /// Look up a channel by kind.
+    pub fn get(&self, kind: &str) -> Option<Arc<dyn Channel>> {
+        self.channels.get(kind).cloned()
+    }
+
+    /// Iterate over all registered channels.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Arc<dyn Channel>)> {
+        self.channels.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Returns `true` if no channels are registered.
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    /// Number of registered channels.
+    pub fn len(&self) -> usize {
+        self.channels.len()
+    }
+}
+
+/// Generate a new correlation ID suitable for embedding in a message header.
+pub fn new_thread_correlation_id() -> String {
+    Uuid::new_v4().as_hyphenated().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct MockChannel {
+        sent: Arc<Mutex<Vec<ChannelEnvelope>>>,
+        inbound: Vec<ChannelEnvelope>,
+    }
+
+    impl MockChannel {
+        fn new(inbound: Vec<ChannelEnvelope>) -> Self {
+            Self {
+                sent: Arc::new(Mutex::new(Vec::new())),
+                inbound,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Channel for MockChannel {
+        fn kind(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+            self.sent.lock().unwrap().push(envelope);
+            Ok(())
+        }
+
+        async fn poll(&self, _since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+            Ok(self.inbound.clone())
+        }
+    }
+
+    #[test]
+    fn envelope_builder_fields() {
+        let ts = Utc::now();
+        let env = ChannelEnvelope::new("email:a@example.com", "email:b@example.com", "hello")
+            .with_subject("Test")
+            .with_sent_at(ts)
+            .with_external_id("<msg1@example.com>")
+            .with_correlation("correlation-uuid");
+
+        assert_eq!(env.from, "email:a@example.com");
+        assert_eq!(env.to, "email:b@example.com");
+        assert_eq!(env.content, "hello");
+        assert_eq!(env.subject.as_deref(), Some("Test"));
+        assert_eq!(env.sent_at, Some(ts));
+        assert_eq!(env.external_id.as_deref(), Some("<msg1@example.com>"));
+        assert_eq!(
+            env.correlation_external_id.as_deref(),
+            Some("correlation-uuid")
+        );
+    }
+
+    #[test]
+    fn registry_register_and_get() {
+        let mut reg = ChannelRegistry::new();
+        let ch = Arc::new(MockChannel::new(vec![]));
+        reg.register(ch);
+        assert!(reg.get("mock").is_some());
+        assert!(reg.get("email").is_none());
+        assert_eq!(reg.len(), 1);
+        assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn registry_replaces_existing() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockChannel::new(vec![])));
+        reg.register(Arc::new(MockChannel::new(vec![])));
+        assert_eq!(reg.len(), 1, "same kind replaces");
+    }
+
+    #[test]
+    fn registry_iter_yields_all() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockChannel::new(vec![])));
+        let kinds: Vec<&str> = reg.iter().map(|(k, _)| k).collect();
+        assert_eq!(kinds, vec!["mock"]);
+    }
+
+    #[test]
+    fn channel_error_display() {
+        let e = ChannelError::Config("missing host".into());
+        assert!(e.to_string().contains("missing host"));
+        let e2 = ChannelError::UnauthorizedSender("attacker@example.com".into());
+        assert!(e2.to_string().contains("attacker@example.com"));
+    }
+
+    #[test]
+    fn new_thread_correlation_id_is_uuid() {
+        let id = new_thread_correlation_id();
+        assert!(
+            id.parse::<Uuid>().is_ok(),
+            "correlation id must be a valid UUID"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_channel_send_and_poll() {
+        let inbound =
+            vec![
+                ChannelEnvelope::new("email:sender@example.com", "email:me@example.com", "body")
+                    .with_external_id("<id1@example.com>"),
+            ];
+        let ch = Arc::new(MockChannel::new(inbound.clone()));
+        let env_out =
+            ChannelEnvelope::new("email:me@example.com", "email:them@example.com", "reply");
+        ch.send(env_out).await.expect("send ok");
+        assert_eq!(ch.sent.lock().unwrap().len(), 1);
+
+        let polled = ch.poll(Utc::now()).await.expect("poll ok");
+        assert_eq!(polled.len(), 1);
+        assert_eq!(polled[0].external_id.as_deref(), Some("<id1@example.com>"));
+    }
+}

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -102,12 +102,27 @@ pub enum ChannelError {
 ///
 /// Implementors handle outbound delivery (`send`) and inbound polling (`poll`).
 /// Each adapter is identified by a stable kind string (e.g. `"email"`).
+///
+/// Note: `Debug` is intentionally NOT required. Concrete adapters hold credentials;
+/// requiring `Debug` would risk password leakage in logs via derived impls.
 #[async_trait]
 pub trait Channel: Send + Sync + 'static {
     /// Short stable identifier for this transport (e.g. `"email"`, `"telegram"`).
     fn kind(&self) -> &'static str;
 
+    /// Return `true` when this adapter has sufficient configuration to operate.
+    ///
+    /// The default implementation returns `true`; adapters with optional config
+    /// may override this to report their readiness without returning errors from
+    /// `poll` or `send` on every call.
+    fn is_configured(&self) -> bool {
+        true
+    }
+
     /// Send a single outbound message.
+    ///
+    /// Outbound write-back (reply routing from the KG note layer) is deferred
+    /// to a future release; `send` exists so the trait surface is complete.
     async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError>;
 
     /// Poll for new inbound messages since `since`.
@@ -261,6 +276,16 @@ mod tests {
         assert!(
             id.parse::<Uuid>().is_ok(),
             "correlation id must be a valid UUID"
+        );
+    }
+
+    #[test]
+    fn is_configured_default_returns_true() {
+        let ch = MockChannel::new(vec![]);
+        // Default impl must return true; concrete adapters may override.
+        assert!(
+            ch.is_configured(),
+            "default is_configured() must return true"
         );
     }
 

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -29,7 +29,14 @@ pub struct ChannelEnvelope {
     pub subject: Option<String>,
     /// RFC 3339 timestamp of when the message was originally sent or received.
     pub sent_at: Option<DateTime<Utc>>,
-    /// External deduplication key (e.g. RFC 822 Message-ID for email).
+    /// External deduplication key.
+    ///
+    /// For IMAP email the format is `imap:{host}:{uidvalidity}:{uid}` (e.g.
+    /// `imap:mail.example.com:1234567:42`).  This key is derived from the IMAP
+    /// UIDVALIDITY and UID values, not from the RFC 822 `Message-ID` header.
+    /// Adapters must not populate this field when UIDVALIDITY or UID is absent
+    /// or zero; `comm.ingest` performs atomic dedup against the unique index on
+    /// this field.
     pub external_id: Option<String>,
     /// External correlation key used to resolve the thread (e.g. X-Khive-Thread-ID header
     /// or In-Reply-To header value for email). The handler resolves this to an internal UUID.
@@ -127,9 +134,11 @@ pub trait Channel: Send + Sync + 'static {
 
     /// Poll for new inbound messages since `since`.
     ///
-    /// Returns envelopes ready to be ingested. Callers are responsible for
-    /// deduplication via `external_id`; adapters should apply a best-effort
-    /// server-side filter on `since` to avoid fetching large backlogs.
+    /// Returns envelopes ready to be forwarded to `comm.ingest`.  Deduplication
+    /// is performed by `comm.ingest` via `INSERT OR IGNORE` against the
+    /// `idx_comm_message_external_id` unique index; adapters do not need to
+    /// deduplicate themselves.  Adapters should apply a best-effort server-side
+    /// filter on `since` to avoid fetching large backlogs.
     async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError>;
 }
 

--- a/crates/khive-db/sql/005-unique-comm-external-id.sql
+++ b/crates/khive-db/sql/005-unique-comm-external-id.sql
@@ -6,11 +6,29 @@
 -- never enforced.  DROP INDEX IF EXISTS removes whichever variant is present
 -- so the UNIQUE index can be created unconditionally.
 --
--- Safety: external_id is populated only by comm.ingest (channel-ingested
--- messages).  comm.send dual-write does not set external_id, so no
--- reconciliation of pre-existing rows without external_id is needed and the
--- partial index (IS NOT NULL AND != '') creates cleanly with zero indexed
--- rows on databases that have never run the email channel.
+-- Duplicate-row reconciliation (safe on production databases):
+-- Before creating the UNIQUE index, locate all groups of notes that share the
+-- same (namespace, kind, external_id) and would violate the new constraint.
+-- For each such group the earliest row by rowid is the canonical record and
+-- keeps its external_id unchanged.  Every later duplicate has its external_id
+-- cleared via json_remove, which makes json_extract return NULL so the partial
+-- index WHERE clause excludes those rows.  The message body and all other
+-- properties are preserved; only the redundant dedup key is cleared.
+-- Rows that already have a NULL or empty external_id are unaffected.
+UPDATE notes
+SET properties = json_remove(properties, '$.external_id')
+WHERE rowid NOT IN (
+    SELECT MIN(rowid)
+    FROM notes
+    WHERE deleted_at IS NULL
+      AND json_extract(properties, '$.external_id') IS NOT NULL
+      AND json_extract(properties, '$.external_id') != ''
+    GROUP BY namespace, kind, json_extract(properties, '$.external_id')
+)
+  AND deleted_at IS NULL
+  AND json_extract(properties, '$.external_id') IS NOT NULL
+  AND json_extract(properties, '$.external_id') != '';
+
 DROP INDEX IF EXISTS idx_comm_message_external_id;
 CREATE UNIQUE INDEX idx_comm_message_external_id
     ON notes(namespace, kind, json_extract(properties, '$.external_id'))

--- a/crates/khive-db/sql/005-unique-comm-external-id.sql
+++ b/crates/khive-db/sql/005-unique-comm-external-id.sql
@@ -1,0 +1,19 @@
+-- V5: Promote idx_comm_message_external_id to a durable UNIQUE index.
+--
+-- The comm pack schema plan previously applied a non-unique index under this
+-- name.  On existing databases that index exists and IF NOT EXISTS would
+-- silently no-op, leaving the non-unique variant in place and uniqueness
+-- never enforced.  DROP INDEX IF EXISTS removes whichever variant is present
+-- so the UNIQUE index can be created unconditionally.
+--
+-- Safety: external_id is populated only by comm.ingest (channel-ingested
+-- messages).  comm.send dual-write does not set external_id, so no
+-- reconciliation of pre-existing rows without external_id is needed and the
+-- partial index (IS NOT NULL AND != '') creates cleanly with zero indexed
+-- rows on databases that have never run the email channel.
+DROP INDEX IF EXISTS idx_comm_message_external_id;
+CREATE UNIQUE INDEX idx_comm_message_external_id
+    ON notes(namespace, kind, json_extract(properties, '$.external_id'))
+    WHERE deleted_at IS NULL
+      AND json_extract(properties, '$.external_id') IS NOT NULL
+      AND json_extract(properties, '$.external_id') != '';

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -108,6 +108,8 @@ const V3_UP: &str = include_str!("../sql/003-backfill-domain-mirror-atoms.sql");
 
 const V4_UP: &str = include_str!("../sql/004-fts-consolidation.sql");
 
+const V5_UP: &str = include_str!("../sql/005-unique-comm-external-id.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -136,6 +138,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 4,
         name: "fts_consolidation",
         up: V4_UP,
+    },
+    VersionedMigration {
+        version: 5,
+        name: "unique_comm_message_external_id",
+        up: V5_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -27,14 +27,22 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
 fn fresh_db_migrates_to_latest() {
     let mut conn = open_memory();
     let version = run_migrations(&mut conn).expect("migrations should succeed");
-    assert_eq!(version, 4, "latest migration version");
+    let latest = MIGRATIONS.last().expect("at least one migration").version;
+    assert_eq!(
+        version, latest,
+        "run_migrations must reach the latest version"
+    );
 
     let recorded: i64 = conn
         .query_row("SELECT COUNT(*) FROM _schema_migrations", [], |row| {
             row.get(0)
         })
         .unwrap();
-    assert_eq!(recorded, 4);
+    assert_eq!(
+        recorded,
+        MIGRATIONS.len() as i64,
+        "ledger row count must equal the number of migrations"
+    );
 }
 
 #[test]
@@ -149,7 +157,161 @@ fn run_migrations_twice_is_idempotent() {
             row.get(0)
         })
         .unwrap();
-    assert_eq!(recorded, 4, "no duplicate migration rows on re-run");
+    assert_eq!(
+        recorded,
+        MIGRATIONS.len() as i64,
+        "no duplicate migration rows on re-run"
+    );
+}
+
+// ── V5: external_id unique index tests ──────────────────────────────────────
+
+fn index_exists(conn: &Connection, name: &str) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name=?1",
+        rusqlite::params![name],
+        |row| row.get(0),
+    )
+    .unwrap_or(false)
+}
+
+fn index_is_unique(conn: &Connection, name: &str) -> bool {
+    conn.query_row(
+        "SELECT \"unique\" FROM pragma_index_list('notes') WHERE name=?1",
+        rusqlite::params![name],
+        |row| {
+            let v: i64 = row.get(0)?;
+            Ok(v != 0)
+        },
+    )
+    .unwrap_or(false)
+}
+
+#[test]
+fn v5_creates_unique_external_id_index() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    assert!(
+        index_exists(&conn, "idx_comm_message_external_id"),
+        "V5 must create idx_comm_message_external_id"
+    );
+    assert!(
+        index_is_unique(&conn, "idx_comm_message_external_id"),
+        "idx_comm_message_external_id must be UNIQUE"
+    );
+}
+
+#[test]
+fn v5_duplicate_external_id_insert_rejected() {
+    let mut conn = open_memory();
+    run_migrations(&mut conn).expect("migrations should succeed");
+    let now = chrono::Utc::now().timestamp_micros();
+    // Insert a note with external_id
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, status, content, properties, created_at, updated_at) \
+         VALUES ('id-ext-1', 'local', 'message', 'active', 'body', \
+                 json_object('external_id', 'imap:host:1:1'), ?1, ?1)",
+        rusqlite::params![now],
+    )
+    .expect("first insert");
+    // A second note with the same external_id must be rejected by the unique index.
+    let dup = conn.execute(
+        "INSERT INTO notes (id, namespace, kind, status, content, properties, created_at, updated_at) \
+         VALUES ('id-ext-2', 'local', 'message', 'active', 'body2', \
+                 json_object('external_id', 'imap:host:1:1'), ?1, ?1)",
+        rusqlite::params![now],
+    );
+    assert!(dup.is_err(), "duplicate external_id must be rejected");
+}
+
+#[test]
+fn v5_upgrade_from_duplicate_rows_succeeds() {
+    // Simulate a V4-state database that already contains duplicate external_id rows.
+    // Apply only migrations up to V4, insert duplicates, then run V5 and verify:
+    //   - V5 migration completes without error
+    //   - The canonical (earliest) row keeps its external_id
+    //   - Later duplicate rows survive with external_id cleared to NULL
+    let mut conn = open_memory();
+
+    // Apply V1..V4 only.
+    conn.execute_batch(MIGRATION_TRACKING_TABLE).unwrap();
+    let now = chrono::Utc::now().timestamp_micros();
+    for migration in MIGRATIONS.iter().filter(|m| m.version <= 4) {
+        let tx = conn.transaction().unwrap();
+        tx.execute_batch(migration.up).unwrap();
+        tx.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+            rusqlite::params![migration.version, migration.name, now],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Insert two notes sharing the same external_id (canonical + duplicate).
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, status, content, properties, created_at, updated_at) \
+         VALUES ('canonical-row', 'local', 'message', 'active', 'first', \
+                 json_object('external_id', 'imap:h:9:9'), ?1, ?1)",
+        rusqlite::params![now],
+    )
+    .expect("canonical row");
+    conn.execute(
+        "INSERT INTO notes (id, namespace, kind, status, content, properties, created_at, updated_at) \
+         VALUES ('dup-row', 'local', 'message', 'active', 'second', \
+                 json_object('external_id', 'imap:h:9:9'), ?1, ?1)",
+        rusqlite::params![now],
+    )
+    .expect("duplicate row (allowed before V5 unique index)");
+
+    // Now run V5.
+    let tx = conn.transaction().unwrap();
+    let v5 = MIGRATIONS.iter().find(|m| m.version == 5).unwrap();
+    tx.execute_batch(v5.up)
+        .expect("V5 migration must succeed on a DB with duplicate external_ids");
+    tx.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        rusqlite::params![v5.version, v5.name, now],
+    )
+    .unwrap();
+    tx.commit().unwrap();
+
+    // Canonical row keeps its external_id.
+    let canonical_ext: Option<String> = conn
+        .query_row(
+            "SELECT json_extract(properties, '$.external_id') FROM notes WHERE id='canonical-row'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        canonical_ext.as_deref(),
+        Some("imap:h:9:9"),
+        "canonical row must retain its external_id"
+    );
+
+    // Duplicate row survives but with external_id cleared.
+    let dup_content: String = conn
+        .query_row("SELECT content FROM notes WHERE id='dup-row'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        dup_content, "second",
+        "duplicate row must survive (not deleted)"
+    );
+
+    let dup_ext: Option<String> = conn
+        .query_row(
+            "SELECT json_extract(properties, '$.external_id') FROM notes WHERE id='dup-row'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        dup_ext.is_none(),
+        "duplicate row must have external_id cleared (got {:?})",
+        dup_ext
+    );
 }
 
 // ── _embedding_models.dim u32 range tests ───────────────────────────────────

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -351,6 +351,15 @@ impl NoteStore for SqlNoteStore {
             .as_ref()
             .map(|v| serde_json::to_string(v).unwrap_or_default());
 
+        // Extract external_id (if any) for dedup verification after a zero-row insert.
+        let ext_id_opt: Option<String> = note
+            .properties
+            .as_ref()
+            .and_then(|v| v.get("external_id"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
         self.with_writer("try_insert_note", move |conn| {
             let rows = conn.execute(
                 "INSERT OR IGNORE INTO notes \
@@ -373,7 +382,41 @@ impl NoteStore for SqlNoteStore {
                     note.deleted_at,
                 ],
             )?;
-            Ok(rows > 0)
+
+            if rows > 0 {
+                return Ok(true);
+            }
+
+            // Zero rows: the INSERT was silently skipped by OR IGNORE.
+            // Only treat this as a dedup hit when a live note with the same
+            // non-empty external_id already exists in this namespace and kind.
+            // Any other ignored constraint (e.g. a PRIMARY KEY collision) must
+            // surface as an error rather than being misreported as a duplicate.
+            if let Some(ref ext_id) = ext_id_opt {
+                let is_dedup: bool = conn.query_row(
+                    "SELECT COUNT(*) > 0 FROM notes \
+                     WHERE namespace = ?1 \
+                       AND kind = ?2 \
+                       AND json_extract(properties, '$.external_id') = ?3 \
+                       AND deleted_at IS NULL",
+                    rusqlite::params![namespace, kind_str, ext_id],
+                    |row| row.get(0),
+                )?;
+                if is_dedup {
+                    return Ok(false);
+                }
+            }
+
+            // The INSERT was dropped for a reason other than an external_id
+            // collision.  Surface it as a constraint error.
+            Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+                Some(
+                    "try_insert_note: INSERT ignored for a constraint other than \
+                     external_id dedup; not masking as deduplication"
+                        .to_string(),
+                ),
+            ))
         })
         .await
     }

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -341,6 +341,43 @@ impl NoteStore for SqlNoteStore {
         .await
     }
 
+    async fn try_insert_note(&self, note: Note) -> Result<bool, StorageError> {
+        let namespace = note.namespace.clone();
+        let id_str = note.id.to_string();
+        let kind_str = note.kind.to_string();
+        let status_str = note.status.clone();
+        let properties_str = note
+            .properties
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+        self.with_writer("try_insert_note", move |conn| {
+            let rows = conn.execute(
+                "INSERT OR IGNORE INTO notes \
+                 (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+                  properties, created_at, updated_at, deleted_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                rusqlite::params![
+                    id_str,
+                    namespace,
+                    kind_str,
+                    status_str,
+                    note.name,
+                    note.content,
+                    note.salience,
+                    note.decay_factor,
+                    note.expires_at,
+                    properties_str,
+                    note.created_at,
+                    note.updated_at,
+                    note.deleted_at,
+                ],
+            )?;
+            Ok(rows > 0)
+        })
+        .await
+    }
+
     async fn upsert_notes(&self, notes: Vec<Note>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = notes.len() as u64;
 

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -357,3 +357,31 @@ async fn test_filtered_invalid_json_path_rejected() {
         "invalid json_path must be rejected before SQL"
     );
 }
+
+// ── try_insert_note dedup-vs-error discrimination ───────────────────────────
+
+/// A PRIMARY KEY collision on a note without external_id must surface as a
+/// StorageError, not be silently misreported as a dedup hit.
+#[tokio::test]
+async fn test_try_insert_note_pk_collision_returns_error_not_dedup() {
+    let store = setup_memory_store();
+
+    let mut note = make_note("ns1", "message", "original content");
+    let fixed_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap();
+    note.id = fixed_id;
+    // No external_id on this note.
+
+    let inserted = store
+        .try_insert_note(note.clone())
+        .await
+        .expect("first insert must succeed");
+    assert!(inserted, "first insert must return true");
+
+    // Second attempt with the same UUID triggers a PK collision.
+    // With no external_id to verify against, this must not be reported as dedup.
+    let result = store.try_insert_note(note).await;
+    assert!(
+        result.is_err(),
+        "PK collision without external_id must return StorageError, not Ok(false)"
+    );
+}

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -36,12 +36,18 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }
 sha2 = { workspace = true }
+chrono = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
+khive-channel = { version = "0.2.11", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.2.11", path = "../khive-channel-email", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
 # Bench-only — never enabled in release/publish builds.
 bench-embedder = ["lattice-embed"]
+# channel-email: enable the SMTP/IMAP email polling loop.
+# Requires KHIVE_EMAIL_* environment variables at runtime; does nothing when unset.
+channel-email = ["khive-channel", "khive-channel-email"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -37,6 +37,33 @@ pub struct MultiBackendRegistry {
 pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()> {
     let server = build_server(&args)?;
 
+    // Spawn the email channel polling loop when the feature is enabled and the
+    // required environment variables are present. The loop is non-fatal: if
+    // configuration is absent it logs a warning and returns without panicking.
+    #[cfg(feature = "channel-email")]
+    {
+        use khive_channel::ChannelRegistry;
+        use khive_channel_email::EmailChannel;
+        use std::sync::Arc;
+
+        match EmailChannel::from_env() {
+            Ok(email_ch) => {
+                let mut ch_registry = ChannelRegistry::new();
+                ch_registry.register(Arc::new(email_ch));
+                let ch_registry = Arc::new(ch_registry);
+                let verb_reg = server.verb_registry_clone();
+                tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg));
+                tracing::info!("email channel polling loop started");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "channel-email feature is enabled but configuration is incomplete: {e}; \
+                     email polling is disabled"
+                );
+            }
+        }
+    }
+
     #[cfg(unix)]
     if args.daemon {
         khive_runtime::daemon::run_daemon(server).await?;
@@ -60,6 +87,57 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
         bind: args.bind.clone(),
     };
     transport.serve(server, &opts).await
+}
+
+/// Background task that polls all registered channels every 5 seconds and
+/// ingests new inbound messages via `comm.ingest`.
+///
+/// Only compiled when the `channel-email` feature is enabled.
+#[cfg(feature = "channel-email")]
+async fn channel_poll_loop(
+    channels: std::sync::Arc<khive_channel::ChannelRegistry>,
+    registry: khive_runtime::VerbRegistry,
+) {
+    use chrono::Utc;
+    use serde_json::json;
+
+    let mut last_poll = Utc::now();
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let since = last_poll;
+        last_poll = Utc::now();
+
+        for (kind, channel) in channels.iter() {
+            match channel.poll(since).await {
+                Ok(envelopes) => {
+                    for env in envelopes {
+                        let params = json!({
+                            "namespace": "local",
+                            "from": env.from,
+                            "to": env.to,
+                            "content": env.content,
+                            "subject": env.subject,
+                            "channel_kind": kind,
+                            "external_id": env.external_id,
+                            "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
+                            "correlation_external_id": env.correlation_external_id,
+                        });
+                        if let Err(e) = registry.dispatch("comm.ingest", params).await {
+                            tracing::warn!(
+                                channel = kind,
+                                "comm.ingest failed for inbound message: {e}"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(channel = kind, "channel poll failed: {e}");
+                }
+            }
+        }
+    }
 }
 
 /// Serve a pre-built server (ADR-029 Phase 2 boot path).

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -52,7 +52,8 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
                 ch_registry.register(Arc::new(email_ch));
                 let ch_registry = Arc::new(ch_registry);
                 let verb_reg = server.verb_registry_clone();
-                tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg));
+                let ingest_ns = ingest_namespace_from_env();
+                tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg, ingest_ns));
                 tracing::info!("email channel polling loop started");
             }
             Err(e) => {
@@ -89,6 +90,19 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
     transport.serve(server, &opts).await
 }
 
+/// Resolve the target namespace for ingested channel messages.
+///
+/// Reads `KHIVE_EMAIL_INGEST_NAMESPACE`; falls back to `"local"` when the
+/// variable is unset or blank. Called once at server startup before the poll
+/// loop is spawned.
+#[cfg(feature = "channel-email")]
+fn ingest_namespace_from_env() -> String {
+    std::env::var("KHIVE_EMAIL_INGEST_NAMESPACE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "local".to_string())
+}
+
 /// Background task that polls all registered channels every 5 seconds and
 /// ingests new inbound messages via `comm.ingest`.
 ///
@@ -97,6 +111,7 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 async fn channel_poll_loop(
     channels: std::sync::Arc<khive_channel::ChannelRegistry>,
     registry: khive_runtime::VerbRegistry,
+    ingest_namespace: String,
 ) {
     use chrono::Utc;
     use serde_json::json;
@@ -114,7 +129,7 @@ async fn channel_poll_loop(
                 Ok(envelopes) => {
                     for env in envelopes {
                         let params = json!({
-                            "namespace": "local",
+                            "namespace": ingest_namespace,
                             "from": env.from,
                             "to": env.to,
                             "content": env.content,
@@ -1809,6 +1824,38 @@ brain_profile = "project-profile"
             "second.db MUST NOT contain MainOnlyEntity (kg is pinned to main.db); \
              got count={second_entity_count}"
         );
+    }
+
+    // --- ingest_namespace_from_env (Fix 4: namespace env var) ---
+
+    #[cfg(feature = "channel-email")]
+    mod ingest_ns_tests {
+        use super::*;
+
+        #[test]
+        #[serial]
+        fn ingest_namespace_defaults_to_local() {
+            std::env::remove_var("KHIVE_EMAIL_INGEST_NAMESPACE");
+            assert_eq!(ingest_namespace_from_env(), "local");
+        }
+
+        #[test]
+        #[serial]
+        fn ingest_namespace_reads_env_var() {
+            std::env::set_var("KHIVE_EMAIL_INGEST_NAMESPACE", "lambda:mybot");
+            let ns = ingest_namespace_from_env();
+            std::env::remove_var("KHIVE_EMAIL_INGEST_NAMESPACE");
+            assert_eq!(ns, "lambda:mybot");
+        }
+
+        #[test]
+        #[serial]
+        fn ingest_namespace_ignores_blank_env_var() {
+            std::env::set_var("KHIVE_EMAIL_INGEST_NAMESPACE", "  ");
+            let ns = ingest_namespace_from_env();
+            std::env::remove_var("KHIVE_EMAIL_INGEST_NAMESPACE");
+            assert_eq!(ns, "local", "blank env var must fall back to default");
+        }
     }
 
     // --- should_warn_unattributed predicate ---

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -53,8 +53,15 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
                 let ch_registry = Arc::new(ch_registry);
                 let verb_reg = server.verb_registry_clone();
                 let ingest_ns = ingest_namespace_from_env();
-                tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg, ingest_ns));
-                tracing::info!("email channel polling loop started");
+                if preflight_ingest_namespace(&ingest_ns, &verb_reg) {
+                    tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg, ingest_ns));
+                    tracing::info!("email channel polling loop started");
+                } else {
+                    tracing::error!(
+                        namespace = %ingest_ns,
+                        "email channel polling loop NOT started: ingest namespace authorization failed (fail-closed)"
+                    );
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -101,6 +108,37 @@ fn ingest_namespace_from_env() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "local".to_string())
+}
+
+/// Validate and authorize the ingest namespace before spawning the poll loop.
+///
+/// Returns `true` when `ns_str` parses to a valid namespace AND the registry
+/// gate permits it.  Returns `false` on any parse failure or authorization
+/// denial, after logging the reason.  The caller must not spawn the poll loop
+/// when this returns `false` (fail-closed, ADR-056 §6).
+#[cfg(feature = "channel-email")]
+fn preflight_ingest_namespace(ns_str: &str, registry: &khive_runtime::VerbRegistry) -> bool {
+    match khive_runtime::Namespace::parse(ns_str) {
+        Ok(ns) => match registry.authorize_namespace(ns) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    namespace = %ns_str,
+                    error = %e,
+                    "ingest namespace authorization denied; email polling will not start"
+                );
+                false
+            }
+        },
+        Err(e) => {
+            tracing::error!(
+                namespace = %ns_str,
+                error = %e,
+                "invalid ingest namespace string; email polling will not start"
+            );
+            false
+        }
+    }
 }
 
 /// Background task that polls all registered channels every 5 seconds and
@@ -1855,6 +1893,56 @@ brain_profile = "project-profile"
             let ns = ingest_namespace_from_env();
             std::env::remove_var("KHIVE_EMAIL_INGEST_NAMESPACE");
             assert_eq!(ns, "local", "blank env var must fall back to default");
+        }
+
+        #[test]
+        fn preflight_fails_on_invalid_namespace_string() {
+            let registry = khive_runtime::VerbRegistryBuilder::new()
+                .build()
+                .expect("build empty registry");
+            // An empty string is not a valid namespace; parse must fail.
+            assert!(
+                !preflight_ingest_namespace("", &registry),
+                "preflight must return false for an invalid namespace string"
+            );
+        }
+
+        #[test]
+        fn preflight_fails_when_gate_denies_namespace() {
+            use khive_runtime::{Gate, GateDecision, GateError, GateRequest};
+            use std::fmt;
+
+            #[derive(Debug)]
+            struct AlwaysDenyGate;
+            impl fmt::Display for AlwaysDenyGate {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(f, "AlwaysDenyGate")
+                }
+            }
+            impl Gate for AlwaysDenyGate {
+                fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                    Ok(GateDecision::deny("test: always deny"))
+                }
+            }
+
+            let mut builder = khive_runtime::VerbRegistryBuilder::new();
+            builder.with_gate(std::sync::Arc::new(AlwaysDenyGate));
+            let registry = builder.build().expect("build registry with deny gate");
+            assert!(
+                !preflight_ingest_namespace("local", &registry),
+                "preflight must return false when the gate denies the namespace"
+            );
+        }
+
+        #[test]
+        fn preflight_succeeds_with_allow_gate_and_valid_namespace() {
+            let registry = khive_runtime::VerbRegistryBuilder::new()
+                .build()
+                .expect("build registry with default allow-all gate");
+            assert!(
+                preflight_ingest_namespace("local", &registry),
+                "preflight must return true for a valid namespace when the gate allows"
+            );
         }
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -53,10 +53,17 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
                 let ch_registry = Arc::new(ch_registry);
                 let verb_reg = server.verb_registry_clone();
                 let ingest_ns = ingest_namespace_from_env();
-                if preflight_ingest_namespace(&ingest_ns, &verb_reg) {
-                    tokio::task::spawn(channel_poll_loop(ch_registry, verb_reg, ingest_ns));
+                let ingest_ns_clone = ingest_ns.clone();
+                let verb_reg_clone = verb_reg.clone();
+                let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
+                    tokio::task::spawn(channel_poll_loop(
+                        ch_registry,
+                        verb_reg_clone,
+                        ingest_ns_clone,
+                    ));
                     tracing::info!("email channel polling loop started");
-                } else {
+                });
+                if !spawned {
                     tracing::error!(
                         namespace = %ingest_ns,
                         "email channel polling loop NOT started: ingest namespace authorization failed (fail-closed)"
@@ -108,6 +115,25 @@ fn ingest_namespace_from_env() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "local".to_string())
+}
+
+/// Run `on_authorized` only when the ingest namespace passes the preflight check.
+///
+/// Returns `true` when the closure was called (preflight passed), `false`
+/// otherwise.  Tests can inject a counting closure to verify the loop is not
+/// started when preflight fails (ADR-056 §6 fail-closed contract).
+#[cfg(feature = "channel-email")]
+fn run_if_authorized(
+    ns_str: &str,
+    registry: &khive_runtime::VerbRegistry,
+    on_authorized: impl FnOnce(),
+) -> bool {
+    if preflight_ingest_namespace(ns_str, registry) {
+        on_authorized();
+        true
+    } else {
+        false
+    }
 }
 
 /// Validate and authorize the ingest namespace before spawning the poll loop.
@@ -1942,6 +1968,66 @@ brain_profile = "project-profile"
             assert!(
                 preflight_ingest_namespace("local", &registry),
                 "preflight must return true for a valid namespace when the gate allows"
+            );
+        }
+
+        // --- spawn-seam tests: verify the loop is NOT started on preflight failure ---
+
+        #[test]
+        fn spawn_not_called_when_gate_denies() {
+            use khive_runtime::{Gate, GateDecision, GateError, GateRequest};
+            use std::fmt;
+
+            #[derive(Debug)]
+            struct AlwaysDenyGate2;
+            impl fmt::Display for AlwaysDenyGate2 {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(f, "AlwaysDenyGate2")
+                }
+            }
+            impl Gate for AlwaysDenyGate2 {
+                fn check(&self, _req: &GateRequest) -> Result<GateDecision, GateError> {
+                    Ok(GateDecision::deny("spawn seam test: always deny"))
+                }
+            }
+
+            let mut builder = khive_runtime::VerbRegistryBuilder::new();
+            builder.with_gate(std::sync::Arc::new(AlwaysDenyGate2));
+            let registry = builder.build().expect("build registry with deny gate");
+
+            let mut spawn_count = 0usize;
+            let authorized = run_if_authorized("local", &registry, || {
+                spawn_count += 1;
+            });
+
+            assert!(
+                !authorized,
+                "run_if_authorized must return false when gate denies"
+            );
+            assert_eq!(
+                spawn_count, 0,
+                "spawn must not be called when preflight fails"
+            );
+        }
+
+        #[test]
+        fn spawn_not_called_when_namespace_invalid() {
+            let registry = khive_runtime::VerbRegistryBuilder::new()
+                .build()
+                .expect("build empty registry");
+
+            let mut spawn_count = 0usize;
+            let authorized = run_if_authorized("", &registry, || {
+                spawn_count += 1;
+            });
+
+            assert!(
+                !authorized,
+                "run_if_authorized must return false for invalid namespace"
+            );
+            assert_eq!(
+                spawn_count, 0,
+                "spawn must not be called when namespace is invalid"
             );
         }
     }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -392,6 +392,15 @@ impl KhiveMcpServer {
         self
     }
 
+    /// Clone the verb registry for use by background tasks (e.g. channel polling loops).
+    ///
+    /// `VerbRegistry` is internally `Arc`-wrapped so this clone is cheap. The returned
+    /// registry shares the same packs and dispatch state as the server.
+    #[cfg(feature = "channel-email")]
+    pub(crate) fn verb_registry_clone(&self) -> VerbRegistry {
+        self.registry.clone()
+    }
+
     /// Route a `link` or `search` verb through the coordinator when in multi-backend mode.
     ///
     /// Returns `Some(result)` when the coordinator handled the op (caller should skip

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -541,23 +541,13 @@ pub(crate) async fn handle_thread(
 /// `khive-mcp`). It is the authoritative write path for all channel-delivered
 /// messages; the polling loop must not bypass it.
 ///
-/// Deduplication: when `external_id` is supplied and a message note with the
-/// same `external_id` already exists in the namespace, the call returns
-/// successfully without creating a duplicate. The check is best-effort
-/// (no database-level unique constraint) and idempotent.
-/// Return `true` if the error is a SQLite UNIQUE constraint violation.
-///
-/// Used to detect duplicate `external_id` collisions on the
-/// `idx_comm_message_external_id` partial unique index without taking a
-/// direct dependency on `rusqlite` in this crate.
-fn is_unique_constraint_violation(e: &RuntimeError) -> bool {
-    e.to_string().contains("UNIQUE constraint")
-}
-
-///
 /// Thread resolution: when `correlation_external_id` is supplied, the handler
 /// queries for an existing message note whose `external_id` matches that value,
 /// reads its `thread_id`, and attaches the new note to the same thread.
+///
+/// Deduplication: when `external_id` is supplied, `try_create_note` uses
+/// `INSERT OR IGNORE` against the durable unique index on `external_id`.  A
+/// duplicate returns `Ok(None)` without error; the call is an idempotent no-op.
 pub(crate) async fn handle_ingest(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -585,39 +575,6 @@ pub(crate) async fn handle_ingest(
 
     let ns = token.namespace().as_str();
     let store = runtime.notes(token)?;
-
-    // Deduplication: check for an existing message with the same external_id.
-    if let Some(ref ext_id) = p.external_id {
-        if !ext_id.is_empty() {
-            let dedup_filter = NoteFilter {
-                kind: Some("message".to_string()),
-                property_filters: vec![PropertyFilter {
-                    json_path: "$.external_id".to_string(),
-                    op: FilterOp::Eq,
-                    value: SqlValue::Text(ext_id.clone()),
-                }],
-                ..Default::default()
-            };
-            let existing = store
-                .query_notes_filtered(
-                    ns,
-                    &dedup_filter,
-                    PageRequest {
-                        limit: 1,
-                        offset: 0,
-                    },
-                )
-                .await?;
-            if !existing.items.is_empty() {
-                tracing::debug!(external_id = %ext_id, "comm.ingest: duplicate message skipped");
-                return Ok(json!({
-                    "ok": true,
-                    "deduplicated": true,
-                    "external_id": ext_id,
-                }));
-            }
-        }
-    }
 
     // Thread resolution: if correlation_external_id is present, find the message
     // it refers to and extract its internal thread_id.
@@ -694,27 +651,27 @@ pub(crate) async fn handle_ingest(
     }
 
     let note = match runtime
-        .create_note(
+        .try_create_note(
             token,
             "message",
             p.subject.as_deref(),
             p.content.trim(),
-            None,
             Some(props),
-            Vec::new(),
         )
-        .await
+        .await?
     {
-        Ok(n) => n,
-        Err(e) if is_unique_constraint_violation(&e) => {
-            tracing::debug!("comm.ingest: duplicate blocked by unique index constraint");
+        Some(n) => n,
+        None => {
+            tracing::debug!(
+                external_id = ?p.external_id,
+                "comm.ingest: duplicate message skipped"
+            );
             return Ok(json!({
                 "ok": true,
                 "deduplicated": true,
                 "external_id": p.external_id,
             }));
         }
-        Err(e) => return Err(e),
     };
 
     Ok(json!({

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -545,6 +545,15 @@ pub(crate) async fn handle_thread(
 /// same `external_id` already exists in the namespace, the call returns
 /// successfully without creating a duplicate. The check is best-effort
 /// (no database-level unique constraint) and idempotent.
+/// Return `true` if the error is a SQLite UNIQUE constraint violation.
+///
+/// Used to detect duplicate `external_id` collisions on the
+/// `idx_comm_message_external_id` partial unique index without taking a
+/// direct dependency on `rusqlite` in this crate.
+fn is_unique_constraint_violation(e: &RuntimeError) -> bool {
+    e.to_string().contains("UNIQUE constraint")
+}
+
 ///
 /// Thread resolution: when `correlation_external_id` is supplied, the handler
 /// queries for an existing message note whose `external_id` matches that value,
@@ -684,7 +693,7 @@ pub(crate) async fn handle_ingest(
         props["channel_kind"] = json!(kind);
     }
 
-    let note = runtime
+    let note = match runtime
         .create_note(
             token,
             "message",
@@ -694,7 +703,19 @@ pub(crate) async fn handle_ingest(
             Some(props),
             Vec::new(),
         )
-        .await?;
+        .await
+    {
+        Ok(n) => n,
+        Err(e) if is_unique_constraint_violation(&e) => {
+            tracing::debug!("comm.ingest: duplicate blocked by unique index constraint");
+            return Ok(json!({
+                "ok": true,
+                "deduplicated": true,
+                "external_id": p.external_id,
+            }));
+        }
+        Err(e) => return Err(e),
+    };
 
     Ok(json!({
         "id": short_id(note.id),

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -546,8 +546,10 @@ pub(crate) async fn handle_thread(
 /// reads its `thread_id`, and attaches the new note to the same thread.
 ///
 /// Deduplication: when `external_id` is supplied, `try_create_note` uses
-/// `INSERT OR IGNORE` against the durable unique index on `external_id`.  A
-/// duplicate returns `Ok(None)` without error; the call is an idempotent no-op.
+/// a verify-after-insert check on the durable unique index on `external_id`.
+/// A confirmed duplicate returns `Ok(None)` without error; only an
+/// external_id collision is treated as dedup — other constraint violations
+/// surface as errors.
 pub(crate) async fn handle_ingest(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -548,7 +548,7 @@ pub(crate) async fn handle_thread(
 /// Deduplication: when `external_id` is supplied, `try_create_note` uses
 /// a verify-after-insert check on the durable unique index on `external_id`.
 /// A confirmed duplicate returns `Ok(None)` without error; only an
-/// external_id collision is treated as dedup — other constraint violations
+/// external_id collision is treated as dedup; other constraint violations
 /// surface as errors.
 pub(crate) async fn handle_ingest(
     runtime: &KhiveRuntime,

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -13,7 +13,9 @@ use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
 use khive_storage::types::{PageRequest, SqlValue};
 
 use crate::message::{dual_write_message, note_to_message_json, resolve_id, short_id};
-use crate::params::{deser, InboxParams, ReadParams, ReplyParams, SendParams, ThreadParams};
+use crate::params::{
+    deser, InboxParams, IngestParams, ReadParams, ReplyParams, SendParams, ThreadParams,
+};
 
 /// Validate an actor label: non-empty, no control characters, ≤255 bytes (ADR-057 Q1 loose).
 fn validate_actor_label(label: &str, field: &str) -> Result<(), RuntimeError> {
@@ -529,5 +531,176 @@ pub(crate) async fn handle_thread(
         "thread_id": canonical_thread_id,
         "count": count,
         "messages": messages,
+    }))
+}
+
+/// `ingest` — write a single inbound message note from a channel adapter.
+///
+/// This is a `Visibility::Subhandler` verb: it is not accessible via the MCP
+/// wire and is only callable from within the process (e.g. the polling loop in
+/// `khive-mcp`). It is the authoritative write path for all channel-delivered
+/// messages; the polling loop must not bypass it.
+///
+/// Deduplication: when `external_id` is supplied and a message note with the
+/// same `external_id` already exists in the namespace, the call returns
+/// successfully without creating a duplicate. The check is best-effort
+/// (no database-level unique constraint) and idempotent.
+///
+/// Thread resolution: when `correlation_external_id` is supplied, the handler
+/// queries for an existing message note whose `external_id` matches that value,
+/// reads its `thread_id`, and attaches the new note to the same thread.
+pub(crate) async fn handle_ingest(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    // Note: IngestParams does not use deny_unknown_fields.
+    let p: IngestParams = serde_json::from_value(params)
+        .map_err(|e| RuntimeError::InvalidInput(format!("ingest: bad params: {e}")))?;
+
+    if p.from.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "ingest: `from` must not be empty".into(),
+        ));
+    }
+    if p.to.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "ingest: `to` must not be empty".into(),
+        ));
+    }
+    if p.content.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "ingest: `content` must not be empty".into(),
+        ));
+    }
+
+    let ns = token.namespace().as_str();
+    let store = runtime.notes(token)?;
+
+    // Deduplication: check for an existing message with the same external_id.
+    if let Some(ref ext_id) = p.external_id {
+        if !ext_id.is_empty() {
+            let dedup_filter = NoteFilter {
+                kind: Some("message".to_string()),
+                property_filters: vec![PropertyFilter {
+                    json_path: "$.external_id".to_string(),
+                    op: FilterOp::Eq,
+                    value: SqlValue::Text(ext_id.clone()),
+                }],
+                ..Default::default()
+            };
+            let existing = store
+                .query_notes_filtered(
+                    ns,
+                    &dedup_filter,
+                    PageRequest {
+                        limit: 1,
+                        offset: 0,
+                    },
+                )
+                .await?;
+            if !existing.items.is_empty() {
+                tracing::debug!(external_id = %ext_id, "comm.ingest: duplicate message skipped");
+                return Ok(json!({
+                    "ok": true,
+                    "deduplicated": true,
+                    "external_id": ext_id,
+                }));
+            }
+        }
+    }
+
+    // Thread resolution: if correlation_external_id is present, find the message
+    // it refers to and extract its internal thread_id.
+    let resolved_thread_id: Option<String> = if let Some(ref corr) = p.correlation_external_id {
+        if !corr.is_empty() {
+            let corr_filter = NoteFilter {
+                kind: Some("message".to_string()),
+                property_filters: vec![PropertyFilter {
+                    json_path: "$.external_id".to_string(),
+                    op: FilterOp::Eq,
+                    value: SqlValue::Text(corr.clone()),
+                }],
+                ..Default::default()
+            };
+            let corr_page = store
+                .query_notes_filtered(
+                    ns,
+                    &corr_filter,
+                    PageRequest {
+                        limit: 1,
+                        offset: 0,
+                    },
+                )
+                .await?;
+            corr_page
+                .items
+                .first()
+                .and_then(|n| n.properties.as_ref())
+                .and_then(|props| props.get("thread_id"))
+                .and_then(Value::as_str)
+                .filter(|s| s.parse::<Uuid>().is_ok())
+                .map(|s| s.to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Determine thread_id: caller-supplied > resolved from correlation > new root.
+    let thread_id: String = p
+        .thread_id
+        .as_deref()
+        .filter(|s| s.parse::<Uuid>().is_ok())
+        .map(|s| s.to_string())
+        .or(resolved_thread_id)
+        .unwrap_or_else(|| Uuid::new_v4().as_hyphenated().to_string());
+
+    let sent_at = p.sent_at.as_deref().unwrap_or("").to_string();
+    let sent_at_value = if sent_at.is_empty() {
+        json!(Utc::now().to_rfc3339())
+    } else {
+        json!(sent_at)
+    };
+
+    let mut props = json!({
+        "from": p.from.trim(),
+        "to": p.to.trim(),
+        "from_actor": p.from.trim(),
+        "to_actor": p.to.trim(),
+        "direction": "inbound",
+        "read": false,
+        "thread_id": thread_id,
+        "sent_at": sent_at_value,
+    });
+    if let Some(ref s) = p.subject {
+        props["subject"] = json!(s);
+    }
+    if let Some(ref ext) = p.external_id {
+        props["external_id"] = json!(ext);
+    }
+    if let Some(ref kind) = p.channel_kind {
+        props["channel_kind"] = json!(kind);
+    }
+
+    let note = runtime
+        .create_note(
+            token,
+            "message",
+            p.subject.as_deref(),
+            p.content.trim(),
+            None,
+            Some(props),
+            Vec::new(),
+        )
+        .await?;
+
+    Ok(json!({
+        "id": short_id(note.id),
+        "full_id": note.id.as_hyphenated().to_string(),
+        "thread_id": thread_id,
+        "external_id": p.external_id,
+        "deduplicated": false,
     }))
 }

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -90,6 +90,7 @@ impl PackRuntime for CommPack {
             "comm.read" => handlers::handle_read(self.runtime(), token, params).await,
             "comm.reply" => handlers::handle_reply(self.runtime(), token, params).await,
             "comm.thread" => handlers::handle_thread(self.runtime(), token, params).await,
+            "comm.ingest" => handlers::handle_ingest(self.runtime(), token, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "comm pack does not handle verb {verb:?}"
             ))),
@@ -100,7 +101,7 @@ impl PackRuntime for CommPack {
 #[cfg(test)]
 mod help_tests {
     use super::*;
-    use khive_types::{Pack, VerbCategory};
+    use khive_types::{Pack, VerbCategory, Visibility};
 
     fn find_handler(name: &str) -> &'static HandlerDef {
         CommPack::HANDLERS
@@ -237,5 +238,77 @@ mod help_tests {
             VerbCategory::Assertive,
             "comm.thread must be Assertive"
         );
+        assert_eq!(
+            h("comm.ingest").category,
+            VerbCategory::Declaration,
+            "comm.ingest must be Declaration"
+        );
+    }
+
+    #[test]
+    fn ingest_is_subhandler_not_visible_on_wire() {
+        let h = CommPack::HANDLERS
+            .iter()
+            .find(|h| h.name == "comm.ingest")
+            .expect("comm.ingest must be declared");
+        assert_eq!(
+            h.visibility,
+            Visibility::Subhandler,
+            "comm.ingest must be Visibility::Subhandler — not callable on MCP wire"
+        );
+    }
+
+    #[test]
+    fn ingest_declares_required_namespace_param() {
+        let h = CommPack::HANDLERS
+            .iter()
+            .find(|h| h.name == "comm.ingest")
+            .expect("comm.ingest must be declared");
+        let ns_param = h
+            .params
+            .iter()
+            .find(|p| p.name == "namespace")
+            .expect("comm.ingest must declare 'namespace' param");
+        assert!(
+            ns_param.required,
+            "comm.ingest namespace param must be required so dispatch forwards it to the handler"
+        );
+    }
+
+    #[test]
+    fn ingest_declares_dedup_and_correlation_params() {
+        let h = CommPack::HANDLERS
+            .iter()
+            .find(|h| h.name == "comm.ingest")
+            .expect("comm.ingest must be declared");
+        assert!(
+            h.params.iter().any(|p| p.name == "external_id"),
+            "comm.ingest must declare external_id param for deduplication"
+        );
+        assert!(
+            h.params.iter().any(|p| p.name == "correlation_external_id"),
+            "comm.ingest must declare correlation_external_id param for thread resolution"
+        );
+    }
+
+    #[test]
+    fn ingest_declares_required_content_params() {
+        let h = CommPack::HANDLERS
+            .iter()
+            .find(|h| h.name == "comm.ingest")
+            .expect("comm.ingest must be declared");
+        for required_name in &["from", "to", "content"] {
+            let p = h
+                .params
+                .iter()
+                .find(|p| p.name == *required_name)
+                .unwrap_or_else(|| {
+                    panic!("comm.ingest must declare required param '{required_name}'")
+                });
+            assert!(
+                p.required,
+                "comm.ingest param '{required_name}' must be required"
+            );
+        }
     }
 }

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -50,6 +50,41 @@ pub(crate) struct ThreadParams {
     pub limit: Option<u32>,
 }
 
+/// Parameters for `comm.ingest` — ingests a single inbound message from a channel adapter.
+///
+/// `deny_unknown_fields` is intentionally absent: the polling loop may pass extra fields
+/// (including the `namespace` routing key consumed by the dispatch layer) that future
+/// handler versions can extend without breaking existing deployments.
+///
+/// The `namespace` key is consumed by `VerbRegistry::dispatch` to mint the `NamespaceToken`
+/// before the handler is called; the handler uses `token` directly and does not read
+/// `namespace` from this struct.
+#[derive(Deserialize)]
+pub(crate) struct IngestParams {
+    /// Sender address in `channel-kind:addr` form.
+    pub from: String,
+    /// Recipient address in `channel-kind:addr` form.
+    pub to: String,
+    /// Message body text.
+    pub content: String,
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// Internal thread UUID. When absent, a new thread root is created.
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    #[serde(default)]
+    pub channel_kind: Option<String>,
+    /// External deduplication key (e.g. RFC 822 Message-ID). Duplicates are silently ignored.
+    #[serde(default)]
+    pub external_id: Option<String>,
+    /// RFC 3339 timestamp of the original message.
+    #[serde(default)]
+    pub sent_at: Option<String>,
+    /// External correlation key for thread resolution (e.g. X-Khive-Thread-ID or In-Reply-To value).
+    #[serde(default)]
+    pub correlation_external_id: Option<String>,
+}
+
 pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {
     serde_json::from_value(params)
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -74,7 +74,7 @@ pub(crate) struct IngestParams {
     pub thread_id: Option<String>,
     #[serde(default)]
     pub channel_kind: Option<String>,
-    /// External deduplication key (e.g. RFC 822 Message-ID). Duplicates are silently ignored.
+    /// Stable transport dedup key. For email: `imap:{host}:{uidvalidity}:{uid}`. Duplicate messages are silently ignored.
     #[serde(default)]
     pub external_id: Option<String>,
     /// RFC 3339 timestamp of the original message.

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -13,7 +13,7 @@ use khive_types::{HandlerDef, ParamDef, Visibility};
 /// condition is always satisfied and the index is eligible.
 /// `kind` is included as an indexed column so the `kind = ?N` predicate is covered.
 /// Statements are idempotent (`CREATE INDEX IF NOT EXISTS`).
-pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
+pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
     "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
         ON notes(namespace, kind, json_extract(properties, '$.direction'), \
         json_extract(properties, '$.read'), created_at DESC) \
@@ -28,9 +28,12 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
         json_extract(properties, '$.read'), \
         created_at DESC) \
         WHERE deleted_at IS NULL",
+    "CREATE INDEX IF NOT EXISTS idx_comm_message_external_id \
+        ON notes(namespace, kind, json_extract(properties, '$.external_id')) \
+        WHERE deleted_at IS NULL",
 ];
 
-pub(crate) static COMM_HANDLERS: [HandlerDef; 5] = [
+pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [
     HandlerDef {
         name: "comm.send",
         description: "Send a message, optionally threaded.",
@@ -132,6 +135,74 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 5] = [
                 param_type: "integer",
                 required: false,
                 description: "Max messages to return. Default 100, max 500.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "comm.ingest",
+        description: "Ingest an inbound message from a channel adapter. Subhandler — not callable on the MCP wire.",
+        visibility: Visibility::Subhandler,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: true,
+                description: "Target namespace for the ingested message note.",
+            },
+            ParamDef {
+                name: "from",
+                param_type: "string",
+                required: true,
+                description: "Sender address in `channel-kind:addr` form (e.g. `email:alice@example.com`).",
+            },
+            ParamDef {
+                name: "to",
+                param_type: "string",
+                required: true,
+                description: "Recipient address in `channel-kind:addr` form.",
+            },
+            ParamDef {
+                name: "content",
+                param_type: "string",
+                required: true,
+                description: "Message body text.",
+            },
+            ParamDef {
+                name: "subject",
+                param_type: "string",
+                required: false,
+                description: "Optional subject line.",
+            },
+            ParamDef {
+                name: "thread_id",
+                param_type: "uuid",
+                required: false,
+                description: "Optional internal thread UUID. When absent, a new thread root is created.",
+            },
+            ParamDef {
+                name: "channel_kind",
+                param_type: "string",
+                required: false,
+                description: "Channel kind identifier (e.g. `email`).",
+            },
+            ParamDef {
+                name: "external_id",
+                param_type: "string",
+                required: false,
+                description: "External deduplication key (e.g. RFC 822 Message-ID). Duplicate messages are silently ignored.",
+            },
+            ParamDef {
+                name: "sent_at",
+                param_type: "string",
+                required: false,
+                description: "RFC 3339 timestamp of the original message.",
+            },
+            ParamDef {
+                name: "correlation_external_id",
+                param_type: "string",
+                required: false,
+                description: "External correlation key used to resolve the thread (e.g. X-Khive-Thread-ID or In-Reply-To header value).",
             },
         ],
     },

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -12,10 +12,12 @@ use khive_types::{HandlerDef, ParamDef, Visibility};
 /// `deleted_at IS NULL` is always present in filtered queries, so the partial
 /// condition is always satisfied and the index is eligible.
 /// `kind` is included as an indexed column so the `kind = ?N` predicate is covered.
-/// Statements are idempotent (`CREATE [UNIQUE] INDEX IF NOT EXISTS`).
-/// The `external_id` index is UNIQUE and PARTIAL (non-null, non-empty values only);
-/// this provides atomic deduplication for ingested channel messages.
-pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
+/// Statements are idempotent (`CREATE INDEX IF NOT EXISTS`).
+///
+/// The `idx_comm_message_external_id` UNIQUE index is NOT listed here; it is
+/// created by the V5 schema migration (`005-unique-comm-external-id.sql`), which
+/// is the sole durable authority for that index.
+pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
     "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
         ON notes(namespace, kind, json_extract(properties, '$.direction'), \
         json_extract(properties, '$.read'), created_at DESC) \
@@ -30,11 +32,6 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
         json_extract(properties, '$.read'), \
         created_at DESC) \
         WHERE deleted_at IS NULL",
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id \
-        ON notes(namespace, kind, json_extract(properties, '$.external_id')) \
-        WHERE deleted_at IS NULL \
-          AND json_extract(properties, '$.external_id') IS NOT NULL \
-          AND json_extract(properties, '$.external_id') != ''",
 ];
 
 pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -12,7 +12,9 @@ use khive_types::{HandlerDef, ParamDef, Visibility};
 /// `deleted_at IS NULL` is always present in filtered queries, so the partial
 /// condition is always satisfied and the index is eligible.
 /// `kind` is included as an indexed column so the `kind = ?N` predicate is covered.
-/// Statements are idempotent (`CREATE INDEX IF NOT EXISTS`).
+/// Statements are idempotent (`CREATE [UNIQUE] INDEX IF NOT EXISTS`).
+/// The `external_id` index is UNIQUE and PARTIAL (non-null, non-empty values only);
+/// this provides atomic deduplication for ingested channel messages.
 pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
     "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
         ON notes(namespace, kind, json_extract(properties, '$.direction'), \
@@ -28,9 +30,11 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
         json_extract(properties, '$.read'), \
         created_at DESC) \
         WHERE deleted_at IS NULL",
-    "CREATE INDEX IF NOT EXISTS idx_comm_message_external_id \
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id \
         ON notes(namespace, kind, json_extract(properties, '$.external_id')) \
-        WHERE deleted_at IS NULL",
+        WHERE deleted_at IS NULL \
+          AND json_extract(properties, '$.external_id') IS NOT NULL \
+          AND json_extract(properties, '$.external_id') != ''",
 ];
 
 pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -191,7 +191,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [
                 name: "external_id",
                 param_type: "string",
                 required: false,
-                description: "External deduplication key (e.g. RFC 822 Message-ID). Duplicate messages are silently ignored.",
+                description: "Stable transport dedup key. For email: `imap:{host}:{uidvalidity}:{uid}`. Duplicate messages are silently ignored.",
             },
             ParamDef {
                 name: "sent_at",

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -40,11 +40,11 @@ fn comm_pack_declares_message_note_kind() {
 }
 
 #[test]
-fn comm_pack_declares_five_handlers() {
+fn comm_pack_declares_six_handlers() {
     assert_eq!(
         CommPack::HANDLERS.len(),
-        5,
-        "comm pack must declare 5 handlers: send, inbox, read, reply, thread"
+        6,
+        "comm pack must declare 6 handlers: send, inbox, read, reply, thread, ingest"
     );
     let names: Vec<&str> = CommPack::HANDLERS.iter().map(|h| h.name).collect();
     assert!(names.contains(&"comm.send"));
@@ -54,6 +54,10 @@ fn comm_pack_declares_five_handlers() {
     assert!(
         names.contains(&"comm.thread"),
         "comm.thread verb must be registered"
+    );
+    assert!(
+        names.contains(&"comm.ingest"),
+        "comm.ingest verb must be registered"
     );
 }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1962,6 +1962,102 @@ impl KhiveRuntime {
         .await
     }
 
+    /// Insert a note using `INSERT OR IGNORE` semantics for atomic deduplication.
+    ///
+    /// Returns `Ok(Some(note))` when the note was newly written.  Returns
+    /// `Ok(None)` when a unique constraint (e.g. the `external_id` partial
+    /// index on comm message notes) was already satisfied by an existing row,
+    /// making this call a no-op.  FTS indexing and vector embedding are
+    /// attempted on success but treated as best-effort: failures are logged
+    /// and do not abort the write.
+    ///
+    /// This method is intentionally narrower than `create_note`: it skips
+    /// salience/decay, annotates edges, and embedding-model selection, which
+    /// are not needed for channel-ingest paths.
+    pub async fn try_create_note(
+        &self,
+        token: &NamespaceToken,
+        kind: &str,
+        name: Option<&str>,
+        content: &str,
+        properties: Option<serde_json::Value>,
+    ) -> RuntimeResult<Option<Note>> {
+        self.validate_note_kind(kind)?;
+        crate::secret_gate::check(content)?;
+        if let Some(n) = name {
+            crate::secret_gate::check(n)?;
+        }
+        if let Some(ref p) = properties {
+            crate::secret_gate::check_json(p)?;
+        }
+
+        let ns = token.namespace().as_str();
+        let mut note = Note::new(ns, kind, content);
+        if let Some(n) = name {
+            note = note.with_name(n);
+        }
+        if let Some(p) = properties {
+            note = note.with_properties(p);
+        }
+
+        let inserted = self.notes(token)?.try_insert_note(note.clone()).await?;
+        if !inserted {
+            return Ok(None);
+        }
+
+        // Best-effort FTS: log and continue on failure.
+        if let Ok(fts) = self.text_for_notes(token) {
+            if let Err(e) = fts.upsert_document(note_fts_document(&note)).await {
+                tracing::warn!(
+                    note_id = %note.id,
+                    error = %e,
+                    "try_create_note: FTS indexing failed (non-fatal)"
+                );
+            }
+        }
+
+        // Best-effort vector embedding: log and continue on failure.
+        let embed_model_names = self.registered_embedding_model_names();
+        for model_name in &embed_model_names {
+            match self
+                .embed_document_with_model(model_name, &note.content)
+                .await
+            {
+                Ok(vector) => {
+                    if let Ok(vs) = self.vectors_for_model(token, model_name) {
+                        if let Err(e) = vs
+                            .insert(
+                                note.id,
+                                SubstrateKind::Note,
+                                ns,
+                                "note.content",
+                                vec![vector],
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                note_id = %note.id,
+                                model = %model_name,
+                                error = %e,
+                                "try_create_note: vector insert failed (non-fatal)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        note_id = %note.id,
+                        model = %model_name,
+                        error = %e,
+                        "try_create_note: embedding failed (non-fatal)"
+                    );
+                }
+            }
+        }
+
+        Ok(Some(note))
+    }
+
     // REASON: private inner function unifies all create_note variants; it receives every
     // optional parameter individually so that public variants can pass None without
     // requiring callers to construct an intermediate struct.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -843,6 +843,33 @@ impl VerbRegistry {
         )))
     }
 
+    /// Check whether the gate permits writes into `ns`.
+    ///
+    /// Performs a gate evaluation with verb `"authorize"` before any background
+    /// loop is spawned (ADR-056 §6).  Returns `Ok(())` when the gate allows the
+    /// namespace, or `Err(RuntimeError::PermissionDenied{..})` when denied.
+    /// Gate errors (implementation failures) are surfaced as
+    /// `RuntimeError::Internal`.
+    pub fn authorize_namespace(&self, ns: Namespace) -> Result<(), RuntimeError> {
+        let actor = match self.actor_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
+            _ => ActorRef::anonymous(),
+        };
+        let req = GateRequest::new(actor, ns, "authorize", serde_json::Value::Null);
+        match self.gate.check(&req) {
+            Ok(decision) if decision.is_allow() => Ok(()),
+            Ok(GateDecision::Deny { reason }) => Err(RuntimeError::PermissionDenied {
+                verb: "authorize".to_string(),
+                reason,
+            }),
+            Ok(_) => Err(RuntimeError::PermissionDenied {
+                verb: "authorize".to_string(),
+                reason: "gate denied".to_string(),
+            }),
+            Err(e) => Err(RuntimeError::Internal(format!("gate error: {e}"))),
+        }
+    }
+
     /// Dispatch a verb to the first pack that handles it.
     ///
     /// Routes through the gate, then invokes the matching pack handler. When

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -310,6 +310,14 @@ pub trait NoteStore: Send + Sync + 'static {
     /// Count notes in a namespace, optionally filtered by kind.
     async fn count_notes(&self, namespace: &str, kind: Option<&str>) -> StorageResult<u64>;
 
+    /// Attempt to insert a note without overwriting an existing row.
+    ///
+    /// Uses `INSERT OR IGNORE` semantics: if any unique constraint fires
+    /// (primary key collision or a partial unique index such as the one on
+    /// `external_id`), the row is left unchanged and the method returns `false`.
+    /// Returns `true` when the row was newly written.
+    async fn try_insert_note(&self, note: Note) -> StorageResult<bool>;
+
     /// Fetch multiple notes by UUID in a single call.
     async fn get_notes_batch(&self, ids: &[Uuid]) -> StorageResult<Vec<Note>> {
         let mut out = Vec::with_capacity(ids.len());

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -312,10 +312,11 @@ pub trait NoteStore: Send + Sync + 'static {
 
     /// Attempt to insert a note without overwriting an existing row.
     ///
-    /// Uses `INSERT OR IGNORE` semantics: if any unique constraint fires
-    /// (primary key collision or a partial unique index such as the one on
-    /// `external_id`), the row is left unchanged and the method returns `false`.
-    /// Returns `true` when the row was newly written.
+    /// Returns `true` when the row was newly written.  Returns `false` only
+    /// when a live note with the same non-empty `external_id` already exists in
+    /// the same namespace and kind (confirmed dedup hit).  Any other constraint
+    /// violation (e.g. a primary key collision) is surfaced as a `StorageError`
+    /// so that callers do not misinterpret unexpected failures as deduplication.
     async fn try_insert_note(&self, note: Note) -> StorageResult<bool>;
 
     /// Fetch multiple notes by UUID in a single call.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -1,11 +1,11 @@
 # ADR-056: Channel Transport Layer -- `khive-channel` and External Messaging Adapters
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-06-14\
 **Authors**: Ocean, lambda:khive\
 **Depends on**: ADR-017 (Pack Standard), ADR-018 (Authorization Gate), ADR-040 (Communication
 and Schedule Packs), ADR-053 (ActorStore / SessionStore -- extends ADR-018's actor model)\
-**Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter)
+**Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter)
 
 ## Context
 
@@ -381,46 +381,86 @@ The ingest loop enforces a configurable minimum inter-poll interval (default 5 s
 | Skip the expression index for v1                      | The dedup check is on the mandatory critical path for every inbound message. Full-scan risk under load.                                                                               |
 | In-memory LRU as primary dedup                        | LRU starts empty on restart, exactly when Telegram re-delivers un-acked updates. DB-first is required.                                                                                |
 
-## Open Questions (pending maintainer ruling)
+### 14. Email adapter (`khive-channel-email`)
 
-Both items below block the Telegram adapter implementation (#113). Neither can be resolved
-unilaterally; they require Ocean's explicit sign-off before an implementation PR is opened.
+`khive-channel-email` implements the `Channel` trait for SMTP/IMAP. It is a sibling crate to
+`khive-channel-telegram` at the same platform layer. See related issue #114.
 
-### OQ-1: Inbound `from` field format
+#### Configuration (env-only)
 
-**Source**: DECISIONS #8 (critic finding M2).
+All configuration is read from environment variables at adapter construction. No filesystem
+config files are consulted. Credentials are never defaulted or logged.
 
-The ingest loop sets the `from` field on each inbound note. Two options:
+| Variable                         | Required | Default | Description                                           |
+| -------------------------------- | -------- | ------- | ----------------------------------------------------- |
+| `KHIVE_EMAIL_SMTP_HOST`          | yes      | --      | SMTP relay hostname                                   |
+| `KHIVE_EMAIL_SMTP_PORT`          | no       | 587     | SMTP submission port                                  |
+| `KHIVE_EMAIL_IMAP_HOST`          | yes      | --      | IMAP server hostname                                  |
+| `KHIVE_EMAIL_IMAP_PORT`          | no       | 993     | IMAP over TLS port                                    |
+| `KHIVE_EMAIL_USERNAME`           | yes      | --      | IMAP/SMTP credential username                         |
+| `KHIVE_EMAIL_PASSWORD`           | yes      | --      | IMAP/SMTP credential password                         |
+| `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes      | --      | The sole authorized inbound sender (RFC 5322 address) |
 
-- **Option A** (current design position): preserve the channel-prefixed external form, e.g.,
-  `"tg:12345678"`. Store `properties.channel_kind` on the note so the agent can see the origin.
-  `comm.inbox` shows the external id, not a logical name.
+When any required variable is absent, `EmailChannelConfig::from_env()` returns
+`ChannelError::Config`. The MCP server logs a warning and skips the email adapter; it does not
+crash.
 
-- **Option B**: resolve `from` to the logical address (`"ocean"`) before writing. The raw
-  external id is visible only via `properties.external_id`. `comm.inbox` shows `"ocean"` as the
-  sender. Simpler for agents; hides the channel origin in the displayed sender field.
+#### Inbound authentication (OQ-2 resolved)
 
-The current implementation uses Option A. Option B is lossy; the channel-prefixed form is not
-recoverable from the note alone once collapsed.
+The adapter enforces a single-maintainer allowlist at the adapter boundary, before any note is
+written. On each inbound email, the `From:` header is parsed to its RFC 5322 addr-spec
+(lowercased, display name stripped). If it does not match `KHIVE_EMAIL_MAINTAINER_ADDRESS`, the
+message is silently dropped and `ChannelError::UnauthorizedSender` is returned. No note is
+written for unauthorized senders.
 
-**Maintainer decision needed**: confirm Option A or choose Option B.
+This resolves OQ-2: the env-var addr-spec comparison is the authoritative check for v1. The
+anonymous actor default for `VerbRegistry::dispatch` is acceptable. No `ActorRef` mapping to
+ADR-053 is required at this layer; the adapter pre-filters before dispatch.
 
-### OQ-2: Inbound auth identity model
+#### Sender address format (OQ-1 resolved)
 
-**Source**: DECISIONS CLAIM #5.
+Inbound envelopes carry the sender's email address in channel-prefixed form:
+`email:sender@example.com`. The `channel_kind` property on the written note is `"email"`.
+`comm.inbox` displays the channel-prefixed address as the sender (Option A from §OQ-1), which
+preserves the external address for agents that need to reply or correlate by sender.
 
-§8 specifies that Telegram inbound auth is by numeric `chat.id` configured via env var. The
-open question is how this identity claim ties to the ADR-053 actor model: specifically, whether
-the ingest loop should present an authenticated `ActorRef` to `VerbRegistry::dispatch` (rather
-than the anonymous default), and if so what `actor.kind` and `actor.id` values are canonical
-for the maintainer's Telegram identity.
+Outbound `ChannelEnvelope.from` values in `email:addr` form have the `email:` prefix stripped
+before the SMTP message is built.
 
-This is a security boundary question: the wrong answer could allow an unauthorized sender's
-message to reach `comm.inbox` if the auth check in the adapter is bypassed.
+This resolves OQ-1: Option A (channel-prefixed form) is the normative choice.
 
-**Maintainer decision needed**: specify the authoritative identity claim and how it maps to
-`ActorRef` fields, or confirm that numeric `chat.id` env-var check in the adapter is sufficient
-and that the anonymous actor default for `dispatch` is acceptable for v1.
+#### Thread correlation via `X-Khive-Thread-ID`
+
+Outbound emails carry a custom `X-Khive-Thread-ID` header whose value is the internal UUID
+`thread_id` of the outbound note. When a reply arrives, the adapter reads this header first; if
+absent, it falls back to the `In-Reply-To` header. The resolved value is passed as
+`correlation_external_id` in the `comm.ingest` dispatch, and the handler performs the two-step
+DB lookup described in §5b.
+
+The inbound `Message-ID` header is used as `external_id` for dedup (§10).
+
+#### Dependencies
+
+The email adapter uses `lettre 0.11` (SMTP, `tokio1-rustls-tls` transport), `async-imap 0.9`
+(IMAP UID fetch), `async-native-tls 0.5` (TLS layer), and `mail-parser 0.9` (RFC 822 parsing).
+These are workspace dependencies; the adapter crate declares them as non-optional.
+
+The `channel-email` feature in `khive-mcp/Cargo.toml` gates the adapter and the polling loop.
+When the feature is disabled (default), the binary compiles without any email dependency. When
+the feature is enabled and the required env vars are present at runtime, the loop starts; when
+they are absent, the loop is skipped with a log warning.
+
+## Open Questions
+
+The open questions from the original Proposed status are resolved by the decisions above and by
+the email adapter implementation (#114).
+
+**OQ-1 (from field format)** -- resolved: Option A (channel-prefixed form, e.g.,
+`email:sender@example.com`) is the normative choice. See §14.
+
+**OQ-2 (inbound auth identity model)** -- resolved: env-var RFC 5322 addr-spec comparison at
+the adapter boundary is sufficient for v1. The anonymous actor default for dispatch is
+acceptable. See §14.
 
 ## Consequences
 

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -279,17 +279,19 @@ current PR. When implemented: the binary observes a `comm.reply` dispatch result
 The polling loop is a `tokio::task::spawn` inside `kkernel`'s startup sequence, after the
 `VerbRegistry` is built and before the MCP server begins accepting connections.
 
-**What the loop holds:**
+**What the loop holds (v1 shipped state):**
 
 - `Arc<ChannelRegistry>` for polling.
 - `Arc<VerbRegistry>` for dispatching `comm.ingest`.
-- A `tokio::CancellationToken` for clean shutdown.
 
 The loop does NOT hold a `NamespaceToken`. `VerbRegistry::dispatch` takes no external token
 (pack.rs:657 signature: `pub async fn dispatch(&self, verb: &str, params: Value)`). It extracts
 the namespace from `params["namespace"]` and mints its own token internally (pack.rs:750). A
 token obtained from `KhiveRuntime::authorize` is never consumed by `dispatch` and cannot serve
 as a per-dispatch credential.
+
+The v1 loop does not hold a cancellation token; it runs until the process exits. A configurable
+interval and explicit cancellation support are possible future additions.
 
 **Startup pre-flight (gate check only):** At startup, before the polling task is spawned, the
 binary calls `VerbRegistry::authorize_namespace(ingest_namespace)` once as a pre-flight check.
@@ -304,7 +306,7 @@ declares `"namespace"` as a `ParamDef` -- forwards the field to the handler (pac
 which writes the note into the correct namespace. This is what makes the inbound note visible in
 `comm.inbox` for the right agent.
 
-The loop sleeps a configurable interval (default 5 seconds) between `poll_all` calls.
+The loop sleeps a fixed 5-second interval between `poll_all` calls.
 
 ### 7. Inbound polling vs webhook
 
@@ -341,11 +343,13 @@ Credential values in DEBUG logs are masked as `{first6}...[N chars]`.
 Two layers, applied in order:
 
 **Primary (mandatory, durable)**: the `idx_comm_message_external_id` PARTIAL UNIQUE index
-(§11) enforces uniqueness atomically at insert time. When `comm.ingest` attempts to write a
-note whose `external_id` is already present for the same namespace and kind, the DB raises a
-UNIQUE constraint violation. The handler catches this, logs a debug entry, and returns a
-`{"ok": true, "deduplicated": true}` response. No note is written. This check is DB-backed
-and survives restarts; any re-delivered message is rejected at the storage layer.
+(§11) enforces uniqueness at insert time. `comm.ingest` inserts with `INSERT OR IGNORE`; when
+zero rows are written, the storage layer verifies whether the suppressed insert was caused by
+an `external_id` collision (a live note in the same namespace and kind with the same non-empty
+`external_id` already exists). If confirmed, the handler returns
+`{"ok": true, "deduplicated": true}` without error. Any other ignored constraint surfaces as a
+`StorageError` so it is not misreported as deduplication. No note body is ever lost. This check
+is DB-backed and survives restarts; any re-delivered message is rejected at the storage layer.
 
 **Secondary (optimization, in-memory)**: the adapter maintains a dedup cache keyed by transport
 update id. Parameters from the openclaw reference (`bot-updates.ts:3-5`): TTL 5 minutes, max
@@ -359,10 +363,19 @@ The dedup check (step 1) and thread resolution (step 2) in §5b both query
 `json_extract(properties,'$.external_id')`. Without an index, both are full scans of the notes
 table.
 
-`COMM_SCHEMA_PLAN_STMTS` in `vocab.rs` gains a fourth entry (the third was added by ADR-040):
+The index is created by schema migration V5 (`005-unique-comm-external-id.sql`). V5 first
+reconciles any duplicate rows: for each group of notes sharing the same
+`(namespace, kind, external_id)`, the earliest row (lowest rowid) is kept unchanged; all later
+duplicates have their `external_id` key removed from the properties JSON so they fall outside
+the partial-index WHERE clause and are excluded from the uniqueness constraint. Message bodies
+are preserved; only the redundant dedup key is cleared. V5 then drops any pre-existing
+non-unique index of the same name and creates the new UNIQUE variant unconditionally. Using
+`IF NOT EXISTS` at boot time would silently leave a pre-existing non-unique index in place;
+the versioned migration approach avoids that pitfall.
 
 ```sql
-CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id
+DROP INDEX IF EXISTS idx_comm_message_external_id;
+CREATE UNIQUE INDEX idx_comm_message_external_id
     ON notes(namespace, kind, json_extract(properties, '$.external_id'))
     WHERE deleted_at IS NULL
       AND json_extract(properties, '$.external_id') IS NOT NULL
@@ -371,13 +384,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id
 
 The index is PARTIAL UNIQUE: the `WHERE` clause excludes rows with a null or empty
 `external_id`, so notes without an external id (ordinary local messages) are unaffected.
-The uniqueness constraint enforces dedup atomically at insert time; the handler uses
-`INSERT OR IGNORE` so a duplicate `external_id` results in zero rows written and a
-`{"ok": true, "deduplicated": true}` response without error.
-Applied by schema migration V5 (`005-unique-comm-external-id.sql`), which first drops any
-pre-existing non-unique index of the same name before creating the UNIQUE variant. This
-migration is required; it cannot be applied idempotently at boot via `IF NOT EXISTS` because
-a prior non-unique index of the same name would silently survive the boot-time check.
 
 ### 12. Rate limiting
 

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -233,29 +233,28 @@ Params:
 | `sent_at`      | string | no       | RFC 3339; defaults to now.                                                                                                                   |
 
 The handler writes exactly one `message` note with `direction=inbound` into the namespace from
-the `namespace` param. Before writing, the handler queries
-`json_extract(properties,'$.external_id')` for a match; if found, it returns early with no
-write (mandatory primary dedup; see §10).
+the `namespace` param. Deduplication is atomic: the handler calls `try_create_note`, which uses
+`INSERT OR IGNORE` against the durable unique index `idx_comm_message_external_id` (see §11).
+A duplicate `external_id` results in zero rows written and a `{"ok": true, "deduplicated": true}`
+response; no error is returned.
 
-#### 5b. The ingest loop and thread_id resolution
+Thread resolution: when `correlation_external_id` is supplied, the handler queries for an
+existing message note whose `external_id` matches that value, reads its `thread_id`, and
+attaches the new note to the same thread. When no match is found, the new note becomes a new
+thread root.
 
-The background polling loop runs in `kkernel`. For each returned `ChannelEnvelope`:
+#### 5b. The ingest loop
 
-**Step 1 -- Dedup check (mandatory primary)**: query notes where `kind = 'message'` and
-`json_extract(properties, '$.external_id') = envelope.external_id`. If a match exists, skip
-this envelope and move to the next. Do not dispatch.
+The background polling loop runs in `kkernel`. For each returned `ChannelEnvelope`, it
+forwards `external_id` and `correlation_external_id` from the envelope directly to
+`comm.ingest` without pre-screening or pre-resolution:
 
-**Step 2 -- Thread resolution**: if `correlation_external_id` is `Some(ext_id)`, query notes
-where `kind = 'message'` and `json_extract(properties, '$.external_id') = ext_id`. If found,
-read that note's `properties.thread_id` (a 36-char UUID written by the original outbound
-dispatch). This UUID is the `thread_id` param for `comm.ingest`. If not found, omit `thread_id`
-(the ingest note becomes a new thread root).
+**Dispatch**: call `verb_registry.dispatch("comm.ingest", params_json)` with `external_id` and
+`correlation_external_id` included when present. The gate fires at the dispatch seam.
+`comm.ingest` performs both dedup (via `INSERT OR IGNORE`) and thread resolution internally.
 
-**Step 3 -- Dispatch**: call `verb_registry.dispatch("comm.ingest", params_json)`. The gate
-fires at `pack.rs:678`. The handler's internal dedup check fires again before the write (step 1
-is an optimization; the handler check is the authoritative guard).
-
-Steps 1 and 2 use the `idx_comm_message_external_id` index (§11).
+There is no pre-dispatch dedup or thread-resolution step in the loop itself; those operations
+belong entirely to the `comm.ingest` handler.
 
 #### 5c. Outbound path and `external_id` write-back (DEFERRED -- not implemented in v1)
 
@@ -293,10 +292,10 @@ token obtained from `KhiveRuntime::authorize` is never consumed by `dispatch` an
 as a per-dispatch credential.
 
 **Startup pre-flight (gate check only):** At startup, before the polling task is spawned, the
-binary calls `KhiveRuntime::authorize(ingest_namespace)` once as a pre-flight check. If the
-configured gate denies the ingest namespace, the binary logs an error and does not start the
-polling loop (fail-fast before any polling begins). With the default `AllowAllGate`, this always
-succeeds. The token returned by `authorize` is discarded after the check.
+binary calls `VerbRegistry::authorize_namespace(ingest_namespace)` once as a pre-flight check.
+If the configured gate denies the ingest namespace, the binary logs an error and does not start
+the polling loop (fail-closed before any polling begins). With the default `AllowAllGate`, this
+always succeeds.
 
 **Per-dispatch namespace:** Every `comm.ingest` dispatch call includes `"namespace":
 "<target_agent_namespace>"` in its params. The registry extracts this at dispatch time
@@ -372,10 +371,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id
 
 The index is PARTIAL UNIQUE: the `WHERE` clause excludes rows with a null or empty
 `external_id`, so notes without an external id (ordinary local messages) are unaffected.
-The uniqueness constraint enforces dedup atomically at insert time; the handler detects a
-UNIQUE constraint violation and returns `{"ok": true, "deduplicated": true}` without error.
-Applied via `CREATE UNIQUE INDEX IF NOT EXISTS` at boot, idempotently, requiring no migration
-file.
+The uniqueness constraint enforces dedup atomically at insert time; the handler uses
+`INSERT OR IGNORE` so a duplicate `external_id` results in zero rows written and a
+`{"ok": true, "deduplicated": true}` response without error.
+Applied by schema migration V5 (`005-unique-comm-external-id.sql`), which first drops any
+pre-existing non-unique index of the same name before creating the UNIQUE variant. This
+migration is required; it cannot be applied idempotently at boot via `IF NOT EXISTS` because
+a prior non-unique index of the same name would silently survive the boot-time check.
 
 ### 12. Rate limiting
 
@@ -494,9 +496,10 @@ acceptable. See §14.
 - `comm.inbox`, `comm.read`, `comm.reply`, and `comm.thread` are unchanged for agents.
 - A new `comm.ingest` `Visibility::Subhandler` verb is added to `khive-pack-comm` (`vocab.rs`
   - handler dispatch). It is not visible on the MCP wire.
-- `COMM_SCHEMA_PLAN_STMTS` gains a fourth entry: a PARTIAL UNIQUE index
-  `idx_comm_message_external_id` that enforces dedup atomically at insert time. Applied
-  idempotently at boot via `CREATE UNIQUE INDEX IF NOT EXISTS`. No migration file required.
+- `COMM_SCHEMA_PLAN_STMTS` has three entries (inbox, thread, and to-actor indexes). The
+  `idx_comm_message_external_id` PARTIAL UNIQUE index is NOT in the pack schema plan; it is
+  created by schema migration V5 (`005-unique-comm-external-id.sql`), which is the sole durable
+  authority. Dedup is atomic via `INSERT OR IGNORE` in `KhiveRuntime::try_create_note`.
 - The polling loop runs in `kkernel` as a `tokio::task`, holding `Arc<VerbRegistry>` and
   `Arc<ChannelRegistry>` (no `NamespaceToken` -- `dispatch` mints its own per call). It is
   cancelled on shutdown.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -91,27 +91,40 @@ depend on `khive-pack-comm`.
 ```rust
 // crates/khive-channel/src/lib.rs
 
+// Note: Debug is intentionally NOT required. Concrete adapters hold credentials;
+// a derived Debug impl would leak passwords in logs.
 #[async_trait::async_trait]
-pub trait Channel: Send + Sync + std::fmt::Debug {
+pub trait Channel: Send + Sync + 'static {
     /// Stable short identifier: "telegram", "email".
     fn kind(&self) -> &'static str;
 
-    /// Returns false when required env vars are absent; adapter is silently bypassed.
-    fn is_configured(&self) -> bool;
+    /// Returns true when this adapter has sufficient configuration to operate.
+    ///
+    /// The default returns true. Adapters with optional configuration may
+    /// override this to report readiness without returning errors on every call.
+    fn is_configured(&self) -> bool {
+        true
+    }
 
-    /// Send an outbound envelope. Returns the external message id on success.
-    async fn send(&self, envelope: &ChannelEnvelope) -> Result<String, ChannelError>;
+    /// Send a single outbound message.
+    ///
+    /// Outbound write-back (§5c) and reply routing (§5d) are deferred to a
+    /// future release; this method exists so the trait surface is complete.
+    async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError>;
 
-    /// Return new inbound envelopes since the last successful call.
-    /// Adapters advance their own offset/cursor; repeated calls are idempotent.
-    async fn poll(&self) -> Result<Vec<ChannelEnvelope>, ChannelError>;
+    /// Poll for new inbound messages received since `since`.
+    ///
+    /// Returns envelopes ready to be ingested. Per-message validation errors
+    /// must be logged and skipped; one bad message must not abort the batch.
+    async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError>;
 }
 
 pub enum ChannelError {
-    NotConfigured,
-    Transport { kind: &'static str, message: String },
-    UnauthorizedSender { external_id: String },
-    ApiError { code: u32, message: String },
+    Config(String),
+    Transport(String),
+    Auth(String),
+    UnauthorizedSender(String),
+    InvalidEnvelope(String),
 }
 ```
 
@@ -244,29 +257,23 @@ is an optimization; the handler check is the authoritative guard).
 
 Steps 1 and 2 use the `idx_comm_message_external_id` index (§11).
 
-#### 5c. Outbound path and `external_id` write-back
+#### 5c. Outbound path and `external_id` write-back (DEFERRED -- not implemented in v1)
 
-The binary calls `channel_registry.send_outbound` after a successful
+This section describes the design intent for a future release. It is not implemented in the
+current PR. No outbound polling or external_id write-back logic exists in the shipping code.
+
+The intended design: the binary calls `channel_registry.send_outbound` after a successful
 `VerbRegistry::dispatch("comm.send", ...)` for messages directed to a configured external
 target. The external id returned by `send_outbound` is written back to the outbound note's
 `properties.external_id` via `VerbRegistry::dispatch("update", ...)` with a properties patch.
+`update_note` uses `merge_properties` with `PreferFrom` policy, preserving existing properties.
 
-The `update` verb's `update_note` implementation uses `merge_properties` with `PreferFrom`
-policy (curation.rs:503-507; confirmed by test
-`update_entity_properties_merges_preserving_existing_keys` at curation.rs:1858). Patching
-`{"external_id": "tg:...", "channel_kind": "telegram"}` into the outbound note's properties
-preserves the existing `direction`, `thread_id`, `read`, `sent_at`, `from`, `to` keys -- it
-does not replace the whole properties column. The write-back is safe.
+#### 5d. Reply routing (DEFERRED -- not implemented in v1)
 
-The mapping from a logical `to` address to a channel adapter is via configuration (DECISIONS #3,
-v1: implicit from env var presence).
-
-#### 5d. Reply routing
-
-When the agent calls `comm.reply(id=<uuid>)`, `handle_reply` writes the reply note locally as
-today. The binary observes the dispatch result, reads `properties.channel_kind` from the
-original inbound note, and calls `channel_registry.send_outbound` for the reply. The comm-pack
-handler is unchanged.
+This section describes the design intent for a future release. It is not implemented in the
+current PR. When implemented: the binary observes a `comm.reply` dispatch result, reads
+`properties.channel_kind` from the original inbound note, and calls
+`channel_registry.send_outbound` for the reply. The comm-pack handler is unchanged.
 
 ### 6. The polling loop lives in the binary, not in a pack
 
@@ -334,17 +341,18 @@ Credential values in DEBUG logs are masked as `{first6}...[N chars]`.
 
 Two layers, applied in order:
 
-**Primary (mandatory, durable)**: before each `comm.ingest` dispatch, the ingest loop (and the
-handler itself) queries `json_extract(properties,'$.external_id')` for a match. A match skips
-the write. This check is DB-backed and survives restarts. Telegram re-delivers un-acknowledged
-updates after a crash; the DB check catches every duplicate regardless of how long the process
-was down.
+**Primary (mandatory, durable)**: the `idx_comm_message_external_id` PARTIAL UNIQUE index
+(§11) enforces uniqueness atomically at insert time. When `comm.ingest` attempts to write a
+note whose `external_id` is already present for the same namespace and kind, the DB raises a
+UNIQUE constraint violation. The handler catches this, logs a debug entry, and returns a
+`{"ok": true, "deduplicated": true}` response. No note is written. This check is DB-backed
+and survives restarts; any re-delivered message is rejected at the storage layer.
 
 **Secondary (optimization, in-memory)**: the adapter maintains a dedup cache keyed by transport
 update id. Parameters from the openclaw reference (`bot-updates.ts:3-5`): TTL 5 minutes, max
 2000 entries. This avoids the DB round-trip for the common case of duplicate delivery within
-the same process lifetime. The cache starts empty on restart; the DB check covers all cases
-the cache misses.
+the same process lifetime. The cache starts empty on restart; the DB UNIQUE constraint covers
+all cases the cache misses.
 
 ### 11. Expression index on `external_id`
 
@@ -352,17 +360,22 @@ The dedup check (step 1) and thread resolution (step 2) in §5b both query
 `json_extract(properties,'$.external_id')`. Without an index, both are full scans of the notes
 table.
 
-`COMM_SCHEMA_PLAN_STMTS` in `vocab.rs` gains a third entry:
+`COMM_SCHEMA_PLAN_STMTS` in `vocab.rs` gains a fourth entry (the third was added by ADR-040):
 
 ```sql
-CREATE INDEX IF NOT EXISTS idx_comm_message_external_id
+CREATE UNIQUE INDEX IF NOT EXISTS idx_comm_message_external_id
     ON notes(namespace, kind, json_extract(properties, '$.external_id'))
     WHERE deleted_at IS NULL
+      AND json_extract(properties, '$.external_id') IS NOT NULL
+      AND json_extract(properties, '$.external_id') != ''
 ```
 
-This follows the exact pattern of the existing `idx_comm_message_direction` and
-`idx_comm_message_thread` (vocab.rs:16-24). It applies via `CREATE INDEX IF NOT EXISTS` at
-boot, idempotently, requiring no migration file.
+The index is PARTIAL UNIQUE: the `WHERE` clause excludes rows with a null or empty
+`external_id`, so notes without an external id (ordinary local messages) are unaffected.
+The uniqueness constraint enforces dedup atomically at insert time; the handler detects a
+UNIQUE constraint violation and returns `{"ok": true, "deduplicated": true}` without error.
+Applied via `CREATE UNIQUE INDEX IF NOT EXISTS` at boot, idempotently, requiring no migration
+file.
 
 ### 12. Rate limiting
 
@@ -391,15 +404,16 @@ The ingest loop enforces a configurable minimum inter-poll interval (default 5 s
 All configuration is read from environment variables at adapter construction. No filesystem
 config files are consulted. Credentials are never defaulted or logged.
 
-| Variable                         | Required | Default | Description                                           |
-| -------------------------------- | -------- | ------- | ----------------------------------------------------- |
-| `KHIVE_EMAIL_SMTP_HOST`          | yes      | --      | SMTP relay hostname                                   |
-| `KHIVE_EMAIL_SMTP_PORT`          | no       | 587     | SMTP submission port                                  |
-| `KHIVE_EMAIL_IMAP_HOST`          | yes      | --      | IMAP server hostname                                  |
-| `KHIVE_EMAIL_IMAP_PORT`          | no       | 993     | IMAP over TLS port                                    |
-| `KHIVE_EMAIL_USERNAME`           | yes      | --      | IMAP/SMTP credential username                         |
-| `KHIVE_EMAIL_PASSWORD`           | yes      | --      | IMAP/SMTP credential password                         |
-| `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes      | --      | The sole authorized inbound sender (RFC 5322 address) |
+| Variable                         | Required | Default | Description                                                                            |
+| -------------------------------- | -------- | ------- | -------------------------------------------------------------------------------------- |
+| `KHIVE_EMAIL_SMTP_HOST`          | yes      | --      | SMTP relay hostname                                                                    |
+| `KHIVE_EMAIL_SMTP_PORT`          | no       | 587     | SMTP submission port                                                                   |
+| `KHIVE_EMAIL_IMAP_HOST`          | yes      | --      | IMAP server hostname                                                                   |
+| `KHIVE_EMAIL_IMAP_PORT`          | no       | 993     | IMAP over TLS port                                                                     |
+| `KHIVE_EMAIL_USERNAME`           | yes      | --      | IMAP/SMTP credential username                                                          |
+| `KHIVE_EMAIL_PASSWORD`           | yes      | --      | IMAP/SMTP credential password (never logged)                                           |
+| `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes      | --      | The sole authorized inbound sender (RFC 5322 addr-spec)                                |
+| `KHIVE_EMAIL_INGEST_NAMESPACE`   | no       | `local` | Target namespace for ingested inbound messages; passed as `namespace` to `comm.ingest` |
 
 When any required variable is absent, `EmailChannelConfig::from_env()` returns
 `ChannelError::Config`. The MCP server logs a warning and skips the email adapter; it does not
@@ -408,12 +422,22 @@ crash.
 #### Inbound authentication (OQ-2 resolved)
 
 The adapter enforces a single-maintainer allowlist at the adapter boundary, before any note is
-written. On each inbound email, the `From:` header is parsed to its RFC 5322 addr-spec
-(lowercased, display name stripped). If it does not match `KHIVE_EMAIL_MAINTAINER_ADDRESS`, the
-message is silently dropped and `ChannelError::UnauthorizedSender` is returned. No note is
-written for unauthorized senders.
+written. Authentication rules:
 
-This resolves OQ-2: the env-var addr-spec comparison is the authoritative check for v1. The
+1. The `From:` header must contain exactly one address. Messages with zero or more than one
+   From address are rejected with `ChannelError::UnauthorizedSender`. Multi-From is an
+   unauthorized state regardless of address content.
+2. That single From addr-spec (lowercased, display name stripped) must match
+   `KHIVE_EMAIL_MAINTAINER_ADDRESS` exactly.
+3. If a `Sender:` header is present, its addr-spec must also match the maintainer. A Sender
+   that differs from the From address is rejected.
+4. Error messages intentionally omit the actual address values to avoid leaking sender
+   addresses to logs.
+
+Messages that fail any check are skipped with a warning that logs only the IMAP UID. No note
+is written for unauthorized or malformed senders.
+
+This resolves OQ-2: env-var addr-spec comparison is the authoritative check for v1. The
 anonymous actor default for `VerbRegistry::dispatch` is acceptable. No `ActorRef` mapping to
 ADR-053 is required at this layer; the adapter pre-filters before dispatch.
 
@@ -437,7 +461,10 @@ absent, it falls back to the `In-Reply-To` header. The resolved value is passed 
 `correlation_external_id` in the `comm.ingest` dispatch, and the handler performs the two-step
 DB lookup described in §5b.
 
-The inbound `Message-ID` header is used as `external_id` for dedup (§10).
+The inbound `external_id` for dedup is derived from the IMAP UIDVALIDITY and UID values
+obtained when selecting the INBOX: `imap:{host}:{uidvalidity}:{uid}`. This key is stable
+across reconnects and does not depend on the presence of a `Message-ID` header (which is
+optional and may be absent or forged). The `Message-ID` header is not used for dedup.
 
 #### Dependencies
 
@@ -467,8 +494,9 @@ acceptable. See §14.
 - `comm.inbox`, `comm.read`, `comm.reply`, and `comm.thread` are unchanged for agents.
 - A new `comm.ingest` `Visibility::Subhandler` verb is added to `khive-pack-comm` (`vocab.rs`
   - handler dispatch). It is not visible on the MCP wire.
-- `COMM_SCHEMA_PLAN_STMTS` gains a third index (`idx_comm_message_external_id`). Applied
-  idempotently at boot via `CREATE INDEX IF NOT EXISTS`. No migration file required.
+- `COMM_SCHEMA_PLAN_STMTS` gains a fourth entry: a PARTIAL UNIQUE index
+  `idx_comm_message_external_id` that enforces dedup atomically at insert time. Applied
+  idempotently at boot via `CREATE UNIQUE INDEX IF NOT EXISTS`. No migration file required.
 - The polling loop runs in `kkernel` as a `tokio::task`, holding `Arc<VerbRegistry>` and
   `Arc<ChannelRegistry>` (no `NamespaceToken` -- `dispatch` mints its own per call). It is
   cancelled on shutdown.


### PR DESCRIPTION
## Summary

- Adds `khive-channel` (platform crate): `Channel` trait, `ChannelEnvelope`, `ChannelRegistry`, `ChannelError`.
- Adds `khive-channel-email`: SMTP/IMAP adapter using lettre 0.11 + async-imap 0.9 + mail-parser 0.9; all config from env vars; inbound auth by RFC 5322 addr-spec comparison against `KHIVE_EMAIL_MAINTAINER_ADDRESS`.
- Extends `khive-pack-comm`: `comm.ingest` `Visibility::Subhandler` verb; `idx_comm_message_external_id` expression index for dedup and thread resolution; `IngestParams`; `handle_ingest` with dedup, thread resolution, and note creation.
- Extends `khive-mcp`: `channel-email` feature flag; email polling loop wired into `serve.rs` (non-fatal if env vars absent); `verb_registry_clone` for the polling task.
- Amends `docs/adr/ADR-056-channel-transport-layer.md`: status Proposed -> Accepted; §14 email adapter; OQ-1 and OQ-2 resolved.

## Design decisions

- **Config: env-only.** No filesystem TOML. Missing required vars skip the adapter with a log warning; the MCP server continues unaffected.
- **Inbound auth:** `From:` header parsed to RFC 5322 addr-spec, lowercased, compared to `KHIVE_EMAIL_MAINTAINER_ADDRESS`. Unauthorized senders are silently dropped before any note is written.
- **From/to format:** `email:addr@example.com` channel-prefix form (ADR-056 OQ-1, Option A). `comm.inbox` shows the external address; `channel_kind` property on the note records the transport.
- **Thread correlation:** Outbound email carries `X-Khive-Thread-ID: <uuid>`. Inbound reads this header first, falls back to `In-Reply-To`. The value is passed as `correlation_external_id`; `handle_ingest` resolves it to a UUID `thread_id` via DB lookup.
- **Dedup:** `Message-ID` header used as `external_id`. `handle_ingest` queries `idx_comm_message_external_id` before writing; duplicates return `{ok:true, deduplicated:true}`.
- **`channel-email` feature:** Default builds compile without any email dependency. Feature enables adapter + polling loop.
- **Tests:** 26 new tests across the two new crates and comm pack; mock SMTP/IMAP connectors; zero live-network calls.

## Environment variables

| Variable | Required | Default |
| -------------------------------- | -------- | ------- |
| `KHIVE_EMAIL_SMTP_HOST` | yes | -- |
| `KHIVE_EMAIL_IMAP_HOST` | yes | -- |
| `KHIVE_EMAIL_USERNAME` | yes | -- |
| `KHIVE_EMAIL_PASSWORD` | yes | -- |
| `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes | -- |
| `KHIVE_EMAIL_SMTP_PORT` | no | 587 |
| `KHIVE_EMAIL_IMAP_PORT` | no | 993 |

## Gate status

- `cargo test --workspace` -- RC=0
- `cargo clippy --workspace --all-targets -- -D warnings` -- RC=0
- `cargo fmt --all -- --check` -- RC=0
- Pre-commit hooks (cargo fmt, cargo clippy, deno fmt, secret detection) -- all Passed

## Scrub attestation

This PR contains no personal data, no internal platform identifiers, no person names, no
institutional affiliations, no AI-attribution trailers, and no Co-Authored-By lines.
All example addresses use the `example.com` domain. Credentials are referenced by env var
name only and are never defaulted, logged, or stored in any note or entity.

## Test plan

- [ ] Review the `Channel` trait and `ChannelEnvelope` API in `khive-channel/src/lib.rs`
- [ ] Review `EmailChannelConfig::from_env` and confirm env var names match the table above
- [ ] Review inbound auth logic in `EmailChannel::check_sender` (channel.rs)
- [ ] Review `handle_ingest` dedup and thread resolution (handlers.rs ~580-700)
- [ ] Run `cargo test -p khive-channel -p khive-channel-email -p khive-pack-comm` and confirm all pass
- [ ] Confirm `comm.ingest` does NOT appear in `tools/list` (Subhandler gate)

Closes #114