### PR TITLE
fix(khive-db): surface first_error in upsert_documents and insert_batch

### DIFF
--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -395,6 +395,7 @@ impl TextSearch for Fts5TextSearch {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let mut affected = 0u64;
             let mut failed = 0u64;
+            let mut first_error = String::new();
 
             for doc in &documents {
                 conn.execute_batch("SAVEPOINT fts_upsert_doc")?;
@@ -428,9 +429,12 @@ impl TextSearch for Fts5TextSearch {
                         conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc")?;
                         affected += 1;
                     }
-                    Err(_) => {
+                    Err(e) => {
                         let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT fts_upsert_doc");
                         let _ = conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc");
+                        if first_error.is_empty() {
+                            first_error = e.to_string();
+                        }
                         failed += 1;
                     }
                 }
@@ -442,7 +446,7 @@ impl TextSearch for Fts5TextSearch {
                 attempted,
                 affected,
                 failed,
-                first_error: String::new(),
+                first_error,
             })
         })
         .await

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1223,6 +1223,6 @@ async fn upsert_documents_first_error_populated_on_item_failure() {
     assert!(
         !summary.first_error.is_empty(),
         "first_error must describe the failure when failed > 0, \
-         but got an empty string — the error is being silently swallowed"
+         but got an empty string; the error is being silently swallowed"
     );
 }

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1174,3 +1174,55 @@ async fn term_stats_missing_term_has_zero_df() {
     assert_eq!(stats.len(), 1);
     assert_eq!(stats[0].document_frequency, 0);
 }
+
+/// Dropping the FTS5 virtual table makes every per-item INSERT in the batch
+/// fail with a SQLite error.  Each failure is caught by the SAVEPOINT so the
+/// outer transaction still commits and the method returns Ok.
+///
+/// Regression: before the fix, `first_error` was always `String::new()` even
+/// when `failed > 0`.  This test is RED against the unfixed code and GREEN
+/// after the fix.
+#[tokio::test]
+async fn upsert_documents_first_error_populated_on_item_failure() {
+    let table_key = "first_err_fts";
+
+    // Keep a clone of the pool so we can manipulate the schema before the batch.
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        ensure_fts5_schema(writer.conn(), table_key).unwrap();
+    }
+    let store = Fts5TextSearch::new(Arc::clone(&pool), false, table_key.to_string());
+
+    // Drop the FTS5 virtual table (which also removes all its shadow tables).
+    // Every subsequent DELETE/INSERT on the table will fail with "no such table".
+    // Each failure is isolated by a SAVEPOINT, so the outer transaction commits.
+    {
+        let writer = pool.writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!("DROP TABLE fts_{}", table_key))
+            .expect("drop FTS5 virtual table");
+    }
+
+    let docs = vec![
+        make_document(Uuid::new_v4(), "Doc A", "body a"),
+        make_document(Uuid::new_v4(), "Doc B", "body b"),
+    ];
+
+    let summary = store.upsert_documents(docs).await.unwrap();
+
+    assert!(
+        summary.failed > 0,
+        "expected at least one item to fail after the FTS5 table was dropped"
+    );
+    assert!(
+        !summary.first_error.is_empty(),
+        "first_error must describe the failure when failed > 0, \
+         but got an empty string — the error is being silently swallowed"
+    );
+}

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -1308,7 +1308,7 @@ mod batch_exists_tests {
 /// Tests for `first_error` surfacing in `insert_batch`.
 ///
 /// These tests use only the pre-SAVEPOINT validation path (wrong vector count
-/// or wrong dimensions) so they do not need the `vectors` feature — no vec0
+/// or wrong dimensions) so they do not need the `vectors` feature; no vec0
 /// virtual table is accessed.
 #[cfg(test)]
 mod first_error_tests {
@@ -1350,7 +1350,7 @@ mod first_error_tests {
         )
         .expect("SqliteVecStore::new");
 
-        // Both records have wrong dimensions — they fail the pre-SAVEPOINT
+        // Both records have wrong dimensions, so they fail the pre-SAVEPOINT
         // validation and never touch the vec0 virtual table.
         let summary = store
             .insert_batch(vec![
@@ -1385,7 +1385,7 @@ mod first_error_tests {
         assert!(
             !summary.first_error.is_empty(),
             "first_error must be populated when failed > 0; \
-             got empty string — the validation error is silently swallowed"
+             got empty string; the validation error is silently swallowed"
         );
     }
 }

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -356,18 +356,33 @@ impl VectorStore for SqliteVecStore {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let mut affected = 0u64;
             let mut failed = 0u64;
+            let mut first_error = String::new();
 
             for record in &records {
                 if record.vectors.len() != 1 {
+                    if first_error.is_empty() {
+                        first_error =
+                            format!("expected 1 vector per record, got {}", record.vectors.len());
+                    }
                     failed += 1;
                     continue;
                 }
                 let embedding = &record.vectors[0];
                 if embedding.len() != dims {
+                    if first_error.is_empty() {
+                        first_error = format!(
+                            "wrong vector dimension: expected {dims}, got {}",
+                            embedding.len()
+                        );
+                    }
                     failed += 1;
                     continue;
                 }
                 if non_finite_index(embedding).is_some() {
+                    if first_error.is_empty() {
+                        first_error =
+                            "embedding contains non-finite values (NaN or Inf)".to_string();
+                    }
                     failed += 1;
                     continue;
                 }
@@ -410,9 +425,12 @@ impl VectorStore for SqliteVecStore {
                         conn.execute_batch("RELEASE SAVEPOINT vec_batch_record")?;
                         affected += 1;
                     }
-                    Err(_) => {
+                    Err(e) => {
                         let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT vec_batch_record");
                         let _ = conn.execute_batch("RELEASE SAVEPOINT vec_batch_record");
+                        if first_error.is_empty() {
+                            first_error = e.to_string();
+                        }
                         failed += 1;
                     }
                 }
@@ -424,7 +442,7 @@ impl VectorStore for SqliteVecStore {
                 attempted,
                 affected,
                 failed,
-                first_error: String::new(),
+                first_error,
             })
         })
         .await
@@ -1283,6 +1301,91 @@ mod batch_exists_tests {
             result.is_err(),
             "hyphenated model_key 'all-minilm-l6-v2' must be rejected; \
              the store's table_name would differ from what a hand-rolled sanitizer produces"
+        );
+    }
+}
+
+/// Tests for `first_error` surfacing in `insert_batch`.
+///
+/// These tests use only the pre-SAVEPOINT validation path (wrong vector count
+/// or wrong dimensions) so they do not need the `vectors` feature — no vec0
+/// virtual table is accessed.
+#[cfg(test)]
+mod first_error_tests {
+    use super::*;
+    use khive_storage::types::VectorRecord;
+    use khive_storage::VectorStore;
+    use khive_types::SubstrateKind;
+    use uuid::Uuid;
+
+    fn make_pool() -> Arc<crate::pool::ConnectionPool> {
+        use crate::pool::{ConnectionPool, PoolConfig};
+        let config = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        Arc::new(ConnectionPool::new(config).expect("in-memory pool"))
+    }
+
+    /// insert_batch must populate `first_error` when records fail the dimension
+    /// validation check.
+    ///
+    /// Both records have the wrong number of dimensions, so both hit the
+    /// `embedding.len() != dims` guard before any SAVEPOINT or vec0 operation.
+    /// The outer transaction still commits (best-effort batch semantics).
+    ///
+    /// Regression: before the fix, `first_error` was always `String::new()` even
+    /// when `failed > 0`.  This test is RED against the unfixed code and GREEN
+    /// after the fix.
+    #[tokio::test]
+    async fn insert_batch_first_error_populated_on_dimension_mismatch() {
+        let dims = 4usize;
+        let store = SqliteVecStore::new(
+            make_pool(),
+            false,
+            "first_err_vec".into(),
+            "first_err_vec".into(),
+            dims,
+            "ns:test".into(),
+        )
+        .expect("SqliteVecStore::new");
+
+        // Both records have wrong dimensions — they fail the pre-SAVEPOINT
+        // validation and never touch the vec0 virtual table.
+        let summary = store
+            .insert_batch(vec![
+                VectorRecord {
+                    subject_id: Uuid::new_v4(),
+                    kind: SubstrateKind::Entity,
+                    namespace: "ns:test".to_string(),
+                    field: "body".to_string(),
+                    embedding_model: None,
+                    vectors: vec![vec![0.0f32; dims + 1]],
+                    updated_at: chrono::Utc::now(),
+                },
+                VectorRecord {
+                    subject_id: Uuid::new_v4(),
+                    kind: SubstrateKind::Entity,
+                    namespace: "ns:test".to_string(),
+                    field: "body".to_string(),
+                    embedding_model: None,
+                    vectors: vec![vec![0.0f32; dims + 2]],
+                    updated_at: chrono::Utc::now(),
+                },
+            ])
+            .await
+            .expect("insert_batch must return Ok (best-effort semantics)");
+
+        assert_eq!(summary.attempted, 2);
+        assert_eq!(
+            summary.failed, 2,
+            "both wrong-dims records must be counted as failed"
+        );
+        assert_eq!(summary.affected, 0);
+        assert!(
+            !summary.first_error.is_empty(),
+            "first_error must be populated when failed > 0; \
+             got empty string — the validation error is silently swallowed"
         );
     }
 }


### PR DESCRIPTION
## Summary

`TextSearch::upsert_documents` and `VectorStore::insert_batch` always returned an
empty `first_error` even when `failed > 0`, silently discarding the underlying
cause of per-item failures in these best-effort batch writes. Callers consume
`first_error` to build diagnostics, so a partial-failure batch surfaced no
actionable detail.

## Fix

- `text.rs` `upsert_documents`: the SAVEPOINT error arm bound `Err(_)`, discarding
  the error. It now binds `Err(e)` and records the first failing error
  (first-error-wins, matching the field name), returning it instead of
  `String::new()`.
- `vectors.rs` `insert_batch`: same SAVEPOINT error-arm fix, plus the three
  pre-SAVEPOINT validation paths (wrong vector count, dimension mismatch,
  non-finite values) now each record a descriptive `first_error` when they
  increment `failed`.

Best-effort batch semantics are unchanged: the outer transaction still commits
and the call still returns `Ok` with `attempted`/`affected`/`failed` counts.

## Tests

Two regression tests, RED against the unfixed code and GREEN after:

- `text_tests::upsert_documents_first_error_populated_on_item_failure` forces
  per-item failures by dropping the FTS5 virtual table before the batch call.
- `vectors::first_error_tests::insert_batch_first_error_populated_on_dimension_mismatch`
  exercises the pre-SAVEPOINT dimension-mismatch path with two wrong-dimension
  records. It deliberately uses only the validation path so it does not require
  the `vectors` feature or touch the vec0 virtual table.

## Gates

- `cargo test -p khive-db`: 160 passed (+2 new)
- `cargo test -p khive-runtime` (the `first_error` consumer): passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
