### PR TITLE
fix(brain): resolve target_id prefix/slug in feedback

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -815,10 +815,8 @@ impl BrainPack {
         let p: FeedbackParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        let target: uuid::Uuid = p
-            .target_id
-            .parse()
-            .map_err(|e| RuntimeError::InvalidInput(format!("invalid target_id: {e}")))?;
+        let target: uuid::Uuid =
+            resolve_auto_feedback_target(&self.runtime, token, &p.target_id).await?;
 
         let signal = match p.signal.as_str() {
             "useful" => "useful",

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3919,3 +3919,35 @@ mod brain_005_section_signals {
         }
     }
 }
+
+// Regression: brain.feedback must accept a short hex prefix for target_id,
+// consistent with every other by-id verb (get, update, delete, link, …).
+// Before the fix, `target_id.parse::<Uuid>()` rejected anything shorter than
+// a full 36-char UUID with "invalid target_id: invalid length: ...".
+#[tokio::test]
+async fn feedback_accepts_short_prefix_target_id() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let full_uuid = create_test_entity(&rt, &token).await;
+    // Take the first 8 hex chars as the short prefix the agent would supply.
+    let prefix = &full_uuid[..8];
+
+    let result = pack
+        .dispatch(
+            "brain.feedback",
+            json!({
+                "target_id": prefix,
+                "signal": "useful",
+                "served_by_profile_id": "balanced-recall-v1"
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.feedback must accept an 8-char hex prefix for target_id");
+
+    assert_eq!(result["emitted"], json!(true), "emitted must be true");
+    assert_eq!(result["signal"], json!("useful"), "signal must round-trip");
+}


### PR DESCRIPTION
## Summary

`brain.feedback` required a full 36-character UUID for `target_id`, while every other
by-id verb (`get`, `update`, `delete`, `link`, and the kg verbs) accepts a short hex
prefix or slug. The common chain `recall(...) | brain.feedback(target_id=$prev.id)`
therefore broke whenever `$prev.id` was a short id, even though the same id resolves
fine on `get`. `brain.feedback` was the only verb bypassing the shared id-resolution
path.

## Fix

`handle_feedback` now resolves `target_id` through `resolve_auto_feedback_target`,
the same helper `brain.auto_feedback` already uses, which delegates to
`KhiveRuntime::resolve_prefix` (UUID -> slug -> hex-prefix order). A full UUID still
resolves to itself, so existing behavior is preserved; short prefixes and slugs now
work too.

Namespace semantics are unchanged (ADR-007 Rev 6): resolution uses the primary
namespace only to disambiguate a prefix; no per-record namespace check is added, and
by-id resolution remains namespace-agnostic.

## Tests

`feedback_accepts_short_prefix_target_id` (RED before, GREEN after): creates an
entity, supplies the first 8 hex characters of its id as `target_id`, and asserts the
feedback is emitted. Before the fix this failed with
`invalid target_id: invalid length: found 8`.

Existing coverage still holds: `w4_c4_feedback_rejects_nonexistent_target` confirms a
well-formed-but-nonexistent target still returns `NotFound` (the fix does not accept
unresolvable ids), and `w4_c4_feedback_accepts_valid_target_and_profile` confirms the
full-UUID path is unchanged.

## Gates

- `cargo test -p khive-pack-brain -p khive-runtime`: 161 + 59 passed (the cross-crate
  runtime consumer included)
- `cargo test -p khive-pack-kg`: 297 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
