### PR TITLE
docs: correct request-tool and superseded-filter ADR citations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,7 +387,7 @@ request(ops="link(source_id=\"<new_note>\", target_id=\"<old_note>\", relation=\
 ```
 
 `search(kind="note")` already excludes notes targeted by a `supersedes` edge (implemented in
-`khive_runtime::operations::search_notes`, per ADR-024 §"Filter superseded notes" step 5). That
+`khive_runtime::operations::search_notes`, per ADR-013 §"Supersession via edge, not field"). That
 exclusion is a **view-layer filter**: superseding **keeps** the old note and its edges and
 marks it superseded; it never deletes, copies, or transfers anything. "Show only current" is a
 query concern. See CLAUDE.md §"Data vs. view — the principle most violated here" before

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Entities are _things_. Notes are _what you think about things_. Events are _what
 
 ## The MCP verb surface
 
-One MCP tool: `request` (ADR-020 + ADR-027). Every verb is a parsed op inside it.
+One MCP tool: `request` (ADR-016 + ADR-027). Every verb is a parsed op inside it.
 
 ```
 request(ops="verb(arg=value, arg=value)")              # single op
@@ -85,7 +85,7 @@ No language SDK to learn.
 │  kkernel mcp      — stdio MCP server (the `kkernel` binary)   │
 │  khived           — persistent daemon (ADR-049): warm runtime │
 │                     auto-spawned on first request             │
-│  1 tool: `request` (ADR-020 + ADR-027) — parses DSL,         │
+│  1 tool: `request` (ADR-016 + ADR-027) — parses DSL,         │
 │  dispatches each op through the VerbRegistry                 │
 └──────────────────────────────────────────────────────────────┘
                             ↕ VerbRegistry dispatch


### PR DESCRIPTION
## Summary

Two doc-to-ADR citations pointed at the wrong ADR. Both are corrected to the ADR that
actually specifies the behavior. Documentation-only; no code change.

## What changed

- **README.md** (lines 53, 88) — the single `request` MCP tool was cited as
  `ADR-020 + ADR-027`. ADR-020 is "Git-native KG implementation"; the request DSL is
  specified by **ADR-016** (request DSL). Corrected to `ADR-016 + ADR-027`, matching
  the citation already used in AGENTS.md for the same tool.
- **AGENTS.md** (line 390) — the superseded-note search filter was cited as
  `ADR-024 §"Filter superseded notes" step 5`. ADR-024 is "Fold cognitive primitives"
  and has no such section. The default exclusion of superseded notes is specified by
  **ADR-013 §"Supersession via edge, not field"** (which records that search filters
  superseded notes by default, implemented via ADR-012 `search_notes`). Corrected the
  citation.

## Verification

- README no longer references ADR-020; AGENTS.md no longer references ADR-024.
- ADR-016 (`docs/adr/ADR-016-request-dsl.md`) and ADR-013's "Supersession via edge,
  not field" section both exist and describe the cited behavior.
- `deno fmt` (markdown) passes via pre-commit.
