### PR TITLE
fix: log swallowed errors in note FTS backfill and daemon respawn recovery

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -509,7 +509,11 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
             // as the probe itself.
             tracing::info!("killing stale daemon (undecodable response) and respawning");
             match kill_and_respawn(&frame.config_id, &frame.namespace).await {
-                Err(_) => return None,
+                Err(e) => {
+                    tracing::warn!(error = %e,
+                        "kill_and_respawn failed during stale-daemon recovery; falling back to local dispatch");
+                    return None;
+                }
                 Ok(RecoveryOutcome::Skipped) => {
                     // Under-lock probe confirmed a live matching daemon; forward the
                     // real request once — this is its ONLY dispatch on this path.

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -780,7 +780,10 @@ impl KhiveRuntime {
                     // to avoid N identical overwrites per note).
                     if model_names.first().map(|n| n.as_str()) == Some(model_name.as_str()) {
                         if let Some(ref ts) = text_store {
-                            let _ = ts.upsert_document(note_fts_document(&note)).await;
+                            if let Err(e) = ts.upsert_document(note_fts_document(&note)).await {
+                                tracing::warn!(id = %id, error = %e,
+                                    "backfill_missing_embeddings: note FTS upsert failed");
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

Two error-handling sites discarded a fallible result without any log, while a
structurally identical sibling path in the same area logged the failure properly. This
makes both sites observable. The changes are log-only: control flow, return values, and
recovery behavior are unchanged.

## What changed

- **`khive-runtime/src/retrieval.rs`** (`backfill_missing_embeddings`) — a failed note
  FTS upsert was dropped with `let _ = ...`, so the FTS index could silently diverge
  from the vector index during a reindex backfill with no trace. It now logs a
  `tracing::warn!` carrying the note id and error, mirroring the sibling vector-insert
  path a few lines below. The backfill loop still continues on error, exactly as before.

- **`khive-mcp/src/daemon.rs`** (stale-daemon recovery in `forward_or_spawn`) — when
  `kill_and_respawn` returned an `Err`, the error was discarded with `Err(_) => return
  None`. `None` here means "fall back to local dispatch", which is the correct recovery
  for a transient respawn failure, so the control flow is preserved. The error is now
  logged with `tracing::warn!` before the fall-back so an operator can see why a respawn
  failed. The `Some(Err(...))` path for a protocol mismatch (a permanent, actionable
  condition) is unrelated and untouched.

## Not changed

A third candidate site in `khive-vamana` (`load_or_build`) was inspected and left
as-is: its error arm triggers a documented `rebuild_from_corpus` fallback (it returns
`Ok`), not a silent abandonment, and that crate does not depend on `tracing`. It is not
a swallowed error.

## Verification

```
cargo test -p khive-runtime -p khive-mcp                  # RC 0
cargo clippy --workspace --all-targets -- -D warnings     # RC 0
cargo fmt --all -- --check                                # RC 0
```

No new tests: these are observability-only changes with no behavioral or return-value
difference, so a behavior test would be tautological. Existing tests pass.
