### PR TITLE
fix: list valid values in section_type and edge-relation errors

### DIFF
--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -300,11 +300,7 @@ impl ProposalApplyWorker {
     ) -> Result<Uuid, RuntimeError> {
         let source_id = Uuid::from_u128(source.to_u128());
         let target_id = Uuid::from_u128(target.to_u128());
-        let storage_relation = {
-            let name = relation.as_str();
-            EdgeRelation::from_str(name)
-                .map_err(|_| RuntimeError::InvalidInput(format!("unknown edge relation: {name}")))?
-        };
+        let storage_relation = crate::handlers::parse_relation(relation.as_str())?;
         let edge = self
             .runtime
             .link(

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -13,14 +13,14 @@ mod search;
 mod stats;
 mod update;
 
-pub(crate) use common::canonical_note_kind;
+pub(crate) use common::{canonical_note_kind, parse_relation};
 
 #[cfg(test)]
 pub(crate) use common::{
     ensure_note_kind, normalize_entity_timestamps, normalize_entity_timestamps_array,
-    parse_relation, resolve_kind_spec, tags_match_any, valid_relations_for_entity_pair,
-    validate_weight, walk_timestamps, KindSpec, ListParams, ProposeParams, ReviewParams,
-    SearchParams, UpdateParams, WithdrawParams,
+    resolve_kind_spec, tags_match_any, valid_relations_for_entity_pair, validate_weight,
+    walk_timestamps, KindSpec, ListParams, ProposeParams, ReviewParams, SearchParams, UpdateParams,
+    WithdrawParams,
 };
 
 #[cfg(test)]

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -346,7 +346,10 @@ impl KnowledgePack {
         let mut signals: Vec<(SectionType, FeedbackSignal)> = Vec::with_capacity(raw.len());
         for (key, val) in raw {
             let section_type = SectionType::from_str_loose(key).ok_or_else(|| {
-                RuntimeError::InvalidInput(format!("unknown section_type: {key:?}"))
+                RuntimeError::InvalidInput(format!(
+                    "unknown section_type: {key:?}; valid: {}",
+                    SectionType::NAMES.join(", ")
+                ))
             })?;
             let signal_str = val.as_str().ok_or_else(|| {
                 RuntimeError::InvalidInput(format!("section signal for {key:?} must be a string"))
@@ -469,6 +472,11 @@ mod tests {
     use std::collections::HashMap;
     use uuid::Uuid;
 
+    use khive_runtime::{KhiveRuntime, Namespace, PackRuntime, VerbRegistryBuilder};
+    use serde_json::json;
+
+    use crate::KnowledgePack;
+
     /// Regression: handle_topic's entity lookup must never panic when an entity_id
     /// is absent from the map.
     ///
@@ -499,6 +507,36 @@ mod tests {
             results,
             vec!["present"],
             "absent entity must be dropped silently"
+        );
+    }
+
+    /// Verify that an unknown `section_signals` key produces an error message that
+    /// lists valid section types, not just the bare "unknown section_type" string.
+    #[tokio::test]
+    async fn invalid_section_type_error_lists_valid_values() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let pack = KnowledgePack::new(rt.clone());
+        let registry = VerbRegistryBuilder::new()
+            .build()
+            .expect("empty registry builds");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+        let err = pack
+            .dispatch(
+                "knowledge.feedback",
+                json!({ "section_signals": { "not_a_real_section": "useful" } }),
+                &registry,
+                &token,
+            )
+            .await
+            .unwrap_err();
+
+        let khive_runtime::RuntimeError::InvalidInput(msg) = err else {
+            panic!("expected InvalidInput, got {err:?}");
+        };
+        assert!(
+            msg.contains("overview"),
+            "error must list valid section types; got: {msg}",
         );
     }
 }


### PR DESCRIPTION
## Summary

Two "unknown X" errors omitted the set of valid values, which the project's error
standard requires ("Invalid entity kinds, note kinds, and edge relations must return
errors with the valid values listed"). Both now list valid values by reusing the
existing in-repo source of truth, so the messages stay correct if the enums change.

## What changed

- **`khive-pack-knowledge/src/handlers.rs`** — `knowledge.feedback` rejected an unknown
  `section_signals` key with a bare `unknown section_type: "..."`. It now appends
  `; valid: <names>` from `SectionType::NAMES`, matching how the brain pack reports the
  same condition. This is a user-facing input path.
- **`khive-pack-kg/src/apply_worker/worker.rs`** — the apply worker re-parsed an edge
  relation with an inline `from_str().map_err(...)` whose error omitted the valid set.
  Replaced with a call to the existing `parse_relation` helper
  (`handlers/common.rs`), which already lists valid relations. Same target type
  (`khive_storage::EdgeRelation`), same success behavior; the duplicated error path is
  removed. `parse_relation` was promoted from a test-only re-export to `pub(crate)` since
  it is now used outside tests.

## Test

`invalid_section_type_error_lists_valid_values` (knowledge pack) dispatches
`knowledge.feedback` with an invalid section key and asserts the error message lists a
valid section name. It fails against the old bare message and passes against the fix.

The apply-worker site delegates entirely to `parse_relation` (already covered by its
existing call sites and tests); no separate test was added because reaching that line in
isolation would require full proposal-apply scaffolding for what is, after the change, a
shared and already-tested parser.

## Verification

```
cargo test -p khive-pack-knowledge -p khive-pack-kg     # RC 0
cargo clippy --workspace --all-targets -- -D warnings   # RC 0
cargo fmt --all -- --check                              # RC 0
```
