### PR TITLE
feat(mcp): output format axis with shape-aware rendering (ADR-078)

### DIFF
--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -297,6 +297,8 @@ pub(crate) mod tests {
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await;
 
@@ -324,6 +326,8 @@ pub(crate) mod tests {
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await;
 
@@ -360,6 +364,8 @@ pub(crate) mod tests {
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await
             .expect("T6d: dispatch must not return an MCP-level error");
@@ -412,6 +418,8 @@ pub(crate) mod tests {
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await;
 

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -69,12 +69,16 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         ops: String,
         presentation: Option<String>,
         presentation_per_op: Option<Vec<Option<String>>>,
+        format: Option<String>,
+        format_per_op: Option<Vec<Option<String>>>,
     ) -> Result<String, String> {
         let params = RequestParams {
             ops,
             presentation,
             presentation_per_op,
             save_to: None,
+            format,
+            format_per_op,
         };
         self.dispatch_request_local(params)
             .await
@@ -381,6 +385,8 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         config_id: config_id.to_string(),
         protocol_version: PROTOCOL_VERSION,
         probe_only: true,
+        format: None,
+        format_per_op: None,
     };
     let deadline = std::time::Duration::from_millis(timeout_ms);
     match tokio::time::timeout(deadline, try_forward_inner(&probe)).await {
@@ -942,6 +948,8 @@ mod tests {
             config_id: "test".to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let out = forward_or_spawn(&frame).await;
         assert!(out.is_none());
@@ -983,6 +991,8 @@ mod tests {
             config_id: config_id.clone(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let resp = exchange(&sock, &req).await;
         assert!(resp.ok, "valid op must succeed; error={:?}", resp.error);
@@ -1002,6 +1012,8 @@ mod tests {
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await
             .expect("local dispatch of stats() must succeed");
@@ -1017,6 +1029,8 @@ mod tests {
             config_id: config_id.clone(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let resp_other = exchange(&sock, &other).await;
         assert!(resp_other.namespace_mismatch);
@@ -1032,6 +1046,8 @@ mod tests {
             config_id: "packs=[kg];db=:memory:;embed=none;extra=[];backend=main".to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let resp_cfg = exchange(&sock, &mismatched_config).await;
         assert!(
@@ -1050,6 +1066,8 @@ mod tests {
             config_id: config_id.clone(),
             protocol_version: 0,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let resp_ver = exchange(&sock, &wrong_version).await;
         assert!(
@@ -1176,6 +1194,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -1277,6 +1297,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         // Call try_forward_inner directly to assert the discriminant.
@@ -1512,6 +1534,8 @@ mod tests {
             _ops: String,
             _presentation: Option<String>,
             _presentation_per_op: Option<Vec<Option<String>>>,
+            _format: Option<String>,
+            _format_per_op: Option<Vec<Option<String>>>,
         ) -> Result<String, String> {
             // Return a string whose serialized DaemonResponseFrame JSON length
             // exceeds MAX_FRAME_BYTES.  The frame JSON overhead is ~200 bytes so
@@ -1574,6 +1598,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -1672,6 +1698,8 @@ mod tests {
             _ops: String,
             _presentation: Option<String>,
             _presentation_per_op: Option<Vec<Option<String>>>,
+            _format: Option<String>,
+            _format_per_op: Option<Vec<Option<String>>>,
         ) -> Result<String, String> {
             DAEMON_DISPATCH.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok("{\"ok\":true,\"counted\":true}".to_string())
@@ -1784,6 +1812,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         let fwd = try_forward_inner(&real_frame).await;
         assert!(
@@ -1926,6 +1956,8 @@ mod tests {
             _ops: String,
             _presentation: Option<String>,
             _presentation_per_op: Option<Vec<Option<String>>>,
+            _format: Option<String>,
+            _format_per_op: Option<Vec<Option<String>>>,
         ) -> Result<String, String> {
             Err("forced dispatch error: verb returned an error for testing".to_string())
         }
@@ -1976,6 +2008,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -2067,6 +2101,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         let outcome = try_forward_inner(&frame).await;
@@ -2140,6 +2176,8 @@ mod tests {
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
 
         let outcome = try_forward_inner(&frame).await;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use khive_runtime::{
     config_from_env, run_migrations, runtime_config_from_khive_config, BackendConfig, BackendId,
-    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, PackRegistry, RuntimeConfig,
-    StorageBackend, VerbRegistryBuilder,
+    BackendKind, ConnectionPool, KhiveConfig, KhiveRuntime, OutputFormat, PackRegistry,
+    RuntimeConfig, StorageBackend, VerbRegistryBuilder,
 };
 
 use crate::args::{resolve_cli_namespace, Args};
@@ -540,7 +540,10 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
                  Set KHIVE_ACTOR or --actor to this lambda's id."
             );
         }
-        return KhiveMcpServer::new(runtime).map_err(|e| anyhow::anyhow!("{e}"));
+        let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
+        return KhiveMcpServer::new(runtime)
+            .map(|s| s.with_default_output_format(fmt))
+            .map_err(|e| anyhow::anyhow!("{e}"));
     }
 
     // Multi-backend path (ADR-028).
@@ -755,8 +758,10 @@ fn build_server_multi_backend(
         None
     };
 
+    let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
     let server =
-        KhiveMcpServer::from_registry_with_meta(registry, default_namespace.as_str(), &config_id);
+        KhiveMcpServer::from_registry_with_meta(registry, default_namespace.as_str(), &config_id)
+            .with_default_output_format(fmt);
 
     Ok(if let Some(p) = pool {
         server.with_pool(p)
@@ -939,6 +944,34 @@ fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
             .filter(|s| !s.trim().is_empty());
     }
     cfg
+}
+
+/// Resolve the server-level default output format (ADR-078 §2 precedence tier 2-3).
+///
+/// Precedence (highest to lowest — called AFTER CLI tier is handled at request time):
+/// 1. `KHIVE_OUTPUT_FORMAT` env var (tier 2)
+/// 2. `khive_cfg.runtime.default_output_format` from TOML (tier 3)
+/// 3. Builtin `OutputFormat::Json` (tier 4)
+///
+/// Returns the resolved [`OutputFormat`] to wire into the server via
+/// `with_default_output_format`.
+fn apply_env_output_format(toml_default: Option<OutputFormat>) -> OutputFormat {
+    // Env var (tier 2) overrides TOML (tier 3).
+    if let Ok(val) = std::env::var("KHIVE_OUTPUT_FORMAT") {
+        match val.trim() {
+            "json" => return OutputFormat::Json,
+            "auto" => return OutputFormat::Auto,
+            "table" => return OutputFormat::Table,
+            _ => {
+                tracing::warn!(
+                    value = %val,
+                    "KHIVE_OUTPUT_FORMAT has unknown value; falling back to TOML / builtin default"
+                );
+            }
+        }
+    }
+    // TOML default (tier 3) or builtin (tier 4).
+    toml_default.unwrap_or(OutputFormat::Json)
 }
 
 /// Resolve the full config (embedding engines + namespace) from file or env.
@@ -1324,6 +1357,8 @@ brain_profile = "project-profile"
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await
             .expect("kg dispatch must not error");
@@ -1345,6 +1380,8 @@ brain_profile = "project-profile"
                 presentation: None,
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await
             .expect("comm dispatch must not error");
@@ -1495,6 +1532,8 @@ brain_profile = "project-profile"
                         presentation: None,
                         presentation_per_op: None,
                         save_to: None,
+                        format: None,
+                        format_per_op: None,
                     })
                     .await
                     .expect("dispatch must not error");
@@ -1800,6 +1839,8 @@ brain_profile = "project-profile"
                         presentation: None,
                         presentation_per_op: None,
                         save_to: None,
+                        format: None,
+                        format_per_op: None,
                     })
                     .await
                     .expect("dispatch must not error")

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -955,7 +955,7 @@ fn apply_env_brain_profile(mut cfg: RuntimeConfig) -> RuntimeConfig {
 ///
 /// Returns the resolved [`OutputFormat`] to wire into the server via
 /// `with_default_output_format`.
-fn apply_env_output_format(toml_default: Option<OutputFormat>) -> OutputFormat {
+pub fn apply_env_output_format(toml_default: Option<OutputFormat>) -> OutputFormat {
     // Env var (tier 2) overrides TOML (tier 3).
     if let Ok(val) = std::env::var("KHIVE_OUTPUT_FORMAT") {
         match val.trim() {

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1256,6 +1256,7 @@ impl KhiveMcpServer {
             &format_per_op,
             presentation,
             &presentation_per_op,
+            &self.registry,
         ))
     }
 }
@@ -1298,10 +1299,12 @@ fn parse_output_format(s: Option<&str>) -> Result<Option<OutputFormat>, String> 
 /// For each op entry in `results`:
 /// - If `ok=false` (error entry): always compact JSON, never reformatted (§8.2).
 /// - If `ok=true`: resolve per-op format (per_op_formats[i] → batch_format) and
-///   per-op presentation (presentation_per_op[i] → batch presentation), apply
-///   `render_format` to the `result` payload with the effective presentation so
-///   that `presentation_per_op=["verbose"]` correctly skips the redundancy-drop
-///   pre-pass (ADR-078 §7 + §8.4).
+///   per-op presentation (presentation_per_op[i] → batch presentation, then the
+///   verb's AlwaysVerbose policy forces Verbose), apply `render_format` to the
+///   `result` payload with the effective presentation so that both
+///   `presentation_per_op=["verbose"]` and AlwaysVerbose verbs (get/link/query/
+///   traverse/neighbors/brain.feedback) correctly skip the redundancy-drop
+///   pre-pass (ADR-078 §7 + §8.4; mirrors `run_parsed`).
 ///
 /// The outer envelope (`{results:[...], summary:{...}}`) is always compact JSON (§8.4).
 /// When the result value is not a compound batch envelope (single-op fast path),
@@ -1312,6 +1315,7 @@ fn render_result(
     format_per_op: &Option<Vec<Option<OutputFormat>>>,
     presentation: PresentationMode,
     presentation_per_op: &Option<Vec<Option<PresentationMode>>>,
+    registry: &VerbRegistry,
 ) -> String {
     // Fast path: if format is json and no per-op overrides, compact-serialize and return.
     if batch_format == OutputFormat::Json && format_per_op.is_none() {
@@ -1329,12 +1333,29 @@ fn render_result(
                     .and_then(|x| *x)
                     .unwrap_or(batch_format);
 
-                // Resolve per-op presentation: per-op entry overrides batch default.
-                let effective_presentation = presentation_per_op
+                // Resolve per-op presentation: per-op entry overrides batch default,
+                // then the AlwaysVerbose verb policy forces Verbose — mirroring the
+                // resolution `run_parsed` applies before presentation. Without this,
+                // a policy-verbose verb (get/link/query/traverse/neighbors/
+                // brain.feedback) dispatched under format=auto/table with the default
+                // Agent presentation would be redundancy-dropped at the format seam,
+                // stripping the namespace/properties it is declared AlwaysVerbose
+                // precisely to preserve.
+                let base_presentation = presentation_per_op
                     .as_ref()
                     .and_then(|v| v.get(i))
                     .and_then(|o| *o)
                     .unwrap_or(presentation);
+                let effective_presentation =
+                    match entry.get("tool").and_then(serde_json::Value::as_str) {
+                        Some(tool)
+                            if registry.presentation_policy_for(tool)
+                                == VerbPresentationPolicy::AlwaysVerbose =>
+                        {
+                            PresentationMode::Verbose
+                        }
+                        _ => base_presentation,
+                    };
 
                 // Error entries are never reformatted (§8.2).
                 let is_ok = entry

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1232,7 +1232,12 @@ impl KhiveMcpServer {
             };
 
         let result = self
-            .run_parsed(parsed.ops, parsed.mode, presentation, presentation_per_op)
+            .run_parsed(
+                parsed.ops,
+                parsed.mode,
+                presentation,
+                presentation_per_op.clone(),
+            )
             .await;
 
         if let Some(path_str) = save_to {
@@ -1250,6 +1255,7 @@ impl KhiveMcpServer {
             batch_format,
             &format_per_op,
             presentation,
+            &presentation_per_op,
         ))
     }
 }
@@ -1291,20 +1297,23 @@ fn parse_output_format(s: Option<&str>) -> Result<Option<OutputFormat>, String> 
 ///
 /// For each op entry in `results`:
 /// - If `ok=false` (error entry): always compact JSON, never reformatted (§8.2).
-/// - If `ok=true`: resolve per-op format (per_op_formats[i] → batch_format), apply
-///   `render_format` to the `result` payload, embed the rendered string as
-///   `Value::String` back into the entry.
+/// - If `ok=true`: resolve per-op format (per_op_formats[i] → batch_format) and
+///   per-op presentation (presentation_per_op[i] → batch presentation), apply
+///   `render_format` to the `result` payload with the effective presentation so
+///   that `presentation_per_op=["verbose"]` correctly skips the redundancy-drop
+///   pre-pass (ADR-078 §7 + §8.4).
 ///
 /// The outer envelope (`{results:[...], summary:{...}}`) is always compact JSON (§8.4).
 /// When the result value is not a compound batch envelope (single-op fast path),
-/// the whole value is rendered with `batch_format`.
+/// the whole value is rendered with `batch_format` and `presentation`.
 fn render_result(
     value: serde_json::Value,
     batch_format: OutputFormat,
     format_per_op: &Option<Vec<Option<OutputFormat>>>,
     presentation: PresentationMode,
+    presentation_per_op: &Option<Vec<Option<PresentationMode>>>,
 ) -> String {
-    // Fast path: if format is json, just compact-serialize and return.
+    // Fast path: if format is json and no per-op overrides, compact-serialize and return.
     if batch_format == OutputFormat::Json && format_per_op.is_none() {
         return serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
     }
@@ -1320,6 +1329,13 @@ fn render_result(
                     .and_then(|x| *x)
                     .unwrap_or(batch_format);
 
+                // Resolve per-op presentation: per-op entry overrides batch default.
+                let effective_presentation = presentation_per_op
+                    .as_ref()
+                    .and_then(|v| v.get(i))
+                    .and_then(|o| *o)
+                    .unwrap_or(presentation);
+
                 // Error entries are never reformatted (§8.2).
                 let is_ok = entry
                     .get("ok")
@@ -1330,9 +1346,11 @@ fn render_result(
                     continue;
                 }
 
-                // For successful entries, render the `result` sub-value.
+                // For successful entries, render the `result` sub-value with the
+                // effective presentation so verbose ops skip the redundancy drop.
                 if let Some(result_val) = entry.get("result") {
-                    let rendered = render_format(result_val.clone(), per_op_fmt, presentation);
+                    let rendered =
+                        render_format(result_val.clone(), per_op_fmt, effective_presentation);
                     // Replace `result` with the rendered string.
                     let mut new_entry = entry.clone();
                     if let serde_json::Value::Object(ref mut emap) = new_entry {
@@ -1352,7 +1370,7 @@ fn render_result(
         }
     }
 
-    // Single-op or unknown shape: render the whole value with batch_format.
+    // Single-op or unknown shape: render the whole value with batch_format and presentation.
     render_format(value, batch_format, presentation)
 }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -23,8 +23,9 @@ use serde_json::{json, Value};
 use khive_db::ConnectionPool;
 use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
 use khive_runtime::{
-    present, KhiveRuntime, Namespace, PackLoadError, PackRegistry, PresentationMode, RuntimeConfig,
-    RuntimeError, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder,
+    present, render_format, KhiveRuntime, Namespace, OutputFormat, PackLoadError, PackRegistry,
+    PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy, VerbRegistry,
+    VerbRegistryBuilder,
 };
 
 use khive_storage::EdgeRelation;
@@ -198,6 +199,10 @@ pub struct KhiveMcpServer {
     /// Pool arc for the WAL checkpoint background task. `None` for in-memory
     /// or registry-only servers that have no persistent database.
     pool: Option<Arc<ConnectionPool>>,
+    /// Server-level default output format (ADR-078). Resolved from TOML →
+    /// `KHIVE_OUTPUT_FORMAT` → builtin `json`. Per-request `format` fields
+    /// override this at dispatch time.
+    default_output_format: OutputFormat,
 }
 
 /// Failure reason inside a [`PackRegError`].
@@ -332,6 +337,7 @@ impl KhiveMcpServer {
             config_id,
             coordinator: None,
             pool,
+            default_output_format: OutputFormat::Json,
         })
     }
 
@@ -351,6 +357,7 @@ impl KhiveMcpServer {
             config_id: "registry-only".to_string(),
             coordinator: None,
             pool: None,
+            default_output_format: OutputFormat::Json,
         }
     }
 
@@ -369,7 +376,18 @@ impl KhiveMcpServer {
             config_id: config_id.to_string(),
             coordinator: None,
             pool: None,
+            default_output_format: OutputFormat::Json,
         }
+    }
+
+    /// Override the server-level default output format (ADR-078).
+    ///
+    /// Called after construction to wire in the format resolved from
+    /// `KHIVE_OUTPUT_FORMAT` or `[runtime] default_output_format` in
+    /// `khive.toml`. Per-request `format` fields override this at dispatch time.
+    pub fn with_default_output_format(mut self, fmt: OutputFormat) -> Self {
+        self.default_output_format = fmt;
+        self
     }
 
     /// Attach a cross-backend coordinator (ADR-029 Phase 2).
@@ -1144,6 +1162,8 @@ result (e.g. create then link with the new entity's id)."#)]
                 config_id: self.config_id.clone(),
                 protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
                 probe_only: false,
+                format: p.format.clone(),
+                format_per_op: p.format_per_op.clone(),
             };
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
                 return res;
@@ -1184,6 +1204,33 @@ impl KhiveMcpServer {
                 None
             };
 
+        // Resolve the output format for this request (ADR-078 §2 precedence):
+        // per-request `format` field → server default (already resolved from
+        // env + toml + builtin by `serve.rs`).
+        let batch_format = parse_output_format(p.format.as_deref())
+            .map_err(|e| McpError::invalid_params(e, None))?
+            .unwrap_or(self.default_output_format);
+
+        // Per-op format overrides (ADR-078 §8.4).
+        let format_per_op: Option<Vec<Option<OutputFormat>>> =
+            if let Some(per_op_strs) = p.format_per_op {
+                let mut fmts = Vec::with_capacity(per_op_strs.len());
+                for s in per_op_strs {
+                    let fmt = match s.as_deref() {
+                        None => None,
+                        Some(v) => Some(
+                            parse_output_format(Some(v))
+                                .map_err(|e| McpError::invalid_params(e, None))?
+                                .unwrap_or(batch_format),
+                        ),
+                    };
+                    fmts.push(fmt);
+                }
+                Some(fmts)
+            } else {
+                None
+            };
+
         let result = self
             .run_parsed(parsed.ops, parsed.mode, presentation, presentation_per_op)
             .await;
@@ -1192,12 +1239,18 @@ impl KhiveMcpServer {
             let path = std::path::Path::new(&path_str);
             let manifest = crate::save_sink::write_and_manifest(&result, path)
                 .map_err(|e| McpError::internal_error(format!("save_to: {e}"), None))?;
-            return serde_json::to_string_pretty(&manifest)
+            // Manifests are always compact JSON regardless of format (lossless metadata).
+            return serde_json::to_string(&manifest)
                 .map_err(|e| McpError::internal_error(format!("serialize manifest: {e}"), None));
         }
 
-        serde_json::to_string_pretty(&result)
-            .map_err(|e| McpError::internal_error(format!("serialize: {e}"), None))
+        // Apply per-op format rendering (ADR-078 §8.4 and §9).
+        Ok(render_result(
+            result,
+            batch_format,
+            &format_per_op,
+            presentation,
+        ))
     }
 }
 
@@ -1217,6 +1270,90 @@ fn parse_presentation_mode(s: Option<&str>) -> Result<PresentationMode, String> 
             "unknown presentation mode {other:?}; valid values: \"agent\", \"verbose\", \"human\""
         )),
     }
+}
+
+/// Parse an optional output format string from the request envelope (ADR-078).
+///
+/// `None` → `None` (caller uses server default). Known values: `"json"`, `"auto"`, `"table"`.
+fn parse_output_format(s: Option<&str>) -> Result<Option<OutputFormat>, String> {
+    match s {
+        None => Ok(None),
+        Some("json") => Ok(Some(OutputFormat::Json)),
+        Some("auto") => Ok(Some(OutputFormat::Auto)),
+        Some("table") => Ok(Some(OutputFormat::Table)),
+        Some(other) => Err(format!(
+            "unknown output format {other:?}; valid values: \"json\", \"auto\", \"table\""
+        )),
+    }
+}
+
+/// Render the `run_parsed` result envelope using per-op format dispatch (ADR-078 §8.4).
+///
+/// For each op entry in `results`:
+/// - If `ok=false` (error entry): always compact JSON, never reformatted (§8.2).
+/// - If `ok=true`: resolve per-op format (per_op_formats[i] → batch_format), apply
+///   `render_format` to the `result` payload, embed the rendered string as
+///   `Value::String` back into the entry.
+///
+/// The outer envelope (`{results:[...], summary:{...}}`) is always compact JSON (§8.4).
+/// When the result value is not a compound batch envelope (single-op fast path),
+/// the whole value is rendered with `batch_format`.
+fn render_result(
+    value: serde_json::Value,
+    batch_format: OutputFormat,
+    format_per_op: &Option<Vec<Option<OutputFormat>>>,
+    presentation: PresentationMode,
+) -> String {
+    // Fast path: if format is json, just compact-serialize and return.
+    if batch_format == OutputFormat::Json && format_per_op.is_none() {
+        return serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
+    }
+
+    // Try to detect the compound batch envelope shape: { results: [...], summary: {...} }
+    if let serde_json::Value::Object(ref map) = value {
+        if let Some(serde_json::Value::Array(results)) = map.get("results") {
+            let mut out_results = Vec::with_capacity(results.len());
+            for (i, entry) in results.iter().enumerate() {
+                let per_op_fmt = format_per_op
+                    .as_ref()
+                    .and_then(|v| v.get(i))
+                    .and_then(|x| *x)
+                    .unwrap_or(batch_format);
+
+                // Error entries are never reformatted (§8.2).
+                let is_ok = entry
+                    .get("ok")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                if !is_ok || per_op_fmt == OutputFormat::Json {
+                    out_results.push(entry.clone());
+                    continue;
+                }
+
+                // For successful entries, render the `result` sub-value.
+                if let Some(result_val) = entry.get("result") {
+                    let rendered = render_format(result_val.clone(), per_op_fmt, presentation);
+                    // Replace `result` with the rendered string.
+                    let mut new_entry = entry.clone();
+                    if let serde_json::Value::Object(ref mut emap) = new_entry {
+                        emap.insert("result".to_string(), serde_json::Value::String(rendered));
+                    }
+                    out_results.push(new_entry);
+                } else {
+                    out_results.push(entry.clone());
+                }
+            }
+
+            // Rebuild envelope: results rendered per-op, summary always compact.
+            let mut out_map = map.clone();
+            out_map.insert("results".to_string(), serde_json::Value::Array(out_results));
+            return serde_json::to_string(&serde_json::Value::Object(out_map))
+                .unwrap_or_else(|_| "null".to_string());
+        }
+    }
+
+    // Single-op or unknown shape: render the whole value with batch_format.
+    render_format(value, batch_format, presentation)
 }
 
 #[tool_handler]

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -60,4 +60,27 @@ pub struct RequestParams {
         description = "File path to sink results as JSONL (returns manifest, not raw results)"
     )]
     pub save_to: Option<String>,
+
+    /// Output serialization format for all ops in this request (ADR-078).
+    ///
+    /// - `"json"` (default): compact, lossless JSON.
+    /// - `"auto"`: shape-aware — markdown table for homogeneous record arrays,
+    ///   flat key-value block for single records, compact-JSON fallback.
+    /// - `"table"`: force markdown-table renderer regardless of shape.
+    ///
+    /// Overrides `KHIVE_OUTPUT_FORMAT` and the TOML `default_output_format`.
+    /// When omitted, the server's resolved default (env → toml → builtin `json`) is used.
+    #[serde(default)]
+    #[schemars(description = "Output format: \"json\" (default), \"auto\", or \"table\"")]
+    pub format: Option<String>,
+
+    /// Per-operation output format overrides (ADR-078).
+    ///
+    /// When provided, entries override `format` per op by index.
+    /// `null` entries fall back to the batch-level `format`.
+    ///
+    /// When omitted, all ops use `format`.
+    #[serde(default)]
+    #[schemars(description = "Per-op output format override (optional)")]
+    pub format_per_op: Option<Vec<Option<String>>>,
 }

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -4128,3 +4128,260 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
         "list(namespace=lambda:leo) must NOT see the local entity; got: {leo_ids:?}"
     );
 }
+
+// ── ADR-078 server-level format tests (Medium 4 — server seam coverage) ──────
+//
+// These tests drive `dispatch_request_local` directly so they pin the PUBLIC
+// server behaviour that combines `format`, `format_per_op`,
+// `presentation_per_op`, ok entries, and error entries.
+
+fn make_format_server() -> KhiveMcpServer {
+    std::env::set_var("KHIVE_NO_DAEMON", "1");
+    let config = khive_runtime::RuntimeConfig {
+        db_path: None,
+        default_namespace: khive_runtime::Namespace::parse("test").unwrap(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        packs: vec!["kg".to_string(), "gtd".to_string()],
+        ..khive_runtime::RuntimeConfig::default()
+    };
+    let rt = khive_runtime::KhiveRuntime::new(config).expect("in-memory runtime");
+    KhiveMcpServer::new(rt).expect("server builds")
+}
+
+/// (fmt-1) Mixed ok/error batch under `format=auto`: error entries must always
+/// be compact JSON; ok entries must be formatted with the requested format.
+///
+/// ADR-078 §8.2: error envelopes are never passed through auto/table renderers.
+/// ADR-078 §8.4: ok results are rendered per-op.
+#[tokio::test]
+async fn format_auto_mixed_ok_error_batch_error_stays_compact() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let server = make_format_server();
+
+    // Batch: op0 succeeds (stats()), op1 fails (bad verb).
+    let params = RequestParams {
+        ops: r#"[stats(), no_such_verb()]"#.to_string(),
+        presentation: None,
+        presentation_per_op: None,
+        save_to: None,
+        format: Some("auto".to_string()),
+        format_per_op: None,
+    };
+
+    let raw = server
+        .dispatch_request_local(params)
+        .await
+        .expect("dispatch must not itself fail");
+
+    // The outer envelope must be valid JSON regardless of format.
+    let body: serde_json::Value =
+        serde_json::from_str(&raw).expect("envelope must be valid JSON under format=auto");
+
+    let results = body["results"]
+        .as_array()
+        .expect("results array must be present");
+    assert_eq!(results.len(), 2, "batch must produce 2 result entries");
+
+    // op0 succeeded — result should have been formatted (rendered as string).
+    assert_eq!(
+        results[0]["ok"],
+        serde_json::json!(true),
+        "op0 (stats) must succeed: {}",
+        results[0]
+    );
+
+    // op1 failed — error envelope must be compact JSON (never reformatted).
+    assert_eq!(
+        results[1]["ok"],
+        serde_json::json!(false),
+        "op1 (no_such_verb) must fail: {}",
+        results[1]
+    );
+    // The error entry must contain a string error field, not a rendered table.
+    assert!(
+        results[1]["error"].is_string(),
+        "error field must be a plain string, not reformatted: {}",
+        results[1]
+    );
+    // Summary must always be present and valid.
+    assert_eq!(body["summary"]["total"], serde_json::json!(2));
+}
+
+/// (fmt-2) `format_per_op` overrides: op0 gets json, op1 gets auto.
+///
+/// Pins ADR-078 §8.4: a single `format` applies uniformly; `format_per_op`
+/// overrides per position.
+#[tokio::test]
+async fn format_per_op_override_selects_format_per_position() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let server = make_format_server();
+
+    // Create two entities, then list — use gtd.assign so results are non-trivial.
+    // First build a state: two assign ops (both json), then one stats op (auto).
+    // Simpler: two parallel stats() calls — one forced json, one forced auto.
+    let params = RequestParams {
+        ops: r#"[stats(), stats()]"#.to_string(),
+        presentation: None,
+        presentation_per_op: None,
+        save_to: None,
+        // Batch default is auto, but op0 overrides to json.
+        format: Some("auto".to_string()),
+        format_per_op: Some(vec![
+            Some("json".to_string()), // op0 → json (compact, parseable)
+            None,                     // op1 → inherits batch "auto"
+        ]),
+    };
+
+    let raw = server
+        .dispatch_request_local(params)
+        .await
+        .expect("dispatch must succeed");
+
+    let body: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON envelope");
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2);
+
+    // op0 was forced json → the result stays as the original JSON Value (not
+    // wrapped as a string).  When format=json, render_result passes the entry
+    // through unchanged (the entry.result remains a JSON object, not a string).
+    assert_eq!(results[0]["ok"], serde_json::json!(true));
+    let op0_result = &results[0]["result"];
+    assert!(
+        op0_result.is_object(),
+        "json-format op result must remain a JSON object (not reformatted to string): {op0_result}"
+    );
+    // stats() returns entity/edge/note counts — these fields must be present.
+    assert!(
+        op0_result.get("entities").is_some() || op0_result.get("total").is_some(),
+        "op0 json result must contain stats fields: {op0_result}"
+    );
+
+    // op1 inherited auto → result is a rendered string (not a raw json object).
+    assert_eq!(results[1]["ok"], serde_json::json!(true));
+    assert!(
+        results[1]["result"].is_string(),
+        "auto-format op result must be a rendered string: {}",
+        results[1]
+    );
+
+    // Summary envelope must be compact JSON regardless of format.
+    assert_eq!(body["summary"]["total"], serde_json::json!(2));
+    assert_eq!(body["summary"]["succeeded"], serde_json::json!(2));
+}
+
+/// (fmt-3) `presentation_per_op=verbose` pins High 1: a verbose op under
+/// `format=auto` must preserve `full_id`, `namespace="local"`, and duplicate
+/// `properties` keys — the redundancy-drop pre-pass must be skipped.
+///
+/// This is the regression pin for the bug fixed in this round: the batch
+/// `presentation` was passed to `render_format` instead of the per-op
+/// effective presentation, so `full_id`/`namespace`/duplicate-props could
+/// be stripped even when that specific op was verbose.
+#[tokio::test]
+async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let server = make_format_server();
+
+    // Create a GTD task so we have a record with duplicated properties
+    // (assignee/priority/status echoed in both top-level and `properties`).
+    let create_params = RequestParams {
+        ops: r#"gtd.assign(title="verbose-pin-task", priority="p1", assignee="lambda:test")"#
+            .to_string(),
+        presentation: Some("verbose".to_string()),
+        presentation_per_op: None,
+        save_to: None,
+        format: None,
+        format_per_op: None,
+    };
+    let create_raw = server
+        .dispatch_request_local(create_params)
+        .await
+        .expect("task creation must succeed");
+    let create_body: serde_json::Value = serde_json::from_str(&create_raw).unwrap();
+    let task_id = create_body["results"][0]["result"]["id"]
+        .as_str()
+        .expect("task id must be present");
+
+    // Now fetch as a 2-op batch: op0 = agent (will be redundancy-dropped),
+    // op1 = verbose (must survive the redundancy-drop pre-pass).
+    //
+    // We use gtd.tasks (which returns records with assignee/priority/status in both
+    // top-level AND properties), then get the specific task in verbose mode.
+    let batch_params = RequestParams {
+        ops: format!(r#"[gtd.tasks(limit=10), get(id="{task_id}")]"#),
+        // Batch default: agent (will apply redundancy drop).
+        presentation: Some("agent".to_string()),
+        // Op1 overrides to verbose — must skip redundancy drop for that op.
+        presentation_per_op: Some(vec![
+            None,                        // op0 → inherits agent
+            Some("verbose".to_string()), // op1 → verbose
+        ]),
+        save_to: None,
+        format: Some("auto".to_string()),
+        format_per_op: None,
+    };
+
+    let raw = server
+        .dispatch_request_local(batch_params)
+        .await
+        .expect("batch dispatch must succeed");
+
+    let body: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON envelope");
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2, "batch must return 2 results");
+
+    // op0 was agent + auto → redundancy drop applied (namespace="local" elided).
+    // The result is a rendered string; just verify it succeeded.
+    assert_eq!(
+        results[0]["ok"],
+        serde_json::json!(true),
+        "op0 (gtd.tasks) must succeed: {}",
+        results[0]
+    );
+
+    // op1 was verbose + auto → redundancy drop MUST be skipped.
+    assert_eq!(
+        results[1]["ok"],
+        serde_json::json!(true),
+        "op1 (get task) must succeed: {}",
+        results[1]
+    );
+
+    // The rendered result for op1 is a string (auto-formatted).
+    // Under verbose mode the redundancy-drop pre-pass is skipped.
+    //
+    // Key differences vs. agent+auto:
+    //   - In agent mode `present_response` shortens `id` to 8 chars and adds a
+    //     separate `full_id` field; redundancy drop then removes that `full_id`.
+    //   - In verbose mode `present_response` keeps the full 36-char UUID in `id`
+    //     directly — there is NO separate `full_id` field to strip.
+    //
+    // What we can assert positively:
+    //   - `namespace` appears (in agent+auto it is elided when "local" per §7.3).
+    //   - `properties` keys that duplicate top-level fields (assignee, priority,
+    //     status) survive (in agent+auto they are deduped away per §7.2).
+    let op1_rendered = results[1]["result"]
+        .as_str()
+        .expect("op1 result must be a rendered string");
+
+    // namespace: elided when "local" in auto+agent mode (§7.3); kept in verbose.
+    assert!(
+        op1_rendered.contains("namespace"),
+        "verbose op: namespace must survive the redundancy-drop pre-pass; rendered: {op1_rendered}"
+    );
+
+    // properties: duplicate keys (assignee, priority, status) must survive in
+    // verbose mode (§7.2 dedup is skipped).  In agent+auto these are removed.
+    assert!(
+        op1_rendered.contains("assignee"),
+        "verbose op: properties.assignee must survive the redundancy-drop pre-pass; rendered: {op1_rendered}"
+    );
+    assert!(
+        op1_rendered.contains("priority"),
+        "verbose op: properties.priority must survive the redundancy-drop pre-pass; rendered: {op1_rendered}"
+    );
+}

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -3561,6 +3561,8 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("dispatch must succeed");
@@ -3578,6 +3580,8 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("get dispatch must succeed");
@@ -3614,6 +3618,8 @@ async fn exec_output_valid_json_with_backslash_escape_content() -> anyhow::Resul
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("update dispatch must succeed");
@@ -4034,6 +4040,8 @@ async fn dispatch_honors_explicit_namespace_else_local_adr007() {
                 presentation: Some("verbose".to_string()),
                 presentation_per_op: None,
                 save_to: None,
+                format: None,
+                format_per_op: None,
             })
             .await
             .expect("dispatch must not error at the MCP level");

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -4385,3 +4385,90 @@ async fn presentation_per_op_verbose_preserves_full_id_namespace_and_props() {
         "verbose op: properties.priority must survive the redundancy-drop pre-pass; rendered: {op1_rendered}"
     );
 }
+
+/// (fmt-4) AlwaysVerbose verbs must skip the redundancy-drop pre-pass under
+/// `format=auto` even with the DEFAULT Agent presentation and NO per-op override.
+///
+/// Pins the round-2 finding: `render_result` recomputed the format-time
+/// presentation only from `presentation_per_op` → batch default, blind to the
+/// `VerbPresentationPolicy::AlwaysVerbose` that `run_parsed` applies. So a
+/// policy-verbose verb (`get`) under `format=auto` with the default Agent mode
+/// was redundancy-dropped, stripping `namespace="local"` and duplicate
+/// `properties` keys it is declared AlwaysVerbose to preserve. The fix folds the
+/// AlwaysVerbose policy into the format-seam presentation. This is the *implicit
+/// policy* sibling of `presentation_per_op_verbose_preserves_*` (explicit override).
+#[tokio::test]
+async fn format_auto_always_verbose_verb_skips_redundancy_drop_without_override() {
+    use khive_mcp::tools::request::RequestParams;
+
+    let server = make_format_server();
+
+    // Create a GTD task: assignee/priority/status are echoed in both top-level
+    // and `properties`, and the record carries namespace="local".
+    let create_params = RequestParams {
+        ops: r#"gtd.assign(title="always-verbose-pin", priority="p1", assignee="lambda:test")"#
+            .to_string(),
+        presentation: Some("verbose".to_string()),
+        presentation_per_op: None,
+        save_to: None,
+        format: None,
+        format_per_op: None,
+    };
+    let create_raw = server
+        .dispatch_request_local(create_params)
+        .await
+        .expect("task creation must succeed");
+    let create_body: serde_json::Value = serde_json::from_str(&create_raw).unwrap();
+    let task_id = create_body["results"][0]["result"]["id"]
+        .as_str()
+        .expect("task id must be present");
+
+    // get() is AlwaysVerbose (ADR-045 §6). Dispatch it under format=auto with the
+    // DEFAULT Agent presentation and NO presentation_per_op override. The
+    // AlwaysVerbose policy must force Verbose at the format seam, so the
+    // redundancy-drop pre-pass is skipped and namespace/properties survive.
+    let get_params = RequestParams {
+        ops: format!(r#"get(id="{task_id}")"#),
+        presentation: None,        // → default Agent
+        presentation_per_op: None, // → no per-op override
+        save_to: None,
+        format: Some("auto".to_string()),
+        format_per_op: None,
+    };
+    let raw = server
+        .dispatch_request_local(get_params)
+        .await
+        .expect("get dispatch must succeed");
+
+    let body: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON envelope");
+    let results = body["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 1, "single get must produce 1 result");
+    assert_eq!(
+        results[0]["ok"],
+        serde_json::json!(true),
+        "get must succeed: {}",
+        results[0]
+    );
+
+    let rendered = results[0]["result"]
+        .as_str()
+        .expect("get result must be a rendered string under format=auto");
+
+    // namespace="local" is elided under agent+auto (§7.3) but MUST survive for an
+    // AlwaysVerbose verb — this is the regression the round-2 fix closes.
+    assert!(
+        rendered.contains("namespace"),
+        "AlwaysVerbose get: namespace must survive redundancy-drop under format=auto + \
+         default agent (no override); rendered: {rendered}"
+    );
+    // Duplicate properties keys (assignee/priority) are deduped under agent+auto
+    // but MUST survive for an AlwaysVerbose verb.
+    assert!(
+        rendered.contains("assignee"),
+        "AlwaysVerbose get: properties.assignee must survive redundancy-drop; rendered: {rendered}"
+    );
+    assert!(
+        rendered.contains("priority"),
+        "AlwaysVerbose get: properties.priority must survive redundancy-drop; rendered: {rendered}"
+    );
+}

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -124,7 +124,7 @@ pub fn acquire_recovery_lock() -> Option<std::fs::File> {
 // ── wire types ────────────────────────────────────────────────────────────────
 
 /// Request frame sent from a client to the daemon.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct DaemonRequestFrame {
     pub ops: String,
     pub presentation: Option<String>,
@@ -148,6 +148,13 @@ pub struct DaemonRequestFrame {
     /// Pre-probe clients omit this field (deserializes to false → normal dispatch).
     #[serde(default)]
     pub probe_only: bool,
+    /// Output format for this request (ADR-078). Forwarded to the daemon's
+    /// serialization seam. `None` means use the daemon's resolved default.
+    #[serde(default)]
+    pub format: Option<String>,
+    /// Per-operation output format overrides (ADR-078).
+    #[serde(default)]
+    pub format_per_op: Option<Vec<Option<String>>>,
 }
 
 /// Response frame sent from the daemon back to a client.
@@ -227,12 +234,14 @@ pub async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> std::io::Re
 /// future transport can do the same.
 #[async_trait]
 pub trait DaemonDispatch: Clone + Send + Sync + 'static {
-    /// Dispatch a verb-DSL request string and return the JSON result.
+    /// Dispatch a verb-DSL request string and return the rendered result.
     async fn dispatch(
         &self,
         ops: String,
         presentation: Option<String>,
         presentation_per_op: Option<Vec<Option<String>>>,
+        format: Option<String>,
+        format_per_op: Option<Vec<Option<String>>>,
     ) -> Result<String, String>;
 
     /// Warm every pack's in-memory state (ANN indexes, etc.).
@@ -337,7 +346,13 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
         }
     } else {
         match dispatcher
-            .dispatch(frame.ops, frame.presentation, frame.presentation_per_op)
+            .dispatch(
+                frame.ops,
+                frame.presentation,
+                frame.presentation_per_op,
+                frame.format,
+                frame.format_per_op,
+            )
             .await
         {
             Ok(result) => DaemonResponseFrame {

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -10,6 +10,8 @@ use khive_types::namespace::Namespace;
 use serde::Deserialize;
 use thiserror::Error;
 
+use crate::presentation::OutputFormat;
+
 // ---- Error type ----
 
 /// Errors produced while loading or validating a `KhiveConfig`.
@@ -282,6 +284,15 @@ pub struct RuntimeSectionConfig {
     /// global tuning prior is used as the final fallback.
     #[serde(default)]
     pub brain_profile: Option<String>,
+
+    /// Default output serialization format (ADR-078).
+    ///
+    /// Mirrors `--output-format` / `KHIVE_OUTPUT_FORMAT`. Precedence (highest to lowest):
+    /// per-request `format` field → `KHIVE_OUTPUT_FORMAT` → this field → builtin `json`.
+    ///
+    /// Accepted values: `"json"` (default), `"auto"`, `"table"`.
+    #[serde(default)]
+    pub default_output_format: Option<OutputFormat>,
 }
 
 impl KhiveConfig {

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -68,7 +68,9 @@ pub use pack::{
     VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder, Visibility,
 };
 pub use portability::{ImportSummary, KgArchive};
-pub use presentation::{micros_to_iso, present, PresentationMode};
+pub use presentation::{
+    apply_redundancy_drop, micros_to_iso, present, render_format, OutputFormat, PresentationMode,
+};
 pub use registry::{ObjectiveRegistry, RegisteredObjective};
 pub use retrieval::{SearchHit, SearchSource};
 pub use runtime::{

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -82,7 +82,7 @@ pub fn render_format(value: Value, format: OutputFormat, presentation: Presentat
 /// Apply the view-only redundancy-reduction pre-pass (ADR-078 §7) to a value.
 ///
 /// Applies at most ONE pass over the value. This function is the canonical
-/// entry for the pre-pass; the per-record logic lives in [`drop_record`].
+/// entry for the pre-pass; the per-record logic lives in `drop_record`.
 ///
 /// Applied only when `format` ∈ {`auto`, `table`} AND `presentation` ≠ `Verbose`.
 /// Callers are responsible for checking those conditions; this function applies
@@ -275,9 +275,12 @@ fn cell_text(value: &Value) -> String {
     // Escape literal `|` and collapse embedded newlines to a space.
     let escaped = raw.replace('|', "\\|").replace(['\n', '\r'], " ");
 
-    // Truncate to approximately CELL_TRUNCATE characters.
-    if escaped.len() > CELL_TRUNCATE {
-        format!("{}...", &escaped[..CELL_TRUNCATE])
+    // Truncate to approximately CELL_TRUNCATE *characters* (char boundary,
+    // not byte index — slicing on a byte offset can panic on multi-byte chars).
+    let char_count = escaped.chars().count();
+    if char_count > CELL_TRUNCATE {
+        let truncated: String = escaped.chars().take(CELL_TRUNCATE).collect();
+        format!("{truncated}...")
     } else {
         escaped
     }
@@ -1082,6 +1085,35 @@ mod tests {
         assert!(
             !rendered.contains(&long),
             "full long string must not appear in table"
+        );
+    }
+
+    /// Cell truncation must not panic on multi-byte UTF-8 characters (High 3).
+    ///
+    /// A string of 119 ASCII bytes followed by a 3-byte CJK character and more
+    /// text has `len() > 120` but byte index 120 falls inside the CJK char.
+    /// The old byte-slice truncation would panic; char-boundary truncation is safe.
+    #[test]
+    fn cell_text_truncation_is_utf8_safe() {
+        // 119 ASCII 'a' bytes, then CJK char U+4E2D (3 bytes each), then more text.
+        // Total byte length: 119 + 3 * 10 + 5 > 120, but byte 120 is inside a CJK char.
+        let prefix = "a".repeat(119);
+        let suffix = "中".repeat(10); // each '中' is 3 bytes
+        let long_multibyte = format!("{prefix}{suffix}trailing");
+        let v = json!([
+            {"col": long_multibyte.clone()},
+            {"col": "ok"}
+        ]);
+        // Must not panic — this was the bug.
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
+        assert!(
+            rendered.contains("..."),
+            "multibyte cell must be truncated with ..."
+        );
+        // The rendered string must be valid UTF-8 (no partial char slicing).
+        assert!(
+            std::str::from_utf8(rendered.as_bytes()).is_ok(),
+            "rendered output must be valid UTF-8"
         );
     }
 }

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -3,11 +3,320 @@
 //! Transforms canonical handler output into caller-appropriate form after dispatch
 //! and before wire serialization. `Agent` mode abbreviates UUIDs/timestamps and drops
 //! empty fields; `Verbose` and `Human` pass through canonical JSON unchanged.
+//!
+//! This module also contains the `OutputFormat` axis (ADR-078) which governs how
+//! the resulting `serde_json::Value` is serialized or rendered to an output string.
+//! `PresentationMode` and `OutputFormat` compose independently.
 
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+
+// ── OutputFormat ─────────────────────────────────────────────────────────────
+
+/// Output serialization format for verb results (ADR-078).
+///
+/// Orthogonal to [`PresentationMode`]: `PresentationMode` controls field-level
+/// transforms (UUID shortening, timestamp compaction, empty-field dropping);
+/// `OutputFormat` controls how the resulting `serde_json::Value` is serialized
+/// or rendered to the wire string.
+///
+/// Default is [`OutputFormat::Json`] on every surface: compact, lossless,
+/// shape-stable machine contract.
+///
+/// Note: `Yaml` is a clean follow-up — implemented as a 3-variant enum
+/// (`Json`, `Auto`, `Table`) per ADR-078 §"yaml" which permits omission when
+/// the in-tree emitter would balloon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputFormat {
+    /// Compact JSON (`serde_json::to_string`). Lossless machine contract. Default.
+    #[default]
+    Json,
+    /// Shape-aware: markdown table for homogeneous record arrays,
+    /// flat key-value block for single records, compact-JSON fallback.
+    Auto,
+    /// Force the markdown-table renderer regardless of detected shape.
+    Table,
+}
+
+/// Cell truncation limit for markdown-table rendering (ADR-078 §3a).
+const CELL_TRUNCATE: usize = 120;
+
+// ── Public render entry point ────────────────────────────────────────────────
+
+/// Render a successful verb result value to a wire string using the given format.
+///
+/// Called at the single serialization seam (ADR-078 §9) AFTER all `$prev` chain
+/// resolution and AFTER the [`PresentationMode`] transform.
+///
+/// Error envelopes (`ok=false`) are never passed here — the caller must handle
+/// them as compact JSON directly (ADR-078 §8.2).
+///
+/// When `format` is [`OutputFormat::Json`], returns compact JSON (`serde_json::to_string`).
+/// When `format` is [`OutputFormat::Auto`] or [`OutputFormat::Table`], applies the
+/// redundancy-reduction pre-pass (§7) — unless `presentation` is [`PresentationMode::Verbose`]
+/// — then dispatches to the shape-aware renderer.
+pub fn render_format(value: Value, format: OutputFormat, presentation: PresentationMode) -> String {
+    match format {
+        OutputFormat::Json => serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string()),
+        OutputFormat::Auto | OutputFormat::Table => {
+            // Redundancy-reduction pre-pass (§7): skipped in Verbose mode.
+            let reduced = if presentation == PresentationMode::Verbose {
+                value
+            } else {
+                apply_redundancy_drop(value)
+            };
+            match format {
+                OutputFormat::Auto => render_auto(reduced),
+                OutputFormat::Table => render_table_forced(reduced),
+                OutputFormat::Json => unreachable!(),
+            }
+        }
+    }
+}
+
+// ── Redundancy-reduction pre-pass (ADR-078 §7) ──────────────────────────────
+
+/// Apply the view-only redundancy-reduction pre-pass (ADR-078 §7) to a value.
+///
+/// Applies at most ONE pass over the value. This function is the canonical
+/// entry for the pre-pass; the per-record logic lives in [`drop_record`].
+///
+/// Applied only when `format` ∈ {`auto`, `table`} AND `presentation` ≠ `Verbose`.
+/// Callers are responsible for checking those conditions; this function applies
+/// unconditionally.
+pub fn apply_redundancy_drop(value: Value) -> Value {
+    match value {
+        Value::Object(_) => drop_record(value),
+        Value::Array(arr) => Value::Array(
+            arr.into_iter()
+                .map(|v| if v.is_object() { drop_record(v) } else { v })
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+/// Apply per-record redundancy rules (§7.1, §7.2, §7.3) to a single record object.
+fn drop_record(value: Value) -> Value {
+    let Value::Object(mut map) = value else {
+        return value;
+    };
+
+    // §7.1: suppress `full_id`.
+    map.remove("full_id");
+
+    // §7.3: elide `namespace` when its value is `"local"`.
+    if map.get("namespace").and_then(Value::as_str) == Some("local") {
+        map.remove("namespace");
+    }
+
+    // §7.2: properties dedup — remove key-value pairs from `properties` that
+    // have an identical counterpart at the top level of this record.
+    let props_val = map.remove("properties");
+    if let Some(Value::Object(props)) = props_val {
+        let mut new_props = Map::new();
+        for (k, v) in props {
+            if map.get(&k) != Some(&v) {
+                new_props.insert(k, v);
+            }
+        }
+        if !new_props.is_empty() {
+            map.insert("properties".to_string(), Value::Object(new_props));
+        }
+    } else if let Some(other) = props_val {
+        map.insert("properties".to_string(), other);
+    }
+
+    // Recurse into array values so nested record arrays are also reduced.
+    let out: Map<String, Value> = map
+        .into_iter()
+        .map(|(k, v)| {
+            let v = match v {
+                Value::Array(arr) => Value::Array(
+                    arr.into_iter()
+                        .map(|item| {
+                            if item.is_object() {
+                                drop_record(item)
+                            } else {
+                                item
+                            }
+                        })
+                        .collect(),
+                ),
+                other => other,
+            };
+            (k, v)
+        })
+        .collect();
+    Value::Object(out)
+}
+
+// ── Shape-aware rendering (`auto`) ──────────────────────────────────────────
+
+/// Render a value using shape-aware dispatch (ADR-078 §3).
+fn render_auto(value: Value) -> String {
+    // Shape (a): homogeneous record array.
+    if let Some((records, keys)) = find_record_array(&value) {
+        return render_table(&records, &keys);
+    }
+    // Shape (b): single record / heterogeneous object.
+    if value.is_object() {
+        return render_kv_block(&value, 0);
+    }
+    // Shape (c): compact-JSON fallback.
+    serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())
+}
+
+/// Force the markdown-table renderer regardless of detected shape (ADR-078 §6).
+fn render_table_forced(value: Value) -> String {
+    if let Some((records, keys)) = find_record_array(&value) {
+        return render_table(&records, &keys);
+    }
+    // No record array detected — fallback to compact JSON per §8.3.
+    serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())
+}
+
+/// Find the first homogeneous record array in `value`.
+///
+/// Checks:
+/// 1. `value` itself is an array of 2+ objects.
+/// 2. `value` is an object with a key whose value is an array of 2+ objects.
+///
+/// Returns `(records_cloned, ordered_column_keys)` when found.
+fn find_record_array(value: &Value) -> Option<(Vec<Value>, Vec<String>)> {
+    match value {
+        Value::Array(arr) if arr.len() >= 2 && arr.iter().all(Value::is_object) => {
+            let keys = collect_keys(arr);
+            Some((arr.clone(), keys))
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                if let Value::Array(arr) = v {
+                    if arr.len() >= 2 && arr.iter().all(Value::is_object) {
+                        let keys = collect_keys(arr);
+                        return Some((arr.clone(), keys));
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Collect column names in first-seen order across all records.
+fn collect_keys(records: &[Value]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut keys = Vec::new();
+    for record in records {
+        if let Value::Object(map) = record {
+            for k in map.keys() {
+                if seen.insert(k.clone()) {
+                    keys.push(k.clone());
+                }
+            }
+        }
+    }
+    keys
+}
+
+// ── Markdown table renderer (ADR-078 §3a) ───────────────────────────────────
+
+/// Render a record array as a GitHub-Flavored Markdown table.
+fn render_table(records: &[Value], keys: &[String]) -> String {
+    let mut out = String::new();
+
+    // Header row.
+    out.push('|');
+    for k in keys {
+        out.push(' ');
+        out.push_str(k);
+        out.push_str(" |");
+    }
+    out.push('\n');
+
+    // Separator row.
+    out.push('|');
+    for _ in keys {
+        out.push_str("---|");
+    }
+    out.push('\n');
+
+    // Data rows.
+    for record in records {
+        out.push('|');
+        for k in keys {
+            let cell = record.get(k).unwrap_or(&Value::Null);
+            let text = cell_text(cell);
+            out.push(' ');
+            out.push_str(&text);
+            out.push_str(" |");
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Format a cell value: escape `|`, collapse newlines, truncate to ~120 chars.
+fn cell_text(value: &Value) -> String {
+    let raw = match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => s.clone(),
+        // Arrays and nested objects use compact JSON in the cell.
+        other => serde_json::to_string(other).unwrap_or_default(),
+    };
+
+    // Escape literal `|` and collapse embedded newlines to a space.
+    let escaped = raw.replace('|', "\\|").replace(['\n', '\r'], " ");
+
+    // Truncate to approximately CELL_TRUNCATE characters.
+    if escaped.len() > CELL_TRUNCATE {
+        format!("{}...", &escaped[..CELL_TRUNCATE])
+    } else {
+        escaped
+    }
+}
+
+// ── Flat key-value block renderer (ADR-078 §3b) ─────────────────────────────
+
+/// Render a single record or heterogeneous object as a flat key-value block.
+fn render_kv_block(value: &Value, depth: usize) -> String {
+    let indent = "  ".repeat(depth);
+    match value {
+        Value::Object(map) => {
+            let mut out = String::new();
+            for (k, v) in map {
+                match v {
+                    Value::Object(_) => {
+                        out.push_str(&format!("{}{}:\n", indent, k));
+                        out.push_str(&render_kv_block(v, depth + 1));
+                    }
+                    Value::Array(arr) if arr.iter().any(Value::is_object) => {
+                        out.push_str(&format!("{}{}:\n", indent, k));
+                        for item in arr {
+                            if item.is_object() {
+                                out.push_str(&render_kv_block(item, depth + 1));
+                            } else {
+                                out.push_str(&format!("{}  - {}\n", indent, cell_text(item)));
+                            }
+                        }
+                    }
+                    _ => {
+                        out.push_str(&format!("{}{}: {}\n", indent, k, cell_text(v)));
+                    }
+                }
+            }
+            out
+        }
+        other => format!("{}{}\n", indent, cell_text(other)),
+    }
+}
 
 /// Convert a microsecond epoch `i64` to an RFC 3339 / ISO-8601 string.
 ///
@@ -552,5 +861,227 @@ mod tests {
         assert_eq!(out["note_id"], json!("a1b2c3d4"));
         assert_eq!(out["source_id"], json!("a1b2c3d4"));
         assert_eq!(out["target_id"], json!("a1b2c3d4"));
+    }
+
+    // ── ADR-078: OutputFormat tests ───────────────────────────────────────────
+
+    /// (a) json format preserves full shape (no field dropped, no transformation).
+    #[test]
+    fn format_json_preserves_full_shape() {
+        let v = json!({
+            "full_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "namespace": "local",
+            "properties": {"k": "v"},
+            "title": "test"
+        });
+        let rendered = render_format(v.clone(), OutputFormat::Json, PresentationMode::Agent);
+        let parsed: Value = serde_json::from_str(&rendered).unwrap();
+        // full_id must NOT be dropped in json mode (§P-C1, §4).
+        assert!(
+            parsed.get("full_id").is_some(),
+            "json mode must keep full_id"
+        );
+        // namespace must NOT be elided in json mode.
+        assert_eq!(
+            parsed.get("namespace").and_then(Value::as_str),
+            Some("local")
+        );
+        // properties must NOT be deduped in json mode.
+        assert!(parsed.get("properties").is_some());
+    }
+
+    /// (a-vs-auto) auto mode drops redundant fields that json mode preserves.
+    #[test]
+    fn format_auto_drops_versus_json_keeps() {
+        let v = json!({
+            "full_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "namespace": "local",
+            "title": "test"
+        });
+        let json_rendered = render_format(v.clone(), OutputFormat::Json, PresentationMode::Agent);
+        let auto_rendered = render_format(v.clone(), OutputFormat::Auto, PresentationMode::Agent);
+        // json keeps both; auto drops namespace="local" and full_id.
+        let json_parsed: Value = serde_json::from_str(&json_rendered).unwrap();
+        assert!(
+            json_parsed.get("full_id").is_some(),
+            "json must keep full_id"
+        );
+        assert_eq!(
+            json_parsed.get("namespace").and_then(Value::as_str),
+            Some("local")
+        );
+        // Auto mode: namespace should be elided (redundancy §7.3), full_id dropped (§7.1).
+        // The value itself is a single record → rendered as kv block.
+        assert!(
+            !auto_rendered.contains("full_id"),
+            "auto kv block must drop full_id"
+        );
+        assert!(
+            !auto_rendered.contains("namespace"),
+            "auto kv block must elide namespace=local"
+        );
+    }
+
+    /// (b1) homogeneous record array → markdown table with header + separator + rows.
+    #[test]
+    fn format_auto_homogeneous_array_renders_markdown_table() {
+        let v = json!([
+            {"id": "abc", "title": "First"},
+            {"id": "def", "title": "Second"}
+        ]);
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
+        // Header row.
+        assert!(rendered.starts_with('|'), "must start with |");
+        assert!(
+            rendered.contains("| id |") || rendered.contains("| id"),
+            "must have id column"
+        );
+        assert!(rendered.contains("title"), "must have title column");
+        // Separator row.
+        assert!(rendered.contains("|---|"), "must have separator row");
+        // Data rows.
+        assert!(rendered.contains("abc"), "must have first row data");
+        assert!(rendered.contains("Second"), "must have second row data");
+    }
+
+    /// (b2) single record → flat kv block.
+    #[test]
+    fn format_auto_single_record_renders_kv_block() {
+        let v = json!({"id": "abc", "title": "Hello World"});
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
+        // kv block uses "key: value\n" format.
+        assert!(rendered.contains("id: abc"), "must have id: abc");
+        assert!(
+            rendered.contains("title: Hello World"),
+            "must have title line"
+        );
+        // Must NOT contain markdown table markers.
+        assert!(
+            !rendered.starts_with('|'),
+            "single record must not be a markdown table"
+        );
+    }
+
+    /// (b3) fallback: auto on heterogeneous/scalar value falls back to compact json.
+    #[test]
+    fn format_auto_scalar_fallback_compact_json() {
+        let v = json!(42);
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
+        assert_eq!(rendered, "42");
+    }
+
+    /// (c) table format forces markdown table even when shape would normally be kv.
+    #[test]
+    fn format_table_forces_markdown_when_array() {
+        let v = json!({
+            "items": [
+                {"name": "A", "score": 1},
+                {"name": "B", "score": 2}
+            ]
+        });
+        let rendered = render_format(v, OutputFormat::Table, PresentationMode::Agent);
+        assert!(
+            rendered.contains("|"),
+            "table format must produce markdown table"
+        );
+        assert!(rendered.contains("name"), "must have name column");
+        assert!(rendered.contains("score"), "must have score column");
+    }
+
+    /// (c-fallback) table format falls back to compact json when no record array found.
+    #[test]
+    fn format_table_falls_back_to_json_when_no_array() {
+        let v = json!({"single": "value"});
+        let rendered = render_format(v, OutputFormat::Table, PresentationMode::Agent);
+        // No record array → compact JSON fallback.
+        let parsed: Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed["single"], json!("value"));
+    }
+
+    /// (d) redundancy-drop: auto/table skipped in Verbose mode (§7).
+    #[test]
+    fn format_auto_verbose_skips_redundancy_drop() {
+        let v = json!({
+            "full_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "namespace": "local",
+            "title": "test"
+        });
+        // In Verbose mode, redundancy drop must be skipped.
+        // The value is a single object → kv block, but full_id and namespace stay.
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Verbose);
+        assert!(
+            rendered.contains("full_id"),
+            "verbose must preserve full_id"
+        );
+        assert!(
+            rendered.contains("namespace"),
+            "verbose must preserve namespace"
+        );
+    }
+
+    /// (e) error envelope invariant: ok=false entries must stay compact json under auto.
+    ///
+    /// This tests the render_result logic via the redundancy-drop + render path.
+    /// The server-level render_result function is tested indirectly: we verify that
+    /// apply_redundancy_drop does NOT touch "ok: false" envelopes (the actual
+    /// invariant is enforced by render_result checking the ok flag before dispatching).
+    #[test]
+    fn redundancy_drop_does_not_corrupt_error_shape() {
+        // An error envelope that might be passed to the pre-pass in a batch.
+        let v = json!({"ok": false, "error": "something failed", "namespace": "local"});
+        // apply_redundancy_drop is a pure value transform; it doesn't know about ok.
+        // The caller (render_result in server.rs) is responsible for bypassing
+        // auto-render on ok=false entries. Here we just verify the pre-pass
+        // doesn't lose the error field.
+        let reduced = apply_redundancy_drop(v.clone());
+        assert!(
+            reduced.get("error").is_some(),
+            "redundancy drop must preserve error field"
+        );
+        assert_eq!(
+            reduced.get("ok").and_then(Value::as_bool),
+            Some(false),
+            "redundancy drop must preserve ok=false"
+        );
+    }
+
+    /// Properties dedup removes only keys that match a top-level sibling exactly.
+    #[test]
+    fn redundancy_drop_properties_dedup() {
+        let v = json!({
+            "id": "abc",
+            "title": "Same",
+            "properties": {
+                "title": "Same",  // duplicate → removed
+                "extra": "unique" // not at top level → kept
+            }
+        });
+        let reduced = apply_redundancy_drop(v);
+        let props = reduced.get("properties").expect("properties must remain");
+        assert!(props.get("extra").is_some(), "unique property must be kept");
+        assert!(
+            props.get("title").is_none(),
+            "duplicate top-level property must be removed"
+        );
+    }
+
+    /// Cell truncation: text > 120 chars gets `...` appended.
+    #[test]
+    fn cell_text_truncates_long_values() {
+        let long = "X".repeat(200);
+        let v = json!([
+            {"col": long.clone()},
+            {"col": "short"}
+        ]);
+        let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
+        // Cell must be truncated to ~120 chars + "..."
+        assert!(
+            rendered.contains("..."),
+            "long cell must be truncated with ..."
+        );
+        assert!(
+            !rendered.contains(&long),
+            "full long string must not appear in table"
+        );
     }
 }

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -1013,6 +1013,8 @@ async fn t7a_multi_backend_search_populates_real_entity_kind() {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("T7a: dispatch");
@@ -1101,6 +1103,8 @@ async fn t7b_multi_backend_search_kind_filter_excludes_off_kind() {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("T7b: dispatch");
@@ -1161,6 +1165,8 @@ async fn t7c_multi_backend_search_min_score_applied() {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .expect("T7c: dispatch");

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -38,7 +38,7 @@ use khive_mcp::server::KhiveMcpServer;
 use khive_mcp::tools::request::RequestParams;
 #[cfg(unix)]
 use khive_runtime::{daemon::PROTOCOL_VERSION, DaemonRequestFrame};
-use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+use khive_runtime::{KhiveConfig, KhiveRuntime, Namespace, RuntimeConfig};
 
 // ── daemon-forward seam (Unix only) ─────────────────────────────────────────
 //
@@ -453,14 +453,22 @@ async fn run_exec_inline_with_forward(
     }
 
     // ── in-process fallback ───────────────────────────────────────────────────
-    // Apply the env-var tier (ADR-078 §2 tier-2: KHIVE_OUTPUT_FORMAT) before
-    // building the server, mirroring the serve path.  The CLI flag is then passed
-    // as the per-request `format` field (tier-1), which overrides the server default
-    // at dispatch time.
+    // Resolve the full ADR-078 §2 precedence chain before building the server,
+    // mirroring the serve path: env-var (tier-2: KHIVE_OUTPUT_FORMAT) over
+    // TOML `[runtime] default_output_format` (tier-3) over builtin json. The CLI
+    // flag is then passed as the per-request `format` field (tier-1), which
+    // overrides the server default at dispatch time. This block only runs in the
+    // in-process fallback — the common daemon-forward path returns above and the
+    // daemon applies its own serve-time TOML resolution — so the config load here
+    // is off the hot path.
     let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     // Note: enforce_strict_actor_mode was called above before the daemon fast-path;
     // it is not repeated here — the single early check covers both paths.
-    let env_fmt = apply_env_output_format(None);
+    let toml_default = KhiveConfig::load_with_home_fallback(None)
+        .ok()
+        .flatten()
+        .and_then(|c| c.runtime.default_output_format);
+    let env_fmt = apply_env_output_format(toml_default);
     let server = KhiveMcpServer::new(rt)
         .map_err(|e| anyhow::anyhow!("{e}"))?
         .with_default_output_format(env_fmt);

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -257,6 +257,8 @@ async fn apply_ops_file(
             presentation: presentation.clone(),
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         };
 
         let raw = server
@@ -409,6 +411,8 @@ async fn run_exec_inline_with_forward(
             config_id: compute_config_id(&cfg, None),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
+            format: None,
+            format_per_op: None,
         };
         if let Some(res) = forward_fn(&frame).await {
             let output = res.map_err(|e| anyhow::anyhow!("{}", e.message))?;
@@ -428,6 +432,8 @@ async fn run_exec_inline_with_forward(
         presentation,
         presentation_per_op: None,
         save_to: save_file,
+        format: None,
+        format_per_op: None,
     };
 
     let output = server
@@ -630,6 +636,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -677,6 +685,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -991,6 +1001,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         };
         let raw = server.dispatch_request_local(params).await.unwrap();
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 
-use khive_mcp::serve::enforce_strict_actor_mode;
+use khive_mcp::serve::{apply_env_output_format, enforce_strict_actor_mode};
 #[cfg(unix)]
 use khive_mcp::server::compute_config_id;
 use khive_mcp::server::KhiveMcpServer;
@@ -117,6 +117,16 @@ pub struct ExecArgs {
     /// Presentation mode: `agent` (default), `verbose`, or `human`.
     #[arg(long)]
     pub presentation: Option<String>,
+
+    /// Output format for verb results (ADR-078 §2 precedence: this flag >
+    /// `KHIVE_OUTPUT_FORMAT` env var > `[runtime] default_output_format` in
+    /// `khive.toml` > builtin `json`).
+    ///
+    /// Valid values: `json` (compact, lossless — default), `auto` (shape-aware:
+    /// markdown table for record arrays, key-value block for single records),
+    /// `table` (force markdown table).
+    #[arg(long, value_name = "FORMAT")]
+    pub output_format: Option<String>,
 
     /// Verbose output: print per-event progress to stderr.
     #[arg(long, short = 'v')]
@@ -343,7 +353,16 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
         Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     match mode {
-        ExecMode::Inline(ops) => run_exec_inline(ops, cfg, args.presentation, args.save_file).await,
+        ExecMode::Inline(ops) => {
+            run_exec_inline(
+                ops,
+                cfg,
+                args.presentation,
+                args.output_format,
+                args.save_file,
+            )
+            .await
+        }
         ExecMode::OpsFile(path) => {
             run_exec_ops_file(path, cfg, args.presentation, args.dry_run).await
         }
@@ -359,13 +378,21 @@ async fn run_exec_inline(
     ops: String,
     cfg: RuntimeConfig,
     presentation: Option<String>,
+    output_format: Option<String>,
     save_file: Option<String>,
 ) -> Result<()> {
     #[cfg(unix)]
-    return run_exec_inline_with_forward(ops, cfg, presentation, save_file, forward_or_spawn_boxed)
-        .await;
+    return run_exec_inline_with_forward(
+        ops,
+        cfg,
+        presentation,
+        output_format,
+        save_file,
+        forward_or_spawn_boxed,
+    )
+    .await;
     #[cfg(not(unix))]
-    return run_exec_inline_with_forward(ops, cfg, presentation, save_file).await;
+    return run_exec_inline_with_forward(ops, cfg, presentation, output_format, save_file).await;
 }
 
 /// Inner implementation of `run_exec_inline`, parameterised over the daemon
@@ -385,6 +412,7 @@ async fn run_exec_inline_with_forward(
     ops: String,
     cfg: RuntimeConfig,
     presentation: Option<String>,
+    output_format: Option<String>,
     save_file: Option<String>,
     #[cfg(unix)] forward_fn: ForwardFnPtr,
 ) -> Result<()> {
@@ -401,6 +429,9 @@ async fn run_exec_inline_with_forward(
     // The daemon path does not support --save-file (the daemon returns a string;
     // we would need to parse it back to apply the sink).  Skip daemon forwarding
     // when --save-file is set so the in-process path handles everything.
+    //
+    // The --output-format CLI flag (ADR-078 tier-1) is forwarded to the daemon as
+    // the per-request `format` field so the daemon applies it at its seam.
     #[cfg(unix)]
     if save_file.is_none() {
         let frame = DaemonRequestFrame {
@@ -411,7 +442,7 @@ async fn run_exec_inline_with_forward(
             config_id: compute_config_id(&cfg, None),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
-            format: None,
+            format: output_format.clone(),
             format_per_op: None,
         };
         if let Some(res) = forward_fn(&frame).await {
@@ -422,17 +453,25 @@ async fn run_exec_inline_with_forward(
     }
 
     // ── in-process fallback ───────────────────────────────────────────────────
+    // Apply the env-var tier (ADR-078 §2 tier-2: KHIVE_OUTPUT_FORMAT) before
+    // building the server, mirroring the serve path.  The CLI flag is then passed
+    // as the per-request `format` field (tier-1), which overrides the server default
+    // at dispatch time.
     let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     // Note: enforce_strict_actor_mode was called above before the daemon fast-path;
     // it is not repeated here — the single early check covers both paths.
-    let server = KhiveMcpServer::new(rt).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let env_fmt = apply_env_output_format(None);
+    let server = KhiveMcpServer::new(rt)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .with_default_output_format(env_fmt);
 
     let params = RequestParams {
         ops,
         presentation,
         presentation_per_op: None,
         save_to: save_file,
-        format: None,
+        // Tier-1: CLI --output-format overrides the server default (env/builtin).
+        format: output_format,
         format_per_op: None,
     };
 
@@ -733,7 +772,7 @@ mod tests {
             ..RuntimeConfig::default()
         };
 
-        let result = run_exec_inline("stats()".to_string(), cfg, None, None).await;
+        let result = run_exec_inline("stats()".to_string(), cfg, None, None, None).await;
 
         // Restore env.
         match prev_strict {
@@ -779,7 +818,7 @@ mod tests {
         };
 
         // The strict gate must pass; the actual dispatch will succeed (stats() is safe).
-        let result = run_exec_inline("stats()".to_string(), cfg, None, None).await;
+        let result = run_exec_inline("stats()".to_string(), cfg, None, None, None).await;
 
         match prev_strict {
             Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
@@ -814,7 +853,7 @@ mod tests {
             ..RuntimeConfig::default()
         };
 
-        let result = run_exec_inline("stats()".to_string(), cfg, None, None).await;
+        let result = run_exec_inline("stats()".to_string(), cfg, None, None, None).await;
 
         match prev_strict {
             Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
@@ -889,6 +928,7 @@ mod tests {
             "stats()".to_string(),
             cfg,
             None,
+            None, // output_format
             None,
             spy_forward_records_call,
         )
@@ -942,6 +982,7 @@ mod tests {
             "stats()".to_string(),
             cfg,
             None,
+            None, // output_format
             None,
             spy_forward_records_call,
         )

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -261,6 +261,15 @@ async fn main() -> Result<()> {
 
                 let coord =
                     SubstrateCoordinatorService::new(SubstrateCoordinator::new(backend_reg));
+                // Resolve the ADR-078 output-format default (env > [runtime] TOML >
+                // builtin json) for this serve path too — the single-backend branch
+                // does this inside `serve::run`, but this multi-backend branch builds
+                // the server directly via `from_registry_with_meta`, which defaults to
+                // Json, so without this the fleet's `default_output_format` opt-in is
+                // silently ignored on the daemon's primary serve surface.
+                let output_format = khive_mcp::serve::apply_env_output_format(
+                    khive_cfg.runtime.default_output_format,
+                );
                 let server = khive_mcp::server::KhiveMcpServer::from_registry_with_meta(
                     multi.registry,
                     &multi.default_namespace,
@@ -268,7 +277,8 @@ async fn main() -> Result<()> {
                 )
                 .with_coordinator(
                     Arc::new(coord) as Arc<dyn khive_mcp::coordinator::CoordinatorService>
-                );
+                )
+                .with_default_output_format(output_format);
 
                 khive_mcp::serve::serve_server(server, &a, &transport_registry).await
             }

--- a/crates/kkernel/src/pending_events.rs
+++ b/crates/kkernel/src/pending_events.rs
@@ -377,6 +377,8 @@ async fn dispatch_action(
             presentation: None,
             presentation_per_op: None,
             save_to: None,
+            format: None,
+            format_per_op: None,
         })
         .await
         .map_err(|e| anyhow::anyhow!("pending-events: dispatch error: {e}"))?;

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -54,8 +54,12 @@ def recv(proc):
 
 
 def _call_request_raw(proc, ops_string):
-    """Send `request(ops=<ops_string>)`. Return the parsed response body."""
-    send(proc, "tools/call", {"name": "request", "arguments": {"ops": ops_string}})
+    """Send `request(ops=<ops_string>)`. Return the parsed response body.
+
+    Pins format=json (ADR-078) so the smoke test always receives lossless compact
+    JSON regardless of the server's default_output_format configuration.
+    """
+    send(proc, "tools/call", {"name": "request", "arguments": {"ops": ops_string, "format": "json"}})
     resp = recv(proc)
     if "error" in resp:
         raise RuntimeError(f"MCP error calling request: {resp['error']}")


### PR DESCRIPTION
## Summary

- Adds `OutputFormat { Json (default), Auto, Table }` as a new orthogonal axis alongside `PresentationMode`; controls how `serde_json::Value` is serialized on the wire
- `Auto` and `Table` modes trigger shape-aware markdown rendering (record-array → markdown table, single record → kv block) with a VIEW-ONLY redundancy-drop pre-pass (`full_id` suppression, `properties` child-key dedup, `namespace="local"` elision); pre-pass is skipped when `PresentationMode::Verbose`
- Error envelopes (`ok=false`) are never reformatted; outer batch envelope is always compact JSON; per-op format supported in batch responses
- Precedence chain wired: CLI `format` param > `KHIVE_OUTPUT_FORMAT` env > TOML `default_output_format` > builtin `json`
- `tests/smoke_test.py` pins `format=json` so all smoke assertions remain lossless

## Files changed

| File | Change | +LOC |
|------|--------|------|
| `crates/khive-runtime/src/presentation.rs` | `OutputFormat` enum, `render_format()`, `apply_redundancy_drop()`, shape detection, markdown table + kv block renderers, 13 new tests | +513 |
| `crates/khive-mcp/src/server.rs` | `dispatch_request_local` wired to `render_result()`, `parse_output_format()`, `with_default_output_format()` builder | +147 |
| `crates/khive-mcp/src/serve.rs` | `apply_env_output_format()` — tier-2 env / tier-3 TOML / tier-4 builtin chain | +49 |
| `crates/khive-mcp/src/daemon.rs` | `DaemonRequestFrame` + `DaemonDispatch::dispatch` signature extended; test mocks updated | +38 |
| `crates/khive-runtime/src/daemon.rs` | `format`/`format_per_op` fields with `#[serde(default)]` | +21 |
| `crates/khive-mcp/src/tools/request.rs` | `format`/`format_per_op` params on `RequestParams` | +23 |
| `crates/khive-runtime/src/engine_config.rs` | `default_output_format: Option<OutputFormat>` on `RuntimeSectionConfig` | +11 |
| `crates/khive-runtime/src/lib.rs` | Re-export `OutputFormat`, `render_format`, `apply_redundancy_drop` | +4 |
| `crates/kkernel/src/exec.rs` + others | Struct construction sites updated for new fields | +12 |
| `tests/smoke_test.py` | Pin `format=json` in `_call_request_raw` | +8 |

**YAML deferred**: ADR-078 §2 explicitly permits omitting `Yaml` when the emitter would balloon the dependency surface. The three-variant enum ships clean; YAML can be added in a follow-up without breaking changes.

## Gates

All gates run from `crates/`:

- `cargo fmt --all -- --check` — PASS
- `cargo check --workspace` — PASS (0 errors)
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS (0 warnings)
- `cargo test --workspace` — PASS (all crates, 0 failed)
- Pre-commit hooks (cargo fmt + cargo clippy + secret scan) — PASS

## Test plan

- [ ] Verify CI green on all crates
- [ ] Smoke test (`tests/smoke_test.py`) passes with the `format=json` pin in place
- [ ] Manual: invoke a `search` or `list` verb with `format=auto` and confirm markdown table output
- [ ] Manual: invoke `stats()` with `format=auto` and confirm kv block output
- [ ] Manual: set `KHIVE_OUTPUT_FORMAT=auto` and verify env tier applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)