### PR TITLE
docs(marketplace): sync plugin version 0.2.11 and verb count 67

### DIFF
--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.2.8   | ≥ 0.2.4 |
+| khive  | 0.2.11  | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "khive",
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
-  "version": "0.2.8",
+  "version": "0.2.11",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 65 verbs across 7 packs.
+exposing one tool — `request` — that dispatches 67 verbs across 7 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the


### PR DESCRIPTION
## What

The umbrella `khive` Claude Code plugin carried stale metadata:

| File | Was | Now |
| ---- | --- | --- |
| `marketplace/khive/.claude-plugin/plugin.json` | `"version": "0.2.8"` | `0.2.11` |
| `marketplace/INSTALL.md` (compat table) | `0.2.8` | `0.2.11` |
| `marketplace/khive/README.md` | `65 verbs across 7 packs` | `67 verbs` |

0.2.11 is the published crate version (matches the top-level README Status section). 67 is the actual verb total across the 7 default packs (kg 16, gtd 5, memory 5, brain 13, comm 5, schedule 4, knowledge 19).

The `kkernel ≥ 0.2.4` compatibility floor is left unchanged (it is a deliberate minimum, not a current-version field). No skill or agent content touched.

Docs/metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)