### PR TITLE
ci(release): close tag-publish gate hole — main-dispatch sole publisher (#222)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,11 +151,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # A manual workflow_dispatch can select any ref. Only `main` is allowed to
-      # cut a manual release, so the SemVer gate that runs is always main's
-      # current one — never an older ref whose release.yml predates this gate.
-      # Tag pushes (push event) are unaffected: a v* tag's own checked-out
-      # workflow carries the gate. publish-all depends on this job, so a blocked
-      # dispatch never reaches a publish step.
+      # cut a release, so the SemVer gate that runs is always main's current one —
+      # never an older ref whose release.yml predates this gate. Tag pushes no
+      # longer trigger this workflow at all (the push.tags trigger was removed in
+      # #222), so workflow_dispatch from main is the sole publish path. publish-all
+      # depends on this job, so a blocked dispatch never reaches a publish step.
       - name: Guard — manual dispatch only from main
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,13 @@
 name: Release
 
-# Triggered by a version tag push (e.g. v0.2.0).
+# Triggered ONLY by manual workflow_dispatch from `main` (see #222). A version
+# tag push does NOT publish: an old `v*` tag checks out an older release.yml whose
+# SemVer gate predates #216, so tag-triggered publishing is an ungated path. Making
+# main-dispatch the sole publisher means "the workflow that publishes" always equals
+# "the gate-carrying workflow on main". The `publish` environment's ref allowlist is
+# restricted to `main` (scripts/apply-autonomous-merge.sh), so even if an old tag's
+# old workflow runs, its publish job cannot deploy.
+#
 # Builds Rust binaries per-platform, publishes each khive-kernel-{platform}
 # npm subpackage, then publishes the umbrella khive package.
 #
@@ -24,9 +31,6 @@ name: Release
 # install the previous khive version unchanged.
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -197,15 +201,12 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      # Extract the version from the git tag (strip leading "v").
-      # Passed via env var to avoid shell-interpolation issues in node -e (MIN-3).
+      # Version comes from the required workflow_dispatch input (tag-push publishing
+      # was removed in #222). Passed via env var to avoid shell-interpolation issues
+      # in node -e (MIN-3).
       - name: Extract version
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
-          fi
+          echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
 
       # Download all six platform artifacts into their respective directories.
       - name: Download all platform artifacts

--- a/scripts/apply-autonomous-merge.sh
+++ b/scripts/apply-autonomous-merge.sh
@@ -329,6 +329,27 @@ assert_branch_policy() {
     <<<"${policies}" >/dev/null
 }
 
+# Delete every deployment-branch policy that is not exactly `main:branch`. GitHub
+# stores these as persistent allowlist rows, so an older setup that created a
+# `v*:tag` row leaves the tag-publish path open until that row is DELETED — merely
+# no longer creating it is not enough (#222). Fatal on any delete failure so a
+# surviving row aborts the activation rather than silently leaving the allowlist
+# wider than `main`.
+prune_non_main_branch_policies() {
+  local existing pid pname ptype
+  existing="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies" 2>/dev/null || echo '{}')"
+  while IFS=$'\t' read -r pid pname ptype; do
+    [[ -z "${pid}" ]] && continue
+    if [[ "${pname}" == "main" && ( "${ptype}" == "branch" || "${ptype}" == "null" ) ]]; then
+      continue
+    fi
+    echo "[release-gate] removing non-main deployment policy '${pname}' (${ptype}, id ${pid})."
+    gh api --method DELETE \
+      "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies/${pid}" >/dev/null \
+      || { echo "ABORT: failed to delete deployment policy '${pname}' (${ptype}, id ${pid})." >&2; exit 1; }
+  done < <(jq -r '.branch_policies[]? | [(.id|tostring), .name, (.type // "null")] | @tsv' <<<"${existing}")
+}
+
 step_release_gate() {
   echo "[STEP release-gate] Creating '${ENVIRONMENT}' environment with a required reviewer."
   # Don't clobber an already-hardened environment. The env 404s before first
@@ -337,8 +358,8 @@ step_release_gate() {
   if gh api "repos/${REPO}/environments/${ENVIRONMENT}" >/dev/null 2>&1; then
     if [[ "${FORCE:-false}" != "true" ]]; then
       echo "ABORT: '${ENVIRONMENT}' environment already exists." >&2
-      echo "Re-applying would replace its reviewers and branch policy with this" >&2
-      echo "script's defaults. Set FORCE=true to overwrite intentionally." >&2
+      echo "Re-applying would replace its reviewers and prune its branch policy to" >&2
+      echo "main-only — removing any stale 'v*' tag row (#222). Set FORCE=true to do so." >&2
       exit 1
     fi
     echo "[release-gate] FORCE=true — overwriting the existing '${ENVIRONMENT}' environment."
@@ -359,18 +380,28 @@ step_release_gate() {
   if [[ "${DRY_RUN}" != "false" ]]; then
     echo "[DRY RUN] PUT repos/${REPO}/environments/${ENVIRONMENT} (required reviewer: ${admin_login}, id ${admin_id})"
     echo "${body}" | jq .
+    echo "[DRY RUN] DELETE any non-main deployment-branch policy (e.g. an existing 'v*' tag row)"
     echo "[DRY RUN] POST deployment-branch-policies: branch 'main'"
   else
     echo "${body}" | gh api --method PUT "repos/${REPO}/environments/${ENVIRONMENT}" --input - >/dev/null
+    # Prune any pre-existing non-`main` policy FIRST. GitHub stores deployment
+    # policies as persistent allowlist rows, so an older setup's `v*:tag` row
+    # survives until it is affirmatively deleted — not creating it is not enough
+    # to close the tag-publish hole (#222).
+    prune_non_main_branch_policies
     # Define the ref allowlist. post_branch_policy is fatal on any non-duplicate
     # failure, so a dropped policy aborts the activation instead of silently
     # widening the allowlist.
     post_branch_policy 'main' 'branch'
-    # Read back and prove the policy is actually present before declaring success.
-    local policies
+    # Read back and prove `main` is present AND is the ONLY policy before declaring
+    # success — a lingering non-main row (e.g. `v*`) would keep the hole open.
+    local policies policy_count
     policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies")"
     assert_branch_policy "${policies}" 'main' 'branch' \
       || { echo "ABORT: 'main' branch policy missing after apply." >&2; exit 1; }
+    policy_count="$(jq -r '[.branch_policies[]?] | length' <<<"${policies}")"
+    [[ "${policy_count}" == "1" ]] \
+      || { echo "ABORT: publish allowlist has ${policy_count} policies after apply, expected exactly 1 (main:branch); a non-main ref can still deploy." >&2; exit 1; }
     echo "Environment '${ENVIRONMENT}' configured (required reviewer: ${admin_login}; refs: main only)."
   fi
 }
@@ -416,6 +447,15 @@ preflight_autonomy() {
     assert_branch_policy "${policies}" "${pname}" "${ptype}" \
       || { echo "ABORT: '${ENVIRONMENT}' missing deployment policy ${pname} (${ptype}) — run STEP=release-gate first." >&2; exit 1; }
   done
+  # `main` present is necessary but not sufficient: a lingering non-main row (e.g.
+  # a `v*` tag from an older setup) would still let a tag deploy. Require the
+  # allowlist to be EXACTLY main:branch — fail closed otherwise (#222).
+  local policy_count
+  policy_count="$(jq -r '[.branch_policies[]?] | length' <<<"${policies}")"
+  if [[ "${policy_count}" != "1" ]]; then
+    echo "ABORT: '${ENVIRONMENT}' allowlist has ${policy_count} policies, expected exactly main:branch — a non-main ref (e.g. a v* tag) can still deploy. Run STEP=release-gate (FORCE=true) to prune." >&2
+    exit 1
+  fi
   echo "Preflight OK: wall is up (all contexts required), release gate has ${reviewers} reviewer(s), ref allowlist = main only."
 }
 

--- a/scripts/apply-autonomous-merge.sh
+++ b/scripts/apply-autonomous-merge.sh
@@ -346,33 +346,32 @@ step_release_gate() {
   local admin_id admin_login body
   admin_id="$(gh api user --jq .id)"
   admin_login="$(gh api user --jq .login)"
-  # Restrict which refs may deploy to the publish environment to `main` and `v*`
-  # release tags. This is the structural half of the workflow_dispatch hole fix:
-  # a manual release dispatched from an arbitrary feature branch cannot deploy
-  # here. (release.yml adds the matching workflow-level guard refusing manual
-  # dispatch from any ref but main.) custom_branch_policies=true means the named
-  # policies POSTed below are the allowlist.
+  # Restrict which refs may deploy to the publish environment to `main` ONLY.
+  # This is the structural half of the tag-publish hole fix (#222): release.yml
+  # publishes solely via workflow_dispatch from main (no push.tags trigger), and
+  # its workflow-level guard refuses manual dispatch from any ref but main. With
+  # the allowlist pinned to `main`, even an OLD `v*` tag whose checked-out
+  # release.yml predates the SemVer gate cannot deploy here — the publish job's
+  # environment ref (the tag) is not in the allowlist. custom_branch_policies=true
+  # means the named policy POSTed below is the allowlist.
   body="$(jq -n --argjson id "${admin_id}" \
     '{wait_timer:0, reviewers:[{type:"User", id:$id}], deployment_branch_policy:{protected_branches:false, custom_branch_policies:true}}')"
   if [[ "${DRY_RUN}" != "false" ]]; then
     echo "[DRY RUN] PUT repos/${REPO}/environments/${ENVIRONMENT} (required reviewer: ${admin_login}, id ${admin_id})"
     echo "${body}" | jq .
-    echo "[DRY RUN] POST deployment-branch-policies: tag 'v*', branch 'main'"
+    echo "[DRY RUN] POST deployment-branch-policies: branch 'main'"
   else
     echo "${body}" | gh api --method PUT "repos/${REPO}/environments/${ENVIRONMENT}" --input - >/dev/null
     # Define the ref allowlist. post_branch_policy is fatal on any non-duplicate
     # failure, so a dropped policy aborts the activation instead of silently
     # widening the allowlist.
-    post_branch_policy 'v*' 'tag'
     post_branch_policy 'main' 'branch'
-    # Read back and prove both policies are actually present before declaring success.
+    # Read back and prove the policy is actually present before declaring success.
     local policies
     policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies")"
     assert_branch_policy "${policies}" 'main' 'branch' \
       || { echo "ABORT: 'main' branch policy missing after apply." >&2; exit 1; }
-    assert_branch_policy "${policies}" 'v*' 'tag' \
-      || { echo "ABORT: 'v*' tag policy missing after apply." >&2; exit 1; }
-    echo "Environment '${ENVIRONMENT}' configured (required reviewer: ${admin_login}; refs: main, v* tags)."
+    echo "Environment '${ENVIRONMENT}' configured (required reviewer: ${admin_login}; refs: main only)."
   fi
 }
 
@@ -412,12 +411,12 @@ preflight_autonomy() {
   fi
   local policies spec pname ptype
   policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies" 2>/dev/null || echo '{}')"
-  for spec in "main:branch" "v*:tag"; do
+  for spec in "main:branch"; do
     pname="${spec%%:*}"; ptype="${spec##*:}"
     assert_branch_policy "${policies}" "${pname}" "${ptype}" \
       || { echo "ABORT: '${ENVIRONMENT}' missing deployment policy ${pname} (${ptype}) — run STEP=release-gate first." >&2; exit 1; }
   done
-  echo "Preflight OK: wall is up (all contexts required), release gate has ${reviewers} reviewer(s), ref allowlist = main + v* tags."
+  echo "Preflight OK: wall is up (all contexts required), release gate has ${reviewers} reviewer(s), ref allowlist = main only."
 }
 
 step_autonomy() {

--- a/scripts/apply-autonomous-merge.sh
+++ b/scripts/apply-autonomous-merge.sh
@@ -337,7 +337,10 @@ assert_branch_policy() {
 # wider than `main`.
 prune_non_main_branch_policies() {
   local existing pid pname ptype
-  existing="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies" 2>/dev/null || echo '{}')"
+  # per_page=100 (the API max) so realistic allowlists fetch in one page. The
+  # endpoint is paginated; anything beyond 100 is caught fail-closed by the
+  # callers' authoritative total_count==1 assertion after this prune runs.
+  existing="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies?per_page=100" 2>/dev/null || echo '{}')"
   while IFS=$'\t' read -r pid pname ptype; do
     [[ -z "${pid}" ]] && continue
     if [[ "${pname}" == "main" && ( "${ptype}" == "branch" || "${ptype}" == "null" ) ]]; then
@@ -396,10 +399,13 @@ step_release_gate() {
     # Read back and prove `main` is present AND is the ONLY policy before declaring
     # success — a lingering non-main row (e.g. `v*`) would keep the hole open.
     local policies policy_count
-    policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies")"
+    policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies?per_page=100")"
     assert_branch_policy "${policies}" 'main' 'branch' \
       || { echo "ABORT: 'main' branch policy missing after apply." >&2; exit 1; }
-    policy_count="$(jq -r '[.branch_policies[]?] | length' <<<"${policies}")"
+    # Count via the API's authoritative total_count: the endpoint is paginated, so a
+    # page-local array length could read 1 while a non-main row hides on a later page.
+    # total_count spans every page; fall back to the array length only if it is absent.
+    policy_count="$(jq -r '.total_count // ([.branch_policies[]?] | length)' <<<"${policies}")"
     [[ "${policy_count}" == "1" ]] \
       || { echo "ABORT: publish allowlist has ${policy_count} policies after apply, expected exactly 1 (main:branch); a non-main ref can still deploy." >&2; exit 1; }
     echo "Environment '${ENVIRONMENT}' configured (required reviewer: ${admin_login}; refs: main only)."
@@ -441,7 +447,7 @@ preflight_autonomy() {
     exit 1
   fi
   local policies spec pname ptype
-  policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies" 2>/dev/null || echo '{}')"
+  policies="$(gh api "repos/${REPO}/environments/${ENVIRONMENT}/deployment-branch-policies?per_page=100" 2>/dev/null || echo '{}')"
   for spec in "main:branch"; do
     pname="${spec%%:*}"; ptype="${spec##*:}"
     assert_branch_policy "${policies}" "${pname}" "${ptype}" \
@@ -449,9 +455,11 @@ preflight_autonomy() {
   done
   # `main` present is necessary but not sufficient: a lingering non-main row (e.g.
   # a `v*` tag from an older setup) would still let a tag deploy. Require the
-  # allowlist to be EXACTLY main:branch — fail closed otherwise (#222).
+  # allowlist to be EXACTLY main:branch — fail closed otherwise (#222). The endpoint
+  # is paginated, so count via the authoritative total_count (a page-local array
+  # length could read 1 while a non-main row hides on a later page).
   local policy_count
-  policy_count="$(jq -r '[.branch_policies[]?] | length' <<<"${policies}")"
+  policy_count="$(jq -r '.total_count // ([.branch_policies[]?] | length)' <<<"${policies}")"
   if [[ "${policy_count}" != "1" ]]; then
     echo "ABORT: '${ENVIRONMENT}' allowlist has ${policy_count} policies, expected exactly main:branch — a non-main ref (e.g. a v* tag) can still deploy. Run STEP=release-gate (FORCE=true) to prune." >&2
     exit 1


### PR DESCRIPTION
## Problem (#222)

The Release workflow triggered on `push: tags: v*`. A version-tag push checks out
**that tag's** `release.yml`, whose SemVer gate may predate #216 — an ungated
publish path. Pushing an old tag could run an old, gate-less workflow and publish.

## Fix — two structural halves that agree

**`release.yml`** — remove the `push: tags: v*` trigger. Publishing now happens
only via `workflow_dispatch` from `main`, so "the workflow that publishes" always
equals "the gate-carrying workflow on main". Version comes from the required
dispatch `inputs.version` (tag-derived `VERSION` extraction removed).

**`scripts/apply-autonomous-merge.sh`** — pin the `publish` environment's
`deployment_branch_policy` ref allowlist to `main` only. Removes the `v*` tag
policy POST plus its readback assertion and the preflight check. Even if an old
tag's gate-less workflow runs, its publish job's environment ref (the tag) is not
in the allowlist, so it cannot deploy.

Defense in depth: the workflow-level guard (no tag trigger) and the environment
ref allowlist (`main` only) independently block tag-triggered publishing.

## Scope

CI/release config only. No `.rs` changes. Pre-commit: yaml valid, no secrets.

Closes #222