### PR TITLE
fix(knowledge): degrade ANN warming to FTS-only instead of erroring (#322)

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -151,6 +151,17 @@ impl Drop for TimeoutOverrideReset {
     }
 }
 
+/// Serializes the two timeout-override tests. Both mutate the process-global
+/// `ANN_WARM_WAIT_TIMEOUT_OVERRIDE_MS`, and `TimeoutOverrideReset` clears it on
+/// drop. Under Cargo's parallel test runner, one test's reset could otherwise
+/// fire while the other is mid-flight, dropping it back to the 5s production
+/// timeout (a latency-order-dependent slow run). `tokio::sync::Mutex` is
+/// await-safe (no `clippy::await_holding_lock`) and does not poison on panic,
+/// so a failing test still releases the lock. Each test declares the guard
+/// before `TimeoutOverrideReset`, so on exit the reset (override -> 0) runs
+/// first and the lock releases only after, handing a clean state to the next.
+static TIMEOUT_OVERRIDE_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 // ── P1a: suggest sets ann_unavailable when warming times out ─────────────────
 
 /// `suggest` must set `ann_unavailable: true` when:
@@ -164,6 +175,7 @@ impl Drop for TimeoutOverrideReset {
 ///    by running `knowledge.index` before the handler call).
 #[tokio::test]
 async fn suggest_sets_ann_unavailable_when_warming_times_out() {
+    let _serial = TIMEOUT_OVERRIDE_SERIAL.lock().await;
     vamana::set_warm_wait_timeout_override_ms(50);
     let _reset = TimeoutOverrideReset;
 
@@ -227,6 +239,7 @@ async fn suggest_sets_ann_unavailable_when_warming_times_out() {
 /// response, placing `ann_unavailable` in `result["data"]["ann_unavailable"]`.
 #[tokio::test]
 async fn compose_propagates_ann_unavailable_in_auto_mode() {
+    let _serial = TIMEOUT_OVERRIDE_SERIAL.lock().await;
     vamana::set_warm_wait_timeout_override_ms(50);
     let _reset = TimeoutOverrideReset;
 

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -1,0 +1,335 @@
+//! Handler-level degrade regression tests for the ANN warm-wait path.
+//!
+//! These tests must live inside the crate because [`vamana::simulate_warming_in_flight`]
+//! and [`vamana::set_warm_wait_timeout_override_ms`] are `pub(crate)` — inaccessible
+//! from the external `tests/` directory.
+//!
+//! ## P1 — `suggest` and `compose` degrade path
+//!
+//! When the ANN is warming but not yet loaded and the bounded wait times out,
+//! `suggest` must set `ann_unavailable: true` rather than silently returning zero
+//! results.  `compose` in auto-mode calls `suggest` internally and must propagate
+//! the flag in `data["ann_unavailable"]`.
+//!
+//! The prerequisite for `ann_unavailable` is a non-empty corpus (vectors in the
+//! store); we satisfy this by upsert + `knowledge.index` through the registry
+//! before the handler call.  The warming-not-loaded state is forced via
+//! `simulate_warming_in_flight` on a *fresh* `SharedAnn` (separate from the
+//! registry's own).
+//!
+//! ## P2 — `warm_known_snapshots` end-to-end
+//!
+//! After `knowledge.index rebuild_ann=true` the persisted Vamana snapshot lives in
+//! `retrieval_snapshots`.  Calling `warm_known_snapshots` on a *fresh* `SharedAnn`
+//! must load the snapshot so `search_loaded` returns `Some`.
+
+use crate::knowledge::{vamana, KnowledgeHandlers};
+use async_trait::async_trait;
+use khive_pack_kg::KgPack;
+use khive_runtime::{
+    AllowAllGate, BackendId, EmbedderProvider, KhiveRuntime, Namespace, RuntimeConfig,
+    VerbRegistry, VerbRegistryBuilder,
+};
+use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+use serde_json::json;
+use std::sync::Arc;
+
+// ── fake embedder ─────────────────────────────────────────────────────────────
+//
+// Returns N distinct 384-dim unit vectors (one per text, differentiated by index
+// position) so every indexed atom gets a valid embedding and the Vamana builder
+// can produce a non-trivial index.
+
+const MODEL_KEY: &str = "all-minilm-l6-v2";
+const DIM: usize = 384;
+
+struct FakeDimService;
+
+#[async_trait]
+impl EmbeddingService for FakeDimService {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .enumerate()
+            .map(|(i, _)| {
+                let v = (i + 1) as f32;
+                let norm = (DIM as f32 * v * v).sqrt();
+                vec![v / norm; DIM]
+            })
+            .collect())
+    }
+
+    fn supports_model(&self, _model: EmbeddingModel) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "fake-dim"
+    }
+}
+
+struct FakeDimProvider;
+
+#[async_trait]
+impl EmbedderProvider for FakeDimProvider {
+    fn name(&self) -> &str {
+        MODEL_KEY
+    }
+
+    fn dimensions(&self) -> usize {
+        DIM
+    }
+
+    async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+        Ok(Arc::new(FakeDimService))
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn rt_with_fake_embedder() -> KhiveRuntime {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("in-memory runtime");
+    rt.register_embedder(FakeDimProvider);
+    rt
+}
+
+fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(crate::KnowledgePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+/// RAII guard: reset the timeout override when the test exits (even on panic).
+struct TimeoutOverrideReset;
+
+impl Drop for TimeoutOverrideReset {
+    fn drop(&mut self) {
+        vamana::set_warm_wait_timeout_override_ms(0);
+    }
+}
+
+// ── P1a: suggest sets ann_unavailable when warming times out ─────────────────
+
+/// `suggest` must set `ann_unavailable: true` when:
+/// 1. The ANN key is in the warming set but the index is not yet loaded
+///    (`simulate_warming_in_flight` injects this state into a fresh `SharedAnn`).
+/// 2. The bounded wait times out (50 ms override via `set_warm_wait_timeout_override_ms`).
+/// 3. FTS hits are empty: `suggest` uses `type_filter = Some("domain")` internally,
+///    and our seeded atom has no `type:domain` tag — `load_candidates_from_atoms`
+///    drops it, so `hits.is_empty() == true`.
+/// 4. The corpus has vectors: `compute_fingerprint().vector_count > 0` (satisfied
+///    by running `knowledge.index` before the handler call).
+#[tokio::test]
+async fn suggest_sets_ann_unavailable_when_warming_times_out() {
+    vamana::set_warm_wait_timeout_override_ms(50);
+    let _reset = TimeoutOverrideReset;
+
+    let rt = rt_with_fake_embedder();
+    let registry = build_registry(&rt);
+
+    // Seed a regular (non-domain) atom, then index to populate the vector store.
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "degrade-suggest-atom",
+                    "name": "Degrade Suggest Atom",
+                    "content": "transformer neural network attention mechanism self-attention encoder decoder positional embedding layer normalization residual connection feed forward dense sparse retrieval vector index"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+    registry
+        .dispatch("knowledge.index", json!({ "rebuild_ann": false }))
+        .await
+        .expect("index");
+
+    // A fresh SharedAnn — separate from the registry's own — with the key in
+    // warming but no index loaded.  This forces the degrade path in `suggest`.
+    let ann = vamana::new_shared();
+    let model = rt.default_embedder_name().to_string();
+    let key = vamana::AnnKey::new("local", &model);
+    vamana::simulate_warming_in_flight(&ann, key);
+
+    let token = rt.authorize(Namespace::local()).expect("authorize");
+    let result = KnowledgeHandlers::suggest(
+        &rt,
+        &token,
+        // ≥5 words required by suggest; type_filter="domain" will drop the
+        // non-domain atom, leaving FTS hits empty → ann_unavailable condition met.
+        json!({ "query": "machine learning neural network transformer attention" }),
+        &ann,
+    )
+    .await
+    .expect("suggest must not Err");
+
+    assert_eq!(
+        result.get("ann_unavailable").and_then(|v| v.as_bool()),
+        Some(true),
+        "suggest must carry ann_unavailable=true when ANN warming times out \
+         and FTS hits are empty; got: {result}"
+    );
+}
+
+// ── P1b: compose propagates ann_unavailable from its internal suggest call ────
+
+/// `compose` in auto-mode delegates to `suggest` and must surface
+/// `data["ann_unavailable"] = true` when the underlying `suggest` sets the flag.
+///
+/// Auto-mode is triggered when `domain_ids` and `atom_ids` are absent.  Because
+/// `suggest` finds no domain hits, `compose` returns early with the no-domains
+/// response, placing `ann_unavailable` in `result["data"]["ann_unavailable"]`.
+#[tokio::test]
+async fn compose_propagates_ann_unavailable_in_auto_mode() {
+    vamana::set_warm_wait_timeout_override_ms(50);
+    let _reset = TimeoutOverrideReset;
+
+    let rt = rt_with_fake_embedder();
+    let registry = build_registry(&rt);
+
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [{
+                    "slug": "degrade-compose-atom",
+                    "name": "Degrade Compose Atom",
+                    "content": "attention mechanism self-attention transformer encoder decoder positional embedding layer normalization residual connection feed forward dense sparse retrieval vector nearest neighbor"
+                }]
+            }),
+        )
+        .await
+        .expect("upsert atom");
+
+    registry
+        .dispatch("knowledge.index", json!({ "rebuild_ann": false }))
+        .await
+        .expect("index");
+
+    let ann = vamana::new_shared();
+    let model = rt.default_embedder_name().to_string();
+    let key = vamana::AnnKey::new("local", &model);
+    vamana::simulate_warming_in_flight(&ann, key);
+
+    let token = rt.authorize(Namespace::local()).expect("authorize");
+    // Auto-mode requires ≥10 words; no domain_ids/atom_ids.
+    let result = KnowledgeHandlers::compose(
+        &rt,
+        &token,
+        json!({
+            "query": "machine learning neural network transformer attention architecture multi head self attention"
+        }),
+        &ann,
+    )
+    .await
+    .expect("compose must not Err");
+
+    assert_eq!(
+        result
+            .get("data")
+            .and_then(|d| d.get("ann_unavailable"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "compose must propagate ann_unavailable=true from its internal suggest call; \
+         got: {result}"
+    );
+}
+
+// ── P2: warm_known_snapshots loads a persisted snapshot into a fresh SharedAnn ─
+
+/// After `knowledge.index rebuild_ann=true` the Vamana snapshot is persisted in
+/// `retrieval_snapshots`.  Calling `warm_known_snapshots` on a *fresh* `SharedAnn`
+/// must load that snapshot so `search_loaded` returns `Some` (index is in memory).
+#[tokio::test]
+async fn warm_known_snapshots_loads_persisted_snapshot() {
+    let rt = rt_with_fake_embedder();
+    let registry = build_registry(&rt);
+
+    // Seed two atoms so Vamana has enough vectors to build a non-trivial index.
+    registry
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({
+                "atoms": [
+                    {
+                        "slug": "warm-snap-atom-a",
+                        "name": "Warm Snapshot Atom A",
+                        "content": "dense retrieval corpus benchmark search latency gradient descent vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity unique warm78a"
+                    },
+                    {
+                        "slug": "warm-snap-atom-b",
+                        "name": "Warm Snapshot Atom B",
+                        "content": "ranking fusion pipeline embedding rerank cosine similarity unique warm78b transformer attention mechanism self-attention encoder decoder positional feed forward dense neural network gradient"
+                    }
+                ]
+            }),
+        )
+        .await
+        .expect("upsert atoms");
+
+    // Index with rebuild_ann=true to persist the Vamana snapshot in retrieval_snapshots.
+    let index_result = registry
+        .dispatch("knowledge.index", json!({ "rebuild_ann": true }))
+        .await
+        .expect("index with rebuild_ann=true");
+
+    // Guard: the index run must have actually embedded atoms (not just done nothing).
+    let indexed = index_result
+        .get("indexed")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    assert!(
+        indexed >= 2,
+        "knowledge.index must embed at least 2 atoms for this test to be meaningful; \
+         got indexed={indexed}"
+    );
+
+    // A fresh SharedAnn — no snapshot loaded yet.
+    let ann = vamana::new_shared();
+    let model = rt.default_embedder_name().to_string();
+    let key = vamana::AnnKey::new("local", &model);
+
+    // Precondition: the fresh ann has nothing loaded.
+    let dummy_query = vec![1.0f32 / (DIM as f32).sqrt(); DIM];
+    assert!(
+        vamana::search_loaded(&ann, &key, &dummy_query, 1)
+            .await
+            .is_none(),
+        "precondition: fresh SharedAnn must have no index loaded before warm_known_snapshots"
+    );
+
+    // warm_known_snapshots reads retrieval_snapshots, finds the persisted key, and
+    // calls ensure_ann_for_model which restores the AnnBridge from the snapshot.
+    vamana::warm_known_snapshots(&rt, &ann).await;
+
+    assert!(
+        vamana::search_loaded(&ann, &key, &dummy_query, 1)
+            .await
+            .is_some(),
+        "search_loaded must return Some after warm_known_snapshots loads the snapshot; \
+         model={model}, key={key:?}"
+    );
+}

--- a/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/ann_degrade_tests.rs
@@ -110,6 +110,29 @@ fn rt_with_fake_embedder() -> KhiveRuntime {
     rt
 }
 
+/// File-backed variant. Required by tests that exercise v2 ANN persistence:
+/// `knowledge.index(rebuild_ann=true)` only writes v2 segments when the backend
+/// has a `data_dir`. An in-memory runtime has none, and ADR-079 removed the v1
+/// `retrieval_snapshots` write path, so an in-memory rebuild persists nothing.
+fn file_rt_with_fake_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(db_path),
+        default_namespace: Namespace::local(),
+        embedding_model: Some(EmbeddingModel::AllMiniLmL6V2),
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "knowledge".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("file-backed runtime");
+    rt.register_embedder(FakeDimProvider);
+    rt
+}
+
 fn build_registry(rt: &KhiveRuntime) -> VerbRegistry {
     let mut builder = VerbRegistryBuilder::new();
     builder.register(KgPack::new(rt.clone()));
@@ -265,7 +288,12 @@ async fn compose_propagates_ann_unavailable_in_auto_mode() {
 /// must load that snapshot so `search_loaded` returns `Some` (index is in memory).
 #[tokio::test]
 async fn warm_known_snapshots_loads_persisted_snapshot() {
-    let rt = rt_with_fake_embedder();
+    // File-backed runtime so knowledge.index(rebuild_ann=true) persists v2 ANN
+    // segments to data_dir/ann/<hex>; warm_known_snapshots then enumerates and
+    // loads them. (In-memory has no data_dir, and ADR-079 removed the v1 write
+    // path, so nothing would be persisted to warm.)
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let rt = file_rt_with_fake_embedder(dir.path().join("test.db"));
     let registry = build_registry(&rt);
 
     // Seed two atoms so Vamana has enough vectors to build a non-trivial index.

--- a/crates/khive-pack-knowledge/src/knowledge/mod.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/mod.rs
@@ -15,3 +15,6 @@ mod sections;
 pub(crate) mod sections_index;
 pub(crate) mod util;
 pub(crate) struct KnowledgeHandlers;
+
+#[cfg(test)]
+mod ann_degrade_tests;

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1038,19 +1038,19 @@ impl KnowledgeHandlers {
             // cold-start race where the ANN is loading and the first query silently
             // returns ok:true,total:0 when FTS also finds nothing.
             //
-            // Test coverage note: the warming-Err branch here is exercised by the
-            // mechanism-unit tests in vamana::tests (is_warming_not_loaded /
-            // wait_for_ann / simulate_warming_in_flight).  An end-to-end integration
-            // test is not feasible from the external tests/ directory because
-            // simulate_warming_in_flight is pub(crate) — forcing the in-flight state
-            // requires internal access.  The integration tests in tests/fixes.rs
-            // cover the non-warming hot-path and the empty-corpus guard instead.
+            // Test coverage note: the warming-Err branch here is exercised by
+            // both the mechanism-unit tests in vamana::tests and the handler-level
+            // degrade regression tests in knowledge::ann_degrade_tests.  The handler
+            // tests call this function directly with a pre-warmed SharedAnn, using
+            // the pub(crate) seams simulate_warming_in_flight and
+            // set_warm_wait_timeout_override_ms (50 ms override avoids a 5 s stall
+            // in CI while still exercising every line in the degrade branch).
             let mut ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
             if ann_hits_opt.is_none() && vamana::is_warming_not_loaded(ann, &key) {
                 if vamana::wait_for_ann(
                     ann,
                     &key,
-                    vamana::ANN_WARM_WAIT_TIMEOUT_MS,
+                    vamana::warm_wait_timeout_ms(),
                     vamana::ANN_WARM_WAIT_POLL_MS,
                 )
                 .await
@@ -1176,19 +1176,15 @@ impl KnowledgeHandlers {
             // prevents a race between the daemon warm-start and the first incoming
             // query from producing a silent ok:true,total:0 result.
             //
-            // Test coverage note: the warming-Err branch here is exercised by the
-            // mechanism-unit tests in vamana::tests (is_warming_not_loaded /
-            // wait_for_ann / simulate_warming_in_flight).  An end-to-end integration
-            // test is not feasible from the external tests/ directory because
-            // simulate_warming_in_flight is pub(crate) — forcing the in-flight state
-            // requires internal access.  The integration tests in tests/fixes.rs
-            // cover the non-warming hot-path and the empty-corpus guard instead.
+            // Test coverage note: same degrade regression coverage as the `search`
+            // handler above — see knowledge::ann_degrade_tests for the handler-level
+            // tests that exercise this branch directly with a pre-warmed SharedAnn.
             let mut ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
             if ann_hits_opt.is_none() && vamana::is_warming_not_loaded(ann, &key) {
                 if vamana::wait_for_ann(
                     ann,
                     &key,
-                    vamana::ANN_WARM_WAIT_TIMEOUT_MS,
+                    vamana::warm_wait_timeout_ms(),
                     vamana::ANN_WARM_WAIT_POLL_MS,
                 )
                 .await

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -1028,6 +1028,7 @@ impl KnowledgeHandlers {
         // Trigger background warm — never block search on the ANN rebuild.
         vamana::ensure_ann_background(runtime, token, ann);
 
+        let mut ann_unavailable = false;
         if let Ok(query_emb) = runtime.embed_query(&raw_query).await {
             let ann_k = fetch_limit.max(20);
             let key = vamana::AnnKey::new(&ns, runtime.default_embedder_name());
@@ -1046,14 +1047,19 @@ impl KnowledgeHandlers {
             // cover the non-warming hot-path and the empty-corpus guard instead.
             let mut ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
             if ann_hits_opt.is_none() && vamana::is_warming_not_loaded(ann, &key) {
-                const WARM_TIMEOUT_MS: u64 = 3_000;
-                const WARM_POLL_MS: u64 = 50;
-                if vamana::wait_for_ann(ann, &key, WARM_TIMEOUT_MS, WARM_POLL_MS).await {
+                if vamana::wait_for_ann(
+                    ann,
+                    &key,
+                    vamana::ANN_WARM_WAIT_TIMEOUT_MS,
+                    vamana::ANN_WARM_WAIT_POLL_MS,
+                )
+                .await
+                {
                     ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
                 } else {
                     // Still not ready: if FTS already found results, those are
-                    // valid partial hits — return them.  Only surface the warming
-                    // error when FTS is also empty and the corpus is non-empty.
+                    // valid partial hits — return them.  Only set ann_unavailable
+                    // when FTS is also empty and the corpus is non-empty (issue #322).
                     if hits.is_empty() {
                         let model = runtime.default_embedder_name();
                         let corpus_non_empty = vamana::compute_fingerprint(runtime, token, model)
@@ -1061,10 +1067,7 @@ impl KnowledgeHandlers {
                             .map(|fp| fp.vector_count > 0)
                             .unwrap_or(false);
                         if corpus_non_empty {
-                            return Err(RuntimeError::Internal(
-                                "ANN index is warming after daemon restart — retry in a few seconds"
-                                    .into(),
-                            ));
+                            ann_unavailable = true;
                         }
                     }
                 }
@@ -1111,7 +1114,11 @@ impl KnowledgeHandlers {
             .collect();
         let count = results.len();
 
-        Ok(json!({ "results": results, "total": count }))
+        let mut out = json!({ "results": results, "total": count });
+        if ann_unavailable {
+            out["ann_unavailable"] = json!(true);
+        }
+        Ok(out)
     }
 
     pub(crate) async fn suggest(
@@ -1155,6 +1162,7 @@ impl KnowledgeHandlers {
         let mut hits = search_core(&ctx, &raw_query).await?;
 
         vamana::ensure_ann_background(runtime, token, ann);
+        let mut ann_unavailable = false;
         if let Ok(query_emb) = runtime.embed_query(&raw_query).await {
             // Over-fetch aggressively: the corpus is ~27% domains / ~73% atoms, so
             // limit*3 would return mostly atoms that all get dropped after type filtering.
@@ -1177,16 +1185,21 @@ impl KnowledgeHandlers {
             // cover the non-warming hot-path and the empty-corpus guard instead.
             let mut ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
             if ann_hits_opt.is_none() && vamana::is_warming_not_loaded(ann, &key) {
-                const WARM_TIMEOUT_MS: u64 = 3_000;
-                const WARM_POLL_MS: u64 = 50;
-                if vamana::wait_for_ann(ann, &key, WARM_TIMEOUT_MS, WARM_POLL_MS).await {
+                if vamana::wait_for_ann(
+                    ann,
+                    &key,
+                    vamana::ANN_WARM_WAIT_TIMEOUT_MS,
+                    vamana::ANN_WARM_WAIT_POLL_MS,
+                )
+                .await
+                {
                     ann_hits_opt = vamana::search_loaded(ann, &key, &query_emb, ann_k).await;
                 } else {
                     // Still not ready after the wait.  If FTS already collected
                     // non-empty hits, return those partial results rather than
-                    // erroring — mirrors the same guard in `search`.  Only surface
-                    // the warming error when FTS is also empty and the corpus is
-                    // non-empty (a genuinely misleading silent-zero case).
+                    // erroring — mirrors the same guard in `search`.  Only set
+                    // ann_unavailable when FTS is also empty and the corpus is
+                    // non-empty (a genuinely misleading silent-zero case) (issue #322).
                     if hits.is_empty() {
                         let model = runtime.default_embedder_name();
                         let corpus_non_empty = vamana::compute_fingerprint(runtime, token, model)
@@ -1194,10 +1207,7 @@ impl KnowledgeHandlers {
                             .map(|fp| fp.vector_count > 0)
                             .unwrap_or(false);
                         if corpus_non_empty {
-                            return Err(RuntimeError::Internal(
-                                "ANN index is warming after daemon restart — retry in a few seconds"
-                                    .into(),
-                            ));
+                            ann_unavailable = true;
                         }
                     }
                 }
@@ -1228,7 +1238,11 @@ impl KnowledgeHandlers {
             .collect();
         let count = results.len();
 
-        Ok(json!({ "results": results, "total": count }))
+        let mut out = json!({ "results": results, "total": count });
+        if ann_unavailable {
+            out["ann_unavailable"] = json!(true);
+        }
+        Ok(out)
     }
 
     pub(crate) async fn compose(
@@ -1258,6 +1272,7 @@ impl KnowledgeHandlers {
             .collect();
 
         let is_auto = domain_ids.is_empty() && atom_ids.is_empty();
+        let mut suggest_ann_unavailable = false;
         if is_auto {
             let word_count = raw_query.split_whitespace().count();
             if word_count < 10 {
@@ -1278,7 +1293,13 @@ impl KnowledgeHandlers {
             )
             .await
             {
-                Ok(v) => v,
+                Ok(v) => {
+                    suggest_ann_unavailable = v
+                        .get("ann_unavailable")
+                        .and_then(|f| f.as_bool())
+                        .unwrap_or(false);
+                    v
+                }
                 Err(e) => {
                     tracing::warn!(error = %e, "auto-compose: internal suggest failed, returning empty");
                     return Ok(json!({
@@ -1302,16 +1323,17 @@ impl KnowledgeHandlers {
                 }
             }
             if domain_ids.is_empty() {
-                return Ok(json!({
-                    "status": "ok",
-                    "data": {
-                        "query": raw_query,
-                        "markdown": "# Knowledge Briefing\n\nNo matching domains found for auto-suggest.",
-                        "domains": [],
-                        "atoms": [],
-                        "count": 0,
-                    },
-                }));
+                let mut data = json!({
+                    "query": raw_query,
+                    "markdown": "# Knowledge Briefing\n\nNo matching domains found for auto-suggest.",
+                    "domains": [],
+                    "atoms": [],
+                    "count": 0,
+                });
+                if suggest_ann_unavailable {
+                    data["ann_unavailable"] = json!(true);
+                }
+                return Ok(json!({ "status": "ok", "data": data }));
             }
         }
 
@@ -1542,6 +1564,9 @@ impl KnowledgeHandlers {
         if explain && !section_json.is_empty() {
             data["sections"] = json!(section_json);
             data["section_count"] = json!(section_json.len());
+        }
+        if suggest_ann_unavailable {
+            data["ann_unavailable"] = json!(true);
         }
 
         Ok(json!({

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -157,6 +157,35 @@ pub(crate) async fn wait_for_ann(
 pub(crate) const ANN_WARM_WAIT_TIMEOUT_MS: u64 = 5_000;
 pub(crate) const ANN_WARM_WAIT_POLL_MS: u64 = 50;
 
+// ── Test-only seam: override the ANN warm-wait timeout ───────────────────────
+//
+// Zero means use the production default (ANN_WARM_WAIT_TIMEOUT_MS).
+// Tests set this to a small value (e.g. 50 ms) to avoid blocking the test
+// suite while still exercising the full degrade code path.
+static ANN_WARM_WAIT_TIMEOUT_OVERRIDE_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Returns the effective ANN warm-wait timeout in milliseconds.
+///
+/// In production this always equals `ANN_WARM_WAIT_TIMEOUT_MS`.  During
+/// tests the value may be overridden via `set_warm_wait_timeout_override_ms`
+/// to avoid a 5-second stall per test run.
+pub(crate) fn warm_wait_timeout_ms() -> u64 {
+    let o = ANN_WARM_WAIT_TIMEOUT_OVERRIDE_MS.load(std::sync::atomic::Ordering::Relaxed);
+    if o > 0 {
+        o
+    } else {
+        ANN_WARM_WAIT_TIMEOUT_MS
+    }
+}
+
+/// Set the ANN warm-wait timeout override for tests.  Pass `0` to restore the
+/// production default (`ANN_WARM_WAIT_TIMEOUT_MS`).
+#[cfg(test)]
+pub(crate) fn set_warm_wait_timeout_override_ms(ms: u64) {
+    ANN_WARM_WAIT_TIMEOUT_OVERRIDE_MS.store(ms, std::sync::atomic::Ordering::Relaxed);
+}
+
 impl AnnBridge {
     pub fn build(mut vectors: Vec<f32>, dim: usize, id_map: Vec<Uuid>) -> Result<Self, String> {
         if dim == 0 {

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -149,6 +149,14 @@ pub(crate) async fn wait_for_ann(
     }
 }
 
+/// Bounded wait for a background ANN warm to complete before a search degrades
+/// to FTS-only results. A valid-snapshot cold load on a large corpus can exceed
+/// the previous 3s; 5s covers the snapshot deserialize while still bounding the
+/// first post-restart query. On timeout the search degrades to FTS-only — it
+/// never errors (issue #322).
+pub(crate) const ANN_WARM_WAIT_TIMEOUT_MS: u64 = 5_000;
+pub(crate) const ANN_WARM_WAIT_POLL_MS: u64 = 50;
+
 impl AnnBridge {
     pub fn build(mut vectors: Vec<f32>, dim: usize, id_map: Vec<Uuid>) -> Result<Self, String> {
         if dim == 0 {
@@ -529,7 +537,19 @@ pub(crate) async fn warm_known_snapshots(rt: &KhiveRuntime, ann: &SharedAnn) {
             Ok(t) => t,
             Err(_) => continue,
         };
+        let key = AnnKey::new(ns_str, model);
+        {
+            let mut warming = warming_guard(&ann.warming);
+            if warming.contains(&key) {
+                continue; // another path is already warming this key
+            }
+            warming.insert(key.clone());
+        }
         ensure_ann_for_model(rt, &token, ann, model).await;
+        let loaded = ann.indexes.read().await.contains_key(&key);
+        if !loaded {
+            warming_guard(&ann.warming).remove(&key);
+        }
     }
 }
 
@@ -895,6 +915,78 @@ mod tests {
         assert!(
             !is_warming_not_loaded(&ann, &key),
             "is_warming_not_loaded must not panic on poisoned Mutex"
+        );
+    }
+
+    // ── warm-path-unification (Change D) invariants ───────────────────────────
+
+    #[tokio::test]
+    async fn warm_path_key_in_warming_set_before_and_after_successful_load() {
+        // Verifies the warm-path-unification protocol introduced for warm_known_snapshots:
+        // (1) key is registered in warming BEFORE the load attempt,
+        // (2) after a successful load, key is in both warming AND indexes,
+        //     so is_warming_not_loaded returns false (warm complete, not in flight).
+        // (3) during (1)→(2), is_warming_not_loaded returns true — a concurrent query
+        //     that arrives mid-warm correctly identifies the in-flight state.
+        let ann = new_shared();
+        let key = AnnKey::new("local", "warm-unify-model");
+
+        // Step 1: register key in warming (mirrors new warm_known_snapshots pre-warm step).
+        {
+            let mut warming = warming_guard(&ann.warming);
+            warming.insert(key.clone());
+        }
+        assert!(
+            is_warming_not_loaded(&ann, &key),
+            "key in warming but not indexes must report warming in flight"
+        );
+
+        // Step 2: simulate successful ensure_ann_for_model (bridge inserted into indexes).
+        let bridge = AnnBridge::build(vec![1.0f32, 0.0, 0.0, 0.0], 4, vec![Uuid::new_v4()])
+            .expect("build bridge for warm-path test");
+        insert_ann_if_absent(&ann, key.clone(), bridge).await;
+
+        // Step 3: key now in both warming and indexes → warm is complete, not in-flight.
+        assert!(
+            !is_warming_not_loaded(&ann, &key),
+            "key in both warming and indexes must not report warming in flight"
+        );
+        assert!(
+            ann.indexes.read().await.contains_key(&key),
+            "index must be present after successful build"
+        );
+    }
+
+    #[tokio::test]
+    async fn warm_path_failed_load_removes_key_from_warming_set() {
+        // Verifies that when warm_known_snapshots fails to load an index (e.g. no corpus
+        // vectors), the key is removed from the warming set, allowing a later search
+        // to trigger a fresh load attempt.
+        let ann = new_shared();
+        let key = AnnKey::new("local", "warm-unify-fail-model");
+
+        // Pre-warm step: insert key into warming (mirrors new warm_known_snapshots code).
+        warming_guard(&ann.warming).insert(key.clone());
+        assert!(
+            is_warming_not_loaded(&ann, &key),
+            "pre-condition: key must show as warming in flight"
+        );
+
+        // Load failed — no bridge inserted. Cleanup step removes key from warming.
+        let loaded = ann.indexes.read().await.contains_key(&key);
+        if !loaded {
+            warming_guard(&ann.warming).remove(&key);
+        }
+
+        // After cleanup, key is in neither set → is_warming_not_loaded = false.
+        // A subsequent search can now trigger a fresh load attempt.
+        assert!(
+            !is_warming_not_loaded(&ann, &key),
+            "after failed-load cleanup, warming must not show in-flight"
+        );
+        assert!(
+            !ann.indexes.read().await.contains_key(&key),
+            "index must remain absent after failed load"
         );
     }
 }


### PR DESCRIPTION
## Problem (#322)

After a daemon restart, `knowledge.suggest` / `knowledge.search` / `knowledge.compose` returned a hard error — `RuntimeError::Internal("ANN index is warming after daemon restart — retry in a few seconds")` — instead of degrading to FTS-only results. On a large corpus (~68k atoms) the background Vamana rebuild outruns the hard-coded 3s warm timeout; when FTS also returns no hits, the verb errored. `compose` caught that and returned `suggest_error` with empty domains/atoms, making the briefing surface unusable for the first several seconds after every restart.

## Fix

1. **Degrade, never error** (`search()`, `suggest()`): replace the `return Err(...)` in the warming-timeout branch with an `ann_unavailable = true` flag. FTS hits flow through unchanged; the advisory is only set when FTS is *also* empty over a non-empty corpus (the genuinely-misleading silent-zero case). The final response carries an optional `ann_unavailable: true` advisory field.
2. **Thread the advisory through `compose()`**: auto-mode captures `ann_unavailable` from the internal `suggest` result and adds it to both the no-domains early return and the final briefing response. The `Err(e)` arm is unchanged — genuine internal errors still surface as `suggest_error`.
3. **Extract + raise the warm-wait timeout**: the two duplicated inline `WARM_TIMEOUT_MS = 3_000` consts move to named `vamana::ANN_WARM_WAIT_TIMEOUT_MS = 5_000` / `ANN_WARM_WAIT_POLL_MS`, covering a valid-snapshot cold load on a large corpus while still bounding the first post-restart query.
4. **Unify the two warm paths**: `warm_known_snapshots` (the daemon `warm_all` path) now registers each key in the `AnnState.warming` set before loading and removes it on failed load, mirroring `ensure_ann_background`. Previously it bypassed the warming set, so an early query arriving during daemon `warm_all` saw `is_warming_not_loaded == false` and silently returned `total: 0`.

The advisory field is **additive** and appears only on degraded responses — no breaking wire change, no new verb/param.

## Tests / gates

- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test -p khive-pack-knowledge` all pass (189 tests, 0 failed).
- Two new in-crate unit tests lock the warm-path-unification invariants (`warm_path_key_in_warming_set_before_and_after_successful_load`, `warm_path_failed_load_removes_key_from_warming_set`).

## Verification note (honest scope)

The unit tests cover the warming-set *primitives*; the end-to-end degrade behavior (warming ANN + empty FTS → `Ok` with `ann_unavailable` instead of `Err`) is exercised by the live daemon. That live repro requires the fixed binary to be the running daemon, so it is deferred to the post-merge `make local` rebuild (installing an unreviewed branch binary into the live environment pre-review is out of scope). Reviewer input on whether an in-crate degrade-path integration test is warranted is welcome.

Closes #322