### PR TITLE
feat(knowledge): ADR-079 core — persist + warm-load v2 ANN segments (#322)

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -18,6 +18,7 @@ use crate::stores::{entity, event, graph, note, sparse, text, vectors};
 pub struct StorageBackend {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
+    path: Option<std::path::PathBuf>,
 }
 
 impl StorageBackend {
@@ -28,14 +29,16 @@ impl StorageBackend {
     /// No schema is applied — call `apply_schema()` for each service.
     pub fn sqlite(path: impl AsRef<Path>) -> Result<Self, SqliteError> {
         crate::extension::ensure_extensions_loaded();
+        let resolved = path.as_ref().to_path_buf();
         let config = PoolConfig {
-            path: Some(path.as_ref().to_path_buf()),
+            path: Some(resolved.clone()),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(config)?;
         Ok(Self {
             pool: Arc::new(pool),
             is_file_backed: true,
+            path: Some(resolved),
         })
     }
 
@@ -50,8 +53,9 @@ impl StorageBackend {
     /// does not create a new file.
     pub fn sqlite_read_only(path: impl AsRef<Path>) -> Result<Self, SqliteError> {
         crate::extension::ensure_extensions_loaded();
+        let resolved = path.as_ref().to_path_buf();
         let config = PoolConfig {
-            path: Some(path.as_ref().to_path_buf()),
+            path: Some(resolved.clone()),
             ..PoolConfig::default()
         };
         let pool = ConnectionPool::new(config)?;
@@ -68,6 +72,7 @@ impl StorageBackend {
         Ok(Self {
             pool: Arc::new(pool),
             is_file_backed: true,
+            path: Some(resolved),
         })
     }
 
@@ -86,6 +91,7 @@ impl StorageBackend {
         Ok(Self {
             pool: Arc::new(pool),
             is_file_backed: false,
+            path: None,
         })
     }
 
@@ -546,6 +552,12 @@ impl StorageBackend {
         self.is_file_backed
     }
 
+    /// Return the directory containing the backend's database file, or `None`
+    /// for an in-memory backend.
+    pub fn data_dir(&self) -> Option<std::path::PathBuf> {
+        self.path.as_ref()?.parent().map(|p| p.to_path_buf())
+    }
+
     /// Access the underlying pool (escape hatch).
     pub fn pool(&self) -> &ConnectionPool {
         &self.pool
@@ -575,6 +587,21 @@ mod tests {
         let backend = StorageBackend::sqlite(&path).expect("file backend should create");
         assert!(backend.is_file_backed());
         assert!(path.exists());
+    }
+
+    #[test]
+    fn data_dir_returns_none_for_memory_backend() {
+        let backend = StorageBackend::memory().expect("memory backend");
+        assert!(backend.data_dir().is_none());
+    }
+
+    #[test]
+    fn data_dir_returns_parent_dir_for_file_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.db");
+        let backend = StorageBackend::sqlite(&path).expect("file backend");
+        let got = backend.data_dir().expect("file backend must return Some");
+        assert_eq!(got, dir.path());
     }
 
     #[tokio::test]

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -36,6 +36,7 @@ khive-storage = { version = "0.2.11", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "knowledge_bench"

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -236,22 +236,9 @@ impl KnowledgeHandlers {
                 Ok(bridge) => {
                     ann_count = Some(bridge.num_vectors());
                     let model_name = runtime.default_embedder_name();
-                    match vamana::compute_fingerprint(runtime, token, model_name).await {
-                        Some(fp) => {
-                            if let Err(e) =
-                                vamana::persist_snapshot(runtime, &ns, model_name, &bridge, fp)
-                                    .await
-                            {
-                                tracing::error!(error = %e, "failed to persist Vamana snapshot");
-                                ann_failed = true;
-                            }
-                        }
-                        None => {
-                            tracing::warn!(
-                                "failed to compute corpus fingerprint; Vamana snapshot will not be persisted"
-                            );
-                            ann_failed = true;
-                        }
+                    if let Err(e) = vamana::persist_ann_v2(runtime, &ns, model_name, &bridge) {
+                        tracing::error!(error = %e, "failed to persist v2 Vamana segments");
+                        ann_failed = true;
                     }
                     let n = bridge.num_vectors();
                     let key = vamana::AnnKey::new(&ns, model_name);

--- a/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/index_handler.rs
@@ -96,10 +96,6 @@ impl KnowledgeHandlers {
             cb(0, total as u64);
         }
 
-        let mut ann_vectors: Vec<f32> = Vec::new();
-        let mut ann_ids: Vec<uuid::Uuid> = Vec::new();
-        let mut ann_dim: usize = 0;
-
         for chunk in atoms.chunks(batch_size) {
             let mut staged: Vec<(uuid::Uuid, String)> = Vec::with_capacity(chunk.len());
             for atom in chunk {
@@ -190,21 +186,6 @@ impl KnowledgeHandlers {
                 }
             }
 
-            if rebuild_ann {
-                for (i, ((id, _), emb)) in staged.iter().zip(embeddings.iter()).enumerate() {
-                    if !chunk_ok[i] {
-                        continue;
-                    }
-                    if ann_dim == 0 {
-                        ann_dim = emb.len();
-                    }
-                    if emb.len() == ann_dim {
-                        ann_ids.push(*id);
-                        ann_vectors.extend_from_slice(emb);
-                    }
-                }
-            }
-
             indexed += chunk_ok.iter().filter(|ok| **ok).count();
 
             if let Some(cb) = on_progress {
@@ -221,30 +202,27 @@ impl KnowledgeHandlers {
         let mut ann_count: Option<usize> = None;
         let mut ann_failed = false;
         let is_full_corpus = p.ids.is_none();
-        if rebuild_ann && is_full_corpus && !ann_vectors.is_empty() && ann_dim > 0 {
-            let n_vecs = ann_ids.len();
-            tracing::info!(
-                vectors = n_vecs,
-                dim = ann_dim,
-                "building Vamana ANN index…"
-            );
+        if rebuild_ann && is_full_corpus && indexed > 0 {
             if let Some(cb) = on_progress {
                 cb(total as u64, total as u64);
             }
-            eprintln!("\n  building Vamana ANN ({n_vecs} vectors, dim={ann_dim})…");
-            match vamana::AnnBridge::build(ann_vectors, ann_dim, ann_ids) {
-                Ok(bridge) => {
-                    ann_count = Some(bridge.num_vectors());
-                    let model_name = runtime.default_embedder_name();
+            let model_name = runtime.default_embedder_name();
+            // Build from the shared corpus scan (ORDER BY subject_id) so the persisted
+            // v2 content_hash matches the warm-path live_content_hash. Building from
+            // atom-iteration order persists a hash the warm path always reads as stale.
+            match vamana::load_and_build_from_vector_store(runtime, token, model_name).await {
+                Ok(Some(bridge)) => {
+                    let n = bridge.num_vectors();
+                    ann_count = Some(n);
                     if let Err(e) = vamana::persist_ann_v2(runtime, &ns, model_name, &bridge) {
                         tracing::error!(error = %e, "failed to persist v2 Vamana segments");
                         ann_failed = true;
                     }
-                    let n = bridge.num_vectors();
                     let key = vamana::AnnKey::new(&ns, model_name);
                     vamana::insert_ann_if_absent(ann, key, bridge).await;
                     eprintln!("  Vamana ANN built ({n} vectors)");
                 }
+                Ok(None) => {}
                 Err(e) => {
                     tracing::error!(error = %e, "failed to build Vamana ANN index");
                     eprintln!("  Vamana ANN build failed: {e}");

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 
 use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_vamana::{CorpusFingerprint, VamanaConfig, VamanaIndex, VamanaSnapshot};
+use khive_vamana::{
+    read_commit_fingerprint, CorpusFingerprint, VamanaConfig, VamanaIndex, VamanaSnapshot,
+};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -220,6 +222,95 @@ impl AnnBridge {
             VamanaIndex::from_snapshot(&snapshot).map_err(|e| format!("snapshot restore: {e}"))?;
         Ok(Self { index, id_map })
     }
+
+    /// Save this bridge to `dir` atomically.
+    ///
+    /// Writes Vamana index segments via [`VamanaIndex::save_atomic`] (which commits
+    /// a v2 KHVVAMG2 record in `metadata.bin` carrying a `content_hash`), then writes
+    /// the id-map sidecar (`external_ids.bin`) atomically via a tmp-then-rename sequence.
+    /// The sidecar is stamped with the corpus `content_hash` taken from the v2 commit
+    /// record.
+    ///
+    /// Crash-safety rationale: the v2 segment commit gate is `metadata.bin`, and the
+    /// sidecar is written second. On any crash between the two writes the sidecar's
+    /// stamped hash will not match the new commit's hash, so the load-time cross-check
+    /// detects the torn pair and the caller rebuilds. Ordering alone is insufficient;
+    /// the cross-check is the guarantee.
+    #[allow(dead_code)]
+    pub fn save_atomic(&self, dir: &std::path::Path) -> Result<(), String> {
+        let count = self.id_map.len();
+        if count != self.index.num_vectors() {
+            return Err(format!(
+                "id_map length {count} != index.num_vectors() {}",
+                self.index.num_vectors()
+            ));
+        }
+
+        // Step 1: write v2 segments atomically (metadata.bin is the commit gate).
+        self.index
+            .save_atomic(dir)
+            .map_err(|e| format!("VamanaIndex::save_atomic: {e}"))?;
+
+        // Step 2: read back the v2 commit fingerprint to obtain the content_hash.
+        // Must be Some — we just committed it. None means an unexpected v1/torn state.
+        let fp = read_commit_fingerprint(dir)
+            .map_err(|e| format!("read_commit_fingerprint after save: {e}"))?
+            .ok_or_else(|| {
+                "save_atomic succeeded but read_commit_fingerprint returned None \
+                 (unexpected v1 or torn commit)"
+                    .to_string()
+            })?;
+
+        // Step 3: write the id-map sidecar atomically (tmp rename), stamped with
+        // the commit's content_hash so a torn pair is self-detecting at load time.
+        write_external_ids_sidecar(dir, &fp.content_hash, &self.id_map)
+    }
+
+    /// Load a bridge from a segment directory previously written by
+    /// [`AnnBridge::save_atomic`].
+    ///
+    /// Both the Vamana v2 commit record and the id-map sidecar must be present and
+    /// self-consistent (matching `content_hash` and vector count). Any mismatch returns
+    /// `Err`; the caller should treat that as a Cold signal and rebuild from the corpus.
+    #[allow(dead_code)]
+    pub fn load(dir: &std::path::Path) -> Result<Self, String> {
+        // Step 1: require a v2 commit fingerprint. Absent/v1/torn → Cold.
+        let fp = read_commit_fingerprint(dir)
+            .map_err(|e| format!("read_commit_fingerprint: {e}"))?
+            .ok_or_else(|| {
+                "no v2 commit fingerprint: segment dir is absent, v1, or has a torn commit"
+                    .to_string()
+            })?;
+
+        // Step 2: raw-load the committed v2 index. VamanaIndex::load is v2-aware
+        // (ADR-079): it reads the segments, verifies their checksums, and restores
+        // graph + lifecycle without a corpus and without rebuilding. A torn or
+        // mismatched segment surfaces as an error, which the caller treats as Cold.
+        let index = VamanaIndex::load(dir).map_err(|e| format!("VamanaIndex::load: {e}"))?;
+
+        // Step 3: read the external_ids sidecar and run cross-checks.
+        let (sidecar_hash, id_map) = read_external_ids_sidecar(dir)?;
+
+        // Cross-check: sidecar content_hash must match the v2 commit's content_hash.
+        // A mismatch means a torn segment/sidecar pair (crash between the segment
+        // commit and the sidecar write in save_atomic).
+        if sidecar_hash != fp.content_hash {
+            return Err(
+                "external_ids.bin content_hash mismatch: torn segment/sidecar pair".to_string(),
+            );
+        }
+
+        // Cross-check: sidecar UUID count must match the loaded index vector count.
+        if id_map.len() != index.num_vectors() {
+            return Err(format!(
+                "external_ids.bin count {} != index.num_vectors() {}",
+                id_map.len(),
+                index.num_vectors()
+            ));
+        }
+
+        Ok(Self { index, id_map })
+    }
 }
 
 fn l2_normalize(v: &mut [f32]) {
@@ -229,6 +320,100 @@ fn l2_normalize(v: &mut [f32]) {
             *x /= norm;
         }
     }
+}
+
+// ── external-id sidecar helpers (slice 1b-i, ADR-079) ────────────────────────
+//
+// Binary format for `external_ids.bin`:
+//   magic       8 bytes   b"KHVANIDS"
+//   content_hash 32 bytes corpus blake3 hash (from v2 commit fingerprint)
+//   count        8 bytes  u64 little-endian — number of UUIDs
+//   ids          16 × count bytes — UUIDs as raw big-endian bytes (uuid_to_bytes_le)
+
+#[allow(dead_code)]
+const SIDECAR_MAGIC: &[u8; 8] = b"KHVANIDS";
+
+/// Write `ids` to `dir/external_ids.bin` using a tmp-then-rename pattern.
+///
+/// The sidecar is stamped with `content_hash` so `AnnBridge::load` can detect
+/// a torn segment/sidecar pair (segments committed with hash A, sidecar still
+/// holding hash B from a prior save, or vice versa).
+#[allow(dead_code)]
+fn write_external_ids_sidecar(
+    dir: &std::path::Path,
+    content_hash: &[u8; 32],
+    ids: &[Uuid],
+) -> Result<(), String> {
+    use std::io::Write as _;
+
+    let tmp_path = dir.join("external_ids.bin.tmp");
+    let final_path = dir.join("external_ids.bin");
+
+    let count = ids.len() as u64;
+    let mut buf: Vec<u8> = Vec::with_capacity(8 + 32 + 8 + ids.len() * 16);
+    buf.extend_from_slice(SIDECAR_MAGIC);
+    buf.extend_from_slice(content_hash);
+    buf.extend_from_slice(&count.to_le_bytes());
+    for id in ids {
+        buf.extend_from_slice(id.as_bytes());
+    }
+
+    let mut f = std::fs::File::create(&tmp_path)
+        .map_err(|e| format!("create external_ids.bin.tmp: {e}"))?;
+    f.write_all(&buf)
+        .map_err(|e| format!("write external_ids.bin.tmp: {e}"))?;
+    f.sync_all()
+        .map_err(|e| format!("sync external_ids.bin.tmp: {e}"))?;
+    drop(f);
+    std::fs::rename(&tmp_path, &final_path)
+        .map_err(|e| format!("rename external_ids.bin.tmp -> external_ids.bin: {e}"))
+}
+
+/// Read `dir/external_ids.bin` and return `(content_hash, ids)`.
+///
+/// Returns `Err` on any I/O error, wrong magic, truncated header, or count/size mismatch.
+#[allow(dead_code)]
+fn read_external_ids_sidecar(dir: &std::path::Path) -> Result<([u8; 32], Vec<Uuid>), String> {
+    let bytes = std::fs::read(dir.join("external_ids.bin"))
+        .map_err(|e| format!("read external_ids.bin: {e}"))?;
+
+    // magic (8) + content_hash (32) + count (8) = 48 bytes minimum header
+    if bytes.len() < 48 {
+        return Err(format!(
+            "external_ids.bin too short: {} bytes (need at least 48)",
+            bytes.len()
+        ));
+    }
+
+    let magic = &bytes[0..8];
+    if magic != SIDECAR_MAGIC {
+        return Err(format!(
+            "external_ids.bin bad magic: got {:?}, expected {:?}",
+            magic, SIDECAR_MAGIC
+        ));
+    }
+
+    let mut content_hash = [0u8; 32];
+    content_hash.copy_from_slice(&bytes[8..40]);
+
+    let count = u64::from_le_bytes(bytes[40..48].try_into().unwrap()) as usize;
+    let expected_len = 48 + count * 16;
+    if bytes.len() != expected_len {
+        return Err(format!(
+            "external_ids.bin length mismatch: got {} bytes, expected {} for {count} UUIDs",
+            bytes.len(),
+            expected_len
+        ));
+    }
+
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let start = 48 + i * 16;
+        let raw: [u8; 16] = bytes[start..start + 16].try_into().unwrap();
+        ids.push(Uuid::from_bytes(raw));
+    }
+
+    Ok((content_hash, ids))
 }
 
 // ── persistence helpers ───────────────────────────────────────────────────────
@@ -895,6 +1080,138 @@ mod tests {
         assert!(
             !is_warming_not_loaded(&ann, &key),
             "is_warming_not_loaded must not panic on poisoned Mutex"
+        );
+    }
+
+    // ── AnnBridge::save_atomic / load (slice 1b-i, ADR-079) ──────────────────
+
+    fn build_test_bridge(dim: usize, n: usize) -> (AnnBridge, Vec<Uuid>) {
+        let ids: Vec<Uuid> = (0..n).map(|_| Uuid::new_v4()).collect();
+        let mut vectors: Vec<f32> = Vec::with_capacity(n * dim);
+        for i in 0..n {
+            for d in 0..dim {
+                vectors.push(if d == i % dim { 1.0 } else { 0.0 });
+            }
+        }
+        let bridge = AnnBridge::build(vectors, dim, ids.clone()).expect("build test bridge");
+        (bridge, ids)
+    }
+
+    #[test]
+    fn ann_bridge_save_atomic_load_round_trip() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let dim = 4;
+        let (bridge, ids) = build_test_bridge(dim, 4);
+        let first_id = ids[0];
+
+        bridge.save_atomic(dir.path()).expect("save_atomic");
+
+        let loaded = AnnBridge::load(dir.path()).expect("load");
+        assert_eq!(
+            loaded.num_vectors(),
+            bridge.num_vectors(),
+            "loaded vector count must match saved"
+        );
+
+        // Search with a query that points at vector 0 (1.0, 0.0, 0.0, 0.0)
+        let query = vec![1.0f32, 0.0, 0.0, 0.0];
+        let hits = loaded.search(&query, 1);
+        assert_eq!(hits.len(), 1, "must return 1 hit");
+        assert_eq!(hits[0].0, first_id, "top hit must be the first UUID");
+    }
+
+    #[test]
+    fn ann_bridge_load_missing_sidecar_err() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let (bridge, _) = build_test_bridge(4, 2);
+
+        bridge.save_atomic(dir.path()).expect("save_atomic");
+        std::fs::remove_file(dir.path().join("external_ids.bin")).expect("remove sidecar");
+
+        let result = AnnBridge::load(dir.path());
+        assert!(
+            result.is_err(),
+            "load must fail when external_ids.bin is missing"
+        );
+    }
+
+    #[test]
+    fn ann_bridge_load_torn_pair_err() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let dim = 4;
+
+        // Save bridge A into the directory — both segments and sidecar for A.
+        let (bridge_a, _) = build_test_bridge(dim, 2);
+        bridge_a.save_atomic(dir.path()).expect("save_atomic A");
+
+        // Overwrite the Vamana segments with bridge B's segments ONLY (no sidecar update).
+        // This simulates a crash after VamanaIndex::save_atomic but before write_external_ids_sidecar.
+        let (bridge_b, _) = build_test_bridge(dim, 3);
+        bridge_b
+            .index
+            .save_atomic(dir.path())
+            .expect("save_atomic B segments");
+
+        // Now: metadata.bin carries B's content_hash, external_ids.bin still has A's hash.
+        let result = AnnBridge::load(dir.path());
+        assert!(
+            result.is_err(),
+            "load must fail when segment content_hash != sidecar content_hash (torn pair)"
+        );
+        let err = result.err().expect("already asserted is_err");
+        assert!(
+            err.contains("content_hash mismatch") || err.contains("torn"),
+            "error message must mention hash mismatch or torn pair, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ann_bridge_load_count_mismatch_err() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let (bridge, _) = build_test_bridge(4, 2);
+        bridge.save_atomic(dir.path()).expect("save_atomic");
+
+        // Read back the sidecar, parse content_hash, then rewrite with wrong count.
+        let sidecar_bytes =
+            std::fs::read(dir.path().join("external_ids.bin")).expect("read sidecar");
+        // content_hash lives at bytes[8..40]; reuse it. Write count=99 instead of 2.
+        let mut new_sidecar: Vec<u8> = Vec::with_capacity(48 + 99 * 16);
+        new_sidecar.extend_from_slice(b"KHVANIDS");
+        new_sidecar.extend_from_slice(&sidecar_bytes[8..40]); // original content_hash
+        new_sidecar.extend_from_slice(&99u64.to_le_bytes()); // wrong count
+        new_sidecar.extend(std::iter::repeat_n(0u8, 99 * 16)); // 99 zero UUIDs
+        std::fs::write(dir.path().join("external_ids.bin"), &new_sidecar)
+            .expect("write patched sidecar");
+
+        let result = AnnBridge::load(dir.path());
+        assert!(
+            result.is_err(),
+            "load must fail when sidecar count != index.num_vectors()"
+        );
+    }
+
+    #[test]
+    fn ann_bridge_load_bad_magic_err() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let (bridge, _) = build_test_bridge(4, 2);
+        bridge.save_atomic(dir.path()).expect("save_atomic");
+
+        // Overwrite the first 8 bytes with a wrong magic.
+        let mut sidecar_bytes =
+            std::fs::read(dir.path().join("external_ids.bin")).expect("read sidecar");
+        sidecar_bytes[0..8].copy_from_slice(b"WRONGMAG");
+        std::fs::write(dir.path().join("external_ids.bin"), &sidecar_bytes)
+            .expect("write bad-magic sidecar");
+
+        let result = AnnBridge::load(dir.path());
+        assert!(
+            result.is_err(),
+            "load must fail when external_ids.bin has wrong magic"
+        );
+        let err = result.err().expect("already asserted is_err");
+        assert!(
+            err.contains("magic"),
+            "error must mention magic mismatch, got: {err}"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -1596,4 +1596,49 @@ mod tests {
             "re-persisted segment must reflect the 5-row corpus (4 initial + 1 mutation)"
         );
     }
+
+    /// `warm_known_snapshots` must warm v2 segments even when the legacy
+    /// `retrieval_snapshots` table is absent (the v1 query errors). Pre-fix it
+    /// early-returned on that error and never reached the filesystem segment
+    /// enumeration, so v2-only databases never warmed at daemon startup.
+    #[tokio::test]
+    async fn warm_known_snapshots_v2_only_no_legacy_table() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        // Setup: build + persist v2 segments to data_dir/ann/<hex>/.
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(
+            ann.indexes.read().await.contains_key(&key),
+            "setup: first ensure must persist v2 segments"
+        );
+
+        // Force the worst case the fix targets: the v1 table is absent, so the
+        // legacy query errors. Pre-fix, that error aborted the whole warm pass.
+        {
+            let sql = rt.sql();
+            let mut w = sql.writer().await.expect("writer");
+            w.execute(SqlStatement {
+                sql: "DROP TABLE IF EXISTS retrieval_snapshots".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("drop retrieval_snapshots");
+        }
+
+        // Cold cache + warm: the v2 filesystem enumeration must still warm the
+        // key despite the v1 query error.
+        let ann_fresh = new_shared();
+        warm_known_snapshots(&rt, &ann_fresh).await;
+        assert!(
+            ann_fresh.indexes.read().await.contains_key(&key),
+            "warm_known_snapshots must warm v2 segments when retrieval_snapshots is absent \
+             (regression: a v1 query error must not abort the v2 filesystem pass)"
+        );
+    }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -433,13 +433,15 @@ fn ann_segment_dir(rt: &KhiveRuntime, ns: &str, model: &str) -> Option<std::path
 /// interprets them as UTF-8, then splits on `"::vamana::"`. Returns `None` on bad
 /// hex, non-UTF-8 bytes, a missing separator, or empty namespace/model parts.
 fn decode_ann_dir_name(name: &str) -> Option<(String, String)> {
-    if !name.len().is_multiple_of(2) {
+    let raw = name.as_bytes();
+    if !raw.len().is_multiple_of(2) {
         return None;
     }
-    let mut bytes = Vec::with_capacity(name.len() / 2);
-    for i in (0..name.len()).step_by(2) {
-        let byte = u8::from_str_radix(&name[i..i + 2], 16).ok()?;
-        bytes.push(byte);
+    let mut bytes = Vec::with_capacity(raw.len() / 2);
+    for pair in raw.chunks_exact(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        bytes.push((hi * 16 + lo) as u8);
     }
     let key = String::from_utf8(bytes).ok()?;
     let (ns, model) = key.split_once("::vamana::")?;
@@ -688,23 +690,24 @@ pub(crate) async fn invalidate_snapshot(rt: &KhiveRuntime, namespace: &str) {
 /// Each unique namespace+model pair gets its own keyed slot; all snapshots are
 /// loaded, not just the first one.
 pub(crate) async fn warm_known_snapshots(rt: &KhiveRuntime, ann: &SharedAnn) {
-    let sql = rt.sql();
-    let mut reader = match sql.reader().await {
-        Ok(r) => r,
-        Err(_) => return,
-    };
-
-    let rows = match reader
-        .query_all(SqlStatement {
-            sql: "SELECT DISTINCT namespace FROM retrieval_snapshots WHERE namespace LIKE ?1"
-                .into(),
-            params: vec![SqlValue::Text("%::vamana::%".into())],
-            label: None,
-        })
-        .await
-    {
-        Ok(r) => r,
-        Err(_) => return,
+    // v1 legacy pass: warm namespaces recorded in retrieval_snapshots, if that
+    // table exists. On a v2-only database it will not, so a query error must fall
+    // through to the v2 segment enumeration below rather than abort the warm pass.
+    let rows = {
+        let sql = rt.sql();
+        match sql.reader().await {
+            Ok(mut reader) => reader
+                .query_all(SqlStatement {
+                    sql:
+                        "SELECT DISTINCT namespace FROM retrieval_snapshots WHERE namespace LIKE ?1"
+                            .into(),
+                    params: vec![SqlValue::Text("%::vamana::%".into())],
+                    label: None,
+                })
+                .await
+                .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
     };
 
     for row in &rows {
@@ -1510,12 +1513,27 @@ mod tests {
             "live_content_hash must equal persisted content_hash (normalize-once invariant)"
         );
 
-        // Hot path: load from persisted v2 segments without rebuilding.
+        // Hot path: load from persisted v2 segments without rebuilding. A rebuild
+        // would call save_atomic and rewrite metadata.bin (new inode); a true Hot
+        // load via AnnBridge::load never writes. Asserting the inode is unchanged
+        // proves the second call took the v2 Hot branch, not a silent rebuild.
+        use std::os::unix::fs::MetadataExt;
+        let meta_path = seg_dir.join("metadata.bin");
+        let ino_before = std::fs::metadata(&meta_path)
+            .expect("metadata.bin must exist after first build")
+            .ino();
         let ann2 = new_shared();
         ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
         assert!(
             ann2.indexes.read().await.contains_key(&key),
             "second call must restore the ANN index from v2 segments"
+        );
+        let ino_after = std::fs::metadata(&meta_path)
+            .expect("metadata.bin must still exist")
+            .ino();
+        assert_eq!(
+            ino_before, ino_after,
+            "second call must NOT rewrite metadata.bin — proves the v2 Hot load path, not a rebuild"
         );
     }
 

--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -11,10 +11,12 @@
 //! Wraps `khive_vamana::VamanaIndex` with an ID map (u32 → UUID) so search
 //! results can be fused with FTS5 candidates via RRF.
 //!
-//! Persistence: `ensure_ann_for_model` loads a validated snapshot from `retrieval_snapshots`
-//! on first access; stale/missing snapshots trigger a full rebuild + re-persist.
-//! `kkernel reindex` actively invalidates snapshots after re-embedding (second
-//! line of staleness defence).
+//! Persistence (ADR-079): v2 binary segments are written to `data_dir/ann/<hex>/`
+//! on every cold-start rebuild or explicit reindex.  `ensure_ann_for_model` checks
+//! the v2 segment directory first (content-hash gated), falling back to legacy v1
+//! JSON rows in `retrieval_snapshots` for in-place upgrades, then rebuilds from the
+//! full sqlite-vec corpus on cache-miss.  `kkernel reindex` re-persists v2 segments
+//! and calls `invalidate_snapshot` to clean up stale v1 rows.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -22,7 +24,8 @@ use std::sync::Arc;
 use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_vamana::{
-    read_commit_fingerprint, CorpusFingerprint, VamanaConfig, VamanaIndex, VamanaSnapshot,
+    corpus_content_hash, read_commit_fingerprint, CorpusFingerprint, VamanaConfig, VamanaIndex,
+    VamanaSnapshot,
 };
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -199,17 +202,6 @@ impl AnnBridge {
 
     pub fn num_vectors(&self) -> usize {
         self.index.num_vectors()
-    }
-
-    pub fn to_vamana_snapshot(
-        &self,
-        namespace: &str,
-        model: &str,
-        fingerprint: CorpusFingerprint,
-    ) -> Result<VamanaSnapshot, khive_vamana::VamanaError> {
-        let external_ids: Vec<String> = self.id_map.iter().map(|id| id.to_string()).collect();
-        self.index
-            .to_snapshot(namespace, model, fingerprint, external_ids)
     }
 
     pub fn from_vamana_snapshot(snapshot: VamanaSnapshot) -> Result<Self, String> {
@@ -423,6 +415,40 @@ pub(crate) fn snapshot_key(namespace: &str, model: &str) -> String {
     format!("{namespace}::vamana::{model}")
 }
 
+/// Filesystem directory for v2 Vamana segment files for a given `(ns, model)` pair.
+///
+/// Returns `Some(data_dir/ann/<hex>)` where `<hex>` is the lowercase hex encoding of
+/// the bytes of `snapshot_key(ns, model)`. Hex encoding is injective, filesystem-safe,
+/// and reversible via `decode_ann_dir_name`. Returns `None` for in-memory backends.
+fn ann_segment_dir(rt: &KhiveRuntime, ns: &str, model: &str) -> Option<std::path::PathBuf> {
+    let data_dir = rt.backend_data_dir()?;
+    let key = snapshot_key(ns, model);
+    let hex: String = key.bytes().map(|b| format!("{b:02x}")).collect();
+    Some(data_dir.join("ann").join(hex))
+}
+
+/// Decode a hex-encoded ann directory name back to `(namespace, model)`.
+///
+/// Reverses the encoding done by `ann_segment_dir`: hex-decodes `name` to bytes,
+/// interprets them as UTF-8, then splits on `"::vamana::"`. Returns `None` on bad
+/// hex, non-UTF-8 bytes, a missing separator, or empty namespace/model parts.
+fn decode_ann_dir_name(name: &str) -> Option<(String, String)> {
+    if !name.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(name.len() / 2);
+    for i in (0..name.len()).step_by(2) {
+        let byte = u8::from_str_radix(&name[i..i + 2], 16).ok()?;
+        bytes.push(byte);
+    }
+    let key = String::from_utf8(bytes).ok()?;
+    let (ns, model) = key.split_once("::vamana::")?;
+    if ns.is_empty() || model.is_empty() {
+        return None;
+    }
+    Some((ns.to_string(), model.to_string()))
+}
+
 /// Model-key sanitization — must match `khive_runtime::sanitize_key`.
 pub(crate) fn sanitize_model_key(s: &str) -> String {
     s.chars()
@@ -430,78 +456,22 @@ pub(crate) fn sanitize_model_key(s: &str) -> String {
         .collect()
 }
 
-/// Create `retrieval_snapshots` if it does not exist yet.
-async fn ensure_snapshot_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
-    let sql = rt.sql();
-    let mut w = sql
-        .writer()
-        .await
-        .map_err(|e| RuntimeError::Internal(e.to_string()))?;
-    w.execute_script(
-        r#"
-        CREATE TABLE IF NOT EXISTS retrieval_snapshots (
-            namespace   TEXT NOT NULL,
-            index_type  TEXT NOT NULL,
-            snapshot    BLOB NOT NULL,
-            created_at  INTEGER NOT NULL,
-            PRIMARY KEY (namespace, index_type)
-        );
-        CREATE INDEX IF NOT EXISTS idx_retrieval_snapshots_namespace
-            ON retrieval_snapshots(namespace);
-        "#
-        .into(),
-    )
-    .await
-    .map_err(|e| RuntimeError::Internal(e.to_string()))
-}
-
-/// Persist `bridge` as a Vamana snapshot under `{namespace}::vamana::{model}`.
-pub(crate) async fn persist_snapshot(
+/// Persist `bridge` as v2 Vamana segments under `data_dir/ann/<hex>/`.
+///
+/// Resolves the segment directory via `ann_segment_dir`. Returns `Ok(())` when the
+/// backend is in-memory (no `data_dir`) — skipping persistence is not an error.
+/// `save_atomic` computes and stamps the `content_hash` internally; callers do not
+/// need to supply a `CorpusFingerprint`.
+pub(crate) fn persist_ann_v2(
     rt: &KhiveRuntime,
-    namespace: &str,
+    ns: &str,
     model: &str,
     bridge: &AnnBridge,
-    fingerprint: CorpusFingerprint,
-) -> Result<(), RuntimeError> {
-    if let Err(e) = ensure_snapshot_schema(rt).await {
-        tracing::warn!(error = %e, "failed to create retrieval_snapshots schema");
-        return Err(e);
+) -> Result<(), String> {
+    match ann_segment_dir(rt, ns, model) {
+        Some(dir) => bridge.save_atomic(&dir),
+        None => Ok(()), // in-memory backend — no filesystem, skip silently
     }
-
-    let snapshot = bridge
-        .to_vamana_snapshot(namespace, model, fingerprint)
-        .map_err(|e| RuntimeError::Internal(format!("to_snapshot: {e}")))?;
-
-    let blob = serde_json::to_vec(&snapshot)
-        .map_err(|e| RuntimeError::Internal(format!("snapshot serialize: {e}")))?;
-
-    let key = snapshot_key(namespace, model);
-    let sql = rt.sql();
-    let mut w = sql
-        .writer()
-        .await
-        .map_err(|e| RuntimeError::Internal(e.to_string()))?;
-    w.execute(SqlStatement {
-        sql: "INSERT OR REPLACE INTO retrieval_snapshots \
-              (namespace, index_type, snapshot, created_at) VALUES (?1, ?2, ?3, ?4)"
-            .into(),
-        params: vec![
-            SqlValue::Text(key),
-            SqlValue::Text("vamana".into()),
-            SqlValue::Blob(blob),
-            SqlValue::Integer(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_micros() as i64,
-            ),
-        ],
-        label: Some("persist_vamana_snapshot".into()),
-    })
-    .await
-    .map_err(|e| RuntimeError::Internal(e.to_string()))?;
-
-    Ok(())
 }
 
 /// Try to load a Vamana snapshot for `namespace`+`model` from `retrieval_snapshots`.
@@ -549,14 +519,18 @@ pub(crate) async fn compute_fingerprint(
     })
 }
 
-/// Scan the sqlite-vec table and build a fresh `AnnBridge`.
+/// Scan the sqlite-vec corpus for `model` and return raw (un-normalized) flat
+/// vectors alongside the ordered UUID id-map.
 ///
-/// Returns `None` when there are no vectors or the model is not configured.
-pub(crate) async fn load_and_build_from_vector_store(
+/// Rows are fetched `ORDER BY subject_id` so the mapping is deterministic.
+/// Returns `Ok(None)` when the model is not configured, the table is empty, or
+/// no rows pass the byte-length validity check.  The caller derives `dims` as
+/// `flat.len() / id_map.len()`.
+async fn scan_corpus_raw(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     model: &str,
-) -> Result<Option<AnnBridge>, RuntimeError> {
+) -> Result<Option<(Vec<f32>, Vec<Uuid>)>, RuntimeError> {
     let store = match rt.vectors_for_model(token, model) {
         Ok(s) => s,
         Err(_) => return Ok(None),
@@ -633,9 +607,47 @@ pub(crate) async fn load_and_build_from_vector_store(
         return Ok(None);
     }
 
+    Ok(Some((flat, id_map)))
+}
+
+/// Scan the sqlite-vec table and build a fresh `AnnBridge`.
+///
+/// Returns `None` when there are no vectors or the model is not configured.
+pub(crate) async fn load_and_build_from_vector_store(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+) -> Result<Option<AnnBridge>, RuntimeError> {
+    let Some((flat, id_map)) = scan_corpus_raw(rt, token, model).await? else {
+        return Ok(None);
+    };
+    let dims = flat.len() / id_map.len();
     AnnBridge::build(flat, dims, id_map)
         .map(Some)
         .map_err(RuntimeError::Internal)
+}
+
+/// Hash the live corpus as it would appear inside a freshly built `AnnBridge`.
+///
+/// Scans the sqlite-vec corpus, L2-normalizes each vector in place (matching
+/// `AnnBridge::build` which calls `l2_normalize` exactly once per row), then
+/// passes the normalized flat buffer through `corpus_content_hash`.  Returns
+/// `None` when the corpus is empty or the model is not configured.
+///
+/// INVARIANT: normalize ONCE here, never re-normalize an already-normalized
+/// buffer.  Calling this on a buffer that has already been normalized produces a
+/// non-idempotent hash and causes always-stale comparisons.
+async fn live_content_hash(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+) -> Option<[u8; 32]> {
+    let (mut flat, id_map) = scan_corpus_raw(rt, token, model).await.ok()??;
+    let dims = flat.len() / id_map.len();
+    for row in flat.chunks_exact_mut(dims) {
+        l2_normalize(row);
+    }
+    Some(corpus_content_hash(&flat))
 }
 
 /// Delete all Vamana snapshots for `namespace` from `retrieval_snapshots`.
@@ -716,6 +728,38 @@ pub(crate) async fn warm_known_snapshots(rt: &KhiveRuntime, ann: &SharedAnn) {
         };
         ensure_ann_for_model(rt, &token, ann, model).await;
     }
+
+    // Enumerate v2 segment directories in `data_dir/ann/` and warm any keys not
+    // already loaded by the v1 DB pass above.
+    let ann_root = match rt.backend_data_dir() {
+        Some(d) => d.join("ann"),
+        None => return,
+    };
+    let read_dir = match std::fs::read_dir(&ann_root) {
+        Ok(rd) => rd,
+        Err(_) => return, // no ann/ dir yet — nothing to warm
+    };
+    for entry in read_dir.flatten() {
+        let name = entry.file_name();
+        let hex = name.to_string_lossy();
+        let Some((ns_str, model)) = decode_ann_dir_name(hex.as_ref()) else {
+            continue;
+        };
+        let ns = match Namespace::parse(&ns_str) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let token = match rt.authorize(ns) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        // Guard: skip if already loaded by the v1 pass.
+        let key = AnnKey::new(&ns_str, &model);
+        if ann.indexes.read().await.contains_key(&key) {
+            continue;
+        }
+        ensure_ann_for_model(rt, &token, ann, &model).await;
+    }
 }
 
 /// Fire-once per-key background warm. Returns immediately. If the key is already
@@ -753,10 +797,21 @@ pub(crate) fn ensure_ann_background(rt: &KhiveRuntime, token: &NamespaceToken, a
     });
 }
 
-/// Lazy warm-load for a specific `model`. If the `{namespace, model}` key is
-/// already in the cache, return immediately. Otherwise attempt to restore from a
-/// valid snapshot; on miss/stale/corrupt, rebuild from the full sqlite-vec corpus
-/// and persist the new snapshot. Write failures are logged and do not block search.
+/// Lazy warm-load for a specific `model`.
+///
+/// Load order (first hit wins):
+///
+/// 1. **Fast path** — already in the in-memory cache; return immediately.
+/// 2. **v2 segment path** — if a `data_dir/ann/<hex>/` directory exists with a
+///    valid `metadata.bin`, compare its `content_hash` against a freshly computed
+///    `live_content_hash`.  On match, load the Vamana binary segments directly via
+///    `AnnBridge::load` (O(load), no rebuild).  On mismatch, fall through.
+/// 3. **v1 JSON snapshot path** — try `retrieval_snapshots`; on hit, validate
+///    the `CorpusFingerprint` (count + dims) and restore from JSON.  On miss /
+///    stale / corrupt, fall through.
+/// 4. **Rebuild fallthrough** — scan the full sqlite-vec corpus, build the index
+///    from scratch, and atomically write a v2 segment directory so the next daemon
+///    restart can use path 2.  Write failures are logged and do not block search.
 pub(crate) async fn ensure_ann_for_model(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -769,44 +824,96 @@ pub(crate) async fn ensure_ann_for_model(
     let ns = token.namespace().as_str().to_owned();
     let key = AnnKey::new(&ns, model);
 
-    // Fast path: already loaded.
+    // 1. Fast path: already loaded.
     if ann.indexes.read().await.contains_key(&key) {
         return;
     }
 
-    // Try snapshot warm-load.
+    // 2. v2 segment path.
+    if let Some(seg_dir) = ann_segment_dir(rt, &ns, model) {
+        match read_commit_fingerprint(&seg_dir) {
+            Ok(Some(persisted)) => {
+                // Cheap count+dims gate before hashing the full corpus.
+                let current_fp = compute_fingerprint(rt, token, model).await;
+                let count_dims_ok = current_fp.is_some_and(|fp| {
+                    fp.vector_count == persisted.vector_count
+                        && fp.dimensions as u64 == persisted.dimensions
+                });
+                if count_dims_ok {
+                    // Full content-hash check (normalizes corpus once).
+                    if let Some(live_hash) = live_content_hash(rt, token, model).await {
+                        if live_hash == persisted.content_hash {
+                            match AnnBridge::load(&seg_dir) {
+                                Ok(bridge) => {
+                                    ann.indexes.write().await.entry(key).or_insert(bridge);
+                                    return;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        dir = %seg_dir.display(),
+                                        "v2 segment load failed; falling through to rebuild"
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::info!(
+                                namespace = %ns,
+                                model = %model,
+                                "stale v2 segment (content-hash mismatch); rebuilding"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::info!(
+                        namespace = %ns,
+                        model = %model,
+                        "stale v2 segment (count/dims mismatch); rebuilding"
+                    );
+                }
+            }
+            Ok(None) => {
+                // No v2 segments yet (or torn write) — fall through to v1 / rebuild.
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    dir = %seg_dir.display(),
+                    "error reading v2 segment fingerprint; falling through"
+                );
+            }
+        }
+    }
+
+    // 3. v1 JSON snapshot path (backwards-compat transition).
     if let Some(snapshot) = try_load_snapshot(rt, &ns, model).await {
         let current_fp = compute_fingerprint(rt, token, model).await;
         if let Some(fp) = current_fp {
             if snapshot.fingerprint == fp {
                 match AnnBridge::from_vamana_snapshot(snapshot) {
                     Ok(bridge) => {
-                        // Re-check under write lock to avoid TOCTOU.
                         ann.indexes.write().await.entry(key).or_insert(bridge);
                         return;
                     }
                     Err(e) => {
-                        tracing::warn!(error = %e, "corrupt Vamana snapshot; rebuilding");
+                        tracing::warn!(error = %e, "corrupt Vamana v1 snapshot; rebuilding");
                     }
                 }
             } else {
                 tracing::info!(
                     namespace = %ns,
                     model = %model,
-                    "stale Vamana snapshot rejected (fingerprint mismatch); rebuilding"
+                    "stale Vamana v1 snapshot (fingerprint mismatch); rebuilding"
                 );
             }
         }
     }
 
-    // Snapshot absent, stale, or corrupt — rebuild from vector store.
+    // 4. Rebuild fallthrough — build from vector store and persist v2 segments.
     match load_and_build_from_vector_store(rt, token, model).await {
         Ok(Some(bridge)) => {
-            let fp = compute_fingerprint(rt, token, model).await;
-            if let Some(fingerprint) = fp {
-                if let Err(e) = persist_snapshot(rt, &ns, model, &bridge, fingerprint).await {
-                    tracing::error!(error = %e, "failed to persist Vamana snapshot after rebuild");
-                }
+            if let Err(e) = persist_ann_v2(rt, &ns, model, &bridge) {
+                tracing::error!(error = %e, "failed to persist v2 Vamana segment after rebuild");
             }
             ann.indexes.write().await.entry(key).or_insert(bridge);
         }
@@ -1212,6 +1319,263 @@ mod tests {
         assert!(
             err.contains("magic"),
             "error must mention magic mismatch, got: {err}"
+        );
+    }
+
+    // ── slice 1b-ii-a: warm-path tests (ADR-079) ─────────────────────────────
+
+    use async_trait::async_trait;
+    use khive_runtime::{AllowAllGate, BackendId, EmbedderProvider, RuntimeConfig};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use tempfile::TempDir;
+
+    const WARM_TEST_MODEL: &str = "ann-test-model";
+    const WARM_DIMS: usize = 4;
+
+    struct ConstVecService;
+
+    #[async_trait]
+    impl EmbeddingService for ConstVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|_| vec![1.0_f32; WARM_DIMS]).collect())
+        }
+
+        fn supports_model(&self, _: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "const-vec"
+        }
+    }
+
+    struct TestEmbedderProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for TestEmbedderProvider {
+        fn name(&self) -> &str {
+            WARM_TEST_MODEL
+        }
+
+        fn dimensions(&self) -> usize {
+            WARM_DIMS
+        }
+
+        async fn build(&self) -> khive_runtime::RuntimeResult<Arc<dyn EmbeddingService>> {
+            Ok(Arc::new(ConstVecService))
+        }
+    }
+
+    fn file_rt_with_embedder(db_path: std::path::PathBuf) -> KhiveRuntime {
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "knowledge".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        })
+        .expect("file-backed runtime");
+        rt.register_embedder(TestEmbedderProvider);
+        rt
+    }
+
+    /// Seed `n` distinct rows into the vec0 table for `WARM_TEST_MODEL`.
+    ///
+    /// Calls `rt.vectors_for_model` first so the virtual table is created, then
+    /// inserts raw f32 LE blobs directly via SQL.
+    async fn seed_warm_corpus(rt: &KhiveRuntime, token: &NamespaceToken, n: usize) {
+        let _store = rt
+            .vectors_for_model(token, WARM_TEST_MODEL)
+            .expect("vec store");
+        let model_key = sanitize_model_key(WARM_TEST_MODEL);
+        let table = format!("vec_{model_key}");
+        let ns = token.namespace().as_str().to_owned();
+        let sql = rt.sql();
+        let mut w = sql.writer().await.expect("writer");
+        for i in 0..n {
+            let id = Uuid::new_v4();
+            let mut v = [0.0_f32; WARM_DIMS];
+            v[i % WARM_DIMS] = 1.0;
+            let bytes: Vec<u8> = v.iter().flat_map(|f| f.to_le_bytes()).collect();
+            w.execute(SqlStatement {
+                sql: format!(
+                    "INSERT INTO {table} \
+                     (subject_id, namespace, kind, field, embedding_model, embedding) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
+                ),
+                params: vec![
+                    SqlValue::Text(id.to_string()),
+                    SqlValue::Text(ns.clone()),
+                    SqlValue::Text("concept".to_string()),
+                    SqlValue::Text("knowledge.atom".to_string()),
+                    SqlValue::Text(WARM_TEST_MODEL.to_string()),
+                    SqlValue::Blob(bytes),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert corpus row");
+        }
+    }
+
+    /// `ann_segment_dir` encodes a round-trippable hex key that `decode_ann_dir_name` reverses.
+    #[tokio::test]
+    async fn ann_segment_dir_encode_decode_round_trip() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL)
+            .expect("file backend must return Some(seg_dir)");
+
+        let dir_name = seg_dir
+            .file_name()
+            .expect("seg_dir must have a basename")
+            .to_string_lossy()
+            .into_owned();
+
+        let (decoded_ns, decoded_model) =
+            decode_ann_dir_name(&dir_name).expect("decode must succeed for a valid encode");
+        assert_eq!(decoded_ns, "local");
+        assert_eq!(decoded_model, WARM_TEST_MODEL);
+
+        // Parent directory is `data_dir/ann/`.
+        let parent = seg_dir.parent().expect("seg_dir must have a parent");
+        assert_eq!(
+            parent.file_name().unwrap().to_string_lossy(),
+            "ann",
+            "seg_dir parent must be named 'ann'"
+        );
+    }
+
+    /// `ensure_ann_for_model` must not panic on an in-memory runtime (no data_dir).
+    #[tokio::test]
+    async fn ensure_ann_no_data_dir_does_not_panic() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ann = new_shared();
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        // No data_dir → v2 path skipped. No corpus → no rebuild. Must complete silently.
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(
+            !ann.indexes.read().await.contains_key(&key),
+            "no index should be loaded when corpus is empty and model is unknown"
+        );
+    }
+
+    /// Cold-start build persists v2 segments; a second call restores from disk.
+    ///
+    /// Also gates the normalize-once invariant: `live_content_hash` must equal the
+    /// persisted commit hash, proving the Hot branch can fire without double-normalization.
+    #[tokio::test]
+    async fn ensure_ann_round_trip_hot() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        // Cold-start: rebuild from corpus, persist v2 segments.
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(
+            ann.indexes.read().await.contains_key(&key),
+            "first call must build the ANN index"
+        );
+
+        // Normalize-once invariant: the live corpus hash must equal the persisted
+        // commit hash.  A double-normalize bug produces always-stale hashes here.
+        let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL)
+            .expect("file backend must have a seg_dir");
+        assert!(
+            seg_dir.join("metadata.bin").exists(),
+            "first call must persist v2 segments (metadata.bin missing)"
+        );
+        let persisted = read_commit_fingerprint(&seg_dir)
+            .expect("read_commit_fingerprint must not err")
+            .expect("metadata.bin must carry a v2 fingerprint");
+        let live = live_content_hash(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("live_content_hash must return Some for a seeded corpus");
+        assert_eq!(
+            live, persisted.content_hash,
+            "live_content_hash must equal persisted content_hash (normalize-once invariant)"
+        );
+
+        // Hot path: load from persisted v2 segments without rebuilding.
+        let ann2 = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
+        assert!(
+            ann2.indexes.read().await.contains_key(&key),
+            "second call must restore the ANN index from v2 segments"
+        );
+    }
+
+    /// After a corpus mutation the persisted v2 segment is stale and triggers a rebuild.
+    ///
+    /// Proves the stale branch is actually exercised (not silently falling through to rebuild),
+    /// and that the rebuild re-persists v2 segments matching the mutated corpus.
+    #[tokio::test]
+    async fn ensure_ann_stale_rebuild() {
+        let dir = TempDir::new().expect("tempdir");
+        let rt = file_rt_with_embedder(dir.path().join("test.db"));
+        let token = rt.authorize(Namespace::local()).expect("authorize");
+        seed_warm_corpus(&rt, &token, 4).await;
+
+        // Initial build: persist v2 segments.
+        let ann = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann, WARM_TEST_MODEL).await;
+        let key = AnnKey::new("local", WARM_TEST_MODEL);
+        assert!(ann.indexes.read().await.contains_key(&key), "initial build");
+
+        // Mutate corpus: add one more row.
+        seed_warm_corpus(&rt, &token, 1).await;
+
+        // Gate: after mutation, live hash must DIFFER from persisted — proves the stale
+        // branch will fire (not silently succeed with the same hash).
+        let seg_dir = ann_segment_dir(&rt, "local", WARM_TEST_MODEL)
+            .expect("file backend must have a seg_dir");
+        let persisted_before = read_commit_fingerprint(&seg_dir)
+            .expect("read_commit_fingerprint must not err")
+            .expect("v2 fingerprint must be present after initial build");
+        let live_after_mutation = live_content_hash(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("live_content_hash must return Some");
+        assert_ne!(
+            live_after_mutation, persisted_before.content_hash,
+            "mutation must make live hash differ from persisted (stale-branch pre-condition)"
+        );
+
+        // Fresh SharedAnn: stale v2 detected → rebuild from corpus.
+        let ann2 = new_shared();
+        ensure_ann_for_model(&rt, &token, &ann2, WARM_TEST_MODEL).await;
+        assert!(
+            ann2.indexes.read().await.contains_key(&key),
+            "must rebuild the index after corpus mutation (stale v2 segment rejected)"
+        );
+
+        // Rebuild must re-persist v2 segments matching the mutated (5-row) corpus.
+        let persisted_after = read_commit_fingerprint(&seg_dir)
+            .expect("read_commit_fingerprint after rebuild must not err")
+            .expect("v2 fingerprint must be present after rebuild");
+        let live_final = live_content_hash(&rt, &token, WARM_TEST_MODEL)
+            .await
+            .expect("live_content_hash must return Some after rebuild");
+        assert_eq!(
+            live_final, persisted_after.content_hash,
+            "rebuild must re-persist v2 matching the mutated corpus"
+        );
+        assert_eq!(
+            persisted_after.vector_count, 5,
+            "re-persisted segment must reflect the 5-row corpus (4 initial + 1 mutation)"
         );
     }
 }

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -275,6 +275,12 @@ impl KhiveRuntime {
         &self.backend
     }
 
+    /// Return the directory containing the backend's database file, or `None`
+    /// for an in-memory backend.
+    pub fn backend_data_dir(&self) -> Option<std::path::PathBuf> {
+        self.backend.data_dir()
+    }
+
     // ---- Store accessors (token-scoped) ----
 
     /// Get an EntityStore scoped to the token's namespace.
@@ -848,6 +854,56 @@ mod tests {
     fn memory_runtime_creates_successfully() {
         let rt = KhiveRuntime::memory().expect("memory runtime should create");
         assert!(rt.config().db_path.is_none());
+    }
+
+    #[test]
+    fn backend_data_dir_returns_none_for_memory_backend() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        assert!(rt.backend_data_dir().is_none());
+    }
+
+    #[test]
+    fn backend_data_dir_returns_parent_dir_for_file_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let config = RuntimeConfig {
+            db_path: Some(path),
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        let rt = KhiveRuntime::new(config).expect("file runtime");
+        let data_dir = rt
+            .backend_data_dir()
+            .expect("file backend must return Some");
+        assert_eq!(data_dir, dir.path());
+    }
+
+    #[test]
+    fn backend_data_dir_returns_none_for_from_backend_with_memory() {
+        let backend = Arc::new(StorageBackend::memory().expect("memory backend"));
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: None,
+        };
+        let rt = KhiveRuntime::from_backend(backend, config);
+        assert!(rt.backend_data_dir().is_none());
     }
 
     #[test]

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -472,9 +472,21 @@ impl VamanaIndex {
         Ok(())
     }
 
-    /// Load an index from a directory previously written by [`VamanaIndex::save`].
+    /// Load an index from a directory previously written by [`VamanaIndex::save`]
+    /// (v1 format) or [`VamanaIndex::save_atomic`] (v2 segmented format).
+    ///
+    /// The format is detected from `metadata.bin`'s magic: a v2 commit takes the raw
+    /// segment path ([`Self::load_v2_raw`]); a legacy v1 metadata blob takes the path
+    /// below. Neither path rebuilds — a corrupt, torn, or absent index returns an error,
+    /// leaving the recovery decision to the caller (see [`Self::load_or_build`]).
     pub fn load(path: &Path) -> Result<Self> {
-        let meta = read_metadata(&path.join("metadata.bin"))?;
+        let metadata_path = path.join("metadata.bin");
+        let head = fs::read(&metadata_path)?;
+        if head.len() >= 8 && &head[..8] == V2_COMMIT_MAGIC {
+            return Self::load_v2_raw(path);
+        }
+
+        let meta = read_metadata(&metadata_path)?;
         let config = VamanaConfig {
             dimensions: meta.dimensions,
             max_degree: meta.max_degree,
@@ -833,6 +845,40 @@ impl VamanaIndex {
             index.save_atomic(path)?;
             Ok(index)
         }
+    }
+
+    /// Load a committed v2 index from `path` without a corpus and without rebuilding.
+    ///
+    /// Verifies the v2 commit magic, parses the commit record, reads and checksum-verifies
+    /// all three segments against the commit fingerprint, then restores the index (graph +
+    /// lifecycle) via [`Self::load_v2_fast`]. Returns an `InvalidFormat` error if `path`
+    /// holds no valid v2 commit — absent, v1-format, torn, checksum mismatch, or an
+    /// inconsistent lifecycle segment. Unlike [`Self::load_or_build`] it never rebuilds;
+    /// callers that hold a corpus decide whether to fall back. [`Self::load`] surfaces the
+    /// error directly.
+    fn load_v2_raw(path: &Path) -> Result<Self> {
+        let metadata_bytes = fs::read(path.join("metadata.bin"))?;
+        if metadata_bytes.len() < 8 || &metadata_bytes[..8] != V2_COMMIT_MAGIC {
+            return Err(VamanaError::invalid_format(
+                "metadata.bin is not a v2 commit".into(),
+            ));
+        }
+        let commit = parse_v2_commit(&metadata_bytes)?;
+
+        let vectors_data = fs::read(path.join("vectors.bin"))?;
+        let graph_data = fs::read(path.join("graph.bin"))?;
+        let lifecycle_data = fs::read(path.join("lifecycle.bin"))?;
+
+        if *blake3::hash(&vectors_data).as_bytes() != commit.vectors_hash
+            || *blake3::hash(&graph_data).as_bytes() != commit.graph_hash
+            || *blake3::hash(&lifecycle_data).as_bytes() != commit.lifecycle_hash
+        {
+            return Err(VamanaError::invalid_format(
+                "v2 segment checksum mismatch".into(),
+            ));
+        }
+
+        Self::load_v2_fast(path, &lifecycle_data)
     }
 
     /// Load all v2 segments from `path` and restore lifecycle state from `lifecycle_data`.
@@ -4103,5 +4149,95 @@ mod tests {
         }
         let h3 = corpus_content_hash(&reordered);
         assert_ne!(h1, h3, "corpus_content_hash must be order-sensitive");
+    }
+
+    // ---- VamanaIndex::load v2-aware dispatch (load_v2_raw) tests ----
+
+    #[test]
+    fn load_reads_v2_segments_after_save_atomic() {
+        // load() must detect the v2 commit magic and raw-load the segments with no
+        // corpus and no rebuild, preserving search results.
+        let vectors = rand_unit_vectors(40, 8, 21);
+        let cfg = VamanaConfig::with_dimensions(8)
+            .with_max_degree(8)
+            .with_search_list_size(16);
+        let original = VamanaIndex::build(&vectors, cfg).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        original.save_atomic(dir.path()).unwrap();
+
+        let loaded = VamanaIndex::load(dir.path()).expect("load must read v2 segments");
+        assert_eq!(loaded.num_vectors(), original.num_vectors());
+
+        let query = rand_unit_vectors(1, 8, 321);
+        assert_eq!(
+            original.search(&query, 5).unwrap(),
+            loaded.search(&query, 5).unwrap(),
+            "v2 raw load must preserve search results"
+        );
+    }
+
+    #[test]
+    fn load_v2_matches_load_or_build_fast_path() {
+        // The raw load() path and load_or_build()'s fast path must agree when the
+        // corpus matches the committed segments.
+        let vectors = rand_unit_vectors(30, 8, 55);
+        let cfg = VamanaConfig::with_dimensions(8)
+            .with_max_degree(8)
+            .with_search_list_size(16);
+        let original = VamanaIndex::build(&vectors, cfg.clone()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        original.save_atomic(dir.path()).unwrap();
+
+        let via_load = VamanaIndex::load(dir.path()).unwrap();
+        let via_lob = VamanaIndex::load_or_build(dir.path(), &vectors, cfg).unwrap();
+
+        let query = rand_unit_vectors(1, 8, 999);
+        assert_eq!(
+            via_load.search(&query, 5).unwrap(),
+            via_lob.search(&query, 5).unwrap(),
+            "raw load and load_or_build fast path must produce identical results"
+        );
+    }
+
+    #[test]
+    fn load_v2_rejects_torn_segment() {
+        // A checksum mismatch on any segment must error (load never rebuilds).
+        let vectors = rand_unit_vectors(20, 4, 8);
+        let cfg = VamanaConfig::with_dimensions(4)
+            .with_max_degree(4)
+            .with_search_list_size(8);
+        let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        idx.save_atomic(dir.path()).unwrap();
+
+        // Flip one body byte of graph.bin; segment length is unchanged so only the
+        // blake3 checksum gate can catch it.
+        let mut gdata = fs::read(dir.path().join("graph.bin")).unwrap();
+        gdata[8] ^= 0xFF;
+        fs::write(dir.path().join("graph.bin"), &gdata).unwrap();
+
+        assert!(matches!(
+            VamanaIndex::load(dir.path()),
+            Err(VamanaError::InvalidFormat { .. })
+        ));
+    }
+
+    #[test]
+    fn load_v2_rejects_missing_segment() {
+        // A v2 commit whose backing segment is gone must error, not rebuild.
+        let vectors = rand_unit_vectors(20, 4, 9);
+        let cfg = VamanaConfig::with_dimensions(4)
+            .with_max_degree(4)
+            .with_search_list_size(8);
+        let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        idx.save_atomic(dir.path()).unwrap();
+
+        fs::remove_file(dir.path().join("lifecycle.bin")).unwrap();
+        assert!(
+            VamanaIndex::load(dir.path()).is_err(),
+            "load must fail when a v2 segment is missing"
+        );
     }
 }

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -47,6 +47,18 @@ pub struct CorpusFingerprint {
     pub dimensions: u32,
 }
 
+/// Persisted commit fingerprint readable without loading the graph or vectors.
+///
+/// Returned by [`read_commit_fingerprint`] for warm-path classification by
+/// callers that need to decide Hot/Stale/Cold without triggering a full graph
+/// restore or rebuild.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersistedFingerprint {
+    pub vector_count: u64,
+    pub dimensions: u64,
+    pub content_hash: [u8; 32],
+}
+
 /// Raw deserialization target for [`VamanaIndexSnapshot`].
 #[derive(Deserialize)]
 struct VamanaIndexSnapshotRaw {
@@ -2566,6 +2578,58 @@ fn mmap_vectors(path: &Path, expected_len_f32: usize) -> Result<VectorStorage> {
     })
 }
 
+/// Read the v2 commit fingerprint from a persisted segment directory without
+/// loading the graph or vectors.
+///
+/// `path` is the segment directory; this function joins `metadata.bin`
+/// internally, matching the convention used by [`VamanaIndex::load`] and
+/// [`VamanaIndex::load_or_build`].
+///
+/// Returns `Ok(None)` when:
+/// - `path/metadata.bin` is absent (clean first run)
+/// - the record does not begin with the KHVVAMG2 magic (v1 format or
+///   unrelated file)
+/// - the record is too short or otherwise cannot be parsed (torn write)
+///
+/// In the `None` cases the caller should treat the segment as Cold and proceed
+/// to build. Returns `Err` only for unexpected IO failures (not `NotFound`).
+pub fn read_commit_fingerprint(path: &Path) -> Result<Option<PersistedFingerprint>> {
+    let metadata_path = path.join("metadata.bin");
+    let bytes = match fs::read(&metadata_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if bytes.len() < 8 || &bytes[..8] != V2_COMMIT_MAGIC {
+        return Ok(None);
+    }
+    match parse_v2_commit(&bytes) {
+        Ok(commit) => Ok(Some(PersistedFingerprint {
+            vector_count: commit.fingerprint.vector_count,
+            dimensions: commit.fingerprint.dimensions,
+            content_hash: commit.fingerprint.content_hash,
+        })),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Canonical content hash over a flat corpus slice.
+///
+/// This is identical to the hash stored by [`VamanaIndex::save_atomic`] in
+/// the v2 commit fingerprint and compared by [`VamanaIndex::load_or_build`]
+/// when deciding whether a persisted index matches the live corpus.
+///
+/// The hash is computed over the raw little-endian f32 bytes of `vectors` with
+/// no header or padding (matching [`write_vectors`] which stores exactly
+/// `cast_slice(vectors)`). It is order-sensitive: reordering vectors produces
+/// a different digest.
+///
+/// Callers must pass the same normalized, row-major flat vectors they pass (or
+/// would pass) to [`VamanaIndex::build`]. This function does not normalize.
+pub fn corpus_content_hash(vectors: &[f32]) -> [u8; 32] {
+    *blake3::hash(cast_slice(vectors)).as_bytes()
+}
+
 // INLINE TEST JUSTIFICATION: Tests in this module exercise private helpers
 // (`exact_search`, `write_metadata`, `read_metadata`, `write_graph`, `read_graph`,
 // `mmap_vectors`) and the internal `VectorStorage` enum that cannot be accessed
@@ -3967,5 +4031,77 @@ mod tests {
             "SQ8 RobustPrune must match f32 variant; got sq8={sq8_result:?} vs f32={f32_result:?} \
              — restoring `_sq8_d2` as predicate RHS makes this test RED"
         );
+    }
+
+    // ---- read_commit_fingerprint + corpus_content_hash tests ----
+
+    #[test]
+    fn read_commit_fingerprint_matches_save_atomic() {
+        // Build a small index from normalized vectors, save it, then verify
+        // that read_commit_fingerprint returns a fingerprint whose content_hash
+        // matches corpus_content_hash over the same input vectors.
+        let vectors = rand_unit_vectors(10, 4, 42);
+        let cfg = VamanaConfig::with_dimensions(4)
+            .with_max_degree(4)
+            .with_search_list_size(8);
+        let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        idx.save_atomic(dir.path()).unwrap();
+
+        let fp = read_commit_fingerprint(dir.path())
+            .expect("IO error")
+            .expect("expected Some fingerprint after save_atomic");
+
+        assert_eq!(fp.vector_count, 10u64, "vector_count mismatch");
+        assert_eq!(fp.dimensions, 4u64, "dimensions mismatch");
+        assert_eq!(
+            fp.content_hash,
+            corpus_content_hash(&vectors),
+            "content_hash must equal corpus_content_hash over the same normalized vectors"
+        );
+    }
+
+    #[test]
+    fn read_commit_fingerprint_absent_dir_returns_none() {
+        // A directory with no metadata.bin must return Ok(None), not an error.
+        let dir = tempfile::tempdir().unwrap();
+        let result = read_commit_fingerprint(dir.path()).expect("unexpected IO error");
+        assert!(result.is_none(), "expected None for empty directory");
+    }
+
+    #[test]
+    fn read_commit_fingerprint_v1_magic_returns_none() {
+        // A metadata.bin with the v1 KHVVAMM1 magic (no v2 commit record) must
+        // return Ok(None) rather than an error.
+        let dir = tempfile::tempdir().unwrap();
+        // Write a metadata.bin whose first 8 bytes are the v1 magic (not KHVVAMG2).
+        let mut fake_meta = b"KHVVAMM1".to_vec();
+        // Pad to a plausible length so any length check doesn't short-circuit first.
+        fake_meta.extend_from_slice(&[0u8; 48]);
+        fs::write(dir.path().join("metadata.bin"), &fake_meta).unwrap();
+
+        let result = read_commit_fingerprint(dir.path()).expect("unexpected IO error");
+        assert!(result.is_none(), "expected None for v1 magic metadata.bin");
+    }
+
+    #[test]
+    fn corpus_content_hash_deterministic_and_order_sensitive() {
+        let vectors = rand_unit_vectors(8, 4, 77);
+
+        // Same input always produces the same digest.
+        let h1 = corpus_content_hash(&vectors);
+        let h2 = corpus_content_hash(&vectors);
+        assert_eq!(h1, h2, "corpus_content_hash must be deterministic");
+
+        // Reordering vectors (swap first and last row) must produce a different digest.
+        let dim = 4;
+        let mut reordered = vectors.clone();
+        let n = reordered.len() / dim;
+        // Swap row 0 and row n-1.
+        for d in 0..dim {
+            reordered.swap(d, (n - 1) * dim + d);
+        }
+        let h3 = corpus_content_hash(&reordered);
+        assert_ne!(h1, h3, "corpus_content_hash must be order-sensitive");
     }
 }

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -476,7 +476,7 @@ impl VamanaIndex {
     /// (v1 format) or [`VamanaIndex::save_atomic`] (v2 segmented format).
     ///
     /// The format is detected from `metadata.bin`'s magic: a v2 commit takes the raw
-    /// segment path ([`Self::load_v2_raw`]); a legacy v1 metadata blob takes the path
+    /// segment path (`load_v2_raw`); a legacy v1 metadata blob takes the path
     /// below. Neither path rebuilds — a corrupt, torn, or absent index returns an error,
     /// leaving the recovery decision to the caller (see [`Self::load_or_build`]).
     pub fn load(path: &Path) -> Result<Self> {
@@ -2666,7 +2666,7 @@ pub fn read_commit_fingerprint(path: &Path) -> Result<Option<PersistedFingerprin
 /// when deciding whether a persisted index matches the live corpus.
 ///
 /// The hash is computed over the raw little-endian f32 bytes of `vectors` with
-/// no header or padding (matching [`write_vectors`] which stores exactly
+/// no header or padding (matching `write_vectors` which stores exactly
 /// `cast_slice(vectors)`). It is order-sensitive: reordering vectors produces
 /// a different digest.
 ///

--- a/crates/khive-vamana/src/lib.rs
+++ b/crates/khive-vamana/src/lib.rs
@@ -10,7 +10,8 @@ pub use config::VamanaConfig;
 pub use error::{Result, VamanaError};
 pub use graph::{GreedySearchResult, VamanaGraph, VisitedSet};
 pub use index::{
-    CorpusFingerprint, VamanaIndex, VamanaIndexSnapshot, VamanaSnapshot, VAMANA_SNAPSHOT_FORMAT,
+    corpus_content_hash, read_commit_fingerprint, CorpusFingerprint, PersistedFingerprint,
+    VamanaIndex, VamanaIndexSnapshot, VamanaSnapshot, VAMANA_SNAPSHOT_FORMAT,
     VAMANA_SNAPSHOT_VERSION,
 };
 


### PR DESCRIPTION
## Summary

Wires ADR-052's v2 mmap ANN persistence into the knowledge-pack daemon warm path, addressing the
root cause behind #322: the warm window was O(rebuild), not O(load). This is the core, independent
unit of ADR-079. It makes v2 segments the persisted format on both write paths and adds a v2-aware
load that skips rebuild when the on-disk segments match the live corpus.

## What changed

- `backend_data_dir()` accessor on the runtime resolves the per-backend data directory (None for
  in-memory backends, which skip v2 and stay rebuild-only).
- khive-vamana: `read_commit_fingerprint` + `corpus_content_hash` warm-decision API. `VamanaIndex::load`
  is now v2-aware: it peeks the metadata magic, verifies the three segment checksums, and loads
  without a rebuild. Legacy v1 metadata still dispatches to the v1 body.
- `AnnBridge::save_atomic` / `load` persist the id-map as an `external_ids.bin` sidecar stamped with
  the commit content hash.
- `ensure_ann_for_model` reads v2 segments first (cheap count + dims gate, then a content-hash
  match) before falling back to the legacy v1 JSON read, then to a rebuild. The rebuild fallthrough
  and the `knowledge.index()` path both persist v2 through a single `persist_ann_v2` helper.
- The v1 write path is removed (`persist_snapshot`, `to_vamana_snapshot`, `ensure_snapshot_schema`).
  The v1 read path is kept so existing databases warm without a migration.
- `warm_known_snapshots` enumerates filesystem segment directories in addition to legacy v1 rows.

## Normalization invariant

The v2 commit content hash is `blake3` over the vectors as stored, which is `l2_normalize` applied
exactly once. The live-corpus staleness hash normalizes the raw scan exactly once before hashing,
so a clean corpus reads Hot and an edited corpus reads Stale. Normalizing twice would diverge from
the stored bytes by floating-point rounding and every warm would read stale forever. The warm
round-trip tests assert this directly (Hot: live hash equals the persisted commit hash; Stale:
assert_ne before mutation, assert_eq on the new count and hash after rebuild) rather than only
asserting cache presence.

## Scope and sequencing

This PR is ADR-079 slices 0 through 1b-ii. The remaining slices (incremental insert/tombstone,
periodic checkpoint, and the `[retrieval]` config surface) follow in a second PR, sequenced after
#335 merges: the config slice removes the warm-wait timeout constants that #335 also edits, and the
Cold serving path builds on #335's FTS-degrade behavior. Splitting here keeps this independent unit
reviewable on its own and avoids a self-inflicted conflict with #335.

ADR: #336 (docs). Relates to #322, #335.

## Test

`cargo test -p khive-pack-knowledge`: 195 passed, 0 failed. `cargo clippy -p khive-pack-knowledge
--all-targets -- -D warnings`: clean. `cargo fmt -p khive-pack-knowledge -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
