### PR TITLE
ci(clippy): lint feature-gated code with --all-features (#315)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ check:
 	cd crates && cargo check --workspace
 
 clippy:
-	cd crates && cargo clippy --workspace -- -D warnings
+	cd crates && cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 test:
 	cd crates && cargo test --workspace

--- a/crates/khive-db/src/migrations_tests.rs
+++ b/crates/khive-db/src/migrations_tests.rs
@@ -275,6 +275,16 @@ fn v5_upgrade_from_duplicate_rows_succeeds() {
     .unwrap();
     tx.commit().unwrap();
 
+    // V5 must have created the unique index.
+    assert!(
+        index_exists(&conn, "idx_comm_message_external_id"),
+        "V5 must create idx_comm_message_external_id"
+    );
+    assert!(
+        index_is_unique(&conn, "idx_comm_message_external_id"),
+        "idx_comm_message_external_id must be UNIQUE after V5 upgrade"
+    );
+
     // Canonical row keeps its external_id.
     let canonical_ext: Option<String> = conn
         .query_row(

--- a/crates/khive-retrieval/src/replay/engine_replay.rs
+++ b/crates/khive-retrieval/src/replay/engine_replay.rs
@@ -1014,7 +1014,7 @@ mod tests {
 
         // At least 2 buckets (today and yesterday within 7 days).
         assert!(
-            rates.len() >= 1,
+            !rates.is_empty(),
             "expected at least 1 day bucket, got {:?}",
             rates
         );

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -31,7 +31,7 @@ cargo clippy --workspace --lib --bins -- $NOSTUB_LINTS
 cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --lib --bins -- $NOSTUB_LINTS
 
 echo "=== Clippy ==="
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 echo "=== Tests ==="
 cargo test --workspace


### PR DESCRIPTION
## Summary

- Adds `--all-features` to the clippy invocation in both `scripts/ci.sh` and the `make clippy` target so all feature-gated code is linted in CI, not just the default feature set.
- Also adds the missing `--all-targets` flag to the Makefile `clippy` target (it was already present in `ci.sh` but absent from the Makefile, causing the two to diverge).
- Fixes one clippy warning that was only visible under `--all-features`: `rates.len() >= 1` changed to `!rates.is_empty()` in `khive-retrieval/src/replay/engine_replay.rs` (inside a test only compiled when the `persist` feature is enabled).
- Strengthens the `v5_upgrade_from_duplicate_rows_succeeds` migration test in `khive-db` to directly assert that `idx_comm_message_external_id` exists and is UNIQUE after V5 runs, using the existing `index_exists`/`index_is_unique` helpers.

## Feature strategy: `--all-features`

All optional features in the workspace are standard Rust feature flags with no broken or unresolvable deps. The full list of optional features found:

| Crate | Optional features |
|---|---|
| khive-db | `vectors` (sqlite-vec) |
| khive-fold | `serde` |
| khive-hnsw | `checkpoint` |
| khive-mcp | `bench-embedder`, `channel-email` |
| khive-retrieval | `policy`, `checkpoint`, `persist`, `storage-adapters`, `native-rerank`, `embed` |
| khive-runtime | `fault-injection` |
| khive-score | `serde` |
| khive-text | `unicode`, `stem`, `full` |
| khive-types | `serde`, `std`, `blake3` |
| kkernel | `bench-embedder` |

`--all-features` compiled cleanly after fixing the one hidden warning above. There is no reason to use a curated feature list.

## Clippy warnings fixed

- `khive-retrieval/src/replay/engine_replay.rs:1017`: `rates.len() >= 1` changed to `!rates.is_empty()` (clippy::len_zero, only fired under `--persist` feature which enables `rusqlite` and the test module that references it).

## Files changed

- `scripts/ci.sh` — clippy step: added `--all-features`
- `Makefile` — clippy target: added `--all-targets --all-features`
- `crates/khive-retrieval/src/replay/engine_replay.rs` — fix hidden clippy::len_zero
- `crates/khive-db/src/migrations_tests.rs` — direct UNIQUE index assertions in `v5_upgrade_from_duplicate_rows_succeeds`

Closes #315