### PR TITLE
test: network-isolate embedding-dependent CI tests (mcp serve + kkernel) (#332)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1297,6 +1297,7 @@ brain_profile = "project-profile"
             gate: std::sync::Arc::new(AllowAllGate),
             default_namespace: Namespace::parse("local").expect("ns"),
             embedding_model: None,
+            additional_embedding_models: vec![],
             packs: vec!["kg".to_string(), "comm".to_string()],
             backend_id: BackendId::main(),
             ..RuntimeConfig::default()

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -612,6 +612,8 @@ mod tests {
     fn isolated_server(db_path: &str) -> KhiveMcpServer {
         let cfg = RuntimeConfig {
             db_path: Some(PathBuf::from(db_path)),
+            embedding_model: None,
+            additional_embedding_models: vec![],
             ..Default::default()
         };
         let rt = KhiveRuntime::new(cfg).expect("runtime on temp db");

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -41,6 +41,7 @@ pub(super) async fn cmd_export(args: ExportArgs) -> Result<()> {
         db_path: Some(args.db.clone()),
         default_namespace: ns.clone(),
         embedding_model: None,
+        additional_embedding_models: vec![],
         ..Default::default()
     };
     let runtime = KhiveRuntime::new(config)?;
@@ -85,6 +86,7 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
         db_path: Some(args.db.clone()),
         default_namespace: ns.clone(),
         embedding_model: None,
+        additional_embedding_models: vec![],
         ..Default::default()
     };
     let runtime = KhiveRuntime::new(config)?;

--- a/crates/kkernel/src/pending_events.rs
+++ b/crates/kkernel/src/pending_events.rs
@@ -502,6 +502,8 @@ mod tests {
         let cfg = RuntimeConfig {
             db_path: Some(std::path::PathBuf::from(db_path)),
             default_namespace: Namespace::parse("local").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
             ..Default::default()
         };
         KhiveRuntime::new(cfg).expect("runtime")


### PR DESCRIPTION
## Root cause

Three tests in `crates/khive-mcp/src/serve.rs` flaked CI on `main` when the GitHub runner's network to `huggingface.co` was slow or unavailable:

- `serve::tests::multi_backend_boots_ok_with_two_memory_backends`
- `serve::tests::multi_backend_isolates_pack_data_to_separate_files`
- `serve::tests::multi_backend_preserves_actor_filtering`

All three build their runtime through `base_runtime_config_for_multi_backend()`, which sets `embedding_model: None` but spreads `..RuntimeConfig::default()`. `RuntimeConfig::default()` fills `additional_embedding_models` with `EmbeddingModel::ParaphraseMultilingualMiniLmL12V2` (the 470 MB multilingual MiniLM). Both `create_entity` (used by `kg create`) and `try_create_note` (used by `comm.send`) iterate `registered_embedding_model_names()` and call `embedder()` for every registered slot. The first call triggers a `lattice-inference` model download from HuggingFace. On a CI runner whose connection to HuggingFace times out, model init fails, the verb returns an error, and assertions that are testing backend routing, file isolation, or actor filtering blow up for completely unrelated reasons.

The common defect: every RuntimeConfig that meant "do not embed" pinned only `embedding_model: None` and inherited the default multilingual `additional_embedding_models` via `..Default::default()`. This PR closes that gap on all three sites where it reaches a record-creating path.

## Fix part 1: serve.rs multi-backend helper (test-only)

One line added to the test-only helper (inside `#[cfg(test)]`):

```rust
additional_embedding_models: vec![],
```

This ensures `configured_embedding_models()` returns an empty list. `build_embedder_registry()` registers zero providers, `registered_embedding_model_names()` returns `[]`, and the embedding branch in both `create_entity` and `try_create_note` short-circuits with zero iterations. No call to `embedder()` is ever made.

## Fix part 2: kkernel test helpers (commit 3a7dbcc9, test-only)

CI then surfaced the **same flake** in three `kkernel` tests that this PR had not touched, all failing with `create_note: Embedding(ModelInitialization("IO error: No such file or directory"))`:

- `pending_events::tests::due_event_is_fired`
- `pending_events::tests::daily_repeat_advances`
- `exec::tests::ops_file_applies_ops_and_summary_matches`

These route through two `kkernel` test helpers that built `RuntimeConfig` via a bare `..Default::default()`:

- `make_rt` (`crates/kkernel/src/pending_events.rs`) — the two `pending_events` tests fire a scheduled event that creates a note.
- `isolated_server` (`crates/kkernel/src/exec.rs`) — `ops_file_applies_...` applies an ops file that creates 3 concepts.

Both now pin `embedding_model: None` + `additional_embedding_models: vec![]`, identical to the `serve.rs` helper.

## Fix part 3: kkernel kg import/export production config (commit 8d7e28ba)

> NOTE FOR REVIEW: this part touches **production** code, not just test helpers.

A completeness sweep found one more site of the same defect, and this one is production: `cmd_export` and `cmd_import` in `crates/kkernel/src/kg/archive.rs` (the `kkernel kg export` / `kkernel kg import` subcommands). Both already pinned `embedding_model: None` — the author's evident intent is "archive ops do not embed" — but inherited the default multilingual `additional_embedding_models` via `..Default::default()`.

Consequence before the fix:

- `kkernel kg import` calls `import_kg`, which upserts each entity and calls `reindex_entity` (`crates/khive-runtime/src/curation.rs`). `reindex_entity` fans out over `registered_embedding_model_names()` and calls `embed_document_with_model`. So import attempted an **incoherent multilingual-only embed** (the primary model was already disabled by `embedding_model: None`) and, under empty cache / offline CI, attempted a HuggingFace model download. The vector step in `reindex_entity` is best-effort (logs a warning and continues), so the three kg import tests (`import_archive_roundtrip`, `import_json_adapter_imports_entities`, `import_ndjson_adapter_imports_entity`) **passed** but were not network-isolated.
- `kkernel kg export` only reads and serializes (`export_kg_json`); it creates no records, so it never reached the embedder. Clearing the field there is **zero-behavior** — included only so the two sibling functions stay coherent.

The fix adds `additional_embedding_models: vec![]` to both blocks (2 lines). This fully honors the pre-existing `embedding_model: None` intent: `configured_embedding_models()` is empty, so `reindex_entity`'s embed loop iterates zero times. Imported entities are embedded via the dedicated `kkernel reindex` command, which is the supported path to (re)populate vectors over the full configured model set. No semantic-search or vector assertion in any import test depends on import-time embedding.

## Network-independence proof

With `embedding_model: None` AND `additional_embedding_models: vec![]` on a record-creating path:

- `configured_embedding_models()` returns `[]`; `build_embedder_registry()` registers zero `LatticeEmbedderProvider` instances; `registered_embedding_model_names()` returns `[]`.
- `create_entity` / `try_create_note` (operations.rs) and `reindex_entity` (curation.rs) all guard on the registered-model list, so their embed branches never iterate. No call to `embedder(name)` is made, no `OnceCell` is initialized, and the `lattice-inference` download path is unreachable regardless of network state.

Empirically confirmed network-free: running the 3 kkernel import tests AND the 3 originally-failing kkernel tests under `LATTICE_MODEL_CACHE=<empty dir>` AND `HF_HUB_OFFLINE=1` (no cache, no network fallback) — all 6 pass, with no `ModelInitialization("IO error: No such file or directory")`.

## Completeness sweep (kkernel)

Across kkernel, the record-creating runtimes are: the two test helpers (fixed in 3a7dbcc9), and the production `cmd_import` (fixed in 8d7e28ba). The remaining kkernel runtimes are already isolated: `KhiveRuntime::memory()` clears both embedding fields; the reindex tests pass `no_embed: true`; the other `exec.rs` test configs run `stats()` (read-only) or `dry_run=true`; `kkernel pack` / `kg validate` build registry metadata without creating records; `kkernel sync` skips vectors explicitly; `cmd_export` creates no records. Production pending-events boot (`pending_events.rs`, non-test) keeps `RuntimeConfig::default()` — it should embed — and is untouched.

## What is not changed

The `serve.rs` and kkernel-helper fixes are entirely inside `#[cfg(test)]`. The `archive.rs` fix touches production `cmd_import`/`cmd_export`, but only completes their existing `embedding_model: None` no-embed intent (import no longer does an incoherent multilingual-only embed; export is unchanged at runtime). The production `build_server_multi_backend` path and the production pending-events runtime are untouched.

## Gate results

All run from `crates/` in the worktree:

- `cargo test -p khive-mcp`: 174 tests, 0 failed
- `cargo test -p kkernel`: 154 tests, 0 failed (incl. the 3 previously-flaking tests + 3 kg import tests)
- `cargo clippy -p khive-mcp --all-targets -- -D warnings`: clean
- `cargo clippy -p kkernel --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Offline proof (`LATTICE_MODEL_CACHE=$(mktemp -d) HF_HUB_OFFLINE=1`): 6 target tests pass

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
