### PR TITLE
feat(session): khive-pack-session M1 — session storage pack (ADR-080)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "khive-pack-formal",
     "khive-pack-template",
     "khive-pack-knowledge",
+    "khive-pack-session",
     "khive-mcp",
     "khive-vcs",
     "khive-vcs-adapters",

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -22,6 +22,7 @@ khive-pack-brain = { version = "0.2.11", path = "../khive-pack-brain" }
 khive-pack-comm = { version = "0.2.11", path = "../khive-pack-comm" }
 khive-pack-schedule = { version = "0.2.11", path = "../khive-pack-schedule" }
 khive-pack-knowledge = { version = "0.2.11", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.2.11", path = "../khive-pack-session" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }

--- a/crates/khive-mcp/src/pack.rs
+++ b/crates/khive-mcp/src/pack.rs
@@ -23,3 +23,5 @@ pub use khive_pack_knowledge::KnowledgePack as _KnowledgePack;
 pub use khive_pack_memory::MemoryPack as _MemoryPack;
 #[doc(hidden)]
 pub use khive_pack_schedule::SchedulePack as _SchedulePack;
+#[doc(hidden)]
+pub use khive_pack_session::SessionPack as _SessionPack;

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "khive-pack-session"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Session verb pack — store/list/resume/export over the notes substrate (ADR-080)"
+
+[dependencies]
+khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+inventory = { workspace = true }
+khive-storage = { version = "0.2.11", path = "../khive-storage" }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+tempfile = { workspace = true }

--- a/crates/khive-pack-session/src/handlers/export.rs
+++ b/crates/khive-pack-session/src/handlers/export.rs
@@ -1,0 +1,64 @@
+//! `session.export` — serialize a session record for downstream use.
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+
+use super::{deser, render_session_full};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExportParams {
+    id: String,
+    #[serde(default)]
+    format: Option<String>,
+}
+
+/// Serialize a session record for downstream use.
+///
+/// `format="json"` (default) returns the full Note envelope as a JSON object.
+/// `format="text"` returns the `content` field as a plain JSON string.
+pub(crate) async fn handle_export(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: ExportParams = deser(params)?;
+    let format = p.format.as_deref().unwrap_or("json");
+
+    if format != "json" && format != "text" {
+        return Err(RuntimeError::InvalidInput(format!(
+            "session.export: format must be \"json\" or \"text\"; got {format:?}"
+        )));
+    }
+
+    let uuid = Uuid::from_str(&p.id).map_err(|_| {
+        RuntimeError::InvalidInput(format!("session.export: id must be a UUID; got {:?}", p.id))
+    })?;
+
+    let note = runtime
+        .notes(token)?
+        .get_note(uuid)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("get_note: {e}")))?
+        .ok_or_else(|| RuntimeError::NotFound(format!("session not found: {}", p.id)))?;
+
+    if note.kind != "session" {
+        return Err(RuntimeError::InvalidInput(format!(
+            "session.export: expected kind=\"session\", got {:?}",
+            note.kind
+        )));
+    }
+    if note.deleted_at.is_some() {
+        return Err(RuntimeError::NotFound(format!("session deleted: {}", p.id)));
+    }
+
+    match format {
+        "text" => Ok(Value::String(note.content.clone())),
+        _ => Ok(render_session_full(&note)),
+    }
+}

--- a/crates/khive-pack-session/src/handlers/list.rs
+++ b/crates/khive-pack-session/src/handlers/list.rs
@@ -1,0 +1,89 @@
+//! `session.list` — list stored sessions, newest first.
+
+use chrono::DateTime;
+use serde::Deserialize;
+use serde_json::Value;
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+
+use super::{deser, render_session_summary};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ListParams {
+    #[serde(default)]
+    agent_id: Option<String>,
+    #[serde(default)]
+    limit: Option<u32>,
+    #[serde(default)]
+    offset: Option<u32>,
+    #[serde(default)]
+    since: Option<String>,
+}
+
+/// List stored sessions, newest first.
+///
+/// Fetches a broad window of `kind=session` notes and applies in-memory
+/// filtering by `agent_id` and `since`, then sorts by `created_at DESC`
+/// before applying `offset` and `limit` pagination.
+pub(crate) async fn handle_list(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: ListParams = deser(params)?;
+    let limit = p.limit.unwrap_or(20).clamp(1, 200) as usize;
+    let offset = p.offset.unwrap_or(0) as usize;
+
+    // Parse the optional `since` filter into microseconds.
+    let since_micros: Option<i64> = match p.since.as_deref() {
+        None => None,
+        Some(s) => {
+            let dt = DateTime::parse_from_rfc3339(s).map_err(|_| {
+                RuntimeError::InvalidInput(format!(
+                    "session.list: since must be ISO-8601 (e.g. 2026-01-01T00:00:00Z); got {s:?}"
+                ))
+            })?;
+            Some(dt.timestamp_micros())
+        }
+    };
+
+    // Fetch a wide window to cover offset + limit + filtering headroom.
+    let window = (offset as u32)
+        .saturating_add(limit as u32)
+        .saturating_add(500);
+    let notes = runtime
+        .list_notes(token, Some("session"), window, 0)
+        .await?;
+
+    // Filter, sort newest-first, then paginate.
+    let mut filtered: Vec<&khive_storage::note::Note> = notes
+        .iter()
+        .filter(|n| n.deleted_at.is_none())
+        .filter(|n| match p.agent_id.as_deref() {
+            None => true,
+            Some(want) => {
+                n.properties
+                    .as_ref()
+                    .and_then(|p| p.get("agent_id"))
+                    .and_then(|v| v.as_str())
+                    == Some(want)
+            }
+        })
+        .filter(|n| match since_micros {
+            None => true,
+            Some(since) => n.created_at >= since,
+        })
+        .collect();
+
+    filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    let result: Vec<Value> = filtered
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(render_session_summary)
+        .collect();
+
+    Ok(Value::Array(result))
+}

--- a/crates/khive-pack-session/src/handlers/list.rs
+++ b/crates/khive-pack-session/src/handlers/list.rs
@@ -49,6 +49,12 @@ pub(crate) async fn handle_list(
     };
 
     // Fetch a wide window to cover offset + limit + filtering headroom.
+    // `list_notes` already returns rows ORDER BY created_at DESC, so the
+    // window pulls the newest records first. The +500 is a headroom allowance
+    // for in-memory agent_id/since filtering: if a caller has a very sparse
+    // agent_id distribution and total session count exceeds (offset+limit+500),
+    // the result may be silently incomplete. This is acceptable for M1 session
+    // volumes; M2 will add a server-side filter parameter.
     let window = (offset as u32)
         .saturating_add(limit as u32)
         .saturating_add(500);
@@ -56,8 +62,9 @@ pub(crate) async fn handle_list(
         .list_notes(token, Some("session"), window, 0)
         .await?;
 
-    // Filter, sort newest-first, then paginate.
-    let mut filtered: Vec<&khive_storage::note::Note> = notes
+    // Filter in-memory, then paginate. No re-sort needed: list_notes returns
+    // rows ORDER BY created_at DESC and in-memory filtering preserves that order.
+    let filtered: Vec<&khive_storage::note::Note> = notes
         .iter()
         .filter(|n| n.deleted_at.is_none())
         .filter(|n| match p.agent_id.as_deref() {
@@ -75,8 +82,6 @@ pub(crate) async fn handle_list(
             Some(since) => n.created_at >= since,
         })
         .collect();
-
-    filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
     let result: Vec<Value> = filtered
         .into_iter()

--- a/crates/khive-pack-session/src/handlers/mod.rs
+++ b/crates/khive-pack-session/src/handlers/mod.rs
@@ -1,0 +1,50 @@
+//! Verb handlers for the session pack, one file per verb.
+
+pub(crate) mod export;
+pub(crate) mod list;
+pub(crate) mod resume;
+pub(crate) mod store;
+
+use khive_runtime::{micros_to_iso, RuntimeError};
+use khive_storage::note::Note;
+use serde_json::{json, Value};
+
+/// Deserialize params from a `Value` into a typed struct.
+pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {
+    serde_json::from_value(params)
+        .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))
+}
+
+/// Compact session summary for list responses.
+pub(crate) fn render_session_summary(note: &Note) -> Value {
+    let props = note.properties.as_ref();
+    let agent_id = props
+        .and_then(|p| p.get("agent_id"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    json!({
+        "id": note.id.as_hyphenated().to_string(),
+        "kind": "session",
+        "agent_id": agent_id,
+        "created_at": micros_to_iso(note.created_at),
+        "namespace": note.namespace,
+    })
+}
+
+/// Full session envelope for store, resume, and export responses.
+pub(crate) fn render_session_full(note: &Note) -> Value {
+    let props = note.properties.clone().unwrap_or_else(|| json!({}));
+    let agent_id = props.get("agent_id").cloned().unwrap_or(Value::Null);
+    let tags = props.get("tags").cloned().unwrap_or(Value::Null);
+    json!({
+        "id": note.id.as_hyphenated().to_string(),
+        "kind": "session",
+        "content": note.content,
+        "agent_id": agent_id,
+        "tags": tags,
+        "properties": props,
+        "created_at": micros_to_iso(note.created_at),
+        "updated_at": micros_to_iso(note.updated_at),
+        "namespace": note.namespace,
+    })
+}

--- a/crates/khive-pack-session/src/handlers/resume.rs
+++ b/crates/khive-pack-session/src/handlers/resume.rs
@@ -1,0 +1,53 @@
+//! `session.resume` — fetch a single session record by UUID.
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+
+use super::{deser, render_session_full};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResumeParams {
+    id: String,
+}
+
+/// Fetch a single session record by UUID for replay or context injection.
+///
+/// Returns the full Note record (`id`, `kind`, `content`, `properties`,
+/// `tags`, `created_at`). Returns `NotFound` if the session does not exist
+/// or has been soft-deleted.
+pub(crate) async fn handle_resume(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: ResumeParams = deser(params)?;
+
+    let uuid = Uuid::from_str(&p.id).map_err(|_| {
+        RuntimeError::InvalidInput(format!("session.resume: id must be a UUID; got {:?}", p.id))
+    })?;
+
+    let note = runtime
+        .notes(token)?
+        .get_note(uuid)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("get_note: {e}")))?
+        .ok_or_else(|| RuntimeError::NotFound(format!("session not found: {}", p.id)))?;
+
+    if note.kind != "session" {
+        return Err(RuntimeError::InvalidInput(format!(
+            "session.resume: expected kind=\"session\", got {:?}",
+            note.kind
+        )));
+    }
+    if note.deleted_at.is_some() {
+        return Err(RuntimeError::NotFound(format!("session deleted: {}", p.id)));
+    }
+
+    Ok(render_session_full(&note))
+}

--- a/crates/khive-pack-session/src/handlers/store.rs
+++ b/crates/khive-pack-session/src/handlers/store.rs
@@ -1,0 +1,75 @@
+//! `session.store` — store a session record as a `kind=session` note.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+
+use super::{deser, render_session_full};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoreParams {
+    content: String,
+    #[serde(default)]
+    agent_id: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+/// Store a session blob as a `kind=session` note.
+///
+/// Builds `properties` from the optional `metadata` object (if provided),
+/// then overlays `agent_id` and `tags` from their explicit params so that
+/// named params always win over metadata keys.
+///
+/// Implementation: `runtime.create_note(token, "session", None, content, None, props, vec![])`.
+pub(crate) async fn handle_store(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: StoreParams = deser(params)?;
+
+    if p.content.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "session.store: content must not be empty".into(),
+        ));
+    }
+
+    // Build properties: start from caller-supplied metadata (if any), then
+    // overlay the named params so explicit args always take precedence.
+    let mut props = match p.metadata {
+        Some(Value::Object(obj)) => Value::Object(obj),
+        Some(_) => {
+            return Err(RuntimeError::InvalidInput(
+                "session.store: metadata must be a JSON object".into(),
+            ))
+        }
+        None => json!({}),
+    };
+
+    let obj = props.as_object_mut().expect("props is object");
+    if let Some(agent_id) = &p.agent_id {
+        obj.insert("agent_id".into(), json!(agent_id));
+    }
+    if let Some(tags) = &p.tags {
+        obj.insert("tags".into(), json!(tags));
+    }
+
+    let note = runtime
+        .create_note(
+            token,
+            "session",
+            None,
+            &p.content,
+            None,
+            Some(props),
+            vec![],
+        )
+        .await?;
+
+    Ok(render_session_full(&note))
+}

--- a/crates/khive-pack-session/src/lib.rs
+++ b/crates/khive-pack-session/src/lib.rs
@@ -1,0 +1,37 @@
+//! khive-pack-session — session storage pack for the khive runtime.
+//!
+//! Registers the `session` note kind and four verbs:
+//! `session.store`, `session.list`, `session.resume`, `session.export`.
+
+pub mod handlers;
+mod pack;
+pub mod vocab;
+
+use khive_runtime::KhiveRuntime;
+use khive_types::{HandlerDef, Pack};
+
+pub(crate) use vocab::SESSION_HANDLERS;
+
+/// Session pack — registers the `session` note kind and session lifecycle verbs.
+pub struct SessionPack {
+    runtime: KhiveRuntime,
+}
+
+impl Pack for SessionPack {
+    const NAME: &'static str = "session";
+    const NOTE_KINDS: &'static [&'static str] = &["session"];
+    const ENTITY_KINDS: &'static [&'static str] = &[];
+    const HANDLERS: &'static [HandlerDef] = &SESSION_HANDLERS;
+    const REQUIRES: &'static [&'static str] = &["kg"];
+}
+
+impl SessionPack {
+    /// Create a new `SessionPack` bound to the given runtime.
+    pub fn new(runtime: KhiveRuntime) -> Self {
+        Self { runtime }
+    }
+
+    pub(crate) fn runtime(&self) -> &KhiveRuntime {
+        &self.runtime
+    }
+}

--- a/crates/khive-pack-session/src/pack.rs
+++ b/crates/khive-pack-session/src/pack.rs
@@ -1,0 +1,78 @@
+//! `SessionPack` self-registration factory and `PackRuntime` dispatch impl.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_types::{EdgeEndpointRule, HandlerDef, Pack};
+
+use crate::{handlers, SessionPack, SESSION_HANDLERS};
+
+// ── inventory self-registration ───────────────────────────────────────────────
+
+struct SessionPackFactory;
+
+impl khive_runtime::PackFactory for SessionPackFactory {
+    fn name(&self) -> &'static str {
+        "session"
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        &["kg"]
+    }
+
+    fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
+        Box::new(SessionPack::new(runtime))
+    }
+}
+
+inventory::submit! { khive_runtime::PackRegistration(&SessionPackFactory) }
+
+// ── PackRuntime impl ──────────────────────────────────────────────────────────
+
+#[async_trait]
+impl PackRuntime for SessionPack {
+    fn name(&self) -> &str {
+        <SessionPack as Pack>::NAME
+    }
+
+    fn note_kinds(&self) -> &'static [&'static str] {
+        <SessionPack as Pack>::NOTE_KINDS
+    }
+
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        <SessionPack as Pack>::ENTITY_KINDS
+    }
+
+    fn handlers(&self) -> &'static [HandlerDef] {
+        &SESSION_HANDLERS
+    }
+
+    fn edge_rules(&self) -> &'static [EdgeEndpointRule] {
+        &[]
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        <SessionPack as Pack>::REQUIRES
+    }
+
+    async fn dispatch(
+        &self,
+        verb: &str,
+        params: Value,
+        _registry: &VerbRegistry,
+        token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        let rt = self.runtime();
+        match verb {
+            "session.store" => handlers::store::handle_store(rt, token, params).await,
+            "session.list" => handlers::list::handle_list(rt, token, params).await,
+            "session.resume" => handlers::resume::handle_resume(rt, token, params).await,
+            "session.export" => handlers::export::handle_export(rt, token, params).await,
+            _ => Err(RuntimeError::InvalidInput(format!(
+                "session pack does not handle verb {verb:?}"
+            ))),
+        }
+    }
+}

--- a/crates/khive-pack-session/src/vocab.rs
+++ b/crates/khive-pack-session/src/vocab.rs
@@ -1,0 +1,110 @@
+//! Session pack vocabulary: handler definitions.
+
+use khive_types::{HandlerDef, ParamDef, VerbCategory, Visibility};
+
+/// Handler table for the session pack.
+///
+/// All four verbs have `Visibility::Verb` (agent-facing MCP surface).
+/// Speech-act categories follow ADR-025:
+///   - `session.store` is a Directive (requests storage of content).
+///   - `session.list`, `session.resume`, `session.export` are Assertive (retrieve state).
+pub(crate) static SESSION_HANDLERS: [HandlerDef; 4] = [
+    HandlerDef {
+        name: "session.store",
+        description: "Store a session record (transcript, context snapshot, or accumulated agent state)",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Directive,
+        params: &[
+            ParamDef {
+                name: "content",
+                param_type: "string",
+                required: true,
+                description: "Session content: transcript, context snapshot, or arbitrary text.",
+            },
+            ParamDef {
+                name: "agent_id",
+                param_type: "string",
+                required: false,
+                description: "Agent identifier stored in properties.agent_id; used as a list filter.",
+            },
+            ParamDef {
+                name: "tags",
+                param_type: "array of string",
+                required: false,
+                description: "Tag list stored in properties.tags.",
+            },
+            ParamDef {
+                name: "metadata",
+                param_type: "object",
+                required: false,
+                description: "Arbitrary JSON object merged into properties. Explicit agent_id and tags params take precedence.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "session.list",
+        description: "List stored sessions, newest first",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[
+            ParamDef {
+                name: "agent_id",
+                param_type: "string",
+                required: false,
+                description: "Filter by properties.agent_id.",
+            },
+            ParamDef {
+                name: "limit",
+                param_type: "integer",
+                required: false,
+                description: "Page size (default 20, max 200).",
+            },
+            ParamDef {
+                name: "offset",
+                param_type: "integer",
+                required: false,
+                description: "Pagination offset (default 0).",
+            },
+            ParamDef {
+                name: "since",
+                param_type: "string",
+                required: false,
+                description: "ISO-8601 datetime; returns only sessions with created_at >= since.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "session.resume",
+        description: "Fetch a single session record by UUID for replay or context injection",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[
+            ParamDef {
+                name: "id",
+                param_type: "uuid",
+                required: true,
+                description: "Session UUID.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "session.export",
+        description: "Serialize a session record for downstream use",
+        visibility: Visibility::Verb,
+        category: VerbCategory::Assertive,
+        params: &[
+            ParamDef {
+                name: "id",
+                param_type: "uuid",
+                required: true,
+                description: "Session UUID.",
+            },
+            ParamDef {
+                name: "format",
+                param_type: "string",
+                required: false,
+                description: "Export format: \"json\" (default) returns the full Note envelope; \"text\" returns content only.",
+            },
+        ],
+    },
+];

--- a/crates/khive-pack-session/tests/integration.rs
+++ b/crates/khive-pack-session/tests/integration.rs
@@ -1,0 +1,460 @@
+//! End-to-end integration tests for `khive-pack-session`.
+//!
+//! All tests use a file-backed runtime (TempDir + db_path: Some(path)).
+//! In-memory runtimes are deliberately avoided: the ANN warm-path (ADR-079)
+//! only writes v2 segments when the backend has a `data_dir`, so in-memory
+//! runtimes silently skip persistence and can produce false negatives.
+//!
+//! FILE SIZE JUSTIFICATION: All tests share a single `file_rt` / `pack` helper
+//! pair and a common `store_session` convenience. Splitting into multiple files
+//! would either duplicate this fixture or require exposing it as a helper crate.
+
+use std::sync::Arc;
+
+use khive_pack_kg::KgPack;
+use khive_pack_session::SessionPack;
+use khive_runtime::{
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig, VerbRegistry,
+    VerbRegistryBuilder,
+};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn file_rt(db_path: std::path::PathBuf) -> KhiveRuntime {
+    KhiveRuntime::new(RuntimeConfig {
+        db_path: Some(db_path),
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "session".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    })
+    .expect("file-backed runtime")
+}
+
+fn build_registry(rt: KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(SessionPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+async fn store_session(registry: &VerbRegistry, content: &str) -> Value {
+    registry
+        .dispatch("session.store", json!({"content": content}))
+        .await
+        .expect("store ok")
+}
+
+// ── metadata tests ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn pack_metadata_matches_trait_consts() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("meta.db"));
+    let registry = build_registry(rt);
+
+    let verbs: Vec<&str> = registry.all_verbs().iter().map(|v| v.name).collect();
+    assert!(
+        verbs.contains(&"session.store"),
+        "session.store not in verbs"
+    );
+    assert!(verbs.contains(&"session.list"), "session.list not in verbs");
+    assert!(
+        verbs.contains(&"session.resume"),
+        "session.resume not in verbs"
+    );
+    assert!(
+        verbs.contains(&"session.export"),
+        "session.export not in verbs"
+    );
+
+    assert!(
+        registry.all_note_kinds().contains(&"session"),
+        "session not in note kinds"
+    );
+}
+
+// ── session.store tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn store_returns_session_envelope() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store.db"));
+    let registry = build_registry(rt);
+
+    let result = registry
+        .dispatch("session.store", json!({"content": "hello session"}))
+        .await
+        .expect("store ok");
+
+    assert_eq!(result["kind"], "session");
+    assert!(result["id"].as_str().is_some(), "id must be a string UUID");
+    assert_eq!(result["content"], "hello session");
+    assert!(
+        result["created_at"].as_str().is_some(),
+        "created_at present"
+    );
+}
+
+#[tokio::test]
+async fn store_with_agent_id_stored_in_properties() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_agent.db"));
+    let registry = build_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "session.store",
+            json!({"content": "agent session", "agent_id": "lambda:khive"}),
+        )
+        .await
+        .expect("store ok");
+
+    assert_eq!(result["agent_id"], "lambda:khive");
+}
+
+#[tokio::test]
+async fn store_with_metadata_merged_into_properties() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_meta.db"));
+    let registry = build_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "session.store",
+            json!({
+                "content": "metadata session",
+                "metadata": {"source": "test", "version": 2}
+            }),
+        )
+        .await
+        .expect("store ok");
+
+    assert_eq!(result["properties"]["source"], "test");
+    assert_eq!(result["properties"]["version"], 2);
+}
+
+#[tokio::test]
+async fn store_explicit_agent_id_wins_over_metadata() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_win.db"));
+    let registry = build_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "session.store",
+            json!({
+                "content": "priority test",
+                "agent_id": "explicit",
+                "metadata": {"agent_id": "from_metadata"}
+            }),
+        )
+        .await
+        .expect("store ok");
+
+    assert_eq!(result["agent_id"], "explicit", "explicit param must win");
+}
+
+#[tokio::test]
+async fn store_empty_content_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_empty.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch("session.store", json!({"content": ""}))
+        .await;
+    assert!(err.is_err(), "empty content must return error");
+}
+
+#[tokio::test]
+async fn store_unknown_field_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_unknown.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch(
+            "session.store",
+            json!({"content": "x", "unknown_field": true}),
+        )
+        .await;
+    assert!(err.is_err(), "unknown field must be rejected");
+}
+
+#[tokio::test]
+async fn store_metadata_non_object_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("store_meta_bad.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch(
+            "session.store",
+            json!({"content": "x", "metadata": "not-an-object"}),
+        )
+        .await;
+    assert!(err.is_err(), "non-object metadata must be rejected");
+}
+
+// ── session.list tests ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_returns_all_sessions_newest_first() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list.db"));
+    let registry = build_registry(rt);
+
+    store_session(&registry, "first").await;
+    // Small sleep to guarantee created_at ordering.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    store_session(&registry, "second").await;
+
+    let all = registry
+        .dispatch("session.list", json!({}))
+        .await
+        .expect("list ok");
+    let arr = all.as_array().expect("list returns array");
+    assert_eq!(arr.len(), 2);
+    // Newest first: "second" must be at index 0.
+    // The summary doesn't include content, but we can check created_at ordering.
+    assert!(
+        arr[0]["created_at"].as_str().unwrap() >= arr[1]["created_at"].as_str().unwrap(),
+        "list must be newest-first"
+    );
+}
+
+#[tokio::test]
+async fn list_filter_by_agent_id() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_agent.db"));
+    let registry = build_registry(rt);
+
+    registry
+        .dispatch(
+            "session.store",
+            json!({"content": "alpha session", "agent_id": "alpha"}),
+        )
+        .await
+        .expect("store alpha");
+    registry
+        .dispatch(
+            "session.store",
+            json!({"content": "beta session", "agent_id": "beta"}),
+        )
+        .await
+        .expect("store beta");
+
+    let alpha_only = registry
+        .dispatch("session.list", json!({"agent_id": "alpha"}))
+        .await
+        .expect("list alpha");
+    let arr = alpha_only.as_array().expect("list returns array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["agent_id"], "alpha");
+}
+
+#[tokio::test]
+async fn list_limit_respected() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_limit.db"));
+    let registry = build_registry(rt);
+
+    for i in 0..5 {
+        store_session(&registry, &format!("session {i}")).await;
+    }
+
+    let limited = registry
+        .dispatch("session.list", json!({"limit": 3}))
+        .await
+        .expect("list limited");
+    assert_eq!(limited.as_array().expect("array").len(), 3);
+}
+
+#[tokio::test]
+async fn list_since_filter() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_since.db"));
+    let registry = build_registry(rt);
+
+    store_session(&registry, "before").await;
+    // Since filter: use a far-future timestamp that excludes the stored session.
+    let future = "2099-01-01T00:00:00Z";
+    let filtered = registry
+        .dispatch("session.list", json!({"since": future}))
+        .await
+        .expect("list since ok");
+    assert_eq!(
+        filtered.as_array().expect("array").len(),
+        0,
+        "since=far-future must return empty"
+    );
+
+    // Use a past timestamp to confirm the session IS included.
+    let past = "2020-01-01T00:00:00Z";
+    let all = registry
+        .dispatch("session.list", json!({"since": past}))
+        .await
+        .expect("list since past ok");
+    assert_eq!(all.as_array().expect("array").len(), 1);
+}
+
+#[tokio::test]
+async fn list_since_invalid_format_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("list_since_bad.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch("session.list", json!({"since": "not-a-date"}))
+        .await;
+    assert!(err.is_err(), "invalid since must return error");
+}
+
+// ── session.resume tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn resume_returns_full_record() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("resume.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "resumeable content").await;
+    let id = stored["id"].as_str().expect("id present").to_string();
+
+    let resumed = registry
+        .dispatch("session.resume", json!({"id": id}))
+        .await
+        .expect("resume ok");
+
+    assert_eq!(resumed["id"], id);
+    assert_eq!(resumed["kind"], "session");
+    assert_eq!(resumed["content"], "resumeable content");
+    assert!(resumed["created_at"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn resume_not_found_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("resume_404.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch(
+            "session.resume",
+            json!({"id": "00000000-0000-0000-0000-000000000001"}),
+        )
+        .await;
+    assert!(err.is_err(), "missing session must return NotFound error");
+}
+
+#[tokio::test]
+async fn resume_invalid_uuid_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("resume_bad_id.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch("session.resume", json!({"id": "not-a-uuid"}))
+        .await;
+    assert!(err.is_err(), "invalid UUID must return error");
+}
+
+// ── session.export tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn export_json_format_returns_full_envelope() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_json.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "exportable content").await;
+    let id = stored["id"].as_str().expect("id present").to_string();
+
+    let exported = registry
+        .dispatch("session.export", json!({"id": id}))
+        .await
+        .expect("export json ok");
+
+    assert_eq!(exported["id"], id);
+    assert_eq!(exported["kind"], "session");
+    assert_eq!(exported["content"], "exportable content");
+}
+
+#[tokio::test]
+async fn export_text_format_returns_content_string() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_text.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "text-only content").await;
+    let id = stored["id"].as_str().expect("id present").to_string();
+
+    let exported = registry
+        .dispatch("session.export", json!({"id": id, "format": "text"}))
+        .await
+        .expect("export text ok");
+
+    assert_eq!(
+        exported.as_str().expect("text format returns string"),
+        "text-only content"
+    );
+}
+
+#[tokio::test]
+async fn export_explicit_json_format() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_json_explicit.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "json explicit").await;
+    let id = stored["id"].as_str().expect("id present").to_string();
+
+    let exported = registry
+        .dispatch("session.export", json!({"id": id, "format": "json"}))
+        .await
+        .expect("export json explicit ok");
+
+    assert!(exported.is_object(), "json format must return object");
+    assert_eq!(exported["content"], "json explicit");
+}
+
+#[tokio::test]
+async fn export_invalid_format_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_bad_fmt.db"));
+    let registry = build_registry(rt);
+
+    let stored = store_session(&registry, "x").await;
+    let id = stored["id"].as_str().expect("id present").to_string();
+
+    let err = registry
+        .dispatch("session.export", json!({"id": id, "format": "yaml"}))
+        .await;
+    assert!(err.is_err(), "invalid format must return error");
+}
+
+#[tokio::test]
+async fn export_not_found_returns_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = file_rt(dir.path().join("export_404.db"));
+    let registry = build_registry(rt);
+
+    let err = registry
+        .dispatch(
+            "session.export",
+            json!({"id": "00000000-0000-0000-0000-000000000002"}),
+        )
+        .await;
+    assert!(err.is_err(), "missing session must return error");
+}


### PR DESCRIPTION
## Summary

Implements ADR-080 M1: a new OSS pack that persists agent session context as notes
of `kind="session"` over the existing notes substrate. No schema migration required —
the `notes` table accepts any kind string registered by a loaded pack.

Closes #344. Implements the storage mechanism specified in #347.

## What ships

**New crate: `crates/khive-pack-session/`**

Four verbs over the notes substrate:

| Verb | Description |
|------|-------------|
| `session.store` | Persist agent session context. Required: `content`. Optional: `agent_id`, `tags`, `metadata` (JSON object merged into properties; named params win). |
| `session.list` | List sessions newest-first. Optional: `agent_id`, `limit` (default 20), `offset` (default 0), `since` (ISO-8601). In-memory filter after `list_notes`. |
| `session.resume` | Fetch a single session by UUID for replay or context injection. |
| `session.export` | Serialize a session record. `format="json"` (default) returns the full Note envelope; `format="text"` returns the `content` string. |

Pack constants:
- `NAME = "session"` | `NOTE_KINDS = &["session"]` | `REQUIRES = &["kg"]`
- `SCHEMA_PLAN = None` (M1; no migration) | `EDGE_RULES = &[]`
- Self-registration via `inventory::submit!` (ADR-027)
- ADR-071 seam: verb handlers call only `KhiveRuntime` public API

**Workspace edits:**
- `crates/Cargo.toml`: `khive-pack-session` added to workspace members
- `crates/khive-mcp/Cargo.toml`: `khive-pack-session` added as dependency

## Test plan

- [x] 21 integration tests, all file-backed (`TempDir + db_path: Some(path)`) per ADR-079 warm-path constraint
- [x] `cargo fmt --all` — PASS (pre-commit hook)
- [x] `cargo clippy -D warnings` — PASS (pre-commit hook)
- [x] `cargo test -p khive-pack-session` — 21/21 PASS
- [x] `cargo check --workspace` — PASS (no regressions in wider workspace)

## Not in scope (M1)

- Search (`session.search`) — deferred to M2 per ADR-080
- Prune/expire — deferred to M2
- Schema migration — not needed; existing `notes` table used as-is
- Docs/ADR — separate PR per standing code-vs-docs split rule

## Merge status

DO NOT MERGE. Held pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)