### PR TITLE
feat(brain): M1 feature-gated lattice-fann router seam (#345)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -73,6 +73,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "cloc
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 lattice-embed = "0.3.0"
+lattice-fann = "0.4.0"
 parking_lot = "0.12"
 rand = "0.8"
 rand_distr = "0.4"

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -18,11 +18,15 @@ khive-fold = { version = "0.2.11", path = "../khive-fold" }
 khive-storage = { version = "0.2.11", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
+lattice-fann = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -918,6 +918,12 @@ impl BrainPack {
 
         {
             let signal = interpret(&event);
+            #[cfg(feature = "lattice-router")]
+            {
+                let context = build_context_vector();
+                let routed = route_via_fann(&context);
+                eprintln!("[brain] lattice-router routed weights: {routed:?}");
+            }
             let mut state = self.state.lock().unwrap();
             let serving_profile = serving_profile_owned.as_str();
 
@@ -1350,6 +1356,48 @@ impl BrainPack {
     }
 }
 
+// ── lattice-router seam (#345 M1) ────────────────────────────────────────────
+
+/// Context-vector dimension for the lattice-fann router seam (#345 M1).
+/// DIM = BalancedRecallState (3 posteriors x {mean, ess} = 6)
+///     + SectionPosteriorState (10 posterior means = 10) = 16.
+/// M1 placeholder: returns a fixed zero vector; real feature extraction is M2.
+#[cfg(feature = "lattice-router")]
+const ROUTER_CONTEXT_DIM: usize = 16;
+
+#[cfg(feature = "lattice-router")]
+fn build_context_vector() -> [f32; ROUTER_CONTEXT_DIM] {
+    [0.0; ROUTER_CONTEXT_DIM]
+}
+
+/// M1 seam: links lattice-fann and produces routed mixture weights.
+/// The real engine `route(context_vector, available_adapters)` (lattice mixture-runtime,
+/// #343) swaps in here when shipped; M1 proves the dependency links and the seam runs.
+#[cfg(feature = "lattice-router")]
+fn route_via_fann(context: &[f32]) -> Vec<f32> {
+    use lattice_fann::{Activation, NetworkBuilder};
+    const ADAPTER_SLOTS: usize = 4;
+    let mut network = match NetworkBuilder::new()
+        .input(ROUTER_CONTEXT_DIM)
+        .hidden(8, Activation::ReLU)
+        .output(ADAPTER_SLOTS, Activation::Softmax)
+        .build()
+    {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("[brain] lattice-router: network build failed (non-fatal): {e}");
+            return Vec::new();
+        }
+    };
+    match network.forward(context) {
+        Ok(weights) => weights.to_vec(),
+        Err(e) => {
+            eprintln!("[brain] lattice-router: forward failed (non-fatal): {e}");
+            Vec::new()
+        }
+    }
+}
+
 // ── brain.auto_feedback helpers ───────────────────────────────────────────────
 
 /// Resolve an `id` from `memory.recall` output to a full UUID.
@@ -1498,5 +1546,22 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
                 "brain pack does not handle verb {verb:?}"
             ))),
         }
+    }
+}
+
+#[cfg(all(test, feature = "lattice-router"))]
+mod router_tests {
+    use super::*;
+
+    #[test]
+    fn route_via_fann_emits_normalized_mixture() {
+        let ctx = build_context_vector();
+        let weights = route_via_fann(&ctx);
+        assert_eq!(weights.len(), 4);
+        let sum: f32 = weights.iter().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-3,
+            "softmax weights must sum to ~1, got {sum}"
+        );
     }
 }


### PR DESCRIPTION
Closes #345. Part of #343 (adaptive brain) / #341.

M1 of the adaptive-brain router: a feature-gated seam that runs the `brain.feedback` context vector through a lattice-fann network and logs the routed mixture weights. The existing Bayesian posteriors (`BalancedRecallState`, `SectionPosteriorState`) remain the sole live path. **The default build is unchanged** — every new line is `#[cfg(feature = "lattice-router")]` gated.

## Changes (3 files, +70 LOC)
- `crates/Cargo.toml`: `lattice-fann = "0.4.0"` workspace dependency (crates.io, mirroring `lattice-embed`).
- `crates/khive-pack-brain/Cargo.toml`: optional `lattice-fann` dep + `[features] lattice-router = ["dep:lattice-fann"]`.
- `crates/khive-pack-brain/src/handlers.rs`:
  - `build_context_vector()` placeholder returning a fixed `[f32; 16]` (DIM = `BalancedRecallState` 3 posteriors × {mean, ess} = 6 + `SectionPosteriorState` 10 means = 10). Real feature extraction is tracked in #352.
  - `route_via_fann()` linking `lattice_fann::NetworkBuilder` (input 16 → hidden 8 ReLU → output 4 Softmax) and `Network::forward()`, returning the normalized mixture.
  - A `#[cfg(feature = "lattice-router")]` call-site block in `handle_feedback()` immediately after `interpret()`, logging the routed weights.
  - A router unit test asserting the softmax output is length-4 and sums to ~1.0.

## Design note
lattice-fann 0.4.0's published surface is `NetworkBuilder`/`Network::forward`, not a `route()` entry point. The engine `route(context_vector, available_adapters) -> mixture_weights` (lattice mixture-runtime, #343) swaps into `route_via_fann` when that seam ships. M1 lands a genuine dependency link and a running seam, not a stub.

## Out of scope (tracked separately)
- `with_dispatch_hook` wiring (#517) — its own PR.
- Real-feature context vector (#352), router-state persistence (#353), `brain.register_adapter` (#354).
- The compose read-path value-gate that makes the router's effect measurable (#346).

## Exit criterion — met
| Gate | Result |
|---|---|
| `cargo build -p khive-pack-brain` (default) | green |
| `cargo build -p khive-pack-brain --features lattice-router` | green |
| `cargo test -p khive-pack-brain --features lattice-router` | green (router test + 161 existing) |
| `cargo clippy ... --features lattice-router --all-targets -D warnings` | clean |
| `cargo clippy ... --all-targets -D warnings` (default) | clean |
| `cargo fmt --check` | clean |

No ADR required at M1.
