### PR TITLE
docs(adr): ADR-032 §6.4 — router_state + adapter_set snapshot persistence (#353)

### DIFF
--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -1084,6 +1084,74 @@ deployment.
 
 ---
 
+### 6.4 Router-state persistence (`router_state` + `adapter_set`)
+
+Amendment (2026-06-29): the adaptive-brain router (issue #343) overlays a per-profile
+gate network on the Bayesian posteriors — a learned mixing function that, given a
+profile's posterior context vector (issue #352), routes over a set of registered
+micro-LoRA adapters. Two pieces of that router must survive a process restart alongside
+the posteriors: the gate's own learned state, and the set of adapters the gate may mix.
+Both attach to `BrainStateSnapshot` (and its live mirror `BrainState`, §2) as additive,
+per-profile fields. The namespace snapshot is persisted as a JSON blob
+(`brain_profile_snapshots.snapshot_json`, §6.1), so each new field carries
+`#[serde(default)]` and every pre-existing snapshot deserializes unchanged with empty
+maps. No schema migration is required.
+
+```rust
+pub struct BrainStateSnapshot {
+    // ... existing fields (profiles, balanced_recall, profile_states, bindings, section_states) ...
+    #[serde(default)]
+    pub router_state: HashMap<String, RouterStateBlob>,    // key = profile_id
+    #[serde(default)]
+    pub adapter_set: HashMap<String, Vec<AdapterRecord>>,  // key = profile_id
+}
+
+pub struct RouterStateBlob {
+    pub schema_version: u32,
+    pub gate_bytes: Vec<u8>,   // opaque to brain; owned/(de)serialized by the gate engine
+}
+
+pub struct AdapterRecord {
+    pub adapter_id: String,
+    pub slot: u32,
+    pub content_hash: String,
+}
+```
+
+Both maps are keyed by `profile_id`, the same key space as `profile_states` and
+`section_states`. A profile with no continual-learning state simply has no `router_state`
+entry — absence, not a sentinel. The per-profile shape is required, not cosmetic: the
+gate is resolved per serving profile, so a single shared blob could not serve two
+profiles whose gates have diverged.
+
+`gate_bytes` is opaque to brain. The gate network's internal layout — its weights, and
+the diagonal Fisher information and replay buffer an EWC-style continual-learning update
+needs — is owned and (de)serialized by the engine that trains the gate (lattice), not by
+brain. Brain stores the byte string verbatim and never parses it. `schema_version` is the
+engine's own envelope version: the engine may evolve its blob format and bump the version
+without a brain ADR or a lockstep release, because brain only ever stores and returns
+whatever bytes and version it was handed. This is a one-schema, two-consumers contract:
+
+- Write side (brain): on snapshot, brain serializes the engine-provided `gate_bytes`
+  verbatim into the profile's `router_state` entry and populates `adapter_set` from the
+  records written by `register_adapter` (issue #354). Brain never inspects `gate_bytes`.
+- Read side (engine restore): `brain.profile` returns `router_state.gate_bytes` untouched;
+  the engine deserializes its own format (gate weights + Fisher + replay) from the blob and
+  restores its router. Brain never parses it.
+
+`AdapterRecord`, by contrast, is brain-native: brain owns adapter identity (`adapter_id`),
+the gate-output `slot` it occupies, and the `content_hash` integrity tag that
+`register_adapter` validates against the active base-model revision (issue #354). The
+adapter's weights live in the artifact/export layer, not in the snapshot.
+
+The boundary stays clean in both directions: brain owns the registry and the posterior
+state; the engine owns the gate's learned internals; the snapshot is the single serialized
+surface that carries both across a restart. If brain-side introspection of the gate
+internals is ever wanted, promoting `gate_bytes` to typed fields is a non-breaking
+additive change (further `#[serde(default)]` fields), so starting opaque costs nothing.
+
+---
+
 ## Consequences
 
 ### Positive

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -709,6 +709,72 @@ variants they knew about; new bindings get the new variant. Renaming on the latt
 side without coordinating with khive is the failure mode lattice ADR-008's "Risks"
 section calls out; this enum is khive's defence against it.
 
+#### 6.4 Router-state persistence (`router_state` + `adapter_set`)
+
+Amendment (2026-06-29): the adaptive-brain router (issue #343) overlays a per-profile
+gate network on the Bayesian posteriors — a learned mixing function that, given a
+profile's posterior context vector (issue #352), routes over a set of registered
+micro-LoRA adapters. Two pieces of that router must survive a process restart alongside
+the posteriors: the gate's own learned state, and the set of adapters the gate may mix.
+Both attach to `BrainStateSnapshot` (and its live mirror `BrainState`, §2) as additive,
+per-profile fields. The namespace snapshot is persisted as a JSON blob
+(`brain_profile_snapshots.snapshot_json`, §6.1), so each new field carries
+`#[serde(default)]` and every pre-existing snapshot deserializes unchanged with empty
+maps. No schema migration is required.
+
+```rust
+pub struct BrainStateSnapshot {
+    // ... existing fields (profiles, balanced_recall, profile_states, bindings, section_states) ...
+    #[serde(default)]
+    pub router_state: HashMap<String, RouterStateBlob>,    // key = profile_id
+    #[serde(default)]
+    pub adapter_set: HashMap<String, Vec<AdapterRecord>>,  // key = profile_id
+}
+
+pub struct RouterStateBlob {
+    pub schema_version: u32,
+    pub gate_bytes: Vec<u8>,   // opaque to brain; owned/(de)serialized by the gate engine
+}
+
+pub struct AdapterRecord {
+    pub adapter_id: String,
+    pub slot: u32,
+    pub content_hash: String,
+}
+```
+
+Both maps are keyed by `profile_id`, the same key space as `profile_states` and
+`section_states`. A profile with no continual-learning state simply has no `router_state`
+entry — absence, not a sentinel. The per-profile shape is required, not cosmetic: the
+gate is resolved per serving profile, so a single shared blob could not serve two
+profiles whose gates have diverged.
+
+`gate_bytes` is opaque to brain. The gate network's internal layout — its weights, and
+the diagonal Fisher information and replay buffer an EWC-style continual-learning update
+needs — is owned and (de)serialized by the engine that trains the gate (lattice), not by
+brain. Brain stores the byte string verbatim and never parses it. `schema_version` is the
+engine's own envelope version: the engine may evolve its blob format and bump the version
+without a brain ADR or a lockstep release, because brain only ever stores and returns
+whatever bytes and version it was handed. This is a one-schema, two-consumers contract:
+
+- Write side (brain): on snapshot, brain serializes the engine-provided `gate_bytes`
+  verbatim into the profile's `router_state` entry and populates `adapter_set` from the
+  records written by `register_adapter` (issue #354). Brain never inspects `gate_bytes`.
+- Read side (engine restore): `brain.profile` returns `router_state.gate_bytes` untouched;
+  the engine deserializes its own format (gate weights + Fisher + replay) from the blob and
+  restores its router. Brain never parses it.
+
+`AdapterRecord`, by contrast, is brain-native: brain owns adapter identity (`adapter_id`),
+the gate-output `slot` it occupies, and the `content_hash` integrity tag that
+`register_adapter` validates against the active base-model revision (issue #354). The
+adapter's weights live in the artifact/export layer, not in the snapshot.
+
+The boundary stays clean in both directions: brain owns the registry and the posterior
+state; the engine owns the gate's learned internals; the snapshot is the single serialized
+surface that carries both across a restart. If brain-side introspection of the gate
+internals is ever wanted, promoting `gate_bytes` to typed fields is a non-breaking
+additive change (further `#[serde(default)]` fields), so starting opaque costs nothing.
+
 ### 7. Snapshot and delta substrate
 
 Profile state persists via `ruvector-snapshot::SnapshotManager` with delta encoding for
@@ -1081,74 +1147,6 @@ deployment.
 | Brain owns state schema; profiles fill in values         | Brain enforces structure          | Every state shape change is a brain breaking change                                      | Wrong locus of evolution; rejected                                               |
 | Gradient-based optimization                              | Can learn nonlinear relationships | Requires differentiable loss, training loop, GPU                                         | Parameter space is ~10-50 posteriors; conjugate updates are O(1) exact; rejected |
 | Brain as a separate service                              | Independent scaling               | Network latency on every pipeline call                                                   | Brain is pure math; no IO; rejected                                              |
-
----
-
-### 6.4 Router-state persistence (`router_state` + `adapter_set`)
-
-Amendment (2026-06-29): the adaptive-brain router (issue #343) overlays a per-profile
-gate network on the Bayesian posteriors — a learned mixing function that, given a
-profile's posterior context vector (issue #352), routes over a set of registered
-micro-LoRA adapters. Two pieces of that router must survive a process restart alongside
-the posteriors: the gate's own learned state, and the set of adapters the gate may mix.
-Both attach to `BrainStateSnapshot` (and its live mirror `BrainState`, §2) as additive,
-per-profile fields. The namespace snapshot is persisted as a JSON blob
-(`brain_profile_snapshots.snapshot_json`, §6.1), so each new field carries
-`#[serde(default)]` and every pre-existing snapshot deserializes unchanged with empty
-maps. No schema migration is required.
-
-```rust
-pub struct BrainStateSnapshot {
-    // ... existing fields (profiles, balanced_recall, profile_states, bindings, section_states) ...
-    #[serde(default)]
-    pub router_state: HashMap<String, RouterStateBlob>,    // key = profile_id
-    #[serde(default)]
-    pub adapter_set: HashMap<String, Vec<AdapterRecord>>,  // key = profile_id
-}
-
-pub struct RouterStateBlob {
-    pub schema_version: u32,
-    pub gate_bytes: Vec<u8>,   // opaque to brain; owned/(de)serialized by the gate engine
-}
-
-pub struct AdapterRecord {
-    pub adapter_id: String,
-    pub slot: u32,
-    pub content_hash: String,
-}
-```
-
-Both maps are keyed by `profile_id`, the same key space as `profile_states` and
-`section_states`. A profile with no continual-learning state simply has no `router_state`
-entry — absence, not a sentinel. The per-profile shape is required, not cosmetic: the
-gate is resolved per serving profile, so a single shared blob could not serve two
-profiles whose gates have diverged.
-
-`gate_bytes` is opaque to brain. The gate network's internal layout — its weights, and
-the diagonal Fisher information and replay buffer an EWC-style continual-learning update
-needs — is owned and (de)serialized by the engine that trains the gate (lattice), not by
-brain. Brain stores the byte string verbatim and never parses it. `schema_version` is the
-engine's own envelope version: the engine may evolve its blob format and bump the version
-without a brain ADR or a lockstep release, because brain only ever stores and returns
-whatever bytes and version it was handed. This is a one-schema, two-consumers contract:
-
-- Write side (brain): on snapshot, brain serializes the engine-provided `gate_bytes`
-  verbatim into the profile's `router_state` entry and populates `adapter_set` from the
-  records written by `register_adapter` (issue #354). Brain never inspects `gate_bytes`.
-- Read side (engine restore): `brain.profile` returns `router_state.gate_bytes` untouched;
-  the engine deserializes its own format (gate weights + Fisher + replay) from the blob and
-  restores its router. Brain never parses it.
-
-`AdapterRecord`, by contrast, is brain-native: brain owns adapter identity (`adapter_id`),
-the gate-output `slot` it occupies, and the `content_hash` integrity tag that
-`register_adapter` validates against the active base-model revision (issue #354). The
-adapter's weights live in the artifact/export layer, not in the snapshot.
-
-The boundary stays clean in both directions: brain owns the registry and the posterior
-state; the engine owns the gate's learned internals; the snapshot is the single serialized
-surface that carries both across a restart. If brain-side introspection of the gate
-internals is ever wanted, promoting `gate_bytes` to typed fields is a non-breaking
-additive change (further `#[serde(default)]` fields), so starting opaque costs nothing.
 
 ---
 


### PR DESCRIPTION
Documents the snapshot contract for #353 (router-state persistence). **Doc-only** — the code that adds the fields is a separate PR per the code/doc split rule, and that code-PR will reference this section.

Adds **ADR-032 §6.4** describing two additive, per-profile fields on `BrainStateSnapshot`:

- `router_state: HashMap<profile_id, RouterStateBlob>` — `RouterStateBlob { schema_version: u32, gate_bytes: Vec<u8> }`. `gate_bytes` is **opaque to brain**: the gate engine (lattice) owns and (de)serializes its own format (gate weights + diagonal Fisher + replay buffer), so it can evolve its blob layout and bump `schema_version` without a brain ADR or a lockstep release.
- `adapter_set: HashMap<profile_id, Vec<AdapterRecord>>` — `AdapterRecord { adapter_id, slot, content_hash }`, **brain-native** (identity + gate slot + integrity tag validated by `register_adapter`, #354).

Both are `#[serde(default)]`, and the namespace snapshot is a JSON blob column (`brain_profile_snapshots.snapshot_json`), so pre-existing snapshots deserialize unchanged with empty maps — **no migration**.

Per-profile keying (same key space as `profile_states` / `section_states`) is required, not cosmetic: the gate is resolved per serving profile, so a single shared blob could not serve two profiles whose gates have diverged.

This is the **one-schema, two-consumers** contract: brain write side serializes engine-provided `gate_bytes` verbatim + populates `adapter_set` from registrations; engine read side (lattice restore) gets `router_state.gate_bytes` untouched and deserializes its own format. Boundary owner-split: brain owns the registry + posterior state; the engine owns the gate's learned internals.

## Scope / gates
- 1 file, +68 lines, `docs/adr/ADR-032-brain-profile-orchestration.md` only.
- `deno fmt docs/...` clean; pre-commit hooks (markdown fmt, secret/leak guards) passed.
- No code, no schema migration, no commercial framing.

Contract approved by the snapshot-contract owner (Option A opaque blob + per-profile, confirmed 2026-06-29). Held pending review.
