### PR TITLE
feat(brain): brain.register_adapter integrity verb (#354)

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -23,6 +23,12 @@ use khive_brain_core::{
     DEFAULT_ESS_CAP,
 };
 
+// ── Adapter revision sentinel ─────────────────────────────────────────────────
+
+/// Base model revision that registered adapters must target; overridable via
+/// KHIVE_BRAIN_BASE_MODEL_REVISION so both accept and reject paths are testable.
+pub(crate) const DEFAULT_BASE_MODEL_REVISION: &str = "base-v0";
+
 // ── Handler table ─────────────────────────────────────────────────────────────
 
 /// Brain pack verb surface. Visibility::Verb = exposed on the MCP `request` tool.
@@ -357,6 +363,39 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 param_type: "object",
                 required: false,
                 description: "Seed priors object. For knowledge_compose: {\"section_posteriors\": {\"overview\": {\"alpha\": 2.0, \"beta\": 2.0}, ...}}. For recall: {\"relevance\": {\"alpha\": 7.0, \"beta\": 3.0}, ...}.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "brain.register_adapter",
+        description: "Register an adapter integrity record so the router only composes \
+            adapters matching the active base model revision",
+        visibility: khive_types::Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            khive_types::ParamDef {
+                name: "adapter_id",
+                param_type: "string",
+                required: true,
+                description: "Stable identifier for the adapter (used as the entity name).",
+            },
+            khive_types::ParamDef {
+                name: "content_hash",
+                param_type: "string",
+                required: true,
+                description: "Content hash of the adapter weights for integrity verification.",
+            },
+            khive_types::ParamDef {
+                name: "base_model_revision",
+                param_type: "string",
+                required: true,
+                description: "Base model revision the adapter was trained against. Must match the active revision or registration is rejected.",
+            },
+            khive_types::ParamDef {
+                name: "metadata",
+                param_type: "object",
+                required: false,
+                description: "Optional additional metadata merged into entity properties.",
             },
         ],
     },
@@ -1354,6 +1393,67 @@ impl BrainPack {
             "description": description,
         }))
     }
+
+    // ── brain.register_adapter ────────────────────────────────────────────
+
+    pub(crate) async fn handle_register_adapter(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RegisterAdapterParams {
+            adapter_id: String,
+            content_hash: String,
+            base_model_revision: String,
+            metadata: Option<serde_json::Value>,
+        }
+        let p: RegisterAdapterParams = serde_json::from_value(params)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        let active_revision = std::env::var("KHIVE_BRAIN_BASE_MODEL_REVISION")
+            .unwrap_or_else(|_| DEFAULT_BASE_MODEL_REVISION.to_string());
+
+        if p.base_model_revision != active_revision {
+            return Err(RuntimeError::InvalidInput(format!(
+                "base_model_revision mismatch: expected {:?}, got {:?}",
+                active_revision, p.base_model_revision
+            )));
+        }
+
+        let mut props = serde_json::json!({
+            "content_hash": p.content_hash,
+            "base_model_revision": p.base_model_revision,
+        });
+        if let Some(serde_json::Value::Object(meta)) = p.metadata {
+            let props_obj = props.as_object_mut().unwrap();
+            for (k, v) in meta {
+                if k != "content_hash" && k != "base_model_revision" {
+                    props_obj.insert(k, v);
+                }
+            }
+        }
+
+        self.runtime
+            .create_entity(
+                token,
+                "artifact",
+                Some("adapter"),
+                &p.adapter_id,
+                None,
+                Some(props),
+                vec![],
+            )
+            .await?;
+
+        Ok(json!({
+            "registered": true,
+            "adapter_id": p.adapter_id,
+            "content_hash": p.content_hash,
+            "base_model_revision": p.base_model_revision,
+        }))
+    }
 }
 
 // ── lattice-router seam (#345 M1) ────────────────────────────────────────────
@@ -1540,6 +1640,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.bind" => self.handle_bind(params).await,
             "brain.unbind" => self.handle_unbind(params).await,
             "brain.create_profile" => self.handle_create_profile(params).await,
+            "brain.register_adapter" => self.handle_register_adapter(token, params).await,
             // Legacy
             "brain.emit" => self.handle_emit(token, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3951,3 +3951,101 @@ async fn feedback_accepts_short_prefix_target_id() {
     assert_eq!(result["emitted"], json!(true), "emitted must be true");
     assert_eq!(result["signal"], json!("useful"), "signal must round-trip");
 }
+
+// ── #354: brain.register_adapter ─────────────────────────────────────────────
+
+// ACCEPT: matching base_model_revision registers the adapter and persists the artifact.
+#[tokio::test]
+async fn register_adapter_accept_matching_revision() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let active_rev = std::env::var("KHIVE_BRAIN_BASE_MODEL_REVISION")
+        .unwrap_or_else(|_| crate::handlers::DEFAULT_BASE_MODEL_REVISION.to_string());
+
+    let result = pack
+        .dispatch(
+            "brain.register_adapter",
+            json!({
+                "adapter_id": "lora-v1",
+                "content_hash": "sha256:abcd1234",
+                "base_model_revision": active_rev,
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("register_adapter with matching revision must succeed");
+
+    assert_eq!(result["registered"], json!(true), "registered must be true");
+    assert_eq!(result["adapter_id"], json!("lora-v1"));
+    assert_eq!(result["content_hash"], json!("sha256:abcd1234"));
+    assert_eq!(result["base_model_revision"], json!(active_rev));
+
+    // Verify the artifact entity was actually persisted.
+    let entities = rt
+        .list_entities(&token, Some("artifact"), Some("adapter"), 10, 0)
+        .await
+        .expect("list_entities must succeed");
+    let found = entities.iter().any(|e| e.name == "lora-v1");
+    assert!(
+        found,
+        "artifact entity 'lora-v1' must exist after successful registration"
+    );
+    let entity = entities.iter().find(|e| e.name == "lora-v1").unwrap();
+    let props = entity
+        .properties
+        .as_ref()
+        .expect("entity must have properties");
+    assert_eq!(
+        props["content_hash"],
+        json!("sha256:abcd1234"),
+        "content_hash must be stored in entity properties"
+    );
+}
+
+// REJECT: mismatching base_model_revision returns an error and does not persist.
+#[tokio::test]
+async fn register_adapter_reject_mismatching_revision() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let err = pack
+        .dispatch(
+            "brain.register_adapter",
+            json!({
+                "adapter_id": "lora-bad",
+                "content_hash": "sha256:deadbeef",
+                "base_model_revision": "wrong-revision-xyz",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap_err();
+
+    if let RuntimeError::InvalidInput(msg) = &err {
+        assert!(
+            msg.contains("mismatch") || msg.contains("expected"),
+            "#354: rejection message must name the mismatch; got: {msg}"
+        );
+        assert!(
+            msg.contains("wrong-revision-xyz") || msg.contains("base_model_revision"),
+            "#354: rejection message must name the supplied revision; got: {msg}"
+        );
+    } else {
+        panic!("#354: mismatching revision must return InvalidInput, got {err:?}");
+    }
+
+    // No artifact entity must have been persisted.
+    let entities = rt
+        .list_entities(&token, Some("artifact"), Some("adapter"), 10, 0)
+        .await
+        .expect("list_entities must succeed");
+    assert!(
+        !entities.iter().any(|e| e.name == "lora-bad"),
+        "#354: rejected registration must not persist an artifact entity"
+    );
+}

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -193,16 +193,16 @@ def main():
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
         # unset) loads 8 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session), so verbs() returns exactly 67 user-facing
+        # knowledge, session), so verbs() returns exactly 68 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack is loaded for the background daemon mirror but
         # contributes 0 agent-facing verbs — its three handlers (store/list/get)
         # are internal subhandlers (Visibility::Subhandler), excluded from the
-        # verbs() surface.
+        # verbs() surface; brain.register_adapter (#354) adds the 68th.
         # Update this number when the pack set or verb surface changes; a silent
         # drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 67, (
-            f"expected 67 user-facing verbs from the 8 default packs "
+        assert verbs_result["total"] == 68, (
+            f"expected 68 user-facing verbs from the 8 default packs "
             f"(session contributes 0 — its verbs are internal subhandlers), "
             f"got {verbs_result['total']}: {verbs_result}"
         )


### PR DESCRIPTION
Closes #354. Part of #343 (adaptive brain) / #341.

**Stacked on #356** (base branch `feat-brain-context-vector-352`). The #354-only delta is `git diff feat-brain-context-vector-352...HEAD`. Review/merge the brain stack (#355 → #356) first.

Adds the `brain.register_adapter` verb: when the adaptive brain mixes micro-LoRA adapters, each must be registered with an integrity record so the router only composes adapters matching the active base model.

## Behavior
- New verb `brain.register_adapter(adapter_id, content_hash, base_model_revision, metadata?)`.
- Persists an `artifact` entity (ADR-001 kind, entity_type `"adapter"`, name = adapter_id) with `content_hash` + `base_model_revision` in properties; optional `metadata` merged in (reserved keys `content_hash`/`base_model_revision` protected from override).
- **Rejects** registration when `base_model_revision` != the active revision (`DEFAULT_BASE_MODEL_REVISION = "base-v0"`, overridable via `KHIVE_BRAIN_BASE_MODEL_REVISION`), returning an error that names expected-vs-supplied.
- Return shape: `{ registered: true, adapter_id, content_hash, base_model_revision }`.
- Brain-native — **not** gated behind `lattice-router`; compiles + lints clean on both feature paths.

## Out of scope
- Adapter training (engine/lattice side).
- The `derived_from` link to a session dataset — deferred to the T1↔T2 bridge (**#357**), which creates the dataset entity this adapter would derive from.

## Scope / gates (run with worktree-local CARGO_TARGET_DIR)
| Gate | Exit |
|---|---|
| `cargo check -p khive-pack-brain` | 0 |
| `cargo check -p khive-pack-brain --features lattice-router` | 0 |
| `cargo test -p khive-pack-brain --lib register_adapter` | 0 (2 passed) |
| `cargo clippy -p khive-pack-brain --all-targets -D warnings` | 0 |
| `cargo clippy -p khive-pack-brain --features lattice-router --all-targets -D warnings` | 0 |
| `cargo fmt --check -p khive-pack-brain` | 0 |

2 files, +196: `handlers.rs` (const + HandlerDef manifest + handle_register_adapter + dispatch arm) and `tests.rs` (accept + reject tests). The `create_entity` error propagates natively (not reclassified). Held pending review.
