### PR TITLE
feat(brain): add brain.assign_adapter_slot verb (#360)

### DIFF
--- a/crates/khive-brain-core/src/lib.rs
+++ b/crates/khive-brain-core/src/lib.rs
@@ -10,7 +10,9 @@ pub mod signal;
 pub mod tunable;
 
 pub use brain_signal::{entity_signal, is_recall_positive, BrainSignal};
-pub use brain_state::{validate_brain_state_snapshot, BrainState, BrainStateSnapshot};
+pub use brain_state::{
+    validate_brain_state_snapshot, AdapterRecord, BrainState, BrainStateSnapshot,
+};
 pub use posterior::{BetaPosterior, EntityPosteriors};
 pub use profile::{
     BalancedRecallSnapshot, BalancedRecallState, ProfileBinding, ProfileLifecycle, ProfileRecord,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -13,15 +13,22 @@ use khive_runtime::{
 };
 use khive_storage::event::{Event, EventFilter};
 use khive_storage::types::PageRequest;
+use khive_storage::EntityFilter;
 use khive_types::HandlerDef;
 
 use crate::event::interpret;
 use crate::{sync_balanced_recall_record, BrainPack, ENTITY_CACHE_CAPACITY};
 use khive_brain_core::derive_deterministic_weights;
 use khive_brain_core::{
-    ProfileBinding, ProfileLifecycle, ProfileRecord, SectionPosteriorState, SectionType,
-    DEFAULT_ESS_CAP,
+    AdapterRecord, ProfileBinding, ProfileLifecycle, ProfileRecord, SectionPosteriorState,
+    SectionType, DEFAULT_ESS_CAP,
 };
+
+// ── Adapter slot bound ────────────────────────────────────────────────────────
+
+/// Number of adapter slots available per profile.
+/// Must equal the lattice-router gate width.
+const ADAPTER_SLOTS: u32 = 4;
 
 // ── Handler table ─────────────────────────────────────────────────────────────
 
@@ -357,6 +364,32 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
                 param_type: "object",
                 required: false,
                 description: "Seed priors object. For knowledge_compose: {\"section_posteriors\": {\"overview\": {\"alpha\": 2.0, \"beta\": 2.0}, ...}}. For recall: {\"relevance\": {\"alpha\": 7.0, \"beta\": 3.0}, ...}.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "brain.assign_adapter_slot",
+        description: "Assign a registered adapter to a gate output slot in a profile",
+        visibility: khive_types::Visibility::Verb,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            khive_types::ParamDef {
+                name: "profile_id",
+                param_type: "string",
+                required: true,
+                description: "Profile ID to update.",
+            },
+            khive_types::ParamDef {
+                name: "adapter_id",
+                param_type: "string",
+                required: true,
+                description: "Adapter identifier (must be registered via brain.register_adapter).",
+            },
+            khive_types::ParamDef {
+                name: "slot",
+                param_type: "integer",
+                required: true,
+                description: "Gate output slot index. Must be < 4 (= ADAPTER_SLOTS).",
             },
         ],
     },
@@ -1348,6 +1381,111 @@ impl BrainPack {
             "description": description,
         }))
     }
+
+    // ── brain.assign_adapter_slot ─────────────────────────────────────────
+
+    pub(crate) async fn handle_assign_adapter_slot(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct AssignAdapterSlotParams {
+            profile_id: String,
+            adapter_id: String,
+            slot: u32,
+        }
+        let p: AssignAdapterSlotParams = serde_json::from_value(params)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        // Validate slot bound.
+        if p.slot >= ADAPTER_SLOTS {
+            return Err(RuntimeError::InvalidInput(format!(
+                "slot {} is out of range; must be < {} (ADAPTER_SLOTS)",
+                p.slot, ADAPTER_SLOTS,
+            )));
+        }
+
+        // Look up the registered adapter entity persisted by brain.register_adapter.
+        // Adapter entities: kind=artifact, entity_type=adapter, name=adapter_id.
+        let filter = EntityFilter {
+            kinds: vec!["artifact".to_owned()],
+            entity_types: vec!["adapter".to_owned()],
+            name_prefix: Some(p.adapter_id.clone()),
+            ..Default::default()
+        };
+        let page = self
+            .runtime
+            .entities(token)?
+            .query_entities(
+                token.namespace().as_str(),
+                filter,
+                PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await?;
+        let adapter_entity = page
+            .items
+            .into_iter()
+            .find(|e| e.name == p.adapter_id)
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "adapter {:?} is not registered; call brain.register_adapter first",
+                    p.adapter_id
+                ))
+            })?;
+        let content_hash = adapter_entity
+            .properties
+            .as_ref()
+            .and_then(|props| props.get("content_hash"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!(
+                    "adapter {:?} entity is missing content_hash property",
+                    p.adapter_id
+                ))
+            })?
+            .to_owned();
+
+        // Apply collision semantics on adapter_set[profile_id].
+        // Invariant: at most one record per slot and per adapter_id within a profile.
+        let mut state = self.state.lock().unwrap();
+        let entries = state.adapter_set.entry(p.profile_id.clone()).or_default();
+
+        // Idempotent: exact (adapter_id, slot) already present.
+        if entries
+            .iter()
+            .any(|r| r.adapter_id == p.adapter_id && r.slot == p.slot)
+        {
+            return Ok(json!({
+                "assigned": true,
+                "profile_id": p.profile_id,
+                "adapter_id": p.adapter_id,
+                "slot": p.slot,
+            }));
+        }
+
+        // Evict any existing occupant of the target slot.
+        entries.retain(|r| r.slot != p.slot);
+        // Move: remove the same adapter from any prior slot.
+        entries.retain(|r| r.adapter_id != p.adapter_id);
+        // Insert the new record.
+        entries.push(AdapterRecord {
+            adapter_id: p.adapter_id.clone(),
+            slot: p.slot,
+            content_hash,
+        });
+
+        Ok(json!({
+            "assigned": true,
+            "profile_id": p.profile_id,
+            "adapter_id": p.adapter_id,
+            "slot": p.slot,
+        }))
+    }
 }
 
 // ── brain.auto_feedback helpers ───────────────────────────────────────────────
@@ -1492,6 +1630,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.bind" => self.handle_bind(params).await,
             "brain.unbind" => self.handle_unbind(params).await,
             "brain.create_profile" => self.handle_create_profile(params).await,
+            "brain.assign_adapter_slot" => self.handle_assign_adapter_slot(token, params).await,
             // Legacy
             "brain.emit" => self.handle_emit(token, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3951,3 +3951,226 @@ async fn feedback_accepts_short_prefix_target_id() {
     assert_eq!(result["emitted"], json!(true), "emitted must be true");
     assert_eq!(result["signal"], json!("useful"), "signal must round-trip");
 }
+
+// ── brain.assign_adapter_slot tests ──────────────────────────────────────────
+
+/// Register a fake adapter entity in the DB the same way brain.register_adapter would.
+async fn register_adapter_entity(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    adapter_id: &str,
+    content_hash: &str,
+) {
+    rt.create_entity(
+        token,
+        "artifact",
+        Some("adapter"),
+        adapter_id,
+        None,
+        Some(json!({"content_hash": content_hash, "base_model_revision": "base-v1"})),
+        vec![],
+    )
+    .await
+    .expect("register adapter entity");
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_happy_path() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    register_adapter_entity(&rt, &token, "lora-A", "hash-abc").await;
+
+    let result = pack
+        .dispatch(
+            "brain.assign_adapter_slot",
+            json!({"profile_id": "p1", "adapter_id": "lora-A", "slot": 0}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("assign_adapter_slot must succeed");
+
+    assert_eq!(result["assigned"], json!(true));
+    assert_eq!(result["profile_id"], json!("p1"));
+    assert_eq!(result["adapter_id"], json!("lora-A"));
+    assert_eq!(result["slot"], json!(0));
+
+    // Verify the record is present in state with the looked-up content_hash.
+    let state = pack.state.lock().unwrap();
+    let entries = state
+        .adapter_set
+        .get("p1")
+        .expect("profile p1 must have entries");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].adapter_id, "lora-A");
+    assert_eq!(entries[0].slot, 0);
+    assert_eq!(entries[0].content_hash, "hash-abc");
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_rejects_slot_out_of_bounds() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    register_adapter_entity(&rt, &token, "lora-B", "hash-def").await;
+
+    let err = pack
+        .dispatch(
+            "brain.assign_adapter_slot",
+            json!({"profile_id": "p1", "adapter_id": "lora-B", "slot": 4}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap_err();
+
+    if let RuntimeError::InvalidInput(msg) = &err {
+        assert!(
+            msg.contains("out of range") || msg.contains("ADAPTER_SLOTS"),
+            "expected slot bound message, got: {msg}"
+        );
+    } else {
+        panic!("expected InvalidInput, got {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_rejects_unregistered_adapter() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    // No entity created — adapter is not registered.
+    let err = pack
+        .dispatch(
+            "brain.assign_adapter_slot",
+            json!({"profile_id": "p1", "adapter_id": "ghost-adapter", "slot": 1}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap_err();
+
+    if let RuntimeError::InvalidInput(msg) = &err {
+        assert!(
+            msg.contains("not registered") || msg.contains("ghost-adapter"),
+            "expected not-registered message, got: {msg}"
+        );
+    } else {
+        panic!("expected InvalidInput, got {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_collision_replace() {
+    // Slot reuse by a different adapter evicts the old occupant.
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    register_adapter_entity(&rt, &token, "lora-X", "hash-x").await;
+    register_adapter_entity(&rt, &token, "lora-Y", "hash-y").await;
+
+    // Assign lora-X to slot 2.
+    pack.dispatch(
+        "brain.assign_adapter_slot",
+        json!({"profile_id": "p1", "adapter_id": "lora-X", "slot": 2}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("first assign must succeed");
+
+    // Reassign slot 2 to lora-Y — should evict lora-X.
+    pack.dispatch(
+        "brain.assign_adapter_slot",
+        json!({"profile_id": "p1", "adapter_id": "lora-Y", "slot": 2}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("replace assign must succeed");
+
+    let state = pack.state.lock().unwrap();
+    let entries = state.adapter_set.get("p1").expect("must have entries");
+    assert_eq!(entries.len(), 1, "only one record per slot");
+    assert_eq!(entries[0].adapter_id, "lora-Y");
+    assert_eq!(entries[0].slot, 2);
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_collision_move() {
+    // Same adapter reassigned to a new slot; no duplicate record.
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    register_adapter_entity(&rt, &token, "lora-M", "hash-m").await;
+
+    // Assign lora-M to slot 0.
+    pack.dispatch(
+        "brain.assign_adapter_slot",
+        json!({"profile_id": "p1", "adapter_id": "lora-M", "slot": 0}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("initial assign must succeed");
+
+    // Move lora-M to slot 3.
+    pack.dispatch(
+        "brain.assign_adapter_slot",
+        json!({"profile_id": "p1", "adapter_id": "lora-M", "slot": 3}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("move assign must succeed");
+
+    let state = pack.state.lock().unwrap();
+    let entries = state.adapter_set.get("p1").expect("must have entries");
+    assert_eq!(entries.len(), 1, "no duplicate after move");
+    assert_eq!(entries[0].adapter_id, "lora-M");
+    assert_eq!(entries[0].slot, 3, "adapter must now be at slot 3");
+}
+
+#[tokio::test]
+async fn test_assign_adapter_slot_collision_idempotent() {
+    // Exact (profile_id, adapter_id, slot) match is a no-op.
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    register_adapter_entity(&rt, &token, "lora-I", "hash-i").await;
+
+    // Assign once.
+    pack.dispatch(
+        "brain.assign_adapter_slot",
+        json!({"profile_id": "p1", "adapter_id": "lora-I", "slot": 1}),
+        &registry,
+        &token,
+    )
+    .await
+    .expect("first assign must succeed");
+
+    // Assign again with identical params — idempotent.
+    let result = pack
+        .dispatch(
+            "brain.assign_adapter_slot",
+            json!({"profile_id": "p1", "adapter_id": "lora-I", "slot": 1}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("idempotent assign must not error");
+
+    assert_eq!(result["assigned"], json!(true));
+
+    let state = pack.state.lock().unwrap();
+    let entries = state.adapter_set.get("p1").expect("must have entries");
+    assert_eq!(entries.len(), 1, "no duplicate on idempotent call");
+    assert_eq!(entries[0].slot, 1);
+}


### PR DESCRIPTION
## What

Adds `brain.assign_adapter_slot(profile_id, adapter_id, slot)` — the per-profile write path that populates the `adapter_set` field added in #353/#361 (ADR-032 §6.4).

`register_adapter` (#359) is a pure **global** integrity gate (validates an adapter's `content_hash` against the base model once, writes the artifact entity, no slot/profile). This verb is the distinct **per-profile** concern that mirrors how profile bindings work.

## Behavior

- **Slot bound**: rejects `slot >= ADAPTER_SLOTS` (4) with `InvalidInput`. `slot` is a real gate-output index (#355/#345 `output(ADAPTER_SLOTS=4, Softmax)`); an out-of-range slot would be unaddressable by the router.
- **Registration precheck**: verifies the adapter was registered via `brain.register_adapter` (the `artifact`/`adapter` entity exists and carries `content_hash`) before writing. `content_hash` is taken from the entity, **not** the caller.
- **Explicit collision semantics** (invariant: at most one record per slot AND per adapter within a profile):
  - re-assigning a slot **replaces** its current occupant
  - re-assigning the same adapter to a new slot **moves** it (no duplicate)
  - exact `(profile_id, adapter_id, slot)` match is an **idempotent no-op**

## Tests

6 new tests: happy-path, slot-out-of-bounds reject, unregistered-adapter reject, and all three collision paths (replace, move, idempotent).

## Notes

- `ADAPTER_SLOTS = 4` is a linked-duplicate const here with a doc comment (`// Must equal the lattice-router gate width`); the lattice-router gate-width const (#355) is not yet in this branch's workspace. Reconciliation to a single source belongs with the #355 landing.
- Default-table verb, no feature gating.

## Stacking / merge order

Stacks on #361 (`feat-brain-snapshot-router-state-353`, the `adapter_set` field). Merge order: **#358 (ADR §6.4) → #361 (field) → #360 (this)**. Base will be retargeted to `main` once #361 lands.

Part of #343 (adaptive brain) / #341.
