### PR TITLE
feat(channel-email): app-only OAuth2 (XOAUTH2) auth path (#364)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ bench-1m-ci:
 	bash scripts/bench_1m.sh --ci
 
 local:
-	@echo "==> Building kkernel (release)..."
-	@cd crates && cargo build --release -p kkernel
+	@echo "==> Building kkernel (release, channel-email)..."
+	@cd crates && cargo build --release -p kkernel --features channel-email
 	@SRC=crates/target/release/kkernel; \
 	DEST=$$HOME/.cargo/bin/kkernel; \
 	if [ ! -f "$$SRC" ]; then echo "==> ERROR: build artifact $$SRC missing"; exit 1; fi; \

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -96,6 +96,8 @@ libc = "0.2"
 proptest = "1"
 crossbeam-queue = "0.3"
 sqlite-vec = { version = "0.1.9" }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+base64 = "0.22"
 
 [profile.release]
 opt-level = 3

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -26,6 +26,8 @@ async-imap = { workspace = true }
 async-native-tls = { workspace = true }
 mail-parser = { workspace = true }
 futures = { workspace = true }
+reqwest = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -1,14 +1,17 @@
 //! `EmailChannel` — implements the `Channel` trait for email transport.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use khive_channel::{Channel, ChannelEnvelope, ChannelError};
 use tracing::{debug, warn};
 
-use crate::config::EmailChannelConfig;
+use crate::config::{EmailAuth, EmailChannelConfig};
 use crate::connector::imap::ImapFetcher;
 use crate::connector::smtp::SmtpSender;
 use crate::connector::{MailAddress, RawEmail};
+use crate::oauth::TokenProvider;
 
 /// Email channel adapter implementing `Channel` via SMTP + IMAP.
 ///
@@ -24,18 +27,49 @@ impl EmailChannel {
     /// Build from environment variables. Fails if any required env var is absent.
     pub fn from_env() -> Result<Self, ChannelError> {
         let config = EmailChannelConfig::from_env()?;
-        let smtp = SmtpSender::new(
-            &config.smtp_host,
-            config.smtp_port,
-            &config.username,
-            &config.password,
-        );
-        let imap = ImapFetcher::new(
-            &config.imap_host,
-            config.imap_port,
-            &config.username,
-            &config.password,
-        );
+
+        let (smtp, imap) = match &config.auth {
+            EmailAuth::Basic { password } => {
+                let smtp = SmtpSender::new(
+                    &config.smtp_host,
+                    config.smtp_port,
+                    &config.username,
+                    password,
+                );
+                let imap = ImapFetcher::new(
+                    &config.imap_host,
+                    config.imap_port,
+                    &config.username,
+                    password,
+                );
+                (smtp, imap)
+            }
+            EmailAuth::OAuth {
+                tenant_id,
+                client_id,
+                client_secret,
+            } => {
+                let token_provider = Arc::new(TokenProvider::new(
+                    tenant_id.clone(),
+                    client_id.clone(),
+                    client_secret.clone(),
+                ));
+                let smtp = SmtpSender::new_oauth(
+                    &config.smtp_host,
+                    config.smtp_port,
+                    &config.mailbox,
+                    Arc::clone(&token_provider),
+                );
+                let imap = ImapFetcher::new_oauth(
+                    &config.imap_host,
+                    config.imap_port,
+                    &config.mailbox,
+                    Arc::clone(&token_provider),
+                );
+                (smtp, imap)
+            }
+        };
+
         Ok(Self { config, smtp, imap })
     }
 
@@ -170,6 +204,7 @@ fn strip_kind_prefix<'a>(addr: &'a str, kind: &str) -> &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::EmailAuth;
     use crate::connector::imap::{ImapConnector, ImapFetcher};
     use crate::connector::smtp::{SmtpConnector, SmtpSender};
     use std::collections::HashMap;
@@ -182,7 +217,10 @@ mod tests {
             imap_host: "imap.example.com".to_string(),
             imap_port: 993,
             username: "user@example.com".to_string(),
-            password: "secret".to_string(),
+            mailbox: "user@example.com".to_string(),
+            auth: EmailAuth::Basic {
+                password: "secret".to_string(),
+            },
             maintainer_address: MailAddress::parse(maintainer).unwrap(),
         }
     }

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -111,10 +111,14 @@ impl EmailChannelConfig {
         let imap_host = require_env("KHIVE_EMAIL_IMAP_HOST")?;
         let imap_port = optional_port("KHIVE_EMAIL_IMAP_PORT", 993)?;
         let username = require_env("KHIVE_EMAIL_USERNAME")?;
+        validate_sasl_string(&username, "KHIVE_EMAIL_USERNAME")?;
 
         let mailbox = match std::env::var("KHIVE_EMAIL_MAILBOX") {
-            Ok(v) if !v.is_empty() => v,
-            _ => username.clone(),
+            Ok(v) if !v.is_empty() => {
+                validate_sasl_string(&v, "KHIVE_EMAIL_MAILBOX")?;
+                v
+            }
+            _ => username.clone(), // already validated above
         };
 
         let auth = build_auth()?;
@@ -200,9 +204,83 @@ fn optional_port(key: &str, default: u16) -> Result<u16, ChannelError> {
     }
 }
 
+/// Validate a string for use in the XOAUTH2 SASL `user=` field.
+///
+/// Rejects:
+/// - empty strings
+/// - strings without `@` (i.e. not an RFC 5322 addr-spec)
+/// - any ASCII control character (U+0000–U+001F, U+007F), including the
+///   `\x01` delimiter used in the SASL payload and the `\r\n` terminators
+///   used in IMAP/SMTP line framing
+///
+/// Called at config construction time so control characters can never reach
+/// the XOAUTH2 SASL payload builder or the IMAP/SMTP connectors.
+fn validate_sasl_string(value: &str, field_name: &str) -> Result<(), ChannelError> {
+    if value.is_empty() {
+        return Err(ChannelError::Config(format!(
+            "{field_name} must not be empty"
+        )));
+    }
+    if !value.contains('@') {
+        return Err(ChannelError::Config(format!(
+            "{field_name} must be a valid email address (no '@' found)"
+        )));
+    }
+    if value.chars().any(|c| matches!(c, '\x00'..='\x1f' | '\x7f')) {
+        return Err(ChannelError::Config(format!(
+            "{field_name} contains disallowed control characters"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    // ── Env-mutation serialization (Finding 3) ────────────────────────────────
+    //
+    // Environment variables are process-global state.  Tests that set or remove
+    // them must not run concurrently or they observe each other's mutations.
+    //
+    // Strategy: a crate-local `ENV_MUTEX` serialises every env-mutating test.
+    // An `EnvSnapshot` captures prior values at test entry and restores them
+    // on drop — even if the test panics — so the mutex lock always releases
+    // with a clean env.
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// RAII snapshot of environment variables.  On drop, each variable is
+    /// restored to its value at capture time (or removed if it was absent).
+    struct EnvSnapshot {
+        vars: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(keys: &[&str]) -> Self {
+            Self {
+                vars: keys
+                    .iter()
+                    .map(|k| (k.to_string(), std::env::var(k).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (k, v) in &self.vars {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    // ── Pure-function tests (no env mutation) ─────────────────────────────────
 
     #[test]
     fn missing_required_env_returns_error() {
@@ -214,32 +292,9 @@ mod tests {
     }
 
     #[test]
-    fn optional_port_uses_default_when_absent() {
-        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST");
-        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST", 587).unwrap();
-        assert_eq!(port, 587);
-    }
-
-    #[test]
-    fn optional_port_parses_set_value() {
-        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST2", "465");
-        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST2", 587).unwrap();
-        assert_eq!(port, 465);
-        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST2");
-    }
-
-    #[test]
-    fn optional_port_rejects_invalid_value() {
-        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST3", "notaport");
-        let result = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST3", 587);
-        assert!(result.is_err());
-        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST3");
-    }
-
-    #[test]
     fn debug_output_does_not_expose_password() {
         let auth = EmailAuth::Basic {
-            password: "super-secret-credential-99".to_string(),
+            password: "super-secret-credential-99".to_string(), // gitleaks:allow
         };
         let debug_output = format!("{auth:?}");
         assert!(
@@ -257,7 +312,7 @@ mod tests {
         let auth = EmailAuth::OAuth {
             tenant_id: "fake-tenant".to_string(),
             client_id: "fake-client-id".to_string(),
-            client_secret: "ultra-secret-client-secret-99".to_string(),
+            client_secret: "ultra-secret-client-secret-99".to_string(), // gitleaks:allow
         };
         let debug_output = format!("{auth:?}");
         assert!(
@@ -279,25 +334,88 @@ mod tests {
         );
     }
 
-    // ── build_auth tests ────────────────────────────────────────────────────
+    // ── Finding 2: validate_sasl_string ──────────────────────────────────────
+
+    #[test]
+    fn validate_sasl_string_rejects_control_char_in_mailbox() {
+        // \x01 is the XOAUTH2 SASL delimiter and must be rejected.
+        let err = validate_sasl_string("user\x01@example.com", "mailbox").unwrap_err();
+        assert!(
+            err.to_string().contains("control characters"),
+            "expected control-char rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_sasl_string_rejects_crlf_in_mailbox() {
+        let err = validate_sasl_string("user@example.com\r\n", "mailbox").unwrap_err();
+        assert!(err.to_string().contains("control characters"));
+    }
+
+    #[test]
+    fn validate_sasl_string_rejects_missing_at_sign() {
+        let err = validate_sasl_string("notanemail", "username").unwrap_err();
+        assert!(err.to_string().contains("'@'"));
+    }
+
+    #[test]
+    fn validate_sasl_string_rejects_empty() {
+        let err = validate_sasl_string("", "username").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn validate_sasl_string_accepts_valid_email() {
+        assert!(validate_sasl_string("leo@khive.ai", "username").is_ok());
+    }
+
+    // ── optional_port tests (env-mutating — serialized with ENV_MUTEX) ────────
+
+    #[test]
+    fn optional_port_uses_default_when_absent() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&["KHIVE_EMAIL_SMTP_PORT_TEST_DEFAULT"]);
+        std::env::remove_var("KHIVE_EMAIL_SMTP_PORT_TEST_DEFAULT");
+        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST_DEFAULT", 587).unwrap();
+        assert_eq!(port, 587);
+    }
+
+    #[test]
+    fn optional_port_parses_set_value() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&["KHIVE_EMAIL_SMTP_PORT_TEST2"]);
+        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST2", "465");
+        let port = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST2", 587).unwrap();
+        assert_eq!(port, 465);
+    }
+
+    #[test]
+    fn optional_port_rejects_invalid_value() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&["KHIVE_EMAIL_SMTP_PORT_TEST3"]);
+        std::env::set_var("KHIVE_EMAIL_SMTP_PORT_TEST3", "notaport");
+        let result = optional_port("KHIVE_EMAIL_SMTP_PORT_TEST3", 587);
+        assert!(result.is_err());
+    }
+
+    // ── build_auth tests (env-mutating — serialized with ENV_MUTEX) ───────────
+
+    const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
+    const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
+    const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+    const PW: &str = "KHIVE_EMAIL_PASSWORD";
 
     /// Temporarily set all three OAuth vars and confirm OAuth variant is returned.
     #[test]
     fn build_auth_oauth_all_vars_present() {
-        // Isolate with unique suffix.
-        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
-        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
-        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&[TID, CID, CS]);
 
         std::env::set_var(TID, "fake-tenant");
         std::env::set_var(CID, "fake-client-id");
-        std::env::set_var(CS, "fake-secret");
+        std::env::set_var(CS, "fake-secret"); // gitleaks:allow
 
         let result = build_auth();
-
-        std::env::remove_var(TID);
-        std::env::remove_var(CID);
-        std::env::remove_var(CS);
 
         let auth = result.expect("all three OAuth vars set must succeed");
         assert!(
@@ -309,21 +427,17 @@ mod tests {
     /// Only tenant_id and client_id present (no secret) → clear error.
     #[test]
     fn build_auth_partial_oauth_returns_error() {
-        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
-        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
-        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&[TID, CID, CS, PW]);
 
         std::env::set_var(TID, "fake-tenant");
         std::env::set_var(CID, "fake-client-id");
         std::env::remove_var(CS);
         // Ensure KHIVE_EMAIL_PASSWORD is also absent so we land in the partial
         // branch regardless.
-        std::env::remove_var("KHIVE_EMAIL_PASSWORD");
+        std::env::remove_var(PW);
 
         let result = build_auth();
-
-        std::env::remove_var(TID);
-        std::env::remove_var(CID);
 
         assert!(result.is_err(), "partial OAuth config must return an error");
         let msg = result.unwrap_err().to_string();
@@ -336,10 +450,8 @@ mod tests {
     /// No OAuth vars and KHIVE_EMAIL_PASSWORD set → Basic variant.
     #[test]
     fn build_auth_basic_no_oauth_vars() {
-        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
-        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
-        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
-        const PW: &str = "KHIVE_EMAIL_PASSWORD";
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&[TID, CID, CS, PW]);
 
         std::env::remove_var(TID);
         std::env::remove_var(CID);
@@ -347,8 +459,6 @@ mod tests {
         std::env::set_var(PW, "test-password");
 
         let result = build_auth();
-
-        std::env::remove_var(PW);
 
         let auth = result.expect("no OAuth vars + password must succeed");
         assert!(

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -6,14 +6,63 @@
 use crate::connector::MailAddress;
 use khive_channel::ChannelError;
 
+/// Authentication mode for SMTP and IMAP connections.
+///
+/// Selected at construction time based on the environment variables that are
+/// present:
+/// - If `KHIVE_EMAIL_OAUTH_CLIENT_ID` is set → `OAuth` mode (tenant_id and
+///   client_secret are also required; missing any one of the three is an error).
+/// - Otherwise → `Basic` mode (password is required).
+///
+/// `Debug` output redacts `password` and `client_secret`.
+#[derive(Clone)]
+pub enum EmailAuth {
+    /// Username + password (standard SMTP AUTH PLAIN / IMAP LOGIN).
+    Basic {
+        /// Login password. Never logged or stored beyond this struct.
+        password: String,
+    },
+    /// App-only OAuth2 client-credentials flow for Microsoft Exchange Online.
+    OAuth {
+        /// Azure AD tenant ID.
+        tenant_id: String,
+        /// Application (client) ID registered in Azure AD.
+        client_id: String,
+        /// Client secret. Never logged or stored beyond this struct.
+        client_secret: String,
+    },
+}
+
+impl std::fmt::Debug for EmailAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EmailAuth::Basic { .. } => f
+                .debug_struct("EmailAuth::Basic")
+                .field("password", &"<redacted>")
+                .finish(),
+            EmailAuth::OAuth {
+                tenant_id,
+                client_id,
+                ..
+            } => f
+                .debug_struct("EmailAuth::OAuth")
+                .field("tenant_id", tenant_id)
+                .field("client_id", client_id)
+                .field("client_secret", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
 /// Configuration for the SMTP sender and IMAP fetcher.
 ///
 /// Build via [`EmailChannelConfig::from_env`]. All fields are sourced
 /// exclusively from environment variables; no defaults are provided for
 /// credentials or host names.
 ///
-/// `Debug` output redacts the password field; see the manual `Debug` impl below.
-#[derive(Clone)]
+/// `Debug` output redacts credentials; see the manual `Debug` impl on
+/// [`EmailAuth`].
+#[derive(Clone, Debug)]
 pub struct EmailChannelConfig {
     /// SMTP relay host (e.g. `smtp.example.com`).
     pub smtp_host: String,
@@ -23,49 +72,53 @@ pub struct EmailChannelConfig {
     pub imap_host: String,
     /// IMAP port. Defaults to 993 (TLS) when `KHIVE_EMAIL_IMAP_PORT` is unset.
     pub imap_port: u16,
-    /// Login username for both SMTP and IMAP.
+    /// Login username for SMTP AUTH / IMAP LOGIN (used in `Basic` mode).
     pub username: String,
-    /// Login password for both SMTP and IMAP. Never logged or stored.
-    pub password: String,
+    /// Mailbox address used as the `user=` field in the XOAUTH2 SASL string.
+    ///
+    /// Defaults to `username` when `KHIVE_EMAIL_MAILBOX` is not set.
+    pub mailbox: String,
+    /// Authentication credentials and mode.
+    pub auth: EmailAuth,
     /// The single authorized maintainer address. Inbound messages from any other
     /// sender are rejected before ingestion.
     pub maintainer_address: MailAddress,
 }
 
-impl std::fmt::Debug for EmailChannelConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EmailChannelConfig")
-            .field("smtp_host", &self.smtp_host)
-            .field("smtp_port", &self.smtp_port)
-            .field("imap_host", &self.imap_host)
-            .field("imap_port", &self.imap_port)
-            .field("username", &self.username)
-            .field("password", &"<redacted>")
-            .field("maintainer_address", &self.maintainer_address)
-            .finish()
-    }
-}
-
 impl EmailChannelConfig {
     /// Load configuration from environment variables.
     ///
-    /// Required variables:
+    /// Required variables (always):
     /// - `KHIVE_EMAIL_SMTP_HOST`
     /// - `KHIVE_EMAIL_IMAP_HOST`
     /// - `KHIVE_EMAIL_USERNAME`
-    /// - `KHIVE_EMAIL_PASSWORD`
     /// - `KHIVE_EMAIL_MAINTAINER_ADDRESS`
+    ///
+    /// Auth-mode selection:
+    /// - If `KHIVE_EMAIL_OAUTH_CLIENT_ID` is present → OAuth mode.
+    ///   Also requires `KHIVE_EMAIL_OAUTH_TENANT_ID` and
+    ///   `KHIVE_EMAIL_OAUTH_CLIENT_SECRET`; a clear error is returned when
+    ///   only a subset is set.
+    /// - Otherwise → Basic mode. `KHIVE_EMAIL_PASSWORD` is required.
     ///
     /// Optional variables with defaults:
     /// - `KHIVE_EMAIL_SMTP_PORT` (default `587`)
     /// - `KHIVE_EMAIL_IMAP_PORT` (default `993`)
+    /// - `KHIVE_EMAIL_MAILBOX` (default: same as `KHIVE_EMAIL_USERNAME`)
     pub fn from_env() -> Result<Self, ChannelError> {
         let smtp_host = require_env("KHIVE_EMAIL_SMTP_HOST")?;
         let smtp_port = optional_port("KHIVE_EMAIL_SMTP_PORT", 587)?;
         let imap_host = require_env("KHIVE_EMAIL_IMAP_HOST")?;
         let imap_port = optional_port("KHIVE_EMAIL_IMAP_PORT", 993)?;
         let username = require_env("KHIVE_EMAIL_USERNAME")?;
-        let password = require_env("KHIVE_EMAIL_PASSWORD")?;
+
+        let mailbox = match std::env::var("KHIVE_EMAIL_MAILBOX") {
+            Ok(v) if !v.is_empty() => v,
+            _ => username.clone(),
+        };
+
+        let auth = build_auth()?;
+
         let maintainer_raw = require_env("KHIVE_EMAIL_MAINTAINER_ADDRESS")?;
         let maintainer_address = MailAddress::parse(&maintainer_raw).ok_or_else(|| {
             ChannelError::Config(format!(
@@ -79,9 +132,54 @@ impl EmailChannelConfig {
             imap_host,
             imap_port,
             username,
-            password,
+            mailbox,
+            auth,
             maintainer_address,
         })
+    }
+}
+
+/// Determine the auth mode from environment variables.
+///
+/// If `KHIVE_EMAIL_OAUTH_CLIENT_ID` is set, OAuth mode is selected and all
+/// three OAuth vars are required.  If only one or two are present an error is
+/// returned; partial config is never silently accepted.
+fn build_auth() -> Result<EmailAuth, ChannelError> {
+    let client_id = std::env::var("KHIVE_EMAIL_OAUTH_CLIENT_ID").ok();
+    let tenant_id = std::env::var("KHIVE_EMAIL_OAUTH_TENANT_ID").ok();
+    let client_secret = std::env::var("KHIVE_EMAIL_OAUTH_CLIENT_SECRET").ok();
+
+    match (tenant_id, client_id, client_secret) {
+        // All three OAuth vars present → OAuth mode.
+        (Some(tid), Some(cid), Some(cs)) => Ok(EmailAuth::OAuth {
+            tenant_id: tid,
+            client_id: cid,
+            client_secret: cs,
+        }),
+        // None present → Basic mode.
+        (None, None, None) => {
+            let password = require_env("KHIVE_EMAIL_PASSWORD")?;
+            Ok(EmailAuth::Basic { password })
+        }
+        // Partial OAuth config → clear error.
+        (tid, cid, cs) => {
+            let mut missing = Vec::new();
+            if tid.is_none() {
+                missing.push("KHIVE_EMAIL_OAUTH_TENANT_ID");
+            }
+            if cid.is_none() {
+                missing.push("KHIVE_EMAIL_OAUTH_CLIENT_ID");
+            }
+            if cs.is_none() {
+                missing.push("KHIVE_EMAIL_OAUTH_CLIENT_SECRET");
+            }
+            Err(ChannelError::Config(format!(
+                "partial OAuth configuration: missing {missing:?}; \
+                 set all three of KHIVE_EMAIL_OAUTH_TENANT_ID, \
+                 KHIVE_EMAIL_OAUTH_CLIENT_ID, and KHIVE_EMAIL_OAUTH_CLIENT_SECRET, \
+                 or set none of them to use basic auth"
+            )))
+        }
     }
 }
 
@@ -108,10 +206,7 @@ mod tests {
 
     #[test]
     fn missing_required_env_returns_error() {
-        // Ensure the key is absent (it may not be set in CI; use a unique key).
         std::env::remove_var("KHIVE_EMAIL_SMTP_HOST_TEST_MISSING");
-        // from_env() will fail because KHIVE_EMAIL_SMTP_HOST is absent in a clean env.
-        // We test require_env directly to avoid environment pollution.
         let result = require_env("KHIVE_EMAIL_SMTP_HOST_TEST_MISSING");
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -143,17 +238,10 @@ mod tests {
 
     #[test]
     fn debug_output_does_not_expose_password() {
-        use crate::connector::MailAddress;
-        let config = EmailChannelConfig {
-            smtp_host: "smtp.example.com".to_string(),
-            smtp_port: 587,
-            imap_host: "imap.example.com".to_string(),
-            imap_port: 993,
-            username: "user@example.com".to_string(),
+        let auth = EmailAuth::Basic {
             password: "super-secret-credential-99".to_string(),
-            maintainer_address: MailAddress::parse("user@example.com").unwrap(),
         };
-        let debug_output = format!("{config:?}");
+        let debug_output = format!("{auth:?}");
         assert!(
             !debug_output.contains("super-secret-credential-99"),
             "Debug output must not expose the password; got: {debug_output:?}"
@@ -161,6 +249,111 @@ mod tests {
         assert!(
             debug_output.contains("<redacted>"),
             "Debug output must include the redaction marker; got: {debug_output:?}"
+        );
+    }
+
+    #[test]
+    fn debug_output_does_not_expose_client_secret() {
+        let auth = EmailAuth::OAuth {
+            tenant_id: "fake-tenant".to_string(),
+            client_id: "fake-client-id".to_string(),
+            client_secret: "ultra-secret-client-secret-99".to_string(),
+        };
+        let debug_output = format!("{auth:?}");
+        assert!(
+            !debug_output.contains("ultra-secret-client-secret-99"),
+            "Debug output must not expose the client_secret; got: {debug_output:?}"
+        );
+        assert!(
+            debug_output.contains("<redacted>"),
+            "Debug output must include the redaction marker; got: {debug_output:?}"
+        );
+        // tenant_id and client_id should be visible (not sensitive).
+        assert!(
+            debug_output.contains("fake-tenant"),
+            "tenant_id should be visible in debug; got: {debug_output:?}"
+        );
+        assert!(
+            debug_output.contains("fake-client-id"),
+            "client_id should be visible in debug; got: {debug_output:?}"
+        );
+    }
+
+    // ── build_auth tests ────────────────────────────────────────────────────
+
+    /// Temporarily set all three OAuth vars and confirm OAuth variant is returned.
+    #[test]
+    fn build_auth_oauth_all_vars_present() {
+        // Isolate with unique suffix.
+        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
+        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
+        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+
+        std::env::set_var(TID, "fake-tenant");
+        std::env::set_var(CID, "fake-client-id");
+        std::env::set_var(CS, "fake-secret");
+
+        let result = build_auth();
+
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let auth = result.expect("all three OAuth vars set must succeed");
+        assert!(
+            matches!(auth, EmailAuth::OAuth { .. }),
+            "expected OAuth variant"
+        );
+    }
+
+    /// Only tenant_id and client_id present (no secret) → clear error.
+    #[test]
+    fn build_auth_partial_oauth_returns_error() {
+        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
+        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
+        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+
+        std::env::set_var(TID, "fake-tenant");
+        std::env::set_var(CID, "fake-client-id");
+        std::env::remove_var(CS);
+        // Ensure KHIVE_EMAIL_PASSWORD is also absent so we land in the partial
+        // branch regardless.
+        std::env::remove_var("KHIVE_EMAIL_PASSWORD");
+
+        let result = build_auth();
+
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+
+        assert!(result.is_err(), "partial OAuth config must return an error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("KHIVE_EMAIL_OAUTH_CLIENT_SECRET"),
+            "error should name the missing variable; got: {msg}"
+        );
+    }
+
+    /// No OAuth vars and KHIVE_EMAIL_PASSWORD set → Basic variant.
+    #[test]
+    fn build_auth_basic_no_oauth_vars() {
+        const TID: &str = "KHIVE_EMAIL_OAUTH_TENANT_ID";
+        const CID: &str = "KHIVE_EMAIL_OAUTH_CLIENT_ID";
+        const CS: &str = "KHIVE_EMAIL_OAUTH_CLIENT_SECRET";
+        const PW: &str = "KHIVE_EMAIL_PASSWORD";
+
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+        std::env::set_var(PW, "test-password");
+
+        let result = build_auth();
+
+        std::env::remove_var(PW);
+
+        let auth = result.expect("no OAuth vars + password must succeed");
+        assert!(
+            matches!(auth, EmailAuth::Basic { .. }),
+            "expected Basic variant"
         );
     }
 }

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -16,6 +16,8 @@ use mail_parser::MessageParser;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::instrument;
 
+use crate::oauth::{TokenProvider, XOAuth2Authenticator};
+
 use super::RawEmail;
 
 /// IMAP session type using TLS over a compat-wrapped tokio stream.
@@ -35,15 +37,27 @@ pub(crate) trait ImapConnector: Send + Sync + 'static {
     ) -> Result<Vec<RawEmail>, ChannelError>;
 }
 
+/// IMAP authentication configuration (basic or OAuth2 XOAUTH2).
+enum ImapAuthConfig {
+    /// Standard IMAP LOGIN with username and password.
+    Basic { username: String, password: String },
+    /// IMAP AUTHENTICATE XOAUTH2 with a bearer token fetched from the provider.
+    OAuth {
+        /// Mailbox address used as the `user=` field in the XOAUTH2 SASL string.
+        mailbox: String,
+        token_provider: Arc<TokenProvider>,
+    },
+}
+
 /// Production IMAP connector backed by `async-imap` with native TLS.
 pub(crate) struct LiveImap {
     host: String,
     port: u16,
-    username: String,
-    password: String,
+    auth: ImapAuthConfig,
 }
 
 impl LiveImap {
+    /// Create a connector using basic IMAP LOGIN credentials.
     pub(crate) fn new(
         host: impl Into<String>,
         port: u16,
@@ -53,8 +67,32 @@ impl LiveImap {
         Self {
             host: host.into(),
             port,
-            username: username.into(),
-            password: password.into(),
+            auth: ImapAuthConfig::Basic {
+                username: username.into(),
+                password: password.into(),
+            },
+        }
+    }
+
+    /// Create a connector using XOAUTH2 (Exchange Online app-only flow).
+    ///
+    /// `mailbox` is the address used in the SASL `user=` field.
+    /// async-imap 0.9's `Client::authenticate("XOAUTH2", authenticator)` is used;
+    /// the authenticator's `process()` returns the raw SASL bytes which async-imap
+    /// base64-encodes before sending.
+    pub(crate) fn new_oauth(
+        host: impl Into<String>,
+        port: u16,
+        mailbox: impl Into<String>,
+        token_provider: Arc<TokenProvider>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            auth: ImapAuthConfig::OAuth {
+                mailbox: mailbox.into(),
+                token_provider,
+            },
         }
     }
 
@@ -68,7 +106,7 @@ impl LiveImap {
         .map_err(|_| ChannelError::Transport("IMAP TCP connect timed out (10s)".into()))?
         .map_err(|e| ChannelError::Transport(format!("IMAP TCP connect failed: {e}")))?;
 
-        // Wrap with compat layer so async-native-tls (which uses futures-io) can use the stream.
+        // Wrap with compat layer so async-native-tls (futures-io) can use the stream.
         let tcp_compat = tcp.compat();
 
         // TLS handshake with 15s timeout.
@@ -81,15 +119,41 @@ impl LiveImap {
         .map_err(|_| ChannelError::Auth("IMAP TLS handshake timed out (15s)".into()))?
         .map_err(|e| ChannelError::Auth(format!("IMAP TLS handshake failed: {e}")))?;
 
-        // IMAP login with 15s timeout.
         let client = async_imap::Client::new(tls_stream);
-        let session: ImapSession = tokio::time::timeout(
-            Duration::from_secs(15),
-            client.login(&self.username, &self.password),
-        )
-        .await
-        .map_err(|_| ChannelError::Auth("IMAP login timed out (15s)".into()))?
-        .map_err(|(e, _)| ChannelError::Auth(format!("IMAP login failed: {e}")))?;
+
+        // Authenticate with 15s timeout, dispatching on auth mode.
+        let session: ImapSession = match &self.auth {
+            ImapAuthConfig::Basic { username, password } => {
+                tokio::time::timeout(Duration::from_secs(15), client.login(username, password))
+                    .await
+                    .map_err(|_| ChannelError::Auth("IMAP login timed out (15s)".into()))?
+                    .map_err(|(e, _)| ChannelError::Auth(format!("IMAP login failed: {e}")))?
+            }
+            ImapAuthConfig::OAuth {
+                mailbox,
+                token_provider,
+            } => {
+                // Fetch (or return cached) bearer token before the IMAP handshake.
+                // XOAuth2Authenticator::process returns the raw SASL bytes;
+                // async-imap 0.9 base64-encodes them in do_auth_handshake (client.rs:282).
+                let token = token_provider.get_token().await?;
+                let authenticator = XOAuth2Authenticator {
+                    mailbox: mailbox.clone(),
+                    token,
+                };
+                tokio::time::timeout(
+                    Duration::from_secs(15),
+                    client.authenticate("XOAUTH2", authenticator),
+                )
+                .await
+                .map_err(|_| {
+                    ChannelError::Auth("IMAP XOAUTH2 authenticate timed out (15s)".into())
+                })?
+                .map_err(|(e, _)| {
+                    ChannelError::Auth(format!("IMAP XOAUTH2 authenticate failed: {e}"))
+                })?
+            }
+        };
 
         Ok(session)
     }
@@ -300,10 +364,22 @@ pub struct ImapFetcher {
 }
 
 impl ImapFetcher {
-    /// Create a production fetcher backed by `async-imap`.
+    /// Create a production fetcher using basic IMAP LOGIN credentials.
     pub fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
         Self {
             inner: Arc::new(LiveImap::new(host, port, username, password)),
+        }
+    }
+
+    /// Create a production fetcher using XOAUTH2 (Exchange Online app-only flow).
+    pub fn new_oauth(
+        host: impl Into<String>,
+        port: u16,
+        mailbox: impl Into<String>,
+        token_provider: Arc<TokenProvider>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(LiveImap::new_oauth(host, port, mailbox, token_provider)),
         }
     }
 

--- a/crates/khive-channel-email/src/connector/smtp.rs
+++ b/crates/khive-channel-email/src/connector/smtp.rs
@@ -10,10 +10,12 @@ use async_trait::async_trait;
 use khive_channel::ChannelError;
 use lettre::{
     message::{header::ContentType, Mailbox},
-    transport::smtp::authentication::Credentials,
+    transport::smtp::authentication::{Credentials, Mechanism},
     AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
 };
 use tracing::instrument;
+
+use crate::oauth::TokenProvider;
 
 /// Custom MIME header for khive thread correlation.
 ///
@@ -39,6 +41,18 @@ impl lettre::message::header::Header for XKhiveThreadId {
     }
 }
 
+/// SMTP authentication configuration (basic or OAuth2 XOAUTH2).
+enum SmtpAuthConfig {
+    /// Standard username + password credentials.
+    Basic(Credentials),
+    /// OAuth2 XOAUTH2: fetch a bearer token from the provider at send time.
+    OAuth {
+        /// Mailbox address used as the `user=` field in the XOAUTH2 SASL string.
+        mailbox: String,
+        token_provider: Arc<TokenProvider>,
+    },
+}
+
 /// Internal trait for the SMTP send operation.
 ///
 /// Allows unit tests to swap in a mock without a live SMTP server.
@@ -58,15 +72,40 @@ pub(crate) trait SmtpConnector: Send + Sync + 'static {
 pub(crate) struct LettreSmtp {
     host: String,
     port: u16,
-    creds: Credentials,
+    auth: SmtpAuthConfig,
 }
 
 impl LettreSmtp {
+    /// Create a connector using basic username/password credentials.
     pub(crate) fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
         Self {
             host: host.into(),
             port,
-            creds: Credentials::new(username.to_string(), password.to_string()),
+            auth: SmtpAuthConfig::Basic(Credentials::new(
+                username.to_string(),
+                password.to_string(),
+            )),
+        }
+    }
+
+    /// Create a connector using XOAUTH2 (Microsoft Exchange Online app-only flow).
+    ///
+    /// `mailbox` is the address used in the SASL `user=` field.
+    /// lettre's `Mechanism::Xoauth2` computes `user=<mailbox>\x01auth=Bearer
+    /// <token>\x01\x01` internally from `Credentials::new(mailbox, access_token)`.
+    pub(crate) fn new_oauth(
+        host: impl Into<String>,
+        port: u16,
+        mailbox: impl Into<String>,
+        token_provider: Arc<TokenProvider>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            auth: SmtpAuthConfig::OAuth {
+                mailbox: mailbox.into(),
+                token_provider,
+            },
         }
     }
 }
@@ -103,11 +142,26 @@ impl SmtpConnector for LettreSmtp {
             .body(body.to_string())
             .map_err(|e| ChannelError::InvalidEnvelope(format!("failed to build message: {e}")))?;
 
-        let transport = AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
+        let relay_builder = AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
             .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
-            .credentials(self.creds.clone())
-            .port(self.port)
-            .build();
+            .port(self.port);
+
+        let transport = match &self.auth {
+            SmtpAuthConfig::Basic(creds) => relay_builder.credentials(creds.clone()).build(),
+            SmtpAuthConfig::OAuth {
+                mailbox,
+                token_provider,
+            } => {
+                // Fetch (or return cached) bearer token, then wire it into lettre.
+                // lettre's Mechanism::Xoauth2 builds the SASL string internally from
+                // Credentials::new(mailbox, access_token).
+                let token = token_provider.get_token().await?;
+                relay_builder
+                    .credentials(Credentials::new(mailbox.clone(), token))
+                    .authentication(vec![Mechanism::Xoauth2])
+                    .build()
+            }
+        };
 
         transport
             .send(msg)
@@ -124,10 +178,22 @@ pub struct SmtpSender {
 }
 
 impl SmtpSender {
-    /// Create a production sender backed by lettre.
+    /// Create a production sender using basic username/password auth.
     pub fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
         Self {
             inner: Arc::new(LettreSmtp::new(host, port, username, password)),
+        }
+    }
+
+    /// Create a production sender using XOAUTH2 (Exchange Online app-only flow).
+    pub fn new_oauth(
+        host: impl Into<String>,
+        port: u16,
+        mailbox: impl Into<String>,
+        token_provider: Arc<TokenProvider>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(LettreSmtp::new_oauth(host, port, mailbox, token_provider)),
         }
     }
 

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod channel;
 pub mod config;
 pub mod connector;
+pub(crate) mod oauth;
 
 pub use channel::EmailChannel;
 pub use config::EmailChannelConfig;

--- a/crates/khive-channel-email/src/oauth.rs
+++ b/crates/khive-channel-email/src/oauth.rs
@@ -11,6 +11,53 @@ use base64::Engine as _;
 use khive_channel::ChannelError;
 use tokio::sync::Mutex;
 
+// ──────────────────────────── OAuth error-body sanitization (Finding 1)
+
+/// Allowlisted OAuth 2.0 error codes from RFC 6749 §5.2 and Microsoft AADSTS.
+///
+/// Any code from the token endpoint that is not in this list is replaced with
+/// the opaque indicator `"oauth_error"`.  The raw response body is **never**
+/// interpolated into a returned error — it may contain credential echoes,
+/// HTML, proxy injection text, or CRLF sequences usable for log forging.
+const ALLOWED_OAUTH_ERROR_CODES: &[&str] = &[
+    "access_denied",
+    "consent_required",
+    "interaction_required",
+    "invalid_client",
+    "invalid_grant",
+    "invalid_request",
+    "invalid_scope",
+    "login_required",
+    "server_error",
+    "slow_down",
+    "temporarily_unavailable",
+    "unauthorized_client",
+    "unsupported_grant_type",
+];
+
+/// Extract and allowlist an OAuth error code from a JSON error response body.
+///
+/// Parses the standardized `error` field from the response JSON.  If the field
+/// is present and its value appears in [`ALLOWED_OAUTH_ERROR_CODES`], that
+/// static string slice is returned.  Otherwise `"oauth_error"` is returned as
+/// an opaque, safe indicator.
+///
+/// The raw `body` string is **never** returned or interpolated.
+fn sanitize_oauth_error(body: &str) -> &'static str {
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(code) = val.get("error").and_then(|v| v.as_str()) {
+            if let Some(allowed) = ALLOWED_OAUTH_ERROR_CODES
+                .iter()
+                .copied()
+                .find(|&c| c == code)
+            {
+                return allowed;
+            }
+        }
+    }
+    "oauth_error"
+}
+
 // ──────────────────────────────────────────────────── XOAUTH2 SASL helpers
 
 /// Return the XOAUTH2 SASL payload as a standard base64 string.
@@ -116,6 +163,47 @@ impl TokenProvider {
 struct TokenResponse {
     access_token: String,
     expires_in: u64,
+    /// Providers may omit this field; when present it must equal `"Bearer"`
+    /// (case-insensitive).  Required by `validate_token_response`.
+    #[serde(default)]
+    token_type: Option<String>,
+}
+
+/// Validate a freshly-deserialized token response before caching it.
+///
+/// Fails closed: rejects an empty `access_token`, control characters in the
+/// token string (which would corrupt the XOAUTH2 SASL payload), a zero
+/// `expires_in`, and a `token_type` that is not `"Bearer"` when the field is
+/// present.
+fn validate_token_response(resp: &TokenResponse) -> Result<(), ChannelError> {
+    if resp.access_token.is_empty() {
+        return Err(ChannelError::Auth(
+            "OAuth2 token response: access_token is empty".to_string(),
+        ));
+    }
+    if resp
+        .access_token
+        .chars()
+        .any(|c| matches!(c, '\x00'..='\x1f' | '\x7f'))
+    {
+        return Err(ChannelError::Auth(
+            "OAuth2 token response: access_token contains disallowed control characters"
+                .to_string(),
+        ));
+    }
+    if resp.expires_in == 0 {
+        return Err(ChannelError::Auth(
+            "OAuth2 token response: expires_in must be positive".to_string(),
+        ));
+    }
+    if let Some(ref tt) = resp.token_type {
+        if !tt.eq_ignore_ascii_case("bearer") {
+            return Err(ChannelError::Auth(
+                "OAuth2 token response: token_type is not Bearer".to_string(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Fetch an app-only OAuth2 token from Microsoft's v2 client-credentials endpoint.
@@ -145,16 +233,23 @@ async fn fetch_token(
         .map_err(|e| ChannelError::Auth(format!("OAuth2 token request failed: {e}")))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
+        // Read the body to extract a standardised error code; the raw body is
+        // intentionally discarded — it may contain credential echoes, HTML, or
+        // CRLF sequences usable for log injection.
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
+        let error_code = sanitize_oauth_error(&body);
         return Err(ChannelError::Auth(format!(
-            "OAuth2 token endpoint returned {status}: {body}"
+            "OAuth2 token endpoint returned HTTP {status}: {error_code}"
         )));
     }
 
-    resp.json::<TokenResponse>()
+    let token_resp = resp
+        .json::<TokenResponse>()
         .await
-        .map_err(|e| ChannelError::Auth(format!("OAuth2 token response parse failed: {e}")))
+        .map_err(|e| ChannelError::Auth(format!("OAuth2 token response parse failed: {e}")))?;
+    validate_token_response(&token_resp)?;
+    Ok(token_resp)
 }
 
 // ───────────────────────────────────────────────────────────── tests
@@ -190,7 +285,7 @@ mod tests {
     fn authenticator_process_returns_raw_bytes() {
         let mut auth = XOAuth2Authenticator {
             mailbox: "m@x.io".to_string(),
-            token: "fake-token".to_string(),
+            token: "fake-token".to_string(), // gitleaks:allow
         };
         let raw = auth.process(&[]);
         // Must be the raw (NOT base64) SASL string.
@@ -207,5 +302,142 @@ mod tests {
             raw, decoded,
             "process() bytes must equal decode(xoauth2_sasl())"
         );
+    }
+
+    // ── Finding 1 regression: sanitize_oauth_error must not leak the body ────
+
+    /// A token-endpoint error body containing credential-shaped strings, a CRLF
+    /// sequence, and bearer-looking text must produce a sanitized indicator that
+    /// contains none of those strings.
+    #[test]
+    fn sanitize_oauth_error_does_not_leak_body() {
+        // Craft a body that looks like a real AADSTS error but also embeds strings
+        // that must never appear in an error message returned to callers.
+        let body = concat!(
+            r#"{"error":"invalid_client","error_description":"AADSTS70011\r\n"#,
+            r#"Authorization: Bearer leaked_bearer","access_token":"leaked_token_abc","#,
+            r#""client_secret":"leaked_secret_xyz","token_type":"Bearer"}"#
+        );
+        let code = sanitize_oauth_error(body);
+
+        // The returned code must come from the static allowlist only.
+        assert!(
+            !code.contains("access_token"),
+            "must not contain 'access_token': {code:?}"
+        );
+        assert!(
+            !code.contains("leaked_token_abc"),
+            "must not contain token value: {code:?}"
+        );
+        assert!(
+            !code.contains("client_secret"),
+            "must not contain 'client_secret': {code:?}"
+        );
+        assert!(
+            !code.contains("leaked_secret_xyz"),
+            "must not contain secret value: {code:?}"
+        );
+        assert!(!code.contains("\r\n"), "must not contain CRLF: {code:?}");
+        assert!(
+            !code.contains("leaked_bearer"),
+            "must not contain bearer-shaped text: {code:?}"
+        );
+        // The standardised error code is recognized and returned verbatim.
+        assert_eq!(code, "invalid_client");
+    }
+
+    /// An error code that is not in the allowlist must be replaced with the
+    /// opaque indicator, preventing injection of arbitrary strings.
+    #[test]
+    fn sanitize_oauth_error_rejects_unknown_codes() {
+        let xss_body = r#"{"error":"<script>alert(1)</script>"}"#;
+        assert_eq!(
+            sanitize_oauth_error(xss_body),
+            "oauth_error",
+            "unknown/dangerous error code must fall back to 'oauth_error'"
+        );
+
+        let long_body = format!(r#"{{"error":"{}"}}"#, "x".repeat(512));
+        assert_eq!(
+            sanitize_oauth_error(&long_body),
+            "oauth_error",
+            "overlong error code must fall back to 'oauth_error'"
+        );
+    }
+
+    /// A body that is not valid JSON must produce the opaque indicator.
+    #[test]
+    fn sanitize_oauth_error_handles_non_json_body() {
+        assert_eq!(
+            sanitize_oauth_error("<html>502 Bad Gateway</html>"),
+            "oauth_error"
+        );
+        assert_eq!(sanitize_oauth_error(""), "oauth_error");
+    }
+
+    // ── Finding 2: validate_token_response rejects dangerous token values ────
+
+    /// A token that contains a control character (\x01 is the XOAUTH2 delimiter)
+    /// must be rejected before being cached or used in a SASL payload.
+    #[test]
+    fn validate_token_response_rejects_control_char_in_access_token() {
+        let resp = TokenResponse {
+            access_token: "valid_prefix\x01injected".to_string(),
+            expires_in: 3600,
+            token_type: Some("Bearer".to_string()),
+        };
+        let err = validate_token_response(&resp).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("control characters"),
+            "error must mention control characters: {msg}"
+        );
+    }
+
+    /// An empty access_token must be rejected.
+    #[test]
+    fn validate_token_response_rejects_empty_access_token() {
+        let resp = TokenResponse {
+            access_token: String::new(),
+            expires_in: 3600,
+            token_type: None,
+        };
+        let err = validate_token_response(&resp).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    /// expires_in == 0 must be rejected.
+    #[test]
+    fn validate_token_response_rejects_zero_expires_in() {
+        let resp = TokenResponse {
+            access_token: "valid_token_abc".to_string(), // gitleaks:allow
+            expires_in: 0,
+            token_type: None,
+        };
+        let err = validate_token_response(&resp).unwrap_err();
+        assert!(err.to_string().contains("positive"));
+    }
+
+    /// A non-Bearer token_type must be rejected when the field is present.
+    #[test]
+    fn validate_token_response_rejects_non_bearer_token_type() {
+        let resp = TokenResponse {
+            access_token: "valid_token_abc".to_string(), // gitleaks:allow
+            expires_in: 3600,
+            token_type: Some("mac".to_string()),
+        };
+        let err = validate_token_response(&resp).unwrap_err();
+        assert!(err.to_string().contains("Bearer"));
+    }
+
+    /// A well-formed response (Bearer, positive expires_in, clean token) must pass.
+    #[test]
+    fn validate_token_response_accepts_valid_response() {
+        let resp = TokenResponse {
+            access_token: "eyJhbGciOiJSUzI1NiJ9.payload.sig".to_string(),
+            expires_in: 3600,
+            token_type: Some("Bearer".to_string()),
+        };
+        assert!(validate_token_response(&resp).is_ok());
     }
 }

--- a/crates/khive-channel-email/src/oauth.rs
+++ b/crates/khive-channel-email/src/oauth.rs
@@ -1,0 +1,211 @@
+//! OAuth2 client-credentials token provider and XOAUTH2 SASL helper.
+//!
+//! Used by the SMTP and IMAP connectors when `KHIVE_EMAIL_OAUTH_CLIENT_ID` is
+//! set. The token endpoint is Microsoft's app-only flow:
+//! `POST https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token`.
+
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use base64::Engine as _;
+use khive_channel::ChannelError;
+use tokio::sync::Mutex;
+
+// ──────────────────────────────────────────────────── XOAUTH2 SASL helpers
+
+/// Return the XOAUTH2 SASL payload as a standard base64 string.
+///
+/// The raw SASL bytes are:
+/// ```text
+/// user=<mailbox>\x01auth=Bearer <token>\x01\x01
+/// ```
+/// which are base64-encoded before being sent on the wire.
+///
+/// For SMTP, `lettre`'s `Mechanism::Xoauth2` constructs the same raw bytes
+/// internally via `Credentials::new(mailbox, access_token)`.
+///
+/// For IMAP, `XOAuth2Authenticator::process` returns the **raw** bytes;
+/// async-imap 0.9 base64-encodes them before sending (see `do_auth_handshake`
+/// in async-imap client.rs:282).  Both paths are therefore wire-equivalent.
+///
+/// This helper is a reference implementation used in tests to verify the
+/// wire encoding.  Production code uses lettre and async-imap directly.
+#[cfg(test)]
+pub(crate) fn xoauth2_sasl(mailbox: &str, token: &str) -> String {
+    let raw = format!("user={mailbox}\x01auth=Bearer {token}\x01\x01");
+    base64::engine::general_purpose::STANDARD.encode(raw.as_bytes())
+}
+
+/// IMAP `Authenticator` implementation for XOAUTH2.
+///
+/// `process` is called by async-imap with the decoded server challenge.
+/// It returns the **raw** SASL bytes; the framework base64-encodes them before
+/// sending (async-imap 0.9 `do_auth_handshake`, client.rs:282).
+pub(crate) struct XOAuth2Authenticator {
+    pub(crate) mailbox: String,
+    pub(crate) token: String,
+}
+
+impl async_imap::Authenticator for XOAuth2Authenticator {
+    type Response = Vec<u8>;
+
+    fn process(&mut self, _challenge: &[u8]) -> Vec<u8> {
+        format!(
+            "user={}\x01auth=Bearer {}\x01\x01",
+            self.mailbox, self.token
+        )
+        .into_bytes()
+    }
+}
+
+// ─────────────────────────────────────────────────── token provider cache
+
+/// A cached OAuth2 access token together with its expiry deadline.
+struct CachedToken {
+    access_token: String,
+    /// Earliest `Instant` at which a refresh should be attempted (60 s before
+    /// the server-reported `expires_in`).
+    expires_at: Instant,
+}
+
+/// Thread-safe OAuth2 token provider with a 60-second early-refresh margin.
+///
+/// Both the SMTP and IMAP connectors hold an `Arc<TokenProvider>` so a single
+/// fetch serves both connections.  A `tokio::sync::Mutex` serialises token
+/// refreshes; the cache-hit path acquires the lock, reads, and releases.
+pub struct TokenProvider {
+    tenant_id: String,
+    client_id: String,
+    client_secret: String,
+    cached: Mutex<Option<CachedToken>>,
+}
+
+impl TokenProvider {
+    /// Create a new provider. No network call is made until `get_token`.
+    pub fn new(tenant_id: String, client_id: String, client_secret: String) -> Self {
+        Self {
+            tenant_id,
+            client_id,
+            client_secret,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Return a valid access token, fetching a new one when the cached token
+    /// has less than 60 seconds of life remaining.
+    pub async fn get_token(&self) -> Result<String, ChannelError> {
+        let mut guard = self.cached.lock().await;
+        if let Some(ref cached) = *guard {
+            if cached.expires_at > Instant::now() {
+                return Ok(cached.access_token.clone());
+            }
+        }
+        let resp = fetch_token(&self.tenant_id, &self.client_id, &self.client_secret).await?;
+        let expires_at = Instant::now() + Duration::from_secs(resp.expires_in.saturating_sub(60));
+        *guard = Some(CachedToken {
+            access_token: resp.access_token.clone(),
+            expires_at,
+        });
+        Ok(resp.access_token)
+    }
+}
+
+// ──────────────────────────────────────── Microsoft token endpoint request
+
+#[derive(serde::Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+/// Fetch an app-only OAuth2 token from Microsoft's v2 client-credentials endpoint.
+///
+/// Scope is fixed to `https://outlook.office365.com/.default` for Exchange Online.
+/// This function performs a live HTTP request and must not be called from unit
+/// tests without a network mock.  Test the pure helpers (`xoauth2_sasl`,
+/// `XOAuth2Authenticator::process`) instead.
+async fn fetch_token(
+    tenant_id: &str,
+    client_id: &str,
+    client_secret: &str,
+) -> Result<TokenResponse, ChannelError> {
+    let url = format!("https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token");
+    let params = [
+        ("grant_type", "client_credentials"),
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+        ("scope", "https://outlook.office365.com/.default"),
+    ];
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| ChannelError::Auth(format!("OAuth2 token request failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ChannelError::Auth(format!(
+            "OAuth2 token endpoint returned {status}: {body}"
+        )));
+    }
+
+    resp.json::<TokenResponse>()
+        .await
+        .map_err(|e| ChannelError::Auth(format!("OAuth2 token response parse failed: {e}")))
+}
+
+// ───────────────────────────────────────────────────────────── tests
+
+#[cfg(test)]
+mod tests {
+    use async_imap::Authenticator as _;
+
+    use super::*;
+
+    /// Verify `xoauth2_sasl` against a manually computed base64 test vector.
+    ///
+    /// raw = b"user=u@h\x01auth=Bearer t\x01\x01" (24 bytes, no padding)
+    ///
+    /// Groups of 3 → base64 chars (A=0 .. Z=25, a=26 .. z=51, 0=52 .. 9=61):
+    ///   [75 73 65] → dXNl   [72 3d 75] → cj11   [40 68 01] → QGgB
+    ///   [61 75 74] → YXV0   [68 3d 42] → aD1C   [65 61 72] → ZWFy
+    ///   [65 72 20] → ZXIg   [74 01 01] → dAEB
+    /// Result: "dXNlcj11QGgBYXV0aD1CZWFyZXIgdAEB"
+    #[test]
+    fn xoauth2_sasl_known_vector() {
+        let got = xoauth2_sasl("u@h", "t");
+        assert_eq!(got, "dXNlcj11QGgBYXV0aD1CZWFyZXIgdAEB");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&got)
+            .expect("must be valid base64");
+        assert_eq!(decoded, b"user=u@h\x01auth=Bearer t\x01\x01" as &[u8]);
+    }
+
+    /// Verify that `XOAuth2Authenticator::process` returns the unencoded SASL
+    /// bytes that async-imap will then base64-encode.
+    #[test]
+    fn authenticator_process_returns_raw_bytes() {
+        let mut auth = XOAuth2Authenticator {
+            mailbox: "m@x.io".to_string(),
+            token: "fake-token".to_string(),
+        };
+        let raw = auth.process(&[]);
+        // Must be the raw (NOT base64) SASL string.
+        assert_eq!(
+            raw,
+            b"user=m@x.io\x01auth=Bearer fake-token\x01\x01" as &[u8]
+        );
+        // The raw bytes are exactly the base64-decode of what xoauth2_sasl returns.
+        let b64 = xoauth2_sasl("m@x.io", "fake-token");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+        assert_eq!(
+            raw, decoded,
+            "process() bytes must equal decode(xoauth2_sasl())"
+        );
+    }
+}

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -50,6 +50,8 @@ lattice-embed = { workspace = true }
 [features]
 # Pass-through: enables the deterministic hash embedder in the serve path (bench use only).
 bench-embedder = ["khive-mcp/bench-embedder"]
+# Pass-through: enables the SMTP/IMAP email polling loop. Inert without KHIVE_EMAIL_* env vars.
+channel-email = ["khive-mcp/channel-email"]
 
 [[bin]]
 name = "kkernel"


### PR DESCRIPTION
## What

Adds the app-only **OAuth2 client-credentials → XOAUTH2** authentication path to `khive-channel-email`. Purely additive: basic username/password keeps working for non-Microsoft mailboxes; OAuth is selected only when the OAuth env vars are present.

**Why:** Microsoft Exchange Online disabled basic auth. A mailbox hosted there must authenticate SMTP/IMAP with an app-only bearer token via XOAUTH2. The basic-auth adapter shipped in #314 cannot reach such a mailbox.

## How

- **`config.rs`** — `EmailAuth` enum `{ Basic { password }, OAuth { tenant_id, client_id, client_secret } }`. Selected by presence of `KHIVE_EMAIL_OAUTH_CLIENT_ID`; if only some OAuth vars are set it is a named error, never a silent half-config. `client_secret` redacted in the manual `Debug` impl (same as `password`).
- **`oauth.rs`** (new) — `TokenProvider` caches the bearer token behind a `tokio::sync::Mutex` and refetches 60s before expiry (client-credentials has no refresh token). One shared XOAUTH2 SASL builder so SMTP and IMAP emit identical bytes. `reqwest` (rustls) for the token POST to `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`, scope `https://outlook.office365.com/.default`.
- **`smtp.rs`** — OAuth branch: `Credentials::new(mailbox, token)` + `Mechanism::Xoauth2` (lettre native).
- **`imap.rs`** — OAuth branch: `client.authenticate("XOAUTH2", authenticator)` (async-imap `Authenticator`; `process` returns raw SASL bytes, the framework base64-encodes). 15s timeout retained.
- **`channel.rs`** — builds one `Arc<TokenProvider>` shared to both connectors.

## Config (env-var only, read at runtime — no IDs or secrets in source)

`KHIVE_EMAIL_OAUTH_TENANT_ID`, `KHIVE_EMAIL_OAUTH_CLIENT_ID`, `KHIVE_EMAIL_OAUTH_CLIENT_SECRET`, `KHIVE_EMAIL_MAILBOX` (falls back to `KHIVE_EMAIL_USERNAME`).

## Tests

`cargo test -p khive-channel-email` — 38 pass. Covers: XOAUTH2 SASL base64 against a hand-computed vector; OAuth-vars-present → OAuth variant; partial OAuth → clear error; no OAuth + password → Basic; Debug redacts `client_secret`. No live network in any test (token fetch is seamed).

## Gates

fmt / check / clippy `-D warnings` / test / `check -p khive-mcp --features channel-email` / `check --workspace` — all exit 0.

## Notes

- Deps added: `reqwest` (rustls, no openssl), `base64` — both already in the workspace lock (no Cargo.lock churn).
- ADR-056 §14.1 amendment lands in a separate docs PR.
- Closes the code half of #364.