### PR TITLE
docs(gate): remove cloud-tier references from public Gate trait doc

### DIFF
--- a/crates/khive-gate/src/gate.rs
+++ b/crates/khive-gate/src/gate.rs
@@ -9,15 +9,16 @@ use crate::{GateDecision, GateError, GateRequest};
 /// Implementations live downstream:
 /// - `AllowAllGate` (this crate) — permissive default
 /// - `RegoGate` (Apache-2.0 sibling crate `khive-gate-rego`) — regorus-backed Rego eval
-/// - `LionGate<G>` (khive-cloud, BUSL) — wraps any `Gate` with lion-core
-///   capability witnesses for verifiable enforcement.
+///
+/// Downstream crates may provide additional implementations, including wrappers
+/// that compose another `Gate` to add stronger enforcement guarantees.
 pub trait Gate: Send + Sync + std::fmt::Debug {
     /// Evaluates the authorization policy for `req` and returns a decision.
     fn check(&self, req: &GateRequest) -> Result<GateDecision, GateError>;
 
     /// Short name of this backend — surfaced in audit events so downstream
-    /// tooling can tell `RegoGate` results apart from `LionGate<RegoGate>`
-    /// results without parsing the type.
+    /// tooling can tell results from different gate implementations apart
+    /// (including a wrapper from the gate it wraps) without parsing the type.
     ///
     /// Defaults to `std::any::type_name::<Self>()`.
     fn impl_name(&self) -> &'static str {


### PR DESCRIPTION
## What

The public `Gate` trait doc comment (`crates/khive-gate/src/gate.rs`) named `LionGate`, khive-cloud, BUSL, and lion-core capability witnesses. Those are downstream/proprietary-tier details that should not appear in the public OSS crate.

## Change

- Drop the `LionGate<G>` bullet and the `LionGate<RegoGate>` example.
- Replace with neutral language: downstream crates may provide additional implementations, including wrappers that compose another `Gate` for stronger enforcement.
- Keep the OSS-available `AllowAllGate` and `RegoGate` references unchanged.

Doc-comment only; no code behavior change.

## Verification

- `cargo fmt -p khive-gate -- --check` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-gate` builds clean
- Repo-wide scan for `liongate|lion-core|khive-cloud|BUSL|capability witness` now returns zero hits in `crates/` and `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)