### PR TITLE
feat(brain): build_context_vector reads live posteriors (#352)

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -996,33 +996,13 @@ impl BrainPack {
                 sync_balanced_recall_record(&mut state);
             }
 
-            // Ensure the serving profile has a section posterior entry.  The
-            // default `balanced-recall-v1` profile is never pre-inserted by
-            // `handle_create_profile`, so the first feedback event must seed it
-            // here using `SectionPosteriorState::new()` — which initialises from
-            // the full `default_priors()` map, not static 0.5 values.
-            // For an existing but incomplete entry (snapshot produced before a new
-            // SectionType variant was added) backfill missing slots from
-            // `default_priors()` so that `apply_signal` and the router-context
-            // snapshot both see a complete, prior-anchored posterior map.
+            // Seed and backfill section posteriors, then apply the signal.
+            // Shared contract with the replay path — see `ensure_section_state_seeded`.
             {
-                let section_state = state
-                    .section_states
-                    .entry(serving_profile_owned.clone())
-                    .or_default();
-                let defaults = SectionPosteriorState::default_priors();
-                for st in SectionType::all() {
-                    if let Some(prior) = defaults.get(st) {
-                        section_state
-                            .posteriors
-                            .entry(*st)
-                            .or_insert_with(|| prior.clone());
-                        section_state
-                            .priors
-                            .entry(*st)
-                            .or_insert_with(|| prior.clone());
-                    }
-                }
+                let section_state = crate::ensure_section_state_seeded(
+                    &mut state.section_states,
+                    &serving_profile_owned,
+                );
                 section_state.apply_signal(&signal);
             }
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -18,6 +18,8 @@ use khive_types::HandlerDef;
 use crate::event::interpret;
 use crate::{sync_balanced_recall_record, BrainPack, ENTITY_CACHE_CAPACITY};
 use khive_brain_core::derive_deterministic_weights;
+#[cfg(feature = "lattice-router")]
+use khive_brain_core::BetaPosterior;
 use khive_brain_core::{
     ProfileBinding, ProfileLifecycle, ProfileRecord, SectionPosteriorState, SectionType,
     DEFAULT_ESS_CAP,
@@ -955,14 +957,22 @@ impl BrainPack {
             .unwrap_or("balanced-recall-v1")
             .to_string();
 
+        // Posteriors snapshotted while the lock is held; routing runs after the lock drops
+        // so the mutex scope is not widened across fann inference.
+        // Declared uninitialized: definitely assigned inside the lock scope below (in
+        // the feature-on build the cfg block always executes, so the compiler can verify
+        // definite initialization without a dead initial-value assignment).
+        #[cfg(feature = "lattice-router")]
+        #[allow(clippy::type_complexity)]
+        let router_inputs: Option<(
+            BetaPosterior,
+            BetaPosterior,
+            BetaPosterior,
+            Option<std::collections::HashMap<SectionType, BetaPosterior>>,
+        )>;
+
         {
             let signal = interpret(&event);
-            #[cfg(feature = "lattice-router")]
-            {
-                let context = build_context_vector();
-                let routed = route_via_fann(&context);
-                eprintln!("[brain] lattice-router routed weights: {routed:?}");
-            }
             let mut state = self.state.lock().unwrap();
             let serving_profile = serving_profile_owned.as_str();
 
@@ -989,6 +999,46 @@ impl BrainPack {
             if let Some(section_state) = state.section_states.get_mut(serving_profile) {
                 section_state.apply_signal(&signal);
             }
+
+            // Snapshot posteriors for lattice-router while the lock is still held.
+            // BetaPosterior is two f64s — cloning is cheap.
+            #[cfg(feature = "lattice-router")]
+            {
+                let (rel, sal, temp) = if serving_profile == "balanced-recall-v1" {
+                    (
+                        state.balanced_recall.relevance.clone(),
+                        state.balanced_recall.salience.clone(),
+                        state.balanced_recall.temporal.clone(),
+                    )
+                } else if let Some(ps) = state.profile_states.get(serving_profile) {
+                    (
+                        ps.relevance.clone(),
+                        ps.salience.clone(),
+                        ps.temporal.clone(),
+                    )
+                } else {
+                    (
+                        state.balanced_recall.relevance.clone(),
+                        state.balanced_recall.salience.clone(),
+                        state.balanced_recall.temporal.clone(),
+                    )
+                };
+                let sec = state
+                    .section_states
+                    .get(serving_profile)
+                    .map(|ss| ss.posteriors.clone());
+                router_inputs = Some((rel, sal, temp, sec));
+            }
+        }
+
+        // lattice-router: build the context vector from snapshotted posteriors and forward
+        // through the fann network. Lock is already released here.
+        // Consumption of routed weights lands with the engine route() seam (#343) and the
+        // compose value-gate (#346); no per-event stdout/stderr spam.
+        #[cfg(feature = "lattice-router")]
+        if let Some((rel, sal, temp, sec)) = router_inputs {
+            let ctx = build_context_vector(&rel, &sal, &temp, sec.as_ref());
+            let _routed = route_via_fann(&ctx);
         }
 
         // Persist feedback to brain_event_log; batch-upsert snapshot when dirty threshold reached.
@@ -1456,18 +1506,53 @@ impl BrainPack {
     }
 }
 
-// ── lattice-router seam (#345 M1) ────────────────────────────────────────────
+// ── lattice-router seam (#345 M1 / #352 M2) ──────────────────────────────────
 
-/// Context-vector dimension for the lattice-fann router seam (#345 M1).
-/// DIM = BalancedRecallState (3 posteriors x {mean, ess} = 6)
-///     + SectionPosteriorState (10 posterior means = 10) = 16.
-/// M1 placeholder: returns a fixed zero vector; real feature extraction is M2.
+/// Context-vector dimension for the lattice-fann router seam.
+/// Layout:
+///   [0..2]  = relevance  {mean, ess}
+///   [2..4]  = salience   {mean, ess}
+///   [4..6]  = temporal   {mean, ess}
+///   [6..16] = 10 section posterior means in `SectionType::all()` order
 #[cfg(feature = "lattice-router")]
 const ROUTER_CONTEXT_DIM: usize = 16;
 
+/// Build a 16-element context vector from live brain posteriors.
+///
+/// ESS values are stored as raw f32 casts.  Normalization is deferred to the
+/// engine `route()` seam (#343) once the network is trained; documenting the
+/// omission here so it is not forgotten.
+///
+/// When `sections` is `None` the 10 section slots are filled from
+/// `SectionPosteriorState::default_priors()` means — deterministically neutral,
+/// never arbitrary zeros.
 #[cfg(feature = "lattice-router")]
-fn build_context_vector() -> [f32; ROUTER_CONTEXT_DIM] {
-    [0.0; ROUTER_CONTEXT_DIM]
+fn build_context_vector(
+    relevance: &BetaPosterior,
+    salience: &BetaPosterior,
+    temporal: &BetaPosterior,
+    sections: Option<&std::collections::HashMap<SectionType, BetaPosterior>>,
+) -> [f32; ROUTER_CONTEXT_DIM] {
+    let mut v = [0.0f32; ROUTER_CONTEXT_DIM];
+    v[0] = relevance.mean() as f32;
+    v[1] = relevance.effective_sample_size() as f32;
+    v[2] = salience.mean() as f32;
+    v[3] = salience.effective_sample_size() as f32;
+    v[4] = temporal.mean() as f32;
+    v[5] = temporal.effective_sample_size() as f32;
+    // Section slots: deterministic ordering via SectionType::all().
+    let default_priors;
+    let posteriors: &std::collections::HashMap<SectionType, BetaPosterior> = match sections {
+        Some(map) => map,
+        None => {
+            default_priors = SectionPosteriorState::default_priors();
+            &default_priors
+        }
+    };
+    for (i, st) in SectionType::all().iter().enumerate() {
+        v[6 + i] = posteriors.get(st).map_or(0.5, |p| p.mean()) as f32;
+    }
+    v
 }
 
 /// M1 seam: links lattice-fann and produces routed mixture weights.
@@ -1656,7 +1741,10 @@ mod router_tests {
 
     #[test]
     fn route_via_fann_emits_normalized_mixture() {
-        let ctx = build_context_vector();
+        let rel = BetaPosterior::new(7.0, 3.0);
+        let sal = BetaPosterior::new(2.0, 8.0);
+        let temp = BetaPosterior::new(1.0, 9.0);
+        let ctx = build_context_vector(&rel, &sal, &temp, None);
         let weights = route_via_fann(&ctx);
         assert_eq!(weights.len(), 4);
         let sum: f32 = weights.iter().sum();
@@ -1664,5 +1752,61 @@ mod router_tests {
             (sum - 1.0).abs() < 1e-3,
             "softmax weights must sum to ~1, got {sum}"
         );
+    }
+
+    #[test]
+    fn context_vector_reflects_posterior_state() {
+        // High-relevance state.
+        let rel_high = BetaPosterior::new(90.0, 10.0);
+        let sal = BetaPosterior::new(2.0, 8.0);
+        let temp = BetaPosterior::new(1.0, 9.0);
+        let v_high = build_context_vector(&rel_high, &sal, &temp, None);
+
+        // Low-relevance state.
+        let rel_low = BetaPosterior::new(1.0, 9.0);
+        let v_low = build_context_vector(&rel_low, &sal, &temp, None);
+
+        // Vectors must differ.
+        assert_ne!(
+            v_high, v_low,
+            "context vectors must differ for different posteriors"
+        );
+
+        // Dimension must be 16.
+        assert_eq!(v_high.len(), ROUTER_CONTEXT_DIM);
+        assert_eq!(v_low.len(), ROUTER_CONTEXT_DIM);
+
+        // Slot 0 = relevance mean; slot 1 = relevance ESS — verify they mirror the input.
+        assert!(
+            (v_high[0] - rel_high.mean() as f32).abs() < 1e-5,
+            "slot 0 must equal relevance mean (high); got {}",
+            v_high[0]
+        );
+        assert!(
+            (v_high[1] - rel_high.effective_sample_size() as f32).abs() < 1e-5,
+            "slot 1 must equal relevance ESS; got {}",
+            v_high[1]
+        );
+        assert!(
+            (v_low[0] - rel_low.mean() as f32).abs() < 1e-5,
+            "slot 0 must equal relevance mean (low); got {}",
+            v_low[0]
+        );
+
+        // Slot 0 must differ substantially between high and low states.
+        assert!(
+            (v_high[0] - v_low[0]).abs() > 0.5,
+            "relevance mean slot must differ by >0.5; high={} low={}",
+            v_high[0],
+            v_low[0]
+        );
+
+        // Section slots [6..16] filled from default priors when sections=None — never zero.
+        for (i, &val) in v_high.iter().enumerate().skip(6) {
+            assert!(
+                val > 0.0,
+                "section slot {i} must be non-zero (default priors); got {val}",
+            );
+        }
     }
 }

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -996,7 +996,33 @@ impl BrainPack {
                 sync_balanced_recall_record(&mut state);
             }
 
-            if let Some(section_state) = state.section_states.get_mut(serving_profile) {
+            // Ensure the serving profile has a section posterior entry.  The
+            // default `balanced-recall-v1` profile is never pre-inserted by
+            // `handle_create_profile`, so the first feedback event must seed it
+            // here using `SectionPosteriorState::new()` — which initialises from
+            // the full `default_priors()` map, not static 0.5 values.
+            // For an existing but incomplete entry (snapshot produced before a new
+            // SectionType variant was added) backfill missing slots from
+            // `default_priors()` so that `apply_signal` and the router-context
+            // snapshot both see a complete, prior-anchored posterior map.
+            {
+                let section_state = state
+                    .section_states
+                    .entry(serving_profile_owned.clone())
+                    .or_default();
+                let defaults = SectionPosteriorState::default_priors();
+                for st in SectionType::all() {
+                    if let Some(prior) = defaults.get(st) {
+                        section_state
+                            .posteriors
+                            .entry(*st)
+                            .or_insert_with(|| prior.clone());
+                        section_state
+                            .priors
+                            .entry(*st)
+                            .or_insert_with(|| prior.clone());
+                    }
+                }
                 section_state.apply_signal(&signal);
             }
 
@@ -1541,16 +1567,18 @@ fn build_context_vector(
     v[4] = temporal.mean() as f32;
     v[5] = temporal.effective_sample_size() as f32;
     // Section slots: deterministic ordering via SectionType::all().
-    let default_priors;
-    let posteriors: &std::collections::HashMap<SectionType, BetaPosterior> = match sections {
-        Some(map) => map,
-        None => {
-            default_priors = SectionPosteriorState::default_priors();
-            &default_priors
-        }
-    };
+    // Pre-compute default priors unconditionally so that slots absent from a
+    // caller-supplied partial map fall back to the configured prior mean, not
+    // an arbitrary 0.5 that would disagree with the seeded posteriors.
+    let default_priors = SectionPosteriorState::default_priors();
+    let posteriors: &std::collections::HashMap<SectionType, BetaPosterior> =
+        sections.unwrap_or(&default_priors);
     for (i, st) in SectionType::all().iter().enumerate() {
-        v[6 + i] = posteriors.get(st).map_or(0.5, |p| p.mean()) as f32;
+        let mean = posteriors
+            .get(st)
+            .or_else(|| default_priors.get(st))
+            .map_or(0.5, |p| p.mean());
+        v[6 + i] = mean as f32;
     }
     v
 }
@@ -1808,5 +1836,45 @@ mod router_tests {
                 "section slot {i} must be non-zero (default priors); got {val}",
             );
         }
+    }
+
+    /// Regression gate: a `Some(map)` that omits one SectionType must fill the
+    /// missing slot from the default prior mean, never from the bare value 0.5.
+    ///
+    /// Formalism has `BetaPosterior(1.5, 4.0)` → mean ≈ 0.273, which differs
+    /// from 0.5 by more than 0.1 and is easy to distinguish.
+    #[test]
+    fn build_context_vector_uses_prior_mean_for_missing_section_slot() {
+        // Build a partial posteriors map that intentionally omits Formalism.
+        let mut partial = SectionPosteriorState::default_priors();
+        partial.remove(&SectionType::Formalism);
+        assert!(
+            !partial.contains_key(&SectionType::Formalism),
+            "Formalism must be absent from the test map before calling the helper"
+        );
+
+        let neutral = BetaPosterior::new(2.0, 2.0);
+        let v = build_context_vector(&neutral, &neutral, &neutral, Some(&partial));
+
+        let formalism_idx = SectionType::all()
+            .iter()
+            .position(|st| *st == SectionType::Formalism)
+            .expect("Formalism must be in SectionType::all()");
+        let slot_val = v[6 + formalism_idx];
+
+        let prior_mean = SectionPosteriorState::default_priors()
+            .get(&SectionType::Formalism)
+            .expect("default_priors must include Formalism")
+            .mean() as f32;
+
+        assert!(
+            (slot_val - prior_mean).abs() < 1e-5,
+            "missing Formalism slot must use prior mean ({prior_mean:.4}), not bare 0.5; \
+             got {slot_val:.4}"
+        );
+        assert!(
+            (slot_val - 0.5_f32).abs() > 0.1,
+            "slot must NOT fall back to the bare 0.5 value; got {slot_val:.4}"
+        );
     }
 }

--- a/crates/khive-pack-brain/src/lib.rs
+++ b/crates/khive-pack-brain/src/lib.rs
@@ -11,6 +11,40 @@ mod pack;
 pub(crate) use pack::sync_balanced_recall_record;
 pub use pack::{BrainPack, ENTITY_CACHE_CAPACITY};
 
+use std::collections::HashMap;
+
+use khive_brain_core::{SectionPosteriorState, SectionType};
+
+/// Ensure `profile_id` has a fully-seeded `SectionPosteriorState` in `section_states`.
+///
+/// Gets-or-inserts the profile entry via `entry(..).or_default()`, then backfills any
+/// missing `posteriors`/`priors` slots from `SectionPosteriorState::default_priors()`
+/// across all `SectionType::all()` variants.
+///
+/// Used by both the live `brain.feedback` handler and the persisted event-replay path
+/// so that section signals are applied identically regardless of whether the loaded
+/// snapshot predates section_states or a new `SectionType` variant was added after it.
+pub(crate) fn ensure_section_state_seeded<'a>(
+    section_states: &'a mut HashMap<String, SectionPosteriorState>,
+    profile_id: &str,
+) -> &'a mut SectionPosteriorState {
+    let section_state = section_states.entry(profile_id.to_owned()).or_default();
+    let defaults = SectionPosteriorState::default_priors();
+    for st in SectionType::all() {
+        if let Some(prior) = defaults.get(st) {
+            section_state
+                .posteriors
+                .entry(*st)
+                .or_insert_with(|| prior.clone());
+            section_state
+                .priors
+                .entry(*st)
+                .or_insert_with(|| prior.clone());
+        }
+    }
+    section_state
+}
+
 /// Validate a `section_signals` JSON value before any state mutation.
 ///
 /// Enforces the section fold contract (ADR-048): keys must be known `SectionType`

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -489,7 +489,9 @@ pub async fn ensure_loaded(
                     .and_then(|v| v.as_str())
                     .unwrap_or("balanced-recall-v1");
 
-                if let Some(section_state) = bs.section_states.get_mut(serving_profile) {
+                {
+                    let section_state =
+                        crate::ensure_section_state_seeded(&mut bs.section_states, serving_profile);
                     section_state.apply_signal(&signal);
                 }
             }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4049,3 +4049,166 @@ async fn register_adapter_reject_mismatching_revision() {
         "#354: rejected registration must not persist an artifact entity"
     );
 }
+
+// ── Router section-state regression tests (require lattice-router feature) ───
+//
+// These tests lock down the live handler path: section_signals sent to a
+// serving profile must seed a section posterior entry on first contact and
+// push the relevant posterior mean away from the default prior.  Without the
+// entry-seeding fix, `balanced-recall-v1` silently dropped section_signals
+// because it had no `section_states` entry, leaving the router context vector
+// frozen at static priors.
+
+#[cfg(feature = "lattice-router")]
+mod router_section_tests {
+    use super::*;
+    use khive_brain_core::{SectionPosteriorState, SectionType};
+
+    #[tokio::test]
+    async fn feedback_section_signals_seeds_balanced_recall_section_state() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        // Before any feedback: `balanced-recall-v1` must NOT have a section_states
+        // entry — that is the precondition the fix corrects.
+        {
+            let state = pack.state.lock().unwrap();
+            assert!(
+                !state.section_states.contains_key("balanced-recall-v1"),
+                "section_states must not contain balanced-recall-v1 before first feedback"
+            );
+        }
+
+        // Fire feedback with section_signals; no `served_by_profile_id` defaults
+        // to `balanced-recall-v1`.
+        pack.dispatch(
+            "brain.feedback",
+            json!({
+                "target_id": target,
+                "signal": "useful",
+                "section_signals": {
+                    "operational_guidance": "useful"
+                }
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("feedback must succeed");
+
+        // After feedback:
+        // (a) balanced-recall-v1 must now have a section_states entry.
+        // (b) The entry must be COMPLETE — all SectionType slots present.
+        // (c) The OperationalGuidance posterior mean must have moved above the
+        //     default prior (useful signal → alpha++).
+        let state = pack.state.lock().unwrap();
+        let ss = state
+            .section_states
+            .get("balanced-recall-v1")
+            .expect("balanced-recall-v1 must have a section_states entry after first feedback");
+
+        assert_eq!(
+            ss.posteriors.len(),
+            SectionType::all().len(),
+            "section state must contain all {} SectionType slots after seeding",
+            SectionType::all().len()
+        );
+
+        let default_og_mean = SectionPosteriorState::default_priors()
+            .get(&SectionType::OperationalGuidance)
+            .expect("default_priors must include OperationalGuidance")
+            .mean();
+        let live_og_mean = ss
+            .posteriors
+            .get(&SectionType::OperationalGuidance)
+            .expect("OperationalGuidance must be present after seeding")
+            .mean();
+
+        assert!(
+            live_og_mean > default_og_mean,
+            "OperationalGuidance mean must increase after useful signal; \
+             default={default_og_mean:.4} live={live_og_mean:.4}"
+        );
+    }
+
+    #[tokio::test]
+    async fn feedback_section_signals_updates_custom_profile_with_seeded_priors() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        // Create a custom profile with a high-alpha seed prior for Formalism.
+        // This verifies that the seeding path (create_profile) and the live
+        // feedback path are consistent: the seeded section state is preserved
+        // and further updated by feedback.
+        pack.dispatch(
+            "brain.create_profile",
+            json!({
+                "name": "test-section-custom",
+                "description": "custom profile for router section-posterior regression",
+                "consumer_kind": "recall",
+                "seed_priors": {
+                    "section_posteriors": {
+                        "formalism": {"alpha": 8.0, "beta": 2.0}
+                    }
+                }
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.create_profile must succeed");
+
+        // Record the Formalism mean from the seeded state before any feedback.
+        let formalism_seeded_mean = {
+            let state = pack.state.lock().unwrap();
+            state
+                .section_states
+                .get("test-section-custom")
+                .expect("test-section-custom must have section_states after create_profile")
+                .posteriors
+                .get(&SectionType::Formalism)
+                .expect("Formalism must be present in seeded state")
+                .mean()
+        };
+
+        // Fire feedback targeting the custom profile with a useful Formalism signal.
+        pack.dispatch(
+            "brain.feedback",
+            json!({
+                "target_id": target,
+                "signal": "useful",
+                "served_by_profile_id": "test-section-custom",
+                "section_signals": {
+                    "formalism": "useful"
+                }
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("feedback to custom profile must succeed");
+
+        // The Formalism posterior mean must have increased from its seeded value.
+        let formalism_live_mean = {
+            let state = pack.state.lock().unwrap();
+            state
+                .section_states
+                .get("test-section-custom")
+                .expect("test-section-custom must still have section_states after feedback")
+                .posteriors
+                .get(&SectionType::Formalism)
+                .expect("Formalism must still be present after feedback")
+                .mean()
+        };
+
+        assert!(
+            formalism_live_mean > formalism_seeded_mean,
+            "Formalism posterior mean must increase after useful signal; \
+             seeded={formalism_seeded_mean:.4} live={formalism_live_mean:.4}"
+        );
+    }
+}

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4211,4 +4211,112 @@ mod router_section_tests {
              seeded={formalism_seeded_mean:.4} live={formalism_live_mean:.4}"
         );
     }
+
+    // ── Replay regression: section posteriors seeded on snapshot reload ────────
+    //
+    // Regression gate for the persisted event-replay path (persist.rs).
+    //
+    // Before the fix, the replay loop used `if let Some(..) = section_states.get_mut(..)`
+    // which silently dropped section signals whenever the snapshot had no entry for the
+    // serving profile.  After a restart the live state then diverged from the event log.
+    //
+    // This test constructs the divergence scenario explicitly:
+    //   1. Write a snapshot with empty section_states to the DB (simulates a snapshot
+    //      from before section_states was introduced, or before the first feedback).
+    //   2. Append a brain.feedback event with section_signals after the snapshot timestamp
+    //      so the replay loop will pick it up.
+    //   3. Create a fresh BrainPack over the same runtime (no pre-loaded state) and
+    //      trigger ensure_loaded via a dispatch.
+    //   4. Assert that the replayed state has all SectionType slots seeded AND that the
+    //      signalled section's posterior mean moved above the default prior.
+
+    #[tokio::test]
+    async fn replay_seeds_section_posteriors_for_missing_profile() {
+        use khive_brain_core::BrainState;
+        use khive_storage::event::Event as StorageEvent;
+        use khive_types::{EventKind, SubstrateKind};
+        use uuid::Uuid;
+
+        let rt = khive_runtime::KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+        let namespace = token.namespace().as_str();
+
+        // Build and persist a snapshot with empty section_states at time T0.
+        // BrainState::new() leaves section_states empty, which is the condition
+        // that triggered the silent-drop bug in the old replay path.
+        let snapshot = BrainState::new(crate::ENTITY_CACHE_CAPACITY).to_snapshot();
+        let t0_us: i64 = 1_000;
+        crate::persist::upsert_snapshot(rt.sql().as_ref(), namespace, &snapshot, t0_us)
+            .await
+            .expect("upsert snapshot");
+
+        // Append a brain.feedback event with section_signals at time T1 > T0.
+        // The full Event struct is serialized to JSON (same wire format as
+        // persist_after_feedback writes during a live dispatch).
+        let mut ev = StorageEvent::new(
+            namespace,
+            "brain.feedback",
+            EventKind::Audit,
+            SubstrateKind::Event,
+            "brain",
+        );
+        ev.target_id = Some(Uuid::new_v4());
+        ev.payload = serde_json::json!({
+            "signal": "useful",
+            "section_signals": {"operational_guidance": "useful"},
+        });
+        let event_value = serde_json::to_value(&ev).expect("serialize event");
+        let t1_us: i64 = t0_us + 1_000;
+        crate::persist::append_brain_event(
+            rt.sql().as_ref(),
+            namespace,
+            "balanced-recall-v1",
+            "brain.feedback",
+            &event_value,
+            t1_us,
+        )
+        .await
+        .expect("append brain event");
+
+        // Fresh BrainPack with no pre-loaded state — ensure_loaded will do the
+        // snapshot load + event replay on the first dispatch.
+        let pack2 = crate::BrainPack::new(rt.clone());
+        let registry = empty_registry();
+        pack2
+            .dispatch("brain.profiles", serde_json::json!({}), &registry, &token)
+            .await
+            .expect("brain.profiles dispatch after replay");
+
+        // Verify that the replay path (now using ensure_section_state_seeded)
+        // produced a fully-seeded entry for balanced-recall-v1.
+        let state = pack2.state.lock().unwrap();
+        let ss = state
+            .section_states
+            .get("balanced-recall-v1")
+            .expect("balanced-recall-v1 must have a section_states entry after replay seeding");
+
+        assert_eq!(
+            ss.posteriors.len(),
+            SectionType::all().len(),
+            "replay must seed all {} SectionType slots; got {}",
+            SectionType::all().len(),
+            ss.posteriors.len()
+        );
+
+        let default_og_mean = SectionPosteriorState::default_priors()
+            .get(&SectionType::OperationalGuidance)
+            .expect("default_priors must include OperationalGuidance")
+            .mean();
+        let replayed_og_mean = ss
+            .posteriors
+            .get(&SectionType::OperationalGuidance)
+            .expect("OperationalGuidance must be present after replay seeding")
+            .mean();
+
+        assert!(
+            replayed_og_mean > default_og_mean,
+            "OperationalGuidance mean must increase after useful replay signal; \
+             default={default_og_mean:.4} replayed={replayed_og_mean:.4}"
+        );
+    }
 }


### PR DESCRIPTION
Recreated from closed #356 (auto-closed when stacked base branch `feat-brain-lattice-router-m1` was deleted on #355 merge). Same head branch `feat-brain-context-vector-352`, now based on main (which contains #355). Prior review approved the #356 head; CI re-running against main.