### PR TITLE
fix(mcp): gate subhandler verbs by wire origin, not globally

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -71,6 +71,7 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         presentation_per_op: Option<Vec<Option<String>>>,
         format: Option<String>,
         format_per_op: Option<Vec<Option<String>>>,
+        from_wire: bool,
     ) -> Result<String, String> {
         let params = RequestParams {
             ops,
@@ -80,7 +81,9 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
             format,
             format_per_op,
         };
-        self.dispatch_request_local(params)
+        // Honor the frame's origin: a wire-origin request enforces verb
+        // visibility even when served by the daemon; an operator request does not.
+        self.dispatch_request_inner(params, from_wire)
             .await
             .map_err(|e| e.message.to_string())
     }
@@ -387,6 +390,7 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         probe_only: true,
         format: None,
         format_per_op: None,
+        from_wire: false,
     };
     let deadline = std::time::Duration::from_millis(timeout_ms);
     match tokio::time::timeout(deadline, try_forward_inner(&probe)).await {
@@ -950,6 +954,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let out = forward_or_spawn(&frame).await;
         assert!(out.is_none());
@@ -993,6 +998,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let resp = exchange(&sock, &req).await;
         assert!(resp.ok, "valid op must succeed; error={:?}", resp.error);
@@ -1031,6 +1037,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let resp_other = exchange(&sock, &other).await;
         assert!(resp_other.namespace_mismatch);
@@ -1048,6 +1055,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let resp_cfg = exchange(&sock, &mismatched_config).await;
         assert!(
@@ -1068,6 +1076,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let resp_ver = exchange(&sock, &wrong_version).await;
         assert!(
@@ -1196,6 +1205,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -1299,6 +1309,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         // Call try_forward_inner directly to assert the discriminant.
@@ -1536,6 +1547,7 @@ mod tests {
             _presentation_per_op: Option<Vec<Option<String>>>,
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
+            _from_wire: bool,
         ) -> Result<String, String> {
             // Return a string whose serialized DaemonResponseFrame JSON length
             // exceeds MAX_FRAME_BYTES.  The frame JSON overhead is ~200 bytes so
@@ -1600,6 +1612,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -1700,6 +1713,7 @@ mod tests {
             _presentation_per_op: Option<Vec<Option<String>>>,
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
+            _from_wire: bool,
         ) -> Result<String, String> {
             DAEMON_DISPATCH.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok("{\"ok\":true,\"counted\":true}".to_string())
@@ -1814,6 +1828,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
         let fwd = try_forward_inner(&real_frame).await;
         assert!(
@@ -1958,6 +1973,7 @@ mod tests {
             _presentation_per_op: Option<Vec<Option<String>>>,
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
+            _from_wire: bool,
         ) -> Result<String, String> {
             Err("forced dispatch error: verb returned an error for testing".to_string())
         }
@@ -2010,6 +2026,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         let result = forward_or_spawn(&frame).await;
@@ -2103,6 +2120,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         let outcome = try_forward_inner(&frame).await;
@@ -2178,6 +2196,7 @@ mod tests {
             probe_only: false,
             format: None,
             format_per_op: None,
+            from_wire: false,
         };
 
         let outcome = try_forward_inner(&frame).await;

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -699,6 +699,22 @@ mod tests {
         crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+gtd")
     }
 
+    /// Server whose pack set includes `brain`, which registers
+    /// `Visibility::Subhandler` verbs (`brain.state`, …). Used to exercise the
+    /// wire visibility gate through the daemon round-trip.
+    fn make_subhandler_test_server() -> crate::server::KhiveMcpServer {
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::parse("braintest").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "brain".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+brain")
+    }
+
     fn clear_daemon_env() {
         std::env::remove_var("KHIVE_SOCKET");
         std::env::remove_var("KHIVE_PID");
@@ -1110,6 +1126,110 @@ mod tests {
         handle.abort();
         let _ = handle.await;
         clear_daemon_env();
+    }
+
+    // ── daemon-forward wire-origin gate (security regression) ────────────────
+    //
+    // The agent-facing MCP `request` tool sets `from_wire=true` on its daemon
+    // frame; the daemon must HONOR that bit so the subhandler visibility gate
+    // fires after the socket round-trip, not only on the local-fallback path.
+    // The local-fallback tests (in tests/integration.rs) run with the daemon
+    // disabled and would stay green even if the MCP frame were flipped to
+    // `from_wire=false` — which would open an agent-reachable subhandler bypass
+    // on every daemon-backed deployment. This pins the round-trip seam.
+    #[tokio::test]
+    #[serial]
+    async fn daemon_round_trip_honors_from_wire_for_subhandlers() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid = dir.path().join("khived.pid");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let reference = make_subhandler_test_server();
+        let config_id = reference.config_id().to_string();
+        let daemon_server = reference.clone();
+        let handle = tokio::spawn(async move {
+            let _ = run_daemon(daemon_server).await;
+        });
+        let _ready = connect_when_ready(&sock).await;
+        drop(_ready);
+
+        let frame = |from_wire: bool| DaemonRequestFrame {
+            ops: "brain.state()".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "braintest".to_string(),
+            config_id: config_id.clone(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire,
+        };
+
+        // (a) from_wire=true → daemon applies the wire visibility gate:
+        // `brain.state` is a Subhandler and must be blocked after the round-trip.
+        let resp_wire = exchange(&sock, &frame(true)).await;
+        assert!(
+            resp_wire.ok,
+            "dispatch itself must succeed (the op carries the gate error); error={:?}",
+            resp_wire.error
+        );
+        let body_wire: serde_json::Value =
+            serde_json::from_str(resp_wire.result.as_deref().expect("wire result body"))
+                .expect("decode wire result json");
+        let first_wire = &body_wire["results"][0];
+        assert_eq!(
+            first_wire["ok"], false,
+            "from_wire=true subhandler must be blocked through the daemon: {first_wire}"
+        );
+        let err_wire = first_wire["error"].as_str().unwrap_or("");
+        assert!(
+            err_wire.contains("permission denied") || err_wire.contains("subhandler"),
+            "daemon-forward wire path must surface the subhandler gate error; got: {err_wire}"
+        );
+
+        // (b) from_wire=false (operator frame, e.g. `kkernel exec`) → the same
+        // Subhandler verb must be REACHED, not gated.
+        let resp_op = exchange(&sock, &frame(false)).await;
+        let body_op: serde_json::Value =
+            serde_json::from_str(resp_op.result.as_deref().expect("operator result body"))
+                .expect("decode operator result json");
+        let first_op = &body_op["results"][0];
+        let err_op = first_op["error"].as_str().unwrap_or("");
+        assert!(
+            !err_op.contains("permission denied") && !err_op.contains("subhandler"),
+            "operator frame must NOT gate the subhandler through the daemon: {first_op}"
+        );
+
+        handle.abort();
+        let _ = handle.await;
+        clear_daemon_env();
+    }
+
+    // The agent-facing `request` tool must stamp `from_wire=true` on its daemon
+    // forward-frame. Without this, a daemon-backed MCP request would dispatch
+    // with `from_wire=false` and silently reopen the agent subhandler bypass
+    // (codex #369 Medium). Pinned at the frame-builder seam so the daemon
+    // round-trip test above (which proves the daemon HONORS the bit) is paired
+    // with proof that the tool SETS it.
+    #[test]
+    fn wire_request_frame_sets_from_wire_true() {
+        let server = make_subhandler_test_server();
+        let params = RequestParams {
+            ops: "brain.state()".to_string(),
+            ..Default::default()
+        };
+        let frame = server.wire_daemon_frame(&params);
+        assert!(
+            frame.from_wire,
+            "request tool must set from_wire=true on the daemon forward-frame"
+        );
+        assert_eq!(frame.ops, "brain.state()");
+        assert_eq!(frame.namespace, "braintest");
     }
 
     // ── new-client + old-daemon regression (fix for #98 BLOCKER) ─────────────

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -497,6 +497,7 @@ impl KhiveMcpServer {
         &self,
         op: ParsedOp,
         prev_result: Option<&Value>,
+        from_wire: bool,
     ) -> Result<Value, (String, Value)> {
         let ParsedOp { tool, args } = op;
 
@@ -590,14 +591,14 @@ impl KhiveMcpServer {
         let args_value = Value::Object(resolved);
 
         // Subhandler verbs are operator-only — block them at the MCP wire
-        // boundary. Internal callers that call VerbRegistry::dispatch directly
-        // are not affected. Exception: `help=true` is short-circuited in
+        // boundary (`from_wire`), never on the operator path (`kkernel exec`,
+        // in-process callers). Exception: `help=true` is short-circuited in
         // VerbRegistry::dispatch before reaching the pack, so introspection works.
         let is_help = args_value
             .get("help")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if !is_help && self.registry.is_subhandler_verb(&tool) {
+        if from_wire && !is_help && self.registry.is_subhandler_verb(&tool) {
             return Err((
                 tool.clone(),
                 json!(format!(
@@ -651,6 +652,7 @@ impl KhiveMcpServer {
         mode: ExecutionMode,
         presentation: PresentationMode,
         presentation_per_op: Option<Vec<Option<PresentationMode>>>,
+        from_wire: bool,
     ) -> Value {
         let now_unix = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -752,7 +754,8 @@ impl KhiveMcpServer {
                         }
                         let args_value = Value::Object(resolved);
 
-                        // Block subhandler verbs at the MCP wire boundary.
+                        // Block subhandler verbs at the MCP wire boundary
+                        // (`from_wire`) only — operator paths pass through.
                         // Exception: help=true is short-circuited in
                         // VerbRegistry::dispatch before the pack, so
                         // introspection passes through.
@@ -760,7 +763,7 @@ impl KhiveMcpServer {
                             .get("help")
                             .and_then(Value::as_bool)
                             .unwrap_or(false);
-                        if !is_help && registry.is_subhandler_verb(&tool) {
+                        if from_wire && !is_help && registry.is_subhandler_verb(&tool) {
                             return json!({
                                 "ok": false,
                                 "tool": tool,
@@ -851,7 +854,7 @@ impl KhiveMcpServer {
                     } else {
                         op_mode
                     };
-                    match self.dispatch_op(op, prev_result.as_ref()).await {
+                    match self.dispatch_op(op, prev_result.as_ref(), from_wire).await {
                         Ok(result_obj) => {
                             // Extract canonical result for $prev (pre-presentation).
                             prev_result = result_obj.get("result").cloned();
@@ -1164,22 +1167,43 @@ result (e.g. create then link with the new entity's id)."#)]
                 probe_only: false,
                 format: p.format.clone(),
                 format_per_op: p.format_per_op.clone(),
+                // This is the agent-facing MCP wire surface: enforce verb
+                // visibility whether the request runs on the daemon or locally.
+                from_wire: true,
             };
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
                 return res;
             }
         }
-        self.dispatch_request_local(p).await
+        self.dispatch_request_wire(p).await
     }
 }
 
 impl KhiveMcpServer {
     /// Parse and dispatch a request against this server's own registry.
     ///
-    /// This is the canonical dispatch path. The stdio `request` tool calls it
-    /// only as a fallback; the daemon calls it directly (never through the tool
-    /// wrapper), so there is no risk of a daemon forwarding to itself.
+    /// This is the canonical **operator** dispatch path: subhandler verbs are
+    /// allowed. `kkernel exec`, in-process callers, and tests use this. The
+    /// agent-facing MCP wire surface goes through `dispatch_request_wire`
+    /// (or sets `from_wire` on the daemon frame), which enforces verb visibility.
     pub async fn dispatch_request_local(&self, p: RequestParams) -> Result<String, McpError> {
+        self.dispatch_request_inner(p, false).await
+    }
+
+    /// Wire-surface dispatch: same as [`Self::dispatch_request_local`] but
+    /// enforces verb visibility (`Visibility::Subhandler` verbs are rejected).
+    /// Used by the stdio `request` tool's local-fallback path.
+    pub(crate) async fn dispatch_request_wire(&self, p: RequestParams) -> Result<String, McpError> {
+        self.dispatch_request_inner(p, true).await
+    }
+
+    /// Shared body for both dispatch surfaces. `from_wire` decides whether the
+    /// subhandler-visibility gate fires (see [`run_parsed`](Self::run_parsed)).
+    pub(crate) async fn dispatch_request_inner(
+        &self,
+        p: RequestParams,
+        from_wire: bool,
+    ) -> Result<String, McpError> {
         let save_to = p.save_to.clone();
         let parsed = parse_request(&p.ops).map_err(dsl_err_to_mcp)?;
 
@@ -1237,6 +1261,7 @@ impl KhiveMcpServer {
                 parsed.mode,
                 presentation,
                 presentation_per_op.clone(),
+                from_wire,
             )
             .await;
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1157,20 +1157,7 @@ result (e.g. create then link with the new entity's id)."#)]
         // mismatch, KHIVE_NO_DAEMON) falls through to local dispatch.
         #[cfg(unix)]
         {
-            let frame = khive_runtime::DaemonRequestFrame {
-                ops: p.ops.clone(),
-                presentation: p.presentation.clone(),
-                presentation_per_op: p.presentation_per_op.clone(),
-                namespace: self.default_namespace.clone(),
-                config_id: self.config_id.clone(),
-                protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
-                probe_only: false,
-                format: p.format.clone(),
-                format_per_op: p.format_per_op.clone(),
-                // This is the agent-facing MCP wire surface: enforce verb
-                // visibility whether the request runs on the daemon or locally.
-                from_wire: true,
-            };
+            let frame = self.wire_daemon_frame(&p);
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
                 return res;
             }
@@ -1180,6 +1167,29 @@ result (e.g. create then link with the new entity's id)."#)]
 }
 
 impl KhiveMcpServer {
+    /// Build the daemon forward-frame for an agent-facing `request` tool call.
+    ///
+    /// `from_wire` is unconditionally `true`: this is the agent wire surface, so
+    /// `Visibility::Subhandler` verbs must be rejected whether the request runs
+    /// on the warm daemon or via the local fallback. Keeping the bit in one
+    /// named, unit-tested place stops the daemon-forward path from silently
+    /// diverging from `dispatch_request_wire`.
+    #[cfg(unix)]
+    pub(crate) fn wire_daemon_frame(&self, p: &RequestParams) -> khive_runtime::DaemonRequestFrame {
+        khive_runtime::DaemonRequestFrame {
+            ops: p.ops.clone(),
+            presentation: p.presentation.clone(),
+            presentation_per_op: p.presentation_per_op.clone(),
+            namespace: self.default_namespace.clone(),
+            config_id: self.config_id.clone(),
+            protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
+            probe_only: false,
+            format: p.format.clone(),
+            format_per_op: p.format_per_op.clone(),
+            from_wire: true,
+        }
+    }
+
     /// Parse and dispatch a request against this server's own registry.
     ///
     /// This is the canonical **operator** dispatch path: subhandler verbs are

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -1951,6 +1951,44 @@ async fn subhandler_verbs_are_blocked_at_mcp_boundary() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The operator path (`dispatch_request_local`, the path `kkernel exec` uses)
+/// must NOT gate subhandler verbs. The visibility gate is wire-only
+/// (`from_wire`): agents cannot reach subhandlers via the MCP `request` tool,
+/// but operators invoke them directly. This is the invariant that regressed
+/// when the gate lived in the shared dispatch — every handler had to be
+/// promoted to `Verb` to stay reachable, which is exactly what we are undoing.
+#[tokio::test]
+async fn subhandler_verbs_are_allowed_on_operator_path() -> anyhow::Result<()> {
+    use khive_mcp::tools::request::RequestParams;
+
+    let server = make_brain_server();
+
+    for verb in &["brain.state", "brain.config", "brain.events"] {
+        let raw = server
+            .dispatch_request_local(RequestParams {
+                ops: format!("{verb}()"),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("operator dispatch must not RPC-fail");
+        let body: Value = serde_json::from_str(&raw)?;
+        let first = &body["results"][0];
+        let err = first["error"].as_str().unwrap_or("");
+        // The gate must NOT have fired: its signature message must be absent.
+        // The handler may still succeed (ok=true) or fail for its own reasons,
+        // but it must have been *reached*, not blocked at the visibility gate.
+        assert!(
+            !err.contains("internal subhandler") && !err.contains("permission denied"),
+            "operator path must NOT gate subhandler {verb:?}: {first}"
+        );
+    }
+    Ok(())
+}
+
 #[tokio::test]
 async fn subhandler_verb_help_introspection_still_works() -> anyhow::Result<()> {
     let (server_transport, client_transport) = tokio::io::duplex(65536);

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -40,7 +40,7 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// Version history:
 ///   1 — initial versioned framing (added `protocol_version` + `version_mismatch`);
 ///       added `probe_only` request field + probe-ack sentinel shape in response
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
 
@@ -155,6 +155,20 @@ pub struct DaemonRequestFrame {
     /// Per-operation output format overrides (ADR-078).
     #[serde(default)]
     pub format_per_op: Option<Vec<Option<String>>>,
+    /// Whether this request originated from the agent-facing MCP `request`
+    /// tool (the wire surface). When `true`, the daemon enforces verb
+    /// visibility — `Visibility::Subhandler` verbs are rejected because agents
+    /// must not invoke internal subhandlers. When `false` (the default, and the
+    /// only value any operator path sends), subhandlers are allowed: `kkernel
+    /// exec` and other in-process callers are trusted operator surfaces.
+    ///
+    /// This is the origin discriminator, not a daemon-vs-local one: operator
+    /// requests flow through the daemon by default too, so the gate cannot key
+    /// on transport. Pre-versioning clients omit this field (deserializes to
+    /// `false` → ungated), which is safe: the only way to reach the gated wire
+    /// surface is the MCP `request` tool, which always sets it explicitly.
+    #[serde(default)]
+    pub from_wire: bool,
 }
 
 /// Response frame sent from the daemon back to a client.
@@ -235,6 +249,11 @@ pub async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> std::io::Re
 #[async_trait]
 pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// Dispatch a verb-DSL request string and return the rendered result.
+    ///
+    /// `from_wire` carries the origin discriminator from
+    /// [`DaemonRequestFrame::from_wire`]: when `true`, the implementor enforces
+    /// verb visibility (rejects `Visibility::Subhandler` verbs); when `false`,
+    /// the request is from a trusted operator surface and subhandlers pass.
     async fn dispatch(
         &self,
         ops: String,
@@ -242,6 +261,7 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
         presentation_per_op: Option<Vec<Option<String>>>,
         format: Option<String>,
         format_per_op: Option<Vec<Option<String>>>,
+        from_wire: bool,
     ) -> Result<String, String>;
 
     /// Warm every pack's in-memory state (ANN indexes, etc.).
@@ -352,6 +372,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 frame.presentation_per_op,
                 frame.format,
                 frame.format_per_op,
+                frame.from_wire,
             )
             .await
         {

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -244,8 +244,10 @@ pub async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> std::io::Re
 
 /// Transport-agnostic dispatch interface for the daemon server.
 ///
-/// The MCP crate implements this by wrapping `dispatch_request_local`; any
-/// future transport can do the same.
+/// The MCP crate implements this by dispatching through the shared request body
+/// while honoring [`DaemonRequestFrame::from_wire`] (so subhandler visibility is
+/// gated by request origin, not by transport); any future transport can do the
+/// same.
 #[async_trait]
 pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// Dispatch a verb-DSL request string and return the rendered result.

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -444,6 +444,9 @@ async fn run_exec_inline_with_forward(
             probe_only: false,
             format: output_format.clone(),
             format_per_op: None,
+            // `kkernel exec` is a trusted operator surface: subhandler verbs are
+            // allowed. Only the agent-facing MCP `request` tool sets this true.
+            from_wire: false,
         };
         if let Some(res) = forward_fn(&frame).await {
             let output = res.map_err(|e| anyhow::anyhow!("{}", e.message))?;


### PR DESCRIPTION
## Problem

The `Visibility::Subhandler` check lived in the **shared** `run_parsed` dispatch, so it rejected non-verb (operator-only) handlers on **both** the agent-facing MCP `request` wire **and** the `kkernel exec` / in-process operator paths. That over-blocking is the root cause behind handlers being promoted to `Verb` just to stay reachable from the operator surface — a known architecture regression ("everything ended up a verb even though much of it shouldn't be").

## Fix

Gate the visibility check on request **origin**, not on which dispatch path runs.

- A `from_wire` bit is set **true only by the MCP `request` tool** (the sole agent wire entry, ADR-016) and ferried through `DaemonRequestFrame`, so the gate holds whether dispatch runs in-process or through the daemon. The daemon is not the discriminating axis — it merely carries the bit as data.
- Operator paths (`kkernel exec`, in-process callers, tests) leave `from_wire = false`.
- Net invariant: a `Visibility::Subhandler` handler is **rejected on the MCP wire** and **invocable via the operator path**.

### Shape

- `dispatch_request_local` — operator default (`from_wire=false`); ~30 existing callers unchanged.
- `dispatch_request_wire` — sets `from_wire=true` for the stdio `request` tool's local-fallback path.
- `dispatch_request_inner(p, from_wire)` — shared body; `run_parsed` / `dispatch_op` thread the bit to the two gate sites.
- `PROTOCOL_VERSION` 1 → 2 — a stale v1 daemon now rejects v2 client frames (`version_mismatch`) and the client falls back to local dispatch, which still gates correctly; this avoids a stale daemon silently ungating subhandlers.

## Tests

- `subhandler_verbs_are_blocked_at_mcp_boundary` — wire half (real duplex transport): `brain.*` subhandlers rejected.
- `subhandler_verbs_are_allowed_on_operator_path` (new) — operator half: same subhandlers dispatch without a visibility error via `dispatch_request_local`.
- `subhandler_verb_help_introspection_still_works` — `help=true` short-circuits the gate on both paths.
- Daemon protocol round-trip (30) and `kkernel exec` (18) green with the new frame field + version bump.

Gate run locally: `cargo fmt --check`, `cargo clippy -p khive-runtime -p khive-mcp -p kkernel --all-targets -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`, all three test buckets — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)