### PR TITLE
fix(channel-email): STARTTLS submission + ~/.khive/.env loader + config template

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -73,6 +73,7 @@ uuid = { version = "1.10", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
+dotenvy = "0.15"
 lattice-embed = "0.3.0"
 lattice-fann = "0.4.0"
 parking_lot = "0.12"

--- a/crates/khive-channel-email/.env.example
+++ b/crates/khive-channel-email/.env.example
@@ -1,0 +1,53 @@
+# khive email channel (ADR-056) — environment configuration template.
+#
+# The kkernel binary loads ~/.khive/.env at startup, so this is the canonical
+# config home: copy the relevant lines into ~/.khive/.env and fill in values.
+# Real process environment variables take precedence over the file.
+#
+# The email polling loop is compiled only with `--features channel-email` and
+# stays inert unless the required variables below resolve. If the feature is on
+# but configuration is incomplete, polling disables itself (it does not error).
+#
+# All variables are read by EmailChannelConfig::from_env()
+# (crates/khive-channel-email/src/config.rs) and the serve wiring
+# (crates/khive-mcp/src/serve.rs). No filesystem config beyond this env is read.
+
+# --- Required ---------------------------------------------------------------
+
+# SMTP + IMAP hostnames (Exchange Online: smtp.office365.com / outlook.office365.com).
+KHIVE_EMAIL_SMTP_HOST=smtp.office365.com
+KHIVE_EMAIL_IMAP_HOST=outlook.office365.com
+
+# SASL login identity. Required even in OAuth mode (where authentication uses the
+# mailbox + token, not this value); set it equal to KHIVE_EMAIL_MAILBOX to avoid
+# ambiguity.
+KHIVE_EMAIL_USERNAME=leo@example.com
+
+# Operator address that receives channel notices. Must be a valid RFC 5322 address.
+KHIVE_EMAIL_MAINTAINER_ADDRESS=ocean@example.com
+
+# --- Authentication: choose exactly one mode --------------------------------
+
+# Mode A — OAuth2 app-only (Microsoft 365 / Exchange Online, XOAUTH2).
+# Set ALL THREE; partial configuration is a hard error.
+KHIVE_EMAIL_OAUTH_TENANT_ID=00000000-0000-0000-0000-000000000000
+KHIVE_EMAIL_OAUTH_CLIENT_ID=00000000-0000-0000-0000-000000000000
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=set-in-your-local-env-not-here
+
+# Mode B — Basic auth (set NONE of the three OAuth vars above, set this instead).
+# KHIVE_EMAIL_PASSWORD=set-in-your-local-env-not-here
+
+# --- Optional ---------------------------------------------------------------
+
+# SMTP/IMAP ports default to 587 / 993 when unset.
+# KHIVE_EMAIL_SMTP_PORT=587
+# KHIVE_EMAIL_IMAP_PORT=993
+
+# Mailbox actually accessed (the XOAUTH2 user in OAuth mode). Defaults to
+# KHIVE_EMAIL_USERNAME when unset.
+KHIVE_EMAIL_MAILBOX=leo@example.com
+
+# Namespace that ingested inbound mail is written under. Defaults to "local",
+# which is the namespace the comm inbox monitor watches — leave unset unless you
+# have a specific reason to route ingested mail elsewhere.
+# KHIVE_EMAIL_INGEST_NAMESPACE=local

--- a/crates/khive-channel-email/src/connector/smtp.rs
+++ b/crates/khive-channel-email/src/connector/smtp.rs
@@ -142,9 +142,18 @@ impl SmtpConnector for LettreSmtp {
             .body(body.to_string())
             .map_err(|e| ChannelError::InvalidEnvelope(format!("failed to build message: {e}")))?;
 
-        let relay_builder = AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
-            .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
-            .port(self.port);
+        // Port 465 is implicit TLS (SMTPS, TLS-on-connect); 587 and everything
+        // else use STARTTLS (connect in plaintext, upgrade after EHLO). Exchange
+        // Online's SMTP AUTH submission endpoint is 587/STARTTLS. Using implicit
+        // TLS on a STARTTLS port makes rustls read the plaintext `220` greeting as
+        // a TLS record and fail with `InvalidContentType`.
+        let relay_builder = if self.port == 465 {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&self.host)
+        }
+        .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
+        .port(self.port);
 
         let transport = match &self.auth {
             SmtpAuthConfig::Basic(creds) => relay_builder.credentials(creds.clone()).build(),

--- a/crates/khive-channel-email/tests/smtp_send_smoke.rs
+++ b/crates/khive-channel-email/tests/smtp_send_smoke.rs
@@ -1,0 +1,24 @@
+use khive_channel::{Channel, ChannelEnvelope};
+use khive_channel_email::{EmailChannel, EmailChannelConfig};
+use std::time::SystemTime;
+
+#[tokio::test]
+#[ignore = "live network + real credentials; run manually with --ignored"]
+async fn smtp_send_to_maintainer_smoke() {
+    let config = EmailChannelConfig::from_env().expect("email config must load from env");
+    let channel = EmailChannel::from_env().expect("email channel must build from env");
+
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let envelope = ChannelEnvelope::new(
+        format!("email:{}", config.mailbox),
+        format!("email:{}", config.maintainer_address),
+        format!("khive email channel smoke test — sent at unix {ts}"),
+    )
+    .with_subject("khive email channel smoke test");
+
+    channel.send(envelope).await.expect("send must succeed");
+}

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 clap = { workspace = true }
+dotenvy = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -195,8 +195,28 @@ enum BackendCommand {
     },
 }
 
+/// Load `~/.khive/.env` into the process environment if present.
+///
+/// khive reads all configuration from process env (`std::env::var`), so this
+/// makes `~/.khive/.env` the canonical config home — credentials set there
+/// reach the daemon however it is spawned. Real environment variables win over
+/// the file (dotenvy does not override what is already set), and a missing file
+/// is not an error.
+fn load_khive_dotenv() {
+    let Some(home) = std::env::var_os("HOME") else {
+        return;
+    };
+    let path = std::path::Path::new(&home).join(".khive/.env");
+    match dotenvy::from_path(&path) {
+        Ok(()) => {}
+        Err(e) if e.not_found() => {}
+        Err(e) => eprintln!("warning: failed to load {}: {e}", path.display()),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    load_khive_dotenv();
     let args = Args::parse();
     init_tracing(&args.log);
 


### PR DESCRIPTION
## Summary

Makes the ADR-056 email channel actually send. Two independent blockers were in the way; this PR fixes the one in our code and documents the one in tenant config.

### 1. SMTP transport: STARTTLS vs implicit TLS (the bug)

`connector/smtp.rs` built the transport with `AsyncSmtpTransport::relay(host)` — lettre's **implicit-TLS / TLS-on-connect** constructor (default port 465) — then forced `.port(587)`. That opens a raw TLS handshake against a STARTTLS port. Exchange Online replies with its plaintext `220` SMTP greeting, rustls reads byte `0x32` as a TLS content type, and the handshake dies with `received corrupt message of type InvalidContentType`.

Fix: select the transport by port — `465` → `relay()` (implicit TLS), everything else → `starttls_relay()` (STARTTLS, which is Exchange Online's `587` submission endpoint). rustls is fine in STARTTLS mode; no TLS-library swap needed.

### 2. `~/.khive/.env` loader

The kkernel/MCP binary reads all configuration from process env (`std::env::var`); nothing loaded `~/.khive/.env`, so credentials placed there never reached the daemon. Added a `dotenvy` loader (`load_khive_dotenv`) at kkernel startup: real env wins over the file, a missing file is not an error. This makes `~/.khive/.env` the canonical config home regardless of how the daemon is spawned.

### 3. Config template

`crates/khive-channel-email/.env.example` documents every `KHIVE_EMAIL_*` var (OAuth app-only mode vs basic mode, required vs optional, the `USERNAME`-required-even-in-OAuth and `MAILBOX`-defaults-to-`USERNAME` gotchas).

### 4. Live smoke test

`tests/smtp_send_smoke.rs` (marked `#[ignore]`) drives a real send through `EmailChannel`. Run manually: `cargo test -p khive-channel-email smtp_send_to_maintainer_smoke -- --ignored`. Needs real credentials in env and tenant SMTP AUTH enabled. Skipped by default `cargo test`/CI.

## Verification

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` (channel-email) — clean
- `cargo check -p kkernel` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (both crates) — clean
- Live send now reaches SMTP AUTH and presents the XOAUTH2 token (TLS handshake succeeds). It currently returns `535 5.7.139 SmtpClientAuthentication is disabled for the Tenant` — a **tenant-side M365 admin setting** (`Set-CASMailbox -SmtpClientAuthenticationEnabled` + the app's `SMTP.SendAsApp` permission), not a code issue. Code correctness is confirmed up to the auth exchange.

## Notes

- `.env.example` is the only doc-ish file; it is config co-located with the code it documents, not narrative docs, so it ships with the fix.
- Merge is gated on maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)