### PR TITLE
feat(channel-email): outbound delivery + Message-ID mint + reply→sending-actor routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# khive email channel — environment variable reference
+# Copy to .env and fill in values. Never commit the filled-in .env.
+
+# ── Connection ──────────────────────────────────────────────────────────────
+
+# SMTP relay host (required)
+KHIVE_EMAIL_SMTP_HOST=smtp.example.com
+
+# SMTP port; default 587 (STARTTLS)
+# KHIVE_EMAIL_SMTP_PORT=587
+
+# IMAP server host (required)
+KHIVE_EMAIL_IMAP_HOST=imap.example.com
+
+# IMAP port; default 993 (TLS)
+# KHIVE_EMAIL_IMAP_PORT=993
+
+# Login username — must be a valid email address (required)
+KHIVE_EMAIL_USERNAME=leo@example.com
+
+# Sender mailbox address; defaults to KHIVE_EMAIL_USERNAME when unset
+# KHIVE_EMAIL_MAILBOX=leo@example.com
+
+# Single authorized maintainer address. Inbound messages from any other sender
+# are rejected before ingestion (required).
+KHIVE_EMAIL_MAINTAINER_ADDRESS=ocean@example.com
+
+# ── Auth — choose Basic or OAuth, not both ──────────────────────────────────
+
+# Basic auth: set this password
+KHIVE_EMAIL_PASSWORD=your-app-password-here
+
+# OAuth (Exchange Online app-only): set all three variables below.
+# When any of these are set, Basic auth is ignored; all three are required.
+# KHIVE_EMAIL_OAUTH_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# KHIVE_EMAIL_OAUTH_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# KHIVE_EMAIL_OAUTH_CLIENT_SECRET=your-client-secret-here
+
+# ── MCP outbox and inbound routing ──────────────────────────────────────────
+
+# Namespace used to store inbound and outbound message notes; default "local"
+# KHIVE_EMAIL_INGEST_NAMESPACE=local
+
+# Actor that receives fresh inbound email (no In-Reply-To correlation match).
+# Default: lambda:leo
+# KHIVE_EMAIL_DEFAULT_ACTOR=lambda:leo
+
+# Comma-separated allowlist of recipient addresses the outbox loop may deliver
+# to. Defaults to KHIVE_EMAIL_MAINTAINER_ADDRESS when unset or empty.
+# KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=ocean@example.com,leo@khive.ai

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -73,6 +73,7 @@ uuid = { version = "1.10", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
+dotenvy = "0.15"
 lattice-embed = "0.3.0"
 lattice-fann = "0.4.0"
 parking_lot = "0.12"

--- a/crates/khive-channel-email/.env.example
+++ b/crates/khive-channel-email/.env.example
@@ -1,0 +1,53 @@
+# khive email channel (ADR-056) — environment configuration template.
+#
+# The kkernel binary loads ~/.khive/.env at startup, so this is the canonical
+# config home: copy the relevant lines into ~/.khive/.env and fill in values.
+# Real process environment variables take precedence over the file.
+#
+# The email polling loop is compiled only with `--features channel-email` and
+# stays inert unless the required variables below resolve. If the feature is on
+# but configuration is incomplete, polling disables itself (it does not error).
+#
+# All variables are read by EmailChannelConfig::from_env()
+# (crates/khive-channel-email/src/config.rs) and the serve wiring
+# (crates/khive-mcp/src/serve.rs). No filesystem config beyond this env is read.
+
+# --- Required ---------------------------------------------------------------
+
+# SMTP + IMAP hostnames (Exchange Online: smtp.office365.com / outlook.office365.com).
+KHIVE_EMAIL_SMTP_HOST=smtp.office365.com
+KHIVE_EMAIL_IMAP_HOST=outlook.office365.com
+
+# SASL login identity. Required even in OAuth mode (where authentication uses the
+# mailbox + token, not this value); set it equal to KHIVE_EMAIL_MAILBOX to avoid
+# ambiguity.
+KHIVE_EMAIL_USERNAME=leo@example.com
+
+# Operator address that receives channel notices. Must be a valid RFC 5322 address.
+KHIVE_EMAIL_MAINTAINER_ADDRESS=ocean@example.com
+
+# --- Authentication: choose exactly one mode --------------------------------
+
+# Mode A — OAuth2 app-only (Microsoft 365 / Exchange Online, XOAUTH2).
+# Set ALL THREE; partial configuration is a hard error.
+KHIVE_EMAIL_OAUTH_TENANT_ID=00000000-0000-0000-0000-000000000000
+KHIVE_EMAIL_OAUTH_CLIENT_ID=00000000-0000-0000-0000-000000000000
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=set-in-your-local-env-not-here
+
+# Mode B — Basic auth (set NONE of the three OAuth vars above, set this instead).
+# KHIVE_EMAIL_PASSWORD=set-in-your-local-env-not-here
+
+# --- Optional ---------------------------------------------------------------
+
+# SMTP/IMAP ports default to 587 / 993 when unset.
+# KHIVE_EMAIL_SMTP_PORT=587
+# KHIVE_EMAIL_IMAP_PORT=993
+
+# Mailbox actually accessed (the XOAUTH2 user in OAuth mode). Defaults to
+# KHIVE_EMAIL_USERNAME when unset.
+KHIVE_EMAIL_MAILBOX=leo@example.com
+
+# Namespace that ingested inbound mail is written under. Defaults to "local",
+# which is the namespace the comm inbox monitor watches — leave unset unless you
+# have a specific reason to route ingested mail elsewhere.
+# KHIVE_EMAIL_INGEST_NAMESPACE=local

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -73,6 +73,22 @@ impl EmailChannel {
         Ok(Self { config, smtp, imap })
     }
 
+    /// The configured mailbox address (e.g. `leo@khive.ai`).
+    ///
+    /// Used by the outbox delivery loop to derive the sender address and
+    /// the domain component of the RFC 822 Message-ID header.
+    pub fn mailbox(&self) -> &str {
+        &self.config.mailbox
+    }
+
+    /// The configured maintainer address as a string.
+    ///
+    /// Used by the outbox delivery loop to build the default allowlist when
+    /// `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` is not set.
+    pub fn maintainer_address(&self) -> &str {
+        self.config.maintainer_address.as_str()
+    }
+
     /// Build from pre-constructed connectors (for testing).
     #[cfg(test)]
     pub(crate) fn with_connectors(
@@ -171,10 +187,11 @@ impl Channel for EmailChannel {
         let to = strip_kind_prefix(&envelope.to, "email");
         let subject = envelope.subject.as_deref().unwrap_or("(no subject)");
         let thread_id = envelope.correlation_external_id.as_deref();
+        let message_id = envelope.message_id.as_deref();
 
         debug!(from, to, subject, "email send");
         self.smtp
-            .send(from, to, subject, &envelope.content, thread_id)
+            .send(from, to, subject, &envelope.content, thread_id, message_id)
             .await
     }
 
@@ -238,6 +255,7 @@ mod tests {
             _subject: &str,
             _body: &str,
             _tid: Option<&str>,
+            _message_id: Option<&str>,
         ) -> Result<(), ChannelError> {
             self.calls.lock().unwrap().push(format!("{from}->{to}"));
             Ok(())

--- a/crates/khive-channel-email/src/connector/smtp.rs
+++ b/crates/khive-channel-email/src/connector/smtp.rs
@@ -65,6 +65,7 @@ pub(crate) trait SmtpConnector: Send + Sync + 'static {
         subject: &str,
         body: &str,
         thread_id_header: Option<&str>,
+        message_id: Option<&str>,
     ) -> Result<(), ChannelError>;
 }
 
@@ -120,6 +121,7 @@ impl SmtpConnector for LettreSmtp {
         subject: &str,
         body: &str,
         thread_id_header: Option<&str>,
+        message_id: Option<&str>,
     ) -> Result<(), ChannelError> {
         let from_mb: Mailbox = from.parse().map_err(|e| {
             ChannelError::InvalidEnvelope(format!("invalid from address {from:?}: {e}"))
@@ -136,6 +138,10 @@ impl SmtpConnector for LettreSmtp {
 
         if let Some(tid) = thread_id_header {
             builder = builder.header(XKhiveThreadId(tid.to_string()));
+        }
+
+        if let Some(mid) = message_id {
+            builder = builder.message_id(Some(mid.to_string()));
         }
 
         let msg = builder
@@ -214,7 +220,11 @@ impl SmtpSender {
         }
     }
 
-    /// Deliver an outbound message. `thread_id` is attached as `X-Khive-Thread-ID`.
+    /// Deliver an outbound message.
+    ///
+    /// `thread_id` is attached as `X-Khive-Thread-ID`. `message_id` is set as the
+    /// RFC 822 `Message-ID` header verbatim (caller must include angle brackets);
+    /// pass `None` to let lettre auto-generate.
     pub async fn send(
         &self,
         from: &str,
@@ -222,8 +232,11 @@ impl SmtpSender {
         subject: &str,
         body: &str,
         thread_id: Option<&str>,
+        message_id: Option<&str>,
     ) -> Result<(), ChannelError> {
-        self.inner.deliver(from, to, subject, body, thread_id).await
+        self.inner
+            .deliver(from, to, subject, body, thread_id, message_id)
+            .await
     }
 }
 
@@ -253,6 +266,7 @@ mod tests {
             subject: &str,
             _body: &str,
             _thread_id_header: Option<&str>,
+            _message_id: Option<&str>,
         ) -> Result<(), ChannelError> {
             self.calls.lock().unwrap().push((
                 from.to_string(),
@@ -275,6 +289,7 @@ mod tests {
                 "to@example.com",
                 "Hello",
                 "body text",
+                None,
                 None,
             )
             .await
@@ -302,6 +317,7 @@ mod tests {
                 _subject: &str,
                 _body: &str,
                 thread_id_header: Option<&str>,
+                _message_id: Option<&str>,
             ) -> Result<(), ChannelError> {
                 self.headers
                     .lock()
@@ -317,11 +333,64 @@ mod tests {
         });
 
         sender
-            .send("a@example.com", "b@example.com", "s", "b", Some("tid-abc"))
+            .send(
+                "a@example.com",
+                "b@example.com",
+                "s",
+                "b",
+                Some("tid-abc"),
+                None,
+            )
             .await
             .unwrap();
 
         let captured = headers.lock().unwrap();
         assert_eq!(captured[0].as_deref(), Some("tid-abc"));
+    }
+
+    #[tokio::test]
+    async fn smtp_sender_passes_message_id() {
+        struct CapturingSmtp {
+            captured: Arc<Mutex<Vec<Option<String>>>>,
+        }
+
+        #[async_trait]
+        impl SmtpConnector for CapturingSmtp {
+            async fn deliver(
+                &self,
+                _from: &str,
+                _to: &str,
+                _subject: &str,
+                _body: &str,
+                _thread_id_header: Option<&str>,
+                message_id: Option<&str>,
+            ) -> Result<(), ChannelError> {
+                self.captured
+                    .lock()
+                    .unwrap()
+                    .push(message_id.map(|s| s.to_string()));
+                Ok(())
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let sender = SmtpSender::with_connector(CapturingSmtp {
+            captured: captured.clone(),
+        });
+
+        sender
+            .send(
+                "a@example.com",
+                "b@example.com",
+                "s",
+                "b",
+                None,
+                Some("<abc123@example.com>"),
+            )
+            .await
+            .unwrap();
+
+        let vals = captured.lock().unwrap();
+        assert_eq!(vals[0].as_deref(), Some("<abc123@example.com>"));
     }
 }

--- a/crates/khive-channel-email/src/connector/smtp.rs
+++ b/crates/khive-channel-email/src/connector/smtp.rs
@@ -142,9 +142,18 @@ impl SmtpConnector for LettreSmtp {
             .body(body.to_string())
             .map_err(|e| ChannelError::InvalidEnvelope(format!("failed to build message: {e}")))?;
 
-        let relay_builder = AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
-            .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
-            .port(self.port);
+        // Port 465 is implicit TLS (SMTPS, TLS-on-connect); 587 and everything
+        // else use STARTTLS (connect in plaintext, upgrade after EHLO). Exchange
+        // Online's SMTP AUTH submission endpoint is 587/STARTTLS. Using implicit
+        // TLS on a STARTTLS port makes rustls read the plaintext `220` greeting as
+        // a TLS record and fail with `InvalidContentType`.
+        let relay_builder = if self.port == 465 {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&self.host)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&self.host)
+        }
+        .map_err(|e| ChannelError::Transport(format!("SMTP relay setup failed: {e}")))?
+        .port(self.port);
 
         let transport = match &self.auth {
             SmtpAuthConfig::Basic(creds) => relay_builder.credentials(creds.clone()).build(),

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -3,6 +3,34 @@
 //! Provides `EmailChannel`, which implements the `Channel` trait from
 //! `khive-channel`. Configure exclusively via environment variables; no
 //! filesystem config is read.
+//!
+//! ## Connection variables
+//!
+//! | Variable | Required | Default | Description |
+//! |---|---|---|---|
+//! | `KHIVE_EMAIL_SMTP_HOST` | yes | — | SMTP relay host |
+//! | `KHIVE_EMAIL_SMTP_PORT` | no | `587` | SMTP port (STARTTLS) |
+//! | `KHIVE_EMAIL_IMAP_HOST` | yes | — | IMAP server host |
+//! | `KHIVE_EMAIL_IMAP_PORT` | no | `993` | IMAP port (TLS) |
+//! | `KHIVE_EMAIL_USERNAME` | yes | — | SMTP/IMAP login username (email address) |
+//! | `KHIVE_EMAIL_MAILBOX` | no | same as username | Mailbox used as sender address |
+//! | `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes | — | Single authorized maintainer address |
+//!
+//! ## Auth variables
+//!
+//! **Basic auth**: set `KHIVE_EMAIL_PASSWORD`.
+//!
+//! **OAuth (Exchange Online)**: set all three of
+//! `KHIVE_EMAIL_OAUTH_TENANT_ID`, `KHIVE_EMAIL_OAUTH_CLIENT_ID`,
+//! `KHIVE_EMAIL_OAUTH_CLIENT_SECRET`. A partial set is rejected at startup.
+//!
+//! ## MCP outbox and routing variables (read by `khive-mcp`)
+//!
+//! | Variable | Default | Description |
+//! |---|---|---|
+//! | `KHIVE_EMAIL_DEFAULT_ACTOR` | `lambda:leo` | Actor that receives fresh inbound email (no In-Reply-To match) |
+//! | `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` | maintainer address | Comma-separated allowlist of recipient addresses the outbox loop may deliver to; defaults to the single maintainer address |
+//! | `KHIVE_EMAIL_INGEST_NAMESPACE` | `local` | Namespace used when persisting inbound and outbound messages |
 
 pub mod channel;
 pub mod config;

--- a/crates/khive-channel-email/tests/smtp_send_smoke.rs
+++ b/crates/khive-channel-email/tests/smtp_send_smoke.rs
@@ -1,0 +1,24 @@
+use khive_channel::{Channel, ChannelEnvelope};
+use khive_channel_email::{EmailChannel, EmailChannelConfig};
+use std::time::SystemTime;
+
+#[tokio::test]
+#[ignore = "live network + real credentials; run manually with --ignored"]
+async fn smtp_send_to_maintainer_smoke() {
+    let config = EmailChannelConfig::from_env().expect("email config must load from env");
+    let channel = EmailChannel::from_env().expect("email channel must build from env");
+
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let envelope = ChannelEnvelope::new(
+        format!("email:{}", config.mailbox),
+        format!("email:{}", config.maintainer_address),
+        format!("khive email channel smoke test — sent at unix {ts}"),
+    )
+    .with_subject("khive email channel smoke test");
+
+    channel.send(envelope).await.expect("send must succeed");
+}

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -43,6 +43,10 @@ pub struct ChannelEnvelope {
     pub correlation_external_id: Option<String>,
     /// Arbitrary transport-specific key-value metadata.
     pub metadata: HashMap<String, String>,
+    /// RFC 822 Message-ID to set on the outbound email (including angle brackets,
+    /// e.g. `<uuid@domain>`). `None` on inbound envelopes and when the transport
+    /// should auto-generate the identifier.
+    pub message_id: Option<String>,
 }
 
 impl ChannelEnvelope {
@@ -57,6 +61,7 @@ impl ChannelEnvelope {
             external_id: None,
             correlation_external_id: None,
             metadata: HashMap::new(),
+            message_id: None,
         }
     }
 
@@ -81,6 +86,12 @@ impl ChannelEnvelope {
     /// Attach a correlation key for thread resolution.
     pub fn with_correlation(mut self, correlation: impl Into<String>) -> Self {
         self.correlation_external_id = Some(correlation.into());
+        self
+    }
+
+    /// Attach an RFC 822 Message-ID (including angle brackets) to set on the outbound email.
+    pub fn with_message_id(mut self, id: impl Into<String>) -> Self {
+        self.message_id = Some(id.into());
         self
     }
 }
@@ -230,7 +241,8 @@ mod tests {
             .with_subject("Test")
             .with_sent_at(ts)
             .with_external_id("<msg1@example.com>")
-            .with_correlation("correlation-uuid");
+            .with_correlation("correlation-uuid")
+            .with_message_id("<abc123@example.com>");
 
         assert_eq!(env.from, "email:a@example.com");
         assert_eq!(env.to, "email:b@example.com");
@@ -242,6 +254,7 @@ mod tests {
             env.correlation_external_id.as_deref(),
             Some("correlation-uuid")
         );
+        assert_eq!(env.message_id.as_deref(), Some("<abc123@example.com>"));
     }
 
     #[test]

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -48,25 +48,48 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 
         match EmailChannel::from_env() {
             Ok(email_ch) => {
+                let email_ch = Arc::new(email_ch);
                 let mut ch_registry = ChannelRegistry::new();
-                ch_registry.register(Arc::new(email_ch));
+                ch_registry.register(Arc::clone(&email_ch));
                 let ch_registry = Arc::new(ch_registry);
                 let verb_reg = server.verb_registry_clone();
                 let ingest_ns = ingest_namespace_from_env();
+                let default_actor = default_inbound_actor_from_env();
+                let mut allowlist = allowed_recipients_from_env();
+                if allowlist.is_empty() {
+                    allowlist.push(email_ch.maintainer_address().to_string());
+                }
+                let mailbox = email_ch.mailbox().to_string();
+
                 let ingest_ns_clone = ingest_ns.clone();
-                let verb_reg_clone = verb_reg.clone();
+                let default_actor_clone = default_actor.clone();
+                let verb_reg_poll = verb_reg.clone();
+                let verb_reg_outbox = verb_reg.clone();
+                let ingest_ns_outbox = ingest_ns.clone();
+                let allowlist_clone = allowlist.clone();
+                let mailbox_clone = mailbox.clone();
+                let email_ch_clone = Arc::clone(&email_ch);
+
                 let spawned = run_if_authorized(&ingest_ns, &verb_reg, || {
                     tokio::task::spawn(channel_poll_loop(
                         ch_registry,
-                        verb_reg_clone,
+                        verb_reg_poll,
                         ingest_ns_clone,
+                        default_actor_clone,
                     ));
-                    tracing::info!("email channel polling loop started");
+                    tokio::task::spawn(channel_outbox_loop(
+                        email_ch_clone,
+                        verb_reg_outbox,
+                        ingest_ns_outbox,
+                        mailbox_clone,
+                        allowlist_clone,
+                    ));
+                    tracing::info!("email channel polling and outbox loops started");
                 });
                 if !spawned {
                     tracing::error!(
                         namespace = %ingest_ns,
-                        "email channel polling loop NOT started: ingest namespace authorization failed (fail-closed)"
+                        "email channel loops NOT started: ingest namespace authorization failed (fail-closed)"
                     );
                 }
             }
@@ -115,6 +138,37 @@ fn ingest_namespace_from_env() -> String {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "local".to_string())
+}
+
+/// Resolve the default inbound actor for fresh (uncorrelated) email messages.
+///
+/// Reads `KHIVE_EMAIL_DEFAULT_ACTOR`; falls back to `"lambda:leo"` when the
+/// variable is unset or blank. Called once at server startup alongside
+/// `ingest_namespace_from_env`.
+#[cfg(feature = "channel-email")]
+fn default_inbound_actor_from_env() -> String {
+    std::env::var("KHIVE_EMAIL_DEFAULT_ACTOR")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "lambda:leo".to_string())
+}
+
+/// Parse the outbox allowlist from `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS`.
+///
+/// Returns a `Vec` of trimmed, non-empty address strings. When the env var is
+/// unset or blank the returned vec is empty; callers should fall back to the
+/// channel maintainer address in that case.
+#[cfg(feature = "channel-email")]
+fn allowed_recipients_from_env() -> Vec<String> {
+    std::env::var("KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(|r| r.trim().to_string())
+                .filter(|r| !r.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Run `on_authorized` only when the ingest namespace passes the preflight check.
@@ -176,6 +230,7 @@ async fn channel_poll_loop(
     channels: std::sync::Arc<khive_channel::ChannelRegistry>,
     registry: khive_runtime::VerbRegistry,
     ingest_namespace: String,
+    default_inbound_actor: String,
 ) {
     use chrono::Utc;
     use serde_json::json;
@@ -202,6 +257,7 @@ async fn channel_poll_loop(
                             "external_id": env.external_id,
                             "sent_at": env.sent_at.map(|ts| ts.to_rfc3339()),
                             "correlation_external_id": env.correlation_external_id,
+                            "default_inbound_actor": default_inbound_actor,
                         });
                         if let Err(e) = registry.dispatch("comm.ingest", params).await {
                             tracing::warn!(
@@ -213,6 +269,194 @@ async fn channel_poll_loop(
                 }
                 Err(e) => {
                     tracing::warn!(channel = kind, "channel poll failed: {e}");
+                }
+            }
+        }
+    }
+}
+
+/// Background task that delivers undelivered outbound email notes every 5 seconds.
+///
+/// Implements AT-LEAST-ONCE delivery: the `external_id` (= RFC 822 Message-ID) is
+/// persisted to the note BEFORE sending. A crash between the SMTP success and the
+/// `delivered_at` write causes a duplicate send on restart; the duplicate carries
+/// the same Message-ID so receiving MTAs typically collapse it.
+///
+/// Only compiled when the `channel-email` feature is enabled.
+#[cfg(feature = "channel-email")]
+async fn channel_outbox_loop(
+    email_channel: std::sync::Arc<khive_channel_email::EmailChannel>,
+    registry: khive_runtime::VerbRegistry,
+    ingest_namespace: String,
+    mailbox: String,
+    allowlist: Vec<String>,
+) {
+    use chrono::Utc;
+    use khive_channel::ChannelEnvelope;
+    use serde_json::json;
+
+    let domain = mailbox.split('@').nth(1).unwrap_or("localhost").to_string();
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        // Query outbound messages via the registry (list with direction=outbound filter).
+        // No StartsWith FilterOp exists; we filter email: prefix in Rust.
+        let list_params = json!({
+            "namespace": ingest_namespace,
+            "kind": "message",
+            "limit": 100,
+        });
+        let list_result = match registry.dispatch("list", list_params).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "outbox loop: list failed");
+                continue;
+            }
+        };
+
+        let notes = match list_result.get("items").and_then(|v| v.as_array()) {
+            Some(arr) => arr.clone(),
+            None => continue,
+        };
+
+        for note_val in notes {
+            let props = match note_val.get("properties") {
+                Some(serde_json::Value::Object(m)) => m.clone(),
+                _ => continue,
+            };
+
+            // Only outbound direction.
+            if props.get("direction").and_then(|v| v.as_str()) != Some("outbound") {
+                continue;
+            }
+
+            // Only email-addressed notes.
+            let to_actor = match props.get("to_actor").and_then(|v| v.as_str()) {
+                Some(a) if a.starts_with("email:") => a.to_string(),
+                _ => continue,
+            };
+
+            // Skip already-delivered notes.
+            if props.get("delivered_at").is_some() {
+                continue;
+            }
+
+            let note_id = match note_val.get("id").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            let recipient = to_actor
+                .strip_prefix("email:")
+                .unwrap_or(to_actor.as_str())
+                .to_string();
+
+            // Allowlist check.
+            if !allowlist.is_empty() && !allowlist.contains(&recipient) {
+                tracing::warn!(
+                    note_id = %note_id,
+                    recipient = %recipient,
+                    "outbox loop: recipient not in allowlist; skipping"
+                );
+                continue;
+            }
+
+            let subject = props
+                .get("subject")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(no subject)")
+                .to_string();
+
+            let content = match note_val.get("content").and_then(|v| v.as_str()) {
+                Some(c) => c.to_string(),
+                None => continue,
+            };
+
+            let thread_id = props
+                .get("thread_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            // Mint-before-send: derive or reuse the Message-ID.
+            let message_id = match props.get("external_id").and_then(|v| v.as_str()) {
+                Some(eid) if !eid.is_empty() => eid.to_string(),
+                _ => {
+                    let mid = format!("<{note_id}@{domain}>");
+                    // Persist the claimed external_id before sending.
+                    let claim_result = registry
+                        .dispatch(
+                            "update",
+                            json!({
+                                "namespace": ingest_namespace,
+                                "id": note_id,
+                                "properties": { "external_id": mid.clone() },
+                            }),
+                        )
+                        .await;
+                    if let Err(e) = claim_result {
+                        tracing::warn!(
+                            note_id = %note_id,
+                            error = %e,
+                            "outbox loop: failed to claim external_id; skipping"
+                        );
+                        continue;
+                    }
+                    mid
+                }
+            };
+
+            // Build and send the envelope.
+            let mut env = ChannelEnvelope::new(
+                format!("email:{mailbox}"),
+                format!("email:{recipient}"),
+                content,
+            )
+            .with_subject(subject)
+            .with_message_id(message_id.clone());
+
+            if let Some(tid) = thread_id {
+                env = env.with_correlation(tid);
+            }
+
+            match email_channel.send(env).await {
+                Ok(()) => {
+                    let delivered_at = Utc::now().to_rfc3339();
+                    let mark_result = registry
+                        .dispatch(
+                            "update",
+                            json!({
+                                "namespace": ingest_namespace,
+                                "id": note_id,
+                                "properties": { "delivered_at": delivered_at },
+                            }),
+                        )
+                        .await;
+                    match mark_result {
+                        Ok(_) => {
+                            tracing::info!(
+                                note_id = %note_id,
+                                recipient = %recipient,
+                                message_id = %message_id,
+                                "outbox loop: delivered"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                note_id = %note_id,
+                                error = %e,
+                                "outbox loop: failed to set delivered_at (AT-LEAST-ONCE: will retry)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        note_id = %note_id,
+                        recipient = %recipient,
+                        error = %e,
+                        "outbox loop: send failed; will retry next cycle"
+                    );
                 }
             }
         }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -310,6 +310,7 @@ async fn channel_outbox_loop(
             "namespace": ingest_namespace,
             "kind": "message",
             "direction": "outbound",
+            "delivered": false,
             "limit": 200,
         });
         let list_result = match registry.dispatch("list", list_params).await {
@@ -331,7 +332,9 @@ async fn channel_outbox_loop(
                 _ => continue,
             };
 
-            // Only outbound direction.
+            // Only outbound direction. The `delivered=false` filter on the list query
+            // ensures only undelivered notes are returned; this check is a cheap
+            // defensive guard for any note that slips through.
             if props.get("direction").and_then(|v| v.as_str()) != Some("outbound") {
                 continue;
             }
@@ -342,7 +345,7 @@ async fn channel_outbox_loop(
                 _ => continue,
             };
 
-            // Skip already-delivered notes.
+            // Defensive: skip already-delivered notes in case the query filter missed any.
             if props.get("delivered_at").is_some() {
                 continue;
             }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -276,6 +276,20 @@ async fn channel_poll_loop(
     }
 }
 
+/// True if a note's `delivered_at` property marks it as already delivered.
+///
+/// Must match the `list` query predicate's null handling (`list.rs`): a
+/// present-but-null `delivered_at` is undelivered, not delivered. Checking
+/// `.is_some()` alone would treat an explicit null (e.g. left by a curation
+/// `update`) as delivered and strand the note in the outbox forever.
+#[cfg(feature = "channel-email")]
+fn note_already_delivered(props: &serde_json::Map<String, serde_json::Value>) -> bool {
+    props
+        .get("delivered_at")
+        .map(|v| !v.is_null())
+        .unwrap_or(false)
+}
+
 /// Background task that delivers undelivered outbound email notes every 5 seconds.
 ///
 /// Implements AT-LEAST-ONCE delivery: the `external_id` (= RFC 822 Message-ID) is
@@ -346,7 +360,7 @@ async fn channel_outbox_loop(
             };
 
             // Defensive: skip already-delivered notes in case the query filter missed any.
-            if props.get("delivered_at").is_some() {
+            if note_already_delivered(&props) {
                 continue;
             }
 
@@ -2494,5 +2508,37 @@ brain_profile = "project-profile"
             "enforce_strict_actor_mode must return Ok when comm pack is not loaded \
              (no party-line risk even without actor)"
         );
+    }
+
+    // --- note_already_delivered: outbox defensive-guard regression (round-2 finding 1) ---
+
+    #[cfg(feature = "channel-email")]
+    mod outbox_delivered_guard_tests {
+        use super::*;
+        use serde_json::json;
+
+        #[test]
+        fn missing_delivered_at_is_undelivered() {
+            let props = json!({}).as_object().unwrap().clone();
+            assert!(!note_already_delivered(&props));
+        }
+
+        #[test]
+        fn explicit_null_delivered_at_is_undelivered() {
+            // Regression: a note with delivered_at explicitly set to null (e.g. via a
+            // curation `update`) must be treated as undelivered, matching the query
+            // predicate in list.rs — not skipped forever by `.is_some()`.
+            let props = json!({ "delivered_at": null }).as_object().unwrap().clone();
+            assert!(!note_already_delivered(&props));
+        }
+
+        #[test]
+        fn present_non_null_delivered_at_is_delivered() {
+            let props = json!({ "delivered_at": "2026-06-30T12:00:00Z" })
+                .as_object()
+                .unwrap()
+                .clone();
+            assert!(note_already_delivered(&props));
+        }
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -50,7 +50,8 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
             Ok(email_ch) => {
                 let email_ch = Arc::new(email_ch);
                 let mut ch_registry = ChannelRegistry::new();
-                ch_registry.register(Arc::clone(&email_ch));
+                let dyn_ch: Arc<dyn khive_channel::Channel> = email_ch.clone();
+                ch_registry.register(dyn_ch);
                 let ch_registry = Arc::new(ch_registry);
                 let verb_reg = server.verb_registry_clone();
                 let ingest_ns = ingest_namespace_from_env();
@@ -292,7 +293,7 @@ async fn channel_outbox_loop(
     allowlist: Vec<String>,
 ) {
     use chrono::Utc;
-    use khive_channel::ChannelEnvelope;
+    use khive_channel::{Channel, ChannelEnvelope};
     use serde_json::json;
 
     let domain = mailbox.split('@').nth(1).unwrap_or("localhost").to_string();
@@ -300,12 +301,16 @@ async fn channel_outbox_loop(
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-        // Query outbound messages via the registry (list with direction=outbound filter).
-        // No StartsWith FilterOp exists; we filter email: prefix in Rust.
+        // Query outbound messages via the registry. The note `list` handler applies
+        // the `direction` filter server-side (scanning up to its internal cap) and
+        // returns a bare JSON array of full note objects. There is no `delivered_at`
+        // or recipient-prefix filter, so the `email:` prefix and the
+        // already-delivered check are applied per-note below.
         let list_params = json!({
             "namespace": ingest_namespace,
             "kind": "message",
-            "limit": 100,
+            "direction": "outbound",
+            "limit": 200,
         });
         let list_result = match registry.dispatch("list", list_params).await {
             Ok(r) => r,
@@ -315,7 +320,7 @@ async fn channel_outbox_loop(
             }
         };
 
-        let notes = match list_result.get("items").and_then(|v| v.as_array()) {
+        let notes = match list_result.as_array() {
             Some(arr) => arr.clone(),
             None => continue,
         };

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -581,8 +581,14 @@ pub(crate) async fn handle_ingest(
     // Thread resolution: if correlation_external_id is present, find the message it refers to
     // and extract both its internal thread_id and the from_actor of the original sender so that
     // replies route back to the actor who sent the original, not to the raw email address.
+    //
+    // Two-query fallback: `corr` may be either a Message-ID (matched via $.external_id) from
+    // a human webmail In-Reply-To header, OR a thread UUID (matched via $.thread_id) from
+    // a preserved X-Khive-Thread-ID header on our own outbound emails.  We try external_id
+    // first (preserves the In-Reply-To path); if that misses we fall back to thread_id.
     let resolved: Option<(String, String)> = if let Some(ref corr) = p.correlation_external_id {
         if !corr.is_empty() {
+            // Pass 1: match by $.external_id (RFC 822 Message-ID, standard In-Reply-To path).
             let corr_filter = NoteFilter {
                 kind: Some("message".to_string()),
                 property_filters: vec![PropertyFilter {
@@ -602,7 +608,7 @@ pub(crate) async fn handle_ingest(
                     },
                 )
                 .await?;
-            corr_page.items.first().and_then(|n| {
+            let pass1 = corr_page.items.first().and_then(|n| {
                 let props = n.properties.as_ref()?;
                 let thread_id = props
                     .get("thread_id")
@@ -615,7 +621,51 @@ pub(crate) async fn handle_ingest(
                     .unwrap_or("")
                     .to_string();
                 Some((thread_id, from_actor))
-            })
+            });
+
+            if pass1.is_some() {
+                pass1
+            } else if corr.parse::<Uuid>().is_ok() {
+                // Pass 2: `corr` is a UUID — may be a thread UUID from X-Khive-Thread-ID.
+                // Match against $.thread_id on an outbound note to recover from_actor.
+                let thread_filter = NoteFilter {
+                    kind: Some("message".to_string()),
+                    property_filters: vec![
+                        PropertyFilter {
+                            json_path: "$.thread_id".to_string(),
+                            op: FilterOp::Eq,
+                            value: SqlValue::Text(corr.clone()),
+                        },
+                        PropertyFilter {
+                            json_path: "$.direction".to_string(),
+                            op: FilterOp::Eq,
+                            value: SqlValue::Text("outbound".to_string()),
+                        },
+                    ],
+                    ..Default::default()
+                };
+                let thread_page = store
+                    .query_notes_filtered(
+                        ns,
+                        &thread_filter,
+                        PageRequest {
+                            limit: 1,
+                            offset: 0,
+                        },
+                    )
+                    .await?;
+                thread_page.items.first().and_then(|n| {
+                    let props = n.properties.as_ref()?;
+                    let from_actor = props
+                        .get("from_actor")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    Some((corr.clone(), from_actor))
+                })
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -578,9 +578,10 @@ pub(crate) async fn handle_ingest(
     let ns = token.namespace().as_str();
     let store = runtime.notes(token)?;
 
-    // Thread resolution: if correlation_external_id is present, find the message
-    // it refers to and extract its internal thread_id.
-    let resolved_thread_id: Option<String> = if let Some(ref corr) = p.correlation_external_id {
+    // Thread resolution: if correlation_external_id is present, find the message it refers to
+    // and extract both its internal thread_id and the from_actor of the original sender so that
+    // replies route back to the actor who sent the original, not to the raw email address.
+    let resolved: Option<(String, String)> = if let Some(ref corr) = p.correlation_external_id {
         if !corr.is_empty() {
             let corr_filter = NoteFilter {
                 kind: Some("message".to_string()),
@@ -601,14 +602,20 @@ pub(crate) async fn handle_ingest(
                     },
                 )
                 .await?;
-            corr_page
-                .items
-                .first()
-                .and_then(|n| n.properties.as_ref())
-                .and_then(|props| props.get("thread_id"))
-                .and_then(Value::as_str)
-                .filter(|s| s.parse::<Uuid>().is_ok())
-                .map(|s| s.to_string())
+            corr_page.items.first().and_then(|n| {
+                let props = n.properties.as_ref()?;
+                let thread_id = props
+                    .get("thread_id")
+                    .and_then(Value::as_str)
+                    .filter(|s| s.parse::<Uuid>().is_ok())
+                    .map(|s| s.to_string())?;
+                let from_actor = props
+                    .get("from_actor")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                Some((thread_id, from_actor))
+            })
         } else {
             None
         }
@@ -622,8 +629,25 @@ pub(crate) async fn handle_ingest(
         .as_deref()
         .filter(|s| s.parse::<Uuid>().is_ok())
         .map(|s| s.to_string())
-        .or(resolved_thread_id)
+        .or_else(|| resolved.as_ref().map(|(tid, _)| tid.clone()))
         .unwrap_or_else(|| Uuid::new_v4().as_hyphenated().to_string());
+
+    // Determine to_actor with 3-tier priority:
+    // 1. from_actor of the correlated original (route reply back to the sending actor)
+    // 2. caller-supplied default_inbound_actor (fresh email landing actor)
+    // 3. p.to.trim() (back-compat: raw recipient address)
+    let to_actor = resolved
+        .as_ref()
+        .map(|(_, fa)| fa.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            p.default_inbound_actor
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| p.to.trim().to_string());
 
     let sent_at = p.sent_at.as_deref().unwrap_or("").to_string();
     let sent_at_value = if sent_at.is_empty() {
@@ -636,7 +660,7 @@ pub(crate) async fn handle_ingest(
         "from": p.from.trim(),
         "to": p.to.trim(),
         "from_actor": p.from.trim(),
-        "to_actor": p.to.trim(),
+        "to_actor": to_actor,
         "direction": "inbound",
         "read": false,
         "thread_id": thread_id,

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -83,6 +83,10 @@ pub(crate) struct IngestParams {
     /// External correlation key for thread resolution (e.g. X-Khive-Thread-ID or In-Reply-To value).
     #[serde(default)]
     pub correlation_external_id: Option<String>,
+    /// Actor to route to when no correlation resolves a prior sender (e.g. `"lambda:leo"`).
+    /// When absent and no correlation match is found, falls back to `p.to.trim()`.
+    #[serde(default)]
+    pub default_inbound_actor: Option<String>,
 }
 
 pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -4108,3 +4108,89 @@ async fn ingest_routing_no_default_falls_back_to_to_field() {
         "no default actor: to_actor must fall back to p.to; got props={props}"
     );
 }
+
+// ── Finding 2: X-Khive-Thread-ID header correlation (thread-UUID fallback) ───
+//
+// When our own outbound email carries X-Khive-Thread-ID = <thread_uuid>, a reply
+// that preserves that header arrives with correlation_external_id = <thread_uuid>.
+// The existing pass-1 (external_id match) finds nothing because thread_uuid ≠
+// the note's external_id (which is a Message-ID).  The new pass-2 matches
+// $.thread_id on an outbound note to recover from_actor and route the reply
+// back to the original sender's actor.
+
+/// (d) Reply correlating via thread-UUID (X-Khive-Thread-ID fallback) routes to
+/// the original sender's actor even when no external_id match exists.
+#[tokio::test]
+async fn ingest_routing_reply_via_thread_uuid_routes_to_original_sender() {
+    use khive_storage::note::Note;
+
+    let (registry, rt) = build_registry_for_ns("local");
+
+    // Plant an outbound message note directly (simulates one we already sent).
+    // Properties: external_id is a standard Message-ID; thread_id is the internal UUID.
+    // from_actor is the actor we expect the reply to route back to.
+    let thread_uuid = uuid::Uuid::new_v4().as_hyphenated().to_string();
+    {
+        let token = rt
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize");
+        let store = rt.notes(&token).expect("notes store");
+        let now = chrono::Utc::now().timestamp_micros();
+        let note = Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "original outbound via thread".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "email:leo@khive.ai",
+                "to": "email:user@example.com",
+                "from_actor": "lambda:khive",
+                "to_actor": "email:user@example.com",
+                // external_id is a real Message-ID — NOT the thread_uuid.
+                "external_id": "<original-message-id@khive.ai>",
+                "thread_id": thread_uuid,
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.upsert_note(note).await.expect("upsert outbound note");
+    }
+
+    // Ingest a reply whose correlation_external_id is the thread_uuid (X-Khive-Thread-ID).
+    // Pass-1 (external_id match) will find nothing because thread_uuid ≠ external_id.
+    // Pass-2 (thread_id match on outbound) must recover from_actor=lambda:khive.
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:user@example.com",
+            "to": "email:leo@khive.ai",
+            "content": "this is a reply via X-Khive-Thread-ID",
+            "correlation_external_id": thread_uuid,
+            "external_id": "imap:mail:thread-uuid-reply:1",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("lambda:khive"),
+        "Finding 2: reply correlating via thread-UUID must route to lambda:khive \
+         (original sender's actor); got props={props}"
+    );
+    assert_eq!(
+        props["thread_id"].as_str(),
+        Some(thread_uuid.as_str()),
+        "Finding 2: ingested reply must be attached to the original thread_id; \
+         got props={props}"
+    );
+}

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -3956,3 +3956,155 @@ async fn i199_anonymous_inbox_sees_local_messages() {
          got count={count}"
     );
 }
+
+// --- ingest routing tests (actor routing via default_inbound_actor + correlation) ---
+
+/// Helper: ingest a message note and return the stored props.
+async fn ingest_and_get_props(
+    registry: &VerbRegistry,
+    rt: &KhiveRuntime,
+    params: serde_json::Value,
+) -> serde_json::Value {
+    let result = registry
+        .dispatch("comm.ingest", params)
+        .await
+        .expect("ingest succeeds");
+    assert!(
+        !result
+            .get("deduplicated")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        "message must not be deduplicated in routing tests"
+    );
+    let full_id = result["full_id"].as_str().expect("full_id present");
+    let uuid = full_id.parse::<uuid::Uuid>().expect("valid UUID");
+    let token = rt
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let store = rt.notes(&token).expect("notes store");
+    let note = store
+        .get_note(uuid)
+        .await
+        .expect("get_note ok")
+        .expect("note exists");
+    note.properties.expect("note has properties")
+}
+
+/// (a) Reply with correlation matching an outbound note whose from_actor=lambda:khive
+/// → ingested note to_actor=lambda:khive.
+#[tokio::test]
+async fn ingest_routing_reply_routes_to_original_sender() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    // Plant an outbound message that looks like one lambda:khive sent.
+    // We use comm.send to write the note, then read its external_id back.
+    // We need a note with properties.external_id set so correlation resolution can find it.
+    // Directly insert via the runtime store to control all fields.
+    let outbound_external_id = "<sent-msg-001@khive.ai>";
+    {
+        use khive_storage::note::Note;
+        let token = rt
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize");
+        let store = rt.notes(&token).expect("notes store");
+        let now = chrono::Utc::now().timestamp_micros();
+        let thread_uuid = uuid::Uuid::new_v4();
+        let note = Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "original outbound".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "email:leo@khive.ai",
+                "to": "email:user@example.com",
+                "from_actor": "lambda:khive",
+                "to_actor": "email:user@example.com",
+                "external_id": outbound_external_id,
+                "thread_id": thread_uuid.as_hyphenated().to_string(),
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.upsert_note(note).await.expect("upsert outbound note");
+    }
+
+    // Ingest a reply whose correlation_external_id matches the outbound note's external_id.
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:user@example.com",
+            "to": "email:leo@khive.ai",
+            "content": "this is a reply",
+            "correlation_external_id": outbound_external_id,
+            "external_id": "imap:mail:1:1",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("lambda:khive"),
+        "reply must route to the original sender's actor; got props={props}"
+    );
+}
+
+/// (b) Fresh message, no correlation, default_inbound_actor=lambda:leo → to_actor=lambda:leo.
+#[tokio::test]
+async fn ingest_routing_fresh_message_uses_default_actor() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:stranger@example.com",
+            "to": "email:leo@khive.ai",
+            "content": "hello from a stranger",
+            "external_id": "imap:mail:1:2",
+            "default_inbound_actor": "lambda:leo",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("lambda:leo"),
+        "fresh message must route to default_inbound_actor; got props={props}"
+    );
+}
+
+/// (c) No correlation, no default_inbound_actor → to_actor=p.to (back-compat).
+#[tokio::test]
+async fn ingest_routing_no_default_falls_back_to_to_field() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:stranger@example.com",
+            "to": "email:leo@khive.ai",
+            "content": "back-compat message",
+            "external_id": "imap:mail:1:3",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("email:leo@khive.ai"),
+        "no default actor: to_actor must fall back to p.to; got props={props}"
+    );
+}

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -257,6 +257,12 @@ pub(crate) static KG_HANDLERS: [HandlerDef; 16] = [
                 required: false,
                 description: "Filter messages by read status (kind=\"message\" only): true = read, false = unread.",
             },
+            ParamDef {
+                name: "delivered",
+                param_type: "bool",
+                required: false,
+                description: "Filter messages by delivery status (kind=\"message\" only): true = delivered, false = undelivered (missing or null delivered_at).",
+            },
         ],
     },
     // Assertive: returns aggregate substrate counts (#280)

--- a/crates/khive-pack-kg/src/handlers/list.rs
+++ b/crates/khive-pack-kg/src/handlers/list.rs
@@ -157,13 +157,15 @@ impl KgPack {
                     || p.direction.is_some()
                     || p.from.is_some()
                     || p.to.is_some()
-                    || p.read.is_some();
+                    || p.read.is_some()
+                    || p.delivered.is_some();
 
                 let thread_id_filter = p.thread_id.as_deref();
                 let direction_filter = p.direction.as_deref();
                 let from_filter = p.from.as_deref();
                 let to_filter = p.to.as_deref();
                 let read_filter = p.read;
+                let delivered_filter = p.delivered;
 
                 const PAGE_SIZE: u32 = 200;
                 const MAX_SCAN_TOTAL: u32 = 10_000;
@@ -240,6 +242,15 @@ impl KgPack {
                                         .and_then(Value::as_bool)
                                         .unwrap_or(false);
                                     if stored != wanted_read {
+                                        return false;
+                                    }
+                                }
+                                if let Some(wanted_delivered) = delivered_filter {
+                                    let is_delivered = props
+                                        .and_then(|p| p.get("delivered_at"))
+                                        .map(|v| !v.is_null())
+                                        .unwrap_or(false);
+                                    if is_delivered != wanted_delivered {
                                         return false;
                                     }
                                 }

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -67,6 +67,8 @@ pub(crate) struct ListParams {
     pub(crate) from: Option<String>,
     pub(crate) to: Option<String>,
     pub(crate) read: Option<bool>,
+    #[serde(default)]
+    pub(crate) delivered: Option<bool>,
     pub(crate) verb: Option<String>,
     pub(crate) verbs: Option<Vec<String>>,
     pub(crate) outcome: Option<String>,

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7403,7 +7403,11 @@ async fn proposal_add_note_changeset_note_exists_in_kg_after_apply() {
 // the 200 most-recent notes and applied the delivered_at check in Rust — so an
 // old undelivered note was permanently stranded behind the delivered ones.
 // After the fix, the query layer filters on delivered=false BEFORE applying the
-// 200-note page, so undelivered notes are always reachable.
+// 200-note page, so undelivered notes are reachable past the old 200-row strand.
+// This does NOT make the scan unbounded: `list` still caps total rows scanned at
+// MAX_SCAN_TOTAL (10_000, see list.rs), so an undelivered note older than 10,000
+// newer message rows is still unreachable. Tracked as a follow-up to push the
+// `delivered` filter into the storage-level NoteFilter/SQL path.
 
 #[tokio::test]
 async fn list_delivered_filter_finds_undelivered_note_past_200_delivered() {

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7396,3 +7396,144 @@ async fn proposal_add_note_changeset_note_exists_in_kg_after_apply() {
          got empty search result"
     );
 }
+
+// ── Finding 1: delivered filter must reach past 200 delivered notes ────────────
+//
+// Regression: before the fix, list(kind=message, direction=outbound) fetched
+// the 200 most-recent notes and applied the delivered_at check in Rust — so an
+// old undelivered note was permanently stranded behind the delivered ones.
+// After the fix, the query layer filters on delivered=false BEFORE applying the
+// 200-note page, so undelivered notes are always reachable.
+
+#[tokio::test]
+async fn list_delivered_filter_finds_undelivered_note_past_200_delivered() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let token = rt.authorize(Namespace::local()).expect("authorize local");
+
+    // Write the OLD undelivered note first (smallest created_at → sorted last by DB).
+    let old_undelivered = rt
+        .create_note(
+            &token,
+            "message",
+            None,
+            "the old undelivered note",
+            None,
+            Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "email:leo@khive.ai",
+                "to": "email:user@example.com",
+                "to_actor": "email:user@example.com",
+            })),
+            vec![],
+        )
+        .await
+        .expect("create old undelivered note");
+    let old_id = old_undelivered.id.as_hyphenated().to_string();
+
+    // Write 210 NEWER delivered notes (these sort before the old one in DESC order).
+    let store = rt.notes(&token).expect("note store");
+    for i in 0..210u32 {
+        let note = Note::new("local", "message", format!("delivered {i}")).with_properties(
+            serde_json::json!({
+                "direction": "outbound",
+                "from": "email:leo@khive.ai",
+                "to": "email:user@example.com",
+                "to_actor": "email:user@example.com",
+                "delivered_at": "2026-01-01T00:00:00Z",
+            }),
+        );
+        store
+            .upsert_note(note)
+            .await
+            .expect("upsert delivered note");
+    }
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+
+    // delivered=false must return the old undelivered note (not strand it behind 210 delivered).
+    // Use kind="note" (the generic substrate level) so the test registry (KgPack-only) can
+    // resolve the kind without needing CommPack's "message" granular registration.
+    let result = registry
+        .dispatch(
+            "list",
+            serde_json::json!({
+                "kind": "note",
+                "direction": "outbound",
+                "delivered": false,
+                "limit": 10,
+            }),
+        )
+        .await
+        .expect("list(delivered=false) must succeed");
+
+    let items = result.as_array().expect("list returns array");
+    assert_eq!(
+        items.len(),
+        1,
+        "Finding 1: list(delivered=false) must find the 1 undelivered note past 210 delivered; \
+         got {} items",
+        items.len()
+    );
+    let returned_id = items[0].get("id").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(
+        returned_id, old_id,
+        "Finding 1: returned note id={returned_id} must equal the undelivered note id={old_id}"
+    );
+
+    // delivered=true must return only delivered notes.
+    // Note: the note list handler caps at 200 per page, so with 210 delivered notes
+    // we request 200 (the cap) and expect 200 — all of them must have delivered_at.
+    let delivered_result = registry
+        .dispatch(
+            "list",
+            serde_json::json!({
+                "kind": "note",
+                "direction": "outbound",
+                "delivered": true,
+                "limit": 200,
+            }),
+        )
+        .await
+        .expect("list(delivered=true) must succeed");
+    let delivered_items = delivered_result.as_array().expect("array");
+    assert_eq!(
+        delivered_items.len(),
+        200,
+        "Finding 1: list(delivered=true) must return 200 delivered notes (page cap); \
+         got {}",
+        delivered_items.len()
+    );
+    for item in delivered_items {
+        let da = item
+            .get("properties")
+            .and_then(|p| p.get("delivered_at"))
+            .and_then(|v| v.as_str());
+        assert!(
+            da.is_some(),
+            "Finding 1: list(delivered=true) items must all have delivered_at; got {item}"
+        );
+    }
+
+    // Absent delivered param must return the page cap worth of notes (back-compat — no extra filter).
+    let all_result = registry
+        .dispatch(
+            "list",
+            serde_json::json!({
+                "kind": "note",
+                "direction": "outbound",
+                "limit": 200,
+            }),
+        )
+        .await
+        .expect("list(no delivered filter) must succeed");
+    let all_items = all_result.as_array().expect("array");
+    assert_eq!(
+        all_items.len(),
+        200,
+        "Finding 1: list(no delivered filter) must return 200 notes (page cap of 211 total); \
+         got {}",
+        all_items.len()
+    );
+}

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 clap = { workspace = true }
+dotenvy = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -195,8 +195,28 @@ enum BackendCommand {
     },
 }
 
+/// Load `~/.khive/.env` into the process environment if present.
+///
+/// khive reads all configuration from process env (`std::env::var`), so this
+/// makes `~/.khive/.env` the canonical config home — credentials set there
+/// reach the daemon however it is spawned. Real environment variables win over
+/// the file (dotenvy does not override what is already set), and a missing file
+/// is not an error.
+fn load_khive_dotenv() {
+    let Some(home) = std::env::var_os("HOME") else {
+        return;
+    };
+    let path = std::path::Path::new(&home).join(".khive/.env");
+    match dotenvy::from_path(&path) {
+        Ok(()) => {}
+        Err(e) if e.not_found() => {}
+        Err(e) => eprintln!("warning: failed to load {}: {e}", path.display()),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    load_khive_dotenv();
     let args = Args::parse();
     init_tracing(&args.log);
 


### PR DESCRIPTION
## What

Completes the email channel round-trip: outbound messages are now actually
delivered (and correlatable), and inbound replies route back to the actor that
sent the original message.

Stacked on #370 (STARTTLS + dotenv). Base will retarget to `main` once #370 merges.

## Why

Before this change, `comm.send` persisted an outbound note but nothing delivered
it over SMTP, and `comm.ingest` stamped every inbound message's `to_actor` with
the raw recipient email address rather than the actor a reply belongs to. A human
reply could not be correlated or routed.

## Changes

1. **`khive-channel`** — `ChannelEnvelope.message_id: Option<String>` carrier +
   `with_message_id()` builder. `None` on inbound.

2. **`khive-channel-email`** — thread `message_id` through
   `SmtpConnector::deliver` → `SmtpSender::send` → lettre
   `MessageBuilder::message_id()`. The value is set verbatim (caller supplies the
   angle brackets; lettre does not re-wrap). `mailbox()` / `maintainer_address()`
   accessors for the outbox loop.

3. **`khive-pack-comm`** — `handle_ingest` resolves the correlated original's
   `from_actor` (not just its `thread_id`) and applies a 3-tier `to_actor` rule:
   correlated sender's actor > caller-supplied `default_inbound_actor` >
   `p.to.trim()` (back-compat). New optional `IngestParams.default_inbound_actor`.

4. **`khive-mcp`** — new `channel_outbox_loop`: every 5s it scans undelivered
   outbound email notes and delivers them. Mint-before-send for crash-safe
   idempotency: the RFC 822 Message-ID (`<{note_id}@{domain}>`) is persisted as
   the note's `external_id` **before** the SMTP send; `delivered_at` is set on
   success. A recipient allowlist (`KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS`, default =
   maintainer address) bounds who the loop may email. The inbound poll loop now
   passes `default_inbound_actor` (from `KHIVE_EMAIL_DEFAULT_ACTOR`, default
   `lambda:leo`) to `comm.ingest`.

5. **Config** — `KHIVE_EMAIL_DEFAULT_ACTOR` and
   `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` documented in the crate-level doc table
   and `.env.example`.

## The correlation linchpin

Human replies from common webmail clients strip custom `X-` headers but set
`In-Reply-To` to the original Message-ID. `comm.ingest` matches
`correlation_external_id` (= `In-Reply-To`) against a stored note's `external_id`.
For that to work, the outbound note must be stored with `external_id` equal to its
own RFC 822 Message-ID, and the same Message-ID must be the header on the wire.
This PR mints and controls that Message-ID on both sides.

## Semantics and known limitations

- **At-least-once delivery.** A crash between SMTP success and the `delivered_at`
  write re-sends on restart; the duplicate carries the same Message-ID so
  receiving servers typically collapse it. Exactly-once over SMTP is not possible.
- **Scan-window bound.** `list` now filters on `delivered=false` in the query
  path itself (not a post-fetch Rust check), so an old undelivered note is no
  longer permanently stranded behind newer delivered ones. The scan is still
  capped at `MAX_SCAN_TOTAL` (10,000 rows) — an undelivered note older than
  10,000 newer message rows is unreachable until those age out. Tracked as a
  follow-up to push the `delivered` filter into the storage-level SQL path.
- **Single namespace.** Only the ingest namespace is scanned. Multi-namespace and
  multi-provider/tenant delivery are out of scope (see #371).
- **Simple retry.** A persistently failing send retries each cycle; no backoff or
  dead-letter in v1.

## Tests

`khive-channel` envelope builder, `smtp` Message-ID passthrough (CapturingSmtp),
and 3 `khive-pack-comm` integration tests covering the routing table (reply →
sending actor; fresh → default actor; no-default → back-compat). Gates:
fmt, clippy `-D warnings`, workspace tests, rustdoc `-D warnings`.

The live IMAP/SMTP round-trip is gated on mailbox grants and is not part of this PR.
