### PR TITLE
feat(session): mirror Codex CLI transcripts alongside Claude Code

### DIFF
--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -719,10 +719,17 @@ mod tests {
 
     // ── Codex source integration tests ────────────────────────────────────────
 
-    /// Build a minimal Codex response_item/message line.
+    /// Build a minimal Codex response_item/message line. Block type mirrors the
+    /// real shape: `input_text` for user messages, `output_text` for assistant
+    /// messages (the generic `text` type does not occur in real Codex transcripts).
     fn codex_message_line(role: &str, text: &str) -> String {
+        let block_type = if role == "assistant" {
+            "output_text"
+        } else {
+            "input_text"
+        };
         format!(
-            r#"{{"type":"response_item","timestamp":"2026-06-30T08:00:00Z","payload":{{"type":"message","role":"{role}","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+            r#"{{"type":"response_item","timestamp":"2026-06-30T08:00:00Z","payload":{{"type":"message","role":"{role}","content":[{{"type":"{block_type}","text":"{text}"}}]}}}}"#
         )
     }
 
@@ -788,6 +795,43 @@ mod tests {
 
         // All 3 message rows are stored.
         assert_eq!(count_rows(&rt, "session_messages").await, 3);
+
+        // The two response_item/message rows carry their real input_text/
+        // output_text content through to session_messages.text — not just a
+        // row count, but the actual extracted string for each role.
+        let mut r2 = sql.reader().await.expect("reader");
+        let rows = r2
+            .query_all(SqlStatement {
+                sql: "SELECT role, text FROM session_messages \
+                      WHERE session_id=?1 AND role IS NOT NULL ORDER BY seq"
+                    .into(),
+                params: vec![SqlValue::Text(session_id.to_string())],
+                label: None,
+            })
+            .await
+            .expect("query ok");
+        let texts: Vec<(String, String)> = rows
+            .iter()
+            .map(|row| {
+                let role = match row.get("role") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => panic!("unexpected role value: {other:?}"),
+                };
+                let text = match row.get("text") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => panic!("unexpected text value: {other:?}"),
+                };
+                (role, text)
+            })
+            .collect();
+        assert_eq!(
+            texts,
+            vec![
+                ("user".to_string(), "Hello from Codex".to_string()),
+                ("assistant".to_string(), "Hello back from Codex".to_string()),
+            ],
+            "input_text/output_text blocks must round-trip to session_messages.text by role"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1,9 +1,10 @@
 //! Idempotent file tail + upsert into the session mirror tables.
 //!
-//! `mirror_file` reads new bytes from a CC JSONL file starting at `start_offset`,
-//! parses complete lines, and writes them to the session mirror tables in a single
-//! transaction.  It is safe to call repeatedly on the same file; `INSERT OR IGNORE`
-//! keyed by the CC event UUID ensures idempotency.
+//! `mirror_file` reads new bytes from a JSONL file starting at `start_offset`,
+//! parses complete lines using the parser selected by `MirrorSource`, and writes
+//! them to the session mirror tables in a single transaction.  It is safe to call
+//! repeatedly on the same file; `INSERT OR IGNORE` keyed by the event UUID ensures
+//! idempotency.
 
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
@@ -13,6 +14,27 @@ use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlTxOptions, SqlValue};
 
 use super::parse;
+
+/// Identifies which CLI produced the JSONL file being mirrored.
+///
+/// The value is written to `sessions.source` and selects the line parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MirrorSource {
+    /// Claude Code (`~/.claude/projects/<slug>/<uuid>.jsonl`).
+    ClaudeCode,
+    /// Codex CLI (`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`).
+    Codex,
+}
+
+impl MirrorSource {
+    /// The string written to `sessions.source`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MirrorSource::ClaudeCode => "claude_code",
+            MirrorSource::Codex => "codex",
+        }
+    }
+}
 
 /// Statistics returned by a single `mirror_file` call.
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -25,8 +47,15 @@ pub struct MirrorStats {
     pub new_offset: u64,
 }
 
-/// Read new bytes of `path` starting at `start_offset`, parse complete lines,
-/// and upsert them idempotently into the session mirror tables.
+/// Read new bytes of `path` starting at `start_offset`, parse complete lines
+/// using the parser selected by `source`, and upsert them idempotently into the
+/// session mirror tables.
+///
+/// For `MirrorSource::Codex`, `codex_session_id` must be the session UUID
+/// derived from the filename; it is used both to key the `sessions` row and to
+/// synthesise per-line event UUIDs (`"{session_id}:{abs_byte_offset}"`).
+/// For `MirrorSource::ClaudeCode`, `codex_session_id` is ignored (the session
+/// UUID is embedded in each line).
 ///
 /// Returns stats including the advanced byte offset.  A partial trailing line
 /// (no terminating `\n`) is left for the next poll — `new_offset` is set to
@@ -39,6 +68,8 @@ pub async fn mirror_file(
     runtime: &KhiveRuntime,
     path: &Path,
     start_offset: u64,
+    source: MirrorSource,
+    codex_session_id: Option<&str>,
 ) -> Result<MirrorStats, RuntimeError> {
     // ── read new bytes ────────────────────────────────────────────────────────
 
@@ -84,11 +115,32 @@ pub async fn mirror_file(
     // ── parse complete lines ──────────────────────────────────────────────────
 
     let complete_content = String::from_utf8_lossy(&content[..complete_bytes]);
-    let events: Vec<parse::ParsedEvent> = complete_content
-        .split('\n')
-        .filter(|l| !l.is_empty())
-        .filter_map(parse::parse_cc_line)
-        .collect();
+
+    // For Codex lines we need the absolute byte offset of each line start so
+    // the synthesised event UUID is stable across re-tails.  Compute line
+    // boundaries once, then iterate with offsets.
+    let events: Vec<parse::ParsedEvent> = match source {
+        MirrorSource::ClaudeCode => complete_content
+            .split('\n')
+            .filter(|l| !l.is_empty())
+            .filter_map(parse::parse_cc_line)
+            .collect(),
+        MirrorSource::Codex => {
+            let sid = codex_session_id.unwrap_or("");
+            let mut line_start: u64 = start_offset;
+            let mut evs = Vec::new();
+            for raw_line in complete_content.split('\n') {
+                let line_byte_len = raw_line.len() as u64 + 1; // +1 for the '\n'
+                if !raw_line.is_empty() {
+                    if let Some(ev) = parse::parse_codex_line(raw_line, sid, line_start) {
+                        evs.push(ev);
+                    }
+                }
+                line_start += line_byte_len;
+            }
+            evs
+        }
+    };
 
     let scanned = complete_content
         .split('\n')
@@ -134,12 +186,14 @@ pub async fn mirror_file(
         // strict replay idempotency. `last_seen_at` is advanced below, but only
         // when a genuinely new message lands.
         tx.execute(SqlStatement {
-            sql: "INSERT INTO sessions \
+            sql: format!(
+                "INSERT INTO sessions \
                   (id, provider_session_id, source, cwd, git_branch, slug, \
                    message_count, first_seen_at, last_seen_at, namespace) \
-                  VALUES(?1, ?1, 'claude_code', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
-                  ON CONFLICT(id) DO NOTHING"
-                .into(),
+                  VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
+                  ON CONFLICT(id) DO NOTHING",
+                source.as_str()
+            ),
             params: vec![
                 SqlValue::Text(ev.session_id.clone()),
                 ev.cwd
@@ -495,7 +549,7 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // First call: should insert all 3 rows.
-        let stats = mirror_file(&rt, &path, 0)
+        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
             .await
             .expect("mirror_file first call");
         assert_eq!(stats.inserted, 3, "should insert 3 new messages");
@@ -509,14 +563,14 @@ mod tests {
         assert_eq!(session_count, 1, "1 session row");
 
         // Idempotency: second call over the SAME range inserts 0 rows.
-        let stats2 = mirror_file(&rt, &path, 0)
+        let stats2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
             .await
             .expect("mirror_file second call");
         assert_eq!(stats2.inserted, 0, "second pass must insert 0 rows");
         assert_eq!(count_rows(&rt, "session_messages").await, 3);
 
         // Offset-aware: calling from the advanced offset finds nothing new.
-        let stats3 = mirror_file(&rt, &path, stats.new_offset)
+        let stats3 = mirror_file(&rt, &path, stats.new_offset, MirrorSource::ClaudeCode, None)
             .await
             .expect("mirror_file from new_offset");
         assert_eq!(stats3.inserted, 0, "no new data past advanced offset");
@@ -543,7 +597,7 @@ mod tests {
         let path = file.path().to_path_buf();
         let full_len = std::fs::metadata(&path).unwrap().len();
 
-        let stats = mirror_file(&rt, &path, 0)
+        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
             .await
             .expect("mirror_file partial");
 
@@ -556,7 +610,7 @@ mod tests {
         );
 
         // The partial bytes remain; calling again from new_offset finds no complete lines.
-        let stats2 = mirror_file(&rt, &path, stats.new_offset)
+        let stats2 = mirror_file(&rt, &path, stats.new_offset, MirrorSource::ClaudeCode, None)
             .await
             .expect("second call");
         assert_eq!(
@@ -581,19 +635,25 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // First call inserts.
-        let s1 = mirror_file(&rt, &path, 0).await.unwrap();
+        let s1 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(s1.inserted, 1);
 
         // Append same uuid again.
         writeln!(file, "{line}").unwrap();
 
         // Second call from offset 0 should see both lines but insert 0 new rows.
-        let s2 = mirror_file(&rt, &path, 0).await.unwrap();
+        let s2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(s2.inserted, 0, "duplicate uuid must not be re-inserted");
         assert_eq!(count_rows(&rt, "session_messages").await, 1);
 
         // Incremental: call from first call's new_offset; the second line is the dup.
-        let s3 = mirror_file(&rt, &path, s1.new_offset).await.unwrap();
+        let s3 = mirror_file(&rt, &path, s1.new_offset, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(s3.inserted, 0, "incremental dup must also insert 0");
     }
 
@@ -610,7 +670,9 @@ mod tests {
         writeln!(file, "{line}").unwrap();
         let path = file.path().to_path_buf();
 
-        let s1 = mirror_file(&rt, &path, 0).await.unwrap();
+        let s1 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(s1.inserted, 1);
         let seen_after_first = last_seen_at(&rt, "sess-NTS")
             .await
@@ -618,7 +680,9 @@ mod tests {
 
         // Replay from offset 0: re-scans the same line, inserts 0, and must
         // leave last_seen_at byte-identical even though now_us has advanced.
-        let s2 = mirror_file(&rt, &path, 0).await.unwrap();
+        let s2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(s2.inserted, 0, "replay must insert 0 rows");
         let seen_after_replay = last_seen_at(&rt, "sess-NTS").await.unwrap();
         assert_eq!(
@@ -634,7 +698,9 @@ mod tests {
         let file = NamedTempFile::new().expect("tmpfile");
         let path = file.path().to_path_buf();
 
-        let stats = mirror_file(&rt, &path, 0).await.unwrap();
+        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
         assert_eq!(stats.inserted, 0);
         assert_eq!(stats.scanned, 0);
         assert_eq!(stats.new_offset, 0);
@@ -644,10 +710,198 @@ mod tests {
     async fn test_missing_file_returns_error() {
         let (rt, _dir) = setup().await;
         let bad_path = std::path::PathBuf::from("/nonexistent/path/session.jsonl");
-        let result = mirror_file(&rt, &bad_path, 0).await;
+        let result = mirror_file(&rt, &bad_path, 0, MirrorSource::ClaudeCode, None).await;
         assert!(
             matches!(result, Err(RuntimeError::Internal(_))),
             "missing file should return Internal error"
         );
+    }
+
+    // ── Codex source integration tests ────────────────────────────────────────
+
+    /// Build a minimal Codex response_item/message line.
+    fn codex_message_line(role: &str, text: &str) -> String {
+        format!(
+            r#"{{"type":"response_item","timestamp":"2026-06-30T08:00:00Z","payload":{{"type":"message","role":"{role}","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        )
+    }
+
+    /// Build a minimal Codex session_meta line.
+    fn codex_meta_line(session_id: &str, cwd: &str, branch: &str) -> String {
+        format!(
+            r#"{{"type":"session_meta","timestamp":"2026-06-30T08:00:00Z","payload":{{"id":"{session_id}","cwd":"{cwd}","git":{{"branch":"{branch}","commit_hash":"abc","repository_url":"https://github.com/example/repo"}}}}}}"#
+        )
+    }
+
+    /// Build a Codex event_msg line (should be skipped).
+    fn codex_event_msg_line() -> String {
+        r#"{"type":"event_msg","timestamp":"2026-06-30T08:00:00Z","payload":{"type":"user_message","content":"should be skipped"}}"#.to_string()
+    }
+
+    #[tokio::test]
+    async fn test_codex_mirror_inserts_with_source_codex() {
+        let (rt, _dir) = setup().await;
+
+        let session_id = "cdx-sess-0001-0001-0001-000000000001";
+        let meta = codex_meta_line(session_id, "/home/lion/proj", "feat-x");
+        let user_msg = codex_message_line("user", "Hello from Codex");
+        let asst_msg = codex_message_line("assistant", "Hello back from Codex");
+        let skip_msg = codex_event_msg_line();
+
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        writeln!(file, "{meta}").unwrap();
+        writeln!(file, "{user_msg}").unwrap();
+        writeln!(file, "{asst_msg}").unwrap();
+        writeln!(file, "{skip_msg}").unwrap();
+
+        let path = file.path().to_path_buf();
+
+        // Mirror the file as Codex source.
+        let stats = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+            .await
+            .expect("codex mirror_file");
+
+        // session_meta + 2 response_item/message rows = 3 parseable, event_msg skipped.
+        assert_eq!(stats.inserted, 3, "meta + 2 messages inserted");
+        assert_eq!(
+            stats.scanned, 4,
+            "4 lines total (including skipped event_msg)"
+        );
+        assert!(stats.new_offset > 0);
+
+        // Session row exists with source='codex'.
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let session_row = r
+            .query_row(SqlStatement {
+                sql: "SELECT source FROM sessions WHERE id=?1".into(),
+                params: vec![SqlValue::Text(session_id.to_string())],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("session row must exist");
+        match session_row.columns.first().map(|c| &c.value) {
+            Some(SqlValue::Text(s)) => assert_eq!(s, "codex", "source must be 'codex'"),
+            other => panic!("unexpected source value: {other:?}"),
+        }
+
+        // All 3 message rows are stored.
+        assert_eq!(count_rows(&rt, "session_messages").await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_codex_event_id_is_stable_and_idempotent() {
+        // Verifies that: (a) synthetic uuid format is "{session_id}:{offset}",
+        // and (b) a second mirror_file pass over the same bytes inserts 0 rows.
+        let (rt, _dir) = setup().await;
+
+        let session_id = "cdx-sess-idem-0001-0001-000000000002";
+        let user_msg = codex_message_line("user", "Idempotency test");
+
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        writeln!(file, "{user_msg}").unwrap();
+
+        let path = file.path().to_path_buf();
+
+        // First pass.
+        let s1 = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+            .await
+            .unwrap();
+        assert_eq!(s1.inserted, 1);
+
+        // Verify the stored id matches the expected synthetic format.
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let msg_row = r
+            .query_row(SqlStatement {
+                sql: "SELECT id FROM session_messages WHERE session_id=?1".into(),
+                params: vec![SqlValue::Text(session_id.to_string())],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("message row must exist");
+        let stored_id = match msg_row.columns.first().map(|c| &c.value) {
+            Some(SqlValue::Text(s)) => s.clone(),
+            other => panic!("unexpected id type: {other:?}"),
+        };
+        // The line starts at byte offset 0.
+        let expected_id = format!("{session_id}:0");
+        assert_eq!(
+            stored_id, expected_id,
+            "synthetic uuid must be {{session_id}}:{{offset}}"
+        );
+
+        // Second pass from offset 0: same lines, 0 new rows (idempotent).
+        let s2 = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+            .await
+            .unwrap();
+        assert_eq!(s2.inserted, 0, "second pass must be idempotent");
+        assert_eq!(count_rows(&rt, "session_messages").await, 1);
+
+        // Incremental pass from advanced offset: no new data.
+        let s3 = mirror_file(
+            &rt,
+            &path,
+            s1.new_offset,
+            MirrorSource::Codex,
+            Some(session_id),
+        )
+        .await
+        .unwrap();
+        assert_eq!(s3.inserted, 0, "incremental pass finds nothing new");
+    }
+
+    #[tokio::test]
+    async fn test_codex_and_cc_are_independent_sessions() {
+        // Both sources can coexist in the same DB; source column distinguishes them.
+        let (rt, _dir) = setup().await;
+
+        let cc_line = user_line("cc-uuid-1", "cc-sess-1", "from claude code");
+        let mut cc_file = NamedTempFile::new().expect("cc tmpfile");
+        writeln!(cc_file, "{cc_line}").unwrap();
+
+        let cdx_session_id = "cdx-sess-coex-0001-0001-000000000003";
+        let cdx_msg = codex_message_line("user", "from codex");
+        let mut cdx_file = NamedTempFile::new().expect("cdx tmpfile");
+        writeln!(cdx_file, "{cdx_msg}").unwrap();
+
+        mirror_file(&rt, cc_file.path(), 0, MirrorSource::ClaudeCode, None)
+            .await
+            .unwrap();
+
+        mirror_file(
+            &rt,
+            cdx_file.path(),
+            0,
+            MirrorSource::Codex,
+            Some(cdx_session_id),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(count_rows(&rt, "sessions").await, 2);
+        assert_eq!(count_rows(&rt, "session_messages").await, 2);
+
+        // Verify sources are distinct.
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT source FROM sessions ORDER BY source".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok");
+        let sources: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("source") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(sources, vec!["claude_code", "codex"]);
     }
 }

--- a/crates/khive-pack-session/src/mirror/mod.rs
+++ b/crates/khive-pack-session/src/mirror/mod.rs
@@ -1,4 +1,4 @@
-//! Background live-mirror service for Claude Code session transcripts.
+//! Background live-mirror service for Claude Code and Codex CLI session transcripts.
 //!
 //! Exposes the three sub-modules and re-exports the public surface used by
 //! `SessionPack::warm()` and tests.
@@ -7,6 +7,6 @@ pub mod ingest;
 pub mod parse;
 pub mod service;
 
-pub use ingest::MirrorStats;
-pub use parse::parse_cc_line;
+pub use ingest::{MirrorSource, MirrorStats};
+pub use parse::{parse_cc_line, parse_codex_line};
 pub use service::{run_mirror_service, MirrorConfig};

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -271,10 +271,20 @@ fn extract_text(content: Option<&Value>) -> Option<String> {
 }
 
 /// Extract a display string from a single content block.
+///
+/// Handled block types:
+/// - `"text"` — Claude Code plain text block.
+/// - `"input_text"` / `"output_text"` — Codex user and assistant text blocks.
+/// - `"tool_use"` — tool invocation (name + input JSON, truncated to 500 chars).
+/// - `"tool_result"` — tool output (content string, truncated to 500 chars).
 fn extract_block(block: &Value) -> Option<String> {
     let map = block.as_object()?;
     match map.get("type")?.as_str()? {
-        "text" => map.get("text").and_then(|v| v.as_str()).map(str::to_string),
+        // Claude Code text block and Codex user/assistant text blocks all carry
+        // their display text in a "text" field — same extraction logic.
+        "text" | "input_text" | "output_text" => {
+            map.get("text").and_then(|v| v.as_str()).map(str::to_string)
+        }
         "tool_use" => {
             let name = map
                 .get("name")
@@ -458,10 +468,17 @@ mod tests {
 
     const CDX_SID: &str = "cdx-session-0001-0001-0001-000000000001";
 
-    /// Build a Codex response_item/message line with text content.
-    fn codex_msg(role: &str, text: &str) -> String {
+    /// Build a Codex user message line using the real `input_text` block shape.
+    fn codex_user_msg(text: &str) -> String {
         format!(
-            r#"{{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{{"type":"message","role":"{role}","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+            r#"{{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"{text}"}}]}}}}"#
+        )
+    }
+
+    /// Build a Codex assistant message line using the real `output_text` block shape.
+    fn codex_asst_msg(text: &str) -> String {
+        format!(
+            r#"{{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"{text}"}}]}}}}"#
         )
     }
 
@@ -472,7 +489,7 @@ mod tests {
         )
     }
 
-    /// Build a Codex response_item with a structured content block (tool_use).
+    /// Build a Codex response_item with a tool_use block (no text block).
     fn codex_tool_use_msg() -> String {
         r#"{"type":"response_item","timestamp":"2026-06-30T09:01:00Z","payload":{"type":"message","role":"assistant","content":[{"type":"tool_use","name":"bash","input":{"command":"cargo test"}}]}}"#.to_string()
     }
@@ -519,24 +536,30 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_user_message() {
-        let line = codex_msg("user", "Hello Codex");
+    fn test_codex_user_message_input_text_block() {
+        // Regression for Finding 1: real Codex user messages use `input_text` blocks.
+        let line = codex_user_msg("Hello Codex");
         let ev = parse_codex_line(&line, CDX_SID, 128).expect("user message should parse");
         assert_eq!(ev.session_id, CDX_SID);
         assert_eq!(ev.msg_type, "response_item");
         assert_eq!(ev.role.as_deref(), Some("user"));
-        let text = ev.text.expect("text must be present");
+        // text must NOT be None — this was the NULL bug.
+        let text = ev.text.expect("text must be non-NULL for input_text block");
         assert_eq!(text, "Hello Codex");
-        // Synthetic uuid encodes the offset.
         assert_eq!(ev.uuid, format!("{CDX_SID}:128"));
     }
 
     #[test]
-    fn test_codex_assistant_message() {
-        let line = codex_msg("assistant", "Hello from assistant");
+    fn test_codex_assistant_message_output_text_block() {
+        // Regression for Finding 1: real Codex assistant messages use `output_text` blocks.
+        let line = codex_asst_msg("Hello from assistant");
         let ev = parse_codex_line(&line, CDX_SID, 256).expect("assistant message should parse");
         assert_eq!(ev.role.as_deref(), Some("assistant"));
-        assert_eq!(ev.text.as_deref(), Some("Hello from assistant"));
+        // text must NOT be None.
+        let text = ev
+            .text
+            .expect("text must be non-NULL for output_text block");
+        assert_eq!(text, "Hello from assistant");
         assert_eq!(ev.uuid, format!("{CDX_SID}:256"));
     }
 
@@ -552,9 +575,9 @@ mod tests {
 
     #[test]
     fn test_codex_text_truncated_at_500_chars() {
-        // Build a 600-character text body.
+        // input_text block with 600-char body — must be truncated.
         let long_text = "x".repeat(600);
-        let line = codex_msg("user", &long_text);
+        let line = codex_user_msg(&long_text);
         let ev = parse_codex_line(&line, CDX_SID, 0).expect("should parse");
         let text = ev.text.expect("text must be present");
         // char count must be ≤ 501 (500 + the '…' ellipsis char).
@@ -568,8 +591,9 @@ mod tests {
 
     #[test]
     fn test_codex_secret_masked_in_text_and_raw() {
+        // input_text block carrying a secret — masking must apply to both text and raw.
         let secret = "sk-ant-api03-AAABBBCCCDDDEEEFFFGGG-XXXXX";
-        let line = codex_msg("user", secret);
+        let line = codex_user_msg(secret);
         let ev = parse_codex_line(&line, CDX_SID, 0).expect("should parse");
         let text = ev.text.expect("text present");
         assert!(!text.contains(secret), "secret must not appear in text");
@@ -588,7 +612,7 @@ mod tests {
     fn test_codex_synthetic_uuid_stable_across_calls() {
         // The same line at the same offset must produce the same uuid regardless
         // of how many times it is called (deterministic, no random component).
-        let line = codex_msg("user", "consistency");
+        let line = codex_user_msg("consistency");
         let ev1 = parse_codex_line(&line, CDX_SID, 999).unwrap();
         let ev2 = parse_codex_line(&line, CDX_SID, 999).unwrap();
         assert_eq!(ev1.uuid, ev2.uuid);
@@ -600,5 +624,14 @@ mod tests {
         // A response_item where payload.type != "message" must be skipped.
         let line = r#"{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{"type":"tool_call","name":"some_tool"}}"#;
         assert!(parse_codex_line(line, CDX_SID, 0).is_none());
+    }
+
+    #[test]
+    fn test_cc_text_block_still_works() {
+        // Regression guard: adding input_text/output_text must not break the
+        // existing CC "text" block handling.
+        let line = r#"{"uuid":"cc-t1","sessionId":"cc-sess","type":"assistant","timestamp":"2026-06-30T09:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"CC still works"}]}}"#;
+        let ev = parse_cc_line(line).expect("CC text block must parse");
+        assert_eq!(ev.text.as_deref(), Some("CC still works"));
     }
 }

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -1,4 +1,4 @@
-//! Pure CC JSONL line parser — no I/O, heavily unit-tested.
+//! JSONL line parsers for Claude Code and Codex CLI session transcripts.
 //!
 //! Every function here is deterministic and side-effect-free so the unit tests
 //! can run without any runtime or DB setup.
@@ -7,18 +7,22 @@ use chrono::DateTime;
 use khive_runtime::secret_gate;
 use serde_json::Value;
 
-/// A single parsed event from a CC session JSONL file.
+/// A single parsed event, source-agnostic.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParsedEvent {
-    /// CC event UUID (the primary key for idempotency).
+    /// Event UUID — the primary key for idempotency.
+    ///
+    /// For Claude Code events this is the top-level `uuid` field.
+    /// For Codex events (which carry no per-message uuid) this is synthesised
+    /// as `"{session_id}:{abs_byte_offset}"`.
     pub uuid: String,
-    /// CC session UUID (`sessionId` field).
+    /// Session UUID.
     pub session_id: String,
     /// Parent event UUID if present.
     pub parent_uuid: Option<String>,
     /// Whether this event is on a sidechain.
     pub is_sidechain: bool,
-    /// `message.role` when present.
+    /// `message.role` (CC) or `payload.role` (Codex) when present.
     pub role: Option<String>,
     /// Top-level `type` field.
     pub msg_type: String,
@@ -30,13 +34,13 @@ pub struct ParsedEvent {
     pub created_at_micros: i64,
     /// `cwd` if present.
     pub cwd: Option<String>,
-    /// `gitBranch` if present.
+    /// `gitBranch` (CC) or `payload.git.branch` (Codex) if present.
     pub git_branch: Option<String>,
-    /// `slug` if present.
+    /// `slug` if present (CC-only; Codex files carry no slug concept).
     pub slug: Option<String>,
 }
 
-/// Parse one CC JSONL line.
+/// Parse one Claude Code JSONL line.
 ///
 /// Returns `None` for:
 /// - blank or whitespace-only lines
@@ -127,6 +131,125 @@ pub fn parse_cc_line(line: &str) -> Option<ParsedEvent> {
         git_branch,
         slug,
     })
+}
+
+/// Parse one Codex CLI JSONL line.
+///
+/// `session_id` must be derived from the filename before calling this function
+/// (e.g. from `rollout-<timestamp>-<uuid>.jsonl`).  `abs_byte_offset` is the
+/// file byte offset of the **start** of this line; it is embedded in the
+/// synthesised event UUID so that `INSERT OR IGNORE` on `session_messages.id`
+/// is idempotent across re-tails of an append-only file.
+///
+/// Returns `None` for:
+/// - blank or whitespace-only lines
+/// - lines that are not valid JSON objects
+/// - lines whose top-level `type` is `"event_msg"` — these are duplicate
+///   event-stream representations of messages and must not be double-stored
+/// - any other line type that carries no useful message content
+///
+/// The returned `raw` and `text` fields have secrets masked.
+pub fn parse_codex_line(line: &str, session_id: &str, abs_byte_offset: u64) -> Option<ParsedEvent> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let obj: Value = serde_json::from_str(trimmed).ok()?;
+    let map = obj.as_object()?;
+
+    let line_type = map.get("type")?.as_str()?;
+
+    // event_msg lines are duplicate event-stream representations — skip them.
+    if line_type == "event_msg" {
+        return None;
+    }
+
+    let created_at_micros = map
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.timestamp_micros())
+        .unwrap_or(0);
+
+    match line_type {
+        "session_meta" => {
+            // session_meta carries cwd and git metadata; the session UUID in
+            // payload.id should match the filename-derived session_id, but we
+            // do NOT use it as the event id — use the synthesised offset key so
+            // the message row is unique and idempotent.
+            let payload = map.get("payload").and_then(|v| v.as_object());
+
+            let cwd = payload
+                .and_then(|p| p.get("cwd"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+
+            let git_branch = payload
+                .and_then(|p| p.get("git"))
+                .and_then(|g| g.as_object())
+                .and_then(|g| g.get("branch"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+
+            let uuid = format!("{session_id}:{abs_byte_offset}");
+            let raw = secret_gate::mask_secrets(trimmed).into_owned();
+
+            Some(ParsedEvent {
+                uuid,
+                session_id: session_id.to_string(),
+                parent_uuid: None,
+                is_sidechain: false,
+                role: None,
+                msg_type: "session_meta".to_string(),
+                text: None,
+                raw,
+                created_at_micros,
+                cwd,
+                git_branch,
+                slug: None,
+            })
+        }
+        "response_item" => {
+            let payload = map.get("payload").and_then(|v| v.as_object())?;
+
+            // Only ingest message items; skip tool_call, completion, etc.
+            if payload.get("type").and_then(|v| v.as_str()) != Some("message") {
+                return None;
+            }
+
+            let role = payload
+                .get("role")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+
+            let text = extract_text(payload.get("content"));
+            let text = text.map(|t| {
+                let masked = secret_gate::mask_secrets(&t).into_owned();
+                truncate(&masked, 500)
+            });
+
+            let uuid = format!("{session_id}:{abs_byte_offset}");
+            let raw = secret_gate::mask_secrets(trimmed).into_owned();
+
+            Some(ParsedEvent {
+                uuid,
+                session_id: session_id.to_string(),
+                parent_uuid: None,
+                is_sidechain: false,
+                role,
+                msg_type: "response_item".to_string(),
+                text,
+                raw,
+                created_at_micros,
+                cwd: None,
+                git_branch: None,
+                slug: None,
+            })
+        }
+        // Unknown line types are silently skipped.
+        _ => None,
+    }
 }
 
 /// Extract a display-friendly text string from a message `content` value.
@@ -329,5 +452,153 @@ mod tests {
         let line = make_line("side-uuid", "sess-side", "user", r#","isSidechain":true"#);
         let ev = parse_cc_line(&line).unwrap();
         assert!(ev.is_sidechain);
+    }
+
+    // ── parse_codex_line tests ─────────────────────────────────────────────────
+
+    const CDX_SID: &str = "cdx-session-0001-0001-0001-000000000001";
+
+    /// Build a Codex response_item/message line with text content.
+    fn codex_msg(role: &str, text: &str) -> String {
+        format!(
+            r#"{{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{{"type":"message","role":"{role}","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        )
+    }
+
+    /// Build a Codex session_meta line.
+    fn codex_meta(cwd: &str, branch: &str) -> String {
+        format!(
+            r#"{{"type":"session_meta","timestamp":"2026-06-30T09:00:00Z","payload":{{"id":"{CDX_SID}","cwd":"{cwd}","git":{{"branch":"{branch}","commit_hash":"abc123","repository_url":"https://github.com/example/repo"}}}}}}"#
+        )
+    }
+
+    /// Build a Codex response_item with a structured content block (tool_use).
+    fn codex_tool_use_msg() -> String {
+        r#"{"type":"response_item","timestamp":"2026-06-30T09:01:00Z","payload":{"type":"message","role":"assistant","content":[{"type":"tool_use","name":"bash","input":{"command":"cargo test"}}]}}"#.to_string()
+    }
+
+    /// Build a Codex event_msg line (duplicate; must be skipped).
+    fn codex_event_msg() -> String {
+        r#"{"type":"event_msg","timestamp":"2026-06-30T09:00:00Z","payload":{"type":"user_message","content":"duplicate"}}"#.to_string()
+    }
+
+    #[test]
+    fn test_codex_blank_returns_none() {
+        assert!(parse_codex_line("", CDX_SID, 0).is_none());
+        assert!(parse_codex_line("   ", CDX_SID, 0).is_none());
+    }
+
+    #[test]
+    fn test_codex_event_msg_skipped() {
+        let line = codex_event_msg();
+        assert!(
+            parse_codex_line(&line, CDX_SID, 42).is_none(),
+            "event_msg must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_codex_unknown_type_skipped() {
+        let line = r#"{"type":"some_other_event","timestamp":"2026-06-30T09:00:00Z","payload":{}}"#;
+        assert!(parse_codex_line(line, CDX_SID, 0).is_none());
+    }
+
+    #[test]
+    fn test_codex_session_meta_produces_event() {
+        let line = codex_meta("/workspace/proj", "main");
+        let ev = parse_codex_line(&line, CDX_SID, 0).expect("session_meta should parse");
+        assert_eq!(ev.session_id, CDX_SID);
+        assert_eq!(ev.msg_type, "session_meta");
+        assert_eq!(ev.cwd.as_deref(), Some("/workspace/proj"));
+        assert_eq!(ev.git_branch.as_deref(), Some("main"));
+        assert!(ev.role.is_none());
+        assert!(ev.text.is_none());
+        // Synthetic uuid: "{session_id}:{offset}".
+        assert_eq!(ev.uuid, format!("{CDX_SID}:0"));
+        assert!(ev.created_at_micros > 0);
+    }
+
+    #[test]
+    fn test_codex_user_message() {
+        let line = codex_msg("user", "Hello Codex");
+        let ev = parse_codex_line(&line, CDX_SID, 128).expect("user message should parse");
+        assert_eq!(ev.session_id, CDX_SID);
+        assert_eq!(ev.msg_type, "response_item");
+        assert_eq!(ev.role.as_deref(), Some("user"));
+        let text = ev.text.expect("text must be present");
+        assert_eq!(text, "Hello Codex");
+        // Synthetic uuid encodes the offset.
+        assert_eq!(ev.uuid, format!("{CDX_SID}:128"));
+    }
+
+    #[test]
+    fn test_codex_assistant_message() {
+        let line = codex_msg("assistant", "Hello from assistant");
+        let ev = parse_codex_line(&line, CDX_SID, 256).expect("assistant message should parse");
+        assert_eq!(ev.role.as_deref(), Some("assistant"));
+        assert_eq!(ev.text.as_deref(), Some("Hello from assistant"));
+        assert_eq!(ev.uuid, format!("{CDX_SID}:256"));
+    }
+
+    #[test]
+    fn test_codex_tool_use_block_extracted() {
+        let line = codex_tool_use_msg();
+        let ev = parse_codex_line(&line, CDX_SID, 512).expect("tool_use message should parse");
+        assert_eq!(ev.role.as_deref(), Some("assistant"));
+        let text = ev.text.expect("text must be present");
+        assert!(text.contains("[tool_use: bash]"), "text: {text}");
+        assert!(text.contains("cargo test"), "text: {text}");
+    }
+
+    #[test]
+    fn test_codex_text_truncated_at_500_chars() {
+        // Build a 600-character text body.
+        let long_text = "x".repeat(600);
+        let line = codex_msg("user", &long_text);
+        let ev = parse_codex_line(&line, CDX_SID, 0).expect("should parse");
+        let text = ev.text.expect("text must be present");
+        // char count must be ≤ 501 (500 + the '…' ellipsis char).
+        assert!(
+            text.chars().count() <= 501,
+            "text must be truncated: len={}",
+            text.chars().count()
+        );
+        assert!(text.ends_with('…'), "truncated text must end with ellipsis");
+    }
+
+    #[test]
+    fn test_codex_secret_masked_in_text_and_raw() {
+        let secret = "sk-ant-api03-AAABBBCCCDDDEEEFFFGGG-XXXXX";
+        let line = codex_msg("user", secret);
+        let ev = parse_codex_line(&line, CDX_SID, 0).expect("should parse");
+        let text = ev.text.expect("text present");
+        assert!(!text.contains(secret), "secret must not appear in text");
+        assert!(
+            text.contains("***MASKED***"),
+            "MASKED marker must appear in text"
+        );
+        assert!(!ev.raw.contains(secret), "secret must not appear in raw");
+        assert!(
+            ev.raw.contains("***MASKED***"),
+            "MASKED marker must appear in raw"
+        );
+    }
+
+    #[test]
+    fn test_codex_synthetic_uuid_stable_across_calls() {
+        // The same line at the same offset must produce the same uuid regardless
+        // of how many times it is called (deterministic, no random component).
+        let line = codex_msg("user", "consistency");
+        let ev1 = parse_codex_line(&line, CDX_SID, 999).unwrap();
+        let ev2 = parse_codex_line(&line, CDX_SID, 999).unwrap();
+        assert_eq!(ev1.uuid, ev2.uuid);
+        assert_eq!(ev1.uuid, format!("{CDX_SID}:999"));
+    }
+
+    #[test]
+    fn test_codex_response_item_non_message_payload_skipped() {
+        // A response_item where payload.type != "message" must be skipped.
+        let line = r#"{"type":"response_item","timestamp":"2026-06-30T09:00:00Z","payload":{"type":"tool_call","name":"some_tool"}}"#;
+        assert!(parse_codex_line(line, CDX_SID, 0).is_none());
     }
 }

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -18,18 +18,34 @@ use std::time::Duration;
 use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
-use super::ingest;
+use super::ingest::{self, MirrorSource};
+
+/// A discovered JSONL file together with its source type and (for Codex) the
+/// session UUID derived from the filename.
+struct DiscoveredFile {
+    path: PathBuf,
+    source: MirrorSource,
+    /// Set for `MirrorSource::Codex`; `None` for `MirrorSource::ClaudeCode`.
+    session_id: Option<String>,
+}
 
 /// Configuration for the mirror service.
 ///
 /// Loaded from environment variables at daemon boot via `MirrorConfig::from_env`.
 pub struct MirrorConfig {
-    /// Whether the mirror service is enabled (default: false — opt-in).
+    /// Whether the Claude Code transcript mirror is enabled (default: false — opt-in).
     pub enabled: bool,
     /// Root directory that contains `<project-slug>/<session-uuid>.jsonl` files.
     ///
     /// Defaults to `$HOME/.claude/projects`.
     pub projects_dir: PathBuf,
+    /// Whether the Codex CLI transcript mirror is enabled (default: false — opt-in,
+    /// independent of `enabled`).
+    pub codex_enabled: bool,
+    /// Root directory that contains `YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` files.
+    ///
+    /// Defaults to `$HOME/.codex/sessions`.
+    pub codex_sessions_dir: PathBuf,
     /// How long to sleep between polling ticks (default: 2 seconds).
     pub poll_interval: Duration,
     /// When true (default), existing files are mirrored from byte offset 0.
@@ -40,23 +56,32 @@ pub struct MirrorConfig {
 impl MirrorConfig {
     /// Build config from environment variables, falling back to safe defaults.
     ///
-    /// | Variable                  | Default                   |
-    /// |---------------------------|---------------------------|
-    /// | `KHIVE_MIRROR_ENABLED`    | `false`                   |
-    /// | `KHIVE_MIRROR_PROJECTS_DIR` | `$HOME/.claude/projects` |
-    /// | `KHIVE_MIRROR_POLL_SECS`  | `2`                       |
-    /// | `KHIVE_MIRROR_BACKFILL`   | `true`                    |
+    /// | Variable                       | Default                        |
+    /// |--------------------------------|--------------------------------|
+    /// | `KHIVE_MIRROR_ENABLED`         | `false`                        |
+    /// | `KHIVE_MIRROR_PROJECTS_DIR`    | `$HOME/.claude/projects`       |
+    /// | `KHIVE_MIRROR_CODEX_ENABLED`   | `false`                        |
+    /// | `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`        |
+    /// | `KHIVE_MIRROR_POLL_SECS`       | `2`                            |
+    /// | `KHIVE_MIRROR_BACKFILL`        | `true`                         |
     pub fn from_env() -> Self {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+
         let enabled = std::env::var("KHIVE_MIRROR_ENABLED")
             .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
             .unwrap_or(false);
 
         let projects_dir = std::env::var("KHIVE_MIRROR_PROJECTS_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
-                PathBuf::from(home).join(".claude").join("projects")
-            });
+            .unwrap_or_else(|_| PathBuf::from(&home).join(".claude").join("projects"));
+
+        let codex_enabled = std::env::var("KHIVE_MIRROR_CODEX_ENABLED")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let codex_sessions_dir = std::env::var("KHIVE_MIRROR_CODEX_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(&home).join(".codex").join("sessions"));
 
         let poll_secs = std::env::var("KHIVE_MIRROR_POLL_SECS")
             .ok()
@@ -70,6 +95,8 @@ impl MirrorConfig {
         Self {
             enabled,
             projects_dir,
+            codex_enabled,
+            codex_sessions_dir,
             poll_interval: Duration::from_secs(poll_secs),
             backfill,
         }
@@ -81,12 +108,18 @@ impl MirrorConfig {
 /// Seed state from the `session_mirror_cursor` table at startup, then loop:
 /// stat each discovered file, tail any new bytes, sleep.
 ///
+/// Claude Code and Codex mirrors are independent: each is enabled by its own
+/// flag and scanned separately each tick.
+///
 /// Per-file errors are logged with `tracing::warn!` and do NOT stop the loop.
 pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
     tracing::info!(
         projects_dir = %config.projects_dir.display(),
+        codex_sessions_dir = %config.codex_sessions_dir.display(),
         poll_interval_ms = config.poll_interval.as_millis(),
         backfill = config.backfill,
+        cc_enabled = config.enabled,
+        codex_enabled = config.codex_enabled,
         "session mirror service starting"
     );
 
@@ -100,30 +133,47 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
     };
 
     loop {
-        let files = scan_jsonl_files(&config.projects_dir);
+        // Collect all files to process this tick.
+        let mut discovered: Vec<DiscoveredFile> = Vec::new();
 
+        if config.enabled {
+            for path in scan_cc_jsonl_files(&config.projects_dir) {
+                discovered.push(DiscoveredFile {
+                    path,
+                    source: MirrorSource::ClaudeCode,
+                    session_id: None,
+                });
+            }
+        }
+
+        if config.codex_enabled {
+            for item in scan_codex_jsonl_files(&config.codex_sessions_dir) {
+                discovered.push(item);
+            }
+        }
+
+        let total_tracked = discovered.len();
         let mut files_mirrored: u64 = 0;
         let mut rows_inserted: u64 = 0;
 
-        for path in &files {
+        for item in &discovered {
             // Seed offset for newly discovered files.
-            if !offsets.contains_key(path) {
+            if !offsets.contains_key(&item.path) {
                 let start = if config.backfill {
                     0
                 } else {
-                    // Skip existing content — start at current EOF.
-                    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+                    std::fs::metadata(&item.path).map(|m| m.len()).unwrap_or(0)
                 };
-                offsets.insert(path.clone(), start);
+                offsets.insert(item.path.clone(), start);
             }
 
-            let offset = *offsets.get(path).unwrap_or(&0);
+            let offset = *offsets.get(&item.path).unwrap_or(&0);
 
             // Fast path: skip if file hasn't grown.
-            let file_len = match std::fs::metadata(path).map(|m| m.len()) {
+            let file_len = match std::fs::metadata(&item.path).map(|m| m.len()) {
                 Ok(len) => len,
                 Err(e) => {
-                    tracing::warn!(path = %path.display(), error = %e, "session mirror: stat failed");
+                    tracing::warn!(path = %item.path.display(), error = %e, "session mirror: stat failed");
                     continue;
                 }
             };
@@ -133,14 +183,23 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             }
 
             // Tail the new bytes.
-            match ingest::mirror_file(&runtime, path, offset).await {
+            match ingest::mirror_file(
+                &runtime,
+                &item.path,
+                offset,
+                item.source,
+                item.session_id.as_deref(),
+            )
+            .await
+            {
                 Ok(stats) => {
-                    offsets.insert(path.clone(), stats.new_offset);
+                    offsets.insert(item.path.clone(), stats.new_offset);
                     if stats.inserted > 0 || stats.new_offset > offset {
                         files_mirrored += 1;
                         rows_inserted += stats.inserted;
                         tracing::debug!(
-                            path = %path.display(),
+                            path = %item.path.display(),
+                            source = ?item.source,
                             inserted = stats.inserted,
                             scanned = stats.scanned,
                             new_offset = stats.new_offset,
@@ -150,7 +209,7 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        path = %path.display(),
+                        path = %item.path.display(),
                         error = %e,
                         "session mirror: per-file error (skipping)"
                     );
@@ -162,11 +221,11 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             tracing::info!(
                 files_mirrored,
                 rows_inserted,
-                total_tracked = files.len(),
+                total_tracked,
                 "session mirror tick"
             );
         } else {
-            tracing::debug!(total_tracked = files.len(), "session mirror: quiet tick");
+            tracing::debug!(total_tracked, "session mirror: quiet tick");
         }
 
         tokio::time::sleep(config.poll_interval).await;
@@ -216,11 +275,11 @@ async fn load_cursors(runtime: &KhiveRuntime) -> Result<HashMap<PathBuf, u64>, R
     }
 }
 
-/// Recursively scan `projects_dir` for `*.jsonl` files one level deep.
+/// Scan `projects_dir` for Claude Code `*.jsonl` files one level deep.
 ///
 /// Expects the layout: `<projects_dir>/<project-slug>/<session-uuid>.jsonl`.
 /// Silently skips unreadable subdirectories.
-fn scan_jsonl_files(projects_dir: &std::path::Path) -> Vec<PathBuf> {
+fn scan_cc_jsonl_files(projects_dir: &std::path::Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
     let Ok(top_entries) = std::fs::read_dir(projects_dir) else {
@@ -244,4 +303,66 @@ fn scan_jsonl_files(projects_dir: &std::path::Path) -> Vec<PathBuf> {
     }
 
     files
+}
+
+/// Recursively scan `sessions_dir` for Codex `rollout-*.jsonl` files.
+///
+/// Expects the date-nested layout:
+/// `<sessions_dir>/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`.
+/// The session UUID is parsed from the filename stem.
+/// Silently skips unreadable directories or filenames that do not match the
+/// expected `rollout-…-<uuid>` pattern.
+fn scan_codex_jsonl_files(sessions_dir: &std::path::Path) -> Vec<DiscoveredFile> {
+    let mut files = Vec::new();
+    scan_codex_dir_recursive(sessions_dir, &mut files);
+    files
+}
+
+/// Recursive helper for `scan_codex_jsonl_files`.
+fn scan_codex_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_codex_dir_recursive(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+            if let Some(session_id) = extract_codex_session_id(&path) {
+                out.push(DiscoveredFile {
+                    path,
+                    source: MirrorSource::Codex,
+                    session_id: Some(session_id),
+                });
+            }
+        }
+    }
+}
+
+/// Extract the session UUID from a Codex filename of the form
+/// `rollout-<timestamp>-<uuid>.jsonl`.
+///
+/// Returns `None` for files whose name does not match the pattern.
+fn extract_codex_session_id(path: &std::path::Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    // Expected: "rollout-<ts>-<uuid>" where uuid is the last hyphen-delimited
+    // group of 5 fields (standard UUID: 8-4-4-4-12).
+    if !stem.starts_with("rollout-") {
+        return None;
+    }
+    // A standard UUID has 5 parts (8-4-4-4-12), so 4 hyphens = 4 separators.
+    // The stem format is: rollout-<ISO-ts>-<8>-<4>-<4>-<4>-<12>
+    // Easier: find the last 5 hyphen-separated segments and join them.
+    let parts: Vec<&str> = stem.split('-').collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    // UUID = last 5 segments.
+    let uuid = parts[parts.len() - 5..].join("-");
+    // Basic sanity: a UUID has exactly 4 hyphens.
+    if uuid.matches('-').count() != 4 {
+        return None;
+    }
+    Some(uuid)
 }

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -343,26 +343,77 @@ fn scan_codex_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>
 /// Extract the session UUID from a Codex filename of the form
 /// `rollout-<timestamp>-<uuid>.jsonl`.
 ///
-/// Returns `None` for files whose name does not match the pattern.
+/// Returns `None` for files whose name does not match the expected pattern or
+/// whose derived candidate is not a valid UUID.  Files whose stem looks like
+/// `rollout-2025-11-11T08-32-36` (no UUID suffix) are rejected here and
+/// silently skipped by the caller.
 fn extract_codex_session_id(path: &std::path::Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
-    // Expected: "rollout-<ts>-<uuid>" where uuid is the last hyphen-delimited
-    // group of 5 fields (standard UUID: 8-4-4-4-12).
     if !stem.starts_with("rollout-") {
         return None;
     }
-    // A standard UUID has 5 parts (8-4-4-4-12), so 4 hyphens = 4 separators.
-    // The stem format is: rollout-<ISO-ts>-<8>-<4>-<4>-<4>-<12>
-    // Easier: find the last 5 hyphen-separated segments and join them.
+    // A standard UUID has 5 hyphen-delimited groups (8-4-4-4-12).
+    // Split the stem and take the last 5 segments as the UUID candidate.
     let parts: Vec<&str> = stem.split('-').collect();
     if parts.len() < 6 {
         return None;
     }
-    // UUID = last 5 segments.
-    let uuid = parts[parts.len() - 5..].join("-");
-    // Basic sanity: a UUID has exactly 4 hyphens.
-    if uuid.matches('-').count() != 4 {
-        return None;
+    let candidate = parts[parts.len() - 5..].join("-");
+    // Validate structurally: reject timestamp-shaped junk like "2025-11-11T08-32-36"
+    // that also happens to have 4 hyphens.  uuid::Uuid::parse_str enforces the
+    // 8-4-4-4-12 hex-character layout.
+    match uuid::Uuid::parse_str(&candidate) {
+        Ok(_) => Some(candidate),
+        Err(_) => {
+            tracing::debug!(
+                path = %path.display(),
+                candidate,
+                "session mirror: codex filename did not yield a valid UUID — skipping"
+            );
+            None
+        }
     }
-    Some(uuid)
+}
+
+#[cfg(test)]
+mod codex_filename_tests {
+    use super::extract_codex_session_id;
+    use std::path::Path;
+
+    #[test]
+    fn real_codex_filename_yields_uuid() {
+        let path =
+            Path::new("rollout-2025-11-11T08-32-36-019a731e-4a58-71b1-a71f-a8d2f9782113.jsonl");
+        assert_eq!(
+            extract_codex_session_id(path).as_deref(),
+            Some("019a731e-4a58-71b1-a71f-a8d2f9782113")
+        );
+    }
+
+    #[test]
+    fn timestamp_only_stem_is_rejected() {
+        // Regression for Finding 2: a stem with no UUID suffix has 4 hyphens
+        // in its trailing segments and must NOT be accepted as a session id.
+        let path = Path::new("rollout-2025-11-11T08-32-36.jsonl");
+        assert_eq!(extract_codex_session_id(path), None);
+    }
+
+    #[test]
+    fn invalid_hex_suffix_is_rejected() {
+        let path =
+            Path::new("rollout-2025-11-11T08-32-36-zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz.jsonl");
+        assert_eq!(extract_codex_session_id(path), None);
+    }
+
+    #[test]
+    fn too_short_suffix_is_rejected() {
+        let path = Path::new("rollout-2025-11-11T08-32-36-aaaa-bbbb-cccc-dddd.jsonl");
+        assert_eq!(extract_codex_session_id(path), None);
+    }
+
+    #[test]
+    fn non_rollout_filename_is_rejected() {
+        let path = Path::new("not-a-rollout-file.jsonl");
+        assert_eq!(extract_codex_session_id(path), None);
+    }
 }

--- a/crates/khive-pack-session/src/pack.rs
+++ b/crates/khive-pack-session/src/pack.rs
@@ -66,7 +66,7 @@ impl PackRuntime for SessionPack {
 
     async fn warm(&self) {
         let config = crate::mirror::MirrorConfig::from_env();
-        if !config.enabled {
+        if !config.enabled && !config.codex_enabled {
             return;
         }
         let runtime = self.runtime().clone();


### PR DESCRIPTION
## What

Extends the session-pack background mirror to ingest **Codex CLI** transcripts
alongside the existing Claude Code mirror. Storage only — both sources land in
the same `sessions` / `session_messages` tables, discriminated by a `source`
column value (`claude_code` | `codex`). Resume/replay is out of scope (deferred;
needs deep CLI integration). Search is a separate ADR (ADR-081, in a doc-only PR).

## Why

The mirror previously hardcoded `source='claude_code'` and scanned only the
Claude Code layout. Codex transcripts live in a different place
(`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`) and a different
line shape. This PR makes the mirror source-agnostic at storage time so a single
session corpus spans both CLIs.

## Changes

1. **`MirrorSource` enum** (`ingest.rs`) — `ClaudeCode | Codex`, `as_str()` →
   the compile-time `sessions.source` literal. Threaded through `mirror_file`,
   replacing the hardcoded source. (Source is enum-bounded, not user input.)

2. **`parse_codex_line`** (`parse.rs`) — maps a Codex `response_item` / `message`
   line to the source-agnostic `ParsedEvent`:
   - `session_id` derived from the filename UUID (the trailing 5 hyphen-groups of
     `rollout-<ts>-<uuid>`; robust because the ISO timestamp's hyphens all precede
     the UUID).
   - synthetic stable event id `session_id:byte_offset` — the file is append-only,
     so the line-start offset is stable across re-tails; `INSERT OR IGNORE` on
     `session_messages.id` keeps ingest idempotent.
   - `event_msg` lines (duplicate event-stream representation) are skipped, as are
     `response_item` payloads that are not `message`.
   - secret masking and 500-char truncation run at parse time, as for Claude Code.

3. **`service.rs`** — recursive scan of `~/.codex/sessions` (date-nested layout),
   independent of the Claude Code scan. New config `KHIVE_MIRROR_CODEX_ENABLED`
   (default off) and `KHIVE_MIRROR_CODEX_DIR` (default `$HOME/.codex/sessions`);
   the existing Claude Code toggles are unchanged. `warm()` starts the service if
   either source is enabled.

## Tests

15 new (12 `parse_codex_line` unit, 3 ingest integration): synthetic-id stability,
idempotent re-tail (second pass inserts 0 rows), `event_msg` skip, secret masking
in text and raw, structured `tool_use` block extraction, 500-char truncation,
`source='codex'` on the session row, and Claude-Code/Codex source isolation.
Gates: fmt, clippy `-D warnings`, `cargo test -p khive-pack-session` (49 pass),
rustdoc `-D warnings` — all clean.

## Scope note

No schema migration: `sessions.source TEXT NOT NULL DEFAULT 'claude_code'`
already exists. The mirror's own architecture governance (its relationship to
ADR-080's stated ingestion scope) is tracked separately as an ADR reconciliation;
this PR is a source-parameterized extension of the already-shipped mechanism.
