### PR TITLE
fix(channel-email): make inbound email round-trip work end-to-end (greeting + maintainer match + reply correlation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,4 +47,4 @@ KHIVE_EMAIL_PASSWORD=your-app-password-here
 
 # Comma-separated allowlist of recipient addresses the outbox loop may deliver
 # to. Defaults to KHIVE_EMAIL_MAINTAINER_ADDRESS when unset or empty.
-# KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=ocean@example.com,leo@khive.ai
+# KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=ocean@example.com,mailbox@example.com

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -86,7 +86,8 @@ impl EmailChannel {
     /// Used by the outbox delivery loop to build the default allowlist when
     /// `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` is not set.
     pub fn maintainer_address(&self) -> &str {
-        self.config.maintainer_address.as_str()
+        // Primary maintainer: from_env guarantees `maintainer_addresses` is non-empty.
+        self.config.maintainer_addresses[0].as_str()
     }
 
     /// Build from pre-constructed connectors (for testing).
@@ -103,8 +104,9 @@ impl EmailChannel {
     ///
     /// Rules:
     /// - `from_addrs` must contain exactly one entry (multi-From is rejected).
-    /// - That single From address must match the configured maintainer.
-    /// - If `sender_addr` is present, it must also match.
+    /// - That single From address must match one of the authorized maintainers
+    ///   (Gmail-aware: dots/`+tag`/`googlemail.com` are insignificant for Gmail).
+    /// - If `sender_addr` is present, it must also match an authorized maintainer.
     ///
     /// Returns `Err(ChannelError::UnauthorizedSender)` on any violation.
     /// Error messages intentionally omit the actual addresses to avoid leaking them to logs.
@@ -123,21 +125,31 @@ impl EmailChannel {
         let from = MailAddress::parse(&from_addrs[0]).ok_or_else(|| {
             ChannelError::UnauthorizedSender("From field does not contain a valid addr-spec".into())
         })?;
-        if from != self.config.maintainer_address {
+        if !self
+            .config
+            .maintainer_addresses
+            .iter()
+            .any(|m| m.matches(&from))
+        {
             return Err(ChannelError::UnauthorizedSender(
-                "From address is not the configured maintainer".into(),
+                "From address is not an authorized maintainer".into(),
             ));
         }
-        // Sender header, when present, must also match the maintainer.
+        // Sender header, when present, must also match an authorized maintainer.
         if let Some(s) = sender_addr {
             let sender = MailAddress::parse(s).ok_or_else(|| {
                 ChannelError::UnauthorizedSender(
                     "Sender field does not contain a valid addr-spec".into(),
                 )
             })?;
-            if sender != self.config.maintainer_address {
+            if !self
+                .config
+                .maintainer_addresses
+                .iter()
+                .any(|m| m.matches(&sender))
+            {
                 return Err(ChannelError::UnauthorizedSender(
-                    "Sender address is not the configured maintainer".into(),
+                    "Sender address is not an authorized maintainer".into(),
                 ));
             }
         }
@@ -155,7 +167,7 @@ impl EmailChannel {
             .to
             .first()
             .map(|a| format!("email:{a}"))
-            .unwrap_or_else(|| format!("email:{}", self.config.maintainer_address));
+            .unwrap_or_else(|| format!("email:{}", self.maintainer_address()));
 
         let mut env = ChannelEnvelope::new(from, to, email.best_body());
 
@@ -202,9 +214,11 @@ impl Channel for EmailChannel {
             let uid = email.uid;
             match self.to_envelope(email) {
                 Ok(env) => envelopes.push(env),
-                Err(_) => {
-                    // Log only the IMAP UID -- never the sender address or any credentials.
-                    warn!(uid, "skipping message: validation failed");
+                Err(e) => {
+                    // Log the IMAP UID and the (address-free) error reason so a rejected
+                    // inbound is observable in the daemon log. ChannelError messages are
+                    // constructed without addresses or credentials, so `%e` is log-safe.
+                    warn!(uid, error = %e, "skipping message: validation failed");
                 }
             }
         }
@@ -238,7 +252,7 @@ mod tests {
             auth: EmailAuth::Basic {
                 password: "secret".to_string(),
             },
-            maintainer_address: MailAddress::parse(maintainer).unwrap(),
+            maintainer_addresses: vec![MailAddress::parse(maintainer).unwrap()],
         }
     }
 
@@ -310,13 +324,25 @@ mod tests {
     }
 
     fn build_channel(maintainer: &str, emails: Vec<RawEmail>) -> EmailChannel {
-        let config = make_config(maintainer);
+        build_channel_from(make_config(maintainer), emails)
+    }
+
+    fn build_channel_from(config: EmailChannelConfig, emails: Vec<RawEmail>) -> EmailChannel {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let smtp = SmtpSender::with_connector(RecordingSmtp {
             calls: calls.clone(),
         });
         let imap = ImapFetcher::with_connector(FixedImap { emails });
         EmailChannel::with_connectors(config, smtp, imap)
+    }
+
+    fn make_config_multi(maintainers: &[&str]) -> EmailChannelConfig {
+        let mut config = make_config(maintainers[0]);
+        config.maintainer_addresses = maintainers
+            .iter()
+            .map(|m| MailAddress::parse(m).unwrap())
+            .collect();
+        config
     }
 
     // --- Basic trait ---
@@ -364,6 +390,51 @@ mod tests {
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert!(envs.is_empty(), "unauthorized From must be dropped");
+    }
+
+    #[tokio::test]
+    async fn gmail_dot_variants_authorize_against_dotted_maintainer() {
+        // Maintainer configured with a dotted Gmail; the client may deliver the
+        // dotless canonical form, a googlemail alias, or a +tag. All are the same
+        // Gmail mailbox and must authorize.
+        for from in [
+            "quantoceanli@gmail.com",
+            "quantocean.li@gmail.com",
+            "quantoceanli@googlemail.com",
+            "quantocean.li+khive@gmail.com",
+        ] {
+            let ch = build_channel(
+                "quantocean.li@gmail.com",
+                vec![make_email(from, "imap:test:0:1")],
+            );
+            let envs = ch.poll(Utc::now()).await.unwrap();
+            assert_eq!(envs.len(), 1, "gmail variant {from} must authorize");
+        }
+    }
+
+    #[tokio::test]
+    async fn non_gmail_dots_remain_significant() {
+        // Dot-insensitivity is a Gmail-only rule; other providers treat dots as
+        // significant, so a dotted variant of a non-Gmail maintainer is rejected.
+        let ch = build_channel(
+            "quantocean.li@outlook.com",
+            vec![make_email("quantoceanli@outlook.com", "imap:test:0:1")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(envs.is_empty(), "non-gmail dot-variant must NOT authorize");
+    }
+
+    #[tokio::test]
+    async fn allowlist_authorizes_any_configured_maintainer() {
+        // Multiple maintainers (e.g. a Gmail and an Outlook) may be registered;
+        // a From matching any entry authorizes.
+        let config = make_config_multi(&["primary@gmail.com", "second@outlook.com"]);
+        let ch = build_channel_from(
+            config,
+            vec![make_email("second@outlook.com", "imap:test:0:1")],
+        );
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1, "any allowlisted maintainer must authorize");
     }
 
     #[tokio::test]

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -73,7 +73,7 @@ impl EmailChannel {
         Ok(Self { config, smtp, imap })
     }
 
-    /// The configured mailbox address (e.g. `leo@khive.ai`).
+    /// The configured mailbox address (e.g. `mailbox@example.com`).
     ///
     /// Used by the outbox delivery loop to derive the sender address and
     /// the domain component of the RFC 822 Message-ID header.
@@ -398,13 +398,13 @@ mod tests {
         // dotless canonical form, a googlemail alias, or a +tag. All are the same
         // Gmail mailbox and must authorize.
         for from in [
-            "quantoceanli@gmail.com",
-            "quantocean.li@gmail.com",
-            "quantoceanli@googlemail.com",
-            "quantocean.li+khive@gmail.com",
+            "samrivera@gmail.com",
+            "sam.rivera@gmail.com",
+            "samrivera@googlemail.com",
+            "sam.rivera+khive@gmail.com",
         ] {
             let ch = build_channel(
-                "quantocean.li@gmail.com",
+                "sam.rivera@gmail.com",
                 vec![make_email(from, "imap:test:0:1")],
             );
             let envs = ch.poll(Utc::now()).await.unwrap();
@@ -417,8 +417,8 @@ mod tests {
         // Dot-insensitivity is a Gmail-only rule; other providers treat dots as
         // significant, so a dotted variant of a non-Gmail maintainer is rejected.
         let ch = build_channel(
-            "quantocean.li@outlook.com",
-            vec![make_email("quantoceanli@outlook.com", "imap:test:0:1")],
+            "sam.rivera@outlook.com",
+            vec![make_email("samrivera@outlook.com", "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert!(envs.is_empty(), "non-gmail dot-variant must NOT authorize");

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -80,9 +80,11 @@ pub struct EmailChannelConfig {
     pub mailbox: String,
     /// Authentication credentials and mode.
     pub auth: EmailAuth,
-    /// The single authorized maintainer address. Inbound messages from any other
-    /// sender are rejected before ingestion.
-    pub maintainer_address: MailAddress,
+    /// The authorized maintainer address(es). Inbound messages from any other
+    /// sender are rejected before ingestion. Populated from a comma-separated
+    /// `KHIVE_EMAIL_MAINTAINER_ADDRESS`; the first entry is the primary, used for
+    /// outbound-allowlist defaulting and envelope `to` fallback. Never empty.
+    pub maintainer_addresses: Vec<MailAddress>,
 }
 
 impl EmailChannelConfig {
@@ -123,12 +125,26 @@ impl EmailChannelConfig {
 
         let auth = build_auth()?;
 
+        // Comma-separated allowlist so the maintainer can register more than one
+        // address (e.g. both a Gmail and an Outlook account). First entry is primary.
         let maintainer_raw = require_env("KHIVE_EMAIL_MAINTAINER_ADDRESS")?;
-        let maintainer_address = MailAddress::parse(&maintainer_raw).ok_or_else(|| {
-            ChannelError::Config(format!(
-                "KHIVE_EMAIL_MAINTAINER_ADDRESS is not a valid RFC 5322 address: {maintainer_raw:?}"
-            ))
-        })?;
+        let maintainer_addresses = maintainer_raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                MailAddress::parse(s).ok_or_else(|| {
+                    ChannelError::Config(format!(
+                        "KHIVE_EMAIL_MAINTAINER_ADDRESS contains an invalid RFC 5322 address: {s:?}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if maintainer_addresses.is_empty() {
+            return Err(ChannelError::Config(
+                "KHIVE_EMAIL_MAINTAINER_ADDRESS must contain at least one address".into(),
+            ));
+        }
 
         Ok(Self {
             smtp_host,
@@ -138,7 +154,7 @@ impl EmailChannelConfig {
             username,
             mailbox,
             auth,
-            maintainer_address,
+            maintainer_addresses,
         })
     }
 }

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn validate_sasl_string_accepts_valid_email() {
-        assert!(validate_sasl_string("leo@khive.ai", "username").is_ok());
+        assert!(validate_sasl_string("mailbox@example.com", "username").is_ok());
     }
 
     // ── optional_port tests (env-mutating — serialized with ENV_MUTEX) ────────

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -119,7 +119,30 @@ impl LiveImap {
         .map_err(|_| ChannelError::Auth("IMAP TLS handshake timed out (15s)".into()))?
         .map_err(|e| ChannelError::Auth(format!("IMAP TLS handshake failed: {e}")))?;
 
-        let client = async_imap::Client::new(tls_stream);
+        let mut client = async_imap::Client::new(tls_stream);
+
+        // Consume the server greeting before issuing any command. `Client::new`
+        // (unlike `async_imap::connect`) does not read it, and an unconsumed
+        // greeting desyncs the response parser: the first command's reply reads
+        // the `* OK ...` greeting instead of its own tagged response, then blocks
+        // waiting for a reply that never arrives (surfaces as the auth timeout).
+        // Direct-TLS on 993 always sends a greeting (unlike STARTTLS on 143).
+        match tokio::time::timeout(Duration::from_secs(15), client.read_response())
+            .await
+            .map_err(|_| ChannelError::Transport("IMAP greeting read timed out (15s)".into()))?
+        {
+            Some(Ok(_)) => {}
+            Some(Err(e)) => {
+                return Err(ChannelError::Transport(format!(
+                    "IMAP greeting read failed: {e}"
+                )));
+            }
+            None => {
+                return Err(ChannelError::Transport(
+                    "IMAP connection closed before greeting".into(),
+                ));
+            }
+        }
 
         // Authenticate with 15s timeout, dispatching on auth mode.
         let session: ImapSession = match &self.auth {

--- a/crates/khive-channel-email/src/connector/mod.rs
+++ b/crates/khive-channel-email/src/connector/mod.rs
@@ -44,6 +44,34 @@ impl MailAddress {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Authorization-equality against another address, applying Gmail's address
+    /// canonicalization: for `gmail.com`/`googlemail.com` addresses, dots and a
+    /// `+tag` suffix in the local part are insignificant and the two domains are
+    /// equivalent (they route to the same mailbox). Non-Gmail domains compare by
+    /// exact (already-lowercased) addr-spec, where dots ARE significant.
+    ///
+    /// This exists because clients such as Gmail emit the account's canonical
+    /// From (often dotless) which need not string-match a dotted address a human
+    /// configured. Exact equality would silently reject the maintainer's own mail.
+    pub fn matches(&self, other: &MailAddress) -> bool {
+        self.canonical() == other.canonical()
+    }
+
+    /// Canonical form used by [`matches`](Self::matches). Only Gmail addresses
+    /// are rewritten; every other domain is returned as its stored addr-spec.
+    fn canonical(&self) -> String {
+        let Some((local, domain)) = self.0.split_once('@') else {
+            return self.0.clone();
+        };
+        if domain == "gmail.com" || domain == "googlemail.com" {
+            let base = local.split('+').next().unwrap_or(local);
+            let dotless: String = base.chars().filter(|c| *c != '.').collect();
+            format!("{dotless}@gmail.com")
+        } else {
+            self.0.clone()
+        }
+    }
 }
 
 impl std::fmt::Display for MailAddress {

--- a/crates/khive-channel-email/tests/smtp_send_smoke.rs
+++ b/crates/khive-channel-email/tests/smtp_send_smoke.rs
@@ -15,7 +15,7 @@ async fn smtp_send_to_maintainer_smoke() {
 
     let envelope = ChannelEnvelope::new(
         format!("email:{}", config.mailbox),
-        format!("email:{}", config.maintainer_address),
+        format!("email:{}", config.maintainer_addresses[0]),
         format!("khive email channel smoke test — sent at unix {ts}"),
     )
     .with_subject("khive email channel smoke test");

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -788,3 +788,35 @@ fn message_id_match_candidates(corr: &str) -> Vec<String> {
         vec![corr.to_string(), bare.to_string()]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::message_id_match_candidates;
+
+    #[test]
+    fn candidates_bare_input_adds_bracketed_form() {
+        // A bracket-free correlation key (as delivered by mail_parser) must also
+        // try the wire form so it matches an outbound `<id@domain>` external_id.
+        assert_eq!(
+            message_id_match_candidates("sent-msg@khive.ai"),
+            vec![
+                "sent-msg@khive.ai".to_string(),
+                "<sent-msg@khive.ai>".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn candidates_bracketed_input_adds_bare_form() {
+        // Reverse direction: a bracketed correlation key must also try the bare
+        // form so it matches a stored bracket-free external_id. Guards the `else`
+        // branch, which no ingest test exercises directly.
+        assert_eq!(
+            message_id_match_candidates("<sent-msg@khive.ai>"),
+            vec![
+                "<sent-msg@khive.ai>".to_string(),
+                "sent-msg@khive.ai".to_string(),
+            ],
+        );
+    }
+}

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -589,39 +589,50 @@ pub(crate) async fn handle_ingest(
     let resolved: Option<(String, String)> = if let Some(ref corr) = p.correlation_external_id {
         if !corr.is_empty() {
             // Pass 1: match by $.external_id (RFC 822 Message-ID, standard In-Reply-To path).
-            let corr_filter = NoteFilter {
-                kind: Some("message".to_string()),
-                property_filters: vec![PropertyFilter {
-                    json_path: "$.external_id".to_string(),
-                    op: FilterOp::Eq,
-                    value: SqlValue::Text(corr.clone()),
-                }],
-                ..Default::default()
-            };
-            let corr_page = store
-                .query_notes_filtered(
-                    ns,
-                    &corr_filter,
-                    PageRequest {
-                        limit: 1,
-                        offset: 0,
-                    },
-                )
-                .await?;
-            let pass1 = corr_page.items.first().and_then(|n| {
-                let props = n.properties.as_ref()?;
-                let thread_id = props
-                    .get("thread_id")
-                    .and_then(Value::as_str)
-                    .filter(|s| s.parse::<Uuid>().is_ok())
-                    .map(|s| s.to_string())?;
-                let from_actor = props
-                    .get("from_actor")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                Some((thread_id, from_actor))
-            });
+            // Our own outbound mail stores its Message-ID in wire form `<id@domain>`
+            // (angle brackets included), while `mail_parser` strips the brackets from an
+            // inbound `In-Reply-To`, yielding `id@domain`. Match the correlation key as
+            // received and in its bracket-toggled form so `<id>` and `id` correlate either
+            // way; the exact form is tried first.
+            let mut pass1 = None;
+            for candidate in message_id_match_candidates(corr) {
+                let corr_filter = NoteFilter {
+                    kind: Some("message".to_string()),
+                    property_filters: vec![PropertyFilter {
+                        json_path: "$.external_id".to_string(),
+                        op: FilterOp::Eq,
+                        value: SqlValue::Text(candidate),
+                    }],
+                    ..Default::default()
+                };
+                let corr_page = store
+                    .query_notes_filtered(
+                        ns,
+                        &corr_filter,
+                        PageRequest {
+                            limit: 1,
+                            offset: 0,
+                        },
+                    )
+                    .await?;
+                pass1 = corr_page.items.first().and_then(|n| {
+                    let props = n.properties.as_ref()?;
+                    let thread_id = props
+                        .get("thread_id")
+                        .and_then(Value::as_str)
+                        .filter(|s| s.parse::<Uuid>().is_ok())
+                        .map(|s| s.to_string())?;
+                    let from_actor = props
+                        .get("from_actor")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    Some((thread_id, from_actor))
+                });
+                if pass1.is_some() {
+                    break;
+                }
+            }
 
             if pass1.is_some() {
                 pass1
@@ -757,4 +768,23 @@ pub(crate) async fn handle_ingest(
         "external_id": p.external_id,
         "deduplicated": false,
     }))
+}
+
+/// Candidate `$.external_id` values to match an inbound correlation key against.
+///
+/// Outbound mail stores its Message-ID in wire form `<id@domain>` (angle brackets
+/// included); `mail_parser` strips those brackets from an inbound `In-Reply-To`,
+/// yielding `id@domain`. To correlate a reply back to the sending actor we must
+/// match either representation, so this returns the key as received plus its
+/// bracket-toggled variant, exact form first.
+fn message_id_match_candidates(corr: &str) -> Vec<String> {
+    let bare = corr
+        .strip_prefix('<')
+        .and_then(|s| s.strip_suffix('>'))
+        .unwrap_or(corr);
+    if bare == corr {
+        vec![corr.to_string(), format!("<{corr}>")]
+    } else {
+        vec![corr.to_string(), bare.to_string()]
+    }
 }

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -4021,7 +4021,7 @@ async fn ingest_routing_reply_routes_to_original_sender() {
             expires_at: None,
             properties: Some(serde_json::json!({
                 "direction": "outbound",
-                "from": "email:leo@khive.ai",
+                "from": "email:mailbox@example.com",
                 "to": "email:user@example.com",
                 "from_actor": "lambda:khive",
                 "to_actor": "email:user@example.com",
@@ -4042,7 +4042,7 @@ async fn ingest_routing_reply_routes_to_original_sender() {
         &rt,
         serde_json::json!({
             "from": "email:user@example.com",
-            "to": "email:leo@khive.ai",
+            "to": "email:mailbox@example.com",
             "content": "this is a reply",
             "correlation_external_id": outbound_external_id,
             "external_id": "imap:mail:1:1",
@@ -4091,7 +4091,7 @@ async fn ingest_routing_reply_correlates_bracket_free_in_reply_to() {
             expires_at: None,
             properties: Some(serde_json::json!({
                 "direction": "outbound",
-                "from": "email:leo@khive.ai",
+                "from": "email:mailbox@example.com",
                 "to": "email:user@example.com",
                 "from_actor": "lambda:khive",
                 "to_actor": "email:user@example.com",
@@ -4111,7 +4111,7 @@ async fn ingest_routing_reply_correlates_bracket_free_in_reply_to() {
         &rt,
         serde_json::json!({
             "from": "email:user@example.com",
-            "to": "email:leo@khive.ai",
+            "to": "email:mailbox@example.com",
             "content": "this is a bracket-free reply",
             "correlation_external_id": inbound_correlation,
             "external_id": "imap:mail:2:1",
@@ -4145,7 +4145,7 @@ async fn ingest_routing_fresh_message_uses_default_actor() {
         &rt,
         serde_json::json!({
             "from": "email:stranger@example.com",
-            "to": "email:leo@khive.ai",
+            "to": "email:mailbox@example.com",
             "content": "hello from a stranger",
             "external_id": "imap:mail:1:2",
             "default_inbound_actor": "lambda:leo",
@@ -4171,7 +4171,7 @@ async fn ingest_routing_no_default_falls_back_to_to_field() {
         &rt,
         serde_json::json!({
             "from": "email:stranger@example.com",
-            "to": "email:leo@khive.ai",
+            "to": "email:mailbox@example.com",
             "content": "back-compat message",
             "external_id": "imap:mail:1:3",
             "namespace": "local",
@@ -4181,7 +4181,7 @@ async fn ingest_routing_no_default_falls_back_to_to_field() {
 
     assert_eq!(
         props["to_actor"].as_str(),
-        Some("email:leo@khive.ai"),
+        Some("email:mailbox@example.com"),
         "no default actor: to_actor must fall back to p.to; got props={props}"
     );
 }
@@ -4225,7 +4225,7 @@ async fn ingest_routing_reply_via_thread_uuid_routes_to_original_sender() {
             expires_at: None,
             properties: Some(serde_json::json!({
                 "direction": "outbound",
-                "from": "email:leo@khive.ai",
+                "from": "email:mailbox@example.com",
                 "to": "email:user@example.com",
                 "from_actor": "lambda:khive",
                 "to_actor": "email:user@example.com",
@@ -4249,7 +4249,7 @@ async fn ingest_routing_reply_via_thread_uuid_routes_to_original_sender() {
         &rt,
         serde_json::json!({
             "from": "email:user@example.com",
-            "to": "email:leo@khive.ai",
+            "to": "email:mailbox@example.com",
             "content": "this is a reply via X-Khive-Thread-ID",
             "correlation_external_id": thread_uuid,
             "external_id": "imap:mail:thread-uuid-reply:1",

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -4058,6 +4058,83 @@ async fn ingest_routing_reply_routes_to_original_sender() {
     );
 }
 
+/// (a2) Regression: outbound stores its Message-ID in wire form `<id@domain>`, but an
+/// inbound `In-Reply-To` is delivered bracket-free (`id@domain`) because `mail_parser`
+/// strips the angle brackets. Pass-1 must still correlate the reply back to the original
+/// sender. Before the bracket-toggle fix this fell through to `default_inbound_actor`
+/// (lambda:leo) with a fresh thread — the exact failure seen on the live round-trip.
+#[tokio::test]
+async fn ingest_routing_reply_correlates_bracket_free_in_reply_to() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    // Outbound note stores the Message-ID WITH angle brackets (wire form).
+    let outbound_external_id = "<sent-msg-002@khive.ai>";
+    // Inbound In-Reply-To arrives WITHOUT brackets (mail_parser strips them).
+    let inbound_correlation = "sent-msg-002@khive.ai";
+    let thread_uuid = uuid::Uuid::new_v4().as_hyphenated().to_string();
+    {
+        use khive_storage::note::Note;
+        let token = rt
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize");
+        let store = rt.notes(&token).expect("notes store");
+        let now = chrono::Utc::now().timestamp_micros();
+        let note = Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "original outbound".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "email:leo@khive.ai",
+                "to": "email:user@example.com",
+                "from_actor": "lambda:khive",
+                "to_actor": "email:user@example.com",
+                "external_id": outbound_external_id,
+                "thread_id": thread_uuid,
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.upsert_note(note).await.expect("upsert outbound note");
+    }
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:user@example.com",
+            "to": "email:leo@khive.ai",
+            "content": "this is a bracket-free reply",
+            "correlation_external_id": inbound_correlation,
+            "external_id": "imap:mail:2:1",
+            "default_inbound_actor": "lambda:leo",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("lambda:khive"),
+        "bracket-free In-Reply-To must correlate to the bracketed outbound external_id \
+         and route to the original sender, not default_inbound_actor; got props={props}"
+    );
+    assert_eq!(
+        props["thread_id"].as_str(),
+        Some(thread_uuid.as_str()),
+        "correlated reply must attach to the original thread, not a fresh root; \
+         got props={props}"
+    );
+}
+
 /// (b) Fresh message, no correlation, default_inbound_actor=lambda:leo → to_actor=lambda:leo.
 #[tokio::test]
 async fn ingest_routing_fresh_message_uses_default_actor() {

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7424,7 +7424,7 @@ async fn list_delivered_filter_finds_undelivered_note_past_200_delivered() {
             None,
             Some(serde_json::json!({
                 "direction": "outbound",
-                "from": "email:leo@khive.ai",
+                "from": "email:mailbox@example.com",
                 "to": "email:user@example.com",
                 "to_actor": "email:user@example.com",
             })),
@@ -7440,7 +7440,7 @@ async fn list_delivered_filter_finds_undelivered_note_past_200_delivered() {
         let note = Note::new("local", "message", format!("delivered {i}")).with_properties(
             serde_json::json!({
                 "direction": "outbound",
-                "from": "email:leo@khive.ai",
+                "from": "email:mailbox@example.com",
                 "to": "email:user@example.com",
                 "to_actor": "email:user@example.com",
                 "delivered_at": "2026-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary

Makes the inbound email round-trip actually work end-to-end: a reply to an outbound khive email ingests over IMAP and routes back to the sending actor's inbox. Three fixes on the inbound path, each an independent root cause.

### 1. `fix(channel-email)`: consume the IMAP server greeting before auth (`8ae17a98`)
`async_imap::Client::new` (unlike `async_imap::connect`) does not read the server greeting. Leaving it unconsumed desyncs async-imap's response parser: the first command's reply reads the `* OK ...` greeting instead of its own tagged response, then blocks forever, surfacing as our 15s auth timeout. **This is why inbound email never ingested at all.** Fix: read and discard the greeting before authenticating.

### 2. `fix(comm)`: bracket-insensitive reply correlation (`357ccbd1`)
Outbound mail stores its Message-ID in wire form `<id@domain>` (angle brackets). `mail_parser` strips the brackets from an inbound `In-Reply-To`, yielding `id@domain`. `comm.ingest` pass-1 matched `$.external_id` by exact SQL equality, so `<id@domain>` never matched `id@domain` and **every reply fell through to `default_inbound_actor` (lambda:leo) with a fresh thread** instead of routing back to the sending actor. Fix: pass-1 tries the correlation key as received plus its bracket-toggled form (exact first).

### 3. `fix(channel-email)`: Gmail-aware maintainer match + allowlist (`450f177c`, pre-existing on branch)
Sender authorization for the maintainer address across Gmail's canonicalization, with an allowlist and observable reject logging.

## Evidence (live round-trip, 2026-07-01)

| | pre-fix reply (11:16) | post-fix reply (11:34) |
|---|---|---|
| `to_actor` | `lambda:leo` ✗ | `lambda:khive` ✓ |
| `thread_id` | fresh root `ba4987c4` ✗ | original thread `8c68cc46` ✓ |
| monitor | did not trip | tripped ✓ |

Same action (replying to the same email), opposite outcome. The From address is unchanged (`leo@khive.ai`) in both, confirming the cause was the correlation match, not the sender identity.

## Tests

- New regression test `ingest_routing_reply_correlates_bracket_free_in_reply_to` reproduces the exact live failure: a bracketed outbound `external_id` with a bracket-free inbound `In-Reply-To`. Verified it **fails without the fix** (`to_actor=lambda:leo`, fresh thread) and passes with it (negative control run manually).
- `cargo test -p khive-pack-comm`: 76 passed. clippy clean, fmt clean.

## Notes for review
- Bug 2's blind spot: the existing test (a) fed the *same bracketed string* on both sides, so it never exercised the real bracket-free inbound path.
- The fix is on the correlation-match seam only; the stored wire form and the outbound minting are unchanged.