### PR TITLE
docs: per-crate READMEs, README template, and full config reference

### DIFF
--- a/crates/khive-brain-core/README.md
+++ b/crates/khive-brain-core/README.md
@@ -1,0 +1,93 @@
+# khive-brain-core
+
+Brain primitives: Beta-Binomial posteriors, the closed section-type taxonomy, profile
+state, and deterministic/sampled weight derivation. Pure state and math — no storage,
+no verb handlers; `khive-pack-brain` wires these primitives to the `brain.*` verbs
+(`brain.feedback`, `brain.profile`, …) and recall-time ranking.
+
+## Usage
+
+```rust
+use khive_brain_core::{BetaPosterior, EntityPosteriors};
+use uuid::Uuid;
+
+// A Beta-Binomial posterior over "is this useful" with a weak prior.
+let mut relevance = BetaPosterior::new(7.0, 3.0);
+relevance.update_success(); // alpha += 1.0 on a positive signal
+relevance.update_failure(); // beta += 1.0 on a negative signal
+let p_useful = relevance.mean();
+
+// Bounded per-entity posteriors (LRU-evicted at `capacity`).
+let mut entities = EntityPosteriors::new(10_000);
+let id = Uuid::new_v4();
+entities
+    .get_or_insert(id, BetaPosterior::default)
+    .update_success();
+```
+
+`BetaPosterior::try_new` rejects non-finite or non-positive `alpha`/`beta` (and so does
+deserialization — invalid wire values fail closed rather than silently coercing).
+`merge` combines two independent posteriors that share the same prior;
+`apply_ess_cap` scales a posterior's effective sample size back toward its prior so a
+single burst of feedback cannot dominate the estimate.
+
+## Section types and weight derivation
+
+```rust
+use khive_brain_core::{derive_deterministic_weights, SectionPosteriorState, SectionType};
+
+let state = SectionPosteriorState::new(); // seeded from SectionType::default_priors()
+let weights = derive_deterministic_weights(&state); // HashMap<SectionType, f64>, posterior means
+
+assert_eq!(SectionType::Overview.as_str(), "overview");
+assert_eq!(SectionType::ALL.len(), 10);
+```
+
+`SectionType` is a closed 10-value taxonomy (`Overview`, `CoreModel`,
+`BoundaryConditions`, `Formalism`, `OperationalGuidance`, `Examples`, `FailureModes`,
+`ExpertLens`, `References`, `Other`) used to weight knowledge-atom sections during
+composition. `SectionPosteriorState::weights` samples via Thompson sampling while
+`exploration_epoch > 0` (early life, more exploration) and falls back to
+`derive_deterministic_weights` (posterior means) once the epoch is exhausted, so
+composition converges from exploratory to exploitative without a separate code path.
+
+## Profiles and signals
+
+`ProfileRecord` / `ProfileLifecycle` (`Defined` → `Registered` → `Active` / `Inactive`
+→ `Archived`) model a brain profile's registry entry; `BalancedRecallState` is the live
+Beta-posterior state for the built-in `balanced-recall-v1` profile (relevance,
+salience, temporal scalars plus per-entity posteriors). `BrainSignal` is the decoded
+signal vocabulary produced from raw events (`RecallHit`, `RecallMiss`, `Feedback`,
+`SemanticFeedback`, `NoteAccessed`, …); `entity_signal` and `is_recall_positive` map a
+`BrainSignal` to the posterior update it implies. `FeedbackSignal`
+(`Useful`/`NotUseful`/`Wrong`) and `FeedbackEventKind`
+(`ExplicitPositive`/`ExplicitNegative`/`ImplicitPositive`/`ImplicitNegative`/`Correction`)
+are the two closed signal enums consumed by `brain.feedback` and semantic-fold updates
+respectively; `FeedbackEventKind::update_weight` gives corrections 4x the posterior
+weight of an implicit signal (2.0 vs 0.5).
+
+`BrainState` aggregates all of the above (profile registry, per-profile
+`BalancedRecallState`, per-profile `SectionPosteriorState`, bindings) with
+`to_snapshot()` / `from_snapshot()` round-trips for persistence.
+
+## Where this sits
+
+`khive-brain-core` depends on `khive-runtime` for the `PackRuntime` trait and
+`RuntimeError` — `PackTunable` (in `tunable.rs`) is an extension trait a pack
+implements to expose a `ParameterSpace` of Beta-prior parameters to brain
+auto-tuning, so this crate sits above the runtime rather than below it:
+
+```text
+types -> score -> storage -> db -> query -> runtime -> khive-brain-core -> khive-pack-brain
+```
+
+`khive-pack-brain` owns the `brain.*` verbs and storage; `khive-brain-core` is the
+pure primitive layer it builds on. Design context: brain as profile-orchestration
+over fold and objective
+([ADR-032](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-032-brain-profile-orchestration.md)),
+the section-type taxonomy
+([ADR-048](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-048-knowledge-section-profiles.md)).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-channel/README.md
+++ b/crates/khive-channel/README.md
@@ -1,0 +1,60 @@
+# khive-channel
+
+Transport abstraction for outbound and inbound message delivery — the `Channel`
+trait, `ChannelEnvelope`, and `ChannelRegistry` that concrete adapters (email,
+Telegram, ...) implement against.
+
+## Usage
+
+```rust
+use khive_channel::{Channel, ChannelEnvelope, ChannelRegistry};
+
+let envelope = ChannelEnvelope::new("email:alice@example.com", "email:bob@example.com", "hello")
+    .with_subject("Test")
+    .with_external_id("<msg1@example.com>");
+
+let mut registry = ChannelRegistry::new();
+// registry.register(Arc::new(my_channel_impl)); // my_channel_impl: impl Channel
+let email_channel = registry.get("email");
+```
+
+`ChannelEnvelope` carries `from`/`to`/`content`/`subject` plus dedup and
+threading metadata: `external_id` (adapter-derived dedup key, e.g.
+`imap:{host}:{uidvalidity}:{uid}` for email), `correlation_external_id` (thread
+correlation, e.g. an `In-Reply-To` header), and `message_id` (RFC 822
+Message-ID to set on outbound mail).
+
+## The `Channel` trait
+
+```rust
+#[async_trait::async_trait]
+pub trait Channel: Send + Sync + 'static {
+    fn kind(&self) -> &'static str;
+    fn is_configured(&self) -> bool { true }
+    async fn send(&self, envelope: ChannelEnvelope) -> Result<(), khive_channel::ChannelError>;
+    async fn poll(&self, since: chrono::DateTime<chrono::Utc>) -> Result<Vec<ChannelEnvelope>, khive_channel::ChannelError>;
+}
+```
+
+`Channel` deliberately does not require `Debug` — concrete adapters hold
+credentials, and a derived `Debug` impl would risk leaking them into logs.
+Deduplication of polled envelopes is the caller's responsibility: the MCP
+server's `comm.ingest` verb performs an `INSERT OR IGNORE` against a unique
+index on `external_id`, so adapters do not need to dedup themselves. Adapters
+should apply a best-effort server-side filter on `since` to avoid fetching
+large backlogs.
+
+## Where this sits
+
+`khive-channel` has no `khive-*` dependencies — it is a leaf crate that concrete
+transport adapters (e.g. `khive-channel-email`) depend on to implement
+`Channel`. The MCP server holds an `Arc<ChannelRegistry>`, polls every
+registered channel in a background loop, and forwards results to `comm.ingest`.
+
+Governing ADR:
+[ADR-056](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-056-channel-transport-layer.md)
+(channel transport layer and external messaging adapters).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-db/README.md
+++ b/crates/khive-db/README.md
@@ -1,0 +1,92 @@
+# khive-db
+
+SQLite storage backend for the khive knowledge graph runtime: entity, note, event, and
+edge storage, FTS5 text search, and optional `sqlite-vec` vector storage over a
+WAL-mode connection pool.
+
+## Features
+
+- **WAL-mode connection pool** — one writer, N concurrent readers (`ConnectionPool`)
+- **Capability-trait factories** — `StorageBackend` hands out `Arc<dyn EntityStore>`,
+  `GraphStore`, `NoteStore`, `EventStore`, `VectorStore`, `SparseStore`, `TextSearch`,
+  and `SqlAccess` from `khive-storage`
+- **Forward-only versioned migrations** — `run_migrations` applies `MIGRATIONS` in
+  order, tracked in `_schema_migrations`
+- **Legacy pack-scoped schema plans** — `ServiceSchemaPlan` / `apply_schema_plan` for
+  pack-auxiliary tables tracked in `_schema_versions`
+- **FTS5 trigram search** (CJK-safe) via `text()` / `text_with_tokenizer()`
+- **`sqlite-vec` vector storage** (feature `vectors`) — per-model `vec0` virtual
+  tables with a namespace-scoped embedding-model registry
+- **Periodic WAL checkpoint task** (`checkpoint` module)
+
+## Usage
+
+```rust
+use khive_db::{run_migrations, StorageBackend};
+
+// File-backed (WAL mode, 1 writer + N readers) or StorageBackend::memory() for tests.
+let backend = StorageBackend::sqlite("/path/to/khive.db")?;
+
+{
+    let mut writer = backend.pool().try_writer()?;
+    run_migrations(writer.conn_mut())?;
+}
+
+let entities = backend.entities()?; // Arc<dyn khive_storage::EntityStore>
+let graph = backend.graph()?; // Arc<dyn khive_storage::GraphStore>
+let text = backend.text("entities_fts")?; // Arc<dyn khive_storage::TextSearch>
+let sql = backend.sql(); // Arc<dyn khive_storage::SqlAccess>, for pack-owned tables
+```
+
+Each capability accessor (`entities`, `graph`, `notes`, `events`, `vectors`, `sparse`,
+`text`) applies its own DDL idempotently on first call, so callers never need a
+separate "create schema" step per store. Namespace-scoped variants
+(`entities_for_namespace`, `graph_for_namespace`, …) validate that the namespace is
+non-empty; the store itself remains namespace-agnostic — callers pass namespace on
+each query.
+
+## Migrations
+
+Two migration systems coexist, both defined in `migrations.rs`:
+
+- **Versioned** (`MIGRATIONS: &[VersionedMigration]`, applied by `run_migrations`) —
+  the forward-only pipeline for core substrate tables (entities, notes, edges,
+  events). `V1` is the consolidated fresh-start baseline loaded from
+  `sql/schema.sql`; `V2..V5` are incremental `.sql` files applied in order and
+  tracked in `_schema_migrations`. A database whose recorded version is ahead of the
+  latest known migration fails loudly rather than silently skipping the baseline.
+- **Legacy per-service** (`ServiceSchemaPlan` / `apply_schema_plan`) — used by packs
+  that declare their own auxiliary DDL, tracked per-service in `_schema_versions`.
+
+Schema DDL is authored in `crates/khive-db/sql/*.sql` and pulled in via
+`include_str!` — never hand-written as inline Rust string literals. Adding a
+migration means a new `.sql` file plus a new `VersionedMigration` entry; `V1` itself
+is never edited on an existing database.
+
+## Vector storage
+
+`vectors_for_namespace(model_key, embedding_model, dimensions, namespace)` creates a
+`vec_<model_key>` virtual table (via `sqlite-vec`, feature `vectors`) sized to
+`dimensions`, with cosine distance. `model_key` must be ASCII
+alphanumeric/underscore. Tables predating the `field`/`embedding_model` columns
+(pre-v0.2.8) are rejected with an explicit error rather than silently dropped —
+vector data is a cache, so callers re-embed after recreating the table.
+
+## Where this sits
+
+`khive-db` implements the `khive-storage` capability traits
+([ADR-005](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-005-storage-capability-traits.md))
+against SQLite, sitting directly above `khive-storage`/`khive-score`/`khive-types` and
+below `khive-query` and `khive-runtime` in the storage dependency chain:
+
+```text
+types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp
+```
+
+`khive-runtime`'s `KhiveRuntime` wraps `StorageBackend` and layers namespace
+authorization and pack dispatch on top. Schema evolution follows
+[ADR-015](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-015-schema-migrations.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-fold/README.md
+++ b/crates/khive-fold/README.md
@@ -1,0 +1,87 @@
+# khive-fold
+
+Cognitive primitives shared across khive's runtime: `Fold` (streaming state
+reduction), `Anchor` (causal provenance graphs), `Objective` (deterministic
+candidate scoring and selection), and `Selector` (budget-constrained packing).
+Depends only on `khive-types` and `khive-score` — see
+[ADR-024](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-024-fold-cognitive-primitives.md).
+
+## Usage
+
+```rust
+use khive_fold::{fold_fn, Fold, FoldContext};
+
+let count_positive = fold_fn(
+    |_ctx: &FoldContext| 0usize,
+    |count, entry: &i32, _ctx| if *entry > 0 { count + 1 } else { count },
+);
+
+let entries = [1, -2, 3, 4, -5];
+let outcome = count_positive.derive(entries.iter(), &FoldContext::new());
+assert_eq!(outcome.state, 3);
+assert_eq!(outcome.entries_processed, 5);
+```
+
+`Fold<L, S>` reduces a stream of `&L` entries into a state `S` via `init` +
+`reduce` (+ optional `finalize`); `fold_fn(initial, step)` builds one from two
+closures without a custom type. `derive` runs the fold to completion and
+returns a `FoldOutcome<S>` (`state`, `entries_processed`); `derive_filtered`
+adds a predicate that skips entries before `reduce` sees them. `TryFold` is
+the fallible counterpart, returning `FoldFailure` on error. `CountFold`,
+`FilterCountFold`, and `SumI64Fold` are ready-made folds for the common
+counting/summing cases.
+
+`FoldContext::new()` defaults `as_of` to the Unix epoch, not wall-clock
+time — this crate never calls a clock. Callers that need "as of now" build a
+context explicitly with `FoldContext::at(timestamp)`.
+
+## Anchor — causal provenance
+
+`AnchorGraph` is an in-memory graph of `AnchorRef` nodes (`id`, `kind`,
+`stable_id`) connected by labeled edges. `Anchor::trace` follows forward edges
+from a starting anchor up to `max_depth` hops; `Anchor::credit` walks backward
+from an outcome anchor, returning `(AnchorRef, weight)` pairs with the
+contribution weight halving per hop. `BfsAnchor` is the provided BFS
+implementation of both.
+
+## Objective — deterministic scoring
+
+`Objective<T>` scores and filters candidates (`score`, `passes_score`,
+`batch_score`, `select`, `select_top`); `DeterministicObjective<T>` extends it
+for `T: HasId`, breaking score ties by ID so `select_top_deterministic` gives
+the same ranking regardless of input order. Built-in objectives
+(`RelevanceObjective`, `RecencyObjective`, `SalienceObjective`,
+`ThresholdObjective`, `MaxScoreObjective`, `FirstMatchObjective`) and combinators
+(`WeightedObjective`, `ConsensusObjective`, `PriorityObjective`,
+`UnionObjective`, `NegateObjective`, `ScaleObjective`) compose via the
+`objective` module; `objective_fn` builds one from a closure.
+
+## Selector — budget-constrained packing
+
+`Selector<T>::select(inputs: Vec<SelectorInput<T>>, budget, weights)` collapses
+N scored, sized candidates into a `SelectorOutput<T>` that fits `budget`.
+`GreedySelector` filters by `SelectorWeights.min_score`, applies
+`category_weights` multipliers, then packs by effective score (score plus an
+optional `epistemic_weight * information_gain` term) with deterministic
+size-then-ID tie-breaking; `diversity_bias > 0` switches to a pick-best-remaining
+loop that penalizes repeated categories.
+
+## Checkpoint — durable fold snapshots
+
+`Checkpoint<S>::new(id, state, uuid, entries_processed, context, fold_version)`
+wraps a serializable fold state with a BLAKE3 content hash (`khive_types::Hash32`)
+computed from the state, verified on load. Like `FoldContext`, it never calls
+a clock — `created_at` defaults to the epoch; callers set it explicitly if wall-clock
+time matters. `CheckpointStore` / `InMemoryCheckpointStore` provide a save/load
+contract for callers that persist checkpoints across restarts.
+
+## Where this sits
+
+Built on `khive-types` and `khive-score` only — no other khive-* dependency,
+by design (ADR-024's boundary). Used by higher layers of the runtime that need
+deterministic state reduction, provenance tracing, or budget-constrained
+context packing without pulling in storage or query machinery.
+
+## License
+
+Apache-2.0.

--- a/crates/khive-fusion/README.md
+++ b/crates/khive-fusion/README.md
@@ -1,0 +1,67 @@
+# khive-fusion
+
+Rank fusion strategies — Reciprocal Rank Fusion (RRF), Weighted, and Union — for
+combining ranked result lists from multiple retrieval sources with deterministic
+scoring.
+
+## Features
+
+- **`FusionStrategy` enum** — `Rrf { k }` (default), `Weighted { weights }`,
+  `Union`, `VectorOnly`, `KeywordOnly`, and `Custom { name, params }` for
+  runtime-registered strategies
+- **Validated construction** — `try_rrf`/`try_weighted`/`try_custom` reject
+  `k == 0`, non-finite weights, and empty custom names; `serde` deserialization
+  runs the same validation
+- **Deterministic** — all scoring goes through `khive-score`'s fixed-point
+  `DeterministicScore`; RRF fusion is permutation-invariant across source order
+- **Weight helpers** — `normalize_weights`, `try_normalize_weights`,
+  `weights_are_normalized` for callers building `Weighted` configs
+
+## Usage
+
+```rust
+use khive_fusion::{fuse, FusionStrategy};
+use khive_score::DeterministicScore;
+
+let vector_hits = vec![
+    ("doc_a", DeterministicScore::from_f64(0.9)),
+    ("doc_b", DeterministicScore::from_f64(0.8)),
+];
+let keyword_hits = vec![
+    ("doc_b", DeterministicScore::from_f64(0.95)),
+    ("doc_c", DeterministicScore::from_f64(0.7)),
+];
+
+let fused = fuse(vec![vector_hits, keyword_hits], &FusionStrategy::rrf(), 10).unwrap();
+for (id, score) in &fused {
+    println!("{id}: {}", score.to_f64());
+}
+```
+
+`fuse` dispatches on `strategy`: `Rrf` and `Union`/`VectorOnly`/`KeywordOnly` are
+computed inline via `reciprocal_rank_fusion`/`union_fusion`; `Weighted` goes
+through `weighted_fusion`. `Custom` strategies return
+`FuseError::CustomRequiresRuntime` — they are dispatched by a runtime's fusion
+registry, which this crate does not implement.
+
+RRF's score is rank-based and ignores the input scores entirely:
+`score(d) = sum(1 / (k + rank_i(d)))` across every source that ranks `d`, with
+`k` defaulting to 60 (`DEFAULT_RRF_K`, per Craswell et al. 2009). A document
+that appears in more source lists accumulates more contributions.
+
+## Where this sits
+
+`khive-fusion` is the fusion leg of khive's hybrid retrieval pipeline: it takes
+ranked `(Id, DeterministicScore)` lists from `khive-hnsw` (vector) and
+`khive-bm25` (keyword) and produces one fused ranking. It depends only on
+`khive-score` and is consumed by `khive-retrieval`'s `HybridSearcher`
+composition and by the runtime's ADR-012 retrieval composition path.
+
+Governing ADR:
+[ADR-006](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-006-deterministic-scoring.md)
+(deterministic scoring — the `DeterministicScore` contract every strategy here
+scores against).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-gate/README.md
+++ b/crates/khive-gate/README.md
@@ -1,0 +1,68 @@
+# khive-gate
+
+Pluggable authorization gate trait for khive verb dispatch, with a permissive
+default implementation.
+
+The runtime consults a [`Gate`] before dispatching each verb. This crate defines the
+trait, the wire types the gate sees and returns, and `AllowAllGate` — the permissive
+default installed in `RuntimeConfig` when no other gate is configured.
+
+## Usage
+
+```rust
+use khive_gate::{ActorRef, AllowAllGate, Gate, GateRequest};
+use khive_types::Namespace;
+use serde_json::json;
+
+let gate = AllowAllGate;
+let req = GateRequest::new(
+    ActorRef::anonymous(),
+    Namespace::local(),
+    "search",
+    json!({ "kind": "entity", "query": "LoRA" }),
+);
+let decision = gate.check(&req).unwrap();
+assert!(decision.is_allow());
+```
+
+`GateRequest::try_new` / `ActorRef::try_new` / `GateDecision::try_deny` return
+`Result` and reject empty `verb`, `actor.kind`, `actor.id`, or deny `reason` fields;
+the panicking `new` / `deny` variants call the same validation and `expect()` the
+result. `Obligation::rate_limit` / `try_rate_limit` validate `window_secs` and `max`
+are both non-zero.
+
+## Contract
+
+- `Gate::check(&GateRequest) -> Result<GateDecision, GateError>` is the only method
+  a backend must implement. `Gate::impl_name()` defaults to the type name and is
+  surfaced in audit events so multiple gate implementations (including wrappers)
+  are distinguishable without inspecting the type.
+- `GateDecision::Allow { obligations }` carries zero or more `Obligation` values
+  (`Audit`, `RateLimit`, `Custom`) the runtime records on dispatch. `GateDecision::Deny
+  { reason }` aborts dispatch — deny is authoritative and requires a non-empty reason.
+- `AuditEvent::from_check` builds the structured audit record (`actor`, `namespace`,
+  `verb`, `decision`, `obligations`, `gate_impl`, `session_id`) emitted once per gate
+  consultation. Its JSON projection is a stable public contract — field names don't
+  change without a new ADR.
+- All wire types (`ActorRef`, `GateRequest`, `GateDecision`, `Obligation`) validate
+  their invariants both at construction (`try_new` / `try_*` constructors) and at
+  deserialization (custom `Deserialize` via a private `TryFrom<Raw*>` shape), so a
+  policy engine handing back malformed JSON fails the same way a caller building the
+  struct directly would.
+
+## Where this sits
+
+`khive-gate` sits below `khive-runtime`, which holds the `RuntimeConfig.gate: GateRef`
+field consulted before every verb dispatch and defaults it to `AllowAllGate`. It has no
+dependency on any other khive crate beyond `khive-types`.
+
+- **`khive-gate` (Apache-2.0)** — this crate; the trait, wire types, and permissive default.
+- [`khive-gate-rego`](https://crates.io/crates/khive-gate-rego) (Apache-2.0) — the OSS
+  reference [Rego](https://www.openpolicyagent.org/) backend (`RegoGate`), installed in
+  place of `AllowAllGate` when a deployment needs real policy enforcement.
+
+Governed by [ADR-018](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-018-authorization-gate.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-hnsw/README.md
+++ b/crates/khive-hnsw/README.md
@@ -1,0 +1,83 @@
+# khive-hnsw
+
+HNSW (Hierarchical Navigable Small World) vector index with INT8 quantized
+two-phase search, tombstone-based deletion, and snapshot persistence.
+
+## Features
+
+- **Incremental insert/delete** — lazy tombstone deletion; `rebuild()` compacts
+  storage and repairs the graph once the tombstone ratio crosses a threshold
+- **INT8 quantized two-phase search** — an INT8 pre-filter screens candidates,
+  full `f32` distance ranks the survivors; toggle at runtime with no rebuild cost
+- **Exact-scan fallback** — indexes at or below ~3K nodes use brute-force SIMD
+  scanning, which beats graph traversal at that scale for Cosine/Dot metrics
+- **Deterministic scoring** via `khive-score`'s fixed-point `DeterministicScore`
+- **Snapshot persistence** — `snapshot()` / `restore_from_snapshot[_embedded]`
+  for warm-start restores; `checkpoint` feature adds `HnswCheckpointStore`
+  integration with `khive-fold`
+- **Memory budgets** — cap heap usage per index with configurable limits
+- **Metrics** — optional `MetricsSink` for insert/search/rebuild observability
+
+## Usage
+
+```rust
+use khive_hnsw::{HnswConfig, HnswIndex, NodeId};
+
+let mut index = HnswIndex::with_config(HnswConfig::with_dimensions(384));
+
+index.insert(NodeId::new([1u8; 16]), vec![0.1_f32; 384]).unwrap();
+
+let results = index.search(&vec![0.1_f32; 384], 10).unwrap();
+for (id, score) in &results {
+    println!("{id}: {}", score.to_f64());
+}
+
+index.delete(NodeId::new([1u8; 16]));
+if index.needs_rebuild() {
+    index.rebuild();
+}
+```
+
+`HnswIndex::new(dimensions)` builds with defaults; `try_with_config` returns a
+`Result` instead of panicking on an invalid `HnswConfig` (useful when the config
+comes from deserialized/external input).
+
+## Configuration
+
+| Parameter           | Default  | Description                                             |
+| ------------------- | -------- | ------------------------------------------------------- |
+| `m`                 | 20       | Max connections per node per layer.                     |
+| `m_max0`            | 40       | Max connections at layer 0 (typically `2*m`).           |
+| `ef_construction`   | 200      | Candidate list size during insert.                      |
+| `ef_search`         | 80       | Candidate list size during search.                      |
+| `dimensions`        | 384      | Vector width; must match the embedding model.           |
+| `metric`            | `Cosine` | `Cosine`, `Dot`, or `L2`.                               |
+| `rebuild_threshold` | 0.10     | Tombstone ratio above which `rebuild()` is recommended. |
+| `seed`              | `None`   | Seeded RNG for reproducible level assignment.           |
+| `memory_budget`     | `None`   | Byte cap; inserts over budget return `BudgetExceeded`.  |
+
+`HnswConfig::validate()` runs on every deserialization and rejects zero `m`,
+zero `ef_construction`/`ef_search`, `m_max0 < m`, non-finite `ml`, and an
+out-of-range `rebuild_threshold`. Presets `HnswConfig::high_recall()`,
+`fast_build()`, and `low_memory()` cover the common op-point trade-offs.
+
+## Where this sits
+
+`khive-hnsw` is the vector-search engine consumed by `khive-retrieval`
+(`https://crates.io/crates/khive-retrieval`), which composes it with
+`khive-bm25` keyword search and `khive-fusion` rank fusion into the hybrid
+retrieval layer. It depends only on `khive-score` (deterministic scoring),
+`khive-types` (shared `DistanceMetric`), and `lattice-embed` (SIMD distance
+kernels); the optional `checkpoint` feature adds a `khive-fold` dependency for
+persisted snapshots.
+
+Governing ADRs:
+[ADR-052](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-052-ann-production-lifecycle.md)
+(SQ8 quantization, tombstone delete, consolidation, crash-safe persistence across
+both ANN engines) and
+[ADR-079](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-079-ann-persistence-warm-path-integration.md)
+(wiring persisted snapshots into the daemon warm path).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-mcp/README.md
+++ b/crates/khive-mcp/README.md
@@ -1,0 +1,58 @@
+# khive-mcp
+
+The khive MCP server library — a single `request` tool that parses the verb-dispatch
+DSL and routes each operation through a `VerbRegistry`.
+
+This crate ships no binary of its own; [`kkernel`](https://crates.io/crates/kkernel)'s
+`mcp` subcommand is the frontend that builds a `KhiveMcpServer` from CLI args and serves
+it. `khive-mcp` owns the server type, the transports it can be served over, the pack
+force-linking, and the daemon protocol — `kkernel` owns argument parsing entry and process
+lifetime.
+
+## Features
+
+- **One tool, `request`** — `RequestParams { ops, presentation, format, save_to, .. }` is
+  the entire MCP-visible surface (ADR-016); verb-specific schemas live in packs, not here
+- **Pluggable transports** — `Transport` trait + `TransportRegistry`; ships `StdioTransport`,
+  open for more (e.g. Streamable HTTP) via `TransportRegistry::register`
+- **Daemon-aware dispatch** — `compute_config_id` fingerprints a resolved `RuntimeConfig`
+  (packs, db target, embedders) so a thin client only forwards to a warm daemon
+  (ADR-049) when the fingerprints match; otherwise it falls back to local dispatch
+- **Result sinking** — `RequestParams::save_to` writes results as JSONL and returns a
+  manifest (`path`, `rows`, `per_column_null_counts`, `schema_fingerprint`, `checksum`)
+  instead of inlining a large result set
+- **Cross-backend coordinator seam** — `CoordinatorService` is a trait khive-mcp defines
+  and `kkernel` implements, avoiding a dependency cycle for multi-backend link/traverse
+
+## Usage
+
+```rust
+use khive_mcp::server::KhiveMcpServer;
+use khive_runtime::{KhiveRuntime, RuntimeConfig};
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default()).expect("valid config");
+let server = KhiveMcpServer::new(runtime).expect("known packs, deps satisfied");
+```
+
+`KhiveMcpServer::new` builds the server from `runtime.config().packs`; `with_packs` takes
+an explicit pack list instead. Both fail fast with `PackRegError` (naming the unknown pack
+or missing dependency) rather than silently dropping packs. Once built, `serve_stdio(self)`
+consumes the server and serves over stdio — the path `StdioTransport::serve` and `kkernel
+mcp` both call.
+
+## Where this sits
+
+`khive-mcp` depends on `khive-db`, `khive-runtime`, `khive-storage`, `khive-request`, and
+every first-party pack crate (`khive-pack-kg`, `-gtd`, `-memory`, `-brain`, `-comm`,
+`-schedule`, `-knowledge`, `-session`) so their `inventory::submit!` verb registrations link
+into any binary that depends on this crate. `kkernel` is that binary: its `mcp` subcommand
+parses `khive_mcp::args::Args`, builds the runtime and pack registry, and calls into
+`khive_mcp::serve::run`.
+
+Governed by [ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)
+(the `request` tool contract) and [ADR-049](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-049-khived-daemon.md)
+(the warm daemon protocol this crate's client/daemon config-fingerprint matching supports).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-merge/README.md
+++ b/crates/khive-merge/README.md
@@ -1,0 +1,82 @@
+# khive-merge
+
+Three-way semantic merge for KG snapshots — entity identity, field-level conflict
+detection, edge weights, and dangling-edge validation.
+
+This is the v2 semantic merge layer, distinct from the v1 line-merge that
+[`khive-vcs`](https://crates.io/crates/khive-vcs) performs today over sorted NDJSON. Where
+the v1 path merges text lines, `khive-merge` understands `KgArchive` structure: it
+categorizes entity and edge changes between a common ancestor and two branches, applies
+field-level conflict rules, and reports conflicts as data rather than failing the merge.
+
+## Usage
+
+```rust
+use khive_merge::{ThreeWayMergeEngine, MergeEngine, MergeResult, SnapshotMergeStrategy};
+use khive_runtime::portability::KgArchive;
+
+fn merge(base: &KgArchive, ours: &KgArchive, theirs: &KgArchive) {
+    let engine = ThreeWayMergeEngine;
+    match engine
+        .merge_branch(base, ours, theirs, SnapshotMergeStrategy::Auto)
+        .expect("namespaces match and all weights are finite")
+    {
+        MergeResult::Clean { merged } => {
+            println!("merged cleanly: {} entities", merged.entities.len());
+        }
+        MergeResult::Conflicts { conflicts } => {
+            println!("{} conflicts need manual resolution", conflicts.len());
+        }
+    }
+}
+```
+
+`SnapshotMergeStrategy::Ours` / `Theirs` skip conflict detection entirely and apply a
+last-write-wins shortcut instead — always `Clean`. `SnapshotMergeStrategy::Auto` runs the
+full three-way algorithm: entity pass, edge pass, dangling-edge validation, deterministic
+sort, and returns `MergeResult::Conflicts` if anything needs a human. The free function
+`khive_merge::three_way_merge(base, ours, theirs, strategy)` is the same algorithm without
+going through the `MergeEngine` trait object.
+
+## Conflicts
+
+`MergeConflict` enumerates what `Auto` can detect: `NameConflict`, `KindConflict`,
+`PropertyMismatch`, `ModifyDelete` (one branch edited, the other deleted),
+`DuplicateAddition` (both branches added the same UUID with different content),
+`EdgeModifyDelete`, and `DanglingEdge` (a merged edge references an entity not in the
+merged set). `BranchSide::{Ours, Theirs}` identifies which branch a `ModifyDelete` /
+`EdgeModifyDelete` change came from.
+
+## Invariants
+
+- **Namespace isolation** — `base`, `ours`, and `theirs` must share one namespace, or the
+  merge is rejected with `MergeError::NamespaceMismatch` before any diff is computed.
+- **Finite weights only** — a non-finite edge weight (`NaN`/`Infinity`) on either branch
+  aborts with `MergeError::InvalidEdgeWeight`, never silently coerced.
+- **Deterministic output** — entities sort by UUID, edges by `(source, target, relation)`;
+  repeated calls over equal inputs produce byte-identical `KgArchive` output.
+- **Edge identity preserved** — a merged edge keeps the `edge_id` of the originating
+  branch's edge rather than minting a fresh UUID.
+
+## Where this sits
+
+`khive-merge` implements `MergeEngine`, the trait a `khive-vcs` integration would call at
+merge time once the VCS layer exposes snapshot ancestry (a `SnapshotReader`-compatible API
+for the lowest-common-ancestor walk this crate's `lca` module performs). It depends on
+`khive-runtime` (for `KgArchive`) and `khive-storage`.
+
+**This crate is forward-deployed: it is excluded from the cargo workspace** (`crates/Cargo.toml`
+`exclude = ["khive-merge"]`) **and not published to crates.io.** It compiles standalone via its
+own `[workspace]` table (`cargo check -p khive-merge` works from its own directory), but no
+production pack currently calls into it — the v1 path (`khive-vcs`, git line-merge over sorted
+NDJSON) governs KG merges today. See `crates/khive-merge/docs/design.md` for the full
+promotion plan.
+
+Relates to [ADR-010](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-010-kg-versioning.md)
+(KG versioning strategy — the v1/v2 merge distinction) and
+[ADR-020](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-020-git-native-kg-implementation.md)
+(git-native KG implementation).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-brain/README.md
+++ b/crates/khive-pack-brain/README.md
@@ -1,0 +1,85 @@
+# khive-pack-brain
+
+Brain pack: profile-oriented orchestration over the `Fold`/`Objective` primitives
+from [`khive-fold`](https://crates.io/crates/khive-fold) (ADR-032). A "profile" is
+a named, lifecycle-managed Beta-posterior state (recall relevance/salience/
+temporal weights, or per-section usefulness weights) that other packs resolve at
+call time and feed back into via explicit or implicit signals.
+
+## Features
+
+- **Profile lifecycle** (`brain.create_profile`, `brain.activate`,
+  `brain.deactivate`, `brain.archive`, `brain.reset`) — a profile moves through
+  `Active` / `Inactive` / `Archived`; reset restores posteriors to priors while
+  preserving event history
+- **Context-based resolution** (`brain.resolve`, `brain.bind`, `brain.unbind`,
+  `brain.bindings`) — a resolution table maps `(actor, namespace, consumer_kind)`
+  wildcards to a profile ID with priority ordering, so different callers can be
+  served different tuned profiles
+- **Feedback ingestion** (`brain.feedback`, `brain.auto_feedback`) — appends a
+  `FeedbackExplicit` event to the shared event log; `brain.auto_feedback` is
+  convenience sugar so an agent can credit the top `memory.recall` hit without
+  constructing a full feedback call
+- **Deterministic Fold-based state** — `BalancedRecallFold` and
+  `SectionPosteriorFold` each implement `khive_fold::Fold<Event, S>`
+  (`init`/`reduce`/`finalize`) over the append-only event log, so profile state is
+  always a pure replay, never a mutation in place
+- **Adapter integrity gating** (`brain.register_adapter`) — records a
+  content-hash + base-model-revision pair so an FFN/LoRA router only composes
+  adapters that match the currently active base model revision
+
+## Usage
+
+`BrainPack` is registered with the runtime via `inventory` and dispatches its
+verbs through the MCP `request` DSL, not called directly as a Rust API:
+
+```text
+request(ops="brain.create_profile(name=\"my-profile-v1\", consumer_kind=\"recall\")")
+request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"lambda:khive\")")
+request(ops="brain.feedback(target_id=\"<uuid>\", signal=\"useful\")")
+```
+
+The `Fold` implementations are exposed as a Rust API for embedding a profile's
+reduction logic in another crate:
+
+```rust
+use khive_fold::{Fold, FoldContext};
+use khive_pack_brain::fold::BalancedRecallFold;
+
+let fold = BalancedRecallFold::new(khive_pack_brain::ENTITY_CACHE_CAPACITY);
+let ctx = FoldContext::default();
+let state = fold.init(&ctx);
+// state = fold.reduce(state, &event, &ctx) for each Event in the log
+```
+
+## Verbs
+
+| Verb                                                                    | What it does                                              |
+| ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| `brain.profiles` / `brain.profile`                                      | List profiles / fetch one profile's metadata and snapshot |
+| `brain.resolve`                                                         | Show which profile would serve a given caller context     |
+| `brain.activate` / `brain.deactivate` / `brain.archive` / `brain.reset` | Lifecycle transitions                                     |
+| `brain.feedback` / `brain.auto_feedback`                                | Emit explicit / implicit feedback events                  |
+| `brain.bind` / `brain.unbind` / `brain.bindings`                        | Manage the profile resolution table                       |
+| `brain.create_profile`                                                  | Create a new profile with optional seed priors            |
+| `brain.register_adapter`                                                | Register an adapter integrity record for router gating    |
+
+`brain.state`, `brain.config`, `brain.events`, and the deprecated `brain.emit` are
+`Visibility::Subhandler` — internal/operator-only, not on the agent-facing MCP
+surface.
+
+## Where this sits
+
+`khive-pack-brain` sits in the pack tier, built on `khive-brain-core` (posterior
+state types), `khive-fold` (the `Fold` trait), `khive-runtime`, and
+`khive-storage`; it `REQUIRES` the [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
+substrate at runtime. Consumers include
+[`khive-pack-knowledge`](https://crates.io/crates/khive-pack-knowledge) (routes
+`knowledge.feedback` section signals to a configured brain profile) and
+[`khive-pack-memory`](https://crates.io/crates/khive-pack-memory) (recall ranking
+weights). Governing ADR:
+[ADR-032 (Brain as Profile-Orchestration over Fold + Objective)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-032-brain-profile-orchestration.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -1,0 +1,84 @@
+# khive-pack-comm
+
+The communication pack for khive — inter-agent messaging (`send`, `inbox`,
+`read`, `reply`, `thread`) over a dedicated `message` note kind, with
+dual-write, actor-addressed delivery.
+
+## Verbs
+
+| Verb          | What it does                                                       |
+| ------------- | ------------------------------------------------------------------ |
+| `comm.send`   | Send a message, optionally threaded                                |
+| `comm.inbox`  | List inbound messages for the caller (filter: unread / read / all) |
+| `comm.read`   | Mark an inbound message as read                                    |
+| `comm.reply`  | Reply to a message, preserving thread linkage                      |
+| `comm.thread` | Retrieve all messages in a conversation thread, chronologically    |
+
+A sixth handler, `comm.ingest`, is `Visibility::Subhandler` — it lets an
+out-of-band channel adapter (email, Telegram, etc.) write an inbound message
+directly, deduplicated by `external_id`, but it is not callable on the MCP wire.
+
+## Dual-write delivery
+
+Every `comm.send` writes two `message` notes via `dual_write_message`
+(`src/message.rs`): an **outbound** copy (`direction=outbound`) and an
+**inbound** copy (`direction=inbound`), linked by `outbound_ref`. If the
+inbound write fails, the outbound note is deleted before the error is
+returned — the pair is atomic.
+
+Two addressing modes govern where the inbound copy lands:
+
+- **Actor-addressed** ([ADR-057](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-057-comm-actor-addressed-delivery.md)) —
+  `to` carries an actor label (e.g. `"lambda:leo"`) stamped into
+  `to_actor`/`from_actor` properties. Both copies land in the caller's
+  namespace; recall is actor-filtered, not namespace-filtered. This is the
+  common case.
+- **Cross-namespace** (original [ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) model) —
+  when `to` is a bare namespace different from the sender's and no actor label
+  is supplied, delivery is gated by the sender's
+  `actor.allowed_outbound_namespaces` allowlist in `khive.toml`; an unlisted
+  namespace returns `RuntimeError::PermissionDenied`.
+
+A root message (`thread_id` absent) gets a canonical `thread_id` equal to the
+outbound note's own UUID, patched into both copies, so `comm.thread` finds
+every reply regardless of which copy it answered.
+
+## Usage
+
+`CommPack` requires the `kg` pack (`REQUIRES = ["kg"]`) for the notes substrate:
+
+```rust
+use khive_pack_comm::CommPack;
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+let mut builder = VerbRegistryBuilder::new();
+builder.register(KgPack::new(runtime.clone()));
+builder.register(CommPack::new(runtime));
+let registry = builder.build()?;
+
+registry
+    .dispatch("comm.send", json!({"to": "lambda:leo", "content": "PR #372 is ready for review"}))
+    .await?;
+
+let inbox = registry.dispatch("comm.inbox", json!({"limit": 20})).await?;
+```
+
+Over MCP: `request(ops="comm.send(to=\"lambda:leo\", content=\"PR #372 is ready for review\")")`.
+
+## Where this sits
+
+`khive-pack-comm` sits alongside `khive-pack-gtd`, `khive-pack-memory`, and
+`khive-pack-schedule` in the pack layer, depending on `khive-pack-kg` for the
+note substrate and registering into `khive-runtime`'s `VerbRegistry`, consumed
+by `khive-mcp`. Governing ADRs:
+[ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),
+[ADR-057](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-057-comm-actor-addressed-delivery.md) (actor-addressed delivery),
+built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-formal/README.md
+++ b/crates/khive-pack-formal/README.md
@@ -1,0 +1,64 @@
+# khive-pack-formal
+
+Formal-math ontology pack: additive edge endpoint rules for six formal-math
+`concept` subtypes — `theorem`, `definition`, `structure`, `instance`, `axiom`,
+`goal` (ADR-069). Pure ontology, no verbs.
+
+`FormalPack` contributes zero note kinds, zero entity kinds, and an empty
+`HANDLERS` table; its `dispatch` unconditionally returns
+`RuntimeError::InvalidInput` for any verb. Its entire contribution is
+`EDGE_RULES` — 21 `EdgeEndpointRule` entries that widen which
+`(source, relation, target)` triples the closed 17-relation edge ontology
+accepts, without adding a relation or tightening the base contract.
+
+## Endpoint rules
+
+Every rule uses `EndpointKind::EntityOfType { kind: "concept", entity_type }` so
+a match requires _both_ the base entity `kind == "concept"` and the declared
+`entity_type` subtype — the full `(EntityKind, entity_type)` pair ADR-001
+requires for granular subtyping. The closed `EdgeRelation` enum is unchanged;
+these rules only add legal endpoint pairs for relations that already exist:
+
+| Relation      | Rule count | Examples                                                            |
+| ------------- | ---------- | ------------------------------------------------------------------- |
+| `depends_on`  | 14         | `theorem -> definition`, `goal -> theorem`, `instance -> structure` |
+| `instance_of` | 1          | `instance -> structure`                                             |
+| `extends`     | 2          | `structure -> structure`, `definition -> definition`                |
+| `variant_of`  | 4          | `theorem -> theorem`, `goal -> theorem`                             |
+
+## Usage
+
+`FormalPack` is registered with the runtime via `inventory` alongside the other
+packs; it contributes no callable verb, so there is no request DSL surface to
+invoke. Its effect is passive: once loaded, edge validation for `concept`
+entities carrying a matching `entity_type` accepts the pairs above in addition
+to the base ADR-002 contract. The rule table itself is a plain constant:
+
+```rust
+use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind};
+
+// from khive-pack-formal's FORMAL_EDGE_RULES — depends_on, theorem -> axiom
+EdgeEndpointRule {
+    relation: EdgeRelation::DependsOn,
+    source: EndpointKind::EntityOfType { kind: "concept", entity_type: "theorem" },
+    target: EndpointKind::EntityOfType { kind: "concept", entity_type: "axiom" },
+};
+```
+
+## Where this sits
+
+`khive-pack-formal` sits in the pack tier on `khive-types` (`EdgeEndpointRule`,
+`EndpointKind`) and `khive-runtime` (`Pack`, `PackRuntime`, inventory
+registration); it `REQUIRES` [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
+for the underlying `concept` entity substrate. Unlike the eight packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
+is only force-linked into `kkernel` (the admin/reindex binary) — it is not part of
+the agent-facing MCP server's pack registry at all today. A deployment that
+ingests formal-math corpora (Lean/mathlib-style theorem/definition/proof graphs)
+through `kkernel` opts in via `KHIVE_PACKS` or `--pack formal` on that binary; wiring
+it into `khive-mcp` would require adding the force-link `pub use` in
+`khive-mcp/src/pack.rs` first. Governing ADR:
+[ADR-069 (The Subject Model — Domain-Ontology Ingestion and Map Pipeline)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-069-subject-model.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-gtd/README.md
+++ b/crates/khive-pack-gtd/README.md
@@ -1,0 +1,84 @@
+# khive-pack-gtd
+
+The GTD (Getting Things Done) verb pack for khive. Adds the `task` note kind
+and five lifecycle verbs (`assign`, `next`, `complete`, `tasks`, `transition`)
+over the notes substrate.
+
+## Verbs
+
+| Verb             | What it does                                                                  |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `gtd.assign`     | Create a task (note with `kind=task`); defaults `status=inbox`, `priority=p2` |
+| `gtd.next`       | List actionable tasks (`status` in `next`/`active`), priority-sorted          |
+| `gtd.complete`   | Mark a task `done` (or `cancelled`) with an optional result note              |
+| `gtd.tasks`      | Filtered task listing by status, assignee, priority                           |
+| `gtd.transition` | Explicit lifecycle change, validated against the state machine below          |
+
+All five verbs are declared in `GTD_HANDLERS` (`src/vocab.rs`) and dispatched
+by `GtdPack::dispatch` (`src/pack.rs`).
+
+## Task lifecycle
+
+The `task` note kind's lifecycle field is `kind_status` (not `status` — that
+name is reserved for `Note.status`, the row-visibility field). States and
+legal transitions, from `GTD_NOTE_KIND_SPECS`:
+
+```text
+inbox ──> next ──> active ──> done
+  │         │         │      cancelled
+  │         ├──> waiting <───┤
+  │         ├──> someday     │
+  └─────────┴────────────────┘
+```
+
+`inbox` is the initial state; `done` and `cancelled` are terminal — no outgoing
+transitions are permitted from either. Common aliases are accepted on write:
+`todo=inbox`, `in_progress=active`, `blocked=waiting`, `later=someday`,
+`finished=done`.
+
+The pack also extends the base `depends_on` edge endpoint contract
+([ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md))
+to allow `task`→`task` edges (`GTD_EDGE_RULES`), so task blockers are
+graph-traversable even though the base contract restricts `depends_on` to
+entity→entity.
+
+## Usage
+
+`GtdPack` requires the `kg` pack (`REQUIRES = ["kg"]`) to be registered on the
+same runtime — it stores tasks as notes and relies on `kg`'s note substrate.
+
+```rust
+use khive_pack_gtd::GtdPack;
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+let mut builder = VerbRegistryBuilder::new();
+builder.register(KgPack::new(runtime.clone()));
+builder.register(GtdPack::new(runtime));
+let registry = builder.build()?;
+
+let result = registry
+    .dispatch(
+        "gtd.assign",
+        json!({"title": "Write crate READMEs", "priority": "p1"}),
+    )
+    .await?;
+```
+
+Over MCP: `request(ops="gtd.assign(title=\"Write crate READMEs\", priority=\"p1\")")`.
+
+## Where this sits
+
+`khive-pack-gtd` sits alongside `khive-pack-memory`, `khive-pack-comm`, and
+`khive-pack-schedule` in the pack layer — each depends on `khive-pack-kg` and
+plugs into `khive-runtime`'s `VerbRegistry`, consumed in turn by `khive-mcp`.
+Governing ADR:
+[ADR-019](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-019-gtd-pack.md) (GTD pack),
+built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -1,0 +1,100 @@
+# khive-pack-kg
+
+The KG verb pack — entity/note CRUD, graph traversal, hybrid search, and
+event-sourced proposals for khive's research knowledge graph substrate. This is
+the first-party pack shipped with the khive binary; every other pack in this
+workspace declares it as a dependency.
+
+## Verbs
+
+16 handlers, registered under [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md):
+
+| Verb        | What it does                                                                    |
+| ----------- | ------------------------------------------------------------------------------- |
+| `create`    | Create an entity or note (singleton), or a batch of entities (bulk via `items`) |
+| `get`       | Fetch any record by UUID (short hex prefix accepted, min 8 chars)               |
+| `list`      | List records with optional filtering                                            |
+| `update`    | Patch an entity or edge                                                         |
+| `delete`    | Soft- or hard-delete a record                                                   |
+| `merge`     | Merge two entities                                                              |
+| `search`    | Hybrid FTS + vector search over entities or notes                               |
+| `link`      | Create a typed directed edge between two entities                               |
+| `neighbors` | Immediate graph neighbors of a node                                             |
+| `traverse`  | Multi-hop BFS over the graph with relation/depth filters                        |
+| `query`     | GQL or SPARQL pattern query compiled to SQL                                     |
+| `propose`   | Create an event-sourced KG change proposal                                      |
+| `review`    | Approve, reject, or comment on a proposal                                       |
+| `withdraw`  | Rescind an open proposal (proposer-only)                                        |
+| `verbs`     | List all MCP-callable verbs registered on the server                            |
+| `stats`     | Aggregate KG substrate counts (entities, edges, notes)                          |
+
+`propose`/`review`/`withdraw` implement the event-sourced proposal lifecycle from
+[ADR-046](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-046-event-sourced-proposals.md).
+
+## Vocabulary
+
+The pack declares 9 entity kinds (`concept`, `document`, `dataset`, `project`,
+`person`, `org`, `artifact`, `service`, `resource`) and 5 note kinds
+(`observation`, `insight`, `question`, `decision`, `reference`) — see
+`KgPack::NOTE_KINDS` / `KgPack::ENTITY_KINDS` in `src/pack.rs`.
+
+It also extends the base edge endpoint contract ([ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md))
+with `person`/`org`-specific pairs — e.g. `part_of` and `instance_of` from a
+`person` entity to an `org` entity, plus several `org`→`org` pairs
+(`depends_on`, `enables`, `contains`, `part_of`, `precedes`). This is
+pack-extensible per ADR-017; the edge relation enum itself stays closed.
+
+## Usage
+
+Packs are consumed through the MCP `request` tool
+([ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)),
+not called as a Rust library. A deployment wires `KgPack` onto a
+`VerbRegistry` and dispatches verbs by name:
+
+```rust
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+let mut builder = VerbRegistryBuilder::new();
+builder.register(KgPack::new(runtime));
+let registry = builder.build()?;
+
+let result = registry
+    .dispatch(
+        "create",
+        json!({"kind": "entity", "entity_kind": "concept", "name": "RoPE"}),
+    )
+    .await?;
+```
+
+Over MCP, the same call is issued as a DSL string:
+
+```text
+request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
+```
+
+`khive-mcp` auto-registers this pack (along with `gtd`, `memory`, `comm`,
+`schedule`) by default; `KHIVE_PACKS` / `--pack` select a subset.
+
+## Where this sits
+
+`khive-pack-kg` sits at the top of the storage stack — `khive-types` →
+`khive-score` → `khive-storage` → `khive-db` → `khive-query` → `khive-runtime`
+→ **`khive-pack-kg`** → `khive-mcp`. Every other pack in this workspace
+(`khive-pack-gtd`, `khive-pack-memory`, `khive-pack-comm`,
+`khive-pack-schedule`) declares `REQUIRES = ["kg"]` and is registered alongside
+it. Governing ADRs:
+[ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md) (entity kinds),
+[ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md) (edge relations),
+[ADR-013](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-013-note-kind-taxonomy.md) (note kinds),
+[ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md) (request DSL),
+[ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard),
+[ADR-023](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-023-declarative-pack-format.md) (verb surface/visibility),
+[ADR-046](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-046-event-sourced-proposals.md) (proposals).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -76,17 +76,18 @@ Over MCP, the same call is issued as a DSL string:
 request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
 ```
 
-`khive-mcp` auto-registers this pack (along with `gtd`, `memory`, `comm`,
-`schedule`) by default; `KHIVE_PACKS` / `--pack` select a subset.
+`khive-mcp` loads a default set of eight packs — `kg`, `gtd`, `memory`, `brain`,
+`comm`, `schedule`, `knowledge`, `session` — with `kg` always present;
+`KHIVE_PACKS` / `--pack` select a subset.
 
 ## Where this sits
 
-`khive-pack-kg` sits at the top of the storage stack — `khive-types` →
-`khive-score` → `khive-storage` → `khive-db` → `khive-query` → `khive-runtime`
-→ **`khive-pack-kg`** → `khive-mcp`. Every other pack in this workspace
-(`khive-pack-gtd`, `khive-pack-memory`, `khive-pack-comm`,
-`khive-pack-schedule`) declares `REQUIRES = ["kg"]` and is registered alongside
-it. Governing ADRs:
+`khive-pack-kg` depends directly on `khive-types`, `khive-runtime`,
+`khive-query`, and `khive-storage`, and is registered into the pack runtime that
+`khive-mcp` serves. Every other pack in this workspace declares
+`REQUIRES = ["kg"]` — `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
+`session`, plus `formal` and `template` — so each depends on `kg` being loaded.
+Governing ADRs:
 [ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md) (entity kinds),
 [ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md) (edge relations),
 [ADR-013](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-013-note-kind-taxonomy.md) (note kinds),

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -1,0 +1,93 @@
+# khive-pack-knowledge
+
+Knowledge verb pack for khive: a corpus of `atoms` (documented techniques, one per
+concept) grouped into `domains`, retrieved by TF-IDF search with optional embedding
+rerank, and composed into markdown briefings under a token budget.
+
+## Features
+
+- **TF-IDF corpus search** (`knowledge.search`) over atom name/tags/content, with
+  score bands (`>=0.46` reliable, `0.42-0.46` mixed, `<0.42` mostly off-target),
+  query decomposition, and RRF fusion against an ANN pass when an embedder is
+  configured
+- **Section-level records** (`knowledge.edit`) — a closed 10-value `section_type`
+  enum (`overview`, `core_model`, `formalism`, `failure_modes`, ... `other`) per
+  atom, each independently disputable and adjudicable (ADR-051)
+- **Budget-constrained fold** (`knowledge.fold`) — knapsack selection of
+  caller-scored candidates against a token/size budget
+- **Domain suggestion + compose** (`knowledge.suggest`, `knowledge.compose`) — find
+  relevant domains for a query, then assemble a reranked markdown briefing from
+  their member atoms
+- **Concept sugar over the KG** (`knowledge.learn`, `knowledge.cite`,
+  `knowledge.topic`) — register a `concept` entity and link it to its introducing
+  `document`/`person` without hand-rolling `create`/`link` calls
+- **Section feedback** (`knowledge.feedback`) — per-section `useful`/`not_useful`/
+  `wrong` signals update posterior weights, optionally forwarded to a configured
+  brain profile (ADR-032)
+
+## Usage
+
+This crate is not called directly as a Rust library — it registers `KnowledgePack`
+with the runtime's `inventory`-based pack registry and dispatches its 19 verbs
+through the MCP `request` DSL (or `kkernel call`). A caller issues:
+
+```text
+request(ops="knowledge.search(query=\"block-max wand posting list pruning\", limit=10)")
+```
+
+or, to build a fresh corpus and immediately reference it:
+
+```text
+request(ops="[knowledge.upsert_atoms(atoms=[{\"slug\":\"bm25-wand\",\"name\":\"BM25 WAND\",\"content\":\"...\"}]), knowledge.compose(atom_ids=[\"bm25-wand\"], query=\"keyword search pruning strategies\")]")
+```
+
+Programmatic embedding is exposed via a small Rust API for the `kkernel reindex`
+binary, independent of the MCP surface:
+
+```rust
+use khive_pack_knowledge::{reindex_knowledge, KnowledgeReindexOptions};
+
+let opts = KnowledgeReindexOptions {
+    atoms: true,
+    sections: true,
+    drop_existing: false,
+    rebuild_ann: true,
+    batch_size: None,
+};
+let report = reindex_knowledge(&runtime, &token, opts, None, None).await?;
+```
+
+## Verbs
+
+| Verb                                                                              | What it does                                               |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `knowledge.upsert_atoms` / `knowledge.upsert_domains`                             | Bulk insert or update atoms / domains                      |
+| `knowledge.get` / `knowledge.list` / `knowledge.delete_atoms` / `knowledge.stats` | Corpus CRUD and aggregate counts                           |
+| `knowledge.index`                                                                 | Backfill embeddings + FTS for atoms/domains                |
+| `knowledge.search` / `knowledge.suggest` / `knowledge.compose`                    | TF-IDF search, domain suggestion, briefing assembly        |
+| `knowledge.fold`                                                                  | Knapsack selection of scored candidates against a budget   |
+| `knowledge.edit`                                                                  | Upsert one atom's sections without wiping the rest         |
+| `knowledge.import`                                                                | Ingest atlas-format markdown as atoms with parsed sections |
+| `knowledge.challenge` / `knowledge.adjudicate`                                    | Dispute and resolve a section's content                    |
+| `knowledge.learn` / `knowledge.cite` / `knowledge.topic`                          | Register/link/browse `concept` entities                    |
+| `knowledge.feedback`                                                              | Apply per-section signals to posterior weights             |
+
+All 19 verbs are `Visibility::Verb` (exposed on the agent-facing MCP surface).
+
+## Where this sits
+
+`khive-pack-knowledge` sits in the pack tier, above `khive-runtime` /
+`khive-storage` / `khive-score` / `khive-fusion` / `khive-vamana` /
+`khive-fold`, alongside sibling packs such as
+[`khive-pack-kg`](https://crates.io/crates/khive-pack-kg) (a hard `REQUIRES`
+dependency for the underlying `concept`/`document` entity substrate) and
+[`khive-pack-brain`](https://crates.io/crates/khive-pack-brain) (feedback
+target). It is one of the eight packs loaded by default in `khive-mcp`. Governing
+ADRs:
+[ADR-017 (Pack Standard)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md),
+[ADR-048 (Knowledge Section Profiles)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-048-knowledge-section-profiles.md),
+[ADR-051 (Section-level Embeddings and Hybrid Compose Scoring)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-051-section-embeddings-hybrid-compose.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -29,10 +29,16 @@ rerank, and composed into markdown briefings under a token budget.
 
 This crate is not called directly as a Rust library — it registers `KnowledgePack`
 with the runtime's `inventory`-based pack registry and dispatches its 19 verbs
-through the MCP `request` DSL (or `kkernel call`). A caller issues:
+through the MCP `request` DSL (or `kkernel exec`). A caller issues:
 
 ```text
 request(ops="knowledge.search(query=\"block-max wand posting list pruning\", limit=10)")
+```
+
+The same DSL runs from the shell without an MCP client via `kkernel exec`:
+
+```bash
+kkernel exec 'knowledge.search(query="block-max wand posting list pruning", limit=10)'
 ```
 
 or, to build a fresh corpus and immediately reference it:

--- a/crates/khive-pack-memory/README.md
+++ b/crates/khive-pack-memory/README.md
@@ -1,0 +1,87 @@
+# khive-pack-memory
+
+The memory verb pack for khive. Provides `memory.remember` and `memory.recall`
+with decay-aware hybrid ranking over a dedicated `memory` note kind, plus
+feedback and curation verbs.
+
+## Verbs
+
+| Verb              | What it does                                                           |
+| ----------------- | ---------------------------------------------------------------------- |
+| `memory.remember` | Create a memory note with salience and decay                           |
+| `memory.recall`   | Recall memories via decay-aware hybrid (FTS + vector) ranking          |
+| `memory.feedback` | Emit explicit feedback on a recalled entity; updates recall posteriors |
+| `memory.prune`    | Soft-delete memories below a salience floor and/or past `expires_at`   |
+| `memory.vacuum`   | Run SQLite `VACUUM` to reclaim space freed by soft-deleted rows        |
+
+These five are `Visibility::Verb` (MCP-callable). `MemoryPack` also declares
+five `Visibility::Subhandler` entries (`memory.recall_embed`,
+`recall_candidates`, `recall_fuse`, `recall_rerank`, `recall_score`) that
+expose the recall pipeline's intermediate stages for introspection — they are
+not dispatched over the MCP wire.
+
+## Decay-aware ranking
+
+Every memory carries a `salience` (0.0-1.0) and a `decay_factor` (>= 0, higher
+decays faster). Defaults are type-differentiated
+(`memory.remember`'s `memory_type` parameter, `src/pack.rs`):
+
+| `memory_type`        | default `salience` | default `decay_factor` | approx. half-life |
+| -------------------- | ------------------ | ---------------------- | ----------------- |
+| `episodic` (default) | 0.3                | 0.02                   | ~35 days          |
+| `semantic`           | 0.5                | 0.005                  | ~139 days         |
+
+Explicit caller-supplied values always override these defaults. `memory.recall`
+fuses lexical and vector retrieval (`khive-fusion`, `khive-retrieval`,
+`khive-vamana`) and folds decay into the composite score, which is always
+normalized to `[0, 1]`; `min_score` / `score_floor` filter below a threshold.
+Recall results also route feedback signals into per-namespace Beta-posterior
+state (`khive-brain-core`'s `BalancedRecallState`) that tunes future ranking.
+
+## Usage
+
+`MemoryPack` requires the `kg` pack (`REQUIRES = ["kg"]`) and a registered
+embedding provider for vector recall (`KhiveRuntime::register_embedder`):
+
+```rust
+use khive_pack_kg::KgPack;
+use khive_pack_memory::MemoryPack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+let mut builder = VerbRegistryBuilder::new();
+builder.register(KgPack::new(runtime.clone()));
+builder.register(MemoryPack::new(runtime));
+let registry = builder.build()?;
+
+registry
+    .dispatch(
+        "memory.remember",
+        json!({"content": "Vamana is sublinear at low intrinsic dimension", "memory_type": "semantic"}),
+    )
+    .await?;
+
+let hits = registry
+    .dispatch("memory.recall", json!({"query": "Vamana intrinsic dimension", "limit": 10}))
+    .await?;
+```
+
+Over MCP: `request(ops="memory.recall(query=\"Vamana intrinsic dimension\", limit=10)")`.
+
+## Where this sits
+
+`khive-pack-memory` sits alongside `khive-pack-gtd`, `khive-pack-comm`, and
+`khive-pack-schedule` in the pack layer, depending on `khive-pack-kg` for the
+note substrate and on `khive-fusion` / `khive-retrieval` / `khive-vamana` /
+`khive-brain-core` for hybrid scoring, ANN recall, and decay-posterior state.
+It registers into `khive-runtime`'s `VerbRegistry`, consumed by `khive-mcp`.
+Governing ADR:
+[ADR-021](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-021-memory-pack.md) (memory pack),
+built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard)
+and [ADR-014](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-014-curation-operations.md) (curation operations, for `prune`/`vacuum`).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-schedule/README.md
+++ b/crates/khive-pack-schedule/README.md
@@ -1,0 +1,70 @@
+# khive-pack-schedule
+
+The schedule pack for khive — time-triggered intent storage (`remind`,
+`schedule`, `agenda`, `cancel`) over a dedicated `scheduled_event` note kind.
+
+## Verbs
+
+| Verb                | What it does                                                            |
+| ------------------- | ----------------------------------------------------------------------- |
+| `schedule.remind`   | Create a time-triggered reminder                                        |
+| `schedule.schedule` | Schedule a future verb dispatch (a DSL string, validated at write time) |
+| `schedule.agenda`   | List upcoming scheduled events, optionally within a time window         |
+| `schedule.cancel`   | Cancel a scheduled event                                                |
+
+`at` is an RFC 3339 timestamp; `repeat` accepts `daily` / `weekly` / `monthly`
+or a 5-field cron expression.
+
+## Semantics
+
+This pack is **intent storage only**. It creates and queries
+`scheduled_event` notes; it does not itself evaluate triggers. `schedule.remind`
+stores a plain reminder payload, while `schedule.schedule`'s `action` parameter
+is a full verb-dispatch string (e.g. `"schedule.remind(content=\"hello\")"`)
+that is parsed with `khive_request::parse_request` at write time — an
+unparseable `action` is rejected before the event is stored, not at trigger
+time. Reading pending events and dispatching their stored payload at
+`trigger_at` is the execution environment's responsibility (a `kkernel
+scheduler` daemon, or an external cron / cloud scheduler invoking the runtime).
+
+## Usage
+
+`SchedulePack` requires the `kg` pack (`REQUIRES = ["kg"]`) for the notes
+substrate:
+
+```rust
+use khive_pack_kg::KgPack;
+use khive_pack_schedule::SchedulePack;
+use khive_runtime::{KhiveRuntime, RuntimeConfig, VerbRegistryBuilder};
+use serde_json::json;
+
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+let mut builder = VerbRegistryBuilder::new();
+builder.register(KgPack::new(runtime.clone()));
+builder.register(SchedulePack::new(runtime));
+let registry = builder.build()?;
+
+registry
+    .dispatch(
+        "schedule.remind",
+        json!({"content": "Ship the 0.2.12 release", "at": "2026-07-05T09:00:00Z"}),
+    )
+    .await?;
+```
+
+Over MCP: `request(ops="schedule.remind(content=\"Ship the 0.2.12 release\", at=\"2026-07-05T09:00:00Z\")")`.
+
+## Where this sits
+
+`khive-pack-schedule` sits alongside `khive-pack-gtd`, `khive-pack-memory`,
+and `khive-pack-comm` in the pack layer, depending on `khive-pack-kg` for the
+note substrate and on `khive-request` to validate `schedule.schedule`'s
+DSL payload, registering into `khive-runtime`'s `VerbRegistry`, consumed by
+`khive-mcp`. Governing ADR:
+[ADR-040](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-040-communication-and-schedule-packs.md) (communication and schedule packs),
+built on [ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md) (pack standard).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-session/README.md
+++ b/crates/khive-pack-session/README.md
@@ -1,0 +1,81 @@
+# khive-pack-session
+
+Session pack: registers the `session` note kind and a background transcript
+mirror that live-tails Claude Code and Codex CLI session logs into two auxiliary
+SQL tables (ADR-080).
+
+## What ships this milestone
+
+The pack declares three verbs — `session.store`, `session.list`, `session.get` —
+over the notes substrate, but all three are `Visibility::Subhandler`: reachable
+via the runtime and `kkernel call`, but **withheld from the agent-facing MCP
+`request` surface** until the session-continuity query UX is designed. They add
+zero verbs to what an agent sees in the `request` tool's catalog today.
+
+The pack's active feature this milestone is the **mirror service**, started from
+the `warm()` pack hook independent of verb visibility. It polls
+`$HOME/.claude/projects/**/*.jsonl` (Claude Code) and
+`$HOME/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` (Codex CLI), tracks a
+byte-offset cursor per file (`session_mirror_cursor`), and appends parsed
+messages into `sessions` / `session_messages` — both idempotent
+(`INSERT OR IGNORE`) so restarting the daemon or double-processing a file is
+safe. The service is opt-in via environment variable, disabled by default.
+
+```text
+KHIVE_MIRROR_ENABLED=true        # enable the Claude Code mirror
+KHIVE_MIRROR_PROJECTS_DIR=...    # default: $HOME/.claude/projects
+KHIVE_MIRROR_CODEX_ENABLED=true  # enable the Codex CLI mirror (independent flag)
+KHIVE_MIRROR_CODEX_DIR=...       # default: $HOME/.codex/sessions
+KHIVE_MIRROR_POLL_SECS=2         # polling interval
+KHIVE_MIRROR_BACKFILL=true       # mirror existing files from byte 0 vs. current EOF
+```
+
+## Usage
+
+The mirror is started automatically by the runtime's pack warm-up; it is not
+called directly. The parse and config surfaces are public for testing and
+alternate embedding:
+
+```rust
+use khive_pack_session::mirror::{parse_cc_line, MirrorConfig};
+
+let config = MirrorConfig::from_env();
+if config.enabled {
+    // a JSONL line from a Claude Code transcript; returns None on a blank or
+    // unparseable line
+    if let Some(event) = parse_cc_line(line) {
+        // event: ParsedEvent — session_id, uuid, role, text, raw JSON, ...
+    }
+}
+```
+
+Once the `session.store`/`list`/`get` verbs are flipped to `Visibility::Verb`,
+the intended call shape is:
+
+```text
+request(ops="session.list(agent_id=\"lambda:khive\", limit=20)")
+```
+
+## Storage
+
+Three tables, applied idempotently via the pack's `schema_plan` hook:
+`sessions` (one row per transcript: `provider_session_id`, `source`, `cwd`,
+`git_branch`, `message_count`, first/last-seen timestamps), `session_messages`
+(one row per parsed message: `seq`, `parent_uuid`, `role`, `msg_type`, `text`,
+raw JSON), and `session_mirror_cursor` (byte-offset bookkeeping per file).
+
+## Where this sits
+
+`khive-pack-session` sits in the pack tier alongside
+[`khive-pack-kg`](https://crates.io/crates/khive-pack-kg) (a `REQUIRES`
+dependency for the `session` note kind's substrate) and is one of the eight
+packs loaded by default in `khive-mcp`. This crate is the OSS storage mechanism
+half of session continuity — the design record explicitly moved the scope
+boundary so the mirror mechanism (this crate, the `session.*` verb surface, and
+the note-kind registration) ships in the open-source repository rather than
+staying a deployment-only concern. Governing ADR:
+[ADR-080 (Session Pack — OSS Storage Mechanism)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-pack-session/README.md
+++ b/crates/khive-pack-session/README.md
@@ -8,8 +8,9 @@ SQL tables (ADR-080).
 
 The pack declares three verbs — `session.store`, `session.list`, `session.get` —
 over the notes substrate, but all three are `Visibility::Subhandler`: reachable
-via the runtime and `kkernel call`, but **withheld from the agent-facing MCP
-`request` surface** until the session-continuity query UX is designed. They add
+via the runtime and `kkernel exec` (a trusted operator surface), but **withheld
+from the agent-facing MCP `request` surface** until the session-continuity query
+UX is designed. They add
 zero verbs to what an agent sees in the `request` tool's catalog today.
 
 The pack's active feature this milestone is the **mirror service**, started from

--- a/crates/khive-pack-template/README.md
+++ b/crates/khive-pack-template/README.md
@@ -1,0 +1,67 @@
+# khive-pack-template
+
+Reference template for authoring a new khive pack (ADR-023 §8). This crate is
+not consumed as a dependency — it is a scaffold you copy.
+
+## Usage
+
+```bash
+cp -r crates/khive-pack-template crates/khive-pack-<name>
+```
+
+Then, per `docs/design.md` in this crate:
+
+1. Rename the crate in `Cargo.toml` (`name`, `description`).
+2. Set `PACK_NAME` in `lib.rs` to your pack's canonical name (e.g. `"exp"`).
+3. Update `NOTE_KINDS` / `ENTITY_KINDS` in `vocab.rs`.
+4. Add verbs to the `HandlerDef` table in `pack.rs`; implement them in
+   `handlers.rs`.
+5. Add the crate to the workspace `Cargo.toml`.
+6. Force-link it in `khive-mcp/src/pack.rs` and `kkernel/src/lib.rs` (a
+   `pub use` referencing any public type — this is what makes the linker
+   include the pack's `inventory::submit!` factory in the final binary).
+7. Add the crate dependency to `khive-mcp/Cargo.toml` and `kkernel/Cargo.toml`.
+
+## What the scaffold demonstrates
+
+`TemplatePack` implements `khive_types::Pack` (`NAME = "template"`, one note kind
+`"template_note"`, `REQUIRES = ["kg"]`) and `khive_runtime::pack::PackRuntime`,
+and registers itself with `inventory::submit! { khive_runtime::PackRegistration(&TemplatePackFactory) }`
+— the same self-registration mechanism every khive pack uses (ADR-027). Its one
+handler, `template.my_verb`, shows the required non-`kg`-pack verb naming
+(`<pack>.<verb>`) and basic parameter validation:
+
+```rust
+// handlers::handle_my_verb — rejects a missing/empty "name" field
+pub(crate) async fn handle_my_verb(
+    _runtime: &khive_runtime::KhiveRuntime,
+    _token: &khive_runtime::NamespaceToken,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, khive_runtime::RuntimeError> {
+    // { "name": "<string>" } -> { "ok": true, "name": "<string>" }
+}
+```
+
+Dispatched through the MCP `request` DSL once loaded:
+
+```text
+request(ops="template.my_verb(name=\"example\")")
+```
+
+`tests/integration.rs` covers the pattern every new pack's tests should follow:
+valid input, invalid input, and dispatch of an unknown verb.
+
+## Where this sits
+
+`khive-pack-template` depends on `khive-types` (`Pack`, `HandlerDef`,
+`Visibility`) and `khive-runtime` (`PackRuntime`, `PackFactory`,
+`KhiveRuntime`), `REQUIRES` [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
+like every other pack, and is never force-linked into a shipping binary — it
+exists purely as the copy-me reference for
+[ADR-023 (Pack Verb Surface, Visibility, and Composition)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-023-declarative-pack-format.md)
+§8 and
+[ADR-027 (Dynamic Pack Loading via Self-Registration)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-027-dynamic-pack-loading.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-quant/README.md
+++ b/crates/khive-quant/README.md
@@ -1,0 +1,68 @@
+# khive-quant
+
+SQ8 scalar quantization codecs for approximate distance computation in ANN
+indexes. Two codecs, chosen by which distance metric the index needs:
+`Sq8Codec` (per-dimension affine scale, for dot product / cosine) and
+`GsSq8Codec` (global shared scale, for L2 — the Vamana acquisition path).
+
+## Usage
+
+```rust
+use khive_quant::Sq8Codec;
+
+let corpus: Vec<Vec<f32>> = vec![
+    vec![0.1, 0.9, 0.4],
+    vec![0.8, 0.2, 0.6],
+];
+
+let codec = Sq8Codec::train(&corpus);
+let encoded: Vec<_> = corpus.iter().map(|v| codec.encode(v)).collect();
+
+let dot = codec.approx_dot(&encoded[0], &encoded[1]);
+let cosine_dist = codec.approx_cosine_dist(&encoded[0], &encoded[1]);
+```
+
+`train` / `train_flat` compute per-dimension `min`/`max` from the corpus and
+derive `scale_i = (max_i - min_i) / 255`; `encode` maps each `f32` dimension to
+a `u8` code via `round((x - min_i) / scale_i)`. `encode_par` / `encode_flat_par`
+parallelize encoding across a batch with `rayon`. `approx_dot`,
+`approx_cosine_dist`, and `approx_l2_sq` reconstruct the original-scale
+distance from `u8` codes using a residual-corrected integer pass, preserving
+ordinal ranking against the exact `f32` computation.
+
+## GsSq8Codec — the Vamana acquisition path
+
+`GsSq8Codec` uses one shared scale `gs = max_range_across_dims / 255` for every
+dimension (per-dim `min_i` offsets are still subtracted before quantizing).
+This makes squared L2 in code space `gs² * sum((a_i - b_i)^2)` algebraically
+exact after the lossy `f32` -> `u8` encode — the offset terms cancel and `gs²`
+factorizes out, so `GsSq8Codec::l2_sq` needs no residual pass or anisotropy
+gate. The trade-off is honest, not hidden: narrow-range dimensions get fewer
+`u8` levels and contribute proportionally less L2 signal than the wide-range
+dimensions that set `gs`. `GsSq8Codec::is_in_distribution` flags query vectors
+whose components fall outside the trained range so a caller can fall back to
+exact `f32` distance for out-of-distribution queries — see
+`VamanaIndex::search`.
+
+## Hot-loop kernels
+
+`u8_dot_u32` and `u8_l2sq_u32` are the shared inner loops both codecs use:
+`u8_dot_u32` computes `sum(a_i * b_i)` as a `u32` accumulator via NEON
+`vmull_u8` (aarch64) or a chunked portable widening fallback elsewhere;
+`u8_l2sq_u32` computes `sum((a_i - b_i)^2)` via NEON `vabdq_u8` + `vmull_u8`
+squaring, or the equivalent portable fallback.
+
+## Where this sits
+
+Built on `rayon` only — no khive-* dependencies. Consumed today by
+[khive-vamana](https://crates.io/crates/khive-vamana) for its SQ8-quantized
+acquisition path. Governed by
+[ADR-052](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-052-ann-production-lifecycle.md),
+which documents why the predecessor per-dimension L2 codec (with an
+anisotropy gate calibrated on a synthetic corpus) silently fell back to a full
+residual pass on real transformer embeddings, and why the global-scale design
+eliminates the gate entirely.
+
+## License
+
+Apache-2.0.

--- a/crates/khive-query/README.md
+++ b/crates/khive-query/README.md
@@ -1,0 +1,81 @@
+# khive-query
+
+GQL and SPARQL parsers with a SQL compiler for knowledge graph queries. Both
+dialects parse into a single shared `GqlQuery` AST, which one compiler lowers to
+parameterized SQL.
+
+## Usage
+
+```rust
+use khive_query::{compile, parse_auto, CompileOptions};
+
+// parse_auto detects the dialect: `SELECT` -> SPARQL, `MATCH` -> GQL, else GQL.
+let query = parse_auto("MATCH (a:concept)-[:extends]->(b:concept) RETURN a, b")?;
+
+let opts = CompileOptions {
+    scopes: vec!["local".to_string()],
+    max_limit: 500,
+};
+let compiled = compile(&query, &opts)?;
+// compiled.sql: parameterized SQL string
+// compiled.params: Vec<QueryValue> bound positionally
+// compiled.return_vars, compiled.warnings
+```
+
+Language can also be selected explicitly:
+
+```rust
+use khive_query::{parse, QueryLanguage};
+
+let query = parse(QueryLanguage::Sparql, "SELECT ?a WHERE { ?a :extends ?b . }")?;
+```
+
+## Architecture
+
+```text
+input string ─┬─ parse_auto() ──dispatch by leading keyword──┬─ parsers::gql::parse()
+              └─ parse(lang, .) ─────────────────────────────┘  parsers::sparql::parse()
+                                        │
+                                    GqlQuery (ast.rs)
+                                        │
+                             validate::validate_with_warnings()
+                                        │
+                              compilers::sql::compile()
+                                        │
+                              CompiledQuery { sql, params, return_vars, warnings }
+```
+
+`validate_with_warnings` runs structural checks (pattern must alternate Node/Edge/Node,
+traversal depth capped at `MAX_DEPTH` = 10 hops) before the compiler emits SQL, and the
+compiler additionally asserts the emitted statement is `SELECT`/`WITH`-only as a
+defense-in-depth guard. Both the SPARQL and GQL entry points reject write-shaped input
+(`CREATE`, `DELETE`, `INSERT`, `SPARQL Update` forms, …) before AST construction —
+`parse_auto` also runs this guard first, so forms like `WITH <g> DELETE …` that don't
+start with a dialect keyword are still caught. `khive-query` never emits mutating SQL;
+graph writes go through `create` / `update` / `link` / `merge` / `delete` at the
+runtime layer instead.
+
+`CompileOptions.scopes` restricts the query to specific namespaces (empty means
+cross-namespace); `max_limit` is a server-side cap — the effective `LIMIT` is
+`min(requested, max_limit)`.
+
+Errors are typed as `QueryError`: `Parse { position, message }`, `Compile(String)`,
+`Validation(String)`, `Unsupported(String)`, `InvalidInput(String)`.
+
+## Where this sits
+
+`khive-query` depends only on `khive-types` and sits between the storage layer and the
+runtime:
+
+```text
+types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp
+```
+
+`khive-runtime` calls `parse_auto`/`parse` and `compile` to serve the `query` verb
+(GQL/SPARQL pattern matching), then executes the resulting `CompiledQuery` through
+`khive-db`'s `SqlAccess`. Parser/validator/compiler separation is governed by
+[ADR-008](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-008-query-layer-separation.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-request/README.md
+++ b/crates/khive-request/README.md
@@ -1,0 +1,84 @@
+# khive-request
+
+Transport-agnostic parser for khive's verb-dispatch request DSL. Parses function-call
+syntax, JSON, and (in the future) LNDL / pipe / bash-style syntaxes into a single
+`ParsedRequest` AST that any transport (MCP, HTTP, CLI) can execute.
+
+## Usage
+
+```rust
+use khive_request::{parse_request, ExecutionMode};
+
+// Single op
+let req = parse_request(r#"search(kind="entity", query="LoRA")"#)?;
+assert_eq!(req.mode, ExecutionMode::Single);
+
+// Parallel batch
+let req = parse_request(r#"[recall(query="x"), remember(content="y")]"#)?;
+assert_eq!(req.mode, ExecutionMode::Parallel);
+
+// Chain — `$prev` resolves against the immediately preceding op's result
+let req = parse_request(r#"create(kind="concept", name="X") | link(source_id=$prev.id, target_id="...", relation="extends")"#)?;
+assert_eq!(req.mode, ExecutionMode::Chain);
+
+for op in &req.ops {
+    // op.tool: String, op.args: BTreeMap<String, ArgValue>
+    println!("{} -> {:?}", op.tool, op.args);
+}
+```
+
+JSON form (`[{"tool": "...", "args": {...}}, ...]`) is also accepted and always parses
+to `ExecutionMode::Parallel` — it has no chain syntax, so a literal `$prev` in JSON
+form is a parse error (`DslError::PrevRefInJsonForm`).
+
+## Result types
+
+- `ParsedRequest { ops: Vec<ParsedOp>, mode: ExecutionMode }`
+- `ParsedOp { tool: String, args: BTreeMap<String, ArgValue> }`
+- `ArgValue` — `Value(serde_json::Value)` for concrete JSON, `PrevRef { path }` for a
+  `$prev`/`$prev.field.path` back-reference, or `Array`/`Object` containers that hold
+  further `ArgValue`s (a pure-JSON array or object with no embedded `$prev` folds
+  straight to `Value`). `ArgValue::resolve_prev` / `resolve_all` resolve references
+  against a preceding op's result.
+- `DslError` — a typed enum (`TooManyOps`, `UnexpectedChar`, `InvalidIdentifier`,
+  `PrevRefOutsideChain`, `WriteKeyConflict`, `ReservedEnvelopeArg`, …), surfaced as
+  `invalid_params` at the MCP boundary.
+
+## Semantics
+
+- **`MAX_OPS`** (100) caps operations per request; exceeding it is `DslError::TooManyOps`.
+- **`$prev` is chain-only.** A `$prev` reference outside `|` chain mode, or anywhere in
+  JSON form, is rejected at parse time rather than deferred to a runtime lookup miss.
+- **Write-key conflict detection** (`write_keys_for_op_pub`) is a preflight check over a
+  parallel batch: two ops that target the same UUID via `update`/`delete` (`id`),
+  `merge` (`into_id`/`from_id`), or `link` (`source_id`/`target_id`) reject the whole
+  batch before any op dispatches, rather than racing.
+- **`RESERVED_ENVELOPE_ARGS`** (`presentation`, `presentation_per_op`) are
+  envelope-level fields; passing them inside a verb's own argument list is rejected
+  (`DslError::ReservedEnvelopeArg`).
+- Mixing `,` and `|` at the top level is rejected (`DslError::MixedSeparators`), as is
+  a dotted verb name with more than one level, e.g. `a.b.c` (`UnsupportedVerbNesting`) —
+  only single-level `pack.verb` names are supported.
+
+## Where this sits
+
+`khive-request` depends only on `serde`/`serde_json` and has no dependency on
+`khive-runtime` or any pack — it is pure syntax, consumed only at the transport
+dispatch boundary:
+
+```text
+types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp
+                                                                   ^
+                                                          khive-request parses
+                                                          the `request` tool's
+                                                          input string here
+```
+
+`khive-mcp`'s `request` tool calls `parse_request`, then routes each `ParsedOp`
+through the runtime's `VerbRegistry::dispatch`. The DSL shape and grammar are
+specified in
+[ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-request/README.md
+++ b/crates/khive-request/README.md
@@ -14,7 +14,7 @@ let req = parse_request(r#"search(kind="entity", query="LoRA")"#)?;
 assert_eq!(req.mode, ExecutionMode::Single);
 
 // Parallel batch
-let req = parse_request(r#"[recall(query="x"), remember(content="y")]"#)?;
+let req = parse_request(r#"[memory.recall(query="x"), memory.remember(content="y")]"#)?;
 assert_eq!(req.mode, ExecutionMode::Parallel);
 
 // Chain — `$prev` resolves against the immediately preceding op's result

--- a/crates/khive-retrieval/README.md
+++ b/crates/khive-retrieval/README.md
@@ -1,0 +1,81 @@
+# khive-retrieval
+
+Hybrid retrieval composer combining HNSW vector search, BM25 keyword search,
+rank fusion, and optional graph/cross-encoder reranking, with deterministic
+scoring throughout.
+
+## Features
+
+- **`HybridSearcher` trait** — combines `VectorSearch` + `KeywordSearch` (same
+  `Id` type) behind one `hybrid_search(query, config)` call
+- **`fuse_search_results`/`fuse_search_results_checked`** — fuse pre-computed
+  vector and keyword result lists per a `HybridConfig`'s `FusionStrategy`, with
+  min-score filtering and top-k truncation applied after fusion
+- **Re-exports the retrieval stack** — `khive-hnsw`, `khive-bm25`,
+  `khive-fusion`, and `lattice-embed` types are re-exported so a caller depends
+  on this one crate for the full hybrid path
+- **`DualIndexRouter`** — routes queries between a primary and legacy vector
+  index during a migration, with a configurable auto-switch threshold
+- **Timeout/cancellation wrappers** — `search_with_timeout`,
+  `search_with_deadline`, `search_with_cancellation` around any search future
+- **Feature-gated extensions** — see Configuration below
+
+## Usage
+
+```rust
+use khive_retrieval::{fuse_search_results, HybridConfig, Query};
+
+let query = Query::hybrid("rust async runtime", vec![0.1_f32; 384]);
+let config = HybridConfig::new(10);
+
+// vector_hits / keyword_hits come from your VectorSearch / KeywordSearch impls
+// (or khive-hnsw::HnswIndex::search / khive-bm25::Bm25Index::search directly).
+let fused = fuse_search_results(vec![vector_hits, keyword_hits], &config);
+for (id, score) in &fused {
+    println!("{id}: {}", score.to_f64());
+}
+```
+
+`HybridConfig::new(top_k)` defaults to RRF fusion (k=60); chain
+`.with_fusion_strategy(..)`, `.with_pool_size(..)`, `.with_min_score(..)`, or
+`.with_weights(vector, keyword)` to customize. `fuse_search_results` falls back
+to RRF if a `Weighted` strategy's weight count doesn't match the source count;
+`fuse_search_results_checked` returns `Err` in that case instead.
+
+## Configuration (Cargo features)
+
+| Feature            | Adds                                                                                                |
+| ------------------ | --------------------------------------------------------------------------------------------------- |
+| `policy`           | `khive-gate`-backed `ClearanceLevel`/`SearchPolicy` result filtering                                |
+| `checkpoint`       | `HnswCheckpoint`/`HnswCheckpointStore` re-exports (khive-hnsw snapshots via `khive-fold`)           |
+| `persist`          | SQLite-based persistence for HNSW and BM25 indexes (`rusqlite`)                                     |
+| `storage-adapters` | `StorageVectorSearch`/`StorageKeywordSearch` bridging sqlite-vec/FTS5 backends to the search traits |
+| `embed`            | Native `lattice-embed` embedding service re-exports                                                 |
+| `native-rerank`    | Cross-encoder reranking — deferred pending `khive-inference` port                                   |
+
+None of these are enabled by default; the base crate stays lightweight and pulls
+in `rusqlite`/`khive-storage`/native embedding only on request.
+
+`SearchConfig` (vector-only/keyword-only/hybrid-balanced presets) and
+`SearchPolicy`/`ClearanceLevel` (with `filter_by_policy`/`filter_by_predicate`)
+are also re-exported for callers that need per-result access control on top of
+fusion.
+
+## Where this sits
+
+`khive-retrieval` sits above `khive-hnsw`, `khive-bm25`, `khive-fusion`,
+`khive-score`, and `khive-types` in the storage stack, and below the runtime's
+ADR-012 composition layer and the `kg`/`memory` packs that call into it for
+hybrid FTS5+vector search.
+
+Governing ADRs:
+[ADR-030](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-030-retrieval-stack-port.md)
+(this crate's charter — engine/adapter ownership split from ADR-012),
+[ADR-012](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-012-retrieval-composition.md)
+(the still-live high-level composition contract), and
+[ADR-031](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-031-multi-engine-retrieval.md)
+(multi-engine embedder registry and pack fan-out this crate composes with).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-retrieval/README.md
+++ b/crates/khive-retrieval/README.md
@@ -53,8 +53,12 @@ to RRF if a `Weighted` strategy's weight count doesn't match the source count;
 | `embed`            | Native `lattice-embed` embedding service re-exports                                                 |
 | `native-rerank`    | Cross-encoder reranking — deferred pending `khive-inference` port                                   |
 
-None of these are enabled by default; the base crate stays lightweight and pulls
-in `rusqlite`/`khive-storage`/native embedding only on request.
+None of these features are enabled by default. The base crate is not
+dependency-free, though: it already depends on `khive-db` (which pulls in
+`khive-storage` and `rusqlite`) and on `lattice-embed` for native embedding. The
+features above gate additional surface — policy filtering, HNSW/BM25 checkpoint
+and persistence, storage-backed search adapters, and cross-encoder reranking —
+not the core storage or embedding stack.
 
 `SearchConfig` (vector-only/keyword-only/hybrid-balanced presets) and
 `SearchPolicy`/`ClearanceLevel` (with `filter_by_policy`/`filter_by_predicate`)

--- a/crates/khive-runtime/README.md
+++ b/crates/khive-runtime/README.md
@@ -1,0 +1,118 @@
+# khive-runtime
+
+Composable Service API used by khive's daemon, MCP server, and CLI: entity/note CRUD,
+graph traversal, hybrid search, and curation, plus the pack registration and
+verb-dispatch machinery that lets packs (`kg`, `gtd`, `memory`, …) extend the surface.
+
+## Features
+
+- **`KhiveRuntime`** — a cloneable handle wrapping a `khive-db::StorageBackend` with
+  namespace-scoped accessors for every storage capability, plus a lazily-configured
+  embedder registry
+- **`VerbRegistry` / `VerbRegistryBuilder`** — registers packs (`PackRuntime` impls),
+  an authorization `Gate`, an actor identity, and dispatches verbs by name
+- **`PackRuntime` trait** — the object-safe runtime counterpart to `khive-types::Pack`;
+  every pack declares handlers, owned entity/note kinds, edge-endpoint extensions, and
+  an optional auxiliary `SchemaPlan`
+- **Curation** (`EntityPatch`, `NotePatch`, `EdgePatch`, `MergeSummary`,
+  `EntityDedupMergePolicy`) — update/merge semantics per
+  [ADR-014](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-014-curation-operations.md)
+- **Retrieval objectives** (`RrfFusionObjective`, `VectorSimilarityObjective`,
+  `TextRelevanceObjective`, `TemporalRecencyObjective`, `DecayAwareSalienceObjective`, …)
+  composed into a `MemoryRecallPipeline`
+- **Graph traversal** (`PathNode`) and **validation** (`ValidationRule`,
+  `ValidationReport`, `Violation`) for domain-specific graph-shape rules
+- **Daemon** (unix only) — `run_daemon`, socket/pid path helpers, and the
+  request/response frame types for the persistent `kkernel mcp --daemon` process
+
+## Usage
+
+```rust
+use khive_runtime::{KhiveRuntime, RuntimeConfig};
+use khive_types::namespace::Namespace;
+
+// In-memory runtime (tests); production callers set RuntimeConfig::db_path or
+// use KhiveRuntime::from_backend with a pre-built StorageBackend.
+let runtime = KhiveRuntime::new(RuntimeConfig::default())?;
+
+// Every read/write is scoped by a NamespaceToken minted through the configured Gate.
+let token = runtime.authorize(Namespace::local())?;
+let entities = runtime.entities(&token)?; // Arc<dyn khive_storage::EntityStore>
+let graph = runtime.graph(&token)?; // Arc<dyn khive_storage::GraphStore>
+```
+
+Packs are composed through the builder, not `KhiveRuntime` directly:
+
+```rust
+use khive_runtime::{VerbRegistryBuilder, GateRef, AllowAllGate};
+use std::sync::Arc;
+
+let mut builder = VerbRegistryBuilder::new();
+builder
+    .with_gate(Arc::new(AllowAllGate) as GateRef)
+    .with_default_namespace("local");
+    // .register(KgPack::new(...))  // any Pack + PackRuntime impl
+let registry = builder.build()?;
+
+let result = registry
+    .dispatch("search", serde_json::json!({"kind": "entity", "query": "LoRA"}))
+    .await?;
+```
+
+## Architecture
+
+```text
+              KhiveRuntime::new(RuntimeConfig)
+                        │
+              StorageBackend (khive-db)
+                        │
+     ┌──────────────────┼──────────────────────┐
+authorize(ns)     entities/graph/notes/…   embedder(name)
+     │             (khive-storage traits)  (lattice-embed)
+     ▼
+NamespaceToken ──── VerbRegistryBuilder::register(pack) × N
+                         │
+                    VerbRegistryBuilder::build()
+                         │
+                    VerbRegistry::dispatch(verb, params)
+                         │           │
+                    Gate::check  first pack whose handlers() match verb
+                    (authoritative
+                     Deny; errors
+                     fail open)
+```
+
+`dispatch` short-circuits to `describe_verb` when `params["help"] == true`, otherwise
+resolves the request namespace (explicit `namespace` arg, else the registry default),
+checks the `Gate`, and routes to the first registered pack whose `HandlerDef`s cover
+the verb. `KhiveRuntime::authorize` mints a `NamespaceToken` whose read-visibility set
+defaults to `[ns]`; `authorize_with_visibility` widens it for callers that read across
+namespaces (e.g. an agent reading both its own and a shared namespace) while writes
+stay pinned to the primary.
+
+## Where this sits
+
+`khive-runtime` sits directly above `khive-db`/`khive-query`/`khive-gate`/`khive-fusion`
+and below every pack crate:
+
+```text
+types -> score -> storage -> db -> query -> runtime -> pack-kg / pack-gtd / … -> mcp
+```
+
+It re-exports the `khive-db` and `khive-gate` types packs need
+(`StorageBackend`, `ConnectionPool`, `Gate`, `GateDecision`, `ActorRef`, …) so most
+pack crates depend on `khive-runtime` alone rather than reaching past it. Governing
+ADRs: pack contract and object-safe dispatch
+([ADR-017](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md)),
+verb surface, visibility and composition
+([ADR-023](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-023-declarative-pack-format.md)),
+dynamic pack loading via self-registration
+([ADR-027](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-027-dynamic-pack-loading.md)),
+pack-scoped backends and per-pack schema
+([ADR-028](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-028-pack-scoped-backends.md)),
+and the authorization gate
+([ADR-018](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-018-authorization-gate.md)).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-score/README.md
+++ b/crates/khive-score/README.md
@@ -1,0 +1,64 @@
+# khive-score
+
+Deterministic fixed-point scoring: `f64` relevance scores are converted to a
+`2^32`-scaled `i64` (`DeterministicScore`) so ranking, aggregation, and RRF
+fusion give bit-identical results across platforms. Also provides sum/avg/min/max
+aggregation, weighted sum, distance-to-score conversion, and ID-tiebreak comparators.
+
+## Usage
+
+```rust
+use khive_score::{cmp_desc_then_id, rrf_score_one_based, DeterministicScore};
+use std::num::NonZeroUsize;
+
+let a = DeterministicScore::from_f64(0.42);
+let b = DeterministicScore::from_f64(0.87);
+assert!(a < b);
+
+// Reciprocal Rank Fusion: 1-based rank, k=60 smoothing constant.
+let fused = rrf_score_one_based(NonZeroUsize::new(1).unwrap(), 60);
+assert!((fused.to_f64() - 1.0 / 61.0).abs() < 1e-9);
+
+// Sort candidates by score descending, lower ID wins ties.
+let mut hits = vec![(b, 2u64), (a, 1u64)];
+hits.sort_by(|(sa, ia), (sb, ib)| cmp_desc_then_id(*sa, ia, *sb, ib));
+```
+
+## Semantics
+
+- `DeterministicScore` saturates at `MAX` (`i64::MAX`) and `NEG_INF`
+  (`i64::MIN + 1`) rather than overflowing. `MIN` (`i64::MIN`) is a reserved
+  sentinel never produced by arithmetic, `from_f64`, or `to_f64` — only
+  `from_raw` can construct it, and the `serde` `Deserialize` impl rejects it.
+- `NaN` inputs map to `ZERO`; `±Infinity` map to `MAX`/`NEG_INF`.
+- `sum_scores`, `avg_scores`, and `weighted_sum` clamp their result to
+  `[NEG_INF, MAX]` and are order-independent regardless of input ordering.
+- `try_score_from_distance` converts a raw distance plus a
+  `khive_types::DistanceMetric` (`Cosine`, `Dot`, `L2`) into a score, erroring
+  on non-finite or out-of-range input; `score_from_distance_lossy` is the
+  infallible variant (`NEG_INF` on error). The un-prefixed `score_from_distance`
+  is deprecated since 0.2.3 — it silently maps `NaN` to a perfect score.
+- `Ranked<T: Ord>` is a `BinaryHeap`-ready max-heap adapter (higher score pops
+  first, lower ID breaks ties). Its `Ord` impl is not a plain ascending sort
+  order — use `cmp_desc_then_id` / `cmp_asc_then_id` when calling `sort()`
+  directly on a `Vec`.
+
+## Where this sits
+
+Built on `khive-types` (for `DistanceMetric`). Consumed by every crate that
+needs cross-platform-identical ranking:
+[khive-bm25](https://crates.io/crates/khive-bm25),
+[khive-hnsw](https://crates.io/crates/khive-hnsw),
+[khive-fusion](https://crates.io/crates/khive-fusion),
+[khive-fold](https://crates.io/crates/khive-fold),
+[khive-storage](https://crates.io/crates/khive-storage),
+[khive-retrieval](https://crates.io/crates/khive-retrieval),
+[khive-db](https://crates.io/crates/khive-db), and
+[khive-runtime](https://crates.io/crates/khive-runtime).
+Deterministic scoring is required so that two nodes evaluating the same query
+produce the same ranked order — see
+[ADR-006](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-006-deterministic-scoring.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-storage/README.md
+++ b/crates/khive-storage/README.md
@@ -1,0 +1,71 @@
+# khive-storage
+
+Storage capability traits for khive's substrate: `SqlAccess`, `VectorStore`,
+`TextSearch`, `GraphStore`, `NoteStore`, `EntityStore`, `EventStore`,
+`SparseStore`. Zero implementations — only contracts
+([ADR-005](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-005-storage-capability-traits.md)).
+A concrete backend (`khive-db`'s SQLite implementation, for example) implements
+these traits; the runtime and every pack depend only on this crate, never on a
+specific backend.
+
+## Capability traits
+
+| Trait                                                      | Surface                                                                          |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `SqlAccess` / `SqlReader` / `SqlWriter` / `SqlTransaction` | pooled connections, transactions, query planning                                 |
+| `VectorStore`                                              | dense embedding insert/search/rebuild, optional filter pushdown and batch search |
+| `TextSearch`                                               | FTS document upsert/search/stats, optional term-stats (IDF)                      |
+| `GraphStore`                                               | edge CRUD, neighbor queries, multi-hop traversal, batched neighbor/edge fetch    |
+| `NoteStore` / `EntityStore` / `EventStore`                 | substrate-specific CRUD and filtered listing                                     |
+| `SparseStore`                                              | sparse (BM25-style) vector storage                                               |
+
+Every method returns `StorageResult<T> = Result<T, StorageError>`.
+`StorageError` variants (`NotFound`, `AlreadyExists`, `Conflict`,
+`InvalidInput`, `Unsupported`, `Pool`, `Timeout`, `Transaction`, …) are tagged
+with the offending `StorageCapability`
+(`Sql | Notes | Entities | Graph | Events | Vectors | Sparse | Text`).
+
+## Usage
+
+Implement the trait(s) your backend supports; callers depend only on the trait object.
+
+```rust
+use async_trait::async_trait;
+use khive_storage::{GraphStore, StorageResult, TraversalRequest, GraphPath};
+use uuid::Uuid;
+
+struct MyBackend;
+
+#[async_trait]
+impl GraphStore for MyBackend {
+    // ... upsert_edge, upsert_edges, get_edge, get_edge_including_deleted,
+    //     delete_edge, query_edges, count_edges, neighbors, purge_incident_edges
+
+    async fn traverse(&self, request: TraversalRequest) -> StorageResult<Vec<GraphPath>> {
+        // multi-hop BFS from request.roots
+        Ok(Vec::new())
+    }
+}
+```
+
+## Capability negotiation
+
+Optional-feature methods (`VectorStore::search_with_filter`,
+`TextSearch::term_stats`, `GraphStore::get_edges` / `batch_neighbors`) ship as
+default trait methods with a conservative fallback, so a minimal backend
+compiles without overriding anything: `get_edges` loops `get_edge` per ID and
+`batch_neighbors` loops `neighbors` per source. Backends that support batched
+`IN (...)` queries or filter pushdown override the corresponding method and
+the trait's `capabilities()` accessor to advertise it.
+
+## Where this sits
+
+Sits directly above `khive-types` and `khive-score` in the storage dependency
+chain (`types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp`).
+`khive-db` is the sole first-party implementation (SQLite + FTS5 +
+sqlite-vec); every pack and the runtime depend on the trait surface defined
+here, never on `khive-db` directly.
+
+## License
+
+Apache-2.0.

--- a/crates/khive-text/README.md
+++ b/crates/khive-text/README.md
@@ -1,0 +1,56 @@
+# khive-text
+
+Text analysis primitives for khive: tokenization, normalization, and token
+filtering. A pluggable `Tokenizer` -> `TokenFilter` chain composed into an
+`Analyzer`, plus named presets for common cases (standard English, CJK,
+identifiers, KG entity names).
+
+## Features
+
+- `unicode` — adds `UnicodeWordTokenizer` (Unicode word-boundary splitting via `unicode-segmentation`)
+- `stem` — adds `SnowballStemmer`, a `TokenFilter` backed by `rust-stemmers` (English by default via `SnowballStemmer::english()`, or any `rust_stemmers::Algorithm` via `for_algorithm`)
+- `full` — both of the above
+
+## Usage
+
+```rust
+use khive_text::{preset, Analyzer};
+
+let tokens = preset::standard().analyze("The quick brown fox jumps over the lazy dog");
+assert_eq!(tokens, vec!["quick", "brown", "fox", "jumps", "lazy", "dog"]);
+```
+
+`preset::standard()` chains `WhitespaceTokenizer` with `LowercaseFilter`,
+`StopWordFilter`, `MinLengthFilter(2)`, and `MaxLengthFilter(40)`. Other named
+presets: `preset::simple()` (whitespace + lowercase only, keeps stop words),
+`preset::keyword()` (whole input as one token), `preset::cjk()`
+(character-level unigrams for CJK scripts, whitespace for Latin), and
+`preset::kg_name()` (identifier-aware splitting tuned for entity names like
+`"bert-base-uncased"`). Build a custom pipeline with the same builder:
+
+```rust
+use khive_text::analyzer::StandardAnalyzer;
+use khive_text::filter::LowercaseFilter;
+use khive_text::tokenizer::IdentifierTokenizer;
+
+let analyzer = StandardAnalyzer::with_tokenizer(IdentifierTokenizer::default())
+    .filter(LowercaseFilter);
+```
+
+## Script detection
+
+`is_cjk_char`, `contains_cjk`, and `is_meaningful_query` (a `ScriptProfile`-based
+heuristic for rejecting queries that are too short or punctuation-only to search
+on) live in the `lang` module for callers that need to branch on script before
+choosing an analyzer.
+
+## Where this sits
+
+`khive-text` has no required khive-* dependencies and no current in-workspace
+consumers — it is a standalone tokenization library extracted for reuse by any
+future retrieval crate that needs a pluggable analyzer independent of
+`khive-bm25`'s built-in `SimpleTokenizer`.
+
+## License
+
+Apache-2.0.

--- a/crates/khive-types/README.md
+++ b/crates/khive-types/README.md
@@ -1,0 +1,80 @@
+# khive-types
+
+Core type primitives — `Id128`, `Timestamp`, `Namespace`, `Header` — and the
+substrate data types (`Note`, `Entity`, `Link`, `Event`) that the rest of khive
+operates on. `#![no_std]` (requires `alloc`), `#![forbid(unsafe_code)]`, and
+depends on nothing beyond `alloc` by default.
+
+## Features
+
+- `std` (default) — enables `std::error::Error` impls for the crate's error types
+- `serde` — `Serialize`/`Deserialize` for every type in the crate
+- `blake3` — content hashing support used by downstream crates (e.g. `khive-fold` checkpoints)
+
+## Usage
+
+```rust
+use khive_types::{Header, Id128, Namespace, Note, NoteStatus, Timestamp};
+
+let header = Header::new(
+    Id128::from_u128(1),
+    Namespace::local(),
+    Timestamp::from_secs(1_700_000_000),
+);
+
+let note = Note {
+    header,
+    kind: "observation".into(),
+    status: NoteStatus::Active,
+    content: "khive ships as a single binary".into(),
+    properties: Default::default(),
+    tags: vec!["release".into()],
+    salience: Some(0.8),
+    decay_factor: Some(0.01),
+    expires_at: None,
+    deleted_at: None,
+};
+assert!(note.is_valid());
+```
+
+`Id128` formats as a hyphenated UUID string and round-trips through `FromStr`.
+`Namespace::parse` rejects empty, over-length, or malformed (`::`, trailing
+separator) input; `Namespace::local()` returns the `"local"` namespace used by
+default across the runtime.
+
+## Substrate types
+
+- **`Note`** — temporal-referential record (`kind`, `content`, `salience`,
+  `decay_factor`, `tags`, `expires_at`); `NoteStatus` is `Active | Archived | Deleted`.
+- **`Entity`** — graph node (`kind: EntityKind`, `entity_type: Option<String>`,
+  `name`, `description`, `properties`, `tags`); `EntityKind` is the closed
+  8-kind taxonomy (`Concept`, `Document`, `Dataset`, `Project`, `Person`, `Org`,
+  `Artifact`, `Service`).
+- **`Link`** — a directed, typed edge between two nodes (`source`, `target`,
+  `relation: EdgeRelation`, `weight: f64` in `[0.0, 1.0]`).
+  `EdgeRelation` is the closed 17-relation ontology, grouped into 9
+  `EdgeCategory` values (Structure, Derivation, Provenance, Temporal,
+  Dependency, Implementation, Lateral, Annotation, Epistemic).
+- **`Event`** — append-only log entry (`verb`, `substrate: SubstrateKind`,
+  `kind: EventKind`, `payload: EventPayload`) produced by every verb execution;
+  `EventOutcome` is `Success | Denied | Error`.
+- **`KhiveError`** — shared error envelope (`ErrorDomain`, `ErrorKind`,
+  `ErrorCode`, `RetryHint`, `Details`) used across packs for structured errors.
+- **`Pack`** trait plus `HandlerDef`, `EdgeEndpointRule`, `NoteKindSpec` — the
+  pack registration contract that lets a pack declare verbs, note kinds, and
+  additional edge endpoint rules.
+
+## Where this sits
+
+`khive-types` is the base of khive's dependency chain — every other crate
+(`khive-score`, `khive-storage`, `khive-db`, every pack) depends on it, directly
+or transitively. It owns the entity kind taxonomy
+([ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md)),
+the edge ontology
+([ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md)),
+and the note kind taxonomy
+([ADR-013](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-013-note-kind-taxonomy.md)).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-vamana/README.md
+++ b/crates/khive-vamana/README.md
@@ -1,0 +1,89 @@
+# khive-vamana
+
+Batch-built Vamana (DiskANN-style) ANN index over pre-normalized vectors, with
+crash-safe atomic persistence and incremental maintenance operations.
+
+## Features
+
+- **Batch build** — `VamanaIndex::build` constructs the proximity graph from a
+  flat row-major `&[f32]` slice in one pass
+- **Two-tier distance** — graph construction and traversal use an SQ8 codec for
+  the acquisition tier; `search()` returns exact `f32` squared-L2 distances for
+  the final ranking, with an out-of-distribution fallback to exact greedy search
+- **Incremental maintenance** — `insert`, `tombstone`/`tombstone_batch`, and
+  `consolidate` for corpora that grow after the initial batch build
+- **Crash-safe persistence** — `save_atomic`/`load_or_build` stage segments,
+  checksum them with blake3, and commit via an atomic rename so a crash mid-write
+  never leaves a torn index; `corpus_content_hash` fingerprints the source vectors
+  so a stale on-disk index is detected and rebuilt automatically
+- **Offline recall evaluation** — `recall_at_k` measures the index's own
+  approximate-vs-exact recall against a query set
+
+## Usage
+
+```rust
+use khive_vamana::{VamanaConfig, VamanaIndex};
+
+// `vectors` is row-major, `vectors.len() == n * config.dimensions`, pre-normalized.
+let config = VamanaConfig::with_dimensions(384);
+let index = VamanaIndex::build(&vectors, config).unwrap();
+
+let neighbors = index.search(&query, 10).unwrap();
+for (node_id, distance) in &neighbors {
+    println!("{node_id}: {distance}");
+}
+```
+
+`khive_vamana::build(vectors, config)` and `khive_vamana::search(&index, query, k)`
+are free-function equivalents of `VamanaIndex::build`/`search` for callers that
+prefer not to import the type directly.
+
+## Configuration
+
+| Parameter          | Default | Description                                                     |
+| ------------------ | ------- | --------------------------------------------------------------- |
+| `dimensions`       | 384     | Vector width; must match the corpus.                            |
+| `max_degree`       | 64      | Max out-degree of any graph node.                               |
+| `search_list_size` | 128     | Greedy-search candidate list capacity; must be `>= max_degree`. |
+| `alpha`            | 1.2     | Robust-prune alpha; must be finite and `>= 1.0`.                |
+
+`VamanaConfig::validate()` rejects zero dimensions/degree/list size,
+`search_list_size < max_degree`, and a non-finite or sub-1.0 `alpha`. Builder
+methods (`with_max_degree`, `with_search_list_size`, `with_alpha`) return a copy
+without re-validating; call `validate()` before use if the values come from
+external input.
+
+## Persistence
+
+```rust
+use std::path::Path;
+use khive_vamana::VamanaIndex;
+
+index.save_atomic(Path::new("./vamana-data")).unwrap();
+
+// On restart: fast-path load if the on-disk fingerprint matches `corpus_vectors`,
+// otherwise falls back to a fresh `build()` from `fallback_config`.
+let restored = VamanaIndex::load_or_build(
+    Path::new("./vamana-data"),
+    &corpus_vectors,
+    VamanaConfig::with_dimensions(384),
+)
+.unwrap();
+```
+
+## Where this sits
+
+`khive-vamana` is the production ANN index used directly by the knowledge pack's
+vector bridge and by `khive-retrieval`'s hybrid searcher. It depends only on
+`khive-quant` plus `rayon`/`memmap2`/`bytemuck`/`blake3` for build parallelism and
+persistence — no dependency on `khive-hnsw`, `khive-fusion`, or `khive-score`.
+
+Governing ADRs:
+[ADR-054](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-054-ann-build-strategy-scaling-limits.md)
+(scaling contract for batch build and query latency) and
+[ADR-052](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-052-ann-production-lifecycle.md)
+(SQ8 quantization, tombstone delete, consolidation, crash-safe persistence).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-vamana/README.md
+++ b/crates/khive-vamana/README.md
@@ -73,10 +73,11 @@ let restored = VamanaIndex::load_or_build(
 
 ## Where this sits
 
-`khive-vamana` is the production ANN index used directly by the knowledge pack's
-vector bridge and by `khive-retrieval`'s hybrid searcher. It depends only on
-`khive-quant` plus `rayon`/`memmap2`/`bytemuck`/`blake3` for build parallelism and
-persistence — no dependency on `khive-hnsw`, `khive-fusion`, or `khive-score`.
+`khive-vamana` is the production ANN index used directly by the knowledge and
+memory packs' vector bridges (`khive-pack-knowledge`, `khive-pack-memory`). It
+depends only on `khive-quant` plus `rayon`/`memmap2`/`bytemuck`/`blake3` for build
+parallelism and persistence — no dependency on `khive-hnsw`, `khive-fusion`, or
+`khive-score`.
 
 Governing ADRs:
 [ADR-054](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-054-ann-build-strategy-scaling-limits.md)

--- a/crates/khive-vcs-adapters/README.md
+++ b/crates/khive-vcs-adapters/README.md
@@ -1,0 +1,70 @@
+# khive-vcs-adapters
+
+Format adapters for the KG import pipeline — parse a source format into the wire
+records `khive kg import` validates and loads.
+
+An adapter is a pure, stateless transform: it reads a source and yields `EntityRecord`
+/ `EdgeRecord` values. It writes no database state and generates no IDs beyond filling
+in a missing UUID. Fatal errors (missing required fields, unknown entity kind or edge
+relation, out-of-range weight) abort the corresponding iterator item; non-fatal issues
+accumulate as strings retrievable via `FormatAdapter::warnings`.
+
+## Usage
+
+```rust
+use khive_vcs_adapters::{FormatAdapter, JsonFormatAdapter};
+
+let input = r#"[
+    {"name": "LoRA", "kind": "concept", "tags": ["peft"]},
+    {"source": "LoRA", "target": "FullFineTuning", "relation": "competes_with"}
+]"#;
+
+let mut adapter = JsonFormatAdapter::new(input).expect("valid JSON array");
+for entity in adapter.entities() {
+    let entity = entity.expect("no missing/invalid fields in this example");
+    println!("{} ({})", entity.name, entity.kind);
+}
+for edge in adapter.edges() {
+    let edge = edge.expect("no missing/invalid fields in this example");
+    println!("{} --{}--> {}", edge.source, edge.relation, edge.target);
+}
+assert!(adapter.warnings().is_empty());
+```
+
+`JsonFormatAdapter::new` parses eagerly and dispatches each array element: an object
+carrying a `source`/`from` **and** `target`/`to` key (case-insensitive) becomes an
+`EdgeRecord`; every other object becomes an `EntityRecord`. Unknown keys fold into the
+record's `properties`.
+
+## Taxonomy validation
+
+- `EntityRecord.kind` is validated against `khive_types::EntityKind` at parse time —
+  an unrecognized kind returns `AdapterError::UnknownKind`, never a silent default.
+- `EdgeRecord.relation` is validated against `khive_types::EdgeRelation` — an
+  unrecognized relation returns `AdapterError::UnknownRelation`. This check applies
+  regardless of any schema-mode setting elsewhere in the pipeline.
+- `EdgeRecord.weight` must be finite and in `[0.0, 1.0]`; deserialization enforces this
+  at the JSON boundary as well as via the `JsonFormatAdapter`'s own `extract_weight`
+  path. Absent, it defaults to `0.7`.
+
+## Format support
+
+Only the JSON array format (`JsonFormatAdapter`) is implemented today. `PHASE0_FORMATS`
+(`"csv"`, `"tsv"`, `"json"`, `"ndjson"`) names the formats the v0.5 adapter registry is
+expected to accept; `AdapterError::NotYetImplemented` is the error path reserved for
+formats declared but not yet backed by an adapter. Additional formats (BibTeX,
+Turtle/N-Triples, JSON-LD, GraphML, GEXF, Markdown) are tracked as deferred work — see
+`docs/protocol.md` in this crate.
+
+## Where this sits
+
+`khive-vcs-adapters` depends only on `khive-types` (for kind/relation validation) —
+it has no dependency on `khive-storage` or `khive-runtime`. Its output feeds the
+standard `khive kg import` pipeline, which is what performs validation and loading
+into `working.db`; the adapter itself never touches a database.
+
+Governed by [ADR-036](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-036-kg-import-export-adapters.md).
+
+## License
+
+Apache-2.0.

--- a/crates/khive-vcs/README.md
+++ b/crates/khive-vcs/README.md
@@ -1,0 +1,82 @@
+# khive-vcs
+
+KG versioning — content-addressed snapshot hashing and NDJSON-to-SQLite sync.
+
+Git-native v1: KG state lives as sorted NDJSON files (`entities.ndjson`, `edges.ndjson`)
+in a git repository. This crate provides the canonical hash that identifies a snapshot's
+content, the sync routine that rebuilds a queryable SQLite database from those NDJSON
+files, and remote-archive fetch with hash-pin verification. Branching, history, and push/pull
+are git's job — there is no custom khive remote protocol.
+
+## Features
+
+- **Canonical SHA-256 snapshot hashing** — deterministic, order-independent content hash
+  over entities and edges (`SnapshotId`, prefixed `sha256:<hex64>`)
+- **NDJSON-to-SQLite sync** — atomic rebuild of a working database from NDJSON sources
+- **Remote archive fetch** — sparse `git clone` of a remote KG archive with SHA-256 pin
+  verification, fail-closed on mismatch
+- **Validated wire types** — `SnapshotId` and its `Deserialize` impl reject anything that
+  isn't exactly `sha256:` + 64 lower-case hex characters
+
+## Usage
+
+```rust
+use khive_runtime::portability::KgArchive;
+use khive_vcs::hash::snapshot_id_for_archive;
+
+fn print_snapshot_id(archive: &KgArchive) {
+    // Deterministic regardless of entity/edge insertion order or property key order.
+    let id = snapshot_id_for_archive(archive).expect("archive hashes cleanly");
+    println!("{id}"); // "sha256:<64 hex chars>"
+}
+```
+
+Rebuilding a working database from NDJSON sources (used by `kkernel sync`):
+
+```rust
+use std::path::Path;
+
+async fn rebuild(repo_root: &Path, db_path: &Path) -> anyhow::Result<()> {
+    let report = khive_vcs::sync::run_sync(repo_root, db_path, "local").await?;
+    println!("{} entities, {} edges -> {}", report.entities, report.edges, report.db_path);
+    Ok(())
+}
+```
+
+`run_sync` reads `.khive/kg/{entities,edges}.ndjson` under `repo_root`, validates every
+edge relation before touching disk, builds the new database in a `.tmp` sibling file, and
+renames it over `db_path` only on success — a crash or parse error leaves the previous
+database intact. `run_sync_remote(repo_root, &RemoteConfig, repin)` fetches a remote KG
+archive (sparse, depth-1 clone), verifies its content hash against `RemoteConfig::pin`
+when set, and populates `.khive/kg/remotes/<name>/` with a `meta.json` recording the
+resolved commit and hash.
+
+## Semantics
+
+- `SnapshotId::from_hash` / `from_prefixed` are the only ways to construct one outside
+  `snapshot_id_for_archive`; both reject anything but 64 lower-case hex characters.
+- `canonical_json` sorts entities by UUID, edges by `(source, target, relation)`, tags
+  lexicographically, and object keys recursively — two archives differing only in
+  insertion order hash identically; two differing in `entity_type` or edge weight do not.
+- `VcsState` tracks `namespace`, `current_branch`, and `last_committed_id` — there is no
+  `dirty` flag; uncommitted changes are computed fresh via a DB-vs-NDJSON diff, not cached.
+- `KG_V1_COVERAGE` records that v1 snapshots cover entities and edges only; notes are
+  excluded pending a note pack that defines versioned export/import/redaction/merge.
+
+## Where this sits
+
+`khive-vcs` depends on `khive-runtime`, `khive-storage`, and `khive-types`, and is a
+regular workspace member and published crate — not forward-deployed. `kkernel` consumes
+it directly for the `sync`, `kg status`, and `kg fetch` subcommands.
+
+[`khive-merge`](https://crates.io/crates/khive-merge) is the forward-deployed v2 semantic
+merge layer that will consume `khive-vcs`'s snapshot ancestry once ADR-039's LCA-walk
+integration lands; today's merge path is git's own line-merge over sorted NDJSON.
+
+Governed by [ADR-010](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-010-kg-versioning.md)
+(versioning strategy) and [ADR-020](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-020-git-native-kg-implementation.md)
+(git-native implementation).
+
+## License
+
+Apache-2.0.

--- a/crates/kkernel/README.md
+++ b/crates/kkernel/README.md
@@ -1,0 +1,115 @@
+# kkernel
+
+The khive kernel — a single Rust binary that serves the MCP `request` surface and
+provides the admin CLI for database, pack, and versioning operations.
+
+`kkernel` is the only binary khive ships. `kkernel mcp` serves the
+[`khive-mcp`](https://crates.io/crates/khive-mcp) `request` tool over stdio (or a
+persistent Unix-socket daemon); the rest of the subcommand tree covers everything an
+operator needs outside of agent dispatch — schema migrations, KG sync/validate/fetch,
+pack introspection, embedding-model lifecycle, and reindexing.
+
+## Install
+
+```bash
+cargo install kkernel
+```
+
+or build from source:
+
+```bash
+git clone https://github.com/ohdearquant/khive.git && cd khive
+cd crates && cargo build --release -p kkernel
+```
+
+The npm package `khive` installs a thin `khive` / `khive-mcp` shim that forwards to
+`kkernel mcp` for users who prefer `npm install -g khive` over Rust tooling; the two
+install paths produce the same binary underneath.
+
+## Usage
+
+Point an MCP client at the binary's `mcp` subcommand:
+
+```json
+{ "mcpServers": { "khive": { "command": "kkernel", "args": ["mcp"] } } }
+```
+
+```bash
+kkernel mcp                            # stdio, default ~/.khive/khive.db
+kkernel mcp --daemon                   # persistent warm daemon over a Unix socket
+kkernel mcp --db :memory:              # ephemeral in-memory database
+kkernel mcp --pack kg --pack gtd       # explicit pack list (default: full production set)
+kkernel mcp --actor my-project         # default namespace for unscoped ops
+```
+
+Run a verb DSL expression directly — the same syntax the `request` tool accepts —
+without going through an MCP client:
+
+```bash
+kkernel exec 'knowledge.stats()'
+kkernel exec 'knowledge.index(rebuild_ann=true)'
+kkernel exec '[knowledge.list(limit=5), knowledge.stats()]'
+kkernel exec --pending-events          # cron-friendly: fire due scheduled_event notes
+```
+
+## Subcommands
+
+| Subcommand | Purpose                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| `mcp`      | Serve the MCP `request` surface — stdio, `--daemon`, or a registered transport              |
+| `exec`     | Run a verb DSL expression (or `--ops-file batch.jsonl`) through the pack registry           |
+| `sync`     | Build a working SQLite database from `.khive/kg/*.ndjson` sources                           |
+| `kg`       | `validate` / `init` / `fetch` / `export` / `import` / `status` / `hook` — KG versioning ops |
+| `db`       | `migrate` / `check` — apply or report pending schema migrations                             |
+| `pack`     | `list` / `handler <name>` — introspect registered packs and their verb surface              |
+| `engine`   | Embedding-model lifecycle: list, status, migrate, drift-check                               |
+| `vector`   | Vector store capabilities and orphan sweep                                                  |
+| `reindex`  | Rebuild embedding vectors and FTS documents for entities, notes, and knowledge atoms        |
+| `backend`  | `list` / `info <name>` — inspect registered storage backends                                |
+
+All subcommands emit JSON on stdout by default (for piping/parsing); pass `--human`
+where supported for a readable table. `kkernel kg`, `kkernel sync`, and the NDJSON-to-SQLite
+rebuild logic they wrap live in [`khive-vcs`](https://crates.io/crates/khive-vcs) and
+[`khive-vcs-adapters`](https://crates.io/crates/khive-vcs-adapters); `kkernel`'s own
+`kg/` module is a thin CLI wrapper over those libraries.
+
+## Configuration
+
+Resolution precedence for the default namespace: `--actor` > `--namespace` (legacy alias) >
+`[actor] id` in a `khive.toml` config file > `"local"`. Config file search order when
+`--config` is not given: `./khive.toml`, `./.khive/config.toml`, `~/.khive/config.toml`.
+`~/.khive/.env` is loaded into the process environment at startup if present (real env vars
+take precedence).
+
+| Environment variable              | Effect                                                        |
+| --------------------------------- | ------------------------------------------------------------- |
+| `KHIVE_DB`                        | Database path (also `kkernel mcp --db`)                       |
+| `KHIVE_ACTOR` / `KHIVE_NAMESPACE` | Default namespace (also `--actor` / `--namespace`)            |
+| `KHIVE_NO_EMBED`                  | Disable local embedding model                                 |
+| `KHIVE_PACKS`                     | Comma/whitespace-separated pack list (also repeated `--pack`) |
+| `KHIVE_CONFIG`                    | Path to the TOML config file (also `--config`)                |
+| `KHIVE_LOG`                       | Log level for stderr (JSON results on stdout are unaffected)  |
+| `KHIVE_BRAIN_PROFILE`             | Brain profile for feedback routing and recall boosting        |
+
+Two feature flags gate optional functionality, both pass-through to `khive-mcp`:
+`bench-embedder` (deterministic hash embedder for benchmarking, never enabled in release
+builds) and `channel-email` (SMTP/IMAP polling loop, inert without `KHIVE_EMAIL_*` env vars).
+
+## Where this sits
+
+`kkernel` sits at the top of the storage dependency chain — it depends on every pack crate
+(`khive-pack-kg`, `-gtd`, `-memory`, `-brain`, `-comm`, `-schedule`, `-formal`, `-knowledge`,
+`-session`), `khive-mcp` (the server library it serves), `khive-vcs` / `khive-vcs-adapters`
+(KG versioning and import/export), and the core storage stack (`khive-runtime`,
+`khive-db`, `khive-storage`, `khive-types`, `khive-score`). Its `_pack_links` module force-
+references each pack crate so the linker keeps their `inventory::submit!` verb registrations
+in the final binary — dependency alone is not enough for that to happen.
+
+Governed by [ADR-016](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-016-request-dsl.md)
+(request DSL), [ADR-049](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-049-khived-daemon.md)
+(the `--daemon` warm runtime), and [ADR-027](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-027-dynamic-pack-loading.md)
+(pack self-registration via `inventory`).
+
+## License
+
+Apache-2.0.

--- a/docs/_templates/crate-README.md
+++ b/docs/_templates/crate-README.md
@@ -1,0 +1,55 @@
+<!--
+  Canonical README template for a khive workspace crate.
+
+  Copy this file to `crates/<crate-name>/README.md` and fill each section.
+  cargo auto-detects `README.md` in a crate root, so no `readme = ` field is
+  needed in Cargo.toml; the file becomes the crate's crates.io landing page.
+
+  House style (see crates/khive-bm25/README.md and crates/khive-gate-rego/README.md
+  for filled exemplars):
+    - Neutral, technical, English. No marketing ("blazingly fast"), no emojis,
+      no first-person, no AI attribution.
+    - Ground every code example in a real public signature from the crate's
+      src/lib.rs. If an exact API is uncertain, describe it in prose and name the
+      core type rather than invent a code block — README snippets are NOT compiled.
+    - Length is proportional to the crate: a thin trait/type crate is ~30-50
+      lines; an engine or server crate is ~80-130.
+    - Link sibling crates to their crates.io page and ADRs via full GitHub URLs:
+      https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-NNN-<slug>.md
+  Delete these comments in the filled README.
+-->
+
+# <crate-name>
+
+<!-- One or two sentences: what the crate is and what it does. Expand the
+     Cargo.toml `description` into a complete sentence. -->
+
+<!-- OPTIONAL — a `## Features` bullet list for feature-rich crates (indexes,
+     engines, servers). Omit for thin trait/type crates. -->
+
+## Usage
+
+<!-- A minimal, accurate example grounded in a real public signature. Keep it
+     short and focused on the crate's primary entry point. -->
+
+```rust
+// grounded example — real types and methods from this crate
+```
+
+<!-- OPTIONAL domain sections as the crate warrants — match the depth of the
+     exemplars: `## Configuration`, `## Semantics`, `## Architecture`,
+     `## Policy contract`, etc. -->
+
+## Where this sits
+
+<!-- One short paragraph or a bullet list placing the crate in khive's storage
+     dependency chain:
+
+       types -> score -> storage -> db -> query -> runtime -> pack-* -> mcp
+
+     Name the crates it builds on and the ones that consume it, and link the
+     governing ADR(s) by full GitHub URL. -->
+
+## License
+
+Apache-2.0.

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -76,9 +76,11 @@
 #
 # The [[engines]] array registers the embedding models available at runtime,
 # replacing the legacy two-tier env-var pair (KHIVE_EMBEDDING_MODEL +
-# KHIVE_ADDITIONAL_EMBEDDING_MODELS — see the env reference at the end). When this
-# array is present it wins; when it is absent the env-var path is the backward-
-# compatible fallback.
+# KHIVE_ADDITIONAL_EMBEDDING_MODELS — see the env reference at the end). The
+# env-var pair is the backward-compatible fallback ONLY when no config file is
+# loaded at all. Once any config file is found, those env vars are ignored — a
+# config file with no [[engines]] uses the built-in default engine, it does NOT
+# fall back to the env pair.
 
 # Exactly one [[engines]] entry must set `default = true`.
 # That engine becomes the primary embedding model used for entity indexing
@@ -187,7 +189,7 @@ fusion_weight = 0.5
 #   KHIVE_OUTPUT_FORMAT=json     Output format json|auto|table (ADR-078). Tier 2 — above
 #                                [runtime] default_output_format, below the per-request `format`.
 #
-# ── Embedding engines (env fallback — used only when [[engines]] is absent) ──────
+# ── Embedding engines (env fallback — used only when NO config file is loaded) ───
 #   KHIVE_EMBEDDING_MODEL=all-minilm-l6-v2
 #                                Primary model. Becomes the default=true engine.
 #   KHIVE_ADDITIONAL_EMBEDDING_MODELS=paraphrase-multilingual-minilm-l12-v2,bge-small-en-v1.5
@@ -258,6 +260,8 @@ fusion_weight = 0.5
 #   KHIVE_RECALL_FTS_GATHER_LIMIT=        Explicit row cap for rank_subset mode (> 0). Default: derived.
 #   KHIVE_RECALL_FTS_CJK_BYPASS=true      CJK queries bypass term-K selection. Accepts 1/true/0/false.
 #   KHIVE_RECALL_PROFILE=1                Emit per-stage recall timing JSON to stderr (presence = on).
+#   ANN_OVERFETCH_MAX_ROUNDS=3           Max ANN over-fetch retry rounds when post-filtering drops
+#                                        candidates below the requested limit (un-prefixed; pack `memory`).
 #
 # ── Index build / brain (advanced) ───────────────────────────────────────────────
 #   KHIVE_BUILD_BATCH=1024                Vamana graph-build batch size (minimum 1).

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -198,7 +198,7 @@ fusion_weight = 0.5
 #                                Primary model. Becomes the default=true engine.
 #   KHIVE_ADDITIONAL_EMBEDDING_MODELS=paraphrase-multilingual-minilm-l12-v2,bge-small-en-v1.5
 #                                Comma-separated secondary models. When [[engines]] is present the
-#                                file wins and these are ignored (with an info-level log).
+#                                file wins and these are ignored (with a warn-level log).
 #
 # ── Deployment / multi-tenant safety ─────────────────────────────────────────────
 #   KHIVE_REQUIRE_ATTRIBUTED_ACTOR=1

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -74,13 +74,17 @@
 
 # ── Embedding engines ──────────────────────────────────────────────────────────
 #
-# The [[engines]] array registers the embedding models available at runtime,
-# replacing the legacy two-tier env-var pair (KHIVE_EMBEDDING_MODEL +
-# KHIVE_ADDITIONAL_EMBEDDING_MODELS — see the env reference at the end). The
-# env-var pair is the backward-compatible fallback ONLY when no config file is
-# loaded at all. Once any config file is found, those env vars are ignored — a
-# config file with no [[engines]] uses the built-in default engine, it does NOT
-# fall back to the env pair.
+# The [[engines]] array registers the embedding models available at runtime.
+# When [[engines]] entries are present they are authoritative: each engine's
+# `model` sets the embedding model used for entity indexing and retrieval. When
+# no [[engines]] block is configured — whether or not a config file is loaded —
+# khive falls back to the legacy two-tier env pair (KHIVE_EMBEDDING_MODEL +
+# KHIVE_ADDITIONAL_EMBEDDING_MODELS; see the env reference at the end), and to
+# the built-in default models when those env vars are unset.
+# Caveat: if a config file is present AND those env vars are set AND no
+# [[engines]] block overrides them, khive logs a warning that the env vars are
+# "ignored" — but with nothing to override them they are still applied via the
+# base runtime config.
 
 # Exactly one [[engines]] entry must set `default = true`.
 # That engine becomes the primary embedding model used for entity indexing
@@ -189,7 +193,7 @@ fusion_weight = 0.5
 #   KHIVE_OUTPUT_FORMAT=json     Output format json|auto|table (ADR-078). Tier 2 — above
 #                                [runtime] default_output_format, below the per-request `format`.
 #
-# ── Embedding engines (env fallback — used only when NO config file is loaded) ───
+# ── Embedding engines (env fallback — used when no [[engines]] block configured) ─
 #   KHIVE_EMBEDDING_MODEL=all-minilm-l6-v2
 #                                Primary model. Becomes the default=true engine.
 #   KHIVE_ADDITIONAL_EMBEDDING_MODELS=paraphrase-multilingual-minilm-l12-v2,bge-small-en-v1.5

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -1,22 +1,84 @@
-# khive.toml — example configuration
+# khive.toml — full configuration reference
 #
-# Save at .khive/config.toml in your project root (project-local default),
-# or pass an explicit path via --config / KHIVE_CONFIG.
-# ~/.khive/config.toml is reserved for personal/global settings and is NOT
-# searched automatically.
+# An annotated example of every configuration surface khive reads. Copy the sections
+# you need into your own config file. Every key is optional and has a built-in
+# default, so an empty file is valid — khive runs on defaults out of the box.
 #
-# This file configures the embedding engines available at runtime.
-# The [[engines]] array replaces the env-var two-tier hack:
-#   KHIVE_EMBEDDING_MODEL (primary)
-#   KHIVE_ADDITIONAL_EMBEDDING_MODELS (comma-separated list)
+# ── Where khive looks for this file ─────────────────────────────────────────────
 #
-# If this file is absent, the env-var path is used as a backward-compat fallback.
-# If both file and env vars are present, the file wins.
+# On startup the runtime searches these locations in order and loads the FIRST that
+# exists:
+#   1. the path given by  --config  /  KHIVE_CONFIG   (explicit override)
+#   2. ./khive.toml                                   (project root)
+#   3. ./.khive/config.toml                           (project-local hidden dir)
+#   4. ~/.khive/config.toml                           (user-global)
 #
-# ADR reference: ADR-031 §D3 (Multi-Engine Retrieval — [[engines]] TOML schema)
-# ADR reference: ADR-035 §1  (Unified khive.toml — one file per scope)
+# Unknown keys are ignored (forward-compatible): a config written for a newer khive
+# still loads on an older build, and vice versa.
+#
+# Sections in this file:
+#   [actor]         default identity + namespace read/write scope
+#   [runtime]       brain profile + default output format
+#   [[engines]]     embedding engines (replaces the KHIVE_EMBEDDING_MODEL env pair)
+#   [[backends]]    named storage backends (ADR-028)
+#   [packs.<name>]  per-pack backend assignment (ADR-028)
+# A reference of every environment variable khive reads follows at the end.
+#
+# ADR references: ADR-031 (multi-engine retrieval), ADR-035 (unified khive.toml),
+# ADR-028 (pack-scoped backends), ADR-007 (namespace / actor model), ADR-078 (output
+# format).
+
+# ── [actor] — identity and namespace scope ──────────────────────────────────────
+#
+# The actor is this instance's attribution identity: a write-stamp and a policy
+# input, NOT a storage-isolation boundary (ADR-007 Rev 6). In OSS single-tenant mode
+# writes are always pinned to the `local` namespace regardless of actor.id; cloud
+# deployments derive the namespace from an authenticated token instead. Every key is
+# optional — the defaults apply when the section is absent.
+
+[actor]
+# Attribution identity. Must be a valid namespace string ("local", "lambda:khive",
+# …). Validated at load — an invalid value is a startup error, not a silent
+# fallback. Absent → `local`. Overridden by --actor / KHIVE_ACTOR. A non-`local` id
+# does NOT route writes; it only widens the default read scope (see below).
+# id = "lambda:khive"
+
+# Human-readable label. Surfaced in introspection and logs only; never used for
+# routing.
+# display_name = "khive lambda"
+
+# Widen the DEFAULT multi-record READ scope to {local} ∪ these namespaces
+# (ADR-007 Rev 4 Rule 3b). Writes stay pinned to `local`. An explicit `namespace=`
+# request parameter is a precise escape and is not widened by this list.
+# visible_namespaces = ["lambda:khive", "local"]
+
+# Namespaces this actor's comm.send / comm.reply may deliver INTO. Empty (default)
+# denies all cross-namespace delivery. Each entry must be a valid namespace.
+# allowed_outbound_namespaces = ["lambda:leo"]
+
+# ── [runtime] — runtime knobs ────────────────────────────────────────────────────
+
+[runtime]
+# Brain profile id used by memory.feedback / knowledge.feedback and for recall-time
+# score boosting. Absent → the namespace-bound profile (brain.resolve) is tried,
+# then the global tuning prior. Mirrors --brain-profile / KHIVE_BRAIN_PROFILE.
+# brain_profile = "khive-default"
+
+# Default output serialization (ADR-078). One of:
+#   "json"  (default) — compact, lossless; the safe choice for machine consumers
+#   "auto"            — human-readable view, drops redundant fields (LOSSY, non-JSON)
+#   "table"           — forced tabular view (LOSSY, non-JSON)
+# Precedence (high→low): per-request `format` → KHIVE_OUTPUT_FORMAT → this → "json".
+# Keep "json" if anything parses khive's output.
+# default_output_format = "json"
 
 # ── Embedding engines ──────────────────────────────────────────────────────────
+#
+# The [[engines]] array registers the embedding models available at runtime,
+# replacing the legacy two-tier env-var pair (KHIVE_EMBEDDING_MODEL +
+# KHIVE_ADDITIONAL_EMBEDDING_MODELS — see the env reference at the end). When this
+# array is present it wins; when it is absent the env-var path is the backward-
+# compatible fallback.
 
 # Exactly one [[engines]] entry must set `default = true`.
 # That engine becomes the primary embedding model used for entity indexing
@@ -66,13 +128,139 @@ fusion_weight = 0.5
 #
 # For linear-score fusion (FusionStrategy::Linear): fusion_weight is the
 # mixing coefficient applied to normalized per-engine cosine scores.
+
+# ── [[backends]] — named storage backends (ADR-028) ──────────────────────────────
 #
-# ── Notes on the env-var fallback ──────────────────────────────────────────────
+# By default khive uses ONE implicit backend named `main`, resolved from
+# --db / KHIVE_DB / the default ~/.khive/khive.db path, and every pack shares it.
+# Declare [[backends]] only to split packs across separate databases.
+
+# [[backends]]
+# name = "main"                # unique; referenced by [packs.<name>].backend
+# kind = "sqlite"              # "sqlite" (default) or "memory" (testing only — lost on restart)
+# path = "~/.khive/khive.db"   # sqlite only; a leading ~ expands to $HOME
+# read_only = false            # open the backend read-only
 #
-# When this file is absent, the legacy env-var path is used automatically:
+# NOTE: `cache_mb` and `journal_mode` are recognized by the parser but NOT yet
+# supported — setting either is a hard startup error. Omit them until a release
+# implements them. (SQLite WAL / cache tuning is available today via the
+# KHIVE_WAL_* / KHIVE_BUSY_TIMEOUT_SECS env vars in the reference below.)
+
+# [[backends]]
+# name = "knowledge"
+# kind = "sqlite"
+# path = "~/.khive/knowledge.db"
+
+# ── [packs.<name>] — per-pack backend assignment (ADR-028) ───────────────────────
 #
+# Route an individual pack to a declared backend. Packs not listed here fall back to
+# `main`. The referenced backend must appear in [[backends]] above. Loadable packs:
+# kg, gtd, memory, brain, comm, schedule, knowledge, session.
+
+# [packs.knowledge]
+# backend = "knowledge"
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# Environment variables
+# ═════════════════════════════════════════════════════════════════════════════════
+#
+# khive also reads configuration from the environment. Some env vars mirror a CLI
+# flag or a key above (precedence is noted); others have no TOML equivalent. Boolean
+# spelling is NOT uniform across vars — the accepted form is given per var. Values
+# shown are defaults unless marked "required". Secrets belong in ~/.khive/.env
+# (loaded into the environment at startup; real env vars take precedence) or a
+# secret manager — never in a committed config file.
+#
+# ── Core (mirror CLI flags) ──────────────────────────────────────────────────────
+#   KHIVE_DB=~/.khive/khive.db   Database path, or the literal `:memory:` for an
+#                                ephemeral in-memory DB. Also --db.
+#   KHIVE_ACTOR=local            Default actor / namespace. Also --actor. Beats [actor] id.
+#   KHIVE_NAMESPACE=local        Legacy alias for KHIVE_ACTOR; loses to it when both are set.
+#   KHIVE_NO_EMBED=false         Disable the local embedding model (skips vector indexing).
+#                                STRICT bool: only "true"/"false" — "1" is a startup error.
+#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session
+#                                Packs to load when --pack is absent. Comma / space separated.
+#   KHIVE_CONFIG=./khive.toml    Path to THIS config file. Also --config. Overrides the search order.
+#   KHIVE_LOG=warn               Stderr log level (JSON results on stdout are unaffected).
+#   KHIVE_BRAIN_PROFILE=         Brain profile id. Tier 3 — after --brain-profile and
+#                                [runtime] brain_profile. Default: unset.
+#   KHIVE_OUTPUT_FORMAT=json     Output format json|auto|table (ADR-078). Tier 2 — above
+#                                [runtime] default_output_format, below the per-request `format`.
+#
+# ── Embedding engines (env fallback — used only when [[engines]] is absent) ──────
 #   KHIVE_EMBEDDING_MODEL=all-minilm-l6-v2
-#   KHIVE_ADDITIONAL_EMBEDDING_MODELS=paraphrase,bge-small-en-v1.5
+#                                Primary model. Becomes the default=true engine.
+#   KHIVE_ADDITIONAL_EMBEDDING_MODELS=paraphrase-multilingual-minilm-l12-v2,bge-small-en-v1.5
+#                                Comma-separated secondary models. When [[engines]] is present the
+#                                file wins and these are ignored (with an info-level log).
 #
-# This is equivalent to the config above with default=true on the primary model.
-# The env-var path will emit an info-level log suggesting migration to this file.
+# ── Deployment / multi-tenant safety ─────────────────────────────────────────────
+#   KHIVE_REQUIRE_ATTRIBUTED_ACTOR=1
+#                                When exactly "1": refuse to start if the comm pack is loaded with
+#                                no actor identity (id None / local), preventing a shared "party-
+#                                line" inbox. Default: off. Only the literal "1" enables it.
+#
+# ── Session transcript mirror (pack `session`, ADR-080) ──────────────────────────
+#   KHIVE_MIRROR_ENABLED=false   Enable the Claude Code (*.jsonl) transcript mirror. true = 1/true/yes.
+#   KHIVE_MIRROR_PROJECTS_DIR=~/.claude/projects   Root scanned for Claude Code transcripts.
+#   KHIVE_MIRROR_CODEX_ENABLED=false   Enable the Codex CLI mirror (independent of the above).
+#   KHIVE_MIRROR_CODEX_DIR=~/.codex/sessions   Root scanned for Codex transcripts.
+#   KHIVE_MIRROR_POLL_SECS=2     Seconds between mirror poll ticks.
+#   KHIVE_MIRROR_BACKFILL=true   true → mirror existing files from offset 0; false → only new bytes
+#                                from EOF. Set false via 0/false/no.
+#
+# ── Email channel (build with feature `channel-email`; inert without these) ──────
+#   Never commit KHIVE_EMAIL_PASSWORD or KHIVE_EMAIL_OAUTH_CLIENT_SECRET.
+#   KHIVE_EMAIL_SMTP_HOST=smtp.example.com    Required. Outbound relay host.
+#   KHIVE_EMAIL_SMTP_PORT=587                 Optional. Default 587 (STARTTLS).
+#   KHIVE_EMAIL_IMAP_HOST=imap.example.com    Required. Inbound polling host.
+#   KHIVE_EMAIL_IMAP_PORT=993                 Optional. Default 993 (TLS).
+#   KHIVE_EMAIL_USERNAME=bot@example.com      Required. SMTP / IMAP login; default mailbox.
+#   KHIVE_EMAIL_PASSWORD=                     Required in Basic-auth mode (no OAuth vars set). Secret.
+#   KHIVE_EMAIL_MAILBOX=bot@example.com       Optional. Sender / XOAUTH2 user. Default: USERNAME.
+#   KHIVE_EMAIL_MAINTAINER_ADDRESS=you@example.com
+#                                Required. Comma-separated allowlist of senders whose inbound mail
+#                                is accepted; the first entry is primary.
+#   KHIVE_EMAIL_DEFAULT_ACTOR=lambda:leo      Actor for new inbound mail with no thread match.
+#   KHIVE_EMAIL_INGEST_NAMESPACE=local        Namespace stamped on channel messages.
+#   KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=you@example.com
+#                                Comma-separated outbound allowlist. Default: the maintainer address.
+#   OAuth (Exchange Online app-only) — all three together select OAuth mode; a partial set errors:
+#   KHIVE_EMAIL_OAUTH_TENANT_ID=              Azure AD tenant GUID.
+#   KHIVE_EMAIL_OAUTH_CLIENT_ID=              Azure AD application (client) GUID. Presence selects OAuth.
+#   KHIVE_EMAIL_OAUTH_CLIENT_SECRET=          Client secret. Secret.
+#
+# ── Daemon / IPC (ADR-049; advanced) ─────────────────────────────────────────────
+#   KHIVE_NO_DAEMON=1            Disable daemon auto-spawn; dispatch every request in-process.
+#                                true = any non-empty value except "0" / "false".
+#   KHIVE_SOCKET=~/.khive/khived.sock            Daemon Unix socket path.
+#   KHIVE_PID=~/.khive/khived.pid                Daemon PID file path.
+#   KHIVE_LOCK=~/.khive/khived.recovery.lock     Stale-daemon recovery lock file path.
+#   KHIVE_DRAIN_TIMEOUT_SECS=10  Seconds the daemon waits for in-flight requests before shutdown.
+#
+# ── SQLite storage tuning (advanced — defaults are well-chosen; change only to profile) ──
+#   An unparseable numeric value here is treated as unset (falls back to the default).
+#   KHIVE_BUSY_TIMEOUT_SECS=30           SQLite busy_timeout per connection.
+#   KHIVE_CHECKOUT_TIMEOUT_SECS=5        Max wait to check out a pooled reader connection.
+#   KHIVE_WAL_AUTOCHECKPOINT_PAGES=4000  PRAGMA wal_autocheckpoint threshold (in pages).
+#   KHIVE_WAL_HIGH_WATER_PAGES=6000      WAL size that logs a high-pressure warning. Must be > 0.
+#   KHIVE_WAL_WARN_PAGES=2000            WAL size that logs a warning. Must be > 0.
+#   KHIVE_JOURNAL_SIZE_LIMIT_BYTES=67108864   PRAGMA journal_size_limit (64 MiB).
+#   KHIVE_CHECKPOINT_INTERVAL_MS=500     Passive WAL checkpoint interval. Must be > 0.
+#
+# ── Recall / FTS tuning (advanced; pack `memory`) ────────────────────────────────
+#   Setting ANY of these activates the FTS candidate-gather optimization; the path is
+#   disabled / baseline otherwise.
+#   KHIVE_RECALL_FTS_GATHER=ranked        Strategy: baseline|ranked|rank_subset|unranked.
+#   KHIVE_RECALL_FTS_SELECTION=original   Top-K term rule: original|lowest_df|highest_idf.
+#   KHIVE_RECALL_FTS_TERM_K=10            Max query terms sent to FTS (1..=10).
+#   KHIVE_RECALL_FTS_GATHER_MULTIPLIER=4  Gather limit = candidate_limit × this (when no explicit LIMIT).
+#   KHIVE_RECALL_FTS_GATHER_LIMIT=        Explicit row cap for rank_subset mode (> 0). Default: derived.
+#   KHIVE_RECALL_FTS_CJK_BYPASS=true      CJK queries bypass term-K selection. Accepts 1/true/0/false.
+#   KHIVE_RECALL_PROFILE=1                Emit per-stage recall timing JSON to stderr (presence = on).
+#
+# ── Index build / brain (advanced) ───────────────────────────────────────────────
+#   KHIVE_BUILD_BATCH=1024                Vamana graph-build batch size (minimum 1).
+#   KHIVE_BRAIN_BASE_MODEL_REVISION=base-v0
+#                                Base-model revision that brain.register_adapter requires an adapter's
+#                                base_model_revision to match.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -63,6 +63,7 @@ CRATES=(
     khive-vcs-adapters
     khive-vcs
     # khive-merge — excluded from workspace (ADR-043 forward-deployed, ahead of khive-vcs)
+    khive-pack-formal    # needs khive-runtime + khive-types (both above); dev-dep of khive-pack-kg, so publish first
     khive-pack-kg
     khive-pack-gtd
     khive-brain-core
@@ -71,7 +72,6 @@ CRATES=(
     khive-pack-comm
     khive-pack-schedule
     khive-pack-knowledge
-    khive-pack-formal    # needs khive-runtime + khive-types (both above); consumed by kkernel
     khive-pack-session   # needs khive-pack-kg + khive-runtime/storage/types (all above)
     khive-pack-template
     khive-channel        # no khive-* deps; transport abstraction

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -71,7 +71,11 @@ CRATES=(
     khive-pack-comm
     khive-pack-schedule
     khive-pack-knowledge
+    khive-pack-formal    # needs khive-runtime + khive-types (both above); consumed by kkernel
+    khive-pack-session   # needs khive-pack-kg + khive-runtime/storage/types (all above)
     khive-pack-template
+    khive-channel        # no khive-* deps; transport abstraction
+    khive-channel-email  # needs khive-channel (above); optional dep of khive-mcp
     khive-mcp
     kkernel
 )
@@ -84,8 +88,11 @@ DELAY=10  # seconds to wait for crates.io index between publishes
 # version bump. This runs at the publish boundary — where the version actually
 # bumps — because mid-cycle on a fixed dev version the check is permanently red
 # (which is why it is NOT a per-PR CI gate). Runs in preflight and live alike so
-# `make publish-dry` validates SemVer before any real publish. khive-quant has
-# no crates.io baseline yet, so it is excluded until its first publish.
+# `make publish-dry` validates SemVer before any real publish. Crates with no
+# crates.io baseline yet (never published) have nothing to diff against and are
+# excluded until their first publish: khive-quant, plus the crates first shipped
+# in this release — khive-channel, khive-channel-email, khive-pack-formal,
+# khive-pack-session. Drop an exclusion once that crate has one published version.
 echo ""
 echo "--- SemVer gate (cargo-semver-checks vs crates.io baseline) ---"
 if ! command -v cargo-semver-checks >/dev/null 2>&1; then
@@ -93,7 +100,12 @@ if ! command -v cargo-semver-checks >/dev/null 2>&1; then
     echo "       Install it:  cargo install cargo-semver-checks --locked" >&2
     exit 1
 fi
-cargo semver-checks check-release --workspace --exclude khive-quant
+cargo semver-checks check-release --workspace \
+    --exclude khive-quant \
+    --exclude khive-channel \
+    --exclude khive-channel-email \
+    --exclude khive-pack-formal \
+    --exclude khive-pack-session
 echo "    SemVer gate OK"
 
 for crate in "${CRATES[@]}"; do


### PR DESCRIPTION
Documentation pass ahead of the next crates.io release. No crate code changes.

## What's in it

**Per-crate READMEs (32 new).** Every publishable crate now ships a `README.md`,
so its crates.io page has real content instead of the workspace fallback. Each
one is written against the crate's actual public API surface — presets, verbs,
feature flags, codec math, dependency position — not boilerplate.

**README template.** `docs/_templates/crate-README.md` is the reusable skeleton
for future crates (title, one-line purpose, usage, "where this sits", license),
matching the structure the 32 READMEs follow.

**Full configuration reference.** `docs/khive-config-example.toml` grows from an
engines-only example into a complete reference:
- all five TOML sections — `[actor]`, `[runtime]`, `[[engines]]`, `[[backends]]`,
  `[packs.<name>]` — with per-key semantics, defaults, and ADR pointers;
- a grouped environment-variable reference (core, embedding fallback, deployment
  safety, session mirror, email channel, daemon/IPC, and advanced storage/recall
  tuning), with defaults, per-var boolean spelling, and precedence noted;
- corrected config-file search order (the user-global `~/.khive/config.toml` IS
  searched, as tier 4); `cache_mb`/`journal_mode` flagged as parsed-but-rejected.

**publish.sh completeness (`chore(release)` commit).** The publish ordering was
missing four crates (`khive-pack-formal`, `khive-pack-session`, `khive-channel`,
`khive-channel-email`); they are added in dependency order and to the
`cargo-semver-checks` exclude set (no crates.io baseline until first publish).
The `CRATES` array now matches all 34 publishable workspace members exactly.

## Verification
- `deno fmt --check` — clean (docs job scope).
- `docs/khive-config-example.toml` parses as valid TOML.
- `publish.sh`: `bash -n` clean; `CRATES` array cross-checked against
  `cargo metadata` — no missing, extra, or duplicate members.
- README API claims spot-checked against source (khive-text presets/features,
  khive-quant dependents, kkernel subcommands).