### PR TITLE
docs: replace stale `kkernel call` references with `kkernel exec`

### DIFF
--- a/crates/khive-pack-session/src/vocab.rs
+++ b/crates/khive-pack-session/src/vocab.rs
@@ -50,7 +50,7 @@ pub(crate) static SESSION_SCHEMA_PLAN_STMTS: [&str; 6] = [
 /// only active feature is the background daemon mirror (the `warm()` hook),
 /// which runs independent of verb visibility. The read/query layer
 /// (store/list/get) is deferred — it stays dispatchable via the runtime and
-/// `kkernel call` but is withheld from the agent surface until the
+/// `kkernel exec` but is withheld from the agent surface until the
 /// session-continuity query UX is designed. Flip to `Visibility::Verb` to
 /// expose (and bump the smoke-test verb count accordingly).
 ///

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -344,7 +344,7 @@ pub enum PresentationMode {
     /// fields truncated to 3 significant figures.
     #[default]
     Agent,
-    /// Full canonical shape. Default for `kkernel call` and CI/scripted callers.
+    /// Full canonical shape. Default for `kkernel exec` and CI/scripted callers.
     ///
     /// No transformation — handler output passes through as-is.
     Verbose,

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -19,7 +19,7 @@ use crate::edge::EdgeRelation;
 pub enum Visibility {
     /// Externally invokable via MCP `request` tool.
     Verb,
-    /// Internal — operator-only via `kkernel call <pack> <handler>`.
+    /// Internal — operator-only via `kkernel exec '<pack>.<handler>(...)'`.
     Subhandler,
 }
 

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -96,7 +96,7 @@ pub struct HandlerDef {
 pub enum Visibility {
     /// Exposed to MCP agents. Agents call via `request("pack.verb(args)")`.
     Verb,
-    /// Not on the MCP wire. Callable only via `kkernel call <pack> <handler>`.
+    /// Not on the MCP wire. Callable only via `kkernel exec '<pack>.<handler>(args)'`.
     /// Examples: `memory.recall_score`, `memory.recall_embed` — addressable
     /// through batch DSL chains but NOT registered as top-level MCP verbs.
     Subhandler,
@@ -106,17 +106,17 @@ pub enum Visibility {
 The MCP transport filters by `visibility == Verb` when building the agent capability
 list. `Subhandler` handlers are unreachable from MCP — agents never see them.
 
-The kkernel CLI exposes the **full** handler surface:
+The kkernel CLI exposes the **full** handler surface via the verb-DSL `exec` subcommand:
 
 ```bash
-kkernel call memory recall       query="..."                  # Verb       — also on MCP
-kkernel call memory recall_embed query="..."                  # Subhandler — admin only
-kkernel call memory recall_fuse  query="..." limit=5          # Subhandler — admin only
-kkernel call memory recall_score candidate_id="..."           # Subhandler — admin only
+kkernel exec 'memory.recall(query="...")'                      # Verb       — also on MCP
+kkernel exec 'memory.recall_embed(query="...")'                 # Subhandler — admin only
+kkernel exec 'memory.recall_fuse(query="...", limit=5)'         # Subhandler — admin only
+kkernel exec 'memory.recall_score(candidate_id="...")'          # Subhandler — admin only
 ```
 
 The same handler is reachable as `memory.recall` from MCP and as
-`kkernel call memory recall` from the CLI. The CLI is the operator's window into the
+`kkernel exec 'memory.recall(...)'` from the CLI. The CLI is the operator's window into the
 full surface; MCP is the agent's filtered view.
 
 This replaces the previous `VerbDef` type. Migration is mechanical: rename
@@ -205,14 +205,14 @@ The single rule: **first dot is always the pack name. There is no second dot.**
 
 Any verb name change or new pack registration that violates §4 will fail CI.
 
-The kkernel CLI uses spaces, not dots, to invoke handlers:
+The kkernel CLI uses the same dotted verb-DSL form as MCP, via the `exec` subcommand:
 
 ```bash
-kkernel call <pack> <handler> [args...]
+kkernel exec '<pack>.<handler>(args...)'
 ```
 
 So the same handler is `memory.recall_candidates` on MCP and
-`kkernel call memory recall_candidates` from the CLI.
+`kkernel exec 'memory.recall_candidates(...)'` from the CLI.
 
 ### 5. Field naming — full words, context-portable
 

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -112,7 +112,7 @@ The kkernel CLI exposes the **full** handler surface via the verb-DSL `exec` sub
 kkernel exec 'memory.recall(query="...")'                      # Verb       — also on MCP
 kkernel exec 'memory.recall_embed(query="...")'                 # Subhandler — admin only
 kkernel exec 'memory.recall_fuse(query="...", limit=5)'         # Subhandler — admin only
-kkernel exec 'memory.recall_score(candidate_id="...")'          # Subhandler — admin only
+kkernel exec 'memory.recall_score(rrf=0.4, salience=0.8, decay_factor=0.02, age_days=7)'  # Subhandler — admin only
 ```
 
 The same handler is reachable as `memory.recall` from MCP and as

--- a/docs/adr/ADR-025-verb-speech-acts.md
+++ b/docs/adr/ADR-025-verb-speech-acts.md
@@ -112,7 +112,7 @@ pub enum VerbCategory {
 ```
 
 The category is a runtime tag (`HandlerDef::category`) consumed by introspection
-(`kkernel call <pack> <handler> --help` per ADR-003) and not enforced at compile time.
+(`kkernel exec '<pack>.<handler>(help=true)'` per ADR-003) and not enforced at compile time.
 Mis-categorization is
 caught in code review, not by the type system. The point is naming the classification so
 verb-addition discussions can reference it.

--- a/docs/adr/ADR-033-recall-pipeline.md
+++ b/docs/adr/ADR-033-recall-pipeline.md
@@ -113,7 +113,7 @@ one per engine, in deterministic order (engine_id ASC). Single-engine deployment
 return a one-element list — the shape is uniform regardless of engine count. It is
 `Internal` because agents have no reason to see the raw embedding vectors (token
 waste); operators inspecting an engine use
-`kkernel call memory recall_embed query="..."`.
+`kkernel exec 'memory.recall_embed(query="...")'`.
 
 The `memory.recall_score` handler returns a score breakdown per result:
 

--- a/docs/adr/ADR-045-verb-response-presentation.md
+++ b/docs/adr/ADR-045-verb-response-presentation.md
@@ -64,7 +64,7 @@ returned by the runtime.
 pub enum PresentationMode {
     /// Token-efficient. Default for MCP callers (agents).
     Agent,
-    /// Full canonical shape. Default for `kkernel call` and CI / scripted callers.
+    /// Full canonical shape. Default for `kkernel exec` and CI / scripted callers.
     Verbose,
     /// Pretty-printed terminal output. Default for `khive` CLI.
     Human,
@@ -81,12 +81,12 @@ the corresponding transform.
 
 ### 2. Selection rules
 
-| Caller surface               | Default mode | Override                                                     |
-| ---------------------------- | ------------ | ------------------------------------------------------------ |
-| MCP (`request` tool)         | `Agent`      | envelope-level `presentation_per_op` array (see §Wire shape) |
-| `kkernel call <pack> <verb>` | `Verbose`    | `--presentation agent` or `--presentation human` flag        |
-| `khive` CLI                  | `Human`      | `--json` for `Agent`, `--verbose` for `Verbose`              |
-| HTTP gateway (future)        | `Agent`      | `?presentation=verbose` query parameter                      |
+| Caller surface                      | Default mode | Override                                                     |
+| ----------------------------------- | ------------ | ------------------------------------------------------------ |
+| MCP (`request` tool)                | `Agent`      | envelope-level `presentation_per_op` array (see §Wire shape) |
+| `kkernel exec '<pack>.<verb>(...)'` | `Verbose`    | `--presentation agent` or `--presentation human` flag        |
+| `khive` CLI                         | `Human`      | `--json` for `Agent`, `--verbose` for `Verbose`              |
+| HTTP gateway (future)               | `Agent`      | `?presentation=verbose` query parameter                      |
 
 The presentation argument is parsed by the runtime envelope, not by the
 handler. Handlers MUST NOT inspect or branch on the mode.
@@ -161,7 +161,7 @@ shape that round-trips through CI / scripted callers without surprises.
 
 **MCP/runtime boundary: `Human` is a no-op at this layer.**
 
-When `presentation=human` is sent over the MCP wire or `kkernel call`, the
+When `presentation=human` is sent over the MCP wire or `kkernel exec`, the
 runtime returns canonical (verbose) JSON — identical to `Verbose`. No
 transformation is applied inside `khive-runtime::presentation`. This is a
 deliberate design decision, not an omission:
@@ -468,7 +468,7 @@ Adding more invites bikeshedding without clear use cases.
 | Mode declared once per session, not per call                           | Some workflows mix verbose and agent calls; per-call control is the safer default        |
 | Use Accept headers (HTTP-style)                                        | MCP doesn't have headers; introducing them for one ADR's worth of feature is overkill    |
 | Truncate to top-N keys based on size budget                            | Brittle; the same call from two agents would return different shapes — non-deterministic |
-| Strip empties only at MCP boundary, leave canonical for `kkernel call` | Already the design — `kkernel call` defaults to verbose                                  |
+| Strip empties only at MCP boundary, leave canonical for `kkernel exec` | Already the design — `kkernel exec` defaults to verbose                                  |
 
 ## Consequences
 
@@ -558,7 +558,7 @@ layer is purely additive.
 **Migration policy:** Agent mode ships as the default for MCP/stdio responses
 IN this release. An escape hatch `KHIVE_DEFAULT_PRESENTATION=verbose` is
 available for one minor version (v0.2.x). The escape hatch is removed in v0.3.
-Verbose remains the default for `kkernel call` and library callers.
+Verbose remains the default for `kkernel exec` and library callers.
 
 Agents that previously parsed against full-shape MCP responses must either
 migrate to Agent-mode shapes or set `presentation=verbose` per call (or

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -452,14 +452,14 @@ verbs and the apply worker each have policy hooks:
 
 ### 10. CLI / MCP surface summary
 
-| Surface                                                        | Action                                                    | How                                    |
-| -------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------- |
-| MCP `propose(...)`                                             | Create a proposal                                         | Verb                                   |
-| MCP `review(id, decision, comment?)`                           | Cast a review                                             | Verb                                   |
-| MCP `withdraw(id, rationale?)`                                 | Withdraw a proposal (proposer-only)                       | Verb                                   |
-| MCP `list(kind=proposal, status="open")`                       | Browse open proposals                                     | Lists from `proposals_open` projection |
-| MCP `get(id=<proposal_id>)`                                    | Fetch a single proposal's `ProposalCreated` payload       | Resolves to the event payload          |
-| CLI `kkernel call kg proposal_cleanup --older-than <duration>` | Archive resolved proposals (deferred — not shipped in v1) | Future operator housekeeping           |
+| Surface                                                           | Action                                                    | How                                    |
+| ----------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------- |
+| MCP `propose(...)`                                                | Create a proposal                                         | Verb                                   |
+| MCP `review(id, decision, comment?)`                              | Cast a review                                             | Verb                                   |
+| MCP `withdraw(id, rationale?)`                                    | Withdraw a proposal (proposer-only)                       | Verb                                   |
+| MCP `list(kind=proposal, status="open")`                          | Browse open proposals                                     | Lists from `proposals_open` projection |
+| MCP `get(id=<proposal_id>)`                                       | Fetch a single proposal's `ProposalCreated` payload       | Resolves to the event payload          |
+| CLI `kkernel exec 'kg.proposal_cleanup(older_than="<duration>")'` | Archive resolved proposals (deferred — not shipped in v1) | Future operator housekeeping           |
 
 `list(kind=proposal)` dispatches to a new `kg.list_proposals` handler under
 the kg pack — it queries `proposals_open` directly, supports the standard


### PR DESCRIPTION
## Summary

Closes #380

The shipped `kkernel` binary exposes a single verb-DSL entrypoint,
`kkernel exec '<pack>.<handler>(args)'`. There is no `call` subcommand — the
`Command` enum in `crates/kkernel/src/main.rs` only has `Exec(exec::ExecArgs)`.
Several ADRs and source doc-comments still referenced the older
`kkernel call <pack> <handler>` invocation form. This PR updates those
references to the shipped `kkernel exec` syntax, translating CLI-style
`kkernel call <pack> <handler> arg="x"` invocations to the verb-DSL form
`kkernel exec '<pack>.<handler>(arg="x")'`, while leaving surrounding design
rationale and prose unchanged.

One occurrence (`ADR-031-multi-engine-retrieval.md:216`, "kkernel calls
`registry.filter(...)`") was intentionally left as-is — it is prose describing
runtime behavior, not a reference to the CLI command.

## Files touched

- `crates/khive-runtime/src/presentation.rs` — doc comment
- `crates/khive-types/src/pack.rs` — doc comment
- `crates/khive-pack-session/src/vocab.rs` — doc comment
- `docs/adr/ADR-023-declarative-pack-format.md`
- `docs/adr/ADR-025-verb-speech-acts.md`
- `docs/adr/ADR-033-recall-pipeline.md`
- `docs/adr/ADR-045-verb-response-presentation.md`
- `docs/adr/ADR-046-event-sourced-proposals.md`

## Test plan

- [x] `grep -rn 'kkernel call' crates/ docs/` — zero command references remain (one legitimate prose hit left intentionally)
- [x] `deno fmt` / `deno fmt --check` on `docs/` — clean
- [x] `cargo fmt -p khive-runtime -p khive-types -p khive-pack-session` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p khive-runtime -p khive-types -p khive-pack-session --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime -p khive-types -p khive-pack-session` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)