### PR TITLE
fix(mcp): correct misleading embedding env-var 'ignored' warning (#379)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1264,10 +1264,11 @@ fn resolve_config(
         Some(khive_cfg) => {
             let env_primary = std::env::var("KHIVE_EMBEDDING_MODEL").ok();
             let env_additional = std::env::var("KHIVE_ADDITIONAL_EMBEDDING_MODELS").ok();
-            if env_primary.is_some() || env_additional.is_some() {
+            if !khive_cfg.engines.is_empty() && (env_primary.is_some() || env_additional.is_some())
+            {
                 tracing::warn!(
-                    "khive config file is present; KHIVE_EMBEDDING_MODEL and \
-                     KHIVE_ADDITIONAL_EMBEDDING_MODELS env vars are ignored"
+                    "khive config [[engines]] present; KHIVE_EMBEDDING_MODEL / \
+                     KHIVE_ADDITIONAL_EMBEDDING_MODELS env vars are overridden"
                 );
             }
 
@@ -1379,6 +1380,48 @@ default = true
             "config file declares one engine; additional list must be empty (not the default's)"
         );
         assert_eq!(resolved.db_path, None, ":memory: must map to in-memory db");
+    }
+
+    /// Regression for #379: when the loaded config file has NO `[[engines]]`
+    /// block, `KHIVE_EMBEDDING_MODEL` is genuinely used as the fallback — it
+    /// must resolve into `RuntimeConfig::embedding_model`, not be discarded.
+    /// The startup warning must not fire in this case either (the env pair is
+    /// applied, not overridden) — see the `resolve_config` fix.
+    #[test]
+    #[serial]
+    fn resolver_falls_back_to_env_when_config_has_no_engines() {
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        std::env::set_var("KHIVE_EMBEDDING_MODEL", "bge-small-en-v1.5");
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Config file present, but with no [[engines]] block at all.
+        let path = write_config(
+            dir.path(),
+            r#"
+[runtime]
+brain_profile = "unrelated"
+"#,
+        );
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(":memory:"),
+            config: Some(&path),
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve config");
+
+        std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+
+        assert_eq!(
+            format!("{:?}", resolved.embedding_model),
+            "Some(BgeSmallEnV15)",
+            "KHIVE_EMBEDDING_MODEL must be applied as the fallback when the \
+             config file has no [[engines]] block, not treated as ignored"
+        );
     }
 
     /// Regression for BLOCKER-1 (PR #52 codex review): project-toml brain_profile


### PR DESCRIPTION
## Summary

Closes #379.

`resolve_config` in `crates/khive-mcp/src/serve.rs` warned that `KHIVE_EMBEDDING_MODEL` / `KHIVE_ADDITIONAL_EMBEDDING_MODELS` were "ignored" any time a config file was loaded and either env var was set — regardless of whether the config file actually declared a `[[engines]]` block.

When the loaded config has **no** `[[engines]]` block, `runtime_config_from_khive_config` returns the base `RuntimeConfig` unchanged (see `crates/khive-runtime/src/config.rs`), which already carries the env-derived embedding model. In that case the env pair is the genuine fallback, not something being discarded — so the "ignored" warning was factually wrong and would mislead anyone debugging why their env-configured model wasn't taking effect (it was).

The fix narrows the warning to fire only when the config **does** declare `[[engines]]` (the case that actually overrides the env pair), and rewords it from "ignored" to "overridden" to describe what happens.

- Documented precedence (config `[[engines]]` > env pair) is unchanged.
- No change to `runtime_config_from_khive_config`, `RuntimeConfig::default`, or embedding resolution logic — diagnostic-only, behavior-preserving.

## Test plan

- [x] Added `resolver_falls_back_to_env_when_config_has_no_engines` (`crates/khive-mcp/src/serve.rs`) — asserts that with a config file containing no `[[engines]]` block and `KHIVE_EMBEDDING_MODEL=bge-small-en-v1.5` set, the resolved `RuntimeConfig::embedding_model` is `Some(BgeSmallEnV15)`, locking in the fallback behavior the old warning mischaracterized.
- [x] `cargo fmt -p khive-mcp`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-mcp --all-targets -- -D warnings`
- [x] `cargo test -p khive-mcp` (107 passed, including the new regression test)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)