### PR TITLE
fix(kkernel): default `kkernel exec` presentation to verbose (ADR-045 §2) (#383)

### DIFF
--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -114,8 +114,14 @@ pub struct ExecArgs {
     #[arg(long, default_value = "local")]
     pub namespace: String,
 
-    /// Presentation mode: `agent` (default), `verbose`, or `human`.
-    #[arg(long)]
+    /// Presentation mode: `verbose` (default), `agent`, or `human`.
+    ///
+    /// ADR-045 §2 selection rules: the `kkernel exec` CLI surface (a trusted
+    /// operator / scripted-caller path) defaults to `Verbose` — the full
+    /// canonical shape — unlike the MCP `request` tool, which defaults to
+    /// `Agent` for token efficiency. Pass `--presentation agent` to opt into
+    /// the trimmed shape, or `--presentation human` for pretty terminal output.
+    #[arg(long, default_value = "verbose")]
     pub presentation: Option<String>,
 
     /// Output format for verb results (ADR-078 §2 precedence: this flag >
@@ -596,6 +602,30 @@ mod tests {
         let args = ExecArgs::parse_from(["exec", "stats()"]);
         assert_eq!(args.ops.as_deref(), Some("stats()"));
         assert!(!args.pending_events);
+    }
+
+    // ── ADR-045 §2: `kkernel exec` CLI surface defaults to Verbose ────────────
+
+    #[test]
+    fn presentation_defaults_to_verbose_when_flag_omitted() {
+        // ADR-045 §2 selection rules: `kkernel exec` (a scripted/operator
+        // surface) defaults to Verbose, unlike the MCP `request` tool (which
+        // defaults to Agent at the envelope layer — see
+        // `khive_mcp::server::parse_presentation_mode`, unchanged by this test).
+        let args = ExecArgs::parse_from(["exec", "stats()"]);
+        assert_eq!(args.presentation.as_deref(), Some("verbose"));
+    }
+
+    #[test]
+    fn presentation_agent_flag_still_selects_agent() {
+        let args = ExecArgs::parse_from(["exec", "stats()", "--presentation", "agent"]);
+        assert_eq!(args.presentation.as_deref(), Some("agent"));
+    }
+
+    #[test]
+    fn presentation_human_flag_still_selects_human() {
+        let args = ExecArgs::parse_from(["exec", "stats()", "--presentation", "human"]);
+        assert_eq!(args.presentation.as_deref(), Some("human"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #383.

ADR-045 §2's selection-rules table specifies that the `kkernel exec` CLI surface
(a trusted operator / scripted-caller path) defaults to **Verbose** — the full
canonical shape — so scripted/operator callers get a stable, round-trippable
response. The shipped `ExecArgs::presentation` field had no clap `default_value`,
so omitting `--presentation` resolved to `None`, which
`khive_mcp::server::parse_presentation_mode` maps to `Agent` (token-trimmed) —
the opposite of the ADR-045 §2 contract for this surface.

- Added `default_value = "verbose"` to the `#[arg(long)]` on
  `ExecArgs::presentation` in `crates/kkernel/src/exec.rs`, so omitting the flag
  now yields `Some("verbose")` from clap instead of `None`. Updated the
  doc-comment (was: `agent (default)` → now `verbose (default)`).
  `--presentation agent` and `--presentation human` still override as before.

## Scope guard (unchanged by design)

The MCP `request`-tool wire's `None -> Agent` default in
`crates/khive-mcp/src/server.rs` (`parse_presentation_mode`) is **intentionally
untouched** — ADR-045 §2 row 1 specifies `Agent` as the MCP surface default.

The existing test `ops_file_applies_ops_and_summary_matches` (and two others)
construct `RequestParams { presentation: None, .. }` directly and dispatch
through `dispatch_request_local`, exercising that envelope-level `None -> Agent`
mapping rather than the CLI flag default. These are still correct and were left
as-is.

## Test plan

- [x] `cargo fmt -p kkernel` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p kkernel --all-targets -- -D warnings` — clean
- [x] `cargo test -p kkernel` — 153 passed (lib) + 2 (bin) + 2 (integration), 0 failed
- [x] New regression tests added in `crates/kkernel/src/exec.rs`:
  - `presentation_defaults_to_verbose_when_flag_omitted`
  - `presentation_agent_flag_still_selects_agent`
  - `presentation_human_flag_still_selects_human`
- [x] Confirmed no other `kkernel exec` caller/test asserts a trimmed/Agent-shaped
      default output (Verbose is a superset shape; the Python smoke test drives
      the MCP `request` tool, not `kkernel exec`, so it is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)