### PR TITLE
chore(release): 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-07-01
+
+### Added
+
+- Email channel transport (ADR-056): SMTP/IMAP adapter, app-only OAuth2
+  (XOAUTH2) authentication, an outbound delivery loop with `Message-ID` and
+  reply-to-actor routing, and an inbound round-trip (greeting, maintainer
+  match, reply correlation).
+- Session pack `khive-pack-session` (ADR-080): OSS session storage with a live
+  daemon mirror of Claude Code sessions and Codex CLI transcript mirroring.
+- Brain router seam: feature-gated lattice-fann router (M1), a
+  `brain.register_adapter` integrity verb, `build_context_vector` reading live
+  posteriors, and `router_state`/`adapter_set` snapshot persistence.
+- ANN persistence (ADR-079): persist and warm-load v2 ANN segments so the
+  daemon warm window is bounded by load cost rather than a full rebuild; ANN
+  warming degrades to FTS-only instead of erroring.
+- Output-format axis (ADR-078): `OutputFormat` (`json` / `auto` / `table`) with
+  shape-aware rendering, orthogonal to presentation mode.
+- Batch `create_many` for bulk entity creation; optional `entity_type` on
+  `neighbors` and properties on `traverse`; property/tag filters on note search.
+- Pack core-backend accessor (ADR-073) and a `SubstrateCoordinator`
+  cross-backend link with federated search (ADR-029 Phase 2).
+
+### Changed
+
+- `kkernel exec` now defaults to `Verbose` presentation per ADR-045 §2 (the
+  scripted / operator surface); the MCP `request` tool keeps the `Agent`
+  default.
+- Subhandler verbs are gated by wire origin rather than globally.
+- Traverse performance: a recursive-CTE join-order fix yields a large speedup,
+  and graph-traversal queries are batched to remove N+1 lookups.
+- Namespace model (ADR-007 Rev 6): attribution-only namespaces, a per-actor
+  episodic memory carve-out, and namespace-blind by-ID storage.
+
+### Fixed
+
+- `knowledge`: `compose` reads resolved section posteriors; recall never
+  returns a silent empty result while the ANN index is warming; a poisoned
+  warming mutex is recovered instead of aborting the server.
+- `retrieval`: property/tag predicates are pushed below result truncation.
+- `runtime`: char-boundary-safe secret gate (no UTF-8/CJK panic); the
+  configured actor is threaded into the gate request.
+- `comm`: actor-addressed delivery (ADR-057) fixes cross-actor messaging; an
+  anonymous inbox read leak is closed.
+- `mcp`: the embedding-env warning fires only when a `[[engines]]` block
+  overrides the `KHIVE_EMBEDDING_MODEL` / `KHIVE_ADDITIONAL_EMBEDDING_MODELS`
+  pair, not when that pair is the applied fallback.
+- Storage hardening: WAL-checkpoint discipline, BM25 poisoned-lock recovery,
+  and `expires_at` honored in recall with `memory.prune` / `memory.vacuum`.
+
+### Docs
+
+- Per-crate READMEs, a crate-README template, and a full configuration
+  reference.
+- Stale `kkernel call` references replaced with `kkernel exec`.
+- New and updated ADRs: 067/068 (cloud topology), 069/072 (Subject model), 073,
+  074, 075, 076 (relation-set calculability), 078, 079, and 080.
+
 ## [0.2.11] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Deno 2.x (for the TypeScript CLI layer — optional)
 
 ## Status
 
-**v0.2.11 — published on [crates.io](https://crates.io/crates/khive-mcp).** 67 verbs across 7
+**v0.2.12 — published on [crates.io](https://crates.io/crates/khive-mcp).** 67 verbs across 7
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -45,7 +45,7 @@ exclude = ["khive-merge"]
 # keep this exclusion from members.
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 
 [dependencies]
-khive-score = { version = "0.2.11", path = "../khive-score" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Brain primitives — Beta posteriors, section types, profile state, weight derivation"
 
 [dependencies]
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Email (SMTP/IMAP) channel adapter for khive (ADR-056)"
 
 [dependencies]
-khive-channel = { version = "0.2.11", path = "../khive-channel" }
+khive-channel = { version = "0.2.12", path = "../khive-channel" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "SQLite storage backend: entities, edges, notes, events, FTS5, sqlite-vec vectors."
 
 [dependencies]
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -32,8 +32,8 @@ sqlite-vec = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
 uuid = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -17,10 +17,10 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-score = { version = "0.2.11", path = "../khive-score" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
 # ADR-024 boundary: khive-types + khive-score only.
 # blake3 feature enables Hash32::from_blake3 for checkpoint hashing.
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["blake3", "serde"] }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["blake3", "serde"] }
 # serde: optional, gated by the `serde` feature above.
 serde = { workspace = true, optional = true }
 # serde_json: kept direct — serde_json::Value is used in FoldContext.extra,

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic scoring"
 
 [dependencies]
-khive-score = { version = "0.2.11", path = "../khive-score" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -12,11 +12,11 @@ description = "Rego (Open Policy Agent) backend for khive-gate, powered by regor
 readme = "README.md"
 
 [dependencies]
-khive-gate = { version = "0.2.11", path = "../khive-gate" }
+khive-gate = { version = "0.2.12", path = "../khive-gate" }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
 regorus = { workspace = true }
 
 [dev-dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Pluggable authorization gate trait + default AllowAllGate impl for khive verb dispatch."
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 quantized two-phase search"
 
 [dependencies]
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-fold = { version = "0.2.11", path = "../khive-fold", optional = true }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-fold = { version = "0.2.12", path = "../khive-fold", optional = true }
 lattice-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -11,18 +11,18 @@ categories.workspace = true
 description = "khive MCP server library — served via the kkernel binary"
 
 [dependencies]
-khive-db = { version = "0.2.11", path = "../khive-db" }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-request = { version = "0.2.11", path = "../khive-request" }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.2.11", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.2.11", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.2.11", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.2.11", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.2.11", path = "../khive-pack-schedule" }
-khive-pack-knowledge = { version = "0.2.11", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.2.11", path = "../khive-pack-session" }
+khive-db = { version = "0.2.12", path = "../khive-db" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-request = { version = "0.2.12", path = "../khive-request" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.2.12", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.2.12", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.2.12", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.2.12", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.2.12", path = "../khive-pack-schedule" }
+khive-pack-knowledge = { version = "0.2.12", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.2.12", path = "../khive-pack-session" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
@@ -39,8 +39,8 @@ libc = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
-khive-channel = { version = "0.2.11", path = "../khive-channel", optional = true }
-khive-channel-email = { version = "0.2.11", path = "../khive-channel-email", optional = true }
+khive-channel = { version = "0.2.12", path = "../khive-channel", optional = true }
+khive-channel-email = { version = "0.2.12", path = "../khive-channel-email", optional = true }
 
 [features]
 # bench-embedder: inject deterministic FNV-1a hash embedder into the serve path.
@@ -53,9 +53,9 @@ channel-email = ["khive-channel", "khive-channel-email"]
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
-khive-types = { version = "0.2.11", path = "../khive-types" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
 async-trait = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }
-khive-pack-knowledge = { version = "0.2.11", path = "../khive-pack-knowledge" }
+khive-pack-knowledge = { version = "0.2.12", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-merge/Cargo.toml
+++ b/crates/khive-merge/Cargo.toml
@@ -5,7 +5,7 @@
 # [workspace.package] below declares the shared version for this standalone workspace.
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 
 [package]
 name = "khive-merge"
@@ -18,8 +18,8 @@ homepage = "https://github.com/ohdearquant"
 description = "KG three-way merge with conflict detection (ADR-039)"
 
 [dependencies]
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 description = "Brain pack — profile-oriented orchestration via Fold + Objective (ADR-032)"
 
 [dependencies]
-khive-brain-core = { version = "0.2.11", path = "../khive-brain-core" }
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-fold = { version = "0.2.11", path = "../khive-fold" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-brain-core = { version = "0.2.12", path = "../khive-brain-core" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-fold = { version = "0.2.12", path = "../khive-fold" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 lattice-fann = { workspace = true, optional = true }
@@ -30,7 +30,7 @@ lattice-router = ["dep:lattice-fann"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "Communication pack — inter-agent messaging (send, inbox, read, reply, thread) (ADR-040)"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -24,11 +24,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
-khive-db = { version = "0.2.11", path = "../khive-db" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
+khive-db = { version = "0.2.12", path = "../khive-db" }
 criterion = { workspace = true }
 toml = { workspace = true }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime", features = ["fault-injection"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "Formal-math ontology pack — typed edge rules for theorem/definition/structure/instance/axiom/goal subtypes"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "GTD verb pack — task lifecycle (assign/next/complete/transition) over the notes substrate"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search for research knowledge graphs"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-query = { version = "0.2.11", path = "../khive-query" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-query = { version = "0.2.12", path = "../khive-query" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -27,7 +27,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-khive-pack-formal = { version = "0.2.11", path = "../khive-pack-formal" }
+khive-pack-formal = { version = "0.2.12", path = "../khive-pack-formal" }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -11,14 +11,14 @@ categories.workspace = true
 description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retrieval, concept registration"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-brain-core = { version = "0.2.11", path = "../khive-brain-core" }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-fold = { version = "0.2.11", path = "../khive-fold" }
-khive-fusion = { version = "0.2.11", path = "../khive-fusion" }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-vamana = { version = "0.2.11", path = "../khive-vamana" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-brain-core = { version = "0.2.12", path = "../khive-brain-core" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-fold = { version = "0.2.12", path = "../khive-fold" }
+khive-fusion = { version = "0.2.12", path = "../khive-fusion" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-vamana = { version = "0.2.12", path = "../khive-vamana" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -30,9 +30,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.2.11", path = "../khive-pack-brain" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.2.12", path = "../khive-pack-brain" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 criterion = { workspace = true }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 description = "Memory verb pack — remember/recall semantics with decay-aware ranking"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-fusion = { version = "0.2.11", path = "../khive-fusion" }
-khive-retrieval = { version = "0.2.11", path = "../khive-retrieval" }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-brain-core = { version = "0.2.11", path = "../khive-brain-core" }
-khive-vamana = { version = "0.2.11", path = "../khive-vamana" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-fusion = { version = "0.2.12", path = "../khive-fusion" }
+khive-retrieval = { version = "0.2.12", path = "../khive-retrieval" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-brain-core = { version = "0.2.12", path = "../khive-brain-core" }
+khive-vamana = { version = "0.2.12", path = "../khive-vamana" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -31,9 +31,9 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-khive-db = { version = "0.2.11", path = "../khive-db" }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
-khive-pack-brain = { version = "0.2.11", path = "../khive-pack-brain" }
+khive-db = { version = "0.2.12", path = "../khive-db" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
+khive-pack-brain = { version = "0.2.12", path = "../khive-pack-brain" }
 tokio = { workspace = true, features = ["test-util"] }
 lattice-embed = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "Schedule pack — time-triggered intent storage (remind, schedule, agenda, cancel) (ADR-040)"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-request = { version = "0.2.11", path = "../khive-request" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-request = { version = "0.2.12", path = "../khive-request" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 description = "Session verb pack — store/list/get over the notes substrate (ADR-080)"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
 inventory = { workspace = true }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -25,5 +25,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
 tempfile = { workspace = true }

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 description = "Reference template for new khive packs (ADR-023 §8). Copy this crate to get a working pack scaffold."
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
 inventory = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "GQL and SPARQL parsers with SQL compiler for knowledge graph queries."
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-encoder) with deterministic scoring"
 
 [dependencies]
-khive-hnsw    = { version = "0.2.11", path = "../khive-hnsw" }
-khive-bm25    = { version = "0.2.11", path = "../khive-bm25" }
-khive-fusion  = { version = "0.2.11", path = "../khive-fusion" }
-khive-score   = { version = "0.2.11", path = "../khive-score" }
-khive-types   = { version = "0.2.11", path = "../khive-types" }
-khive-fold    = { version = "0.2.11", path = "../khive-fold", optional = true }
-khive-storage = { version = "0.2.11", path = "../khive-storage", optional = true }
-khive-db      = { version = "0.2.11", path = "../khive-db" }
-khive-gate    = { version = "0.2.11", path = "../khive-gate", optional = true }
+khive-hnsw    = { version = "0.2.12", path = "../khive-hnsw" }
+khive-bm25    = { version = "0.2.12", path = "../khive-bm25" }
+khive-fusion  = { version = "0.2.12", path = "../khive-fusion" }
+khive-score   = { version = "0.2.12", path = "../khive-score" }
+khive-types   = { version = "0.2.12", path = "../khive-types" }
+khive-fold    = { version = "0.2.12", path = "../khive-fold", optional = true }
+khive-storage = { version = "0.2.12", path = "../khive-storage", optional = true }
+khive-db      = { version = "0.2.12", path = "../khive-db" }
+khive-gate    = { version = "0.2.12", path = "../khive-gate", optional = true }
 lattice-embed = { workspace = true }
 
 serde = { workspace = true }
@@ -58,8 +58,8 @@ embed = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-fusion = { version = "0.2.11", path = "../khive-fusion" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-fusion = { version = "0.2.12", path = "../khive-fusion" }
 
 [[bench]]
 name = "fusion_bench"

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -14,14 +14,14 @@ description = "Composable Service API: entity/note CRUD, graph traversal, hybrid
 fault-injection = []
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-fusion = { version = "0.2.11", path = "../khive-fusion" }
-khive-fold = { version = "0.2.11", path = "../khive-fold" }
-khive-db = { version = "0.2.11", path = "../khive-db", features = ["vectors"] }
-khive-query = { version = "0.2.11", path = "../khive-query" }
-khive-gate = { version = "0.2.11", path = "../khive-gate" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-fusion = { version = "0.2.12", path = "../khive-fusion" }
+khive-fold = { version = "0.2.12", path = "../khive-fold" }
+khive-db = { version = "0.2.12", path = "../khive-db", features = ["vectors"] }
+khive-query = { version = "0.2.12", path = "../khive-query" }
+khive-gate = { version = "0.2.12", path = "../khive-gate" }
 inventory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
@@ -39,7 +39,7 @@ libc = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-khive-gate-rego = { version = "0.2.11", path = "../khive-gate-rego" }
+khive-gate-rego = { version = "0.2.12", path = "../khive-gate-rego" }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -14,7 +14,7 @@ default = ["serde"]
 serde = ["dep:serde"]
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-types = { version = "0.2.11", path = "../khive-types", features = ["serde"] }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-types = { version = "0.2.12", path = "../khive-types", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "KG import/export format adapters — CSV, JSON, and future format support (ADR-036)"
 
 [dependencies]
-khive-types = { version = "0.2.11", path = "../khive-types" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -9,9 +9,9 @@ homepage.workspace = true
 description = "KG versioning — git-native core types, canonical hash, and NDJSON-to-SQLite sync (ADR-010/ADR-020)"
 
 [dependencies]
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-types = { version = "0.2.11", path = "../khive-types" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -25,4 +25,4 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
-khive-vcs-adapters = { version = "0.2.11", path = "../khive-vcs-adapters" }
+khive-vcs-adapters = { version = "0.2.12", path = "../khive-vcs-adapters" }

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -11,24 +11,24 @@ categories.workspace = true
 description = "khive kernel — stdio MCP server binary and admin CLI (sync, pack introspection, db ops)"
 
 [dependencies]
-khive-runtime = { version = "0.2.11", path = "../khive-runtime" }
-khive-mcp = { version = "0.2.11", path = "../khive-mcp" }
-khive-score = { version = "0.2.11", path = "../khive-score" }
-khive-db = { version = "0.2.11", path = "../khive-db" }
-khive-storage = { version = "0.2.11", path = "../khive-storage" }
-khive-types = { version = "0.2.11", path = "../khive-types" }
-khive-vcs = { version = "0.2.11", path = "../khive-vcs" }
-khive-vcs-adapters = { version = "0.2.11", path = "../khive-vcs-adapters" }
-khive-pack-kg = { version = "0.2.11", path = "../khive-pack-kg" }
-khive-pack-gtd = { version = "0.2.11", path = "../khive-pack-gtd" }
-khive-pack-memory = { version = "0.2.11", path = "../khive-pack-memory" }
-khive-pack-brain = { version = "0.2.11", path = "../khive-pack-brain" }
-khive-pack-comm = { version = "0.2.11", path = "../khive-pack-comm" }
-khive-pack-schedule = { version = "0.2.11", path = "../khive-pack-schedule" }
-khive-pack-formal = { version = "0.2.11", path = "../khive-pack-formal" }
-khive-pack-knowledge = { version = "0.2.11", path = "../khive-pack-knowledge" }
-khive-pack-session = { version = "0.2.11", path = "../khive-pack-session" }
-khive-request = { version = "0.2.11", path = "../khive-request" }
+khive-runtime = { version = "0.2.12", path = "../khive-runtime" }
+khive-mcp = { version = "0.2.12", path = "../khive-mcp" }
+khive-score = { version = "0.2.12", path = "../khive-score" }
+khive-db = { version = "0.2.12", path = "../khive-db" }
+khive-storage = { version = "0.2.12", path = "../khive-storage" }
+khive-types = { version = "0.2.12", path = "../khive-types" }
+khive-vcs = { version = "0.2.12", path = "../khive-vcs" }
+khive-vcs-adapters = { version = "0.2.12", path = "../khive-vcs-adapters" }
+khive-pack-kg = { version = "0.2.12", path = "../khive-pack-kg" }
+khive-pack-gtd = { version = "0.2.12", path = "../khive-pack-gtd" }
+khive-pack-memory = { version = "0.2.12", path = "../khive-pack-memory" }
+khive-pack-brain = { version = "0.2.12", path = "../khive-pack-brain" }
+khive-pack-comm = { version = "0.2.12", path = "../khive-pack-comm" }
+khive-pack-schedule = { version = "0.2.12", path = "../khive-pack-schedule" }
+khive-pack-formal = { version = "0.2.12", path = "../khive-pack-formal" }
+khive-pack-knowledge = { version = "0.2.12", path = "../khive-pack-knowledge" }
+khive-pack-session = { version = "0.2.12", path = "../khive-pack-session" }
+khive-request = { version = "0.2.12", path = "../khive-request" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.2.11  | ≥ 0.2.4 |
+| khive  | 0.2.12  | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "khive",
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "author": {
     "name": "Ocean (HaiyangLi)",
     "url": "https://github.com/ohdearquant"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khive",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Research knowledge graph runtime over MCP stdio, with typed entities, closed ontology, and hybrid search for AI research agents.",
   "license": "Apache-2.0",
   "repository": {
@@ -35,11 +35,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@khive-ai/kernel-darwin-arm64": "0.2.11",
-    "@khive-ai/kernel-darwin-x64": "0.2.11",
-    "@khive-ai/kernel-linux-x64-gnu": "0.2.11",
-    "@khive-ai/kernel-linux-x64-musl": "0.2.11",
-    "@khive-ai/kernel-linux-arm64": "0.2.11",
-    "@khive-ai/kernel-win32-x64": "0.2.11"
+    "@khive-ai/kernel-darwin-arm64": "0.2.12",
+    "@khive-ai/kernel-darwin-x64": "0.2.12",
+    "@khive-ai/kernel-linux-x64-gnu": "0.2.12",
+    "@khive-ai/kernel-linux-x64-musl": "0.2.12",
+    "@khive-ai/kernel-linux-arm64": "0.2.12",
+    "@khive-ai/kernel-win32-x64": "0.2.12"
   }
 }


### PR DESCRIPTION
Release 0.2.12. Bumps all crate and distribution versions `0.2.11` → `0.2.12`
and adds the 0.2.12 CHANGELOG entry.

This release captures the work merged since the `v0.2.11` tag (2026-06-13):

- **Email channel transport** (ADR-056): SMTP/IMAP adapter, app-only OAuth2 (XOAUTH2), outbound delivery with `Message-ID` + reply-to-actor routing, inbound round-trip.
- **Session pack** `khive-pack-session` (ADR-080): OSS session storage + live daemon mirror of Claude Code sessions, plus Codex CLI transcript mirroring.
- **Brain router seam**: feature-gated lattice-fann router (M1), `brain.register_adapter`, live-posterior `build_context_vector`, snapshot persistence.
- **ANN persistence** (ADR-079): persist + warm-load v2 ANN segments; FTS-only degrade path.
- **Output-format axis** (ADR-078) and a large docs/ADR wave (per-crate READMEs, ADR-067/068/069/072/073/074/075/076/078/079/080).

Full detail in `CHANGELOG.md`.

**Merge order:** published to crates.io from this branch first, then merged, then tagged `v0.2.12` on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)