### PR TITLE
fix(db): sanitize FTS5 $ metachar and fail-open on FTS search errors

### DIFF
--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -196,8 +196,11 @@ fn micros_to_dt(micros: i64) -> DateTime<Utc> {
 /// 1. **Replace** grouping/separator chars with spaces so adjacent tokens are
 ///    not merged. This prevents `NEAR(smile,5)` from becoming `NEARsmile5`.
 ///    Chars replaced with space: `(`, `)`, `,`
-/// 2. **Remove** remaining FTS5 operator characters (H1: `~`, `!` added):
-///    `*`, `"`, `+`, `-`, `:`, `^`, `.`, `~`, `!`, `\0`, control characters
+/// 2. **Remove** remaining FTS5 operator characters (H1: `~`, `!` added;
+///    issue #388: `$` added — FTS5's MATCH-expression parser treats a bareword
+///    starting with, containing, or consisting solely of `$` as a syntax
+///    error regardless of tokenizer, e.g. the DSL-doc query `$prev.id`):
+///    `*`, `"`, `+`, `-`, `:`, `^`, `.`, `~`, `!`, `$`, `\0`, control characters
 ///
 /// After character processing, split on whitespace and remove FTS5 keyword
 /// tokens: AND, OR, NOT, NEAR.
@@ -221,12 +224,15 @@ fn sanitize_fts5_query(query: &str) -> String {
     // Pass 2: remove remaining FTS5 special chars and control characters.
     // Single quote (apostrophe) is included because FTS5 Plain-mode queries treat
     // it as a string-literal delimiter causing "syntax error near '''".
+    // Dollar sign is included (#388) because FTS5's MATCH parser rejects it
+    // unconditionally — `syntax error near "$"` — wherever it appears in the
+    // expression, e.g. "$prev.id" (a common agent query for DSL docs).
     let sanitized: String = spaced
         .chars()
         .filter(|c| {
             !matches!(
                 c,
-                '*' | '"' | '\'' | '+' | '-' | '^' | '.' | '~' | '!' | '\0'
+                '*' | '"' | '\'' | '+' | '-' | '^' | '.' | '~' | '!' | '$' | '\0'
             ) && !c.is_control()
         })
         .collect();

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -439,6 +439,13 @@ async fn test_sanitize_fts5_query() {
     assert_eq!(sanitize_fts5_query("   "), "");
     // operator-only after stripping becomes empty
     assert_eq!(sanitize_fts5_query("AND OR NOT"), "");
+    // #388: dollar sign is an unconditional FTS5 MATCH-parser syntax error
+    // ("syntax error near \"$\"") regardless of position in the token or query.
+    assert_eq!(sanitize_fts5_query("$prev.id"), "previd");
+    assert_eq!(sanitize_fts5_query("$prev"), "prev");
+    assert_eq!(sanitize_fts5_query("foo$bar"), "foobar");
+    assert_eq!(sanitize_fts5_query("$"), "");
+    assert_eq!(sanitize_fts5_query("$$"), "");
 }
 
 /// H1 regression: queries with tilde (~) must not produce "fts5: syntax error near '~'".
@@ -593,6 +600,135 @@ async fn test_search_with_fts_operator_matrix_does_not_crash() {
             result.err()
         );
     }
+}
+
+/// #388 regression: a bareword `$` query (e.g. the DSL doc query `$prev.id`) must not
+/// crash the FTS5 leg. Previously `$` was untouched by `sanitize_fts5_query`, so it
+/// reached FTS5 raw and produced `fts5: syntax error near "$"`, aborting the whole
+/// search instead of degrading.
+#[tokio::test]
+async fn test_search_with_dollar_sign_does_not_crash() {
+    let store = setup_memory_store("dollar_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "DSL docs",
+            "chain results with the previd token",
+        ))
+        .await
+        .unwrap();
+
+    let result = store
+        .search(TextSearchRequest {
+            query: "$prev.id".to_string(),
+            mode: TextQueryMode::Plain,
+            filter: Some(ns_filter("test_ns")),
+            top_k: 10,
+            snippet_chars: 64,
+        })
+        .await;
+    assert!(
+        result.is_ok(),
+        "#388 dollar-sign query must not crash FTS5, got: {:?}",
+        result.err()
+    );
+    // sanitize_fts5_query("$prev.id") == "previd" (both '$' and '.' stripped, no
+    // space inserted) — it still matches a document containing that literal token,
+    // confirming legitimate text search stays intact after sanitization.
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+/// #388 regression: a bareword query consisting solely of `$` sanitizes to an empty
+/// match expression. `search()` must short-circuit to an empty result set rather than
+/// sending an empty/invalid MATCH string to FTS5.
+#[tokio::test]
+async fn test_search_with_bare_dollar_returns_empty_not_error() {
+    let store = setup_memory_store("bare_dollar_query");
+
+    store
+        .upsert_document(make_document(Uuid::new_v4(), "doc", "some content"))
+        .await
+        .unwrap();
+
+    let result = store
+        .search(TextSearchRequest {
+            query: "$".to_string(),
+            mode: TextQueryMode::Plain,
+            filter: Some(ns_filter("test_ns")),
+            top_k: 10,
+            snippet_chars: 64,
+        })
+        .await;
+    assert!(
+        result.is_ok(),
+        "#388 bare-$ query must not crash FTS5, got: {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().is_empty());
+}
+
+/// #388 regression: `$` combined with an embedded quote must not crash the FTS5 leg
+/// either, exercising both the apostrophe (#570) and dollar-sign (#388) fixes together.
+#[tokio::test]
+async fn test_search_with_dollar_and_quote_does_not_crash() {
+    let store = setup_memory_store("dollar_quote_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "mixed",
+            "operator syntax reference content",
+        ))
+        .await
+        .unwrap();
+
+    let result = store
+        .search(TextSearchRequest {
+            query: "$prev \"operator syntax\"".to_string(),
+            mode: TextQueryMode::Plain,
+            filter: Some(ns_filter("test_ns")),
+            top_k: 10,
+            snippet_chars: 64,
+        })
+        .await;
+    assert!(
+        result.is_ok(),
+        "#388 dollar+quote query must not crash FTS5, got: {:?}",
+        result.err()
+    );
+}
+
+/// #388 regression: `AnyTerm` mode (used by memory.recall fanout) must also survive a
+/// `$`-bearing query — this mode sanitizes each term independently before joining with OR.
+#[tokio::test]
+async fn test_search_any_term_mode_with_dollar_does_not_crash() {
+    let store = setup_memory_store("dollar_any_term_query");
+
+    store
+        .upsert_document(make_document(
+            Uuid::new_v4(),
+            "DSL docs",
+            "chain results with prev id",
+        ))
+        .await
+        .unwrap();
+
+    let result = store
+        .search(TextSearchRequest {
+            query: "$prev id".to_string(),
+            mode: TextQueryMode::AnyTerm,
+            filter: Some(ns_filter("test_ns")),
+            top_k: 10,
+            snippet_chars: 64,
+        })
+        .await;
+    assert!(
+        result.is_ok(),
+        "#388 AnyTerm dollar query must not crash FTS5, got: {:?}",
+        result.err()
+    );
+    assert_eq!(result.unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1031,4 +1031,58 @@ mod tests {
              got {hits:?}"
         );
     }
+
+    /// PR #389 codex round-1 High-1 regression: `search(kind="note", ...)` must
+    /// not hard-fail on a residual FTS5 metacharacter.
+    ///
+    /// `sanitize_fts5_query` (khive-db) strips known-unsafe characters like `$`,
+    /// but by design stays minimal — it does not strip every character SQLite
+    /// FTS5's bareword parser rejects. `@` is one of 17 residual characters codex
+    /// round 1 found still crash the parser. Before this fix, `search_notes`
+    /// (khive-runtime/operations.rs) propagated that FTS error with `.await?`,
+    /// so `search(kind="note")` aborted instead of degrading to vector-only
+    /// results — unlike the entity branch and `memory.recall`, which already
+    /// fail open. This exercises the fix end to end through verb dispatch.
+    #[tokio::test]
+    async fn handler_search_note_residual_fts5_char_does_not_error() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let tok = rt.authorize(Namespace::local()).unwrap();
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+        let pack = KgPack::new(rt.clone());
+
+        pack.dispatch(
+            "create",
+            json!({
+                "kind": "observation",
+                "content": "use foo@bar to chain calls"
+            }),
+            &registry,
+            &tok,
+        )
+        .await
+        .expect("note create must succeed");
+
+        let result = pack
+            .dispatch(
+                "search",
+                json!({
+                    "kind": "note",
+                    "query": "foo@bar",
+                    "limit": 10
+                }),
+                &registry,
+                &tok,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#389 search(kind=\"note\") must not hard-fail on a residual FTS5 char ('@'), \
+             got: {:?}",
+            result.err()
+        );
+    }
 }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -571,7 +571,12 @@ impl MemoryPack {
         let t_fts = if prof { Some(Instant::now()) } else { None };
         let searcher = self.runtime.text_for_notes(token)?;
 
-        let hits = if fts_gather.enabled {
+        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
+        // runtime (anything sanitization misses), degrade to an empty candidate set
+        // instead of aborting the whole memory.recall (the vector leg runs
+        // independently in collect_recall_candidates and still contributes).
+        let fts_result: Result<Vec<TextSearchHit>, RuntimeError> = if fts_gather.enabled {
             crate::text_gather::collect_text_hits(
                 searcher.as_ref(),
                 query,
@@ -582,9 +587,9 @@ impl MemoryPack {
                 fts_gather,
                 &terms,
             )
-            .await?
+            .await
         } else {
-            let mut h = searcher
+            searcher
                 .search(TextSearchRequest {
                     query: terms.join(" "),
                     mode: TextQueryMode::AnyTerm,
@@ -596,10 +601,24 @@ impl MemoryPack {
                     top_k: candidate_limit,
                     snippet_chars: snippet_policy.snippet_chars(),
                 })
-                .await?;
-            h.sort_by_key(|h| h.rank);
-            h.truncate(candidate_limit as usize);
-            h
+                .await
+                .map_err(RuntimeError::from)
+        };
+
+        let hits = match fts_result {
+            Ok(mut h) => {
+                h.sort_by_key(|h| h.rank);
+                h.truncate(candidate_limit as usize);
+                h
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    query = %query,
+                    "collect_recall_text_hits: FTS leg failed, degrading to vector-only recall"
+                );
+                Vec::new()
+            }
         };
 
         if prof {

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -571,11 +571,27 @@ impl MemoryPack {
         let t_fts = if prof { Some(Instant::now()) } else { None };
         let searcher = self.runtime.text_for_notes(token)?;
 
-        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
-        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
-        // runtime (anything sanitization misses), degrade to an empty candidate set
-        // instead of aborting the whole memory.recall (the vector leg runs
-        // independently in collect_recall_candidates and still contributes).
+        // Fail-open on the FTS leg only, and only for FTS5 parser syntax errors
+        // (#388, #389 round-2 High): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors
+        // at runtime on residual punctuation the sanitizer does not strip,
+        // degrade to an empty candidate set instead of aborting the whole
+        // memory.recall (the vector leg runs independently in
+        // collect_recall_candidates and still contributes). A genuine backend
+        // outage (pool exhaustion, connection failure, etc.) is NOT a bad
+        // query and must propagate.
+        //
+        // Note: when `fts_gather.enabled`, `collect_text_hits` (text_gather.rs)
+        // already collapses every `StorageError` into `RuntimeError::Internal`
+        // via `.map_err(|e| RuntimeError::Internal(e.to_string()))` before this
+        // match ever sees it — the structured error is gone by the time it
+        // gets here, so it can never be classified as an FTS5 syntax error and
+        // always propagates in that branch. That is a pre-existing, separate
+        // information-loss issue in `collect_text_hits`, out of scope for this
+        // fix (which targets the four fail-open match arms named in #389 round
+        // 2, not `collect_text_hits`'s own `?`-propagation); it does not weaken
+        // this fix — it only means the gather-optimization path never degrades
+        // (always propagates), which is the safe direction.
         let fts_result: Result<Vec<TextSearchHit>, RuntimeError> = if fts_gather.enabled {
             crate::text_gather::collect_text_hits(
                 searcher.as_ref(),
@@ -611,14 +627,15 @@ impl MemoryPack {
                 h.truncate(candidate_limit as usize);
                 h
             }
-            Err(e) => {
+            Err(RuntimeError::Storage(ref se)) if se.is_fts5_syntax_error() => {
                 tracing::warn!(
-                    error = %e,
+                    error = %se,
                     query = %query,
-                    "collect_recall_text_hits: FTS leg failed, degrading to vector-only recall"
+                    "collect_recall_text_hits: FTS leg failed on a parser syntax error, degrading to vector-only recall"
                 );
                 Vec::new()
             }
+            Err(e) => return Err(e),
         };
 
         if prof {

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -587,19 +587,20 @@ impl MemoryPack {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
     use khive_pack_kg::KgPack;
-    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_runtime::{EmbedderProvider, KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
 
     use crate::MemoryPack;
 
-    /// #388 regression: the `memory.recall` verb must not hard-fail on a query
-    /// containing FTS5 metacharacters like `$` (e.g. the DSL doc query `$prev.id`).
-    /// `sanitize_fts5_query` (khive-db) now strips `$`, but this exercises the
-    /// full verb-dispatch path end to end: `collect_recall_text_hits`
-    /// (khive-pack-memory) degrades to an empty candidate set on any residual FTS
-    /// error instead of aborting the recall, and the in-memory runtime here has no
-    /// embedder registered, so the vector leg trivially contributes zero hits —
-    /// isolating the assertion to the FTS leg's fail-open behavior.
+    /// #388 regression (sanitizer path): `sanitize_fts5_query` (khive-db) strips
+    /// `$`, so this query no longer reaches the runtime-level fail-open `Err` arm
+    /// added in PR #389 — it exercises the *sanitizer*, not the fail-open net.
+    /// See `recall_with_residual_fts5_char_degrades_and_vector_leg_survives` below
+    /// for a test that forces the `Err` arm itself (PR #389 codex round-1 Medium).
     #[tokio::test]
     async fn recall_with_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -637,6 +638,138 @@ mod tests {
             result.is_ok(),
             "#388 memory.recall must not hard-fail on a '$'-bearing query, got: {:?}",
             result.err()
+        );
+    }
+
+    // Deterministic embedding service: distinct vector per unique text via FNV
+    // hash (copied from `pack.rs`'s `ann_route_tests` — not semantically
+    // meaningful, but reproducible: identical input text always yields an
+    // identical vector, which is all a cosine-similarity vector leg needs to
+    // prove it found the right note).
+    struct HashVecService {
+        dims: usize,
+    }
+
+    fn fnv_to_vec(text: &str, dims: usize) -> Vec<f32> {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in text.bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0001_0000_01b3);
+        }
+        let mut v = Vec::with_capacity(dims);
+        let mut s = h;
+        for _ in 0..dims {
+            s = s
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            v.push(((s >> 33) as f32) / (0x7fff_ffff_u32 as f32) - 1.0);
+        }
+        v
+    }
+
+    #[async_trait]
+    impl EmbeddingService for HashVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|t| fnv_to_vec(t, self.dims)).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "hash-vec"
+        }
+    }
+
+    struct HashVecProvider {
+        model_name: String,
+        dims: usize,
+    }
+
+    #[async_trait]
+    impl EmbedderProvider for HashVecProvider {
+        fn name(&self) -> &str {
+            &self.model_name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        async fn build(&self) -> Result<Arc<dyn EmbeddingService>, khive_runtime::RuntimeError> {
+            Ok(Arc::new(HashVecService { dims: self.dims }))
+        }
+    }
+
+    /// PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped
+    /// by `sanitize_fts5_query` (by design — the sanitizer stays minimal per
+    /// #388 scope; the fail-open net is the systematic answer for residual
+    /// punctuation). SQLite FTS5's bareword parser still rejects `@`
+    /// unconditionally, so this query reaches the `Err` arm added to
+    /// `collect_recall_text_hits` (khive-pack-memory/handlers/common.rs) and must
+    /// degrade to vector-only results rather than aborting the recall.
+    ///
+    /// Ties Medium to the codex round-1 High-2 finding: with a real (non-null)
+    /// embedder registered, this proves the vector leg still returns the
+    /// correct note while the FTS leg is degraded — i.e. degradation loses only
+    /// the FTS signal, not the overall recall. (This test does NOT assert an
+    /// `fts_degraded`/`partial` advisory field: `memory.recall`'s common-path
+    /// wire shape is a bare JSON array today, so adding such a field here would
+    /// be a breaking array-to-object shape change — reported separately as
+    /// blocked-on-shape, not fixed in this PR.)
+    #[tokio::test]
+    async fn recall_with_residual_fts5_char_degrades_and_vector_leg_survives() {
+        const MODEL: &str = "recall-residual-char-test-model";
+        const DIMS: usize = 32;
+        const NOTE_TEXT: &str = "foo@bar chain call helper note";
+
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        // embedding_model: None — create_note auto-detects the registered
+        // custom provider (resolve_embedding_model only handles lattice
+        // aliases; custom provider names go through the auto-detect path).
+        rt.create_note(&token, "memory", None, NOTE_TEXT, Some(0.7), None, vec![])
+            .await
+            .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        // Query text matches the note content exactly so the hash-vec embedder
+        // (which has no semantic notion of similarity) produces an identical
+        // vector for query and note, guaranteeing a vector-leg hit.
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": NOTE_TEXT,
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("#389 memory.recall must not hard-fail on a residual FTS5 char ('@')");
+
+        let hits = result
+            .as_array()
+            .expect("memory.recall common-path result is a bare JSON array");
+        assert!(
+            !hits.is_empty(),
+            "vector leg must still return the seeded note while the FTS leg is \
+             degraded by the residual FTS5 char ('@'), got empty results"
         );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -584,3 +584,59 @@ impl MemoryPack {
         to_json(&results)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use khive_pack_kg::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+
+    use crate::MemoryPack;
+
+    /// #388 regression: the `memory.recall` verb must not hard-fail on a query
+    /// containing FTS5 metacharacters like `$` (e.g. the DSL doc query `$prev.id`).
+    /// `sanitize_fts5_query` (khive-db) now strips `$`, but this exercises the
+    /// full verb-dispatch path end to end: `collect_recall_text_hits`
+    /// (khive-pack-memory) degrades to an empty candidate set on any residual FTS
+    /// error instead of aborting the recall, and the in-memory runtime here has no
+    /// embedder registered, so the vector leg trivially contributes zero hits —
+    /// isolating the assertion to the FTS leg's fail-open behavior.
+    #[tokio::test]
+    async fn recall_with_dollar_sign_query_does_not_error() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns).expect("authorize local");
+
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "use $prev.id to chain calls",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "$prev.id",
+                    "limit": 10
+                }),
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#388 memory.recall must not hard-fail on a '$'-bearing query, got: {:?}",
+            result.err()
+        );
+    }
+}

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -148,7 +148,12 @@ impl KhiveRuntime {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
         let ns = token.namespace().as_str().to_owned();
-        let text_hits = self
+        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
+        // runtime (anything sanitization misses), degrade to vector-only fusion
+        // instead of aborting the whole hybrid search. Errors from any other leg
+        // (vector search) still propagate normally.
+        let text_hits = match self
             .text(token)?
             .search(TextSearchRequest {
                 query: query_text.to_string(),
@@ -160,7 +165,18 @@ impl KhiveRuntime {
                 top_k: candidates,
                 snippet_chars: 200,
             })
-            .await?;
+            .await
+        {
+            Ok(hits) => hits,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    query = %query_text,
+                    "hybrid_search_with_strategy: FTS leg failed, degrading to vector-only fusion"
+                );
+                Vec::new()
+            }
+        };
 
         let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {
             self.vector_search(
@@ -406,5 +422,36 @@ mod tests {
             let back: FusionStrategy = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(strategy, back, "roundtrip failed for {json}");
         }
+    }
+
+    // 10. #388 regression: hybrid_search_with_strategy must not hard-fail on a query
+    // containing FTS5 metacharacters like `$`. sanitize_fts5_query (khive-db) strips
+    // `$`, but this exercises the runtime-level fail-open: if the FTS leg ever errors,
+    // the call degrades to vector-only fusion instead of propagating the error.
+    #[tokio::test]
+    async fn hybrid_search_with_strategy_dollar_sign_query_does_not_error() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "DSL docs",
+            Some("use $prev.id to chain calls"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let result = rt
+            .hybrid_search_with_strategy(&tok, "$prev.id", None, FusionStrategy::default(), 10)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#388 hybrid_search_with_strategy must not hard-fail on a '$'-bearing query, got: {:?}",
+            result.err()
+        );
     }
 }

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -425,9 +425,11 @@ mod tests {
     }
 
     // 10. #388 regression: hybrid_search_with_strategy must not hard-fail on a query
-    // containing FTS5 metacharacters like `$`. sanitize_fts5_query (khive-db) strips
-    // `$`, but this exercises the runtime-level fail-open: if the FTS leg ever errors,
-    // the call degrades to vector-only fusion instead of propagating the error.
+    // containing FTS5 metacharacters like `$`. After this test was first written,
+    // sanitize_fts5_query (khive-db) already strips `$`, so this alone takes the `Ok`
+    // path and does not exercise the runtime-level fail-open `Err` arm (PR #389 codex
+    // round-1 Medium finding) — kept as a sanitizer-path regression; see test 11 below
+    // for the fail-open-branch regression.
     #[tokio::test]
     async fn hybrid_search_with_strategy_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -451,6 +453,40 @@ mod tests {
         assert!(
             result.is_ok(),
             "#388 hybrid_search_with_strategy must not hard-fail on a '$'-bearing query, got: {:?}",
+            result.err()
+        );
+    }
+
+    // 11. PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped by
+    // sanitize_fts5_query (by design — the sanitizer stays minimal per #388 scope; the
+    // fail-open net is the systematic answer for residual punctuation). SQLite FTS5's
+    // bareword parser still rejects `@` unconditionally, so this query reaches the
+    // runtime-level `Err` arm added in hybrid_search_with_strategy and must degrade to
+    // vector-only fusion rather than propagating the error.
+    #[tokio::test]
+    async fn hybrid_search_with_strategy_residual_fts5_char_degrades_to_vector_only() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "DSL docs",
+            Some("use foo@bar to chain calls"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let result = rt
+            .hybrid_search_with_strategy(&tok, "foo@bar", None, FusionStrategy::default(), 10)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#389 hybrid_search_with_strategy must not hard-fail when the FTS leg errors \
+             on a residual FTS5 char ('@'), got: {:?}",
             result.err()
         );
     }

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -148,11 +148,15 @@ impl KhiveRuntime {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
         let ns = token.namespace().as_str().to_owned();
-        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
-        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
-        // runtime (anything sanitization misses), degrade to vector-only fusion
-        // instead of aborting the whole hybrid search. Errors from any other leg
-        // (vector search) still propagate normally.
+        // Fail-open on the FTS leg only, and only for FTS5 parser syntax errors
+        // (#388, #389 round-2 High): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors
+        // at runtime on residual punctuation the sanitizer does not strip,
+        // degrade to vector-only fusion. A genuine backend outage (pool
+        // exhaustion, connection failure, etc.) is NOT a bad query and must
+        // propagate — `is_fts5_syntax_error` is the narrow gate that tells the
+        // two apart. Errors from any other leg (vector search) still
+        // propagate normally.
         let text_hits = match self
             .text(token)?
             .search(TextSearchRequest {
@@ -168,14 +172,15 @@ impl KhiveRuntime {
             .await
         {
             Ok(hits) => hits,
-            Err(e) => {
+            Err(e) if e.is_fts5_syntax_error() => {
                 tracing::warn!(
                     error = %e,
                     query = %query_text,
-                    "hybrid_search_with_strategy: FTS leg failed, degrading to vector-only fusion"
+                    "hybrid_search_with_strategy: FTS leg failed on a parser syntax error, degrading to vector-only fusion"
                 );
                 Vec::new()
             }
+            Err(e) => return Err(e.into()),
         };
 
         let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -85,6 +85,14 @@ static FTS_FAIL_MANY_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::ne
 /// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+/// Non-parser FTS *search*-leg failure injection for `search_notes` (issue #389
+/// round-2 High regression coverage) — distinct from `FTS_FAIL_NS` (which
+/// injects at the FTS *upsert*/write step of `create_note_inner`). Injects a
+/// `StorageError::Timeout` at the `search()` call the FTS fail-open arm
+/// guards, so the arm's `is_fts5_syntax_error()` gate can be exercised against
+/// a genuine non-parser failure and asserted to propagate rather than degrade.
+#[cfg(any(test, feature = "fault-injection"))]
+static FTS_SEARCH_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
 /// Arm the FTS failure injection for `create_note_inner` targeting namespace `ns`.
 ///
@@ -118,6 +126,20 @@ pub fn arm_fts_fail_many(ns: &str) {
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_fts_fail_many_partial(ns: &str) {
     *FTS_FAIL_MANY_PARTIAL_NS.lock().unwrap() = Some(ns.to_string());
+}
+
+/// Arm a non-parser FTS *search*-leg failure injection for `search_notes` targeting
+/// any call whose visible namespaces include `ns`.
+///
+/// The next `search_notes` call touching `ns` returns `StorageError::Timeout` from
+/// the FTS leg instead of calling the real `TextSearch::search`, then disarms.
+/// Used to prove the fail-open arm in `search_notes` propagates non-parser
+/// `StorageError`s (issue #389 round-2 High) instead of silently degrading them
+/// the way a genuine FTS5 parser syntax error is degraded.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
+pub fn arm_fts_search_fail(ns: &str) {
+    *FTS_SEARCH_FAIL_NS.lock().unwrap() = Some(ns.to_string());
 }
 
 /// Arm the vector insertion failure injection for `create_note_inner` targeting `ns`.
@@ -2538,36 +2560,65 @@ impl KhiveRuntime {
 
         // FTS5 over the notes index — search all visible namespaces.
         //
-        // Fail-open on the FTS leg only (#388, #389 round 2): sanitize_fts5_query
-        // strips known-unsafe FTS5 metacharacters, but residual punctuation the
+        // Fail-open on the FTS leg only, and only for FTS5 parser syntax errors
+        // (#388, #389 round 2, #389 round-2 High): sanitize_fts5_query strips
+        // known-unsafe FTS5 metacharacters, but residual punctuation the
         // sanitizer does not strip (by design — the sanitizer stays minimal, the
         // fail-open net is the systematic answer) can still reach the FTS5 parser
-        // and error. Degrade to vector-only fusion instead of aborting the whole
-        // note search. Errors from any other leg (vector search, note hydration)
-        // still propagate normally.
-        let text_hits = match self
-            .text_for_notes(token)?
-            .search(TextSearchRequest {
-                query: query_text.to_string(),
-                mode: TextQueryMode::Plain,
-                filter: Some(TextFilter {
-                    namespaces: visible_ns.clone(),
-                    ..TextFilter::default()
-                }),
-                top_k: candidates,
-                snippet_chars: 200,
+        // and error. Degrade to vector-only fusion in that case. A genuine
+        // backend outage (pool exhaustion, connection failure, etc.) is NOT a
+        // bad query and must propagate — `is_fts5_syntax_error` is the narrow
+        // gate that tells the two apart. Errors from any other leg (vector
+        // search, note hydration) still propagate normally.
+        //
+        // Injection: check FTS_SEARCH_FAIL_NS (armed by `arm_fts_search_fail(ns)`)
+        // — issue #389 round-2 High regression coverage for the propagate branch.
+        // Fires only when the armed namespace is among this call's visible
+        // namespaces, then clears (one-shot).
+        #[cfg(any(test, feature = "fault-injection"))]
+        let fts_search_inject = {
+            let mut g = FTS_SEARCH_FAIL_NS.lock().unwrap();
+            match g.as_deref() {
+                Some(armed) if visible_ns.iter().any(|ns| ns == armed) => {
+                    *g = None;
+                    true
+                }
+                _ => false,
+            }
+        };
+        #[cfg(not(any(test, feature = "fault-injection")))]
+        let fts_search_inject = false;
+
+        let text_search_result = if fts_search_inject {
+            Err(khive_storage::StorageError::Timeout {
+                operation: "fts_search".into(),
             })
-            .await
-        {
+        } else {
+            self.text_for_notes(token)?
+                .search(TextSearchRequest {
+                    query: query_text.to_string(),
+                    mode: TextQueryMode::Plain,
+                    filter: Some(TextFilter {
+                        namespaces: visible_ns.clone(),
+                        ..TextFilter::default()
+                    }),
+                    top_k: candidates,
+                    snippet_chars: 200,
+                })
+                .await
+        };
+
+        let text_hits = match text_search_result {
             Ok(hits) => hits,
-            Err(e) => {
+            Err(e) if e.is_fts5_syntax_error() => {
                 tracing::warn!(
                     error = %e,
                     query = %query_text,
-                    "search_notes: FTS leg failed, degrading to vector-only fusion"
+                    "search_notes: FTS leg failed on a parser syntax error, degrading to vector-only fusion"
                 );
                 Vec::new()
             }
+            Err(e) => return Err(e.into()),
         };
 
         // Vector search filtered to notes.
@@ -4714,6 +4765,62 @@ mod tests {
         assert!(
             hits.iter().any(|h| h.subject_id == note.id),
             "note should be indexed in FTS5 after create"
+        );
+    }
+
+    /// #389 round-2 High regression: the `search_notes` FTS fail-open arm must
+    /// only degrade genuine FTS5 parser syntax errors (see
+    /// `handler_search_note_residual_fts5_char_does_not_error` in
+    /// khive-pack-kg for that case). A non-parser `StorageError` — e.g. a pool
+    /// exhaustion or connection timeout on the text-search backend — is not a
+    /// bad query and must propagate as `Err`, not be silently swallowed into
+    /// an empty (falsely "successful") result set. This is the representative
+    /// site for the four fail-open arms named in the finding: `search_notes`
+    /// (khive-runtime/operations.rs), `hybrid_search`
+    /// (khive-runtime/retrieval.rs), `hybrid_search_with_strategy`
+    /// (khive-runtime/fusion.rs), and `collect_recall_text_hits`
+    /// (khive-pack-memory/handlers/common.rs) all share the exact same
+    /// `is_fts5_syntax_error()` gate added to `StorageError` — proving the
+    /// predicate propagates a non-parser error at one call site generalizes to
+    /// the other three, which route through the identical `match ... Err(e)
+    /// if e.is_fts5_syntax_error() => degrade, Err(e) => return Err(e.into())`
+    /// shape.
+    #[tokio::test]
+    async fn search_notes_propagates_non_parser_fts_error() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        rt.create_note(
+            &tok,
+            "observation",
+            None,
+            "FlashAttention reduces memory by using tiling",
+            Some(0.8),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let ns = tok.namespace().as_str().to_string();
+        arm_fts_search_fail(&ns);
+
+        let result = rt
+            .search_notes(&tok, "FlashAttention", None, 10, None, false, &[], None)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "search_notes must propagate a non-parser FTS StorageError (Timeout) \
+             as Err, not silently degrade it to an empty result, got: {:?}",
+            result.ok()
+        );
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                RuntimeError::Storage(khive_storage::StorageError::Timeout { .. })
+            ),
+            "propagated error must be the injected StorageError::Timeout, unwrapped \
+             through RuntimeError::Storage"
         );
     }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -2537,7 +2537,15 @@ impl KhiveRuntime {
             .collect();
 
         // FTS5 over the notes index — search all visible namespaces.
-        let text_hits = self
+        //
+        // Fail-open on the FTS leg only (#388, #389 round 2): sanitize_fts5_query
+        // strips known-unsafe FTS5 metacharacters, but residual punctuation the
+        // sanitizer does not strip (by design — the sanitizer stays minimal, the
+        // fail-open net is the systematic answer) can still reach the FTS5 parser
+        // and error. Degrade to vector-only fusion instead of aborting the whole
+        // note search. Errors from any other leg (vector search, note hydration)
+        // still propagate normally.
+        let text_hits = match self
             .text_for_notes(token)?
             .search(TextSearchRequest {
                 query: query_text.to_string(),
@@ -2549,7 +2557,18 @@ impl KhiveRuntime {
                 top_k: candidates,
                 snippet_chars: 200,
             })
-            .await?;
+            .await
+        {
+            Ok(hits) => hits,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    query = %query_text,
+                    "search_notes: FTS leg failed, degrading to vector-only fusion"
+                );
+                Vec::new()
+            }
+        };
 
         // Vector search filtered to notes.
         let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -399,11 +399,15 @@ impl KhiveRuntime {
             .iter()
             .map(|ns| ns.as_str().to_owned())
             .collect();
-        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
-        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
-        // runtime (anything sanitization misses), degrade to vector-only fusion
-        // instead of aborting the whole hybrid search. Errors from any other leg
-        // (vector search, entity hydration) still propagate normally.
+        // Fail-open on the FTS leg only, and only for FTS5 parser syntax errors
+        // (#388, #389 round-2 High): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors
+        // at runtime on residual punctuation the sanitizer does not strip,
+        // degrade to vector-only fusion. A genuine backend outage (pool
+        // exhaustion, connection failure, etc.) is NOT a bad query and must
+        // propagate — `is_fts5_syntax_error` is the narrow gate that tells the
+        // two apart. Errors from any other leg (vector search, entity
+        // hydration) still propagate normally.
         let text_hits = match self
             .text(token)?
             .search(TextSearchRequest {
@@ -419,14 +423,15 @@ impl KhiveRuntime {
             .await
         {
             Ok(hits) => hits,
-            Err(e) => {
+            Err(e) if e.is_fts5_syntax_error() => {
                 tracing::warn!(
                     error = %e,
                     query = %query_text,
-                    "hybrid_search: FTS leg failed, degrading to vector-only fusion"
+                    "hybrid_search: FTS leg failed on a parser syntax error, degrading to vector-only fusion"
                 );
                 Vec::new()
             }
+            Err(e) => return Err(e.into()),
         };
 
         let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -1326,10 +1326,12 @@ mod tests {
     }
 
     /// #388 regression: `hybrid_search` must not hard-fail on a query containing FTS5
-    /// metacharacters like `$` (e.g. the DSL doc query `$prev.id`). Even though
-    /// `sanitize_fts5_query` (khive-db) now strips `$`, this exercises the
-    /// runtime-level fail-open: if the FTS leg ever errors, `hybrid_search` degrades
-    /// to vector-only fusion instead of propagating the error.
+    /// metacharacters like `$` (e.g. the DSL doc query `$prev.id`). After this test was
+    /// first written, `sanitize_fts5_query` (khive-db) already strips `$`, so this alone
+    /// takes the `Ok` path and does not exercise the runtime-level fail-open `Err` arm
+    /// (PR #389 codex round-1 Medium finding) — it stays as a sanitizer-path regression;
+    /// see `hybrid_search_with_residual_fts5_char_degrades_to_vector_only` below for the
+    /// fail-open-branch regression.
     #[tokio::test]
     async fn hybrid_search_with_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -1353,6 +1355,40 @@ mod tests {
         assert!(
             result.is_ok(),
             "#388 hybrid_search must not hard-fail on a '$'-bearing query, got: {:?}",
+            result.err()
+        );
+    }
+
+    /// PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped by
+    /// `sanitize_fts5_query` (by design — the sanitizer stays minimal per #388 scope;
+    /// the fail-open net is the systematic answer for residual punctuation). SQLite
+    /// FTS5's bareword parser still rejects `@` unconditionally, so this query reaches
+    /// the runtime-level `Err` arm added in `hybrid_search` and must degrade to
+    /// vector-only fusion rather than propagating the error.
+    #[tokio::test]
+    async fn hybrid_search_with_residual_fts5_char_degrades_to_vector_only() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "DSL docs",
+            Some("use foo@bar to chain calls"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let result = rt
+            .hybrid_search(&tok, "foo@bar", None, 10, None, None, &[], None)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#389 hybrid_search must not hard-fail when the FTS leg errors on a residual \
+             FTS5 char ('@'), got: {:?}",
             result.err()
         );
     }

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -399,7 +399,12 @@ impl KhiveRuntime {
             .iter()
             .map(|ns| ns.as_str().to_owned())
             .collect();
-        let text_hits = self
+        // Fail-open on the FTS leg only (#388): sanitize_fts5_query already strips
+        // known-unsafe FTS5 metacharacters, but if the lexical leg still errors at
+        // runtime (anything sanitization misses), degrade to vector-only fusion
+        // instead of aborting the whole hybrid search. Errors from any other leg
+        // (vector search, entity hydration) still propagate normally.
+        let text_hits = match self
             .text(token)?
             .search(TextSearchRequest {
                 query: query_text.to_string(),
@@ -411,7 +416,18 @@ impl KhiveRuntime {
                 top_k: candidates,
                 snippet_chars: 200,
             })
-            .await?;
+            .await
+        {
+            Ok(hits) => hits,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    query = %query_text,
+                    "hybrid_search: FTS leg failed, degrading to vector-only fusion"
+                );
+                Vec::new()
+            }
+        };
 
         let vector_hits = if query_vector.is_some() || self.config().embedding_model.is_some() {
             self.vector_search(
@@ -1306,6 +1322,38 @@ mod tests {
         assert!(
             hit.title.as_deref().unwrap().contains("FlashAttention"),
             "title must contain entity name"
+        );
+    }
+
+    /// #388 regression: `hybrid_search` must not hard-fail on a query containing FTS5
+    /// metacharacters like `$` (e.g. the DSL doc query `$prev.id`). Even though
+    /// `sanitize_fts5_query` (khive-db) now strips `$`, this exercises the
+    /// runtime-level fail-open: if the FTS leg ever errors, `hybrid_search` degrades
+    /// to vector-only fusion instead of propagating the error.
+    #[tokio::test]
+    async fn hybrid_search_with_dollar_sign_query_does_not_error() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let tok = NamespaceToken::local();
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            "DSL docs",
+            Some("use $prev.id to chain calls"),
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let result = rt
+            .hybrid_search(&tok, "$prev.id", None, 10, None, None, &[], None)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "#388 hybrid_search must not hard-fail on a '$'-bearing query, got: {:?}",
+            result.err()
         );
     }
 

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -117,4 +117,151 @@ impl StorageError {
             Self::Pool { .. } | Self::Timeout { .. } | Self::Transaction { .. }
         )
     }
+
+    /// Whether this error is an FTS5 query-parser rejection of the MATCH
+    /// expression itself, as opposed to a connection/pool/driver-level
+    /// failure of the text-search backend.
+    ///
+    /// Callers that fail-open the FTS leg of a hybrid search (degrading to
+    /// vector-only results on a bad query string) MUST gate on this predicate
+    /// rather than on `StorageError` broadly. `TextSearch::search` returns the
+    /// same `Driver` variant for a malformed MATCH expression *and* for a
+    /// genuine backend outage (pool exhaustion, connection failure, reader
+    /// open failure) — treating every `Err` as degradable turns a real outage
+    /// into a silently-empty "successful" search (issue #389 round-2 High).
+    ///
+    /// SQLite's FTS5 query parser (`sqlite3Fts5ParseError`, fts5_expr.c)
+    /// prefixes every message it emits with the literal `"fts5: "` token —
+    /// e.g. `fts5: syntax error near "@"`, `fts5: parser stack overflow`,
+    /// `fts5: column queries are not supported (detail=none)`. This is a
+    /// stable SQLite-internal convention, not a substring picked to match one
+    /// observed message. It excludes non-parser FTS5 subsystem failures such
+    /// as `fts5: error creating shadow table ...` (schema/storage corruption)
+    /// by requiring the message to name one of the parser's own failure
+    /// modes, not just the `fts5:` namespace prefix.
+    ///
+    /// Only applies to `Driver` errors from the `Text` capability at the
+    /// `fts_search` operation — the exact seam `Fts5TextSearch::search` uses
+    /// (`crates/khive-db/src/stores/text.rs`). Pool, Timeout, Transaction,
+    /// and any other `operation` value (e.g. `fts_count`, `open_fts_reader`)
+    /// always propagate.
+    pub fn is_fts5_syntax_error(&self) -> bool {
+        let Self::Driver {
+            capability,
+            operation,
+            source,
+        } = self
+        else {
+            return false;
+        };
+        if *capability != StorageCapability::Text || operation.as_ref() != "fts_search" {
+            return false;
+        }
+        let msg = source.to_string();
+        msg.contains("fts5: syntax error")
+            || msg.contains("fts5: parser stack overflow")
+            || msg.contains("fts5: column queries are not supported")
+            || msg.contains("queries are not supported (detail")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct FakeSource(String);
+
+    impl fmt::Display for FakeSource {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl StdError for FakeSource {}
+
+    fn driver_err(operation: &'static str, message: &str) -> StorageError {
+        StorageError::driver(
+            StorageCapability::Text,
+            operation,
+            FakeSource(message.into()),
+        )
+    }
+
+    #[test]
+    fn fts5_syntax_error_at_fts_search_is_classified_as_syntax_error() {
+        let e = driver_err("fts_search", "fts5: syntax error near \"@\"");
+        assert!(e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn fts5_parser_stack_overflow_is_classified_as_syntax_error() {
+        let e = driver_err("fts_search", "fts5: parser stack overflow");
+        assert!(e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn fts5_unsupported_column_query_is_classified_as_syntax_error() {
+        let e = driver_err(
+            "fts_search",
+            "fts5: column queries are not supported (detail=none)",
+        );
+        assert!(e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn timeout_is_not_classified_as_syntax_error() {
+        let e = StorageError::Timeout {
+            operation: "fts_search".into(),
+        };
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn pool_failure_is_not_classified_as_syntax_error() {
+        let e = StorageError::Pool {
+            operation: "fts_search".into(),
+            message: "pool exhausted".into(),
+        };
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn driver_error_at_non_search_operation_is_not_classified_as_syntax_error() {
+        // Same message text, but at a different operation (e.g. reader open
+        // failure) — must not be classified as a syntax error even if the
+        // underlying message happened to mention "fts5:".
+        let e = driver_err("open_fts_reader", "fts5: syntax error near \"@\"");
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn driver_error_with_unrelated_message_is_not_classified_as_syntax_error() {
+        // A genuine connection/driver outage at the fts_search operation, but
+        // whose message does not name a parser failure mode — must propagate.
+        let e = driver_err("fts_search", "disk I/O error");
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn fts5_shadow_table_corruption_is_not_classified_as_syntax_error() {
+        // A real FTS5-subsystem failure (schema/storage corruption), not a
+        // MATCH-expression parser rejection — must propagate, not degrade.
+        let e = driver_err(
+            "fts_search",
+            "fts5: error creating shadow table notes_content: no such table",
+        );
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn non_text_capability_is_not_classified_as_syntax_error() {
+        let e = StorageError::Driver {
+            capability: StorageCapability::Vectors,
+            operation: "fts_search".into(),
+            source: Box::new(FakeSource("fts5: syntax error near \"@\"".into())),
+        };
+        assert!(!e.is_fts5_syntax_error());
+    }
 }

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -161,7 +161,8 @@ impl StorageError {
         msg.contains("fts5: syntax error")
             || msg.contains("fts5: parser stack overflow")
             || msg.contains("fts5: column queries are not supported")
-            || msg.contains("queries are not supported (detail")
+            || msg.contains("fts5: phrase queries are not supported (detail")
+            || msg.contains("fts5: NEAR queries are not supported (detail")
     }
 }
 
@@ -241,6 +242,36 @@ mod tests {
         // A genuine connection/driver outage at the fts_search operation, but
         // whose message does not name a parser failure mode — must propagate.
         let e = driver_err("fts_search", "disk I/O error");
+        assert!(!e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn fts5_phrase_detail_query_is_classified_as_syntax_error() {
+        let e = driver_err(
+            "fts_search",
+            "fts5: phrase queries are not supported (detail!=full)",
+        );
+        assert!(e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn fts5_near_detail_query_is_classified_as_syntax_error() {
+        let e = driver_err(
+            "fts_search",
+            "fts5: NEAR queries are not supported (detail!=full)",
+        );
+        assert!(e.is_fts5_syntax_error());
+    }
+
+    #[test]
+    fn unprefixed_detail_message_is_not_classified_as_syntax_error() {
+        // Round-3 High: a driver message containing the detail-mode substring
+        // WITHOUT the `fts5: ` parser prefix is not from the FTS5 query
+        // parser — must propagate, not degrade.
+        let e = driver_err(
+            "fts_search",
+            "phrase queries are not supported (detail!=full)",
+        );
         assert!(!e.is_fts5_syntax_error());
     }
 


### PR DESCRIPTION
## Summary

- `kg search` (and hybrid FTS+vector search generally) hard-failed with `fts5: syntax error near "$"` whenever the query contained a `$`, e.g. the common agent query `$prev.id` for DSL docs. FTS5's MATCH parser rejects `$` unconditionally, regardless of tokenizer or position, and the error aborted the whole hybrid search even though the vector leg was unaffected.
- Fixes both halves called for in #388:
  1. **Sanitize**: `sanitize_fts5_query` (khive-db) now strips `$` alongside the existing `*"'+-^.~!` operator-character set. This sanitizer is shared by kg `search`, `memory.recall`, and other Plain/AnyTerm FTS callers.
  2. **Degrade, never abort**: as a safety net for anything sanitization misses, the FTS leg of each hybrid search call site now degrades to vector-only fusion on error instead of propagating it — `khive-runtime/src/retrieval.rs::hybrid_search` (kg `search` verb), `khive-runtime/src/fusion.rs::hybrid_search_with_strategy`, and `khive-pack-memory/src/handlers/common.rs::collect_recall_text_hits` (`memory.recall`). Each logs `tracing::warn!` and returns an empty hit set for the FTS leg only; errors from the vector leg or entity/note hydration still propagate normally.
- Write-path FTS calls (document upsert/delete in `curation.rs`/`operations.rs`) are intentionally left as hard-fail — a failed index write should still error.
- `khive-pack-knowledge`'s `knowledge.search` was not touched: it builds its MATCH expression via `quote_fts5_phrase` (wraps the whole query in an escaped double-quoted phrase), empirically confirmed immune to `$` already.

## Test plan

- [x] 5 new regression tests in `khive-db/src/stores/text_tests.rs`: sanitizer unit assertions for `$prev.id` / `$prev` / `foo$bar` / bare `$`, plus 4 end-to-end tests through the real `Fts5TextSearch::search` path (dollar sign alone, bare dollar → empty result not error, dollar + embedded quote combined, `AnyTerm` mode with dollar).
- [x] `hybrid_search_with_dollar_sign_query_does_not_error` (khive-runtime/retrieval.rs) — kg `search` verb path.
- [x] `hybrid_search_with_strategy_dollar_sign_query_does_not_error` (khive-runtime/fusion.rs).
- [x] `recall_with_dollar_sign_query_does_not_error` (khive-pack-memory/handlers/recall.rs) — full `memory.recall` verb dispatch, in-memory runtime with no embedder registered so the vector leg trivially contributes zero hits, isolating the assertion to FTS fail-open.
- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `cargo test --workspace` — pass (133 test-result blocks, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)