### PR TITLE
feat(scripts): off-studio box bootstrap kit (systemd unit, env template, cutover runbook)

### DIFF
--- a/scripts/box/README.md
+++ b/scripts/box/README.md
@@ -138,6 +138,11 @@ nothing loud to notice it. `bootstrap.sh` closes that gap by calling the
 same OAuth2 `client_credentials` token endpoint the daemon itself would use,
 at bootstrap time.
 
+While the client secret is resolved and in scope, the script also suspends
+any shell tracing that was already active (`set -x`, or running the whole
+script as `bash -x scripts/box/bootstrap.sh`) and restores it only after the
+secret variable has been unset, so tracing output cannot print the secret.
+
 What it checks: whether `KHIVE_EMAIL_OAUTH_CLIENT_ID`,
 `KHIVE_EMAIL_OAUTH_CLIENT_SECRET`, and `KHIVE_EMAIL_OAUTH_TENANT_ID` (read
 the same way the daemon reads them: a real process environment variable
@@ -160,6 +165,11 @@ What PASS/FAIL mean:
 - **Partial config** (only one or two of the three variables set): a loud
   warning, since this is the exact condition under which the channel
   silently disables itself.
+- **Malformed id**: if `KHIVE_EMAIL_OAUTH_CLIENT_ID` or
+  `KHIVE_EMAIL_OAUTH_TENANT_ID` is set but is not shaped like a Microsoft
+  GUID (`8-4-4-4-12` hex digits), a warning names the affected variable
+  (value masked, never raw) and the smoke is skipped non-fatally without
+  calling the token endpoint.
 - **FAIL**: a loud warning containing the `error` and `error_description`
   fields from Microsoft's response. That text is Microsoft's own
   diagnostic and is safe to print, but since it can echo a configured

--- a/scripts/box/README.md
+++ b/scripts/box/README.md
@@ -67,14 +67,18 @@ new binary, on the operator's terms.
 cp scripts/box/env.template ~/.khive/.env
 chmod 600 ~/.khive/.env
 # edit ~/.khive/.env with real values
-systemctl --user restart kkernel.service
+scripts/box/bootstrap.sh
 ```
 
 See `env.template` for the full variable list and which combinations are
 required. The email channel (`channel-email` feature, built in by
 `bootstrap.sh`) is inert until this file has valid SMTP/IMAP/auth values; an
 incomplete config disables the email channel with a warning in the logs
-rather than crashing the daemon.
+rather than crashing the daemon. Re-running `bootstrap.sh`, rather than only
+`systemctl --user restart kkernel.service`, both picks up the new secrets
+and exercises the OAuth token-endpoint check described below, so a bad or
+incomplete secret is caught at bootstrap time instead of discovered later
+from a silently-disabled channel.
 
 ## Actor identity
 
@@ -122,6 +126,64 @@ This kit installs one systemd unit, so this box runs as one actor identity.
 If more than one lambda needs an independent identity on the same physical
 box, that is a separate per-agent `~/.khive` home and daemon instance, not
 covered by this single-daemon bootstrap flow.
+
+## Email channel auth smoke
+
+The email channel does not crash the daemon when its OAuth configuration is
+incomplete or its client secret is invalid or expired; it disables itself
+with a warning in the logs (`crates/khive-channel-email/src/config.rs`). On
+a headless box nobody is watching those logs by default, so a rotated or
+expired client secret otherwise means email quietly stops working with
+nothing loud to notice it. `bootstrap.sh` closes that gap by calling the
+same OAuth2 `client_credentials` token endpoint the daemon itself would use,
+at bootstrap time.
+
+What it checks: whether `KHIVE_EMAIL_OAUTH_CLIENT_ID`,
+`KHIVE_EMAIL_OAUTH_CLIENT_SECRET`, and `KHIVE_EMAIL_OAUTH_TENANT_ID` (read
+the same way the daemon reads them: a real process environment variable
+wins, otherwise `~/.khive/.env`) resolve to a working client secret against
+`https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`.
+
+When it runs: on every `bootstrap.sh` run, including re-runs, not on a bare
+`systemctl --user restart`. Before secrets are placed, all three variables
+are absent and the check prints a one-line skip note; this is the normal
+first-run path, not a warning. See "Placing secrets" above: the documented
+flow after placing secrets is re-running `bootstrap.sh`, not only
+restarting the unit, specifically so this check runs against the new
+values.
+
+What PASS/FAIL mean:
+
+- **PASS**: the token endpoint returned an access token. The script prints
+  only the client id, masked (first 6 characters then an ellipsis); it
+  never prints the client secret or the token.
+- **Partial config** (only one or two of the three variables set): a loud
+  warning, since this is the exact condition under which the channel
+  silently disables itself.
+- **FAIL**: a loud warning containing the `error` and `error_description`
+  fields from Microsoft's response. That text is Microsoft's own
+  diagnostic and is safe to print, but since it can echo a configured
+  client id or tenant id verbatim (for example "Application with
+  identifier 'xxx' was not found in the directory"), the script scrubs any
+  occurrence of the configured client id or tenant id from it first,
+  replacing each with its masked form. `AADSTS7000222` means the client
+  secret has expired; `AADSTS7000215` means it is invalid. Either way, the
+  fix is in the Entra portal, under App registrations, then the
+  application, then Certificates & secrets: client secrets have bounded
+  lifetimes, and rotating one means updating `~/.khive/.env` and re-running
+  `bootstrap.sh`.
+
+Like the `stats()` smoke test and the actor-identity check, this is
+non-fatal: a box without email configured, or one with a transient network
+blip during bootstrap, is not a bootstrap failure.
+
+This smoke test does not cover Basic auth mode
+(`KHIVE_EMAIL_PASSWORD`). There is no equivalent safe check for it: probing
+would mean either attempting a live IMAP login from a bootstrap script or
+inventing a lighter check that does not actually verify the password. For
+Basic auth mode, the daemon's own startup log is the check: watch
+`journalctl --user -u kkernel.service` after restarting for whether the
+email channel reports itself enabled or disabled.
 
 ## Verifying boot persistence
 

--- a/scripts/box/README.md
+++ b/scripts/box/README.md
@@ -1,0 +1,274 @@
+# Off-Studio box bootstrap kit
+
+Bootstrap kit for running the khive substrate (the `kkernel` daemon plus
+`khive.db`) on a standalone Linux box, off the Mac.
+
+Status: the scripts and the systemd unit in this directory were authored and
+reviewed on macOS. They have not been executed on a target Linux box. Treat
+the first run as a validation pass, not a known-good deploy, and read
+`bootstrap.sh` before running it.
+
+## Contents
+
+- `bootstrap.sh`: installs build dependencies, Rust, clones/updates the repo,
+  builds `kkernel` in release mode with the `channel-email` feature, installs
+  the binary, and installs/starts a systemd `--user` unit.
+- `kkernel.service`: the systemd `--user` unit installed by `bootstrap.sh`.
+- `env.template`: placeholder environment file to copy to `~/.khive/.env`.
+- `README.md`: this file.
+
+## Prerequisites
+
+- A Linux box with `sudo` access for the account that will run `kkernel`
+  (needed once, for apt package installation).
+- Outbound HTTPS access, at minimum to fetch the rustup installer, clone the
+  repo, and pull crates.io dependencies during the build.
+- An SSH key already authorized on the box, if you plan to use the SSH
+  forwarding pattern described under "Mac-side access" below.
+
+## Running bootstrap.sh
+
+```bash
+git clone https://github.com/ohdearquant/khive.git
+cd khive
+scripts/box/bootstrap.sh
+```
+
+By default this clones/builds `~/khive` at `main` and installs the binary to
+`~/.cargo/bin/kkernel`. Override with a positional argument or environment
+variables:
+
+```bash
+# Build a different ref into a different directory
+REF=v0.3.0 scripts/box/bootstrap.sh /opt/khive
+
+# Build from a fork
+REPO_URL=https://github.com/<you>/khive.git scripts/box/bootstrap.sh
+```
+
+The script is idempotent: re-running it after a `git` update on the box (or
+after changing `REF`) rebuilds, reinstalls the binary, and restarts the
+systemd unit so the new build takes effect. It does not touch `~/.khive/.env`
+or `~/.khive/khive.db`.
+
+Unlike the Mac `make local` target, `bootstrap.sh` does not `pkill` running
+`kkernel` processes before installing the new binary. On this Mac, `make
+local` killing every `kkernel` process was flagged as a production-impacting
+step; on Linux the atomic `mv` used here is safe against a running process
+(the old process keeps its already-open handle to the old inode), and
+`systemctl --user restart kkernel.service` is what actually cuts over to the
+new binary, on the operator's terms.
+
+## Placing secrets
+
+`bootstrap.sh` does not write `~/.khive/.env`. After the first bootstrap run:
+
+```bash
+cp scripts/box/env.template ~/.khive/.env
+chmod 600 ~/.khive/.env
+# edit ~/.khive/.env with real values
+systemctl --user restart kkernel.service
+```
+
+See `env.template` for the full variable list and which combinations are
+required. The email channel (`channel-email` feature, built in by
+`bootstrap.sh`) is inert until this file has valid SMTP/IMAP/auth values; an
+incomplete config disables the email channel with a warning in the logs
+rather than crashing the daemon.
+
+## Actor identity
+
+This is a separate requirement from the email secrets above, and lives in a
+different file: TOML config, not `.env`.
+
+`comm.send` stamps `from_actor` from the caller's dispatch token
+(`crates/khive-pack-comm/src/handlers.rs`). A daemon with no actor identity
+configured mints anonymous tokens, so every `comm.send` stamps
+`from_actor="local"`. A reply routed back to that outbound note then
+resolves `to_actor="local"` instead of this box's inbox: a silent misroute,
+not an error either side would notice on its own (tracked as issue #200 in
+source). If this box is standing up as a specific lambda in the fleet
+(`lambda:leo`, `lambda:khive`, or a sub-lambda), it needs its own identity
+set before it sends or expects to receive addressed mail.
+
+Set it in `~/.khive/config.toml` (create the file if it does not exist yet):
+
+```toml
+[actor]
+id = "lambda:<you>"                # e.g. "lambda:leo", "lambda:khive"
+display_name = "<optional human label>"
+```
+
+Then restart the daemon so it picks up the change:
+
+```bash
+systemctl --user restart kkernel.service
+```
+
+A `KHIVE_ACTOR` environment variable is also read as a fallback when no
+`id` is set in `config.toml`, but when both are present the TOML value
+wins, so treat `config.toml` as the source of truth for this box.
+
+`bootstrap.sh` checks `~/.khive/config.toml` for a non-empty `[actor] id` as
+the last step of its smoke test and prints a loud warning if it is missing,
+listing the exact fix. It does not invent a default value: the runtime
+itself treats a missing actor id as valid (an anonymous, single-tenant
+"local" identity, the pre-issue-#200 default), so this box can legitimately
+run without one if that is genuinely the intended deployment. The check
+exists so that omission is a deliberate choice, not an oversight discovered
+later from misrouted mail.
+
+This kit installs one systemd unit, so this box runs as one actor identity.
+If more than one lambda needs an independent identity on the same physical
+box, that is a separate per-agent `~/.khive` home and daemon instance, not
+covered by this single-daemon bootstrap flow.
+
+## Verifying boot persistence
+
+A systemd `--user` unit stops when the owning user's last session ends,
+unless lingering is enabled for that user:
+
+```bash
+loginctl enable-linger $USER
+```
+
+Run this once. Without it, the daemon dies when the SSH session that
+installed it closes, and does not come back on reboot.
+
+## Moving the database
+
+To move an existing `khive.db` from the Mac (or another box) onto this one:
+
+1. On the **source** machine, stop everything writing to the database first
+   (the MCP client process, any `kkernel mcp --daemon`, `li play`/loop
+   processes). SQLite's WAL mode tolerates concurrent readers but a mid-copy
+   write from a live process can hand you a torn snapshot.
+
+2. Still on the source machine, checkpoint the WAL back into the main
+   database file so the copy is self-contained:
+
+   ```bash
+   sqlite3 ~/.khive/khive.db 'PRAGMA wal_checkpoint(TRUNCATE);'
+   ```
+
+3. Copy `khive.db` **and its sidecar files**. `~/.khive/khive.db` may have
+   `khive.db-wal`, `khive.db-shm`, and `khive.db-journal` alongside it
+   depending on state at copy time, so take the whole `~/.khive/` directory
+   rather than a single file so nothing is left behind:
+
+   ```bash
+   scp -r source-host:~/.khive/ ~/.khive-incoming
+   # then merge the DB (and only the DB) into the box's ~/.khive/, with
+   # kkernel stopped on the box:
+   systemctl --user stop kkernel.service
+   cp ~/.khive-incoming/khive.db* ~/.khive/
+   systemctl --user start kkernel.service
+   ```
+
+4. Do not run `bootstrap.sh` and a manual DB copy concurrently against the
+   same `~/.khive/khive.db`: stop the service, copy, then start the service.
+
+This procedure moves data, it does not merge two independently-written
+databases. If both the Mac and the box have accumulated writes since the
+last sync, this is a one-way overwrite; treat the box's prior `khive.db` (if
+any) as disposable before doing this, or back it up first.
+
+## Timezone (schedule pack)
+
+Fresh Linux VPS images commonly default to UTC. The `schedule` pack's
+`remind`/`schedule` verbs take an ISO datetime in the `at` field; when that
+datetime carries no explicit UTC offset, the box's system timezone
+determines how it resolves. Set the box to the timezone the fleet actually
+reasons in to avoid a reminder landing hours off from what an operator
+expected:
+
+```bash
+sudo timedatectl set-timezone America/New_York
+```
+
+Where possible, prefer ISO datetimes with an explicit offset (e.g.
+`2026-07-15T09:00:00-04:00`) when scheduling from another machine, so the
+result does not depend on which box's local time zone is in effect.
+
+## Embedding first-warm smoke test
+
+`bootstrap.sh` runs `kkernel exec 'stats()'` as its own smoke test, which
+only confirms the daemon answers requests and does not exercise the
+embedding path. Once secrets are in place, run a query that forces an
+embedding call:
+
+```bash
+~/.cargo/bin/kkernel exec 'knowledge.search(query="off studio box bootstrap smoke test", limit=3)'
+```
+
+The embedding backend (`lattice-embed`) may need to acquire model state on
+first use. This kit does not assert exactly how that acquisition works; if
+this first call is unexpectedly slow or fails, check
+`journalctl --user -u kkernel.service -n 100 --no-pager` for network activity
+or errors before assuming the box is misconfigured, and confirm the box has
+outbound HTTPS egress.
+
+## Email round-trip smoke test
+
+The outbound path is a poll loop (`channel_outbox_loop` in
+`crates/khive-mcp/src/serve.rs`): every 5 seconds it lists notes with
+`kind="message"`, `direction="outbound"`, `delivered=false` in the
+configured ingest namespace, and sends any whose `to_actor` property starts
+with `email:`. To smoke-test sending, create such a note directly through
+the substrate:
+
+```bash
+~/.cargo/bin/kkernel exec 'create(kind="message", content="box bootstrap smoke test", properties={"direction":"outbound","to_actor":"email:<your-address>","subject":"khive box smoke test"})'
+```
+
+Then watch the logs for the outcome:
+
+```bash
+journalctl --user -u kkernel.service -f
+```
+
+A successful send logs `outbox loop: delivered` with the note id, recipient,
+and generated Message-ID, and stamps a `delivered_at` property on the note
+(the delivery loop is at-least-once: a crash between the SMTP send
+succeeding and that stamp being written causes a retry with the same
+Message-ID on the next pass, which most receiving mail servers collapse as a
+duplicate). If `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` is set, the recipient
+address must be on that list or the send is skipped with a warning log
+instead of an error.
+
+Inbound polling is a separate loop (`channel_poll_loop`). Send a message to
+the configured mailbox from another account and look for a matching inbound
+note via `kkernel exec 'list(kind="message", direction="inbound", limit=5)'`.
+
+## Monitor dependency on sqlite3
+
+The fleet's standing inbox-wakeup pattern (a background `Monitor` polling
+`MAX(created_at)` on inbound mail) queries `~/.khive/khive.db` directly with
+the `sqlite3` CLI rather than through the MCP surface, so that a wake check
+is a single lightweight read with no daemon round-trip. `bootstrap.sh`
+installs `sqlite3` via apt for exactly this reason, in addition to its use
+in the WAL-checkpoint step above. If you strip packages from this kit,
+`sqlite3` is not optional for any lambda that arms that Monitor pattern on
+this box.
+
+## Mac-side access
+
+To reach this box's daemon socket directly from the Mac (rather than
+running a second `kkernel` there), forward it over SSH. OpenSSH supports
+local-socket-to-remote-socket forwarding directly:
+
+```bash
+ssh -N -L /tmp/khived.sock:/home/<remote-user>/.khive/khived.sock <remote-user>@<box-host>
+```
+
+Then, in the Mac shell that should talk to the box, point the client at the
+forwarded socket instead of the local one:
+
+```bash
+KHIVE_SOCKET=/tmp/khived.sock kkernel exec 'stats()'
+```
+
+`KHIVE_SOCKET` overrides the default `~/.khive/khived.sock` path on the
+client side; it is meant for exactly this kind of operational override, not
+for normal use. Close the `ssh -N -L` session when done; it holds no shell,
+only the forwarded socket.

--- a/scripts/box/bootstrap.sh
+++ b/scripts/box/bootstrap.sh
@@ -91,14 +91,26 @@ mask_value() {
   printf '%s...\n' "${1:0:6}"
 }
 
+# True (exit 0) when `$1` matches the Microsoft GUID shape (8-4-4-4-12 hex
+# digits) used for both client_id and tenant_id. The email auth smoke below
+# calls this on both values, before either can reach scrub_value or a curl
+# argument, so a malformed .env value (stray glob characters, whitespace,
+# wrong length) is rejected at the gate instead of passed further down.
+is_guid_shaped() {
+  local re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+  [[ "$1" =~ $re ]]
+}
+
 # Replace every literal occurrence of `value` in `text` with its masked
 # form. Used only to scrub a client_id or tenant_id out of Microsoft's
 # error/error_description text before printing it, since that text
 # sometimes echoes a configured id verbatim (e.g. "Application with
-# identifier 'xxx' was not found in the directory"). Client ids and tenant
-# ids are Microsoft-issued GUIDs, which cannot contain glob metacharacters,
-# so bash's `${text//pattern/repl}` pattern matching is a safe literal
-# replacement here.
+# identifier 'xxx' was not found in the directory"). Every caller passes
+# only a value that has already passed is_guid_shaped(), which guarantees
+# no glob metacharacters (*, ?, [, ]) are present, so bash's
+# `${text//pattern/repl}` pattern matching (where `pattern` is a glob, not
+# a literal string) is a safe literal replacement here. Do not call this
+# with a value that has not been through is_guid_shaped() first.
 scrub_value() {
   local text="$1" value="$2" masked
   if [ -z "$value" ]; then
@@ -293,6 +305,20 @@ fi
 # the client secret, in any form, on any path.
 stage "Email channel auth smoke"
 
+# Shell tracing (a caller-set `set -x`, or `bash -x scripts/box/bootstrap.sh`)
+# prints each command and its expanded arguments to stderr as it runs. Left
+# on through this stage, that would print both the EMAIL_CLIENT_SECRET
+# assignment below and the curl --data-urlencode argument that carries it,
+# in full, regardless of every other guard in this stage. Capture the
+# caller's xtrace state and force it off before any OAuth value is
+# resolved. The single exit seam at the bottom of this stage unsets the
+# secret (and the raw HTTP response) first and only then restores tracing,
+# so the secret exists only while tracing is off.
+case $- in
+  *x*) __smoke_had_xtrace=1; set +x ;;
+  *) __smoke_had_xtrace=0 ;;
+esac
+
 # The whole stage is best-effort: a curl failure, a malformed response, or a
 # missing python3 fallback path are all reported as warnings, matching the
 # non-fatal convention of the stats() smoke test and the actor-identity check
@@ -332,6 +358,22 @@ elif [ "$EMAIL_OAUTH_PRESENT" -lt 3 ]; then
   echo "         all three to use Basic auth (KHIVE_EMAIL_PASSWORD) instead," >&2
   echo "         then:" >&2
   echo "           systemctl --user restart kkernel.service" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+elif ! is_guid_shaped "$EMAIL_CLIENT_ID"; then
+  echo "" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  echo "WARNING: KHIVE_EMAIL_OAUTH_CLIENT_ID ($(mask_value "$EMAIL_CLIENT_ID")) is not" >&2
+  echo "         GUID-shaped (expected 8-4-4-4-12 hex digits); skipping email" >&2
+  echo "         auth smoke. Check $DOTENV for a copy-paste error or stray" >&2
+  echo "         characters." >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+elif ! is_guid_shaped "$EMAIL_TENANT_ID"; then
+  echo "" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  echo "WARNING: KHIVE_EMAIL_OAUTH_TENANT_ID ($(mask_value "$EMAIL_TENANT_ID")) is not" >&2
+  echo "         GUID-shaped (expected 8-4-4-4-12 hex digits); skipping email" >&2
+  echo "         auth smoke. Check $DOTENV for a copy-paste error or stray" >&2
+  echo "         characters." >&2
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
 else
   TOKEN_URL="https://login.microsoftonline.com/${EMAIL_TENANT_ID}/oauth2/v2.0/token"
@@ -373,6 +415,16 @@ else
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
   fi
 fi
+
+# Single exit seam for this stage: every path above (unconfigured skip,
+# partial-config warning, malformed-GUID skip x2, curl failure, parse
+# failure, PASS, FAIL) falls through to here with no early return. Unset the
+# secret and the raw HTTP response before restoring the caller's xtrace
+# state, so neither value can be traced by any later command in this stage
+# or by a future edit that re-enables tracing before they would otherwise
+# have gone out of scope.
+unset EMAIL_CLIENT_SECRET EMAIL_RESPONSE
+[ "${__smoke_had_xtrace}" = "1" ] && set -x
 
 set -e
 

--- a/scripts/box/bootstrap.sh
+++ b/scripts/box/bootstrap.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# bootstrap.sh: off-Studio Linux box bootstrap for the khive substrate.
+#
+# Idempotent: safe to re-run. Each stage checks current state before acting so a
+# second invocation (e.g. to pick up a new release) only redoes the parts that
+# changed (git update, rebuild, binary install, systemd restart).
+#
+# Usage:
+#   scripts/box/bootstrap.sh [REPO_DIR]
+#
+# Env overrides:
+#   REPO_DIR  Local checkout path (default: ~/khive; overridden by $1 if given)
+#   REPO_URL  Git remote to clone (default: https://github.com/ohdearquant/khive.git)
+#   REF       Branch/tag/commit to build (default: main)
+#
+# This script only touches this box: apt packages, ~/.cargo, a checkout under
+# REPO_DIR, ~/.cargo/bin/kkernel, and a systemd --user unit. It does not touch
+# ~/.khive/khive.db or ~/.khive/.env. See scripts/box/README.md for the DB
+# migration and secrets setup steps that precede/follow this script.
+
+set -euo pipefail
+
+stage() {
+  printf '\n==> [%s] %s\n' "$(date -u +%H:%M:%S)" "$1"
+}
+
+# Extract `id` from the `[actor]` TOML table in a khive config file. Prints the
+# value (unquoted, trimmed) on stdout and returns 0 when found and non-empty;
+# returns 1 (silently) otherwise. This is a lightweight section-scoped scan for
+# a bootstrap sanity check, not a full TOML parser: it does not handle inline
+# comments after the value, multi-line strings, or a re-opened [actor] table
+# further down the file (first occurrence wins, matching how the runtime's
+# TOML deserializer would also reject a duplicate table).
+actor_id_from_config() {
+  local cfg="$1" raw val
+  [ -f "$cfg" ] || return 1
+  raw="$(awk '
+    /^[[:space:]]*\[actor\][[:space:]]*$/ { insec=1; next }
+    /^[[:space:]]*\[/ { insec=0 }
+    insec && /^[[:space:]]*id[[:space:]]*=/ { print; exit }
+  ' "$cfg")"
+  [ -n "$raw" ] || return 1
+  val="${raw#*=}"
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  val="${val%\"}"; val="${val#\"}"
+  val="${val%\'}"; val="${val#\'}"
+  [ -n "$val" ] || return 1
+  printf '%s\n' "$val"
+}
+
+# --- Guard: Linux only ------------------------------------------------------
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "ERROR: bootstrap.sh targets Linux (systemd --user units, apt). Detected: $(uname -s)." >&2
+  echo "This kit is for the off-Studio VPS box, not the Mac dev machine." >&2
+  exit 1
+fi
+
+REPO_DIR="${1:-${REPO_DIR:-$HOME/khive}}"
+REPO_URL="${REPO_URL:-https://github.com/ohdearquant/khive.git}"
+REF="${REF:-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+echo "==> khive box bootstrap"
+echo "    REPO_DIR: $REPO_DIR"
+echo "    REPO_URL: $REPO_URL"
+echo "    REF:      $REF"
+
+# --- Stage (a): apt dependencies --------------------------------------------
+stage "Installing apt dependencies"
+if command -v apt-get >/dev/null 2>&1; then
+  $SUDO apt-get update
+  $SUDO apt-get install -y \
+    build-essential clang pkg-config git sqlite3 curl ca-certificates
+else
+  echo "ERROR: apt-get not found. This script targets Debian/Ubuntu." >&2
+  echo "Install manually and re-run: build-essential clang pkg-config git sqlite3 curl ca-certificates" >&2
+  exit 1
+fi
+
+# --- Stage (b): rustup stable -----------------------------------------------
+stage "Ensuring Rust toolchain"
+if command -v cargo >/dev/null 2>&1; then
+  echo "Rust toolchain already present: $(cargo --version)"
+else
+  echo "Installing rustup (stable toolchain)..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+fi
+# shellcheck source=/dev/null
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+# --- Stage (c): clone or update repo checkout -------------------------------
+stage "Syncing repo checkout at $REPO_DIR (ref: $REF)"
+if [ -d "$REPO_DIR/.git" ]; then
+  echo "Existing checkout found, updating..."
+  git -C "$REPO_DIR" fetch origin "$REF"
+  git -C "$REPO_DIR" checkout "$REF" 2>/dev/null || git -C "$REPO_DIR" checkout -b "$REF" "origin/$REF"
+  git -C "$REPO_DIR" reset --hard "origin/$REF" 2>/dev/null || git -C "$REPO_DIR" reset --hard "$REF"
+else
+  echo "No checkout found, cloning..."
+  git clone "$REPO_URL" "$REPO_DIR"
+  git -C "$REPO_DIR" checkout "$REF"
+fi
+# REPO_DIR is a deployment checkout, not a workspace for local edits. The
+# reset --hard on update is intentional so re-running this script always
+# converges on the exact state of $REF upstream.
+
+# --- Stage (d): release build (must include channel-email) -----------------
+stage "Building kkernel (release, channel-email); this can take several minutes"
+(cd "$REPO_DIR/crates" && cargo build --release -p kkernel --features channel-email)
+
+SRC="$REPO_DIR/crates/target/release/kkernel"
+if [ ! -f "$SRC" ]; then
+  echo "ERROR: build artifact $SRC missing after build." >&2
+  exit 1
+fi
+
+# --- Stage (e): install binary ----------------------------------------------
+stage "Installing kkernel to ~/.cargo/bin"
+mkdir -p "$HOME/.cargo/bin"
+DEST="$HOME/.cargo/bin/kkernel"
+# Atomic mv into place. Unlike the Mac `make local` target, this does NOT pkill
+# running kkernel processes first. On Linux, replacing the inode under a running
+# process's feet is safe (the old process keeps its already-open file handle to
+# the old inode until it exits/restarts). The systemd restart in stage (f) is
+# what actually swaps the running process over to the new binary.
+cp "$SRC" "$DEST.new"
+chmod +x "$DEST.new"
+mv "$DEST.new" "$DEST"
+echo "Installed: $DEST ($("$DEST" --version 2>&1 || echo 'version check failed'))"
+
+# --- Stage (f): systemd user unit -------------------------------------------
+stage "Installing systemd --user unit"
+mkdir -p "$HOME/.config/systemd/user"
+mkdir -p "$HOME/.khive"
+cp "$SCRIPT_DIR/kkernel.service" "$HOME/.config/systemd/user/kkernel.service"
+systemctl --user daemon-reload
+systemctl --user enable kkernel.service
+systemctl --user restart kkernel.service
+echo "systemd --user unit installed and (re)started."
+echo "NOTE: for this unit to survive logout and start on boot, run once:"
+echo "      loginctl enable-linger $USER"
+
+# --- Stage (g): smoke test ---------------------------------------------------
+stage "Smoke test"
+SOCK="$HOME/.khive/khived.sock"
+echo "Waiting up to 10s for daemon socket at $SOCK..."
+for _ in $(seq 1 10); do
+  [ -S "$SOCK" ] && break
+  sleep 1
+done
+
+if "$DEST" exec 'stats()'; then
+  echo "Smoke test passed: kkernel exec stats() responded."
+else
+  echo "WARNING: smoke test call failed. Check: systemctl --user status kkernel.service" >&2
+  echo "         and: journalctl --user -u kkernel.service -n 50 --no-pager" >&2
+fi
+
+# --- Check: actor identity (issue #200) -------------------------------------
+# comm.send stamps from_actor from the dispatch token's actor. A daemon with no
+# [actor] id configured mints anonymous tokens, so comm.send stamps
+# from_actor="local"; a reply routed back to that outbound note then resolves
+# to_actor="local" instead of this box's inbox: a silent misroute, not an
+# error either side would notice on its own. This check only verifies a human
+# has deliberately set an id in this daemon's config; it does not invent one
+# (the right id is deployment-specific, see scripts/box/README.md).
+CONFIG_TOML="$HOME/.khive/config.toml"
+ACTOR_ID="$(actor_id_from_config "$CONFIG_TOML" || true)"
+if [ -z "$ACTOR_ID" ]; then
+  echo "" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  echo "WARNING: no [actor] id set in $CONFIG_TOML" >&2
+  echo "         This daemon will mint anonymous dispatch tokens. comm.send" >&2
+  echo "         will stamp from_actor=\"local\", and replies routed back to" >&2
+  echo "         it will silently misroute instead of reaching this box's" >&2
+  echo "         inbox (issue #200). Fix: create/edit $CONFIG_TOML with:" >&2
+  echo "           [actor]" >&2
+  echo "           id = \"lambda:<you>\"" >&2
+  echo "         then: systemctl --user restart kkernel.service" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+else
+  echo "Actor identity: [actor] id = \"$ACTOR_ID\" ($CONFIG_TOML)"
+fi
+
+cat <<'EOF'
+
+==> Bootstrap complete. Next steps:
+
+  1. Place secrets:
+       cp scripts/box/env.template ~/.khive/.env
+       # edit ~/.khive/.env with real values (see scripts/box/README.md)
+       systemctl --user restart kkernel.service
+
+  2. If this box is replacing the Mac as the primary substrate host, copy the
+     existing khive.db over (see scripts/box/README.md "Moving the database").
+
+  3. Verify boot persistence:
+       loginctl enable-linger $USER
+
+  4. From the Mac, forward the daemon socket over SSH if you need direct access
+     (see scripts/box/README.md "Mac-side access").
+
+  5. Set this box's actor identity if the check above warned about it
+     (see scripts/box/README.md "Actor identity").
+
+EOF

--- a/scripts/box/bootstrap.sh
+++ b/scripts/box/bootstrap.sh
@@ -49,6 +49,100 @@ actor_id_from_config() {
   printf '%s\n' "$val"
 }
 
+# Resolve one of the three KHIVE_EMAIL_OAUTH_* values the way
+# load_khive_dotenv() would (crates/kkernel/src/main.rs): a real process
+# environment variable wins; otherwise fall back to parsing (never sourcing)
+# the given dotenv-style file, so a value containing shell metacharacters
+# cannot execute code. dotenvy::from_path() never overrides an already-set
+# variable and, for a key repeated in the file, applies the first occurrence
+# (dotenvy 0.15.7 src/iter.rs Iter::load). This helper mirrors both rules.
+# Prints the resolved value on stdout and returns 0 when found and non-empty;
+# returns 1 (silently) otherwise.
+oauth_var() {
+  local name="$1" file="$2" existing raw val
+  case "$name" in
+    KHIVE_EMAIL_OAUTH_CLIENT_ID) existing="${KHIVE_EMAIL_OAUTH_CLIENT_ID:-}" ;;
+    KHIVE_EMAIL_OAUTH_CLIENT_SECRET) existing="${KHIVE_EMAIL_OAUTH_CLIENT_SECRET:-}" ;;
+    KHIVE_EMAIL_OAUTH_TENANT_ID) existing="${KHIVE_EMAIL_OAUTH_TENANT_ID:-}" ;;
+    *) existing="" ;;
+  esac
+  if [ -n "$existing" ]; then
+    printf '%s\n' "$existing"
+    return 0
+  fi
+  [ -f "$file" ] || return 1
+  raw="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" "$file" 2>/dev/null | head -n 1)"
+  [ -n "$raw" ] || return 1
+  val="${raw#*=}"
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  [ -n "$val" ] || return 1
+  printf '%s\n' "$val"
+}
+
+# Mask a GUID-shaped value for display: first 6 characters, then an ellipsis
+# marker. Only ever called on a client_id or tenant_id (see the email auth
+# smoke below); never called on the client secret.
+mask_value() {
+  printf '%s...\n' "${1:0:6}"
+}
+
+# Replace every literal occurrence of `value` in `text` with its masked
+# form. Used only to scrub a client_id or tenant_id out of Microsoft's
+# error/error_description text before printing it, since that text
+# sometimes echoes a configured id verbatim (e.g. "Application with
+# identifier 'xxx' was not found in the directory"). Client ids and tenant
+# ids are Microsoft-issued GUIDs, which cannot contain glob metacharacters,
+# so bash's `${text//pattern/repl}` pattern matching is a safe literal
+# replacement here.
+scrub_value() {
+  local text="$1" value="$2" masked
+  if [ -z "$value" ]; then
+    printf '%s\n' "$text"
+    return 0
+  fi
+  masked="$(mask_value "$value")"
+  printf '%s\n' "${text//$value/$masked}"
+}
+
+# Extract a top-level string field from a JSON object. Prefers python3
+# (correct quote/escape handling); falls back to a grep/sed pass that
+# assumes a flat, single-line-ish body with no escaped quotes or embedded
+# newlines inside the value, which is what Microsoft's token endpoint
+# returns for its error/error_description fields. Prints the value on
+# stdout and returns 0 when found and non-empty; returns 1 (silently)
+# otherwise.
+extract_json_field() {
+  local json="$1" field="$2"
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(1)
+value = data.get(sys.argv[1])
+if not isinstance(value, str) or not value:
+    sys.exit(1)
+sys.stdout.write(value)
+' "$field"
+    return $?
+  fi
+  local match
+  match="$(printf '%s' "$json" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -n 1)"
+  [ -n "$match" ] || return 1
+  match="${match#*:}"
+  match="${match#"${match%%[![:space:]]*}"}"
+  match="${match#\"}"
+  match="${match%\"}"
+  [ -n "$match" ] || return 1
+  printf '%s\n' "$match"
+}
+
 # --- Guard: Linux only ------------------------------------------------------
 if [ "$(uname -s)" != "Linux" ]; then
   echo "ERROR: bootstrap.sh targets Linux (systemd --user units, apt). Detected: $(uname -s)." >&2
@@ -188,6 +282,100 @@ else
   echo "Actor identity: [actor] id = \"$ACTOR_ID\" ($CONFIG_TOML)"
 fi
 
+# --- Check: email channel auth smoke (config.rs OAuth contract) -------------
+# The email channel disables itself with a warning log, not a crash, when its
+# OAuth config is incomplete or the client secret is invalid or expired
+# (crates/khive-channel-email/src/config.rs). On a headless box nobody is
+# tailing journalctl by default, so a rotated or expired secret otherwise
+# means email quietly stops working with nothing loud to notice it. This
+# check calls the same client_credentials token endpoint the daemon itself
+# would use and makes that failure loud at bootstrap time. It never prints
+# the client secret, in any form, on any path.
+stage "Email channel auth smoke"
+
+# The whole stage is best-effort: a curl failure, a malformed response, or a
+# missing python3 fallback path are all reported as warnings, matching the
+# non-fatal convention of the stats() smoke test and the actor-identity check
+# above (a box without email configured, or one hitting a transient network
+# blip during bootstrap, is not a bootstrap failure). set +e removes any risk
+# that a failing command in this stage trips the script's set -e and aborts
+# bootstrap; it is restored immediately after.
+set +e
+
+DOTENV="$HOME/.khive/.env"
+EMAIL_CLIENT_ID="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$DOTENV")"
+EMAIL_CLIENT_SECRET="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_SECRET "$DOTENV")"
+EMAIL_TENANT_ID="$(oauth_var KHIVE_EMAIL_OAUTH_TENANT_ID "$DOTENV")"
+
+EMAIL_OAUTH_PRESENT=0
+[ -n "$EMAIL_CLIENT_ID" ] && EMAIL_OAUTH_PRESENT=$((EMAIL_OAUTH_PRESENT + 1))
+[ -n "$EMAIL_CLIENT_SECRET" ] && EMAIL_OAUTH_PRESENT=$((EMAIL_OAUTH_PRESENT + 1))
+[ -n "$EMAIL_TENANT_ID" ] && EMAIL_OAUTH_PRESENT=$((EMAIL_OAUTH_PRESENT + 1))
+
+if [ "$EMAIL_OAUTH_PRESENT" -eq 0 ]; then
+  echo "email OAuth not configured; skipping auth smoke"
+elif [ "$EMAIL_OAUTH_PRESENT" -lt 3 ]; then
+  EMAIL_MISSING=""
+  [ -z "$EMAIL_CLIENT_ID" ] && EMAIL_MISSING="$EMAIL_MISSING KHIVE_EMAIL_OAUTH_CLIENT_ID"
+  [ -z "$EMAIL_CLIENT_SECRET" ] && EMAIL_MISSING="$EMAIL_MISSING KHIVE_EMAIL_OAUTH_CLIENT_SECRET"
+  [ -z "$EMAIL_TENANT_ID" ] && EMAIL_MISSING="$EMAIL_MISSING KHIVE_EMAIL_OAUTH_TENANT_ID"
+  echo "" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  echo "WARNING: partial email OAuth config in $DOTENV" >&2
+  echo "         missing:$EMAIL_MISSING" >&2
+  echo "         KHIVE_EMAIL_OAUTH_CLIENT_ID, KHIVE_EMAIL_OAUTH_CLIENT_SECRET," >&2
+  echo "         and KHIVE_EMAIL_OAUTH_TENANT_ID must be set together or not" >&2
+  echo "         at all (crates/khive-channel-email/src/config.rs). With only" >&2
+  echo "         some of the three set, the email channel disables itself" >&2
+  echo "         with a warning log rather than crashing the daemon, so this" >&2
+  echo "         is easy to miss on a headless box. Set all three, or remove" >&2
+  echo "         all three to use Basic auth (KHIVE_EMAIL_PASSWORD) instead," >&2
+  echo "         then:" >&2
+  echo "           systemctl --user restart kkernel.service" >&2
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+else
+  TOKEN_URL="https://login.microsoftonline.com/${EMAIL_TENANT_ID}/oauth2/v2.0/token"
+  EMAIL_RESPONSE="$(curl -sS --max-time 15 \
+    --data-urlencode "grant_type=client_credentials" \
+    --data-urlencode "scope=https://outlook.office365.com/.default" \
+    --data-urlencode "client_id=${EMAIL_CLIENT_ID}" \
+    --data-urlencode "client_secret=${EMAIL_CLIENT_SECRET}" \
+    "$TOKEN_URL" 2>&1)"
+  EMAIL_CURL_RC=$?
+
+  if [ "$EMAIL_CURL_RC" -ne 0 ]; then
+    echo "" >&2
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+    echo "WARNING: email auth smoke could not reach the token endpoint (curl exit $EMAIL_CURL_RC)" >&2
+    echo "         Check outbound HTTPS access to login.microsoftonline.com" >&2
+    echo "         from this box." >&2
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  elif printf '%s' "$EMAIL_RESPONSE" | grep -q '"access_token"'; then
+    echo "Email channel auth smoke: PASS (client_id $(mask_value "$EMAIL_CLIENT_ID"))"
+  else
+    EMAIL_ERR="$(extract_json_field "$EMAIL_RESPONSE" "error")"
+    EMAIL_ERR_DESC="$(extract_json_field "$EMAIL_RESPONSE" "error_description")"
+    EMAIL_ERR="$(scrub_value "$EMAIL_ERR" "$EMAIL_CLIENT_ID")"
+    EMAIL_ERR="$(scrub_value "$EMAIL_ERR" "$EMAIL_TENANT_ID")"
+    EMAIL_ERR_DESC="$(scrub_value "$EMAIL_ERR_DESC" "$EMAIL_CLIENT_ID")"
+    EMAIL_ERR_DESC="$(scrub_value "$EMAIL_ERR_DESC" "$EMAIL_TENANT_ID")"
+    echo "" >&2
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+    echo "WARNING: email channel auth smoke FAILED" >&2
+    echo "         error: ${EMAIL_ERR:-<unparsed response>}" >&2
+    echo "         error_description: ${EMAIL_ERR_DESC:-<unparsed response>}" >&2
+    echo "         AADSTS7000222 = expired client secret. AADSTS7000215 =" >&2
+    echo "         invalid client secret. Entra portal: App registrations >" >&2
+    echo "         (this app) > Certificates & secrets. Client secrets have" >&2
+    echo "         bounded lifetimes and this one may have expired. After" >&2
+    echo "         rotating it, update $DOTENV and re-run:" >&2
+    echo "           scripts/box/bootstrap.sh" >&2
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+  fi
+fi
+
+set -e
+
 cat <<'EOF'
 
 ==> Bootstrap complete. Next steps:
@@ -195,7 +383,10 @@ cat <<'EOF'
   1. Place secrets:
        cp scripts/box/env.template ~/.khive/.env
        # edit ~/.khive/.env with real values (see scripts/box/README.md)
-       systemctl --user restart kkernel.service
+       scripts/box/bootstrap.sh
+       # re-running exercises the email auth smoke against the new secrets.
+       # systemctl --user restart kkernel.service also picks up the change,
+       # but only bootstrap.sh runs the smoke.
 
   2. If this box is replacing the Mac as the primary substrate host, copy the
      existing khive.db over (see scripts/box/README.md "Moving the database").

--- a/scripts/box/env.template
+++ b/scripts/box/env.template
@@ -42,6 +42,11 @@ KHIVE_EMAIL_MAINTAINER_ADDRESS=<maintainer@example.com>
 KHIVE_EMAIL_OAUTH_CLIENT_ID=<client-id>
 KHIVE_EMAIL_OAUTH_CLIENT_SECRET=<client-secret>
 KHIVE_EMAIL_OAUTH_TENANT_ID=<tenant-id>
+# Once these three are set, bootstrap.sh (on any re-run) calls the Entra
+# token endpoint to confirm the client secret is still valid, and warns
+# loudly if it is missing, partial, or rejected (expired/rotated secret)
+# instead of letting the channel fail silently. See scripts/box/README.md
+# "Email channel auth smoke".
 # Basic auth mode (use instead of the three OAuth vars above):
 # KHIVE_EMAIL_PASSWORD=<mailbox-password>
 

--- a/scripts/box/env.template
+++ b/scripts/box/env.template
@@ -1,0 +1,59 @@
+# env.template: placeholders only. Copy to ~/.khive/.env and fill in real values.
+#
+#   cp scripts/box/env.template ~/.khive/.env
+#   chmod 600 ~/.khive/.env
+#
+# kkernel loads this file automatically at startup (load_khive_dotenv() in
+# crates/kkernel/src/main.rs) before it parses CLI args. Real process
+# environment variables always take precedence over values set here.
+#
+# NEVER commit a filled-in copy of this file. ~/.khive/.env stays on the box.
+#
+# Variable names verified against crates/khive-channel-email/src/config.rs,
+# crates/khive-channel-email/src/lib.rs, and crates/khive-mcp/src/serve.rs.
+# The `channel-email` feature (built into the kkernel binary by bootstrap.sh)
+# is inert unless these are set. An incomplete config disables the email
+# channel with a warning log; it does not crash the daemon.
+#
+# --- Also required: actor identity (NOT in this file) ------------------------
+# This box's daemon needs its own attribution identity, or comm.send stamps
+# from_actor="local" and replies silently misroute instead of reaching this
+# box's inbox (issue #200; see crates/khive-pack-comm/src/handlers.rs). Actor
+# identity is TOML config, not an env var, so it does not live in this file.
+# Create/edit ~/.khive/config.toml (separate from ~/.khive/.env) with:
+#
+#   [actor]
+#   id = "lambda:<you>"                        # e.g. "lambda:leo", "lambda:khive"
+#   display_name = "<optional human label>"
+#
+# bootstrap.sh checks for this and prints a loud warning if it is missing or
+# empty; it deliberately does not invent a default, since the correct id is
+# specific to which lambda/agent this box is standing up. See
+# scripts/box/README.md "Actor identity" for the full explanation.
+
+# --- Required always ---------------------------------------------------------
+KHIVE_EMAIL_USERNAME=<mailbox-username>
+KHIVE_EMAIL_SMTP_HOST=<smtp.example.com>
+KHIVE_EMAIL_IMAP_HOST=<imap.example.com>
+KHIVE_EMAIL_MAINTAINER_ADDRESS=<maintainer@example.com>
+
+# --- Auth: choose ONE mode, not both -----------------------------------------
+# OAuth mode (all three required together, or omit all three):
+KHIVE_EMAIL_OAUTH_CLIENT_ID=<client-id>
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=<client-secret>
+KHIVE_EMAIL_OAUTH_TENANT_ID=<tenant-id>
+# Basic auth mode (use instead of the three OAuth vars above):
+# KHIVE_EMAIL_PASSWORD=<mailbox-password>
+
+# --- Optional (defaults shown in comments) -----------------------------------
+# KHIVE_EMAIL_SMTP_PORT=587
+# KHIVE_EMAIL_IMAP_PORT=993
+# KHIVE_EMAIL_MAILBOX=<defaults to KHIVE_EMAIL_USERNAME>
+# KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS=<addr1@example.com,addr2@example.com>
+# KHIVE_EMAIL_DEFAULT_ACTOR=lambda:leo
+# KHIVE_EMAIL_INGEST_NAMESPACE=local
+
+# --- Optional: substrate paths (defaults shown in comments) ------------------
+# KHIVE_DB=<absolute-path-to-khive.db>          # default: ~/.khive/khive.db
+# KHIVE_CONFIG=<absolute-path-to-config.toml>   # default search: ./khive.toml, ./.khive/config.toml, ~/.khive/config.toml
+# KHIVE_LOG=<error|warn|info|debug|trace>       # default: warn

--- a/scripts/box/kkernel.service
+++ b/scripts/box/kkernel.service
@@ -1,0 +1,31 @@
+# kkernel.service: systemd USER unit for the khive substrate daemon.
+#
+# Install path: ~/.config/systemd/user/kkernel.service (installed by bootstrap.sh).
+#
+# kkernel mcp --daemon runs khive_runtime::daemon::run_daemon() in the FOREGROUND
+# (binds ~/.khive/khived.sock, then blocks in a tokio::select! accept-loop vs.
+# SIGTERM/SIGINT). It does not fork or self-daemonize, so Type=simple is correct
+# here: systemd's own process supervision IS the daemonization.
+#
+# kkernel loads ~/.khive/.env itself via load_khive_dotenv() (crates/kkernel/src/main.rs),
+# called unconditionally at the top of main() before argument parsing. Real
+# environment variables always win over values in that file, and a missing file
+# is not an error. No EnvironmentFile= directive is needed in this unit.
+#
+# For this unit to start on boot and keep running after you log out of the SSH
+# session that installed it, enable lingering for this user once:
+#   loginctl enable-linger $USER
+
+[Unit]
+Description=khive kernel daemon (kkernel mcp --daemon)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.cargo/bin/kkernel mcp --daemon
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/box/test_email_oauth_smoke.sh
+++ b/scripts/box/test_email_oauth_smoke.sh
@@ -1,0 +1,581 @@
+#!/usr/bin/env bash
+# Fixture harness for the "Email channel auth smoke" helpers and stage in
+# scripts/box/bootstrap.sh (the off-Studio box bootstrap kit's OAuth
+# client-secret validity check). Two testing strategies, both against the
+# code that actually ships, never a reimplementation:
+#
+#   1. The small helper functions (oauth_var, mask_value, is_guid_shaped,
+#      scrub_value, extract_json_field) are copy-pasted verbatim below and
+#      exercised directly.
+#   2. The stage's control flow itself (the xtrace guard, the GUID-shape
+#      gate, the set +e/set -e bracket, the single exit seam) is extracted
+#      fresh from bootstrap.sh at run time via sed, then sourced inside an
+#      isolated subshell (fake HOME, curl replaced by a network-free stub)
+#      so this always tests the current shipped stage, never a stale copy.
+#
+# No network calls are made anywhere in this file. Every id, GUID, and
+# secret in the fixtures below is fabricated for this test; none of them
+# are, or have ever been, valid Microsoft Entra credentials.
+#
+# Run from anywhere; all state lives under a throwaway mktemp directory
+# that is removed on exit.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_SH="$SCRIPT_DIR/bootstrap.sh"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/khive-box-email-smoke-test.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+FIXDIR="$SCRATCH/fixtures"
+mkdir -p "$FIXDIR"
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1" expect="$2" got="$3"
+  if [ "$got" = "$expect" ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc"
+    echo "      expected: $expect"
+    echo "      got:      $got"
+  fi
+}
+
+check_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      PASS=$((PASS + 1))
+      echo "PASS: $desc"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      echo "FAIL: $desc"
+      echo "      expected to contain: $needle"
+      echo "      got: $haystack"
+      ;;
+  esac
+}
+
+check_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      FAIL=$((FAIL + 1))
+      echo "FAIL: $desc"
+      echo "      expected NOT to contain: $needle"
+      echo "      got: $haystack"
+      ;;
+    *)
+      PASS=$((PASS + 1))
+      echo "PASS: $desc"
+      ;;
+  esac
+}
+
+check_bool() {
+  local desc="$1" expect="$2" got
+  shift 2
+  if "$@" >/dev/null 2>&1; then got="true"; else got="false"; fi
+  check "$desc" "$expect" "$got"
+}
+
+# --- Fixtures: sample ~/.khive/.env files ------------------------------------
+
+cat > "$FIXDIR/env_all_quoted.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID="cid-quoted-111111"
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET="cs-quoted-222222"
+KHIVE_EMAIL_OAUTH_TENANT_ID="tid-quoted-333333"
+EOF
+
+cat > "$FIXDIR/env_all_unquoted.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=cid-unquoted-111111
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=cs-unquoted-222222
+KHIVE_EMAIL_OAUTH_TENANT_ID=tid-unquoted-333333
+EOF
+
+cat > "$FIXDIR/env_partial_one.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=only-client-id-set
+EOF
+
+cat > "$FIXDIR/env_partial_two.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=cid-partial
+KHIVE_EMAIL_OAUTH_TENANT_ID=tid-partial
+EOF
+
+cat > "$FIXDIR/env_empty_value.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=cs-set
+KHIVE_EMAIL_OAUTH_TENANT_ID=tid-set
+EOF
+
+cat > "$FIXDIR/env_unrelated_only.env" <<'EOF'
+KHIVE_EMAIL_USERNAME=someone@example.com
+KHIVE_EMAIL_SMTP_HOST=smtp.example.com
+EOF
+
+# Fake-but-GUID-shaped triple: passes the is_guid_shaped gate, so the stage
+# proceeds to the (stubbed) curl call in the stage-integration tests below.
+FAKE_SMOKE_SECRET="xtrace-canary-secret-do-not-leak-9f8e7d"
+cat > "$FIXDIR/env_all_three_fake.env" <<EOF
+KHIVE_EMAIL_OAUTH_CLIENT_ID=66666666-7777-8888-9999-aaaaaaaaaaaa
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=$FAKE_SMOKE_SECRET
+KHIVE_EMAIL_OAUTH_TENANT_ID=11111111-2222-3333-4444-555555555555
+EOF
+
+# Malformed client_id (contains a glob metacharacter): all three vars are
+# present (so the stage does not take the partial-config branch), but the
+# id itself is not GUID-shaped.
+cat > "$FIXDIR/env_malformed_client_id.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=not-a-real-guid*marker-abc123
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=some-fake-secret-value-for-testing
+KHIVE_EMAIL_OAUTH_TENANT_ID=11111111-2222-3333-4444-555555555555
+EOF
+
+# Malformed tenant_id (contains embedded spaces): same shape, the other
+# side of the gate.
+cat > "$FIXDIR/env_malformed_tenant_id.env" <<'EOF'
+KHIVE_EMAIL_OAUTH_CLIENT_ID=66666666-7777-8888-9999-aaaaaaaaaaaa
+KHIVE_EMAIL_OAUTH_CLIENT_SECRET=some-fake-secret-value-for-testing
+KHIVE_EMAIL_OAUTH_TENANT_ID=has spaces not a guid
+EOF
+
+# --- Verbatim copies of the functions under test -----------------------------
+# (Copy-pasted from scripts/box/bootstrap.sh, not reimplemented, so this
+# exercises the actual logic that ships. stage() is included because the
+# extracted stage fragment used below calls it as its first line.)
+
+stage() {
+  printf '\n==> [%s] %s\n' "$(date -u +%H:%M:%S)" "$1"
+}
+
+oauth_var() {
+  local name="$1" file="$2" existing raw val
+  case "$name" in
+    KHIVE_EMAIL_OAUTH_CLIENT_ID) existing="${KHIVE_EMAIL_OAUTH_CLIENT_ID:-}" ;;
+    KHIVE_EMAIL_OAUTH_CLIENT_SECRET) existing="${KHIVE_EMAIL_OAUTH_CLIENT_SECRET:-}" ;;
+    KHIVE_EMAIL_OAUTH_TENANT_ID) existing="${KHIVE_EMAIL_OAUTH_TENANT_ID:-}" ;;
+    *) existing="" ;;
+  esac
+  if [ -n "$existing" ]; then
+    printf '%s\n' "$existing"
+    return 0
+  fi
+  [ -f "$file" ] || return 1
+  raw="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" "$file" 2>/dev/null | head -n 1)"
+  [ -n "$raw" ] || return 1
+  val="${raw#*=}"
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  [ -n "$val" ] || return 1
+  printf '%s\n' "$val"
+}
+
+mask_value() {
+  printf '%s...\n' "${1:0:6}"
+}
+
+is_guid_shaped() {
+  local re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+  [[ "$1" =~ $re ]]
+}
+
+scrub_value() {
+  local text="$1" value="$2" masked
+  if [ -z "$value" ]; then
+    printf '%s\n' "$text"
+    return 0
+  fi
+  masked="$(mask_value "$value")"
+  printf '%s\n' "${text//$value/$masked}"
+}
+
+extract_json_field() {
+  local json="$1" field="$2"
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(1)
+value = data.get(sys.argv[1])
+if not isinstance(value, str) or not value:
+    sys.exit(1)
+sys.stdout.write(value)
+' "$field"
+    return $?
+  fi
+  local match
+  match="$(printf '%s' "$json" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -n 1)"
+  [ -n "$match" ] || return 1
+  match="${match#*:}"
+  match="${match#"${match%%[![:space:]]*}"}"
+  match="${match#\"}"
+  match="${match%\"}"
+  [ -n "$match" ] || return 1
+  printf '%s\n' "$match"
+}
+
+# Test-only twin that always takes the grep/sed branch, regardless of
+# whether python3 is on PATH, so the fallback body itself is exercised
+# deterministically on every machine this harness runs on.
+extract_json_field_fallback_only() {
+  local json="$1" field="$2" match
+  match="$(printf '%s' "$json" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -n 1)"
+  [ -n "$match" ] || return 1
+  match="${match#*:}"
+  match="${match#"${match%%[![:space:]]*}"}"
+  match="${match#\"}"
+  match="${match%\"}"
+  [ -n "$match" ] || return 1
+  printf '%s\n' "$match"
+}
+
+# --- oauth_var: file parsing --------------------------------------------------
+
+echo "=== oauth_var: file parsing ==="
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$FIXDIR/env_all_quoted.env")"
+check "quoted value: strips surrounding double quotes" "cid-quoted-111111" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_SECRET "$FIXDIR/env_all_quoted.env")"
+check "quoted value (secret var): strips surrounding double quotes" "cs-quoted-222222" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_TENANT_ID "$FIXDIR/env_all_unquoted.env")"
+check "unquoted value: read as-is" "tid-unquoted-333333" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_SECRET "$FIXDIR/env_partial_one.env" 2>/dev/null || echo "__MISSING__")"
+check "var absent from file: oauth_var fails (empty result)" "__MISSING__" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$FIXDIR/env_empty_value.env" 2>/dev/null || echo "__MISSING__")"
+check "var present but empty in file: treated as absent" "__MISSING__" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$FIXDIR/env_unrelated_only.env" 2>/dev/null || echo "__MISSING__")"
+check "var not in file at all: oauth_var fails" "__MISSING__" "$v"
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$SCRATCH/does-not-exist.env" 2>/dev/null || echo "__MISSING__")"
+check "file does not exist: oauth_var fails without erroring" "__MISSING__" "$v"
+
+# --- oauth_var: real env wins over file (documented precedence) -------------
+
+echo ""
+echo "=== oauth_var: process env takes precedence over the file ==="
+
+KHIVE_EMAIL_OAUTH_CLIENT_ID="from-real-env"
+export KHIVE_EMAIL_OAUTH_CLIENT_ID
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$FIXDIR/env_all_quoted.env")"
+check "already-exported var beats the file value" "from-real-env" "$v"
+unset KHIVE_EMAIL_OAUTH_CLIENT_ID
+
+v="$(oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$FIXDIR/env_all_quoted.env")"
+check "after unset, file value is used again" "cid-quoted-111111" "$v"
+
+# --- PRESENT_COUNT classification (mirrors the stage's own 0 / 1-2 / 3 split) --
+
+echo ""
+echo "=== EMAIL_OAUTH_PRESENT classification ==="
+
+count_present() {
+  local file="$1" n=0
+  oauth_var KHIVE_EMAIL_OAUTH_CLIENT_ID "$file" >/dev/null 2>&1 && n=$((n + 1))
+  oauth_var KHIVE_EMAIL_OAUTH_CLIENT_SECRET "$file" >/dev/null 2>&1 && n=$((n + 1))
+  oauth_var KHIVE_EMAIL_OAUTH_TENANT_ID "$file" >/dev/null 2>&1 && n=$((n + 1))
+  echo "$n"
+}
+
+v="$(count_present "$FIXDIR/env_all_quoted.env")"
+check "all three set: PRESENT_COUNT == 3" "3" "$v"
+
+v="$(count_present "$FIXDIR/env_partial_one.env")"
+check "one set: PRESENT_COUNT == 1" "1" "$v"
+
+v="$(count_present "$FIXDIR/env_partial_two.env")"
+check "two set: PRESENT_COUNT == 2" "2" "$v"
+
+v="$(count_present "$FIXDIR/env_unrelated_only.env")"
+check "none set: PRESENT_COUNT == 0" "0" "$v"
+
+# --- mask_value ---------------------------------------------------------------
+
+echo ""
+echo "=== mask_value ==="
+
+v="$(mask_value "abcdefgh-secret")"
+check "masks to first 6 chars + ellipsis" "abcdef..." "$v"
+
+v="$(mask_value "ab")"
+check "short value: no padding, just what's there + ellipsis" "ab..." "$v"
+
+v="$(mask_value "")"
+check "empty value: just the ellipsis" "..." "$v"
+
+# --- is_guid_shaped ------------------------------------------------------------
+
+echo ""
+echo "=== is_guid_shaped ==="
+
+check_bool "accepts a lowercase-hex GUID" "true" is_guid_shaped "11111111-2222-3333-4444-555555555555"
+check_bool "accepts an uppercase-hex GUID" "true" is_guid_shaped "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+check_bool "accepts a mixed-case-hex GUID" "true" is_guid_shaped "66666666-7777-8888-9999-aaaaaaaaaaaa"
+check_bool "rejects a value containing a glob star" "false" is_guid_shaped "not-a-real-guid*marker-abc123"
+check_bool "rejects a value containing an embedded space" "false" is_guid_shaped "11111111-2222-3333-4444-5555555555 5"
+check_bool "rejects a value containing brackets" "false" is_guid_shaped "[1111111]-2222-3333-4444-555555555555"
+check_bool "rejects a too-short value" "false" is_guid_shaped "11111111-2222-3333-4444-55555555"
+check_bool "rejects a too-long value" "false" is_guid_shaped "11111111-2222-3333-4444-5555555555555555"
+check_bool "rejects a value with non-hex characters" "false" is_guid_shaped "gggggggg-2222-3333-4444-555555555555"
+check_bool "rejects an empty string" "false" is_guid_shaped ""
+check_bool "rejects a plain word with no GUID structure" "false" is_guid_shaped "not-a-guid-at-all"
+
+# --- extract_json_field + scrub_value against a real AADSTS response --------
+
+echo ""
+echo "=== extract_json_field + scrub_value against a real AADSTS90002 response ==="
+
+# Captured from a live (rejected) token request against a nonexistent fake
+# tenant. Contains no credentials; the tenant GUID and trace/correlation
+# IDs are not secrets, and the tenant does not exist.
+LIVE_JSON='{"error":"invalid_request","error_description":"AADSTS90002: Tenant '"'"'11111111-2222-3333-4444-555555555555'"'"' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: 06d036b0-8892-4cb4-94f9-8a2d3e9c2000 Correlation ID: f1b414c3-83bd-457f-bb87-a358fd5232e1 Timestamp: 2026-07-02 14:44:48Z","error_codes":[90002],"timestamp":"2026-07-02 14:44:48Z","trace_id":"06d036b0-8892-4cb4-94f9-8a2d3e9c2000","correlation_id":"f1b414c3-83bd-457f-bb87-a358fd5232e1","error_uri":"https://login.microsoftonline.com/error?code=90002"}'
+
+FAKE_TENANT="11111111-2222-3333-4444-555555555555"
+FAKE_CLIENT="66666666-7777-8888-9999-aaaaaaaaaaaa"
+
+err="$(extract_json_field "$LIVE_JSON" "error")"
+check "extract_json_field: error field" "invalid_request" "$err"
+
+desc="$(extract_json_field "$LIVE_JSON" "error_description")"
+check_contains "extract_json_field: error_description contains AADSTS code" "AADSTS90002" "$desc"
+check_contains "extract_json_field: error_description preserves apostrophes around the tenant" "Tenant '11111111-2222-3333-4444-555555555555' not found" "$desc"
+check_contains "extract_json_field: error_description runs to the real end (Timestamp line)" "Timestamp: 2026-07-02" "$desc"
+
+scrubbed="$(scrub_value "$desc" "$FAKE_TENANT")"
+check_not_contains "scrub_value: raw tenant GUID removed from error_description" "$FAKE_TENANT" "$scrubbed"
+check_contains "scrub_value: masked tenant GUID present instead" "111111..." "$scrubbed"
+
+scrubbed="$(scrub_value "$desc" "$FAKE_CLIENT")"
+check "scrub_value: scrubbing a value that is not present is a no-op" "$desc" "$scrubbed"
+
+err_fb="$(extract_json_field_fallback_only "$LIVE_JSON" "error")"
+check "fallback path: error field" "invalid_request" "$err_fb"
+
+desc_fb="$(extract_json_field_fallback_only "$LIVE_JSON" "error_description")"
+check_contains "fallback path: error_description contains AADSTS code" "AADSTS90002" "$desc_fb"
+check_contains "fallback path: error_description preserves apostrophes around the tenant" "Tenant '11111111-2222-3333-4444-555555555555' not found" "$desc_fb"
+check "fallback path: does not confuse error_description with error (no substring bleed)" "invalid_request" "$err_fb"
+
+scrubbed_fb="$(scrub_value "$desc_fb" "$FAKE_TENANT")"
+check_not_contains "fallback path + scrub_value: raw tenant GUID removed" "$FAKE_TENANT" "$scrubbed_fb"
+
+FAKE_SUCCESS='{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"fake.not.a.real.jwt.eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}'
+has_token="$(printf '%s' "$FAKE_SUCCESS" | grep -q '"access_token"' && echo "yes" || echo "no")"
+check "PASS-shaped response: access_token detection works" "yes" "$has_token"
+
+# --- extract_json_field: real dispatcher without python3 on PATH ------------
+
+echo ""
+echo "=== extract_json_field: real dispatcher falls back correctly when python3 is not on PATH ==="
+
+NOPY_DIR="$SCRATCH/no-python-path"
+mkdir -p "$NOPY_DIR"
+for bin in grep head; do
+  src="$(command -v "$bin")"
+  ln -sf "$src" "$NOPY_DIR/$bin"
+done
+
+err_nopy="$(
+  (
+    PATH="$NOPY_DIR"
+    extract_json_field "$LIVE_JSON" "error"
+  ) 2>&1
+)"
+check "extract_json_field (real dispatcher, not the _fallback_only twin): takes the grep/sed path and still extracts 'error' correctly" "invalid_request" "$err_nopy"
+
+desc_nopy="$(
+  (
+    PATH="$NOPY_DIR"
+    extract_json_field "$LIVE_JSON" "error_description"
+  ) 2>&1
+)"
+check_contains "extract_json_field (no python3 on PATH): error_description still extracted" "AADSTS90002" "$desc_nopy"
+
+# --- static-shape checks against the real bootstrap.sh -----------------------
+
+echo ""
+echo "=== static-shape checks against the shipped bootstrap.sh ==="
+
+if grep -n 'scrub_value' "$BOOTSTRAP_SH" | grep -v 'EMAIL_CLIENT_SECRET' | grep -q .; then
+  PASS=$((PASS + 1))
+  echo "PASS: scrub_value is called in bootstrap.sh (sanity: the function is actually used)"
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: scrub_value does not appear to be called anywhere in bootstrap.sh"
+fi
+
+if grep -n 'scrub_value.*EMAIL_CLIENT_SECRET\|EMAIL_CLIENT_SECRET.*scrub_value' "$BOOTSTRAP_SH" | grep -q .; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: scrub_value appears to be called with EMAIL_CLIENT_SECRET (the secret must never reach scrub_value's text argument)"
+else
+  PASS=$((PASS + 1))
+  echo "PASS: scrub_value is never called with EMAIL_CLIENT_SECRET"
+fi
+
+if grep -nE '(echo|printf).*EMAIL_CLIENT_SECRET' "$BOOTSTRAP_SH" | grep -q .; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: found an echo/printf that references EMAIL_CLIENT_SECRET directly in bootstrap.sh"
+else
+  PASS=$((PASS + 1))
+  echo "PASS: no echo/printf in bootstrap.sh references EMAIL_CLIENT_SECRET directly"
+fi
+
+if grep -n 'is_guid_shaped "\$EMAIL_CLIENT_ID"' "$BOOTSTRAP_SH" | grep -q .; then
+  PASS=$((PASS + 1))
+  echo "PASS: bootstrap.sh validates EMAIL_CLIENT_ID with is_guid_shaped before the curl call"
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: no is_guid_shaped check found for EMAIL_CLIENT_ID in bootstrap.sh"
+fi
+
+if grep -n 'is_guid_shaped "\$EMAIL_TENANT_ID"' "$BOOTSTRAP_SH" | grep -q .; then
+  PASS=$((PASS + 1))
+  echo "PASS: bootstrap.sh validates EMAIL_TENANT_ID with is_guid_shaped before the curl call"
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: no is_guid_shaped check found for EMAIL_TENANT_ID in bootstrap.sh"
+fi
+
+if grep -n '__smoke_had_xtrace=1' "$BOOTSTRAP_SH" | grep -q .; then
+  PASS=$((PASS + 1))
+  echo "PASS: bootstrap.sh captures the caller's xtrace state before resolving any OAuth value"
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: no xtrace-capture guard found in bootstrap.sh"
+fi
+
+# --- sanity check: this harness's leak-detection method actually detects a leak
+
+echo ""
+echo "=== sanity check: xtrace DOES print an assigned value when left on unguarded ==="
+echo "    (proves the 'fake secret never appears' assertions below are not vacuous)"
+
+XTRACE_CANARY="xtrace-mechanism-canary-3f9c1a"
+sanity_trace_out="$(bash -c 'set -x; PROBE_VALUE="'"$XTRACE_CANARY"'"; : "$PROBE_VALUE"' 2>&1)"
+check_contains "sanity: plain bash xtrace prints an assigned value when tracing is left on" "$XTRACE_CANARY" "$sanity_trace_out"
+
+# --- stage-level integration: extract the live stage from bootstrap.sh ------
+
+echo ""
+echo "=== email-auth-smoke stage: dynamic extraction from the shipped bootstrap.sh ==="
+
+STAGE_FRAGMENT="$SCRATCH/extracted_email_smoke_stage.sh"
+sed -n '/^stage "Email channel auth smoke"$/,/^set -e$/p' "$BOOTSTRAP_SH" > "$STAGE_FRAGMENT"
+STAGE_FRAGMENT_LINES="$(wc -l < "$STAGE_FRAGMENT" | tr -d ' ')"
+if [ "$STAGE_FRAGMENT_LINES" -lt 20 ]; then
+  echo "FATAL: extracted email-auth-smoke stage from $BOOTSTRAP_SH is suspiciously" >&2
+  echo "       short ($STAGE_FRAGMENT_LINES lines). The anchor lines this harness"   >&2
+  echo "       sed's on ('stage \"Email channel auth smoke\"' .. 'set -e') may have" >&2
+  echo "       changed in bootstrap.sh; update this harness to match."               >&2
+  exit 1
+fi
+
+CURL_MARKER="$SCRATCH/.curl_called_marker"
+
+# Sources the ACTUAL current email-auth-smoke stage (extracted fresh above,
+# not reimplemented) inside an isolated subshell: a fake HOME so DOTENV
+# resolves to a fixture file, the three KHIVE_EMAIL_OAUTH_* process-env vars
+# unset so only the file is in play, and curl replaced by a network-free
+# stub so no request ever leaves this machine. Sets globals STAGE_OUT
+# (combined stdout+stderr) and STAGE_RC (exit status of the sourced stage).
+run_stage_case() {
+  local label="$1" fixture="$2" trace_mode="$3" fakehome
+  fakehome="$SCRATCH/fakehome_$label"
+  rm -rf "$fakehome"
+  mkdir -p "$fakehome/.khive"
+  [ -n "$fixture" ] && cp "$fixture" "$fakehome/.khive/.env"
+  rm -f "$CURL_MARKER"
+  STAGE_OUT="$(
+    (
+      set -e
+      HOME="$fakehome"
+      export HOME
+      unset KHIVE_EMAIL_OAUTH_CLIENT_ID KHIVE_EMAIL_OAUTH_CLIENT_SECRET KHIVE_EMAIL_OAUTH_TENANT_ID
+      curl() { : >"$CURL_MARKER"; printf '%s' "$LIVE_JSON"; }
+      [ "$trace_mode" = "traced" ] && set -x
+      # shellcheck source=/dev/null
+      . "$STAGE_FRAGMENT"
+    ) 2>&1
+  )"
+  STAGE_RC=$?
+}
+
+echo ""
+echo "--- case: unconfigured (0 vars) ---"
+run_stage_case "unconfigured" "" "plain"
+check "unconfigured: exits 0 (non-fatal)" "0" "$STAGE_RC"
+check_contains "unconfigured: prints the skip note" "email OAuth not configured; skipping auth smoke" "$STAGE_OUT"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "unconfigured: never calls curl" "no" "$curl_called"
+
+echo ""
+echo "--- case: partial config (2 of 3 vars) ---"
+run_stage_case "partial" "$FIXDIR/env_partial_two.env" "plain"
+check "partial config: exits 0 (non-fatal)" "0" "$STAGE_RC"
+check_contains "partial config: prints the partial-config warning banner" "WARNING: partial email OAuth config" "$STAGE_OUT"
+check_contains "partial config: names the missing var" "KHIVE_EMAIL_OAUTH_CLIENT_SECRET" "$STAGE_OUT"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "partial config: never calls curl" "no" "$curl_called"
+
+echo ""
+echo "--- case: malformed client_id (contains a glob star) ---"
+run_stage_case "malformed_cid" "$FIXDIR/env_malformed_client_id.env" "plain"
+check "malformed client_id: exits 0 (non-fatal)" "0" "$STAGE_RC"
+check_contains "malformed client_id: warning names KHIVE_EMAIL_OAUTH_CLIENT_ID" "KHIVE_EMAIL_OAUTH_CLIENT_ID" "$STAGE_OUT"
+check_contains "malformed client_id: warning says not GUID-shaped" "GUID-shaped" "$STAGE_OUT"
+check_contains "malformed client_id: warning says the smoke is being skipped" "skipping email" "$STAGE_OUT"
+check_contains "malformed client_id: masked value shown instead of raw" "not-a-..." "$STAGE_OUT"
+check_not_contains "malformed client_id: raw value prefix never printed" "not-a-real-guid" "$STAGE_OUT"
+check_not_contains "malformed client_id: raw value suffix never printed" "marker-abc123" "$STAGE_OUT"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "malformed client_id: never reaches curl (gated before the network call)" "no" "$curl_called"
+
+echo ""
+echo "--- case: malformed tenant_id (contains embedded spaces) ---"
+run_stage_case "malformed_tid" "$FIXDIR/env_malformed_tenant_id.env" "plain"
+check "malformed tenant_id: exits 0 (non-fatal)" "0" "$STAGE_RC"
+check_contains "malformed tenant_id: warning names KHIVE_EMAIL_OAUTH_TENANT_ID" "KHIVE_EMAIL_OAUTH_TENANT_ID" "$STAGE_OUT"
+check_contains "malformed tenant_id: warning says not GUID-shaped" "GUID-shaped" "$STAGE_OUT"
+check_contains "malformed tenant_id: warning says the smoke is being skipped" "skipping email" "$STAGE_OUT"
+check_contains "malformed tenant_id: masked value shown instead of raw" "has sp..." "$STAGE_OUT"
+check_not_contains "malformed tenant_id: raw value never printed" "has spaces not a guid" "$STAGE_OUT"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "malformed tenant_id: never reaches curl (gated before the network call)" "no" "$curl_called"
+
+echo ""
+echo "--- case: all three present and GUID-shaped -> reaches the (stubbed) curl call ---"
+run_stage_case "all_fake_valid" "$FIXDIR/env_all_three_fake.env" "plain"
+check "all-fake-valid: exits 0 (non-fatal)" "0" "$STAGE_RC"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "all-fake-valid: DOES reach curl (the GUID gate lets a well-shaped fake pair through)" "yes" "$curl_called"
+check_contains "all-fake-valid: FAIL banner prints (stub returns the AADSTS90002 fixture)" "WARNING: email channel auth smoke FAILED" "$STAGE_OUT"
+check_contains "all-fake-valid: the underlying AADSTS error code still surfaces" "AADSTS90002" "$STAGE_OUT"
+check_not_contains "all-fake-valid: raw tenant GUID scrubbed from the FAIL output" "11111111-2222-3333-4444-555555555555" "$STAGE_OUT"
+check_not_contains "all-fake-valid: fake secret never appears, even untraced" "$FAKE_SMOKE_SECRET" "$STAGE_OUT"
+
+echo ""
+echo "--- case: same fixture, with shell tracing (set -x) active throughout (Finding 2 regression) ---"
+run_stage_case "all_fake_valid_traced" "$FIXDIR/env_all_three_fake.env" "traced"
+check "traced: exits 0 (non-fatal even under active xtrace)" "0" "$STAGE_RC"
+[ -f "$CURL_MARKER" ] && curl_called="yes" || curl_called="no"
+check "traced: still reaches the (stubbed) curl call (the risky code path was actually exercised)" "yes" "$curl_called"
+check_not_contains "traced: fake secret NEVER appears in combined stdout+stderr, even under set -x" "$FAKE_SMOKE_SECRET" "$STAGE_OUT"
+
+echo ""
+echo "TOTAL: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds `scripts/box/`, a bootstrap kit for running the khive substrate (the `kkernel` daemon plus `khive.db`) on a standalone Linux box instead of the Mac. Scripts and docs only, no Rust changes.

- `bootstrap.sh`: idempotent stages for apt deps, rustup, repo checkout, release build (`kkernel` package, `channel-email` feature), binary install, systemd `--user` unit install/restart, and a `stats()` smoke test. Package/feature/bin names are verified against `Makefile`'s `local` target and the relevant `Cargo.toml` files, not guessed. Unlike `make local`, it does not `pkill` running `kkernel` processes: on Linux an atomic `mv` is safe under a running process, and `systemctl --user restart` is what actually cuts over to the new binary.
- `kkernel.service`: systemd `--user` unit. `Type=simple` because `kkernel mcp --daemon` runs `run_daemon()` in the foreground (verified in `khive-runtime/src/daemon.rs`: binds the Unix socket, then blocks in a `tokio::select!` accept-loop vs. SIGTERM/SIGINT, no fork/setsid). No `EnvironmentFile=` is needed since `kkernel` loads `~/.khive/.env` itself via `load_khive_dotenv()`.
- `env.template`: masked `KHIVE_EMAIL_*` placeholders, cross-checked against `khive-channel-email/src/config.rs`, `lib.rs`, and `khive-mcp/src/serve.rs` (the literal `.env.example` file could not be read directly under this session's permission settings; verified the same variable contract from Rust source instead, which is authoritative anyway).
- `README.md`: cutover runbook covering prerequisites, DB move procedure (WAL checkpoint + sidecar files), boot persistence (`loginctl enable-linger`), a timezone note for the `schedule` pack, embedding/email smoke tests, the `sqlite3` CLI dependency for the inbox-wakeup Monitor pattern, and SSH socket forwarding for Mac-side access.

### Actor identity (added mid-review, issue #200)

A daemon with no `[actor] id` configured mints anonymous dispatch tokens, so `comm.send` stamps `from_actor="local"`, and replies routed back silently misroute instead of reaching this box's inbox. `bootstrap.sh`'s smoke-test stage now checks `~/.khive/config.toml` for a non-empty `[actor] id` and prints a loud warning with the exact fix if missing, without inventing a default (the correct id is deployment-specific). `env.template` and `README.md` both document this, since it lives in a separate TOML file, not `.env`.

## Status

The systemd unit and script logic are verified by source review and manual reasoning; they have **not been executed on a target Linux box** (this session runs on macOS, and no cargo build was run as part of this task). Treat the first real run as a validation pass.

## Test plan

- [x] `bash -n scripts/box/bootstrap.sh` — syntax OK
- [x] `shellcheck` — not installed on this machine, skipped (task treats it as optional/conditional)
- [x] `actor_id_from_config()` TOML-section parser — verified empirically against 8 hand-built fixture cases (normal, quoting variants, missing section, empty value, missing key, wrong section, missing file, key-ordering) in an isolated scratch script before wiring into `bootstrap.sh`
- [x] `make fmt-check` from repo root — pass (no Rust files touched)
- [x] `deno fmt --check scripts/box/README.md` — pass, already conforms to the repo's `lineWidth=100, proseWrap=preserve, indentWidth=2` config (this file is outside the `deno.json` `fmt.include` allowlist and the pre-commit `deno fmt` hook's scope, so `make fmt-check`/pre-commit don't cover it automatically; checked directly instead)
- [x] Pre-commit hooks (trailing whitespace, secrets scan, etc.) — all passed on commit
- [ ] Execution on an actual target Linux box (not done in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)