### PR TITLE
fix(comm): harden ingest correlation — pass-1 outbound filter + real RFC822 parse regression test

### DIFF
--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -526,6 +526,55 @@ mod tests {
     }
 
     #[test]
+    fn parse_raw_bytes_strips_angle_brackets_from_real_in_reply_to() {
+        // Real RFC 822 bytes routed through mail_parser (not a synthetic
+        // RawEmail/headers map like the tests below) — pins the bracket-
+        // stripping behavior that comm.ingest's bracket-toggle matching
+        // depends on. mail_parser's id parser (used for
+        // In-Reply-To/Message-ID/References) strips the `<...>` envelope
+        // for the single-ancestor case, so the headers map must carry the
+        // bracket-free form.
+        let raw = b"From: alice@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: Re: original thread\r\n\
+                    Message-ID: <reply-id@khive.ai>\r\n\
+                    In-Reply-To: <some-id@khive.ai>\r\n\
+                    Date: Mon, 1 Jul 2026 10:00:00 +0000\r\n\
+                    \r\n\
+                    This is a reply.";
+        let email = parse_raw_bytes(11, raw, "imap.example.com", 42).unwrap();
+        assert_eq!(
+            email.headers.get("in-reply-to").map(String::as_str),
+            Some("some-id@khive.ai"),
+            "mail_parser must strip angle brackets for the single-ancestor case"
+        );
+        assert_eq!(
+            email.correlation(),
+            Some("some-id@khive.ai"),
+            "correlation() falls through to in_reply_to when X-Khive-Thread-ID is absent"
+        );
+    }
+
+    #[test]
+    fn parse_raw_bytes_correlation_prefers_khive_thread_id_when_present() {
+        let raw = b"From: alice@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: Re: original thread\r\n\
+                    Message-ID: <reply-id@khive.ai>\r\n\
+                    In-Reply-To: <some-id@khive.ai>\r\n\
+                    X-Khive-Thread-ID: thread-uuid-123\r\n\
+                    Date: Mon, 1 Jul 2026 10:00:00 +0000\r\n\
+                    \r\n\
+                    This is a reply.";
+        let email = parse_raw_bytes(12, raw, "imap.example.com", 42).unwrap();
+        assert_eq!(
+            email.correlation(),
+            Some("thread-uuid-123"),
+            "correlation() must prefer X-Khive-Thread-ID over In-Reply-To"
+        );
+    }
+
+    #[test]
     fn raw_email_khive_thread_id_header() {
         let mut headers = HashMap::new();
         headers.insert("x-khive-thread-id".to_string(), "some-uuid".to_string());

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -539,7 +539,7 @@ mod tests {
                     Subject: Re: original thread\r\n\
                     Message-ID: <reply-id@khive.ai>\r\n\
                     In-Reply-To: <some-id@khive.ai>\r\n\
-                    Date: Mon, 1 Jul 2026 10:00:00 +0000\r\n\
+                    Date: Wed, 1 Jul 2026 10:00:00 +0000\r\n\
                     \r\n\
                     This is a reply.";
         let email = parse_raw_bytes(11, raw, "imap.example.com", 42).unwrap();
@@ -563,7 +563,7 @@ mod tests {
                     Message-ID: <reply-id@khive.ai>\r\n\
                     In-Reply-To: <some-id@khive.ai>\r\n\
                     X-Khive-Thread-ID: thread-uuid-123\r\n\
-                    Date: Mon, 1 Jul 2026 10:00:00 +0000\r\n\
+                    Date: Wed, 1 Jul 2026 10:00:00 +0000\r\n\
                     \r\n\
                     This is a reply.";
         let email = parse_raw_bytes(12, raw, "imap.example.com", 42).unwrap();

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -593,16 +593,25 @@ pub(crate) async fn handle_ingest(
             // (angle brackets included), while `mail_parser` strips the brackets from an
             // inbound `In-Reply-To`, yielding `id@domain`. Match the correlation key as
             // received and in its bracket-toggled form so `<id>` and `id` correlate either
-            // way; the exact form is tried first.
+            // way; the exact form is tried first. Restricted to outbound notes (mirrors
+            // Pass 2) so an inbound note's own external_id can never be matched as a
+            // threading parent.
             let mut pass1 = None;
             for candidate in message_id_match_candidates(corr) {
                 let corr_filter = NoteFilter {
                     kind: Some("message".to_string()),
-                    property_filters: vec![PropertyFilter {
-                        json_path: "$.external_id".to_string(),
-                        op: FilterOp::Eq,
-                        value: SqlValue::Text(candidate),
-                    }],
+                    property_filters: vec![
+                        PropertyFilter {
+                            json_path: "$.external_id".to_string(),
+                            op: FilterOp::Eq,
+                            value: SqlValue::Text(candidate),
+                        },
+                        PropertyFilter {
+                            json_path: "$.direction".to_string(),
+                            op: FilterOp::Eq,
+                            value: SqlValue::Text("outbound".to_string()),
+                        },
+                    ],
                     ..Default::default()
                 };
                 let corr_page = store


### PR DESCRIPTION
## Summary

Two hardening gaps found by a verification pass on the email reply-threading chain, both in `comm.ingest`'s thread correlation path.

- **Pass-1 outbound filter** (`crates/khive-pack-comm/src/handlers.rs`, `handle_ingest`): the two-pass correlation resolution matches Pass 1 by `$.external_id` against `message_id_match_candidates`, with no `direction` predicate. Pass 2 (`$.thread_id` match) already restricts to `direction=outbound`. This PR adds the same `direction=outbound` predicate to Pass 1, so an inbound note's own `external_id` can never be matched as a threading parent. This is defense-in-depth — today the two ID spaces cannot collide (inbound notes carry the IMAP dedup key `imap:{host}:{uidvalidity}:{uid}` as `external_id`, never an RFC 822 Message-ID shape), but nothing in the schema enforces that separation going forward.
- **Real RFC822 regression test** (`crates/khive-channel-email/src/connector/imap.rs`): `parse_raw_bytes` runs `mail_parser` over raw message bytes and collects headers into a lowercase, first-occurrence-wins map. `mail_parser`'s id parser (used for `In-Reply-To`/`Message-ID`/`References`) strips the `<...>` envelope for the single-ancestor case, so the headers map carries the bracket-free form (`id@domain`) — exactly what `comm.ingest`'s bracket-toggle matching (`message_id_match_candidates`) depends on. The existing `in_reply_to`/`khive_thread_id` tests construct `RawEmail.headers` synthetically, bypassing `mail_parser` entirely, so this behavior was pinned by nothing in CI. Added a test that builds a real RFC 822 byte string and runs it through `parse_raw_bytes`, asserting the bracket-free header value and `correlation()` fallthrough, plus a second case asserting `correlation()` prefers `X-Khive-Thread-ID` when present.

### Why this matters for the reply-threading chain

Phone/webmail MUAs replying to our outbound mail typically carry only `In-Reply-To` (not our `X-Khive-Thread-ID` header, which some clients strip). The bracket-toggle match in `comm.ingest` is the mechanism that correlates that bracket-free `In-Reply-To` back to our bracketed outbound `external_id`. Before this PR, the bracket-stripping half of that chain (inside `mail_parser`) was exercised only via synthetic `RawEmail` construction in tests, never via an actual parsed message — so a `mail_parser` upgrade or config change that altered id-stripping behavior would not have been caught. The Pass-1 filter closes a structurally-inert-today gap so the symmetry holds even if the two ID formats ever converge.

No behavior change intended for legitimate traffic — verified via the existing `khive-pack-comm` correlation regression suite (see test plan).

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `cargo test -p khive-channel-email -p khive-pack-comm` — pass (57 + 96 tests)
- [x] `cargo test --workspace` — pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — pass
- [x] Confirmed the three existing correlation regression tests in `khive-pack-comm/tests/integration.rs` (`ingest_routing_reply_routes_to_original_sender`, `ingest_routing_reply_correlates_bracket_free_in_reply_to`, `ingest_routing_reply_via_thread_uuid_routes_to_original_sender`) still pass unchanged — all three already plant `direction: "outbound"` on their fixture notes, so the new Pass-1 filter does not change their outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
