### PR TITLE
fix(ci): free ubuntu runner disk and cap debuginfo to stop ENOSPC link SIGBUS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,26 @@ jobs:
     defaults:
       run:
         working-directory: crates
+    env:
+      # CI gates do not need full debuginfo. line-tables-only keeps file:line
+      # in test backtraces while cutting most of the target-dir and linker
+      # footprint that filled the ubuntu runner disk (ENOSPC surfaces as
+      # `ld terminated with signal 7 [Bus error]`, e.g. run 28604091732).
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v7
+      # ubuntu-latest runners start with ~21GB free on /. The workspace's
+      # check + clippy + test + release passes exceed that, and ld's mmap'd
+      # writes turn ENOSPC into SIGBUS. Purge preinstalled toolchains this
+      # repo never uses (Android, .NET, GHC, CodeQL, docker images) to
+      # reclaim ~25GB before the build starts.
+      - name: Free runner disk (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
@@ -30,6 +48,9 @@ jobs:
         with:
           workspaces: crates
           cache-on-failure: true
+          # Cache key bump: artifacts built with full debuginfo predate the
+          # line-tables-only profile; restoring them would defeat the disk cap.
+          key: line-tables
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x


### PR DESCRIPTION
## Summary
- ubuntu-latest CI jobs intermittently die with `LLVM ERROR: IO failure on output stream: No space left on device` and `ld terminated with signal 7 [Bus error]` (main run 28604091732 and PR #408's first run). The runner starts with ~21GB free; the workspace's check + clippy(all-targets, all-features) + test + release-build sequence with full debuginfo exceeds that, and ld's mmap'd writes turn ENOSPC into SIGBUS — a flake lottery dependent on cache state.
- Fix, scoped to the `ci` matrix job only:
  - **Free runner disk (Linux)** step after checkout: removes preinstalled Android/.NET/GHC/CodeQL toolchains and docker images this repo never uses (~25GB reclaimed; `df -h` printed before/after for visibility).
  - **`CARGO_PROFILE_DEV_DEBUG: line-tables-only`** job env: test/dev profiles keep file:line backtraces but drop most debuginfo bulk from `target/`. Does not affect `debug_assertions`.
  - **rust-cache `key: line-tables`** bump so caches built with full debuginfo are not restored on top of the new profile.
- doc-build and coverage jobs are untouched (they pass today).

## Test plan
- [x] This PR's own CI run exercises the new workflow version (PR runs use the PR's workflow) — the ubuntu job passing with headroom validates the fix
- [x] `df -h /` output in the new step shows reclaimed space
- [ ] Fresh main run goes green after merge (the red main run 28604091732 predates this workflow and cannot be rerun onto it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)