### PR TITLE
docs(adr): ADR-056 inbound authentication hardening (SPF/DKIM alignment + quarantine)

### DIFF
--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -60,7 +60,21 @@ an arbitrary `Authentication-Results` header. It MUST:
 - when several such headers are present, use the topmost (most recently prepended by the trusted
   boundary), and ignore all `Authentication-Results` headers bearing any other `authserv-id`;
 - treat the absence of any trusted-authserv-id `Authentication-Results` header as a failed
-  authentication (quarantine), not as a pass.
+  authentication (quarantine), not as a pass;
+- never derive, learn, or select the trusted `authserv-id` from message content. It comes from
+  configuration only.
+
+**Operational precondition (RFC 8601 §1.6, §5).** `Authentication-Results` carries no integrity
+mechanism; the topmost-wins rule is sound only when the receiving boundary itself makes it so.
+Configuring `KHIVE_EMAIL_AUTHSERV_ID` is therefore only valid for a receiving boundary that is
+verified to prepend its own `Authentication-Results` on every delivered message and to remove or
+rename inbound headers claiming that same `authserv-id` (the ADMD-entry scrubbing RFC 8601
+requires). A deployment MUST verify this behavior against the live mailbox before enabling
+attribution: send a probe message carrying a forged `Authentication-Results` with the trusted
+`authserv-id` and confirm the boundary strips it or that the boundary's genuine stamp lands above
+it. If the boundary does neither, attribution MUST NOT be enabled for that mailbox; all inbound
+mail is quarantined until it is. The observed `authserv-id` string from a real delivered message,
+not provider documentation, is the source of the configured value.
 
 Re-verifying SPF/DKIM inside the adapter is out of scope for v1. The adapter is a downstream IMAP
 consumer; the receiving MTA has already performed SPF/DKIM/DMARC at delivery and recorded the
@@ -414,17 +428,25 @@ URL exists.
 ### 8. Inbound authentication
 
 Each adapter validates the external sender identity on every update before returning an
-envelope. Updates from unauthorized senders return `ChannelError::UnauthorizedSender` and are
-dropped. No note is written. This mirrors the `isSenderAllowed` pattern from the openclaw
-reference (`bot-access.ts:46-66`), simplified for the single-maintainer case.
+envelope. For Telegram, updates from unauthorized senders return
+`ChannelError::UnauthorizedSender` and are dropped with no note written. This mirrors the
+`isSenderAllowed` pattern from the openclaw reference (`bot-access.ts:46-66`), simplified for
+the single-maintainer case.
+
+> **Email disposition amended 2026-07-02.** For the email adapter, drop-with-no-note is
+> superseded: mail that fails authentication or the allowlist is quarantined (stored
+> unattributed by default) rather than dropped. See
+> [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening). The
+> Telegram drop behavior is unchanged.
 
 For Telegram, authentication is by numeric `chat.id` (stable across username changes),
 configured via env var. Username matching is a fallback only, as usernames can be reassigned.
 The maintainer identity is never stored in the KG.
 
 The exact identity model (which identity claim is authoritative and how it ties to the ADR-053
-actor model) is an open question requiring maintainer sign-off before implementation (see
-§OQ-2).
+actor model) was an open question at the original Proposed status; it is resolved by OQ-2 as
+hardened by the 2026-07-02 amendment (domain authentication with alignment plus allowlist
+before attribution; quarantined mail carries no trusted actor identity).
 
 ### 9. No secrets in the store
 
@@ -543,12 +565,17 @@ written. Authentication rules:
 4. Error messages intentionally omit the actual address values to avoid leaking sender
    addresses to logs.
 
-Messages that fail any check are skipped with a warning that logs only the IMAP UID. No note
-is written for unauthorized or malformed senders.
+_(Superseded 2026-07-02)_ ~~Messages that fail any check are skipped with a warning that logs
+only the IMAP UID. No note is written for unauthorized or malformed senders.~~ Failed messages
+are now quarantined per the amendment (stored unattributed when `KHIVE_EMAIL_QUARANTINE_STORE`
+is on; dropped with only the IMAP UID logged when it is off).
 
-This resolves OQ-2: env-var addr-spec comparison is the authoritative check for v1. The
-anonymous actor default for `VerbRegistry::dispatch` is acceptable. No `ActorRef` mapping to
-ADR-053 is required at this layer; the adapter pre-filters before dispatch.
+_(Superseded 2026-07-02)_ ~~This resolves OQ-2: env-var addr-spec comparison is the
+authoritative check for v1.~~ The addr-spec comparison is retained only as the allowlist
+condition; it is not authoritative on its own. The anonymous actor default for
+`VerbRegistry::dispatch` remains acceptable for quarantined mail specifically -- quarantined
+notes are exactly the ones that must not carry a trusted actor identity. Attributed mail
+requires both amendment conditions before the maintainer identity is stamped.
 
 #### Sender address format (OQ-1 resolved)
 
@@ -617,8 +644,9 @@ attributed. See [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authen
   `"namespace"` param on each call.
 - No credentials appear in any note, entity, or KG store.
 - `CommPack` construction and `PackFactory` wiring are unchanged.
-- `khive-channel` and `khive-channel-telegram` are new crates at the platform layer (blocked on
-  OQ-1 and OQ-2 above).
+- `khive-channel` and `khive-channel-telegram` are new crates at the platform layer. (OQ-1 and
+  OQ-2 are resolved; OQ-2 as hardened by the 2026-07-02 amendment. The email adapter's
+  attribution gate and quarantine disposition follow that amendment.)
 
 ## Related ADRs
 
@@ -629,5 +657,7 @@ attributed. See [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authen
 - ADR-053: Authorization Gate (ActorStore / SessionStore extension) -- extends ADR-018's actor
   model. `KhiveRuntime::authorize` (the public gate-checked door) and
   `NamespaceToken::mint_authorized` (`pub(crate)`, unreachable externally) are introduced here.
-  OQ-2 above requires a ruling on how the ingest loop's identity interacts with this model.
+  The ruling on how the ingest loop's identity interacts with this model is delivered by the
+  2026-07-02 amendment: attribution requires the two-part authentication gate, and quarantined
+  mail is written without a trusted actor identity.
 - ADR-028: Pack-Scoped Backends -- offset/cursor persistence pattern for channel adapters.

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -1,11 +1,105 @@
 # ADR-056: Channel Transport Layer -- `khive-channel` and External Messaging Adapters
 
-**Status**: Accepted\
-**Date**: 2026-06-14\
+**Status**: Accepted (amended 2026-07-02 -- inbound authentication hardening; see
+[§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening))\
+**Date**: 2026-06-14 (amended 2026-07-02)\
 **Authors**: Ocean, lambda:khive\
 **Depends on**: ADR-017 (Pack Standard), ADR-018 (Authorization Gate), ADR-040 (Communication
 and Schedule Packs), ADR-053 (ActorStore / SessionStore -- extends ADR-018's actor model)\
-**Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter)
+**Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter),
+#448 (inbound header spoofing -- resolved by this amendment)
+
+## Amendment 2026-07-02 -- Inbound authentication hardening
+
+This amendment supersedes the original OQ-2 resolution (env-var `From:` addr-spec comparison as
+the authoritative inbound check). That resolution is retained below, marked superseded, as the
+historical decision.
+
+### Motivation
+
+The original OQ-2 model authenticates a sender by comparing the `From:` (and `Sender:`) addr-spec
+against `KHIVE_EMAIL_MAINTAINER_ADDRESS`. RFC 5322 originator headers (`From:`, `Sender:`,
+`Return-Path:`) are asserted by the sending client and are not authenticated by SMTP transport.
+Any party that can reach the receiving mailbox can set `From:` to the maintainer address and pass
+the allowlist. The addr-spec comparison therefore authenticates nothing on its own.
+
+This is not a low-severity gap. An inbound `message` note attributed to the maintainer lands in a
+lambda's `comm.inbox` and is surfaced by the inbox wake-up monitor with the highest trust tier a
+lambda has: maintainer-directed, principal-priority instructions. A spoofed `From:` is a direct
+prompt-injection vector into the autonomous loop -- an attacker who can email the ingest mailbox
+can inject instructions that a lambda treats as coming from its principal. Attribution, not
+delivery, is the trust boundary that must be earned.
+
+### Decision
+
+Inbound email attribution requires cryptographic path authentication in addition to the sender
+allowlist. Attribution is granted only when both hold:
+
+1. **Domain authentication with alignment.** The message carries an `Authentication-Results`
+   header, inserted by the adapter's own trusted receiving boundary (matched by a configured
+   `authserv-id`), that shows `dmarc=pass`, or equivalently at least one of SPF-pass with
+   RFC 7208 envelope-from alignment to the `From:` domain or DKIM-pass with an RFC 6376 `d=`
+   signing domain aligned to the `From:` domain. Alignment is mandatory: an unaligned SPF or
+   DKIM pass (a pass for a domain other than the `From:` domain) does not satisfy this check.
+2. **Sender allowlist.** The single `From:` addr-spec matches the maintainer allowlist, under the
+   existing OQ-2 addr-spec rules (single From, `Sender:` must also match if present).
+
+A message satisfying both is attributed to the maintainer actor identity. A message failing
+either is **quarantined**: it is never attributed, never surfaced as a trusted actor, and never
+triggers principal-priority handling.
+
+### Trusted-header selection (the load-bearing detail)
+
+`Authentication-Results` is an ordinary header and can appear multiple times, including copies
+forged by the sender before the message reached the receiving server. The adapter MUST NOT trust
+an arbitrary `Authentication-Results` header. It MUST:
+
+- select only `Authentication-Results` headers whose `authserv-id` equals the configured
+  `KHIVE_EMAIL_AUTHSERV_ID` (the receiving MTA's own identifier, e.g. the Exchange Online host
+  that delivers to the ingest mailbox);
+- when several such headers are present, use the topmost (most recently prepended by the trusted
+  boundary), and ignore all `Authentication-Results` headers bearing any other `authserv-id`;
+- treat the absence of any trusted-authserv-id `Authentication-Results` header as a failed
+  authentication (quarantine), not as a pass.
+
+Re-verifying SPF/DKIM inside the adapter is out of scope for v1. The adapter is a downstream IMAP
+consumer; the receiving MTA has already performed SPF/DKIM/DMARC at delivery and recorded the
+result. The adapter's job is to trust that record only from its own boundary and to enforce
+alignment, not to recompute it.
+
+### Quarantine semantics (quarantine is itself an injection surface)
+
+Quarantined mail may be stored so the maintainer can review what arrived, but storage must not
+reintroduce the injection it prevents:
+
+- A quarantined message is written with no `from_actor` (or an explicit anonymous/quarantine
+  actor). It carries a property marking it quarantined and the reason (auth-absent,
+  dmarc-fail, unaligned, or off-allowlist). It is never stamped with the maintainer actor.
+- Quarantined notes MUST NOT trigger the inbox wake-up monitor's trusted-sender path and MUST be
+  distinguishable by agents so their content is never treated as principal instructions. Content
+  of a quarantined message is data to be shown, never a command to be followed -- the same
+  instruction-source boundary the loop applies to all untrusted observed content.
+- Storing quarantined mail is a configurable behavior (`KHIVE_EMAIL_QUARANTINE_STORE`, default
+  on so that legitimate mail failing a transient auth check is not silently lost). When off, a
+  failed message is dropped with only the IMAP UID logged, matching the prior behavior.
+
+### Configuration additions
+
+| Variable                       | Required | Default | Description                                                                                                   |
+| ------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `KHIVE_EMAIL_AUTHSERV_ID`      | yes      | --      | The trusted receiving MTA's `authserv-id`. Only `Authentication-Results` headers bearing this id are trusted. |
+| `KHIVE_EMAIL_QUARANTINE_STORE` | no       | `on`    | When `on`, unauthenticated mail is stored as an unattributed quarantined note; when `off`, it is dropped.     |
+
+`KHIVE_EMAIL_MAINTAINER_ADDRESS` remains the sender allowlist. It stays a single addr-spec for
+v1; a multi-entry allowlist is a compatible later extension.
+
+### Scope
+
+This amendment governs the email adapter (#114, #448). The Telegram adapter's numeric `chat.id`
+authentication (§8) is a stable transport-authenticated identifier and is unaffected. The
+`comm.ingest` dispatch path, the single-dispatch-site gate invariant, and the dedup model are
+unchanged; the amendment adds an attribution gate in front of them and a quarantine disposition
+beside them. Implementation (#448) follows this accepted revision.
 
 ## Context
 
@@ -429,6 +523,13 @@ crash.
 
 #### Inbound authentication (OQ-2 resolved)
 
+> **Superseded 2026-07-02.** The addr-spec allowlist described here is necessary but not
+> sufficient: `From:`/`Sender:` are spoofable, so this check alone authenticates nothing. See
+> [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening), which
+> requires `Authentication-Results` domain authentication with alignment before attribution and
+> quarantines everything else. The allowlist rules below remain in force as one of the two
+> required conditions.
+
 The adapter enforces a single-maintainer allowlist at the adapter boundary, before any note is
 written. Authentication rules:
 
@@ -493,9 +594,11 @@ the email adapter implementation (#114).
 **OQ-1 (from field format)** -- resolved: Option A (channel-prefixed form, e.g.,
 `email:sender@example.com`) is the normative choice. See §14.
 
-**OQ-2 (inbound auth identity model)** -- resolved: env-var RFC 5322 addr-spec comparison at
-the adapter boundary is sufficient for v1. The anonymous actor default for dispatch is
-acceptable. See §14.
+**OQ-2 (inbound auth identity model)** -- resolved 2026-06-14, **hardened 2026-07-02**: the
+env-var addr-spec comparison is retained as the sender allowlist but is no longer sufficient on
+its own. Attribution now also requires `Authentication-Results` domain authentication with
+alignment from the trusted receiving boundary; unauthenticated mail is quarantined and never
+attributed. See [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening).
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Amends ADR-056 to supersede the original OQ-2 resolution (From: addr-spec comparison as the authoritative inbound email check). RFC 5322 originator headers are SMTP-spoofable, so the allowlist alone authenticates nothing; a spoofed `From:` lands in an inbox attributed to a trusted principal — a direct prompt-injection vector into the autonomous loop (audit finding #448).

**Amendment (docs-only):**
- Attribution now requires BOTH: (1) domain authentication with alignment — `Authentication-Results` from the trusted receiving boundary showing `dmarc=pass`, or SPF/DKIM pass aligned to the `From:` domain; (2) the existing sender allowlist.
- Trusted-header selection: only `Authentication-Results` headers bearing the configured `KHIVE_EMAIL_AUTHSERV_ID` are trusted (topmost wins); absence = quarantine, never pass. The adapter does not recompute SPF/DKIM; it trusts only its own receiving MTA's record.
- Quarantine semantics: unauthenticated mail may be stored (`KHIVE_EMAIL_QUARANTINE_STORE`, default on) but is never attributed, never surfaced as a trusted actor, and its content is data, never instructions.
- New config: `KHIVE_EMAIL_AUTHSERV_ID` (required — note this is a config addition for existing email-channel deploys), `KHIVE_EMAIL_QUARANTINE_STORE` (optional, default on).
- Original OQ-2 text preserved and marked superseded (history-preserving, per the data-vs-view principle). Telegram `chat.id` auth unaffected.

Implementation follows in a separate code PR against #448 once this revision is accepted.

## Test plan
- [x] deno fmt clean (pre-commit hooks passed)
- [x] Docs-only — no code, no schema
