### PR TITLE
fix(channel-email): require authenticated identity for inbound attribution (#448)

### DIFF
--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -5,11 +5,23 @@
 //! `HeaderValue::Text` (or `TextList` when duplicated) via the generic `Other`
 //! header path. This module hand-parses only what the attribution gate needs:
 //! the `authserv-id`, and the `dmarc`/`spf`/`dkim` method verdicts plus the
-//! `header.d` / `smtp.mailfrom` / `header.from` alignment properties. It does
-//! not attempt full ABNF conformance (CFWS comments, quoted-string pvalues,
-//! `ptype.property` values containing `=`) -- those are tolerated as harmless
-//! unmatched tokens, never as false positives against the three keys this
-//! module actually reads.
+//! `header.d` / `smtp.mailfrom` / `header.from` alignment properties.
+//!
+//! The top-level split into `resinfo` segments is CFWS-aware: it walks the raw
+//! header value once, tracking quoted-string state (honoring `\` escapes) and
+//! `(...)` comment nesting (RFC 5322 comments nest), and only treats a `;` as a
+//! segment boundary when it appears outside both. Comments are stripped
+//! entirely before segment text is retained; quoted-string content is kept
+//! verbatim (including any `;` or `=` it contains) as part of the single
+//! segment it belongs to. This guarantees a `;` inside a `reason="..."`
+//! quoted pvalue or inside a `(...)` comment can never manufacture an
+//! additional, unintended `method=result` segment -- see
+//! `parse_header_reason_quoted_semicolon_does_not_forge_dmarc_pass` and
+//! `parse_header_comment_semicolon_does_not_forge_dmarc_pass` below. It does
+//! not attempt full ABNF conformance beyond that (e.g. `ptype.property`
+//! values containing bare `=`) -- those are tolerated as harmless unmatched
+//! tokens, never as false positives against the three keys this module
+//! actually reads.
 
 use std::collections::HashMap;
 
@@ -87,6 +99,66 @@ fn domain_of(value: &str) -> String {
     }
 }
 
+/// Split a raw `Authentication-Results` header value into top-level
+/// `resinfo` segments on `;`, tracking RFC 5322 quoted-string state (with `\`
+/// escapes) and `(...)` comment nesting so a `;` inside either is never
+/// treated as a segment boundary. Comment text is stripped entirely (CFWS is
+/// insignificant for token purposes); quoted-string text -- including any `;`
+/// or `=` inside it -- is preserved verbatim as part of its enclosing
+/// segment.
+fn split_top_level_segments(raw: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut comment_depth: u32 = 0;
+    let mut chars = raw.chars();
+
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            current.push(c);
+            match c {
+                '\\' => {
+                    // Quoted-pair: the following character is escaped and never
+                    // terminates the quoted string, regardless of what it is.
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                }
+                '"' => in_quotes = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        if comment_depth > 0 {
+            match c {
+                '\\' => {
+                    // Quoted-pair inside a comment: consume and discard the
+                    // escaped character without altering comment depth.
+                    chars.next();
+                }
+                '(' => comment_depth += 1,
+                ')' => comment_depth -= 1,
+                _ => {}
+            }
+            continue;
+        }
+
+        match c {
+            '"' => {
+                in_quotes = true;
+                current.push(c);
+            }
+            '(' => comment_depth += 1,
+            ';' => segments.push(std::mem::take(&mut current)),
+            _ => current.push(c),
+        }
+    }
+    segments.push(current);
+
+    segments
+}
+
 /// Parse one raw `Authentication-Results` header value.
 ///
 /// Returns `None` only when no `authserv-id` token can be extracted at all
@@ -95,7 +167,7 @@ fn domain_of(value: &str) -> String {
 /// to an `AuthResults` with empty method vectors -- the gate treats "no
 /// recognized passing method" uniformly regardless of which of those it was.
 pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
-    let mut segments = raw.split(';');
+    let mut segments = split_top_level_segments(raw).into_iter();
     let authserv_id = segments.next()?.split_whitespace().next()?.to_string();
     if authserv_id.is_empty() {
         return None;
@@ -118,6 +190,10 @@ pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
         let Some((method, result)) = methodspec.split_once('=') else {
             continue;
         };
+        // RFC 8601 permits an optional "/version" suffix on the method name
+        // (e.g. `dkim/1=pass`). Strip it before matching so a versioned method
+        // is recognized the same as its unversioned form.
+        let method = method.split_once('/').map_or(method, |(base, _)| base);
 
         let mut props = HashMap::new();
         for token in tokens {
@@ -189,6 +265,76 @@ mod tests {
     fn parse_header_empty_value_returns_none() {
         assert!(parse_header("").is_none());
         assert!(parse_header("   ").is_none());
+    }
+
+    // --- Finding 1: quoted-string / CFWS-comment semicolons must not forge a method ---
+
+    #[test]
+    fn parse_header_reason_quoted_semicolon_does_not_forge_dmarc_pass() {
+        // codex #496 repro: a `;` inside a quoted reason= pvalue must never be
+        // treated as a top-level segment boundary, so this must NOT produce a
+        // dmarc method result at all -- the real result here is spf=fail.
+        let parsed = parse_header(
+            r#"mx.example.com; spf=fail reason="remote said; dmarc=pass; still fail" smtp.mailfrom=attacker.net"#,
+        )
+        .unwrap();
+        assert!(
+            parsed.dmarc.is_empty(),
+            "quoted text must never manufacture a dmarc method entry; got {:?}",
+            parsed.dmarc
+        );
+        assert!(!parsed.dmarc_pass());
+    }
+
+    #[test]
+    fn parse_header_comment_semicolon_does_not_forge_dmarc_pass() {
+        // Same attack shape via a `(...)` CFWS comment instead of a quoted pvalue.
+        let parsed = parse_header(
+            "mx.example.com; spf=fail smtp.mailfrom=attacker.net (comment; dmarc=pass; end)",
+        )
+        .unwrap();
+        assert!(
+            parsed.dmarc.is_empty(),
+            "comment text must never manufacture a dmarc method entry; got {:?}",
+            parsed.dmarc
+        );
+        assert!(!parsed.dmarc_pass());
+    }
+
+    #[test]
+    fn parse_header_legitimate_quoted_reason_does_not_hide_a_real_later_dmarc_pass() {
+        // A quoted pvalue with a harmless embedded `;` must not prevent a genuine,
+        // separate top-level dmarc=pass segment later in the same header from
+        // being recognized -- the tokenizer must not over-fail-close.
+        let parsed = parse_header(
+            r#"mx.example.com; spf=fail reason="passed; ok" smtp.mailfrom=attacker.net; dmarc=pass header.from=example.com"#,
+        )
+        .unwrap();
+        assert!(
+            parsed.dmarc_pass(),
+            "a genuine top-level dmarc=pass after a quoted reason must still be recognized"
+        );
+    }
+
+    // --- Finding 3: RFC 8601 method "/version" suffix must not fail closed ---
+
+    #[test]
+    fn parse_header_dkim_version_suffix_is_stripped_before_matching() {
+        let parsed = parse_header("mx.example.com; dkim/1=pass header.d=example.com").unwrap();
+        assert!(parsed.dkim_pass_aligned("example.com"));
+    }
+
+    #[test]
+    fn parse_header_spf_version_suffix_is_stripped_before_matching() {
+        let parsed =
+            parse_header("mx.example.com; spf/1=pass smtp.mailfrom=alice@example.com").unwrap();
+        assert!(parsed.spf_pass_aligned("example.com"));
+    }
+
+    #[test]
+    fn parse_header_dmarc_version_suffix_is_stripped_before_matching() {
+        let parsed = parse_header("mx.example.com; dmarc/1=pass header.from=example.com").unwrap();
+        assert!(parsed.dmarc_pass());
     }
 
     #[test]

--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -1,0 +1,255 @@
+//! RFC 8601 `Authentication-Results` header parsing (structural subset).
+//!
+//! `mail-parser` has no structured support for this header -- it is not one of
+//! the RFC 5322 shapes it recognizes, so it always falls through to
+//! `HeaderValue::Text` (or `TextList` when duplicated) via the generic `Other`
+//! header path. This module hand-parses only what the attribution gate needs:
+//! the `authserv-id`, and the `dmarc`/`spf`/`dkim` method verdicts plus the
+//! `header.d` / `smtp.mailfrom` / `header.from` alignment properties. It does
+//! not attempt full ABNF conformance (CFWS comments, quoted-string pvalues,
+//! `ptype.property` values containing `=`) -- those are tolerated as harmless
+//! unmatched tokens, never as false positives against the three keys this
+//! module actually reads.
+
+use std::collections::HashMap;
+
+/// One `resinfo` entry: a single method's verdict plus its properties.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MethodResult {
+    pub result: String,
+    pub props: HashMap<String, String>,
+}
+
+/// A parsed `Authentication-Results` header value.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct AuthResults {
+    pub authserv_id: String,
+    pub dmarc: Vec<MethodResult>,
+    pub spf: Vec<MethodResult>,
+    pub dkim: Vec<MethodResult>,
+}
+
+impl AuthResults {
+    /// `dmarc=pass` is present. DMARC's own verdict already encodes alignment
+    /// (RFC 7489 §3.1), so no separate domain check applies here.
+    pub fn dmarc_pass(&self) -> bool {
+        self.dmarc
+            .iter()
+            .any(|e| e.result.eq_ignore_ascii_case("pass"))
+    }
+
+    /// `spf=pass` is present AND its `smtp.mailfrom` domain matches `from_domain`.
+    pub fn spf_pass_aligned(&self, from_domain: &str) -> bool {
+        Self::method_pass_aligned(&self.spf, "smtp.mailfrom", from_domain)
+    }
+
+    /// `dkim=pass` is present AND its `header.d` domain matches `from_domain`.
+    pub fn dkim_pass_aligned(&self, from_domain: &str) -> bool {
+        Self::method_pass_aligned(&self.dkim, "header.d", from_domain)
+    }
+
+    /// True when spf or dkim passed but its alignment domain did not match
+    /// `from_domain` -- distinguishes an "unaligned" quarantine reason from a
+    /// flat authentication failure.
+    pub fn has_unaligned_pass(&self, from_domain: &str) -> bool {
+        let spf_passed = self
+            .spf
+            .iter()
+            .any(|e| e.result.eq_ignore_ascii_case("pass"));
+        let dkim_passed = self
+            .dkim
+            .iter()
+            .any(|e| e.result.eq_ignore_ascii_case("pass"));
+        (spf_passed && !self.spf_pass_aligned(from_domain))
+            || (dkim_passed && !self.dkim_pass_aligned(from_domain))
+    }
+
+    fn method_pass_aligned(entries: &[MethodResult], prop_key: &str, from_domain: &str) -> bool {
+        entries.iter().any(|e| {
+            e.result.eq_ignore_ascii_case("pass")
+                && e.props
+                    .get(prop_key)
+                    .map(|v| domain_of(v).eq_ignore_ascii_case(from_domain))
+                    .unwrap_or(false)
+        })
+    }
+}
+
+/// Extract the domain component of a property value. Values may be a bare
+/// domain (`header.d=example.com`) or a full mailbox
+/// (`smtp.mailfrom=alice@example.com`) -- only the part after `@`, if any, is
+/// significant for alignment either way.
+fn domain_of(value: &str) -> String {
+    let v = value.trim().trim_end_matches('.');
+    match v.rsplit_once('@') {
+        Some((_, domain)) => domain.to_lowercase(),
+        None => v.to_lowercase(),
+    }
+}
+
+/// Parse one raw `Authentication-Results` header value.
+///
+/// Returns `None` only when no `authserv-id` token can be extracted at all
+/// (an empty or malformed header). A bare `authserv-id; none` or an
+/// `authserv-id` with no method the gate recognizes both parse successfully
+/// to an `AuthResults` with empty method vectors -- the gate treats "no
+/// recognized passing method" uniformly regardless of which of those it was.
+pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
+    let mut segments = raw.split(';');
+    let authserv_id = segments.next()?.split_whitespace().next()?.to_string();
+    if authserv_id.is_empty() {
+        return None;
+    }
+
+    let mut out = AuthResults {
+        authserv_id,
+        ..Default::default()
+    };
+
+    for segment in segments {
+        let segment = segment.trim();
+        if segment.is_empty() || segment.eq_ignore_ascii_case("none") {
+            continue;
+        }
+        let mut tokens = segment.split_whitespace();
+        let Some(methodspec) = tokens.next() else {
+            continue;
+        };
+        let Some((method, result)) = methodspec.split_once('=') else {
+            continue;
+        };
+
+        let mut props = HashMap::new();
+        for token in tokens {
+            if let Some((ptype_property, pvalue)) = token.split_once('=') {
+                props.insert(ptype_property.to_lowercase(), pvalue.to_string());
+            }
+        }
+
+        let entry = MethodResult {
+            result: result.to_lowercase(),
+            props,
+        };
+        match method.to_lowercase().as_str() {
+            "dmarc" => out.dmarc.push(entry),
+            "spf" => out.spf.push(entry),
+            "dkim" => out.dkim.push(entry),
+            _ => {}
+        }
+    }
+
+    Some(out)
+}
+
+/// Select the first (topmost) `Authentication-Results` header, in document
+/// order, whose `authserv-id` matches `configured_id` (case-insensitive).
+///
+/// Topmost wins: a receiving MTA prepends its own stamp on each hop, so the
+/// header nearest the top of the document is the one added by the final,
+/// trusted receiving boundary -- PROVIDED that boundary strips or renames any
+/// pre-existing header already claiming its own `authserv-id` before adding
+/// its stamp. That stripping is an operational precondition of the receiving
+/// MTA, verified by deployment configuration, not re-derived from message
+/// content here (see ADR-056 Amendment 2026-07-02, "Trusted-header
+/// selection").
+pub(crate) fn select_trusted(raw_headers: &[String], configured_id: &str) -> Option<AuthResults> {
+    raw_headers
+        .iter()
+        .filter_map(|raw| parse_header(raw))
+        .find(|parsed| parsed.authserv_id.eq_ignore_ascii_case(configured_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_header_extracts_authserv_id_and_dmarc_pass() {
+        let parsed = parse_header("mx.example.com; dmarc=pass header.from=example.com").unwrap();
+        assert_eq!(parsed.authserv_id, "mx.example.com");
+        assert!(parsed.dmarc_pass());
+    }
+
+    #[test]
+    fn parse_header_authserv_id_with_version_token() {
+        // RFC 8601 permits an optional version after authserv-id.
+        let parsed = parse_header("mx.example.com 1; dmarc=pass").unwrap();
+        assert_eq!(parsed.authserv_id, "mx.example.com");
+    }
+
+    #[test]
+    fn parse_header_none_result_has_no_methods() {
+        let parsed = parse_header("mx.example.com; none").unwrap();
+        assert!(!parsed.dmarc_pass());
+        assert!(parsed.spf.is_empty());
+        assert!(parsed.dkim.is_empty());
+    }
+
+    #[test]
+    fn parse_header_empty_value_returns_none() {
+        assert!(parse_header("").is_none());
+        assert!(parse_header("   ").is_none());
+    }
+
+    #[test]
+    fn spf_pass_aligned_matches_envelope_from_domain() {
+        let parsed =
+            parse_header("mx.example.com; spf=pass smtp.mailfrom=alice@example.com").unwrap();
+        assert!(parsed.spf_pass_aligned("example.com"));
+        assert!(!parsed.spf_pass_aligned("other.com"));
+    }
+
+    #[test]
+    fn dkim_pass_aligned_matches_header_d_domain() {
+        let parsed =
+            parse_header("mx.example.com; dkim=pass header.d=example.com header.s=sel1").unwrap();
+        assert!(parsed.dkim_pass_aligned("example.com"));
+        assert!(!parsed.dkim_pass_aligned("other.com"));
+    }
+
+    #[test]
+    fn has_unaligned_pass_true_when_spf_passes_but_domain_mismatches() {
+        let parsed =
+            parse_header("mx.example.com; spf=pass smtp.mailfrom=alice@attacker.net").unwrap();
+        assert!(!parsed.spf_pass_aligned("example.com"));
+        assert!(parsed.has_unaligned_pass("example.com"));
+    }
+
+    #[test]
+    fn has_unaligned_pass_false_when_no_method_passed() {
+        let parsed =
+            parse_header("mx.example.com; spf=fail smtp.mailfrom=alice@attacker.net").unwrap();
+        assert!(!parsed.has_unaligned_pass("example.com"));
+    }
+
+    #[test]
+    fn select_trusted_picks_topmost_matching_authserv_id() {
+        let headers = vec![
+            "mx.example.com; dmarc=pass header.from=example.com".to_string(),
+            "mx.example.com; dmarc=fail header.from=example.com".to_string(),
+        ];
+        let selected = select_trusted(&headers, "mx.example.com").unwrap();
+        assert!(
+            selected.dmarc_pass(),
+            "the topmost matching header must win, not a later one"
+        );
+    }
+
+    #[test]
+    fn select_trusted_ignores_non_matching_authserv_id() {
+        let headers = vec!["forged-mx.evil.com; dmarc=pass header.from=example.com".to_string()];
+        assert!(select_trusted(&headers, "mx.example.com").is_none());
+    }
+
+    #[test]
+    fn select_trusted_none_when_no_headers() {
+        assert!(select_trusted(&[], "mx.example.com").is_none());
+    }
+
+    #[test]
+    fn domain_of_extracts_after_at_sign() {
+        assert_eq!(domain_of("alice@example.com"), "example.com");
+        assert_eq!(domain_of("example.com"), "example.com");
+        assert_eq!(domain_of("EXAMPLE.COM"), "example.com");
+    }
+}

--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -190,10 +190,17 @@ pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
         let Some((method, result)) = methodspec.split_once('=') else {
             continue;
         };
-        // RFC 8601 permits an optional "/version" suffix on the method name
-        // (e.g. `dkim/1=pass`). Strip it before matching so a versioned method
-        // is recognized the same as its unversioned form.
-        let method = method.split_once('/').map_or(method, |(base, _)| base);
+        // RFC 8601 §2.2 permits an optional "/version" suffix on the method name
+        // (method-version = 1*DIGIT). §2.6 requires consumers to IGNORE resinfo
+        // for a method version they do not support -- an unsupported or
+        // non-numeric version must never be silently trusted as the current
+        // version. This module supports only version 1 (absent suffix is
+        // implicitly version 1); anything else skips the whole segment.
+        let method = match method.split_once('/') {
+            None => method,
+            Some((base, "1")) => base,
+            Some(_) => continue,
+        };
 
         let mut props = HashMap::new();
         for token in tokens {
@@ -335,6 +342,33 @@ mod tests {
     fn parse_header_dmarc_version_suffix_is_stripped_before_matching() {
         let parsed = parse_header("mx.example.com; dmarc/1=pass header.from=example.com").unwrap();
         assert!(parsed.dmarc_pass());
+    }
+
+    #[test]
+    fn parse_header_dkim_non_numeric_version_suffix_is_ignored_not_trusted_as_v1() {
+        // codex round-2 evidence: a non-numeric "version" must never be silently
+        // treated as the supported version 1 -- the whole resinfo must be ignored.
+        let parsed = parse_header("mx.example.com; dkim/evil=pass header.d=example.com").unwrap();
+        assert!(
+            parsed.dkim.is_empty(),
+            "a non-numeric method-version must not record a dkim entry; got {:?}",
+            parsed.dkim
+        );
+        assert!(!parsed.dkim_pass_aligned("example.com"));
+    }
+
+    #[test]
+    fn parse_header_dkim_unsupported_numeric_version_is_ignored_not_trusted_as_v1() {
+        // RFC 8601 §2.6: consumers must ignore resinfo for a method version they
+        // do not support. This module supports only version 1, so /2 must be
+        // ignored entirely, not coerced down to version 1's semantics.
+        let parsed = parse_header("mx.example.com; dkim/2=pass header.d=example.com").unwrap();
+        assert!(
+            parsed.dkim.is_empty(),
+            "an unsupported method-version must not record a dkim entry; got {:?}",
+            parsed.dkim
+        );
+        assert!(!parsed.dkim_pass_aligned("example.com"));
     }
 
     #[test]

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -926,6 +926,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn quoted_reason_semicolon_forging_dmarc_pass_does_not_bypass_gate() {
+        // Regression for codex #496 Finding 1, driven through the REAL byte-parsing
+        // path (parse_raw_bytes), not a hand-built AuthResults: a quoted reason=
+        // pvalue containing "; dmarc=pass; " must never be split into a separate
+        // dmarc method -- the gate must see the genuine spf=fail result and
+        // quarantine, never attribute to the maintainer.
+        let raw = b"Authentication-Results: mx.example.com; spf=fail reason=\"remote said; dmarc=pass; still fail\" smtp.mailfrom=attacker.net\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: quoted reason attack\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(
+            envs[0].from, "email:quarantine",
+            "a forged dmarc=pass hidden inside a quoted reason pvalue must never attribute mail"
+        );
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("dmarc-fail")
+        );
+    }
+
+    #[tokio::test]
     async fn spf_pass_unaligned_envelope_from_quarantines_unaligned() {
         let raw = b"Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=alice@attacker.net\r\n\
                     From: maintainer@example.com\r\n\

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -7,11 +7,38 @@ use chrono::{DateTime, Utc};
 use khive_channel::{Channel, ChannelEnvelope, ChannelError};
 use tracing::{debug, warn};
 
+use crate::auth_results;
 use crate::config::{EmailAuth, EmailChannelConfig};
 use crate::connector::imap::ImapFetcher;
 use crate::connector::smtp::SmtpSender;
 use crate::connector::{MailAddress, RawEmail};
 use crate::oauth::TokenProvider;
+
+/// Reason a message failed the attribution gate (ADR-056 Amendment
+/// 2026-07-02) and was quarantined instead of attributed to the maintainer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuarantineReason {
+    /// No `Authentication-Results` header was selected: none were present, or
+    /// none carried the configured `authserv-id`.
+    AuthAbsent,
+    /// A trusted header was selected but showed no passing, aligned method.
+    DmarcFail,
+    /// spf or dkim passed, but its alignment domain did not match the From: domain.
+    Unaligned,
+    /// Domain authentication passed, but the sender is not on the maintainer allowlist.
+    OffAllowlist,
+}
+
+impl std::fmt::Display for QuarantineReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            QuarantineReason::AuthAbsent => "auth-absent",
+            QuarantineReason::DmarcFail => "dmarc-fail",
+            QuarantineReason::Unaligned => "unaligned",
+            QuarantineReason::OffAllowlist => "off-allowlist",
+        })
+    }
+}
 
 /// Email channel adapter implementing `Channel` via SMTP + IMAP.
 ///
@@ -156,11 +183,79 @@ impl EmailChannel {
         Ok(())
     }
 
-    /// Convert a `RawEmail` to a `ChannelEnvelope`, validating the sender.
-    fn to_envelope(&self, email: RawEmail) -> Result<ChannelEnvelope, ChannelError> {
-        self.check_sender(&email.from_addrs, email.sender_addr.as_deref())?;
+    /// Evaluate the domain-authentication half of the attribution gate
+    /// (ADR-056 Amendment 2026-07-02): trust only the topmost
+    /// `Authentication-Results` header whose `authserv-id` matches this
+    /// deployment's configured trust anchor, and require `dmarc=pass`, or
+    /// `spf=pass` with an aligned envelope-from, or `dkim=pass` with an
+    /// aligned `d=` domain. Absence of any trusted header fails closed.
+    fn evaluate_auth(&self, email: &RawEmail) -> Result<(), QuarantineReason> {
+        let selected =
+            auth_results::select_trusted(&email.authentication_results, &self.config.authserv_id)
+                .ok_or(QuarantineReason::AuthAbsent)?;
 
-        // Safe: check_sender verified exactly one entry.
+        let from_domain = email
+            .from_addrs
+            .first()
+            .and_then(|addr| addr.rsplit_once('@'))
+            .map(|(_, domain)| domain.to_lowercase())
+            .unwrap_or_default();
+
+        if selected.dmarc_pass()
+            || selected.spf_pass_aligned(&from_domain)
+            || selected.dkim_pass_aligned(&from_domain)
+        {
+            return Ok(());
+        }
+        if selected.has_unaligned_pass(&from_domain) {
+            return Err(QuarantineReason::Unaligned);
+        }
+        Err(QuarantineReason::DmarcFail)
+    }
+
+    /// Run the full attribution gate: domain authentication, then the sender
+    /// allowlist. Both must pass for a message to be attributed to the
+    /// maintainer; either failing quarantines it (never partially attributed).
+    fn gate(&self, email: &RawEmail) -> Result<(), QuarantineReason> {
+        self.evaluate_auth(email)?;
+        self.check_sender(&email.from_addrs, email.sender_addr.as_deref())
+            .map_err(|_| QuarantineReason::OffAllowlist)
+    }
+
+    /// Build the envelope recorded for a message that failed the attribution
+    /// gate. Per ADR-056 Amendment 2026-07-02, a quarantined message must
+    /// never be attributed to (or look like) the maintainer: `from` is the
+    /// fixed `email:quarantine` marker rather than the message's own
+    /// (possibly forged) From address, and no correlation key is set --  an
+    /// unauthenticated message claiming to be a reply must not inherit a
+    /// legitimate thread's context.
+    fn quarantine_envelope(&self, email: &RawEmail, reason: QuarantineReason) -> ChannelEnvelope {
+        let to = format!("email:{}", self.maintainer_address());
+        let mut env = ChannelEnvelope::new("email:quarantine", to, email.best_body());
+
+        if !email.subject.is_empty() {
+            env = env.with_subject(&email.subject);
+        }
+        if let Some(date) = email.date {
+            env = env.with_sent_at(date);
+        }
+        env = env.with_external_id(&email.imap_external_id);
+
+        env.metadata
+            .insert("quarantined".to_string(), "true".to_string());
+        env.metadata
+            .insert("quarantine_reason".to_string(), reason.to_string());
+        if let Some(claimed_from) = email.from_addrs.first() {
+            env.metadata
+                .insert("quarantine_claimed_from".to_string(), claimed_from.clone());
+        }
+
+        env
+    }
+
+    /// Convert a `RawEmail` that has already passed `gate` into a `ChannelEnvelope`.
+    fn to_envelope(&self, email: RawEmail) -> ChannelEnvelope {
+        // Safe: gate() verified exactly one From entry before this is called.
         let from_addr = &email.from_addrs[0];
         let from = format!("email:{from_addr}");
         let to = email
@@ -194,7 +289,7 @@ impl EmailChannel {
             env = env.with_wire_references(refs);
         }
 
-        Ok(env)
+        env
     }
 }
 
@@ -233,13 +328,20 @@ impl Channel for EmailChannel {
         let mut envelopes = Vec::new();
         for email in raw {
             let uid = email.uid;
-            match self.to_envelope(email) {
-                Ok(env) => envelopes.push(env),
-                Err(e) => {
-                    // Log the IMAP UID and the (address-free) error reason so a rejected
-                    // inbound is observable in the daemon log. ChannelError messages are
-                    // constructed without addresses or credentials, so `%e` is log-safe.
-                    warn!(uid, error = %e, "skipping message: validation failed");
+            match self.gate(&email) {
+                Ok(()) => envelopes.push(self.to_envelope(email)),
+                Err(reason) => {
+                    if self.config.quarantine_store {
+                        envelopes.push(self.quarantine_envelope(&email, reason));
+                    } else {
+                        // Address-free: only the IMAP UID and the quarantine reason
+                        // are logged, never the (possibly forged) From address.
+                        warn!(
+                            uid,
+                            reason = %reason,
+                            "quarantine-store disabled: dropping unattributed message"
+                        );
+                    }
                 }
             }
         }
@@ -262,6 +364,9 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
+    /// The `authserv-id` this test suite's channels are configured to trust.
+    const TEST_AUTHSERV_ID: &str = "mx.example.com";
+
     fn make_config(maintainer: &str) -> EmailChannelConfig {
         EmailChannelConfig {
             smtp_host: "smtp.example.com".to_string(),
@@ -274,7 +379,20 @@ mod tests {
                 password: "secret".to_string(),
             },
             maintainer_addresses: vec![MailAddress::parse(maintainer).unwrap()],
+            authserv_id: TEST_AUTHSERV_ID.to_string(),
+            quarantine_store: true,
         }
+    }
+
+    /// A trusted `Authentication-Results` header that authenticates cleanly
+    /// for `from_addr`'s own domain, so tests that are exercising allowlist
+    /// logic (not the auth gate) get an attributed baseline by default.
+    fn trusted_auth_header(from_addr: &str) -> String {
+        let domain = from_addr
+            .rsplit_once('@')
+            .map(|(_, d)| d)
+            .unwrap_or("example.com");
+        format!("{TEST_AUTHSERV_ID}; dmarc=pass header.from={domain}")
     }
 
     struct RecordingSmtp {
@@ -314,7 +432,10 @@ mod tests {
         }
     }
 
-    /// Build a RawEmail with a single-address From and a stable IMAP external ID.
+    /// Build a RawEmail with a single-address From, a stable IMAP external ID,
+    /// and a trusted, self-aligned `Authentication-Results` header -- so
+    /// callers that are exercising allowlist logic (not the auth gate itself)
+    /// get an attributed baseline by default.
     fn make_email(from_addr: &str, imap_id: &str) -> RawEmail {
         RawEmail {
             uid: 1,
@@ -327,11 +448,18 @@ mod tests {
             body_text: Some("body text".to_string()),
             body_html: None,
             headers: HashMap::new(),
+            authentication_results: vec![trusted_auth_header(from_addr)],
         }
     }
 
-    /// Build a RawEmail with an explicit From address list.
+    /// Build a RawEmail with an explicit From address list and a trusted
+    /// `Authentication-Results` header (aligned to the first From address, or
+    /// to `example.com` when the list is empty).
     fn make_email_with_from_addrs(from_addrs: Vec<String>, imap_id: &str) -> RawEmail {
+        let auth_header = from_addrs
+            .first()
+            .map(|addr| trusted_auth_header(addr))
+            .unwrap_or_else(|| format!("{TEST_AUTHSERV_ID}; dmarc=pass header.from=example.com"));
         RawEmail {
             uid: 1,
             imap_external_id: imap_id.to_string(),
@@ -343,6 +471,7 @@ mod tests {
             body_text: Some("body text".to_string()),
             body_html: None,
             headers: HashMap::new(),
+            authentication_results: vec![auth_header],
         }
     }
 
@@ -444,7 +573,8 @@ mod tests {
         // References chain (mail-parser's `HeaderValue::TextList`) -- exercise the
         // REAL byte-parsing path here, not a hand-built RawEmail.headers map, since
         // that hand-built shortcut is exactly what let the live-path bug through.
-        let raw = b"From: maintainer@example.com\r\n\
+        let raw = b"Authentication-Results: mx.example.com; dmarc=pass header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
                     To: me@example.com\r\n\
                     Subject: Multi-id References test\r\n\
                     References: <grandparent1@example.com> <grandparent2@example.com>\r\n\
@@ -492,13 +622,29 @@ mod tests {
     // --- Authorization: rejected senders (Fix 1) ---
 
     #[tokio::test]
-    async fn unauthorized_sender_is_silently_skipped() {
+    async fn unauthorized_sender_with_valid_auth_is_quarantined_off_allowlist() {
+        // Domain authentication passes (attacker@example.com's own AR header is
+        // trusted and aligned), but the sender is not on the maintainer
+        // allowlist -- must be quarantined with reason off-allowlist, never
+        // attributed to the (non-maintainer) sender or silently dropped.
         let ch = build_channel(
             "maintainer@example.com",
             vec![make_email("attacker@example.com", "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(envs.is_empty(), "unauthorized From must be dropped");
+        assert_eq!(envs.len(), 1, "must be stored as quarantine, not dropped");
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
+        );
+        assert_eq!(
+            envs[0].metadata.get("quarantined").map(String::as_str),
+            Some("true")
+        );
     }
 
     #[tokio::test]
@@ -524,13 +670,25 @@ mod tests {
     #[tokio::test]
     async fn non_gmail_dots_remain_significant() {
         // Dot-insensitivity is a Gmail-only rule; other providers treat dots as
-        // significant, so a dotted variant of a non-Gmail maintainer is rejected.
+        // significant, so a dotted variant of a non-Gmail maintainer fails the
+        // allowlist half of the gate (quarantined, not attributed).
         let ch = build_channel(
             "sam.rivera@outlook.com",
             vec![make_email("samrivera@outlook.com", "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(envs.is_empty(), "non-gmail dot-variant must NOT authorize");
+        assert_eq!(envs.len(), 1);
+        assert_ne!(
+            envs[0].from, "email:samrivera@outlook.com",
+            "non-gmail dot-variant must NOT authorize"
+        );
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
+        );
     }
 
     #[tokio::test]
@@ -548,7 +706,8 @@ mod tests {
 
     #[tokio::test]
     async fn multi_from_addresses_rejected() {
-        // RFC 5322 permits multiple From addresses; we treat it as unauthorized.
+        // RFC 5322 permits multiple From addresses; we treat it as unauthorized
+        // (quarantined off-allowlist, since domain auth on the first address passes).
         let ch = build_channel(
             "maintainer@example.com",
             vec![make_email_with_from_addrs(
@@ -560,7 +719,19 @@ mod tests {
             )],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(envs.is_empty(), "multi-From message must be rejected");
+        assert_eq!(
+            envs.len(),
+            1,
+            "multi-From message must be quarantined, not dropped"
+        );
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
+        );
     }
 
     #[tokio::test]
@@ -570,9 +741,17 @@ mod tests {
             vec![make_email_with_from_addrs(vec![], "imap:test:0:1")],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(
-            envs.is_empty(),
-            "message with no From address must be rejected"
+        assert_eq!(
+            envs.len(),
+            1,
+            "message with no From address must be quarantined, not dropped"
+        );
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
         );
     }
 
@@ -583,7 +762,18 @@ mod tests {
         email.sender_addr = Some("attacker@example.com".to_string());
         let ch = build_channel("maintainer@example.com", vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
-        assert!(envs.is_empty(), "Sender mismatch must be rejected");
+        assert_eq!(
+            envs.len(),
+            1,
+            "Sender mismatch must be quarantined, not dropped"
+        );
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
+        );
     }
 
     #[tokio::test]
@@ -611,6 +801,185 @@ mod tests {
         );
     }
 
+    // --- Attribution gate: Authentication-Results (ADR-056 Amendment 2026-07-02) ---
+    //
+    // These exercise the REAL byte-parsing path (parse_raw_bytes), not hand-built
+    // RawEmail/authentication_results literals, per the same real-parse discipline
+    // as poll_preserves_multi_id_wire_references_through_real_parse above: a
+    // synthetic header map would not exercise mail-parser's actual header
+    // iteration and could hide a live-path bug the same way it did there.
+
+    #[tokio::test]
+    async fn spoofed_from_no_authentication_results_quarantines_auth_absent() {
+        // The original #448 regression: a message whose From: claims to be the
+        // maintainer, with no Authentication-Results header at all. Must be
+        // quarantined -- and critically, the quarantine envelope's `from` must
+        // NOT be the claimed maintainer address, or the vulnerability persists
+        // one layer up (comm.ingest stamps from_actor straight from envelope.from).
+        let raw = b"From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: spoofed, no auth at all\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_ne!(
+            envs[0].from, "email:maintainer@example.com",
+            "quarantined mail must never carry the claimed maintainer address as `from`"
+        );
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("auth-absent")
+        );
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_claimed_from")
+                .map(String::as_str),
+            Some("maintainer@example.com"),
+            "the claimed From is preserved in metadata for review, but not as `from`"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_authentication_results_topmost_trusted_id_wins_over_forged_below() {
+        // Two Authentication-Results headers share the trusted authserv-id: the
+        // genuine one (dmarc=pass) is topmost (added last, by the final trusted
+        // hop); a forged one (dmarc=fail) was injected below it. Topmost wins,
+        // per the ADR's trusted-header selection rule -- the genuine stamp is
+        // used regardless of what a lower, same-id header claims.
+        let raw = b"Authentication-Results: mx.example.com; dmarc=pass header.from=example.com\r\n\
+                    Authentication-Results: mx.example.com; dmarc=fail header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: genuine on top, forged below\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(
+            envs[0].from, "email:maintainer@example.com",
+            "topmost genuine dmarc=pass must win over a same-id forged header below it"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_authresults_with_trusted_id_is_mechanically_trusted_operational_precondition() {
+        // OPERATIONAL-PRECONDITION BOUNDARY, not a bug: when exactly one
+        // Authentication-Results header is present and it carries the
+        // configured trusted authserv-id, the gate has no way to distinguish
+        // "the receiving MTA genuinely stamped this" from "an attacker injected
+        // a single header claiming our trusted id before the (misconfigured or
+        // absent) receiving MTA had a chance to strip it and add its own".
+        // Per ADR-056 Amendment 2026-07-02 ("Trusted-header selection"), that
+        // stripping is a deployment-time responsibility of the receiving
+        // boundary, not something this parser re-verifies from message content
+        // (doing so would mean deriving trust from the very content the header
+        // is supposed to authenticate). Given that precondition holds in
+        // production, this header is mechanically trusted.
+        let raw = b"Authentication-Results: mx.example.com; dmarc=pass header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: single AR header, trusted id\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].from, "email:maintainer@example.com");
+    }
+
+    #[tokio::test]
+    async fn authresults_with_untrusted_authserv_id_is_ignored_quarantines_auth_absent() {
+        // A header is present, but its authserv-id does not match this
+        // deployment's configured trust anchor -- it must be ignored entirely
+        // (never treated as a partial signal), leaving no trusted header, hence
+        // auth-absent.
+        let raw =
+            b"Authentication-Results: forged-mx.evil.com; dmarc=pass header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: wrong authserv-id\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("auth-absent")
+        );
+    }
+
+    #[tokio::test]
+    async fn spf_pass_unaligned_envelope_from_quarantines_unaligned() {
+        let raw = b"Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=alice@attacker.net\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: spf pass, mismatched envelope domain\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("unaligned")
+        );
+    }
+
+    #[tokio::test]
+    async fn dkim_pass_aligned_d_domain_is_attributed() {
+        let raw = b"Authentication-Results: mx.example.com; dkim=pass header.d=example.com header.s=sel1\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: dkim pass, aligned d=\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel("maintainer@example.com", vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].from, "email:maintainer@example.com");
+    }
+
+    #[tokio::test]
+    async fn quarantine_store_off_drops_unattributed_message() {
+        let mut config = make_config("maintainer@example.com");
+        config.quarantine_store = false;
+        let raw = b"From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: no auth, quarantine store off\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let ch = build_channel_from(config, vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert!(
+            envs.is_empty(),
+            "quarantine_store=false must drop the message, not store it"
+        );
+    }
+
     // --- Batch isolation (Fix 3) ---
 
     #[tokio::test]
@@ -618,23 +987,33 @@ mod tests {
         let ch = build_channel(
             "maintainer@example.com",
             vec![
-                // First message: unauthorized -- should be skipped.
+                // First message: unauthorized -- must be quarantined, not abort the batch.
                 make_email("attacker@example.com", "imap:test:0:1"),
-                // Second message: authorized -- must be returned.
+                // Second message: authorized -- must be attributed.
                 make_email("maintainer@example.com", "imap:test:0:2"),
             ],
         );
         let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 2, "both messages must produce an envelope");
+
+        let quarantined = envs
+            .iter()
+            .find(|e| e.external_id.as_deref() == Some("imap:test:0:1"))
+            .expect("unauthorized message must still be present, quarantined");
+        assert_eq!(quarantined.from, "email:quarantine");
         assert_eq!(
-            envs.len(),
-            1,
-            "only the authorized message must be returned"
+            quarantined
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("off-allowlist")
         );
-        assert_eq!(
-            envs[0].external_id.as_deref(),
-            Some("imap:test:0:2"),
-            "the authorized message must be the one returned"
-        );
+
+        let attributed = envs
+            .iter()
+            .find(|e| e.external_id.as_deref() == Some("imap:test:0:2"))
+            .expect("authorized message must be attributed");
+        assert_eq!(attributed.from, "email:maintainer@example.com");
     }
 
     // --- SMTP send path ---

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -85,6 +85,17 @@ pub struct EmailChannelConfig {
     /// `KHIVE_EMAIL_MAINTAINER_ADDRESS`; the first entry is the primary, used for
     /// outbound-allowlist defaulting and envelope `to` fallback. Never empty.
     pub maintainer_addresses: Vec<MailAddress>,
+    /// The `authserv-id` this deployment trusts in inbound `Authentication-Results`
+    /// headers (ADR-056 Amendment 2026-07-02). Required: there is no safe default
+    /// that would not either trust an attacker-controlled id or silently accept
+    /// unauthenticated mail, so a missing value fails config construction rather
+    /// than falling back to an open default.
+    pub authserv_id: String,
+    /// Whether a message that fails the attribution gate (domain authentication
+    /// or sender allowlist) is stored as an unattributed quarantine record
+    /// instead of being dropped. Defaults to `true`. When `false`, such messages
+    /// are dropped with only the IMAP UID and quarantine reason logged.
+    pub quarantine_store: bool,
 }
 
 impl EmailChannelConfig {
@@ -95,6 +106,7 @@ impl EmailChannelConfig {
     /// - `KHIVE_EMAIL_IMAP_HOST`
     /// - `KHIVE_EMAIL_USERNAME`
     /// - `KHIVE_EMAIL_MAINTAINER_ADDRESS`
+    /// - `KHIVE_EMAIL_AUTHSERV_ID`
     ///
     /// Auth-mode selection:
     /// - If `KHIVE_EMAIL_OAUTH_CLIENT_ID` is present → OAuth mode.
@@ -107,6 +119,7 @@ impl EmailChannelConfig {
     /// - `KHIVE_EMAIL_SMTP_PORT` (default `587`)
     /// - `KHIVE_EMAIL_IMAP_PORT` (default `993`)
     /// - `KHIVE_EMAIL_MAILBOX` (default: same as `KHIVE_EMAIL_USERNAME`)
+    /// - `KHIVE_EMAIL_QUARANTINE_STORE` (default `true`)
     pub fn from_env() -> Result<Self, ChannelError> {
         let smtp_host = require_env("KHIVE_EMAIL_SMTP_HOST")?;
         let smtp_port = optional_port("KHIVE_EMAIL_SMTP_PORT", 587)?;
@@ -146,6 +159,9 @@ impl EmailChannelConfig {
             ));
         }
 
+        let authserv_id = require_env("KHIVE_EMAIL_AUTHSERV_ID")?;
+        let quarantine_store = optional_bool("KHIVE_EMAIL_QUARANTINE_STORE", true)?;
+
         Ok(Self {
             smtp_host,
             smtp_port,
@@ -155,6 +171,8 @@ impl EmailChannelConfig {
             mailbox,
             auth,
             maintainer_addresses,
+            authserv_id,
+            quarantine_store,
         })
     }
 }
@@ -217,6 +235,20 @@ fn optional_port(key: &str, default: u16) -> Result<u16, ChannelError> {
                 "environment variable {key:?} must be a valid port number (1-65535), got: {v:?}"
             ))
         }),
+    }
+}
+
+fn optional_bool(key: &str, default: bool) -> Result<bool, ChannelError> {
+    match std::env::var(key) {
+        Err(_) => Ok(default),
+        Ok(v) => match v.to_lowercase().as_str() {
+            "1" | "true" | "on" | "yes" => Ok(true),
+            "0" | "false" | "off" | "no" => Ok(false),
+            _ => Err(ChannelError::Config(format!(
+                "environment variable {key:?} must be a boolean \
+                 (true/false, 1/0, on/off, yes/no), got: {v:?}"
+            ))),
+        },
     }
 }
 
@@ -481,5 +513,149 @@ mod tests {
             matches!(auth, EmailAuth::Basic { .. }),
             "expected Basic variant"
         );
+    }
+
+    // ── optional_bool tests (env-mutating — serialized with ENV_MUTEX) ────────
+
+    #[test]
+    fn optional_bool_uses_default_when_absent() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _snap = EnvSnapshot::capture(&["KHIVE_EMAIL_QUARANTINE_STORE_TEST_DEFAULT"]);
+        std::env::remove_var("KHIVE_EMAIL_QUARANTINE_STORE_TEST_DEFAULT");
+        let v = optional_bool("KHIVE_EMAIL_QUARANTINE_STORE_TEST_DEFAULT", true).unwrap();
+        assert!(v);
+    }
+
+    #[test]
+    fn optional_bool_parses_true_variants() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let key = "KHIVE_EMAIL_QUARANTINE_STORE_TEST_TRUE";
+        let _snap = EnvSnapshot::capture(&[key]);
+        for v in ["1", "true", "TRUE", "on", "yes"] {
+            std::env::set_var(key, v);
+            assert!(optional_bool(key, false).unwrap(), "{v:?} must parse true");
+        }
+    }
+
+    #[test]
+    fn optional_bool_parses_false_variants() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let key = "KHIVE_EMAIL_QUARANTINE_STORE_TEST_FALSE";
+        let _snap = EnvSnapshot::capture(&[key]);
+        for v in ["0", "false", "FALSE", "off", "no"] {
+            std::env::set_var(key, v);
+            assert!(!optional_bool(key, true).unwrap(), "{v:?} must parse false");
+        }
+    }
+
+    #[test]
+    fn optional_bool_rejects_invalid_value() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let key = "KHIVE_EMAIL_QUARANTINE_STORE_TEST_INVALID";
+        let _snap = EnvSnapshot::capture(&[key]);
+        std::env::set_var(key, "maybe");
+        assert!(optional_bool(key, true).is_err());
+    }
+
+    // ── from_env: KHIVE_EMAIL_AUTHSERV_ID is required (Amendment 2026-07-02) ──
+
+    #[test]
+    fn from_env_missing_authserv_id_fails_closed() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let keys = [
+            "KHIVE_EMAIL_SMTP_HOST",
+            "KHIVE_EMAIL_IMAP_HOST",
+            "KHIVE_EMAIL_USERNAME",
+            "KHIVE_EMAIL_MAINTAINER_ADDRESS",
+            "KHIVE_EMAIL_AUTHSERV_ID",
+            "KHIVE_EMAIL_PASSWORD",
+            TID,
+            CID,
+            CS,
+        ];
+        let _snap = EnvSnapshot::capture(&keys);
+
+        std::env::set_var("KHIVE_EMAIL_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("KHIVE_EMAIL_IMAP_HOST", "imap.example.com");
+        std::env::set_var("KHIVE_EMAIL_USERNAME", "user@example.com");
+        std::env::set_var("KHIVE_EMAIL_MAINTAINER_ADDRESS", "maintainer@example.com");
+        std::env::set_var("KHIVE_EMAIL_PASSWORD", "test-password");
+        std::env::remove_var("KHIVE_EMAIL_AUTHSERV_ID");
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let result = EmailChannelConfig::from_env();
+        assert!(
+            result.is_err(),
+            "missing KHIVE_EMAIL_AUTHSERV_ID must fail closed, not default-open"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("KHIVE_EMAIL_AUTHSERV_ID"), "got: {msg}");
+    }
+
+    #[test]
+    fn from_env_quarantine_store_defaults_true() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let keys = [
+            "KHIVE_EMAIL_SMTP_HOST",
+            "KHIVE_EMAIL_IMAP_HOST",
+            "KHIVE_EMAIL_USERNAME",
+            "KHIVE_EMAIL_MAINTAINER_ADDRESS",
+            "KHIVE_EMAIL_AUTHSERV_ID",
+            "KHIVE_EMAIL_PASSWORD",
+            "KHIVE_EMAIL_QUARANTINE_STORE",
+            TID,
+            CID,
+            CS,
+        ];
+        let _snap = EnvSnapshot::capture(&keys);
+
+        std::env::set_var("KHIVE_EMAIL_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("KHIVE_EMAIL_IMAP_HOST", "imap.example.com");
+        std::env::set_var("KHIVE_EMAIL_USERNAME", "user@example.com");
+        std::env::set_var("KHIVE_EMAIL_MAINTAINER_ADDRESS", "maintainer@example.com");
+        std::env::set_var("KHIVE_EMAIL_AUTHSERV_ID", "mx.example.com");
+        std::env::set_var("KHIVE_EMAIL_PASSWORD", "test-password");
+        std::env::remove_var("KHIVE_EMAIL_QUARANTINE_STORE");
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let config = EmailChannelConfig::from_env().expect("valid config must succeed");
+        assert_eq!(config.authserv_id, "mx.example.com");
+        assert!(config.quarantine_store, "must default to true when unset");
+    }
+
+    #[test]
+    fn from_env_quarantine_store_off() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let keys = [
+            "KHIVE_EMAIL_SMTP_HOST",
+            "KHIVE_EMAIL_IMAP_HOST",
+            "KHIVE_EMAIL_USERNAME",
+            "KHIVE_EMAIL_MAINTAINER_ADDRESS",
+            "KHIVE_EMAIL_AUTHSERV_ID",
+            "KHIVE_EMAIL_PASSWORD",
+            "KHIVE_EMAIL_QUARANTINE_STORE",
+            TID,
+            CID,
+            CS,
+        ];
+        let _snap = EnvSnapshot::capture(&keys);
+
+        std::env::set_var("KHIVE_EMAIL_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("KHIVE_EMAIL_IMAP_HOST", "imap.example.com");
+        std::env::set_var("KHIVE_EMAIL_USERNAME", "user@example.com");
+        std::env::set_var("KHIVE_EMAIL_MAINTAINER_ADDRESS", "maintainer@example.com");
+        std::env::set_var("KHIVE_EMAIL_AUTHSERV_ID", "mx.example.com");
+        std::env::set_var("KHIVE_EMAIL_PASSWORD", "test-password");
+        std::env::set_var("KHIVE_EMAIL_QUARANTINE_STORE", "off");
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let config = EmailChannelConfig::from_env().expect("valid config must succeed");
+        assert!(!config.quarantine_store);
     }
 }

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -386,6 +386,28 @@ pub(crate) fn parse_raw_bytes(
         }
     }
 
+    // Every Authentication-Results occurrence, in document order (topmost
+    // first), verbatim. Collected separately from `headers` above because that
+    // map keeps only the first occurrence of a header name; the attribution
+    // gate needs every occurrence to find the topmost one carrying the
+    // configured trust anchor (ADR-056 Amendment 2026-07-02).
+    let mut authentication_results: Vec<String> = Vec::new();
+    for header in msg.headers() {
+        if !header.name().eq_ignore_ascii_case("authentication-results") {
+            continue;
+        }
+        match header.value() {
+            mail_parser::HeaderValue::Text(v) => authentication_results.push(v.to_string()),
+            mail_parser::HeaderValue::TextList(list) => authentication_results.push(
+                list.iter()
+                    .map(|v| v.as_ref())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            ),
+            _ => {}
+        }
+    }
+
     Some(RawEmail {
         uid,
         imap_external_id,
@@ -397,6 +419,7 @@ pub(crate) fn parse_raw_bytes(
         body_text,
         body_html,
         headers,
+        authentication_results,
     })
 }
 
@@ -480,6 +503,7 @@ mod tests {
             body_text: Some("body".to_string()),
             body_html: None,
             headers: HashMap::new(),
+            authentication_results: Vec::new(),
         }
     }
 
@@ -614,6 +638,56 @@ mod tests {
     }
 
     #[test]
+    fn parse_raw_bytes_collects_single_authentication_results_header() {
+        let raw = b"Authentication-Results: mx.example.com; dmarc=pass header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: single AR header\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        assert_eq!(
+            email.authentication_results,
+            vec!["mx.example.com; dmarc=pass header.from=example.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_raw_bytes_preserves_all_authentication_results_in_document_order() {
+        // The general `headers` map keeps only the first occurrence of a header
+        // name; Authentication-Results needs every occurrence, in the order an
+        // MTA stamps them (topmost = most recently added), to support the
+        // "topmost trusted authserv-id wins" attribution gate.
+        let raw = b"Authentication-Results: mx.example.com; dmarc=pass header.from=example.com\r\n\
+                    Authentication-Results: mx.example.com; dmarc=fail header.from=example.com\r\n\
+                    From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: two AR headers\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        assert_eq!(
+            email.authentication_results,
+            vec![
+                "mx.example.com; dmarc=pass header.from=example.com".to_string(),
+                "mx.example.com; dmarc=fail header.from=example.com".to_string(),
+            ],
+            "both occurrences must survive, topmost first"
+        );
+    }
+
+    #[test]
+    fn parse_raw_bytes_no_authentication_results_header_yields_empty_vec() {
+        let raw = b"From: maintainer@example.com\r\n\
+                    To: me@example.com\r\n\
+                    Subject: no auth header\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        assert!(email.authentication_results.is_empty());
+    }
+
+    #[test]
     fn raw_email_khive_thread_id_header() {
         let mut headers = HashMap::new();
         headers.insert("x-khive-thread-id".to_string(), "some-uuid".to_string());
@@ -628,6 +702,7 @@ mod tests {
             body_text: None,
             body_html: None,
             headers,
+            authentication_results: Vec::new(),
         };
         assert_eq!(email.khive_thread_id(), Some("some-uuid"));
         assert_eq!(email.correlation(), Some("some-uuid"));
@@ -724,6 +799,7 @@ mod tests {
             body_text: Some("reply body".to_string()),
             body_html: None,
             headers,
+            authentication_results: Vec::new(),
         };
         assert_eq!(email.in_reply_to(), Some("<orig@example.com>"));
         assert_eq!(email.correlation(), Some("<orig@example.com>"));

--- a/crates/khive-channel-email/src/connector/mod.rs
+++ b/crates/khive-channel-email/src/connector/mod.rs
@@ -113,6 +113,15 @@ pub struct RawEmail {
     pub body_html: Option<String>,
     /// All headers as a flat map (lowercase key, first-occurrence value).
     pub headers: HashMap<String, String>,
+    /// Every `Authentication-Results` header value, in document order (topmost
+    /// first), verbatim.
+    ///
+    /// Kept separate from `headers` because that map keeps only the first
+    /// occurrence of a header name, while the attribution gate (ADR-056
+    /// Amendment 2026-07-02) must see every occurrence to find the topmost one
+    /// whose `authserv-id` matches the configured trust anchor -- an MTA can
+    /// legitimately stamp more than one hop's worth of this header.
+    pub authentication_results: Vec<String>,
 }
 
 impl RawEmail {

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -15,6 +15,8 @@
 //! | `KHIVE_EMAIL_USERNAME` | yes | — | SMTP/IMAP login username (email address) |
 //! | `KHIVE_EMAIL_MAILBOX` | no | same as username | Mailbox used as sender address |
 //! | `KHIVE_EMAIL_MAINTAINER_ADDRESS` | yes | — | Single authorized maintainer address |
+//! | `KHIVE_EMAIL_AUTHSERV_ID` | yes | — | `authserv-id` this deployment trusts in `Authentication-Results` headers (ADR-056 Amendment 2026-07-02) |
+//! | `KHIVE_EMAIL_QUARANTINE_STORE` | no | `true` | Store messages that fail the attribution gate (unattributed) instead of dropping them |
 //!
 //! ## Auth variables
 //!
@@ -32,6 +34,7 @@
 //! | `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` | maintainer address | Comma-separated allowlist of recipient addresses the outbox loop may deliver to; defaults to the single maintainer address |
 //! | `KHIVE_EMAIL_INGEST_NAMESPACE` | `local` | Namespace used when persisting inbound and outbound messages |
 
+pub(crate) mod auth_results;
 pub mod channel;
 pub mod config;
 pub mod connector;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -261,6 +261,7 @@ async fn channel_poll_loop(
                             "default_inbound_actor": default_inbound_actor,
                             "wire_message_id": env.wire_message_id,
                             "wire_references": env.wire_references,
+                            "metadata": env.metadata,
                         });
                         if let Err(e) = registry.dispatch("comm.ingest", params).await {
                             tracing::warn!(

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -777,6 +777,19 @@ pub(crate) async fn handle_ingest(
     if let Some(ref kind) = p.channel_kind {
         props["channel_kind"] = json!(kind);
     }
+    // Generic transport-layer metadata passthrough (issue #448 Finding 2): merged
+    // additively so it can never clobber the identity/routing fields set above --
+    // a key already present (from, to, from_actor, to_actor, direction, read,
+    // thread_id, sent_at, subject, external_id, wire_message_id, wire_references,
+    // channel_kind) always wins. The comm pack does not interpret any metadata
+    // key; the email channel happens to use it for quarantine markers.
+    if let Some(metadata) = p.metadata {
+        if let Some(obj) = props.as_object_mut() {
+            for (k, v) in metadata {
+                obj.entry(k).or_insert(v);
+            }
+        }
+    }
 
     let note = match runtime
         .try_create_note(

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -302,6 +302,26 @@ mod help_tests {
     }
 
     #[test]
+    fn ingest_declares_optional_metadata_param() {
+        // ADR-084 Rule 3 (help fidelity): comm.ingest's IngestParams.metadata
+        // field (issue #448 Finding 2, quarantine marker passthrough) must be
+        // reflected in the ParamDef/help schema, not just the Rust struct.
+        let h = CommPack::HANDLERS
+            .iter()
+            .find(|h| h.name == "comm.ingest")
+            .expect("comm.ingest must be declared");
+        let metadata_param = h
+            .params
+            .iter()
+            .find(|p| p.name == "metadata")
+            .expect("comm.ingest must declare 'metadata' param");
+        assert!(
+            !metadata_param.required,
+            "metadata must be optional so absent metadata preserves today's behavior exactly"
+        );
+    }
+
+    #[test]
     fn ingest_declares_required_content_params() {
         let h = CommPack::HANDLERS
             .iter()

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -99,6 +99,16 @@ pub(crate) struct IngestParams {
     /// own Message-ID (issue #403).
     #[serde(default)]
     pub wire_references: Option<String>,
+    /// Optional transport-layer metadata passthrough, merged verbatim into the
+    /// stored note's properties alongside the fields above. Generic and
+    /// channel-agnostic: the comm pack does not interpret any key in this map,
+    /// it only persists it. A channel adapter that needs to attach adapter-specific
+    /// markers (e.g. the email channel's quarantine flags, ADR-056 Amendment
+    /// 2026-07-02) sets `ChannelEnvelope.metadata`; the MCP poll loop forwards it
+    /// here unchanged. Absent metadata is today's behavior exactly (issue #448
+    /// Finding 2).
+    #[serde(default)]
+    pub metadata: Option<serde_json::Map<String, Value>>,
 }
 
 pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -217,6 +217,12 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [
                 required: false,
                 description: "This message's own RFC 822 References header value, verbatim. Persisted so a later reply can extend the full ancestor chain instead of truncating it to the immediate parent.",
             },
+            ParamDef {
+                name: "metadata",
+                param_type: "object",
+                required: false,
+                description: "Optional transport-layer metadata passthrough, merged additively into the stored note's properties (never overrides an already-set field). Generic and channel-agnostic; the email channel uses it for quarantine markers (quarantined, quarantine_reason, quarantine_claimed_from — ADR-056 Amendment 2026-07-02).",
+            },
         ],
     },
 ];

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -4765,3 +4765,134 @@ async fn reply_dedups_tainted_parent_references_chain_containing_parent_id() {
          got props={props}"
     );
 }
+
+// --- issue #448 Finding 2: quarantine metadata must survive comm.ingest persistence ---
+
+/// A quarantined envelope (as `EmailChannel::quarantine_envelope` builds it, ADR-056
+/// Amendment 2026-07-02) must persist its `quarantined`/`quarantine_reason`/
+/// `quarantine_claimed_from` markers through `comm.ingest`, and `from`/`from_actor`
+/// must stay the fixed `email:quarantine` marker -- `quarantine_claimed_from` is
+/// carried for maintainer review only, never as an attribution source.
+#[tokio::test]
+async fn ingest_persists_quarantine_metadata_and_never_attributes_claimed_sender() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:quarantine",
+            "to": "email:maintainer@example.com",
+            "content": "spoofed body",
+            "subject": "spoofed, no auth at all",
+            "channel_kind": "email",
+            "external_id": "imap:mail:1:1",
+            "namespace": "local",
+            "metadata": {
+                "quarantined": "true",
+                "quarantine_reason": "auth-absent",
+                "quarantine_claimed_from": "maintainer@example.com",
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["quarantined"].as_str(),
+        Some("true"),
+        "quarantine marker must reach persisted properties; got props={props}"
+    );
+    assert_eq!(
+        props["quarantine_reason"].as_str(),
+        Some("auth-absent"),
+        "quarantine reason must reach persisted properties; got props={props}"
+    );
+    assert_eq!(
+        props["quarantine_claimed_from"].as_str(),
+        Some("maintainer@example.com"),
+        "the claimed From is preserved in metadata for maintainer review; got props={props}"
+    );
+    assert_eq!(
+        props["from"].as_str(),
+        Some("email:quarantine"),
+        "quarantine_claimed_from must never be used as an authoritative sender: \
+         `from` must stay the fixed quarantine marker"
+    );
+    assert_eq!(
+        props["from_actor"].as_str(),
+        Some("email:quarantine"),
+        "quarantine_claimed_from must never be used as an authoritative sender: \
+         `from_actor` must stay the fixed quarantine marker"
+    );
+}
+
+/// Absent `metadata` must leave persisted properties exactly as before this fix
+/// (no `quarantined`/`quarantine_reason`/`quarantine_claimed_from` keys at all).
+#[tokio::test]
+async fn ingest_without_metadata_persists_no_quarantine_keys() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:user@example.com",
+            "to": "email:mailbox@example.com",
+            "content": "ordinary message",
+            "external_id": "imap:mail:2:1",
+            "namespace": "local",
+        }),
+    )
+    .await;
+
+    assert!(
+        props.get("quarantined").is_none(),
+        "absent metadata must not fabricate a quarantined key; got props={props}"
+    );
+    assert!(
+        props.get("quarantine_reason").is_none(),
+        "absent metadata must not fabricate a quarantine_reason key; got props={props}"
+    );
+    assert!(
+        props.get("quarantine_claimed_from").is_none(),
+        "absent metadata must not fabricate a quarantine_claimed_from key; got props={props}"
+    );
+}
+
+/// Metadata must merge additively: it must never be able to override an
+/// identity/routing field the handler already stamped (from, from_actor,
+/// to_actor, direction). This is the safety property that makes the generic
+/// passthrough non-leaky even though the comm pack does not special-case any key.
+#[tokio::test]
+async fn ingest_metadata_cannot_override_stamped_identity_fields() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let props = ingest_and_get_props(
+        &registry,
+        &rt,
+        serde_json::json!({
+            "from": "email:quarantine",
+            "to": "email:maintainer@example.com",
+            "content": "spoofed body",
+            "external_id": "imap:mail:3:1",
+            "namespace": "local",
+            "metadata": {
+                "from_actor": "lambda:leo",
+                "to_actor": "lambda:leo",
+                "direction": "outbound",
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        props["from_actor"].as_str(),
+        Some("email:quarantine"),
+        "metadata must never override the handler-stamped from_actor; got props={props}"
+    );
+    assert_eq!(
+        props["direction"].as_str(),
+        Some("inbound"),
+        "metadata must never override the handler-stamped direction; got props={props}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the ADR-056 Amendment 2026-07-02 inbound-attribution gate (issue #448, CHANNELEMAIL-AUD-001, high/security). Inbound email is attributed to the maintainer only when BOTH hold: (1) a trusted `Authentication-Results` record shows `dmarc=pass`, or an SPF/DKIM pass aligned to the `From:` domain; and (2) the existing single-From + maintainer-allowlist + Sender-if-present check. Anything else is quarantined, never attributed.

- **`auth_results.rs` (new)**: structural RFC 8601 parser (`mail-parser` has no structured support for this header). `select_trusted` picks the topmost header in document order whose `authserv-id` equals `KHIVE_EMAIL_AUTHSERV_ID`; all other-id headers are ignored; absence fails closed.
- **`channel.rs`**: `gate()` = `evaluate_auth` (alignment mandatory; unaligned pass is its own quarantine reason) then allowlist. `poll()` routes gate failures to `quarantine_envelope` (when `KHIVE_EMAIL_QUARANTINE_STORE`, default on) or drops with only UID+reason logged. Quarantine envelopes carry `from = "email:quarantine"` (never the claimed From), metadata `quarantined=true` + reason ∈ {auth-absent, dmarc-fail, unaligned, off-allowlist} + `quarantine_claimed_from` for review, and deliberately no correlation/wire-threading fields so an unauthenticated message cannot inherit a legitimate thread's context.
- **`config.rs`**: `KHIVE_EMAIL_AUTHSERV_ID` required (missing ⇒ config error, fail-closed); `KHIVE_EMAIL_QUARANTINE_STORE` optional bool, default on.
- **`connector/imap.rs` + `mod.rs`**: `RawEmail.authentication_results` collects every physical `Authentication-Results` occurrence verbatim in document order (the existing `headers` map keeps only first occurrence).

## Design decisions

1. `from` is rewritten to `email:quarantine` because `comm.ingest` stamps `from_actor` unconditionally from the envelope `from`; a metadata-only flag would still attribute the forged address.
2. Alignment is exact-domain (case-insensitive), the conservative reading; organizational-domain alignment is a compatible follow-up if subdomain-signing setups need it.
3. Trusted-header cases with no recognized passing method bucket as `dmarc-fail`.

## Deployment gate (does NOT block this merge)

Per the amendment's operational precondition and the review conditions on #448: before the live channel flips on, the real EXO mailbox must be probed to (a) observe the actual `authserv-id` string for `KHIVE_EMAIL_AUTHSERV_ID`, and (b) confirm the boundary strips or out-positions sender-forged `Authentication-Results` bearing that id. The `single_authresults_with_trusted_id_is_mechanically_trusted_operational_precondition` test documents this boundary assumption explicitly.

## Test plan (102 pass, `--all-features`)

- [x] Spoofed `From:` maintainer with no Authentication-Results ⇒ quarantine `auth-absent` (the original #448 scenario)
- [x] Multi-A-R forgery: genuine topmost beats same-id forged header below; different-id header ignored ⇒ quarantine
- [x] `spf=pass` unaligned envelope-from ⇒ `unaligned`; `dkim=pass` aligned `d=` ⇒ attributed
- [x] Valid auth + off-allowlist sender ⇒ `off-allowlist` (silent-drop semantics replaced by quarantine-store)
- [x] `quarantine_store=off` ⇒ dropped, UID-only logging
- [x] All gate tests drive real raw RFC 822 bytes through `parse_raw_bytes` (no synthetic header maps)
- [x] `cargo fmt` / `clippy -D warnings` / `test -p khive-channel-email --all-features` / `RUSTDOCFLAGS="-D warnings" cargo doc` all rc=0

Refs #448. Contract: `docs/adr/ADR-056-channel-transport-layer.md` §Amendment 2026-07-02.