### PR TITLE
fix(brain): namespace-agnostic feedback target resolution (ADR-007 Rule 2)

### DIFF
--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -878,20 +878,25 @@ impl BrainPack {
             }
         };
 
-        // Validate target_id in the PRIMARY namespace only. A visible-only
-        // (foreign) record must not be targeted by a mutation (feedback event).
-        // NotFound (not Forbidden) per ADR-007:215-219.
-        let resolved = self
+        // Resolve the target by UUID with no namespace filter (ADR-007 Rule 2 /
+        // PR-A1: by-ID ops are namespace-agnostic; authorization is the Gate's,
+        // not a post-fetch namespace check). Rule 3b recall fans out actor-stamped
+        // memories from other namespaces by design, so a primary-only check would
+        // reject the flywheel's own recalled targets. NotFound only for a
+        // genuinely absent UUID.
+        use khive_runtime::Resolved;
+        match self
             .runtime
-            .resolve_primary(token, target)
+            .resolve_by_id(token, target)
             .await
-            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
-        if resolved.is_none() {
-            return Err(RuntimeError::NotFound(format!(
-                "target_id {:?} not found in namespace {:?}",
-                target,
-                token.namespace().as_str()
-            )));
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
+        {
+            Some(Resolved::Entity(_)) | Some(Resolved::Note(_)) => {}
+            _ => {
+                return Err(RuntimeError::NotFound(format!(
+                    "target_id {target:?} not found"
+                )));
+            }
         }
 
         // Compute the effective serving profile (explicit or default), then validate

--- a/crates/khive-pack-brain/tests/dispatch_hook.rs
+++ b/crates/khive-pack-brain/tests/dispatch_hook.rs
@@ -320,71 +320,87 @@ async fn cold_hook_signal_applies_on_top_of_persisted_snapshot() {
     );
 }
 
-// ---- Finding 3 regression: brain.feedback target_id must be primary-only ----
+// ---- bfbb65d1 regression: brain.feedback target_id is namespace-agnostic ----
 
-/// `brain.feedback` must reject a `target_id` that lives in a visible (non-primary)
-/// namespace. A visible-only record must not be the target of a feedback mutation.
+/// `brain.feedback` must ACCEPT a `target_id` that lives in another namespace.
 ///
-/// This tests that the fix from `resolve` to `resolve_primary` is in effect:
-/// a record the caller can READ but not MUTATE returns NotFound on feedback.
+/// ADR-007 Rule 2 / PR-A1: by-ID ops (get / update / delete / merge — and
+/// feedback) resolve a globally-unique UUID with no namespace check; the Gate
+/// owns authorization, not a post-fetch namespace comparison. Rule 3b recall
+/// fans out actor-stamped memories from other namespaces by design (a lambda's
+/// episodic memories carry its actor namespace), so a primary-only check
+/// rejected the flywheel's own recalled targets — exactly the fleet-wide
+/// feedback-discipline breakage this fixes.
+///
+/// This reverses the earlier "Finding 3" primary-only behavior, which cited
+/// ADR-007 for a rule the document does not contain (the word "feedback" never
+/// appears in ADR-007; lines 213-221 are the dispatch-boundary token-minting
+/// paragraph, unrelated to targeting foreign records).
 #[tokio::test]
-async fn brain_feedback_rejects_visible_only_target_id() {
+async fn brain_feedback_accepts_foreign_namespace_target_id() {
     let rt = KhiveRuntime::memory().expect("in-memory runtime");
 
     let ns_primary = Namespace::parse("brain-primary-ns").unwrap();
     let ns_foreign = Namespace::parse("brain-foreign-ns").unwrap();
 
-    // Create a KG entity in the foreign namespace.
+    // A recalled note (the episodic-memory analog) stamped in the foreign
+    // namespace — the Rule 3b fanout target class.
     let tok_foreign = rt.authorize(ns_foreign.clone()).unwrap();
-    let foreign_entity = rt
-        .create_entity(
+    let foreign_note = rt
+        .create_note(
             &tok_foreign,
-            "concept",
+            "observation",
             None,
-            "ForeignTarget",
+            "foreign-namespace recalled memory",
             None,
             None,
             vec![],
         )
         .await
         .unwrap();
-    let foreign_id = foreign_entity.id.as_hyphenated().to_string();
+    let foreign_id = foreign_note.id.as_hyphenated().to_string();
 
-    // Build a visible-set token: primary-ns can read (but not mutate) foreign-ns.
+    // Caller in a different primary namespace (visible-set can read foreign-ns).
     let tok_vis = rt
         .authorize_with_visibility(ns_primary.clone(), vec![ns_foreign.clone()])
         .unwrap();
 
-    // Verify the visible-set token CAN read the foreign entity (control check).
-    let found = rt.get_entity(&tok_vis, foreign_entity.id).await;
-    assert!(
-        found.is_ok(),
-        "visible-set token must be able to read the foreign entity; got: {found:?}"
-    );
-
-    // brain.feedback with the foreign entity as target_id must fail NotFound.
     let brain = BrainPack::new(rt.clone());
     let empty_registry = VerbRegistryBuilder::new().build().unwrap();
-
-    // First promote the primary namespace.
     brain
         .dispatch("brain.profiles", json!({}), &empty_registry, &tok_vis)
         .await
         .expect("promote primary namespace");
 
-    let err = brain
+    // Feedback on the foreign-namespace target now RESOLVES and emits
+    // (previously returned NotFound under the primary-only check).
+    let out = brain
         .dispatch(
             "brain.feedback",
             json!({ "target_id": foreign_id, "signal": "useful" }),
             &empty_registry,
             &tok_vis,
         )
+        .await;
+    assert!(
+        out.is_ok(),
+        "brain.feedback on a foreign-namespace target must succeed \
+         (ADR-007 Rule 2 by-ID resolution); got: {out:?}"
+    );
+
+    // A genuinely absent UUID still returns NotFound.
+    let absent = "00000000-0000-4000-8000-000000000000";
+    let err = brain
+        .dispatch(
+            "brain.feedback",
+            json!({ "target_id": absent, "signal": "useful" }),
+            &empty_registry,
+            &tok_vis,
+        )
         .await
         .unwrap_err();
-
-    let msg = err.to_string();
     assert!(
-        msg.to_lowercase().contains("not found"),
-        "brain.feedback with visible-only target_id must return NotFound; got: {msg}"
+        err.to_string().to_lowercase().contains("not found"),
+        "brain.feedback on an absent target_id must return NotFound; got: {err}"
     );
 }

--- a/crates/khive-pack-brain/tests/dispatch_hook.rs
+++ b/crates/khive-pack-brain/tests/dispatch_hook.rs
@@ -360,15 +360,17 @@ async fn brain_feedback_accepts_foreign_namespace_target_id() {
         .unwrap();
     let foreign_id = foreign_note.id.as_hyphenated().to_string();
 
-    // Caller in a different primary namespace (visible-set can read foreign-ns).
-    let tok_vis = rt
-        .authorize_with_visibility(ns_primary.clone(), vec![ns_foreign.clone()])
-        .unwrap();
+    // Caller in a different primary namespace with NO visibility grant for the
+    // foreign ns. resolve_by_id is ID-only (ignores namespace AND visible set),
+    // so feedback must still resolve the foreign target. Using a bare token pins
+    // the FULL ns-agnostic contract: this test fails under the old primary-only
+    // `resolve_primary` AND under any future visible-set-gated `resolve`.
+    let tok_primary = rt.authorize(ns_primary.clone()).unwrap();
 
     let brain = BrainPack::new(rt.clone());
     let empty_registry = VerbRegistryBuilder::new().build().unwrap();
     brain
-        .dispatch("brain.profiles", json!({}), &empty_registry, &tok_vis)
+        .dispatch("brain.profiles", json!({}), &empty_registry, &tok_primary)
         .await
         .expect("promote primary namespace");
 
@@ -379,7 +381,7 @@ async fn brain_feedback_accepts_foreign_namespace_target_id() {
             "brain.feedback",
             json!({ "target_id": foreign_id, "signal": "useful" }),
             &empty_registry,
-            &tok_vis,
+            &tok_primary,
         )
         .await;
     assert!(
@@ -395,7 +397,7 @@ async fn brain_feedback_accepts_foreign_namespace_target_id() {
             "brain.feedback",
             json!({ "target_id": absent, "signal": "useful" }),
             &empty_registry,
-            &tok_vis,
+            &tok_primary,
         )
         .await
         .unwrap_err();


### PR DESCRIPTION
## Problem
`brain.feedback` / `brain.auto_feedback` validated the `target_id` via `resolve_primary` (primary-namespace-only). Rule 3b recall fans out **actor-stamped episodic memories from other namespaces by design** (each actor's episodic memories carry its own actor namespace), so an agent's own recalled targets returned `NotFound` — feedback was broken for every cross-namespace recalled memory. Observed live in production usage.

## Root cause
`handle_feedback` (handlers.rs:881-895) carried a comment citing **ADR-007:215-219** for a "visible-only record must not be targeted by a mutation" rule. Content check: the word **"feedback" appears zero times in ADR-007**; lines 213-221 are the dispatch-boundary token-minting paragraph, unrelated to targeting foreign records. The only source for the rule was the comment itself. ADR-007 actually says (Rule 2, line 175) **"By-ID ops are namespace-agnostic (SHIPPED, PR-A1)"** and (line 99) namespace "never gates by-ID access"; PR-A1 (commit 2607e263) removed exactly this post-fetch ns-check class from `get_entity`/`get_note`/`delete_entity`/`update_entity`. The brain feedback handler missed that sweep — the dev-guide anti-pattern section says this check pattern "must not return."

## Fix
- `handle_feedback` resolves the target via **`resolve_by_id`** (no namespace filter), mirroring the by-ID contract of `get`/`update`/`delete`/`merge`. Authorization stays at the Gate. `NotFound` only for a genuinely absent UUID.
- Deleted the false ADR-007:215-219 citation comment; replaced with an accurate Rule 2 / PR-A1 / Rule 3b note.

## Test
Inverts the prior **"Finding 3" regression test** (`brain_feedback_rejects_visible_only_target_id`) — that test deliberately encoded the primary-only behavior via a visible-set token, on the same misread-ADR basis. New `brain_feedback_accepts_foreign_namespace_target_id`: a foreign-namespace **note** (episodic-memory analog) fed back on from a different primary namespace now **resolves + emits**; a genuinely absent UUID still returns `NotFound`.

## Scope (deliberately tight)
- **Feedback only.** Short-prefix resolution (`resolve_prefix`) stays namespace-scoped — the truncated-id path (`'no record matches id prefix'`) opens the 32-bit prefix-enumeration surface tracked under the **#395** lane and is NOT bundled here. A full UUID is not enumerable, so the recall→auto_feedback mainline (full UUIDs) is fully fixed by this change.
- `gtd depends_on` / `link` / `annotate` primary-only `resolve_primary` validations are **unchanged** (separate semantics with their own passing tests).

## Gates
fmt clean, clippy `-D warnings` clean, `khive-pack-brain` 154 lib + 5 dispatch_hook + 4 secret_gate tests passing. Reviewed through the standard internal review process.

Closes part of the brain.auto_feedback friction; the #395 prefix half remains its own lane.
