### PR TITLE
fix(channel-email): handle Exchange Online no-authserv-id Authentication-Results

### DIFF
--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -25,6 +25,8 @@
 
 use std::collections::HashMap;
 
+use crate::config::TrustAnchor;
+
 /// One `resinfo` entry: a single method's verdict plus its properties.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MethodResult {
@@ -33,21 +35,45 @@ pub(crate) struct MethodResult {
 }
 
 /// A parsed `Authentication-Results` header value.
+///
+/// `authserv_id: None` means the no-authserv-id form (e.g. Exchange Online's
+/// internal-hop stamp); `Some(id)` means an RFC 8601-compliant boundary's id.
+/// `parse_header` only ever produces `Some` from a non-empty first token, so
+/// `Some` is always non-empty -- this is a type-level invariant, not just a
+/// convention: an "empty configured id" can never be *represented* as a
+/// matchable authserv_id, let alone accidentally match one (Leo, SPEC-GATE,
+/// 2026-07-03: "guards decay; types don't").
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct AuthResults {
-    pub authserv_id: String,
+    pub authserv_id: Option<String>,
     pub dmarc: Vec<MethodResult>,
     pub spf: Vec<MethodResult>,
     pub dkim: Vec<MethodResult>,
 }
 
 impl AuthResults {
-    /// `dmarc=pass` is present. DMARC's own verdict already encodes alignment
-    /// (RFC 7489 §3.1), so no separate domain check applies here.
+    /// `dmarc=pass` is present, without regard to `header.from` alignment.
+    ///
+    /// This is the raw method verdict only. The attribution gate does NOT use
+    /// this directly -- reading `dmarc=pass` without confirming its
+    /// `header.from` equals the From domain the gate is about to attribute
+    /// mail to is a latent alignment gap (a dmarc=pass entry's `header.from`
+    /// is the domain DMARC itself aligned against, which is not necessarily
+    /// the domain the gate is attributing to). Use [`Self::dmarc_pass_aligned`]
+    /// for the gate's aligned check; this method remains for callers (tests,
+    /// diagnostics) that want the unaligned raw verdict.
+    // Only exercised by `#[cfg(test)]` callers now that the gate uses
+    // `dmarc_pass_aligned`; not dead code, just test/diagnostic-only.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn dmarc_pass(&self) -> bool {
         self.dmarc
             .iter()
             .any(|e| e.result.eq_ignore_ascii_case("pass"))
+    }
+
+    /// `dmarc=pass` is present AND its `header.from` domain matches `from_domain`.
+    pub fn dmarc_pass_aligned(&self, from_domain: &str) -> bool {
+        Self::method_pass_aligned(&self.dmarc, "header.from", from_domain)
     }
 
     /// `spf=pass` is present AND its `smtp.mailfrom` domain matches `from_domain`.
@@ -161,24 +187,56 @@ fn split_top_level_segments(raw: &str) -> Vec<String> {
 
 /// Parse one raw `Authentication-Results` header value.
 ///
-/// Returns `None` only when no `authserv-id` token can be extracted at all
-/// (an empty or malformed header). A bare `authserv-id; none` or an
-/// `authserv-id` with no method the gate recognizes both parse successfully
-/// to an `AuthResults` with empty method vectors -- the gate treats "no
+/// Detects two shapes for the first `resinfo`-or-authserv-id segment:
+///
+/// - **RFC 8601 form**: the first whitespace token of the first top-level
+///   segment is the `authserv-id` (a dot-atom/value that can never contain an
+///   unquoted `=`). The remaining segments are parsed as `resinfo` entries.
+/// - **No-authserv-id form** (observed from Exchange Online's internal-hop
+///   stamp): the first whitespace token of the first segment itself contains
+///   an unquoted `=`, which is impossible for a valid authserv-id and
+///   unambiguous for a `resinfo` (`method[/version]=result`). In this case
+///   `authserv_id` is set to `None` and segment 0 is parsed as a `resinfo`
+///   entry through the *same* loop as every other segment -- it is never
+///   discarded as a (nonexistent) authserv-id.
+///
+/// Returns `None` when no signal can be extracted at all: an empty/whitespace
+/// header (no first token), or -- in the no-authserv-id form only -- a header
+/// whose segments contain no recognized `dmarc`/`spf`/`dkim` method entry
+/// anywhere. In the RFC 8601 form, a non-empty authserv-id with no method the
+/// gate recognizes still parses successfully to an `AuthResults` with empty
+/// method vectors (unchanged from prior behavior) -- the gate treats "no
 /// recognized passing method" uniformly regardless of which of those it was.
 pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
-    let mut segments = split_top_level_segments(raw).into_iter();
-    let authserv_id = segments.next()?.split_whitespace().next()?.to_string();
-    if authserv_id.is_empty() {
-        return None;
-    }
+    let mut all_segments = split_top_level_segments(raw).into_iter();
+    let first_segment = all_segments.next()?;
+    let first_token = first_segment.split_whitespace().next()?;
+
+    // A valid RFC 8601 authserv-id can never contain `=`; a resinfo always
+    // begins `method[/version]=result`. An unquoted `=` in the first
+    // whitespace token is therefore unambiguous evidence that this boundary
+    // emits no authserv-id at all, regardless of whether an optional
+    // method-version suffix (`method/version=result`) is also present --
+    // the `=` survives that suffix either way.
+    let is_no_authserv_id_form = first_token.contains('=');
+
+    let (authserv_id, method_segments): (Option<String>, Box<dyn Iterator<Item = String>>) =
+        if is_no_authserv_id_form {
+            (
+                None,
+                Box::new(std::iter::once(first_segment).chain(all_segments)),
+            )
+        } else {
+            (Some(first_token.to_string()), Box::new(all_segments))
+        };
 
     let mut out = AuthResults {
         authserv_id,
         ..Default::default()
     };
+    let mut recognized_any = false;
 
-    for segment in segments {
+    for segment in method_segments {
         let segment = segment.trim();
         if segment.is_empty() || segment.eq_ignore_ascii_case("none") {
             continue;
@@ -201,6 +259,11 @@ pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
             Some((base, "1")) => base,
             Some(_) => continue,
         };
+        let method_lower = method.to_lowercase();
+        if !matches!(method_lower.as_str(), "dmarc" | "spf" | "dkim") {
+            continue;
+        }
+        recognized_any = true;
 
         let mut props = HashMap::new();
         for token in tokens {
@@ -213,33 +276,68 @@ pub(crate) fn parse_header(raw: &str) -> Option<AuthResults> {
             result: result.to_lowercase(),
             props,
         };
-        match method.to_lowercase().as_str() {
+        match method_lower.as_str() {
             "dmarc" => out.dmarc.push(entry),
             "spf" => out.spf.push(entry),
             "dkim" => out.dkim.push(entry),
-            _ => {}
+            _ => unreachable!("filtered to dmarc|spf|dkim above"),
         }
+    }
+
+    // In the no-authserv-id form there is no authserv-id signal at all, so a
+    // header that also carries no recognized method entry is genuine zero
+    // signal (equivalent to the empty/malformed case) and must fail closed to
+    // `None`, not a vacuously-successful empty `AuthResults`.
+    if is_no_authserv_id_form && !recognized_any {
+        return None;
     }
 
     Some(out)
 }
 
-/// Select the first (topmost) `Authentication-Results` header, in document
-/// order, whose `authserv-id` matches `configured_id` (case-insensitive).
+/// Select the trusted `Authentication-Results` header per the configured
+/// [`TrustAnchor`] (ADR-056 Amendment 2026-07-03, "EXO no-authserv-id trust
+/// anchor").
 ///
-/// Topmost wins: a receiving MTA prepends its own stamp on each hop, so the
-/// header nearest the top of the document is the one added by the final,
-/// trusted receiving boundary -- PROVIDED that boundary strips or renames any
-/// pre-existing header already claiming its own `authserv-id` before adding
-/// its stamp. That stripping is an operational precondition of the receiving
-/// MTA, verified by deployment configuration, not re-derived from message
-/// content here (see ADR-056 Amendment 2026-07-02, "Trusted-header
-/// selection").
-pub(crate) fn select_trusted(raw_headers: &[String], configured_id: &str) -> Option<AuthResults> {
-    raw_headers
-        .iter()
-        .filter_map(|raw| parse_header(raw))
-        .find(|parsed| parsed.authserv_id.eq_ignore_ascii_case(configured_id))
+/// - [`TrustAnchor::AuthservId`]: the first (topmost) header, in document
+///   order, whose `authserv-id` matches the configured id (case-insensitive).
+///   Topmost wins: a receiving MTA prepends its own stamp on each hop, so the
+///   header nearest the top of the document is the one added by the final,
+///   trusted receiving boundary -- PROVIDED that boundary strips or renames
+///   any pre-existing header already claiming its own `authserv-id` before
+///   adding its stamp. That stripping is an operational precondition of the
+///   receiving MTA, verified by deployment configuration, not re-derived from
+///   message content here.
+/// - [`TrustAnchor::TopmostNoAuthservId`]: the boundary emits no authserv-id
+///   at all (e.g. Exchange Online's internal-hop stamp), so position is the
+///   *sole* discriminator. Only the literal topmost `Authentication-Results`
+///   header (`raw_headers[0]`) is ever considered -- never a later one, even
+///   if the topmost fails to parse. It is trusted only if it parses AND is
+///   itself in the no-authserv-id form (`authserv_id.is_none()`); if the
+///   topmost carries any authserv-id, or fails to parse, that violates the
+///   invariant that this boundary's own stamp is topmost and unadorned, so the
+///   message quarantines (fails closed) rather than falling through to a
+///   lower header.
+pub(crate) fn select_trusted(raw_headers: &[String], anchor: &TrustAnchor) -> Option<AuthResults> {
+    match anchor {
+        TrustAnchor::AuthservId(configured_id) => raw_headers
+            .iter()
+            .filter_map(|raw| parse_header(raw))
+            .find(|parsed| {
+                parsed
+                    .authserv_id
+                    .as_deref()
+                    .is_some_and(|a| a.eq_ignore_ascii_case(configured_id))
+            }),
+        TrustAnchor::TopmostNoAuthservId => {
+            let topmost = parse_header(raw_headers.first()?)?;
+            if topmost.authserv_id.is_none() {
+                Some(topmost)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -249,7 +347,7 @@ mod tests {
     #[test]
     fn parse_header_extracts_authserv_id_and_dmarc_pass() {
         let parsed = parse_header("mx.example.com; dmarc=pass header.from=example.com").unwrap();
-        assert_eq!(parsed.authserv_id, "mx.example.com");
+        assert_eq!(parsed.authserv_id.as_deref(), Some("mx.example.com"));
         assert!(parsed.dmarc_pass());
     }
 
@@ -257,7 +355,7 @@ mod tests {
     fn parse_header_authserv_id_with_version_token() {
         // RFC 8601 permits an optional version after authserv-id.
         let parsed = parse_header("mx.example.com 1; dmarc=pass").unwrap();
-        assert_eq!(parsed.authserv_id, "mx.example.com");
+        assert_eq!(parsed.authserv_id.as_deref(), Some("mx.example.com"));
     }
 
     #[test]
@@ -408,7 +506,8 @@ mod tests {
             "mx.example.com; dmarc=pass header.from=example.com".to_string(),
             "mx.example.com; dmarc=fail header.from=example.com".to_string(),
         ];
-        let selected = select_trusted(&headers, "mx.example.com").unwrap();
+        let anchor = TrustAnchor::AuthservId("mx.example.com".to_string());
+        let selected = select_trusted(&headers, &anchor).unwrap();
         assert!(
             selected.dmarc_pass(),
             "the topmost matching header must win, not a later one"
@@ -418,12 +517,14 @@ mod tests {
     #[test]
     fn select_trusted_ignores_non_matching_authserv_id() {
         let headers = vec!["forged-mx.evil.com; dmarc=pass header.from=example.com".to_string()];
-        assert!(select_trusted(&headers, "mx.example.com").is_none());
+        let anchor = TrustAnchor::AuthservId("mx.example.com".to_string());
+        assert!(select_trusted(&headers, &anchor).is_none());
     }
 
     #[test]
     fn select_trusted_none_when_no_headers() {
-        assert!(select_trusted(&[], "mx.example.com").is_none());
+        let anchor = TrustAnchor::AuthservId("mx.example.com".to_string());
+        assert!(select_trusted(&[], &anchor).is_none());
     }
 
     #[test]
@@ -431,5 +532,126 @@ mod tests {
         assert_eq!(domain_of("alice@example.com"), "example.com");
         assert_eq!(domain_of("example.com"), "example.com");
         assert_eq!(domain_of("EXAMPLE.COM"), "example.com");
+    }
+
+    // --- EXO no-authserv-id trust anchor (ADR-056 Amendment 2026-07-03) ---
+
+    /// The plain (non-ARC) `Authentication-Results` header value Exchange
+    /// Online stamps on its internal hop, taken verbatim from the real fixture
+    /// `/Users/lion/projects/.khive/workspaces/20260703/email-restore/ocean_0110_raw_headers.txt`
+    /// (unfolded), minus the leading `Authentication-Results: ` field name.
+    const EXO_FIXTURE_HEADER_VALUE: &str = "spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100";
+
+    #[test]
+    fn parse_header_exo_fixture_has_empty_authserv_id_and_recognizes_all_methods() {
+        let parsed = parse_header(EXO_FIXTURE_HEADER_VALUE).unwrap();
+        assert!(
+            parsed.authserv_id.is_none(),
+            "EXO's plain A-R stamp carries no authserv-id"
+        );
+        assert!(
+            parsed.dmarc_pass(),
+            "segment 0 (spf) must not have eaten the dmarc segment; dmarc=pass must be recognized"
+        );
+        assert!(
+            parsed.spf_pass_aligned("gmail.com"),
+            "segment 0 itself (spf=pass smtp.mailfrom=gmail.com) must be parsed as a method, not consumed as authserv-id"
+        );
+    }
+
+    #[test]
+    fn select_trusted_topmost_no_authserv_id_mode_picks_topmost_no_id_header() {
+        let headers = vec![EXO_FIXTURE_HEADER_VALUE.to_string()];
+        let selected = select_trusted(&headers, &TrustAnchor::TopmostNoAuthservId).unwrap();
+        assert!(selected.dmarc_pass());
+        assert!(selected.spf_pass_aligned("gmail.com"));
+    }
+
+    #[test]
+    fn select_trusted_topmost_no_authserv_id_mode_quarantines_when_topmost_carries_an_id() {
+        // The topmost header unexpectedly carries an authserv-id -- this
+        // violates the invariant that EXO's plain stamp is topmost and
+        // unadorned, so it must quarantine (None), not fall through.
+        let headers = vec!["mx.example.com; dmarc=pass header.from=example.com".to_string()];
+        assert!(select_trusted(&headers, &TrustAnchor::TopmostNoAuthservId).is_none());
+    }
+
+    #[test]
+    fn select_trusted_topmost_no_authserv_id_mode_forged_second_header_does_not_override_topmost() {
+        // EXO's genuine no-id dmarc=fail stamp is topmost; a forged no-id
+        // dmarc=pass header sits below it. Position alone decides -- the
+        // topmost (fail) must be the one selected, staying quarantined.
+        let headers = vec![
+            "spf=fail smtp.mailfrom=evil.com; dmarc=fail header.from=gmail.com".to_string(),
+            "dmarc=pass header.from=gmail.com".to_string(),
+        ];
+        let selected = select_trusted(&headers, &TrustAnchor::TopmostNoAuthservId).unwrap();
+        assert!(
+            !selected.dmarc_pass(),
+            "the topmost (failing) no-id header must win over a forged passing header below it"
+        );
+    }
+
+    #[test]
+    fn parse_header_empty_and_whitespace_still_none() {
+        assert!(parse_header("").is_none());
+        assert!(parse_header("   ").is_none());
+    }
+
+    #[test]
+    fn dmarc_pass_aligned_rejects_mismatched_header_from_domain() {
+        let parsed = parse_header("mx.example.com; dmarc=pass header.from=attacker.net").unwrap();
+        assert!(parsed.dmarc_pass(), "raw dmarc_pass is unaligned by design");
+        assert!(
+            !parsed.dmarc_pass_aligned("example.com"),
+            "dmarc_pass_aligned must reject a header.from domain that does not match the message From domain"
+        );
+    }
+
+    #[test]
+    fn authserv_id_mode_no_id_header_never_matches_a_configured_id_fail_closed() {
+        // An attacker header shaped like `evil=x; dmarc=pass ...` now parses to
+        // the no-id form (authserv_id == ""). In AuthservId mode, "" must never
+        // match a configured non-empty id -- no new bypass.
+        let headers = vec!["evil=x; dmarc=pass header.from=gmail.com".to_string()];
+        let parsed = parse_header(&headers[0]).unwrap();
+        assert!(parsed.authserv_id.is_none());
+        assert!(parsed.dmarc_pass());
+
+        let anchor = TrustAnchor::AuthservId("mx.example.com".to_string());
+        assert!(
+            select_trusted(&headers, &anchor).is_none(),
+            "no-id-form header must never match a configured non-empty authserv-id"
+        );
+    }
+
+    #[test]
+    fn select_trusted_authserv_id_mode_empty_configured_id_never_matches_no_id_header() {
+        // Leo's exact point (SPEC-GATE 2026-07-03), independent of the
+        // config-layer require_nonempty_env guard: construct
+        // TrustAnchor::AuthservId(String::new()) directly, bypassing
+        // from_env entirely, against a header that parses to
+        // authserv_id == None. Even if config validation were somehow
+        // bypassed, an empty configured id can never match a no-id header --
+        // there is no `"" == ""` comparison left to perform, because a no-id
+        // header's authserv_id is not the empty string, it is the *absence*
+        // of a value.
+        let headers = vec![EXO_FIXTURE_HEADER_VALUE.to_string()];
+        let parsed = parse_header(&headers[0]).unwrap();
+        assert!(parsed.authserv_id.is_none());
+
+        let anchor = TrustAnchor::AuthservId(String::new());
+        assert!(
+            select_trusted(&headers, &anchor).is_none(),
+            "an empty configured authserv-id must never match a no-id header, \
+             even bypassing from_env's require_nonempty_env guard entirely"
+        );
+    }
+
+    #[test]
+    fn parse_header_no_id_form_with_zero_recognized_method_is_none() {
+        // No authserv-id (first token contains '=') AND no recognized
+        // dmarc/spf/dkim method anywhere -- genuine zero signal, must be None.
+        assert!(parse_header("evil=x").is_none());
     }
 }

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -184,14 +184,16 @@ impl EmailChannel {
     }
 
     /// Evaluate the domain-authentication half of the attribution gate
-    /// (ADR-056 Amendment 2026-07-02): trust only the topmost
-    /// `Authentication-Results` header whose `authserv-id` matches this
-    /// deployment's configured trust anchor, and require `dmarc=pass`, or
-    /// `spf=pass` with an aligned envelope-from, or `dkim=pass` with an
-    /// aligned `d=` domain. Absence of any trusted header fails closed.
+    /// (ADR-056 Amendment 2026-07-02, refined 2026-07-03): trust only the
+    /// header selected per this deployment's configured [`TrustAnchor`]
+    /// (topmost matching `authserv-id`, or the topmost no-authserv-id header
+    /// for an EXO-shaped boundary), and require `dmarc=pass` aligned to the
+    /// From domain, or `spf=pass` with an aligned envelope-from, or
+    /// `dkim=pass` with an aligned `d=` domain. Absence of any trusted header
+    /// fails closed.
     fn evaluate_auth(&self, email: &RawEmail) -> Result<(), QuarantineReason> {
         let selected =
-            auth_results::select_trusted(&email.authentication_results, &self.config.authserv_id)
+            auth_results::select_trusted(&email.authentication_results, &self.config.trust_anchor)
                 .ok_or(QuarantineReason::AuthAbsent)?;
 
         let from_domain = email
@@ -201,7 +203,7 @@ impl EmailChannel {
             .map(|(_, domain)| domain.to_lowercase())
             .unwrap_or_default();
 
-        if selected.dmarc_pass()
+        if selected.dmarc_pass_aligned(&from_domain)
             || selected.spf_pass_aligned(&from_domain)
             || selected.dkim_pass_aligned(&from_domain)
         {
@@ -358,7 +360,7 @@ fn strip_kind_prefix<'a>(addr: &'a str, kind: &str) -> &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::EmailAuth;
+    use crate::config::{EmailAuth, TrustAnchor};
     use crate::connector::imap::{parse_raw_bytes, ImapConnector, ImapFetcher};
     use crate::connector::smtp::{SmtpConnector, SmtpSender};
     use std::collections::HashMap;
@@ -379,7 +381,7 @@ mod tests {
                 password: "secret".to_string(),
             },
             maintainer_addresses: vec![MailAddress::parse(maintainer).unwrap()],
-            authserv_id: TEST_AUTHSERV_ID.to_string(),
+            trust_anchor: TrustAnchor::AuthservId(TEST_AUTHSERV_ID.to_string()),
             quarantine_store: true,
         }
     }
@@ -736,6 +738,13 @@ mod tests {
 
     #[tokio::test]
     async fn empty_from_list_rejected() {
+        // With no From address there is no domain to align dmarc's
+        // header.from against, so `dmarc_pass_aligned` (hardening #3, ADR-056
+        // Amendment 2026-07-03) now correctly fails alignment and the
+        // attribution gate catches this at the auth leg (dmarc-fail) before
+        // ever reaching the sender allowlist -- still quarantined, just a
+        // stricter (and more accurate) reason than the pre-hardening
+        // off-allowlist path.
         let ch = build_channel(
             "maintainer@example.com",
             vec![make_email_with_from_addrs(vec![], "imap:test:0:1")],
@@ -751,7 +760,7 @@ mod tests {
                 .metadata
                 .get("quarantine_reason")
                 .map(String::as_str),
-            Some("off-allowlist")
+            Some("dmarc-fail")
         );
     }
 
@@ -990,6 +999,67 @@ mod tests {
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
         assert_eq!(envs[0].from, "email:maintainer@example.com");
+    }
+
+    // --- EXO no-authserv-id trust anchor, end-to-end (ADR-056 Amendment 2026-07-03) ---
+
+    #[tokio::test]
+    async fn exo_no_authserv_id_fixture_end_to_end_is_attributed() {
+        // Real Exchange Online header shape (verbatim values from the live
+        // fixture `ocean_0110_raw_headers.txt`): an ARC-Authentication-Results
+        // header (must be ignored -- collecting/trusting ARC is the rejected
+        // Shape B, out of scope) precedes the plain Authentication-Results
+        // header EXO stamps on its own internal hop, which carries no
+        // authserv-id at all. In TopmostNoAuthservId mode this must attribute
+        // cleanly through the real byte-parsing path.
+        let raw = b"ARC-Authentication-Results: i=2; mx.microsoft.com 1; spf=pass smtp.mailfrom=gmail.com; dmarc=pass header.from=gmail.com; dkim=pass header.d=gmail.com\r\n\
+                    Authentication-Results: spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100\r\n\
+                    From: Ocean Li <quantocean.li@gmail.com>\r\n\
+                    To: Leo Li <leo@khive.ai>\r\n\
+                    Subject: Khive email subject disappears into body\r\n\
+                    \r\n\
+                    body text";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+
+        let mut config = make_config("quantocean.li@gmail.com");
+        config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
+        let ch = build_channel_from(config, vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(
+            envs[0].from, "email:quantocean.li@gmail.com",
+            "the real EXO no-authserv-id header must attribute cleanly in TopmostNoAuthservId mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn exo_mode_topmost_carrying_an_authserv_id_quarantines_auth_absent() {
+        // If the topmost Authentication-Results unexpectedly carries an
+        // authserv-id while this deployment is configured for
+        // TopmostNoAuthservId mode, that violates the invariant that EXO's
+        // own stamp is topmost and unadorned (Microsoft could start emitting
+        // one, or an attacker's forged header floated to the top) --
+        // quarantine rather than trust it.
+        let raw = b"Authentication-Results: mx.microsoft.com; dmarc=pass header.from=gmail.com\r\n\
+                    From: Ocean Li <quantocean.li@gmail.com>\r\n\
+                    To: Leo Li <leo@khive.ai>\r\n\
+                    Subject: forged topmost carries an id\r\n\
+                    \r\n\
+                    body";
+        let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
+        let mut config = make_config("quantocean.li@gmail.com");
+        config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
+        let ch = build_channel_from(config, vec![email]);
+        let envs = ch.poll(Utc::now()).await.unwrap();
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].from, "email:quarantine");
+        assert_eq!(
+            envs[0]
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("auth-absent")
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-channel-email/src/config.rs
+++ b/crates/khive-channel-email/src/config.rs
@@ -6,6 +6,43 @@
 use crate::connector::MailAddress;
 use khive_channel::ChannelError;
 
+/// Reserved sentinel value for `KHIVE_EMAIL_AUTHSERV_ID` that selects
+/// [`TrustAnchor::TopmostNoAuthservId`] mode. `!` is not excluded by RFC 8601
+/// `authserv-id` grammar (it is not a `tspecial`, so it is legal in an
+/// unquoted token) -- this sentinel is safe by *convention*, not by grammar
+/// guarantee: no real-world domain-form receiving-boundary identifier begins
+/// with `!`, and this config contract reserves the exact string.
+pub const TOPMOST_NO_AUTHSERV_ID_SENTINEL: &str = "!topmost-no-authserv-id";
+
+/// The trust-anchor mode this deployment uses to select which
+/// `Authentication-Results` header to trust (ADR-056 Amendment 2026-07-03,
+/// "EXO no-authserv-id trust anchor"). Parsed once, at config load, from
+/// `KHIVE_EMAIL_AUTHSERV_ID` -- never re-derived from message content.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrustAnchor {
+    /// RFC-compliant boundary: trust the topmost header whose `authserv-id`
+    /// equals this configured string (case-insensitive).
+    AuthservId(String),
+    /// A boundary that emits no `authserv-id` at all (e.g. Exchange Online's
+    /// internal-hop stamp): trust the topmost header only if it is itself in
+    /// the no-authserv-id form. Selected by the exact sentinel
+    /// [`TOPMOST_NO_AUTHSERV_ID_SENTINEL`]; any other value is treated as a
+    /// literal (and, for a typo, non-matching) `authserv-id` -- there is no
+    /// input that silently falls back to this mode.
+    TopmostNoAuthservId,
+}
+
+impl TrustAnchor {
+    /// Parse the raw `KHIVE_EMAIL_AUTHSERV_ID` value into a `TrustAnchor`.
+    fn parse(raw: String) -> Self {
+        if raw == TOPMOST_NO_AUTHSERV_ID_SENTINEL {
+            TrustAnchor::TopmostNoAuthservId
+        } else {
+            TrustAnchor::AuthservId(raw)
+        }
+    }
+}
+
 /// Authentication mode for SMTP and IMAP connections.
 ///
 /// Selected at construction time based on the environment variables that are
@@ -85,12 +122,15 @@ pub struct EmailChannelConfig {
     /// `KHIVE_EMAIL_MAINTAINER_ADDRESS`; the first entry is the primary, used for
     /// outbound-allowlist defaulting and envelope `to` fallback. Never empty.
     pub maintainer_addresses: Vec<MailAddress>,
-    /// The `authserv-id` this deployment trusts in inbound `Authentication-Results`
-    /// headers (ADR-056 Amendment 2026-07-02). Required: there is no safe default
-    /// that would not either trust an attacker-controlled id or silently accept
-    /// unauthenticated mail, so a missing value fails config construction rather
-    /// than falling back to an open default.
-    pub authserv_id: String,
+    /// The trust anchor this deployment uses to select which inbound
+    /// `Authentication-Results` header to trust (ADR-056 Amendment
+    /// 2026-07-02, refined 2026-07-03 for EXO's no-authserv-id boundary
+    /// shape). Required: there is no safe default that would not either
+    /// trust an attacker-controlled id or silently accept unauthenticated
+    /// mail, so a missing value fails config construction rather than
+    /// falling back to an open default. See [`TrustAnchor`] and
+    /// [`TOPMOST_NO_AUTHSERV_ID_SENTINEL`].
+    pub trust_anchor: TrustAnchor,
     /// Whether a message that fails the attribution gate (domain authentication
     /// or sender allowlist) is stored as an unattributed quarantine record
     /// instead of being dropped. Defaults to `true`. When `false`, such messages
@@ -159,7 +199,8 @@ impl EmailChannelConfig {
             ));
         }
 
-        let authserv_id = require_env("KHIVE_EMAIL_AUTHSERV_ID")?;
+        let authserv_id_raw = require_nonempty_env("KHIVE_EMAIL_AUTHSERV_ID")?;
+        let trust_anchor = TrustAnchor::parse(authserv_id_raw);
         let quarantine_store = optional_bool("KHIVE_EMAIL_QUARANTINE_STORE", true)?;
 
         Ok(Self {
@@ -171,7 +212,7 @@ impl EmailChannelConfig {
             mailbox,
             auth,
             maintainer_addresses,
-            authserv_id,
+            trust_anchor,
             quarantine_store,
         })
     }
@@ -225,6 +266,22 @@ fn require_env(key: &str) -> Result<String, ChannelError> {
     std::env::var(key).map_err(|_| {
         ChannelError::Config(format!("required environment variable {key:?} is not set"))
     })
+}
+
+/// Like [`require_env`], but also rejects a set-but-empty (or whitespace-only)
+/// value. `std::env::var` returns `Ok("")` for `KEY=""`, which `require_env`
+/// alone would pass straight through -- for a security-relevant value like
+/// `KHIVE_EMAIL_AUTHSERV_ID` that must never silently degrade to an "empty"
+/// trust anchor, the guard belongs here at config construction, not inside
+/// [`TrustAnchor::parse`].
+fn require_nonempty_env(key: &str) -> Result<String, ChannelError> {
+    let value = require_env(key)?;
+    if value.trim().is_empty() {
+        return Err(ChannelError::Config(format!(
+            "environment variable {key:?} must not be empty"
+        )));
+    }
+    Ok(value)
 }
 
 fn optional_port(key: &str, default: u16) -> Result<u16, ChannelError> {
@@ -595,6 +652,47 @@ mod tests {
     }
 
     #[test]
+    fn from_env_empty_authserv_id_fails_closed() {
+        // Sibling of from_env_missing_authserv_id_fails_closed: `std::env::var`
+        // returns Ok("") for a set-but-empty var, so a bare `require_env` guard
+        // alone would let KHIVE_EMAIL_AUTHSERV_ID="" flow through to
+        // TrustAnchor::AuthservId(""), which then matches EXO's empty-authserv-id
+        // header form and silently degrades to trust-topmost without the
+        // sentinel opt-in. This must fail closed instead.
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let keys = [
+            "KHIVE_EMAIL_SMTP_HOST",
+            "KHIVE_EMAIL_IMAP_HOST",
+            "KHIVE_EMAIL_USERNAME",
+            "KHIVE_EMAIL_MAINTAINER_ADDRESS",
+            "KHIVE_EMAIL_AUTHSERV_ID",
+            "KHIVE_EMAIL_PASSWORD",
+            TID,
+            CID,
+            CS,
+        ];
+        let _snap = EnvSnapshot::capture(&keys);
+
+        std::env::set_var("KHIVE_EMAIL_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("KHIVE_EMAIL_IMAP_HOST", "imap.example.com");
+        std::env::set_var("KHIVE_EMAIL_USERNAME", "user@example.com");
+        std::env::set_var("KHIVE_EMAIL_MAINTAINER_ADDRESS", "maintainer@example.com");
+        std::env::set_var("KHIVE_EMAIL_AUTHSERV_ID", "");
+        std::env::set_var("KHIVE_EMAIL_PASSWORD", "test-password");
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let result = EmailChannelConfig::from_env();
+        assert!(
+            result.is_err(),
+            "set-but-empty KHIVE_EMAIL_AUTHSERV_ID must fail closed, not default-open"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("KHIVE_EMAIL_AUTHSERV_ID"), "got: {msg}");
+    }
+
+    #[test]
     fn from_env_quarantine_store_defaults_true() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let keys = [
@@ -623,7 +721,10 @@ mod tests {
         std::env::remove_var(CS);
 
         let config = EmailChannelConfig::from_env().expect("valid config must succeed");
-        assert_eq!(config.authserv_id, "mx.example.com");
+        assert_eq!(
+            config.trust_anchor,
+            TrustAnchor::AuthservId("mx.example.com".to_string())
+        );
         assert!(config.quarantine_store, "must default to true when unset");
     }
 
@@ -657,5 +758,57 @@ mod tests {
 
         let config = EmailChannelConfig::from_env().expect("valid config must succeed");
         assert!(!config.quarantine_store);
+    }
+
+    // ── TrustAnchor sentinel parsing (Amendment 2026-07-03) ───────────────────
+
+    #[test]
+    fn trust_anchor_parses_exact_sentinel_to_topmost_no_authserv_id() {
+        assert_eq!(
+            TrustAnchor::parse(TOPMOST_NO_AUTHSERV_ID_SENTINEL.to_string()),
+            TrustAnchor::TopmostNoAuthservId
+        );
+    }
+
+    #[test]
+    fn trust_anchor_typo_of_sentinel_is_treated_as_literal_authserv_id_fail_closed() {
+        // A typo of the sentinel (missing trailing chars) must NOT silently
+        // fall back to topmost-no-authserv-id trust -- it is treated as a
+        // literal (and therefore non-matching, fail-closed) authserv-id.
+        let typo = "!topmost-no-authserv".to_string();
+        assert_eq!(
+            TrustAnchor::parse(typo.clone()),
+            TrustAnchor::AuthservId(typo)
+        );
+    }
+
+    #[test]
+    fn from_env_authserv_id_sentinel_selects_topmost_no_authserv_id_mode() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let keys = [
+            "KHIVE_EMAIL_SMTP_HOST",
+            "KHIVE_EMAIL_IMAP_HOST",
+            "KHIVE_EMAIL_USERNAME",
+            "KHIVE_EMAIL_MAINTAINER_ADDRESS",
+            "KHIVE_EMAIL_AUTHSERV_ID",
+            "KHIVE_EMAIL_PASSWORD",
+            TID,
+            CID,
+            CS,
+        ];
+        let _snap = EnvSnapshot::capture(&keys);
+
+        std::env::set_var("KHIVE_EMAIL_SMTP_HOST", "smtp.example.com");
+        std::env::set_var("KHIVE_EMAIL_IMAP_HOST", "imap.example.com");
+        std::env::set_var("KHIVE_EMAIL_USERNAME", "user@example.com");
+        std::env::set_var("KHIVE_EMAIL_MAINTAINER_ADDRESS", "maintainer@example.com");
+        std::env::set_var("KHIVE_EMAIL_AUTHSERV_ID", TOPMOST_NO_AUTHSERV_ID_SENTINEL);
+        std::env::set_var("KHIVE_EMAIL_PASSWORD", "test-password");
+        std::env::remove_var(TID);
+        std::env::remove_var(CID);
+        std::env::remove_var(CS);
+
+        let config = EmailChannelConfig::from_env().expect("valid config must succeed");
+        assert_eq!(config.trust_anchor, TrustAnchor::TopmostNoAuthservId);
     }
 }


### PR DESCRIPTION
Implements **ADR-056 Amendment 2026-07-03** (doc PR **#499** — merge that first). Contract inlined below since the amendment is not yet on `main`.

## Problem

Exchange Online omits the `authserv-id` token on its plain `Authentication-Results` header (a Microsoft RFC-8601 deviation — the header opens directly at `spf=pass`). The Amendment 2026-07-02 gate trusts a header only when its `authserv-id` equals the configured `KHIVE_EMAIL_AUTHSERV_ID`, so the strict equality matched nothing and **quarantined every EXO delivery**. The #448 inbound-auth gap was code-shaped, not ops-shaped: no env value can match an absent token. Verified against a real production message fixture.

## Contract (from the ADR-056 amendment)

1. **Typed trust anchor.** `KHIVE_EMAIL_AUTHSERV_ID` is parsed once at config load into `TrustAnchor { AuthservId(String), TopmostNoAuthservId }`. Any value except the reserved sentinel `!topmost-no-authserv-id` is a literal `authserv-id` (unchanged RFC-compliant behavior). The sentinel selects positional trust of the **topmost** no-authserv-id `Authentication-Results` — sound because EXO prepends its own stamp above all sender content on every delivery to the polled mailbox; a spoofer's injected `Authentication-Results` sits *below* it.
2. **dmarc alignment hardening.** The domain-auth gate requires `dmarc=pass` **with `header.from` alignment** (`dmarc_pass` → `dmarc_pass_aligned`). A bare `dmarc=pass` for an unaligned domain no longer satisfies the check.
3. **No silent degrade.** Empty/whitespace `KHIVE_EMAIL_AUTHSERV_ID` fails config construction (`require_nonempty_env`) — loud fail-at-load, never a silent quarantine-all. The sentinel is matched exactly; a typo is a literal (non-matching) id → quarantine-all, never trust-topmost.

## Implementation notes

- `parse_header` detects the no-authserv-id form via an unquoted `=` in the first token (an `authserv-id` can never contain one) and parses segment 0 as a `resinfo` instead of eating it as the id; a no-id header with zero recognized method fails closed to `None`.
- **Type-level bypass closure** (design principle: guards decay, types don't): `AuthResults.authserv_id` is `Option<String>` (`None` = no-id form). `select_trusted`'s AuthservId branch matches only via `is_some_and`, so an empty/absent id can never match a no-id header *at the type level*, independent of the config guard.
- Rejected alternatives (ARC-Authentication-Results string match, ARC-Seal crypto): `mx.microsoft.com` is shared across all M365 tenants; only position does real security work.

## Tests (all green — 126 pass, clippy `-D warnings` clean, fmt clean; independently re-verified)

- Real EXO fixture selected + all methods parsed under sentinel mode (spf not eaten).
- Sentinel mode + topmost carrying an authserv-id → quarantine (`auth-absent`).
- Sentinel typo → literal id → matches nothing → quarantine-all.
- `dmarc=pass` with unaligned `header.from` → auth leg fails.
- Set-but-empty `KHIVE_EMAIL_AUTHSERV_ID` → `from_env` Err.
- `AuthservId("")` constructed directly never matches a no-id header (type-level closure, independent of config guard).
- End-to-end EXO fixture bytes attributed; forged-topmost-carrying-id quarantined.

## Merge order & gating

- **Doc PR #499 merges first.**
- This PR goes through the standard review process, with a maintainer review of the trust-anchor logic before merge.