### PR TITLE
fix(vamana): harden persistence load path against malformed input (#434, #444, #435)

### DIFF
--- a/crates/khive-vamana/src/graph.rs
+++ b/crates/khive-vamana/src/graph.rs
@@ -283,6 +283,12 @@ impl VamanaGraph {
     ) -> Result<Self> {
         config.validate()?;
         let num_vectors = validate_vectors(vectors, config.dimensions)?;
+        if encoded.len() != num_vectors {
+            return Err(VamanaError::DimensionMismatch {
+                expected: num_vectors,
+                actual: encoded.len(),
+            });
+        }
 
         if num_vectors > u32::MAX as usize {
             return Err(VamanaError::TooManyVectors { count: num_vectors });
@@ -1672,5 +1678,27 @@ mod tests {
             .unwrap_or(BUILD_BATCH_SIZE)
             .max(1);
         assert_eq!(zero_parse, 1);
+    }
+
+    #[test]
+    fn build_sq8_rejects_encoded_row_count_mismatch_not_panic() {
+        let dim = 2usize;
+        let vectors = vec![0.0f32, 0.0, 1.0, 0.0]; // 2 valid rows
+        let cfg = VamanaConfig::with_dimensions(dim)
+            .with_max_degree(1)
+            .with_search_list_size(1);
+        let codec = GsSq8Codec::train_flat(&vectors, dim);
+        let mut encoded = codec.encode_flat_par(&vectors, dim);
+        encoded.truncate(0); // malformed: expected 2 encoded rows, actual 0
+
+        let result =
+            std::panic::catch_unwind(|| VamanaGraph::build_sq8(&vectors, &encoded, &codec, &cfg));
+        assert!(matches!(
+            result,
+            Ok(Err(VamanaError::DimensionMismatch {
+                expected: 2,
+                actual: 0
+            }))
+        ));
     }
 }

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -2144,6 +2144,20 @@ fn parse_v2_commit(data: &[u8]) -> Result<V2Commit> {
         ));
     }
 
+    VamanaConfig {
+        dimensions,
+        max_degree,
+        search_list_size,
+        alpha,
+    }
+    .validate()
+    .map_err(|err| match err {
+        VamanaError::InvalidConfig { reason } => {
+            VamanaError::invalid_format(format!("v2 commit invalid config: {reason}"))
+        }
+        other => other,
+    })?;
+
     Ok(V2Commit {
         vectors_hash,
         graph_hash,

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -956,6 +956,12 @@ impl VamanaIndex {
             .map(|w| w.count_ones() as usize)
             .sum();
 
+        if tombstone_count > num_vectors {
+            return Err(VamanaError::invalid_format(format!(
+                "lifecycle.bin tombstone_count {tombstone_count} exceeds num_vectors {num_vectors}"
+            )));
+        }
+
         let (gs_codec, gs_codes) = train_codec_and_encode(storage.as_slice()?, dimensions);
 
         Ok(Self {
@@ -2277,10 +2283,30 @@ fn parse_lifecycle(data: &[u8], num_vectors: usize, _max_degree: usize) -> Resul
         tombstones.push(word);
         offset += 8;
     }
-    // Ensure tombstone bitvec covers all nodes.
+    // Ensure tombstone bitvec covers exactly the valid node-id domain.
     let needed_words = num_vectors.div_ceil(64);
     if tombstones.len() < needed_words {
         tombstones.resize(needed_words, 0);
+    } else if tombstones.len() > needed_words {
+        if tombstones[needed_words..].iter().any(|&word| word != 0) {
+            return Err(VamanaError::invalid_format(
+                "lifecycle.bin tombstone words exceed num_vectors".into(),
+            ));
+        }
+        tombstones.truncate(needed_words);
+    }
+
+    let valid_bits_in_last_word = num_vectors % 64;
+    if valid_bits_in_last_word != 0 {
+        let valid_mask = (1u64 << valid_bits_in_last_word) - 1;
+        if tombstones
+            .last()
+            .is_some_and(|last_word| last_word & !valid_mask != 0)
+        {
+            return Err(VamanaError::invalid_format(
+                "lifecycle.bin tombstone bits outside num_vectors".into(),
+            ));
+        }
     }
 
     // Free slots.

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -979,3 +979,40 @@ fn v2_parse_lifecycle_fs_add_overflow_returns_invalid_format_not_panic() {
     let meta_after = fs::read(dir.path().join("metadata.bin")).unwrap();
     assert_eq!(&meta_after[..8], b"KHVVAMG2");
 }
+
+// ---- Issue #444: v2 commit config validation must feed the corrupt-snapshot rebuild path ----
+
+/// Regression: a persisted v2 commit with an invalid embedded config (e.g. max_degree = 0)
+/// used to surface as `VamanaError::InvalidConfig` from `load_v2_fast`'s `config.validate()`
+/// call, which `load_or_build`'s rebuild match only catches for `InvalidFormat`. That let a
+/// corrupt commit record propagate as an error out of `load_or_build` instead of rebuilding.
+/// With the fix, `parse_v2_commit` validates the embedded config and maps failures to
+/// `InvalidFormat`, so the existing corrupt-snapshot rebuild path handles it.
+#[test]
+fn load_or_build_rebuilds_when_v2_commit_config_invalid() {
+    let dim = 8usize;
+    let vectors = rand_unit_vectors(20, dim, 0xA6_44);
+    let cfg = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(8)
+        .with_search_list_size(16);
+    let idx = VamanaIndex::build(&vectors, cfg.clone()).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    idx.save_atomic(dir.path()).unwrap();
+
+    let meta_path = dir.path().join("metadata.bin");
+    let mut meta = fs::read(&meta_path).unwrap();
+    meta[168..176].copy_from_slice(&0u64.to_le_bytes()); // malformed persisted max_degree
+    fs::write(&meta_path, &meta).unwrap();
+
+    assert!(matches!(
+        VamanaIndex::load(dir.path()),
+        Err(VamanaError::InvalidFormat { .. })
+    ));
+
+    let fallback = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(8)
+        .with_search_list_size(16);
+    let loaded = VamanaIndex::load_or_build(dir.path(), &vectors, fallback.clone()).unwrap();
+    assert_eq!(loaded.config(), &fallback);
+    assert_eq!(loaded.num_vectors(), vectors.len() / dim);
+}

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -1016,3 +1016,46 @@ fn load_or_build_rebuilds_when_v2_commit_config_invalid() {
     assert_eq!(loaded.config(), &fallback);
     assert_eq!(loaded.num_vectors(), vectors.len() / dim);
 }
+
+// ---- Issue #435: v2 lifecycle parser must reject tombstone bits past num_vectors ----
+
+/// Regression: parse_lifecycle resized the tombstone bitvec up to `needed_words` when it was
+/// too short but never rejected (or masked) extra set bits at or beyond `num_vectors` when the
+/// persisted word count already covered `needed_words`. Those out-of-range set bits were
+/// counted into `tombstone_count` and silently treated as tombstoned nodes past the valid
+/// node-id domain. With the fix, `parse_lifecycle` rejects tombstone bits set beyond
+/// `num_vectors` with `InvalidFormat` instead of accepting the corrupt state.
+#[test]
+fn v2_parse_lifecycle_rejects_tombstone_bits_past_num_vectors_not_panic() {
+    let dim = 4usize;
+    let n = 9usize;
+    let vectors = rand_unit_vectors(n, dim, 0xA6_35);
+    let cfg = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let idx = VamanaIndex::build(&vectors, cfg).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    idx.save_atomic(dir.path()).unwrap();
+
+    let mut lifecycle_body = fs::read(dir.path().join("lifecycle.bin")).unwrap();
+    assert_eq!(&lifecycle_body[..8], b"KHVVLIF1");
+    assert_eq!(
+        u64::from_le_bytes(lifecycle_body[8..16].try_into().unwrap()),
+        1
+    );
+    // For num_vectors = 9, valid tombstone bits are 0..=8; this word sets only bits 9..=63.
+    lifecycle_body[16..24].copy_from_slice(&0xffff_ffff_ffff_fe00u64.to_le_bytes());
+    install_corrupt_lifecycle(dir.path(), &lifecycle_body);
+
+    let load_result = std::panic::catch_unwind(|| VamanaIndex::load(dir.path()));
+    assert!(matches!(
+        load_result,
+        Ok(Err(VamanaError::InvalidFormat { .. }))
+    ));
+
+    let fallback = VamanaConfig::with_dimensions(dim)
+        .with_max_degree(4)
+        .with_search_list_size(8);
+    let rebuilt = VamanaIndex::load_or_build(dir.path(), &vectors, fallback).unwrap();
+    assert_eq!(rebuilt.num_vectors(), n);
+}


### PR DESCRIPTION
Resolves three khive-vamana persistence-path defect-audit findings (label audit-20260702).

- **#434** — SQ8 encoded row-count mismatch now returns a typed error instead of panicking on an out-of-range index.
- **#444** — Persisted v2 commit config is validated before the rebuild gate; an invalid config maps to `InvalidFormat` and takes the rebuild path.
- **#435** — v2 lifecycle tombstone bits past `num_vectors` are rejected via a last-word bitmask; defensive `tombstone_count > num_vectors` guard added.

Each fix ships a regression test in `tests/persistence.rs`. `cargo test/clippy/fmt -p khive-vamana` clean.

Closes #434
Closes #444
Closes #435