### PR TITLE
fix(retrieval,fusion): confine single-source fusion, guard non-finite weights (#431, #432, #451)

### DIFF
--- a/crates/khive-fusion/src/fuse.rs
+++ b/crates/khive-fusion/src/fuse.rs
@@ -24,13 +24,27 @@ pub fn fuse<Id: Eq + Hash + Clone + Ord>(
         FusionStrategy::Rrf { k } => reciprocal_rank_fusion(sources, *k),
         FusionStrategy::Weighted { weights } => weighted_fusion(sources, weights),
         FusionStrategy::Union => union_fusion(sources),
-        FusionStrategy::VectorOnly | FusionStrategy::KeywordOnly => union_fusion(sources),
+        FusionStrategy::VectorOnly => passthrough_source(sources, 0),
+        FusionStrategy::KeywordOnly => passthrough_source(sources, 1),
         FusionStrategy::Custom { name, .. } => {
             return Err(FuseError::CustomRequiresRuntime(name.clone()));
         }
     };
 
     Ok(fused.into_iter().take(top_k).collect())
+}
+
+/// Select a single source by index, treating a lone source as authoritative
+/// regardless of the requested index (e.g. vector-only search with no keyword source).
+fn passthrough_source<Id>(
+    sources: Vec<Vec<(Id, DeterministicScore)>>,
+    source_index: usize,
+) -> Vec<(Id, DeterministicScore)> {
+    if sources.len() == 1 {
+        return sources.into_iter().next().unwrap_or_default();
+    }
+
+    sources.into_iter().nth(source_index).unwrap_or_default()
 }
 
 /// Error from the [`fuse`] entry point.
@@ -156,6 +170,24 @@ mod tests {
 
         assert_eq!(fused.len(), 2);
         assert_eq!(fused[0].0, 1);
+    }
+
+    #[test]
+    fn vector_only_two_sources_returns_only_vector_source() {
+        let vector = make_results(vec![("vec_only", 0.9)]);
+        let keyword = make_results(vec![("kw_only", 1.0)]);
+        let out = fuse(vec![vector, keyword], &FusionStrategy::VectorOnly, 10).unwrap();
+        let ids: Vec<_> = out.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec!["vec_only"]);
+    }
+
+    #[test]
+    fn keyword_only_two_sources_returns_only_keyword_source() {
+        let vector = make_results(vec![("vec_only", 0.9)]);
+        let keyword = make_results(vec![("kw_only", 1.0)]);
+        let out = fuse(vec![vector, keyword], &FusionStrategy::KeywordOnly, 10).unwrap();
+        let ids: Vec<_> = out.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec!["kw_only"]);
     }
 
     #[test]

--- a/crates/khive-retrieval/src/hybrid/dual_index.rs
+++ b/crates/khive-retrieval/src/hybrid/dual_index.rs
@@ -172,8 +172,13 @@ where
                 fuse(sources, safe, top_k).expect("non-Custom strategies are infallible")
             }
             DualIndexStrategy::Weighted { primary_weight } => {
-                let w = primary_weight.clamp(0.0, 1.0);
-                let strategy = FusionStrategy::weighted(vec![w, 1.0 - w]);
+                let w = if primary_weight.is_nan() {
+                    0.5
+                } else {
+                    primary_weight.clamp(0.0, 1.0)
+                };
+                let strategy = FusionStrategy::try_weighted(vec![w, 1.0 - w])
+                    .unwrap_or_else(|_| FusionStrategy::weighted(vec![0.5, 0.5]));
                 let sources = vec![primary_results, legacy_results];
                 fuse(sources, &strategy, top_k).expect("Weighted is infallible")
             }
@@ -366,6 +371,38 @@ mod tests {
         assert!(ids.contains(&"a"));
         assert!(ids.contains(&"b"));
         assert!(ids.contains(&"c"));
+    }
+
+    #[test]
+    fn test_merge_weighted_non_finite_weights_do_not_panic() {
+        let cases = [
+            (f64::NAN, vec!["a_primary", "z_legacy"]),
+            (f64::INFINITY, vec!["a_primary"]),
+            (f64::NEG_INFINITY, vec!["z_legacy"]),
+        ];
+
+        for (primary_weight, expected_ids) in cases {
+            let config = DualIndexConfig::default()
+                .with_strategy(DualIndexStrategy::Weighted { primary_weight });
+            let router = DualIndexRouter::<String>::new(config);
+
+            let result = std::panic::catch_unwind(|| {
+                router.merge_results(
+                    make_results(vec![("a_primary", 0.9)]),
+                    make_results(vec![("z_legacy", 0.8)]),
+                    10,
+                )
+            });
+
+            assert!(
+                result.is_ok(),
+                "merge_results must not panic for primary_weight={primary_weight}"
+            );
+
+            let merged = result.unwrap();
+            let ids: Vec<_> = merged.iter().map(|(id, _)| id.as_str()).collect();
+            assert_eq!(ids, expected_ids);
+        }
     }
 
     #[test]

--- a/crates/khive-retrieval/tests/fusion_surface.rs
+++ b/crates/khive-retrieval/tests/fusion_surface.rs
@@ -41,6 +41,26 @@ fn fuse_search_results_empty_sources_returns_empty() {
 }
 
 #[test]
+fn fuse_search_results_vector_only_returns_only_vector_source() {
+    let vector = vec![("vec_only", DeterministicScore::from_f64(0.9))];
+    let keyword = vec![("kw_only", DeterministicScore::from_f64(1.0))];
+    let config = HybridConfig::new(10).with_fusion_strategy(FusionStrategy::VectorOnly);
+    let results = fuse_search_results(vec![vector, keyword], &config);
+    let ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(ids, vec!["vec_only"]);
+}
+
+#[test]
+fn fuse_search_results_keyword_only_returns_only_keyword_source() {
+    let vector = vec![("vec_only", DeterministicScore::from_f64(0.9))];
+    let keyword = vec![("kw_only", DeterministicScore::from_f64(1.0))];
+    let config = HybridConfig::new(10).with_fusion_strategy(FusionStrategy::KeywordOnly);
+    let results = fuse_search_results(vec![vector, keyword], &config);
+    let ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(ids, vec!["kw_only"]);
+}
+
+#[test]
 fn fuse_search_results_single_source_truncates_to_top_k() {
     let source: Vec<_> = (0..20)
         .map(|i| {


### PR DESCRIPTION
Resolves three khive-retrieval / khive-fusion defect-audit findings (label audit-20260702).

- **#431 / #451** — `VectorOnly` and `KeywordOnly` fusion strategies were including the opposite source. Fixed once at the shared khive-fusion layer: a `passthrough_source` helper returns only the requested positional source (`[vector, keyword]`); khive-retrieval consumes it.
- **#432** — A non-finite (NaN) dual-index weight could panic in the public merge path. The weight is now NaN-guarded (defaults to 0.5) and clamped to `[0, 1]`, so ±inf is handled too.

Regression tests added for both the single-source contract and the non-finite weight path. `cargo test/clippy/fmt -p khive-retrieval -p khive-fusion` clean.

Closes #431
Closes #432
Closes #451