### PR TITLE
fix(hnsw): arena growth guard, tombstone reinsert, snapshot dup-reject, reader TOCTOU, Debug lock-order (#412,#414,#416,#417,#418)

### DIFF
--- a/crates/khive-hnsw/src/alias/manager.rs
+++ b/crates/khive-hnsw/src/alias/manager.rs
@@ -114,27 +114,61 @@ impl IndexAliasManager {
     }
 
     /// Acquire a reader guard; holds an `Arc<HnswIndex>` snapshot that stays alive until dropped.
-    /// Critical section is minimal: resolve alias, clone Arc, increment counter.
+    ///
+    /// Holds the `aliases` read lock for the entire resolve -> lookup ->
+    /// count sequence (not just alias resolution). `switch_alias` needs the
+    /// `aliases` write lock, so it cannot swap the alias -- and therefore
+    /// cannot make a concurrent `drain_and_remove` observe a zero reader
+    /// count -- until this reader has been counted or has failed outright
+    /// (#417).
     pub fn acquire_reader(&self, alias: &str) -> Result<ReaderGuard, AliasError> {
-        // Resolve alias -> collection name
-        let collection_name = {
-            let aliases = self.aliases.read();
-            aliases
-                .get(alias)
-                .ok_or_else(|| AliasError::AliasNotFound(alias.to_string()))?
-                .clone()
-        };
+        let aliases = self.aliases.read();
+        let collection_name = aliases
+            .get(alias)
+            .ok_or_else(|| AliasError::AliasNotFound(alias.to_string()))?;
 
-        // Get collection and create reader guard
         let collections = self.collections.read();
         let collection = collections
-            .get(&collection_name)
+            .get(collection_name)
             .ok_or_else(|| AliasError::CollectionNotFound(collection_name.clone()))?;
 
-        Ok(ReaderGuard::new(
+        let guard = ReaderGuard::new(
             Arc::clone(&collection.index),
             Arc::clone(&collection.readers),
-        ))
+        );
+        drop(collections);
+        drop(aliases);
+        Ok(guard)
+    }
+
+    /// Test-only variant of `acquire_reader` that runs `hook` right after
+    /// alias resolution while still holding the `aliases` read lock, used
+    /// to deterministically exercise the switch/drain race window (#417).
+    #[cfg(test)]
+    pub(crate) fn acquire_reader_with_test_hook(
+        &self,
+        alias: &str,
+        hook: impl FnOnce(),
+    ) -> Result<ReaderGuard, AliasError> {
+        let aliases = self.aliases.read();
+        let collection_name = aliases
+            .get(alias)
+            .ok_or_else(|| AliasError::AliasNotFound(alias.to_string()))?;
+
+        hook();
+
+        let collections = self.collections.read();
+        let collection = collections
+            .get(collection_name)
+            .ok_or_else(|| AliasError::CollectionNotFound(collection_name.clone()))?;
+
+        let guard = ReaderGuard::new(
+            Arc::clone(&collection.index),
+            Arc::clone(&collection.readers),
+        );
+        drop(collections);
+        drop(aliases);
+        Ok(guard)
     }
 
     /// Switch an alias to a different collection, optionally validating first.
@@ -169,25 +203,27 @@ impl IndexAliasManager {
         Ok(old_collection)
     }
 
-    /// Wait for all readers on a collection to drain, then remove it.
-    /// If drain times out, the collection is NOT removed and an error is returned.
+    /// Retire a collection from manager ownership and wait for its readers to drain.
+    ///
+    /// The collection is removed from `self.collections` *before* waiting,
+    /// not after: outstanding `ReaderGuard`s hold their own `Arc<HnswIndex>`
+    /// clone, so removing the manager's entry does not affect them. This
+    /// means that even if drain times out below, the manager no longer
+    /// owns the retired collection forever -- its memory is reclaimed
+    /// normally once the last guard drops (#418).
     pub async fn drain_and_remove(&self, collection: &str) -> Result<(), AliasError> {
-        // Extract the reader counter (under read lock -- we just need the Arc)
         let counter = {
-            let collections = self.collections.read();
+            let mut collections = self.collections.write();
             let coll = collections
-                .get(collection)
+                .remove(collection)
                 .ok_or_else(|| AliasError::CollectionNotFound(collection.to_string()))?;
             Arc::clone(&coll.readers)
         };
 
-        // Wait for readers to drain (async, no locks held)
-        drain_readers(&counter, self.drain_timeout, self.drain_poll_interval).await?;
-
-        // Remove the collection (exclusive lock)
-        let mut collections = self.collections.write();
-        collections.remove(collection);
-        Ok(())
+        // Wait for readers to drain (async, no locks held). A timeout here
+        // no longer leaves the collection manager-owned -- it was already
+        // retired above.
+        drain_readers(&counter, self.drain_timeout, self.drain_poll_interval).await
     }
 
     /// Build new index, validate, swap alias atomically, drain old; returns `MigrationReport`.
@@ -286,11 +322,11 @@ impl IndexAliasManager {
         // Switch the alias
         self.switch_alias(alias, &new_collection_name, None)?;
 
-        // Drain and remove old collection
-        // Note: if drain times out, the old collection stays around but the
-        // alias already points to the new one. This is acceptable -- readers
-        // on the old index will finish eventually, and the memory will be
-        // reclaimed when the last Arc is dropped.
+        // Retire and drain the old collection. `drain_and_remove` removes it
+        // from `self.collections` up front, so even if drain times out below
+        // the manager no longer owns it -- outstanding reader guards keep
+        // their own Arc<HnswIndex> clone alive and the memory is reclaimed
+        // normally once the last guard drops (#418).
         let drain_result = self.drain_and_remove(&old_collection_name).await;
 
         let swap_drain_duration = swap_drain_start.elapsed();
@@ -299,8 +335,8 @@ impl IndexAliasManager {
         // Log drain timeout but don't fail the migration -- the alias is
         // already switched, so new queries go to the new index.
         if let Err(AliasError::DrainTimeout { .. }) = &drain_result {
-            // The old collection will be cleaned up when the last reader drops.
-            // We report this in the migration report but don't fail.
+            // The old collection is already retired from manager ownership;
+            // we report this in the migration report but don't fail.
         } else if let Err(e) = drain_result {
             return Err(e);
         }
@@ -536,5 +572,121 @@ mod tests {
         // The alias should now point to the new collection
         let guard = mgr.acquire_reader("active").unwrap();
         assert_eq!(guard.len(), 8);
+    }
+
+    /// Regression for #417: acquiring a reader must not race a concurrent
+    /// alias switch + drain/remove of the collection the reader resolved
+    /// to. Pauses right after alias resolution (deterministic via channel,
+    /// no sleep), then performs a switch+drain+remove that would, on the
+    /// buggy code, remove the collection before the reader is counted.
+    #[tokio::test]
+    async fn test_acquire_reader_switch_drain_race_does_not_return_collection_not_found() {
+        let mgr = Arc::new(IndexAliasManager::new(Duration::from_secs(5)));
+        mgr.register_collection("v1", make_index(4, 5)).unwrap();
+        mgr.register_collection("v2", make_index(4, 10)).unwrap();
+        mgr.create_alias("active", "v1").unwrap();
+
+        let (paused_tx, paused_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (b_done_tx, b_done_rx) = std::sync::mpsc::channel::<()>();
+
+        let mgr_a = Arc::clone(&mgr);
+        let handle_a = std::thread::spawn(move || {
+            mgr_a.acquire_reader_with_test_hook("active", || {
+                paused_tx.send(()).expect("send paused signal");
+                release_rx.recv().expect("recv release signal");
+            })
+        });
+
+        // Wait until thread A has resolved alias -> v1 and is paused.
+        paused_rx.recv().expect("recv paused signal");
+
+        // Concurrently switch the alias to v2 and drain+remove v1 on a
+        // second thread -- exactly what a migration does. On the buggy
+        // code this has no lock contention and completes immediately,
+        // removing v1 before A is released below. On the fixed code it
+        // blocks behind A's held `aliases` read lock until A is released.
+        let mgr_b = Arc::clone(&mgr);
+        let handle_b = std::thread::spawn(move || {
+            mgr_b.switch_alias("active", "v2", None).unwrap();
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build nested runtime for thread B");
+            rt.block_on(mgr_b.drain_and_remove("v1")).unwrap();
+            b_done_tx.send(()).ok();
+        });
+
+        // Give B a bounded window to run to completion if nothing blocks it
+        // (the pre-fix case: B finishes almost instantly). Whether or not
+        // it finished, release A next -- on the fixed code B is still
+        // blocked at this point and only proceeds once A releases the
+        // `aliases` lock below.
+        let _ = b_done_rx.recv_timeout(Duration::from_millis(200));
+        release_tx.send(()).expect("send release signal");
+
+        let result = handle_a.join().expect("thread A join");
+        let a_len = match result {
+            Ok(guard) => {
+                let len = guard.len();
+                // Drop the guard so B's drain_and_remove (waiting on this
+                // reader on the fixed code) does not block on join below.
+                drop(guard);
+                len
+            }
+            Err(e) => panic!(
+                "acquire_reader must not return an error due to a switch/drain race, got {e:?}"
+            ),
+        };
+        handle_b.join().expect("thread B join");
+
+        assert_eq!(a_len, 5, "must return the old v1 snapshot");
+    }
+
+    /// Regression for #418: if drain times out during migration, the old
+    /// collection must be retired from `self.collections` immediately
+    /// (not kept forever), even though the held reader guard keeps the
+    /// underlying index alive until it is dropped.
+    #[tokio::test]
+    async fn test_migrate_timeout_retires_old_collection_from_manager() {
+        let mgr = Arc::new(IndexAliasManager::new(Duration::ZERO));
+        mgr.register_collection("v1", make_index(4, 5)).unwrap();
+        mgr.create_alias("active", "v1").unwrap();
+
+        // Hold a reader guard on v1 so drain can never complete within the
+        // zero-duration timeout.
+        let guard = mgr.acquire_reader("active").unwrap();
+        assert_eq!(guard.len(), 5);
+
+        let vectors: Vec<(NodeId, Vec<f32>)> = (0..8u8)
+            .map(|i| (NodeId::new([i; 16]), vec![i as f32; 4]))
+            .collect();
+        let config = HnswConfig::with_dimensions(4);
+
+        let report = mgr
+            .migrate("active", vectors, config, None)
+            .await
+            .expect("migration must succeed even if drain times out");
+        assert_eq!(report.old_collection, "v1");
+
+        assert_eq!(
+            mgr.resolve_alias("active"),
+            Some(report.new_collection.clone())
+        );
+        assert_eq!(
+            mgr.reader_count("v1"),
+            None,
+            "old collection must no longer be manager-owned even though drain timed out"
+        );
+        assert_eq!(
+            mgr.collection_count(),
+            1,
+            "manager must not keep the retired collection around forever"
+        );
+
+        // The held guard must still be usable until dropped.
+        assert_eq!(guard.len(), 5);
+        drop(guard);
+        assert_eq!(mgr.collection_count(), 1);
     }
 }

--- a/crates/khive-hnsw/src/alias/manager.rs
+++ b/crates/khive-hnsw/src/alias/manager.rs
@@ -379,8 +379,11 @@ impl IndexAliasManager {
 
 impl std::fmt::Debug for IndexAliasManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let collections = self.collections.read();
+        // Canonical lock order is aliases -> collections, matching
+        // `acquire_reader`; do not flip this or a concurrent
+        // migrate/switch_alias can form a lock cycle with this fmt (#417).
         let aliases = self.aliases.read();
+        let collections = self.collections.read();
         f.debug_struct("IndexAliasManager")
             .field("collections", &collections.keys().collect::<Vec<_>>())
             .field("aliases", &*aliases)

--- a/crates/khive-hnsw/src/arena/arena.rs
+++ b/crates/khive-hnsw/src/arena/arena.rs
@@ -1,16 +1,27 @@
-//! Bump arena allocator for HNSW search operations. Reset is O(1).
+//! Bump arena allocator for HNSW search operations. Reset is O(1) amortized.
+//!
+//! Backed by a list of fixed-size chunks rather than one growable buffer:
+//! growth allocates a new chunk instead of resizing an existing one, so
+//! pointers returned by a prior `alloc()` call are never invalidated by a
+//! later `alloc()` call on the same arena (see #412).
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 /// Default arena size: 1 MiB. Sufficient for ef=256 searches (~10 KiB worst-case).
 pub const DEFAULT_ARENA_SIZE: usize = 1 << 20; // 1 MiB
 
 /// Bump arena allocator for HNSW search operations. Uses interior mutability for shared allocation.
 pub struct SearchArena {
-    /// Backing memory slab.
-    slab: Cell<Vec<u8>>,
-    /// Current bump offset into the slab.
+    /// Backing memory chunks. A `Box<[u8]>`'s heap allocation never moves
+    /// once created, even when the outer `Vec` reallocates to hold more
+    /// chunk handles, so pointers into earlier chunks stay valid.
+    chunks: RefCell<Vec<Box<[u8]>>>,
+    /// Index of the chunk currently being bumped into.
+    current_chunk: Cell<usize>,
+    /// Current bump offset into the current chunk.
     offset: Cell<usize>,
+    /// Cumulative element bytes allocated since the last reset.
+    bytes_used: Cell<usize>,
 }
 
 impl SearchArena {
@@ -18,8 +29,10 @@ impl SearchArena {
     pub fn new(capacity: usize) -> Self {
         let cap = capacity.max(1024); // Minimum 1 KiB
         Self {
-            slab: Cell::new(vec![0u8; cap]),
+            chunks: RefCell::new(vec![vec![0u8; cap].into_boxed_slice()]),
+            current_chunk: Cell::new(0),
             offset: Cell::new(0),
+            bytes_used: Cell::new(0),
         }
     }
 
@@ -28,27 +41,35 @@ impl SearchArena {
         Self::new(DEFAULT_ARENA_SIZE)
     }
 
-    /// Reset the arena in O(1); all prior allocations become invalid.
+    /// Reset the arena in O(1) amortized; all prior allocations become invalid.
+    ///
+    /// If growth created extra chunks since the last reset, only the
+    /// largest (most recently created) chunk is retained, so memory does
+    /// not grow unboundedly across repeated grow/reset cycles.
     #[inline]
     pub fn reset(&self) {
+        let mut chunks = self.chunks.borrow_mut();
+        if chunks.len() > 1 {
+            if let Some(last) = chunks.pop() {
+                chunks.clear();
+                chunks.push(last);
+            }
+        }
+        self.current_chunk.set(0);
         self.offset.set(0);
+        self.bytes_used.set(0);
     }
 
     /// Current number of bytes allocated from this arena.
     #[inline]
     pub fn bytes_used(&self) -> usize {
-        self.offset.get()
+        self.bytes_used.get()
     }
 
-    /// Total capacity of the arena in bytes.
+    /// Total capacity of the arena in bytes (sum of all backing chunks).
     #[inline]
     pub fn capacity(&self) -> usize {
-        // SAFETY: We take the slab out, read its capacity, and put it back.
-        // This is safe because we don't keep any references across the take/set.
-        let slab = self.slab.take();
-        let cap = slab.capacity();
-        self.slab.set(slab);
-        cap
+        self.chunks.borrow().iter().map(|c| c.len()).sum()
     }
 
     /// Allocate `count` elements of type `T`; grows automatically.
@@ -65,32 +86,36 @@ impl SearchArena {
             return std::ptr::dangling_mut::<T>(); // ZST: return aligned dangling pointer
         }
 
-        let mut current = self.offset.get();
+        let mut chunks = self.chunks.borrow_mut();
+        let mut chunk_idx = self.current_chunk.get();
+        let mut aligned = {
+            let current = self.offset.get();
+            (current + align - 1) & !(align - 1)
+        };
 
-        // Align up
-        let aligned = (current + align - 1) & !(align - 1);
-        let new_offset = aligned + size;
+        let fits = aligned
+            .checked_add(size)
+            .map(|end| end <= chunks[chunk_idx].len())
+            .unwrap_or(false);
 
-        // Take slab, work with it, put it back
-        let mut slab = self.slab.take();
-
-        if new_offset > slab.len() {
-            // Grow: double or fit, whichever is larger
-            let new_cap = (slab.len() * 2).max(new_offset).max(slab.len() + size);
-            slab.resize(new_cap, 0);
-            // Recompute alignment in case resize moved the buffer
-            current = self.offset.get();
-            let aligned = (current + align - 1) & !(align - 1);
-            let new_offset = aligned + size;
-            let ptr = slab.as_mut_ptr().wrapping_add(aligned) as *mut T;
-            self.offset.set(new_offset);
-            self.slab.set(slab);
-            return ptr;
+        if !fits {
+            // Grow by allocating a brand-new chunk sized to fit this
+            // request; never resize/move an existing chunk, so pointers
+            // returned into earlier chunks remain valid.
+            let prev_len = chunks[chunk_idx].len();
+            let new_len = prev_len
+                .saturating_mul(2)
+                .max(size.saturating_add(align))
+                .max(1024);
+            chunks.push(vec![0u8; new_len].into_boxed_slice());
+            chunk_idx = chunks.len() - 1;
+            self.current_chunk.set(chunk_idx);
+            aligned = 0;
         }
 
-        let ptr = slab.as_mut_ptr().wrapping_add(aligned) as *mut T;
-        self.offset.set(new_offset);
-        self.slab.set(slab);
+        let ptr = chunks[chunk_idx].as_mut_ptr().wrapping_add(aligned) as *mut T;
+        self.offset.set(aligned + size);
+        self.bytes_used.set(self.bytes_used.get() + size);
         ptr
     }
 

--- a/crates/khive-hnsw/src/arena/tests.rs
+++ b/crates/khive-hnsw/src/arena/tests.rs
@@ -436,3 +436,19 @@ fn test_arena_default_capacity() {
     let arena = SearchArena::with_default_capacity();
     assert!(arena.capacity() >= super::arena::DEFAULT_ARENA_SIZE);
 }
+
+#[test]
+fn arena_vec_growth_after_slab_growth_preserves_existing_elements() {
+    // Regression for #412: a second push that triggers arena growth must not
+    // read from a dangling pointer into a since-moved backing allocation.
+    let arena = SearchArena::new(1024);
+    let mut vec: ArenaVec<[u8; 1024]> = ArenaVec::new(&arena, 1);
+
+    vec.push([0xAB; 1024]);
+    vec.push([0xCD; 1024]);
+
+    assert_eq!(vec.len(), 2);
+    assert_eq!(vec[0], [0xAB; 1024]);
+    assert_eq!(vec[1], [0xCD; 1024]);
+    assert!(arena.capacity() >= 2048);
+}

--- a/crates/khive-hnsw/src/checkpoint/snapshot.rs
+++ b/crates/khive-hnsw/src/checkpoint/snapshot.rs
@@ -13,6 +13,12 @@ pub(crate) fn is_zero(val: &usize) -> bool {
     *val == 0
 }
 
+/// Return the first ID that appears more than once in `ids`, if any.
+fn first_duplicate(ids: &[NodeId]) -> Option<NodeId> {
+    let mut seen = HashSet::with_capacity(ids.len());
+    ids.iter().copied().find(|id| !seen.insert(*id))
+}
+
 /// Errors that can occur during snapshot verification.
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum SnapshotError {
@@ -51,6 +57,20 @@ pub enum SnapshotError {
     #[error("tombstoned id {id:?} not found in indexed_ids")]
     TombstoneNotInIndex {
         /// The missing tombstone ID.
+        id: NodeId,
+    },
+
+    /// `indexed_ids` contains the same ID more than once.
+    #[error("indexed_ids contains duplicate id {id:?}")]
+    DuplicateIndexedId {
+        /// The duplicated ID.
+        id: NodeId,
+    },
+
+    /// `tombstoned_ids` contains the same ID more than once.
+    #[error("tombstoned_ids contains duplicate id {id:?}")]
+    DuplicateTombstonedId {
+        /// The duplicated ID.
         id: NodeId,
     },
 
@@ -160,9 +180,15 @@ impl HnswSnapshot {
                 self.live_nodes = self.vector_count;
                 self.tombstone_count = 0;
             } else if !self.indexed_ids.is_empty() {
-                // Fallback: infer from indexed_ids
+                // Fallback: infer from indexed_ids. Use saturating_sub so a
+                // malformed legacy snapshot (more tombstones than indexed
+                // ids) cannot panic here; `verify()` is the rejecting
+                // boundary and will catch the resulting inconsistency.
                 self.total_nodes = self.indexed_ids.len();
-                self.live_nodes = self.indexed_ids.len() - self.tombstoned_ids.len();
+                self.live_nodes = self
+                    .indexed_ids
+                    .len()
+                    .saturating_sub(self.tombstoned_ids.len());
                 self.tombstone_count = self.tombstoned_ids.len();
             }
         }
@@ -175,8 +201,12 @@ impl HnswSnapshot {
 
     /// Verify internal consistency: counts, ID list lengths, tombstone membership.
     pub fn verify(&self) -> Result<(), SnapshotError> {
-        // Check count consistency
-        if self.total_nodes != self.live_nodes + self.tombstone_count {
+        // Check count consistency. Use checked_add so a malformed snapshot
+        // with `live_nodes + tombstone_count` overflowing `usize` is
+        // rejected instead of panicking (or, in release builds, wrapping
+        // and silently comparing equal to a bogus total_nodes) (#415).
+        let expected_total = self.live_nodes.checked_add(self.tombstone_count);
+        if expected_total != Some(self.total_nodes) {
             return Err(SnapshotError::InconsistentCounts {
                 total: self.total_nodes,
                 live: self.live_nodes,
@@ -198,6 +228,17 @@ impl HnswSnapshot {
                 expected: self.tombstone_count,
                 actual: self.tombstoned_ids.len(),
             });
+        }
+
+        // Reject duplicate indexed/tombstoned IDs before any restore path
+        // can build ID maps from them (#416): last-wins `HashMap::insert`
+        // during restore would otherwise silently corrupt `internal_to_id`
+        // by mapping two live internal nodes to the same external ID.
+        if let Some(id) = first_duplicate(&self.indexed_ids) {
+            return Err(SnapshotError::DuplicateIndexedId { id });
+        }
+        if let Some(id) = first_duplicate(&self.tombstoned_ids) {
+            return Err(SnapshotError::DuplicateTombstonedId { id });
         }
 
         // Check all tombstoned IDs are in indexed_ids
@@ -301,7 +342,20 @@ impl TryFrom<RawHnswSnapshot> for HnswSnapshot {
                 raw.tombstone_count = 0;
             } else if !raw.indexed_ids.is_empty() {
                 raw.total_nodes = raw.indexed_ids.len();
-                raw.live_nodes = raw.indexed_ids.len() - raw.tombstoned_ids.len();
+                // checked_sub: a malformed legacy snapshot can report more
+                // tombstones than indexed ids; reject it here instead of
+                // panicking on unchecked subtraction (#415). `verify()`
+                // below is still the primary rejecting boundary for
+                // well-formed-but-inconsistent snapshots.
+                raw.live_nodes = raw
+                    .indexed_ids
+                    .len()
+                    .checked_sub(raw.tombstoned_ids.len())
+                    .ok_or(SnapshotError::InconsistentCounts {
+                        total: raw.indexed_ids.len(),
+                        live: raw.indexed_ids.len(),
+                        tombstones: raw.tombstoned_ids.len(),
+                    })?;
                 raw.tombstone_count = raw.tombstoned_ids.len();
             }
         }

--- a/crates/khive-hnsw/src/checkpoint/tests.rs
+++ b/crates/khive-hnsw/src/checkpoint/tests.rs
@@ -767,3 +767,70 @@ fn canonical_snapshot_serializes_deterministically() {
         "Canonical snapshots should serialize identically"
     );
 }
+
+// ── #415 / #416 regression tests ─────────────────────────────────────────
+
+/// Regression for #415: a legacy (v1-style) snapshot whose `tombstoned_ids`
+/// somehow exceeds `indexed_ids` must not panic on unchecked subtraction
+/// while normalizing cardinality in `TryFrom<RawHnswSnapshot>`.
+#[test]
+fn try_from_rejects_legacy_tombstones_exceed_indexed_without_panic() {
+    use super::snapshot::RawHnswSnapshot;
+    let x = make_id(1);
+    let raw = RawHnswSnapshot {
+        vector_count: 0,
+        total_nodes: 0, // triggers legacy normalization fallback
+        live_nodes: 0,
+        tombstone_count: 0,
+        max_layer: 0,
+        entry_point: Some(x),
+        config: sample_config(),
+        indexed_ids: vec![x],
+        tombstoned_ids: vec![x, x], // more tombstones than indexed ids
+        layers: vec![vec![(x, vec![])]],
+        vectors: vec![],
+    };
+
+    let result = HnswSnapshot::try_from(raw);
+    assert!(
+        result.is_err(),
+        "TryFrom must reject invalid legacy cardinality instead of panicking"
+    );
+}
+
+/// Regression for #415: `verify()` must not panic on unchecked addition
+/// when `live_nodes + tombstone_count` would overflow `usize`.
+#[test]
+fn verify_rejects_wrapping_count_sum_without_panic() {
+    let mut snap = sample_snapshot();
+    snap.total_nodes = 0;
+    snap.live_nodes = usize::MAX;
+    snap.tombstone_count = 1;
+    snap.indexed_ids = vec![];
+    snap.tombstoned_ids = vec![];
+
+    let result = snap.verify();
+    assert!(
+        matches!(result, Err(SnapshotError::InconsistentCounts { .. })),
+        "verify() must reject a wrapping count sum instead of panicking, got {result:?}"
+    );
+}
+
+/// Regression for #416: `verify()` must reject duplicate `indexed_ids`
+/// before restore can build ID maps from them (last-wins insertion would
+/// otherwise silently corrupt `internal_to_id`).
+#[test]
+fn verify_rejects_duplicate_indexed_ids() {
+    let x = make_id(1);
+    let mut snap = sample_snapshot();
+    snap.total_nodes = 2;
+    snap.live_nodes = 2;
+    snap.tombstone_count = 0;
+    snap.indexed_ids = vec![x, x];
+
+    let result = snap.verify();
+    assert!(
+        matches!(result, Err(SnapshotError::DuplicateIndexedId { id }) if id == x),
+        "verify() must reject duplicate indexed_ids, got {result:?}"
+    );
+}

--- a/crates/khive-hnsw/src/checkpoint/tests.rs
+++ b/crates/khive-hnsw/src/checkpoint/tests.rs
@@ -834,3 +834,22 @@ fn verify_rejects_duplicate_indexed_ids() {
         "verify() must reject duplicate indexed_ids, got {result:?}"
     );
 }
+
+/// Regression for #416: `verify()` must reject duplicate `tombstoned_ids`
+/// before restore can build ID maps from them (last-wins insertion would
+/// otherwise silently corrupt the tombstone set).
+#[test]
+fn verify_rejects_duplicate_tombstoned_ids() {
+    let x = make_id(1);
+    let mut snap = sample_snapshot();
+    snap.total_nodes = 2;
+    snap.live_nodes = 0;
+    snap.tombstone_count = 2;
+    snap.tombstoned_ids = vec![x, x];
+
+    let result = snap.verify();
+    assert!(
+        matches!(result, Err(SnapshotError::DuplicateTombstonedId { id }) if id == x),
+        "verify() must reject duplicate tombstoned_ids, got {result:?}"
+    );
+}

--- a/crates/khive-hnsw/src/index/insert.rs
+++ b/crates/khive-hnsw/src/index/insert.rs
@@ -80,16 +80,18 @@ impl HnswIndex {
         if let Some(&iid) = self.id_to_internal.get(&id) {
             let is_tombstoned = iid < self.tombstones.len() && self.tombstones[iid];
             if is_tombstoned {
-                // Undo the tombstone so `delete` does not double-count it,
-                // and so the fresh insert below sees the ID as gone.
-                self.tombstones[iid] = false;
-                self.tombstone_count -= 1;
-                // Remove from the ID maps so insert_inner treats this as a new node.
-                // The internal slot (iid) becomes a permanent hole (like any deleted node).
-                self.id_to_internal.remove(&id);
-                // internal_to_id still holds the old external ID at position iid;
-                // leave it in place — the slot is effectively dead (tombstoned above).
-                // Fall through to the fresh-insert path below.
+                // Compact away tombstoned slots (including this one) before
+                // falling through to the fresh-insert path below. Merely
+                // clearing the tombstone and removing `id` from
+                // `id_to_internal` left `internal_to_id[iid]` still pointing
+                // at `id`, so the fresh-insert path would append a second
+                // internal slot for the same external ID -- duplicating
+                // `internal_to_id` / `snapshot.indexed_ids` and letting
+                // exact-scan search return the stale pre-delete vector
+                // (#414). `rebuild()` physically removes the old slot and
+                // its `id_to_internal` entry, so the fresh insert below
+                // allocates a single, clean internal ID for `id`.
+                self.rebuild();
             } else {
                 // Live node update: just swap the vector. Graph edges remain valid
                 // because neighbors were chosen by proximity; after an in-place

--- a/crates/khive-hnsw/tests/hnsw_tests.rs
+++ b/crates/khive-hnsw/tests/hnsw_tests.rs
@@ -1838,6 +1838,54 @@ mod snapshot_tests {
         );
     }
 
+    /// Regression for #416: restore must reject a snapshot with duplicate
+    /// `indexed_ids` before mutating the existing index. Accepting it would
+    /// let last-wins `HashMap::insert` corrupt `internal_to_id` with two
+    /// live internal nodes mapped to the same external ID.
+    #[test]
+    fn restore_rejects_duplicate_indexed_ids_before_mutation() {
+        let config = HnswConfig::with_dimensions(4);
+        let mut index = HnswIndex::with_config(config.clone());
+
+        let keep_id = make_id(99);
+        index
+            .insert(keep_id, vec![1.0, 0.0, 0.0, 0.0])
+            .expect("insert");
+
+        let x = make_id(1);
+        let snap = khive_hnsw::checkpoint::HnswSnapshot {
+            vector_count: 0,
+            total_nodes: 2,
+            live_nodes: 2,
+            tombstone_count: 0,
+            max_layer: 0,
+            entry_point: Some(x),
+            config: khive_hnsw::checkpoint::HnswCheckpointConfig {
+                m: 20,
+                ef_construction: 200,
+                metric: "cosine".to_string(),
+            },
+            indexed_ids: vec![x, x], // duplicate
+            tombstoned_ids: vec![],
+            layers: vec![vec![(x, vec![])]],
+            vectors: vec![(x, vec![0.0, 1.0, 0.0, 0.0])],
+        };
+
+        let vectors = HashMap::new();
+        let result = index.restore_from_snapshot(&snap, &vectors);
+        assert!(result.is_err(), "should reject duplicate indexed_ids");
+
+        assert_eq!(
+            index.len(),
+            1,
+            "existing index must be unmodified after rejected restore"
+        );
+        assert!(
+            index.get_vector(&keep_id).is_some(),
+            "existing node must still be present"
+        );
+    }
+
     /// Large snapshot round-trip preserves search quality.
     #[test]
     fn snapshot_restore_preserves_search_quality() {

--- a/crates/khive-hnsw/tests/hnsw_tests.rs
+++ b/crates/khive-hnsw/tests/hnsw_tests.rs
@@ -105,6 +105,53 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_reinsert_tombstoned_node_does_not_duplicate_internal_id() {
+        // Regression for #414: re-inserting a tombstoned NodeId must not
+        // resurrect the old internal slot alongside a fresh one. That would
+        // inflate len()/len_live(), let exact-scan search return the stale
+        // pre-delete vector, and duplicate the ID in snapshot.indexed_ids.
+        let mut index = HnswIndex::new(3);
+
+        let x = make_id(1);
+        let y = make_id(2);
+        let z = make_id(3);
+
+        index.insert(x, vec![1.0, 0.0, 0.0]).expect("insert x");
+        index.insert(y, vec![0.9, 0.1, 0.0]).expect("insert y");
+        index.insert(z, vec![0.0, 1.0, 0.0]).expect("insert z");
+
+        assert!(index.delete(x));
+        index
+            .insert(x, vec![0.0, 0.0, 1.0])
+            .expect("reinsert tombstoned x");
+
+        assert_eq!(index.len(), 3, "no duplicate internal slot for x");
+        assert_eq!(index.len_live(), 3, "no duplicate internal slot for x");
+        assert_eq!(index.tombstone_stats().tombstone_count, 0);
+
+        let stale_hit = index
+            .search(&[1.0, 0.0, 0.0], 1)
+            .expect("search for stale x vector");
+        assert_ne!(
+            stale_hit[0].0, x,
+            "stale pre-delete vector must not resolve back to x"
+        );
+
+        let fresh_hit = index
+            .search(&[0.0, 0.0, 1.0], 1)
+            .expect("search for fresh x vector");
+        assert_eq!(fresh_hit[0].0, x, "fresh vector must resolve to x");
+
+        let snap = index.snapshot();
+        let unique_ids: HashSet<_> = snap.indexed_ids.iter().collect();
+        assert_eq!(
+            unique_ids.len(),
+            snap.indexed_ids.len(),
+            "snapshot.indexed_ids must not contain duplicate IDs"
+        );
+    }
+
+    #[test]
     fn test_delete_tombstone() {
         let mut index = HnswIndex::new(3);
 


### PR DESCRIPTION
## Summary
Resolves 5 defect findings from an internal audit sweep in `khive-hnsw`:
- #412: guard arena growth against live pointer invalidation
- #414: compact tombstones before reinserting a deleted NodeId
- #416: reject duplicate indexed_ids on snapshot restore
- #417: close acquire_reader switch/drain TOCTOU race + Debug lock-order inversion
- #418: (bundled with #417 fix)

## Review
- Independent adversarial review: approved, 0 Blocker/High/Medium/Low findings
- Maintainer review (content level, all 5 commits): clear — arena chunked allocator correct (Box<[u8]> chunks never move, reset keeps largest chunk), rebuild-before-reinsert correct (O(n) per tombstoned-ID reinsert, correctness-first), snapshot checks correct, lock discipline verified (switch_alias never holds both locks simultaneously, no cycle)
- One non-blocking observation: arena alignment still relative to u8 buffer base (pre-existing, unchanged by this diff)
- `cargo test -p khive-hnsw`: 66 passed; clippy clean; fmt clean

## Test plan
- [x] cargo test -p khive-hnsw (66 passed)
- [x] cargo clippy -p khive-hnsw --all-targets -- -D warnings
- [x] cargo fmt -p khive-hnsw -- --check
- [x] Independent adversarial review (approved)
- [x] Maintainer review (clear)