### PR TITLE
fix(pack-memory): scope recall to memory-kind before cap; weighted-fusion fallback + feedback signal validation (#429,#430,#442)

### DIFF
--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -110,7 +110,7 @@ pub(super) fn parse_fusion_strategy_str(s: &str) -> Result<FusionStrategy, Runti
     match s {
         "rrf" => Ok(FusionStrategy::Rrf { k: 60 }),
         "weighted" => Ok(FusionStrategy::Weighted {
-            weights: vec![0.3, 0.7],
+            weights: vec![0.7, 0.3],
         }),
         "union" => Ok(FusionStrategy::Union),
         "vector_only" => Ok(FusionStrategy::VectorOnly),

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -31,6 +31,7 @@ impl MemoryPack {
         let p: FeedbackParams = serde_json::from_value(params).map_err(|e| {
             RuntimeError::InvalidInput(format!("memory.feedback: invalid params: {e}"))
         })?;
+        validate_feedback_signal(&p.signal)?;
 
         let target_id = p.target_id.parse::<Uuid>().map_err(|_| {
             RuntimeError::InvalidInput(format!(
@@ -58,6 +59,22 @@ impl MemoryPack {
         }
 
         Ok(json!({ "ok": true, "target_id": p.target_id, "signal": p.signal }))
+    }
+}
+
+/// Validate that `signal` is a known feedback vocabulary entry before it is routed
+/// to any tier. Tier-3 (`on_explicit_feedback`) silently no-ops on unknown strings,
+/// which would otherwise let an invalid signal return `ok=true`.
+fn validate_feedback_signal(signal: &str) -> Result<(), RuntimeError> {
+    let semantic = khive_brain_core::FeedbackEventKind::from_signal_str(signal).is_some();
+    let legacy = serde_json::from_value::<khive_brain_core::FeedbackSignal>(json!(signal)).is_ok();
+    if semantic || legacy {
+        Ok(())
+    } else {
+        Err(RuntimeError::InvalidInput(format!(
+            "memory.feedback: invalid signal {signal:?}; valid: useful | not_useful | wrong | \
+             explicit_positive | explicit_negative | implicit_positive | implicit_negative | correction"
+        )))
     }
 }
 
@@ -126,7 +143,7 @@ async fn resolve_namespace_profile(
 #[cfg(test)]
 mod tests {
     use khive_pack_kg::KgPack;
-    use khive_runtime::{Namespace, RuntimeConfig, VerbRegistryBuilder};
+    use khive_runtime::{Namespace, RuntimeConfig, RuntimeError, VerbRegistryBuilder};
 
     fn build_memory_rt(brain_profile: Option<String>) -> khive_runtime::KhiveRuntime {
         let tmp = tempfile::Builder::new()
@@ -233,6 +250,56 @@ mod tests {
 
         assert_eq!(r["ok"], true);
         assert_eq!(r["signal"], "not_useful");
+    }
+
+    /// Tier-3: an invalid signal string must be rejected before it reaches
+    /// `on_explicit_feedback`, which otherwise silently no-ops and still
+    /// returns `ok=true` (AUD-004).
+    #[tokio::test]
+    async fn feedback_tier3_invalid_signal_is_rejected() {
+        let rt = build_memory_rt(None);
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let note_id = rt
+            .create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                "invalid signal note",
+                Some(0.5),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+
+        let memory_pack = crate::MemoryPack::new(rt.clone());
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(memory_pack);
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.feedback",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "target_id": note_id.id.to_string(),
+                    "signal": "bad_value",
+                }),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "invalid signal must be rejected, got {:?}",
+            result
+        );
+        assert!(matches!(result.unwrap_err(), RuntimeError::InvalidInput(_)));
     }
 
     /// Tier-1: explicit brain_profile config routes to brain.feedback (which errors

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -133,12 +133,21 @@ impl MemoryPack {
             .ann_overfetch_max_rounds
             .unwrap_or_else(super::common::ann_overfetch_max_rounds);
 
-        let candidates = self
+        // #430: the FTS/vector candidate cap (`candidate_limit`) is applied over all
+        // note kinds, not just `memory` rows, so a query pool dominated by higher-ranking
+        // non-memory notes can starve out eligible memories before hydration ever sees
+        // them. `load_memory_candidate_notes` is the first point where kind=="memory"
+        // eligibility is known, so widen the cap and re-gather here (bounded by
+        // `ann_overfetch_max_rounds` and `max_recall_candidates`) until enough eligible
+        // memories are hydrated or the corpus is exhausted, instead of applying the
+        // memory-kind scope only after the cap has already discarded candidates.
+        let mut current_candidate_limit = candidate_limit;
+        let mut candidates = self
             .collect_recall_candidates(
                 query_trimmed,
                 token,
                 RecallCandidateParams {
-                    candidate_limit,
+                    candidate_limit: current_candidate_limit,
                     embedding_model: p.embedding_model.as_deref(),
                     cjk_fts_bypass,
                     use_multilingual,
@@ -149,6 +158,48 @@ impl MemoryPack {
                 },
             )
             .await?;
+        let (mut memory_ids, mut notes_by_id) =
+            self.load_memory_candidate_notes(token, &candidates).await?;
+
+        for _round in 1..ann_overfetch_max_rounds {
+            if memory_ids.len() >= limit {
+                break;
+            }
+            let corpus_exhausted = candidates.text_hits.len() < current_candidate_limit as usize
+                && candidates
+                    .vector_hits_per_model
+                    .iter()
+                    .all(|(_, h)| h.len() < current_candidate_limit as usize);
+            if corpus_exhausted {
+                break;
+            }
+            let widened = current_candidate_limit
+                .saturating_mul(4)
+                .min(scoring_cfg.max_recall_candidates as u32);
+            if widened <= current_candidate_limit {
+                break;
+            }
+            current_candidate_limit = widened;
+            candidates = self
+                .collect_recall_candidates(
+                    query_trimmed,
+                    token,
+                    RecallCandidateParams {
+                        candidate_limit: current_candidate_limit,
+                        embedding_model: p.embedding_model.as_deref(),
+                        cjk_fts_bypass,
+                        use_multilingual,
+                        scoring_cfg: &scoring_cfg,
+                        snippet_policy: TextSnippetPolicy::Omit,
+                        fts_gather: &effective_fts_gather,
+                        ann_overfetch_max_rounds,
+                    },
+                )
+                .await?;
+            (memory_ids, notes_by_id) =
+                self.load_memory_candidate_notes(token, &candidates).await?;
+        }
+        let candidate_limit = current_candidate_limit;
 
         if prof {
             if let Some(ref t) = t_stage {
@@ -168,8 +219,6 @@ impl MemoryPack {
         }
 
         let actual_multilingual_routed = candidates.multilingual_routed;
-        let (memory_ids, mut notes_by_id) =
-            self.load_memory_candidate_notes(token, &candidates).await?;
 
         if prof {
             if let Some(ref t) = t_stage {

--- a/crates/khive-pack-memory/src/handlers/tests.rs
+++ b/crates/khive-pack-memory/src/handlers/tests.rs
@@ -181,6 +181,61 @@ fn test_weighted_strategy_preserves_pack_weights() {
 }
 
 #[test]
+fn test_weighted_strategy_from_rrf_config_uses_vector_heavy_defaults() {
+    let base = RecallConfig {
+        fuse_strategy: FusionStrategy::Rrf { k: 60 },
+        ..RecallConfig::default()
+    };
+
+    let p = RecallParams {
+        query: "test".to_string(),
+        limit: None,
+        memory_type: None,
+        min_score: None,
+        min_salience: None,
+        config: None,
+        top_k: None,
+        fusion_strategy: Some("weighted".to_string()),
+        score_floor: None,
+        embedding_model: None,
+        include_breakdown: None,
+        tags: None,
+        tag_mode: TagMode::Any,
+        entity_names: None,
+        full_content: None,
+    };
+
+    let mut cfg = p.effective_config(base);
+    if let Some(ref fs) = p.fusion_strategy {
+        let mut new_strategy = parse_fusion_strategy_str(fs).unwrap();
+        if let (
+            FusionStrategy::Weighted {
+                weights: ref mut new_w,
+            },
+            FusionStrategy::Weighted {
+                weights: ref existing_w,
+            },
+        ) = (&mut new_strategy, &cfg.fuse_strategy)
+        {
+            *new_w = existing_w.clone();
+        }
+        cfg.fuse_strategy = new_strategy;
+    }
+
+    match cfg.fuse_strategy {
+        FusionStrategy::Weighted { weights } => {
+            assert_eq!(
+                weights,
+                vec![0.7, 0.3],
+                "fusion_strategy=weighted must fall back to vector-heavy defaults [0.7, 0.3] \
+                 when overriding a non-Weighted (e.g. RRF) effective config"
+            );
+        }
+        other => panic!("expected Weighted strategy, got {other:?}"),
+    }
+}
+
+#[test]
 fn fusion_strategy_change_produces_observable_ordering_difference() {
     use khive_storage::types::{TextSearchHit, VectorSearchHit};
     use std::collections::HashSet;

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -944,6 +944,82 @@ async fn test_recall_excludes_non_memory_notes() {
     }
 }
 
+/// Regression test for issue #430: recall must return the requested count of
+/// memory results even when a tiny `candidate_limit` and many higher-ranking
+/// non-memory notes would otherwise exhaust the candidate cap before the
+/// memory-kind scope is ever applied.
+#[tokio::test]
+async fn recall_candidate_cap_counts_eligible_memories_not_generic_notes() {
+    let rt = make_runtime();
+    let registry = make_registry(rt.clone());
+
+    // 30 non-memory notes, all matching the query, all ranked ahead of the
+    // memory notes below (higher salience is irrelevant to FTS/vector rank,
+    // but sheer count is enough to exhaust a `candidate_limit` of 5).
+    let tok = rt.authorize(Namespace::local()).unwrap();
+    for i in 0..30 {
+        rt.create_note(
+            &tok,
+            "observation",
+            None,
+            &format!("observation {i} about quokka migration patterns in tundra"),
+            Some(0.9),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create observation");
+    }
+
+    let want = 5usize;
+    let mut memory_ids = Vec::with_capacity(want);
+    for i in 0..want {
+        let mem = registry
+            .dispatch(
+                "memory.remember",
+                json!({
+                    "content": format!("memory note {i} about quokka migration patterns in tundra"),
+                    "salience": 0.6
+                }),
+            )
+            .await
+            .expect("remember");
+        memory_ids.push(mem["id"].as_str().unwrap().to_string());
+    }
+
+    // `candidate_limit: 5` is smaller than the 30 non-memory notes competing
+    // for the same candidate window — without memory-kind scoping applied
+    // before the cap, the 5 memory notes can be starved out entirely.
+    let result = registry
+        .dispatch(
+            "memory.recall",
+            json!({
+                "query": "quokka migration patterns tundra",
+                "limit": want,
+                "config": { "candidate_limit": 5 },
+            }),
+        )
+        .await
+        .expect("recall succeeds");
+
+    let hits = result.as_array().expect("array of hits");
+    assert_eq!(
+        hits.len(),
+        want,
+        "recall must return the requested count of memories even when non-memory \
+         notes dominate a small candidate window; got {} of {want}: {hits:?}",
+        hits.len()
+    );
+    let ids: std::collections::HashSet<&str> =
+        hits.iter().map(|h| h["id"].as_str().unwrap()).collect();
+    for mid in &memory_ids {
+        assert!(
+            ids.contains(mid.as_str()),
+            "expected memory {mid} in recall results, got {ids:?}"
+        );
+    }
+}
+
 /// Regression for #159: PackTunable::apply_config must actually affect recall
 /// scoring, not just mutate a Mutex that handlers ignore.
 ///


### PR DESCRIPTION
## Summary
Resolves 3 defect findings from an internal audit sweep in `khive-pack-memory`:
- #429: false positive (already correctly filtered — verified no fix needed, deleted_at+kind double-checked before fusion)
- #430: bounded widen-retry so non-memory candidates don't starve the recall cap
- #442 (AUD-003, AUD-004): weighted-fusion default fallback + feedback signal validation

## Review
- Independent adversarial review: approved, 0 Blocker/High/Medium/Low findings
- `cargo test -p khive-pack-memory`: 166 unit + 82 integration passed; clippy clean; fmt clean
- One MINOR (non-blocking) noted during review and independently reconfirmed: the widen-retry stop condition counts kind-eligible candidates only: downstream filters can still trim the final result count. Characterized as a bounded limitation of the workaround, not the original generic-note-cap bug — tracked, not gating.

## Test plan
- [x] cargo test -p khive-pack-memory (166 unit + 82 integration passed)
- [x] cargo clippy -p khive-pack-memory --all-targets -- -D warnings
- [x] cargo fmt -p khive-pack-memory -- --check
- [x] Independent adversarial review (approved)
