### PR TITLE
fix(knowledge): domain/atom UUID resolution, atomic upsert, split-brain delete, clean slug-reuse errors

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -366,6 +366,23 @@ impl KnowledgeHandlers {
         let mut reader = sql.reader().await.map_err(|e| sql_err("get reader", e))?;
 
         if is_uuid {
+            // Domain-first: a domain's canonical row and its FTS mirror atom share
+            // the same UUID, so the UUID branch must match the slug branch below
+            // and prefer knowledge_domains — otherwise a domain UUID resolves to
+            // its own mirror atom instead of the canonical domain record.
+            let row = reader
+                .query_row(SqlStatement {
+                    sql: "SELECT * FROM knowledge_domains WHERE id = ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(id.clone()), SqlValue::Text(ns.clone())],
+                    label: None,
+                })
+                .await
+                .map_err(|e| sql_err("get domain by id", e))?;
+            if let Some(r) = row {
+                return domain_from_row(&r)
+                    .map(|d| domain_to_json(&d))
+                    .ok_or_else(|| RuntimeError::Internal("domain row parse failed".into()));
+            }
             let row = reader
                 .query_row(SqlStatement {
                     sql: "SELECT * FROM knowledge_atoms WHERE id = ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 1".into(),
@@ -383,19 +400,6 @@ impl KnowledgeHandlers {
                     out["sections"] = fetch_sections(runtime, &ns, &atom_id).await?;
                 }
                 return Ok(out);
-            }
-            let row = reader
-                .query_row(SqlStatement {
-                    sql: "SELECT * FROM knowledge_domains WHERE id = ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 1".into(),
-                    params: vec![SqlValue::Text(id.clone()), SqlValue::Text(ns.clone())],
-                    label: None,
-                })
-                .await
-                .map_err(|e| sql_err("get domain by id", e))?;
-            if let Some(r) = row {
-                return domain_from_row(&r)
-                    .map(|d| domain_to_json(&d))
-                    .ok_or_else(|| RuntimeError::Internal("domain row parse failed".into()));
             }
         }
 

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -12,7 +12,7 @@ use super::schema::{
 use super::sections::{section_from_row, section_to_json};
 use super::util::{
     atom_from_row, atom_to_json, compute_embedding_coverage, deser, domain_from_row,
-    domain_to_json, new_id, now_us, row_str, sql_err, status_sql_clause, status_values,
+    domain_to_json, new_id, now_us, row_i64, row_str, sql_err, status_sql_clause, status_values,
     tags_to_json, validate_atom_content,
 };
 use super::KnowledgeHandlers;
@@ -96,14 +96,25 @@ impl KnowledgeHandlers {
                 .reader()
                 .await
                 .map_err(|e| sql_err("upsert_atoms reader", e))?;
+            // Look up by slug WITHOUT the deleted_at filter so a tombstoned row that
+            // still owns the (namespace, slug) unique index is detected before the
+            // insert path runs — otherwise SQLite raises a raw unique-constraint
+            // error instead of a defined lifecycle error.
             let existing = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT id FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
+                    sql: "SELECT id, deleted_at FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 LIMIT 1".into(),
                     params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(slug.clone())],
                     label: None,
                 })
                 .await
                 .map_err(|e| sql_err("upsert_atoms lookup", e))?;
+            if let Some(row) = &existing {
+                if row_i64(row, "deleted_at").is_some() {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "atom slug {slug:?} was previously deleted; choose a new slug"
+                    )));
+                }
+            }
 
             let mut writer = sql
                 .writer()
@@ -242,14 +253,24 @@ impl KnowledgeHandlers {
                 .reader()
                 .await
                 .map_err(|e| sql_err("upsert_domains reader", e))?;
+            // Look up by slug WITHOUT the deleted_at filter so a tombstoned domain
+            // that still owns the (namespace, slug) unique index is detected before
+            // the insert path runs, instead of leaking a raw unique-constraint error.
             let existing = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT id FROM knowledge_domains WHERE namespace = ?1 AND slug = ?2 AND deleted_at IS NULL LIMIT 1".into(),
+                    sql: "SELECT id, deleted_at FROM knowledge_domains WHERE namespace = ?1 AND slug = ?2 LIMIT 1".into(),
                     params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(slug.clone())],
                     label: None,
                 })
                 .await
                 .map_err(|e| sql_err("upsert_domains lookup", e))?;
+            if let Some(row) = &existing {
+                if row_i64(row, "deleted_at").is_some() {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "domain slug {slug:?} was previously deleted; choose a new slug"
+                    )));
+                }
+            }
 
             let id = match &existing {
                 Some(row) => row_str(row, "id").ok_or_else(|| {

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -102,13 +102,23 @@ impl KnowledgeHandlers {
             // error instead of a defined lifecycle error.
             let existing = reader
                 .query_row(SqlStatement {
-                    sql: "SELECT id, deleted_at FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 LIMIT 1".into(),
+                    sql: "SELECT id, deleted_at, tags FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 LIMIT 1".into(),
                     params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(slug.clone())],
                     label: None,
                 })
                 .await
                 .map_err(|e| sql_err("upsert_atoms lookup", e))?;
             if let Some(row) = &existing {
+                // A domain's mirror atom shares the (namespace, slug) index with
+                // ordinary atoms. Reject here (mirroring the delete_atoms guard)
+                // so a plain upsert_atoms call can never blind-overwrite the
+                // mirror's tags/content and desynchronize it from its domain.
+                let existing_tags = row_str(row, "tags").unwrap_or_default();
+                if existing_tags.contains("type:domain") {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "atom slug {slug:?} collides with a domain mirror; use upsert_domains instead"
+                    )));
+                }
                 if row_i64(row, "deleted_at").is_some() {
                     return Err(RuntimeError::InvalidInput(format!(
                         "atom slug {slug:?} was previously deleted; choose a new slug"

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -251,94 +251,109 @@ impl KnowledgeHandlers {
                 .await
                 .map_err(|e| sql_err("upsert_domains lookup", e))?;
 
+            let id = match &existing {
+                Some(row) => row_str(row, "id").ok_or_else(|| {
+                    RuntimeError::Internal("missing id in existing domain row".into())
+                })?,
+                None => new_id(),
+            };
+
+            // Preflight: a normal atom (or a tombstoned atom that still owns the
+            // unique (namespace, slug) index) must never share this domain's slug.
+            // The mirror atom for THIS domain shares its id with the domain, so the
+            // collision is only real when the colliding row belongs to a different
+            // id. This must run BEFORE any write so a collision never leaves a
+            // partially-committed domain row behind.
+            let atom_collision = reader
+                .query_row(SqlStatement {
+                    sql:
+                        "SELECT id FROM knowledge_atoms WHERE namespace = ?1 AND slug = ?2 LIMIT 1"
+                            .into(),
+                    params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(slug.clone())],
+                    label: None,
+                })
+                .await
+                .map_err(|e| sql_err("upsert_domains atom collision check", e))?;
+            if let Some(row) = &atom_collision {
+                let collision_id = row_str(row, "id").ok_or_else(|| {
+                    RuntimeError::Internal("missing id in colliding atom row".into())
+                })?;
+                if collision_id != id {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "domain slug {slug:?} collides with an existing atom of the same slug"
+                    )));
+                }
+            }
+
+            // Mirror write is keyed by id (shared with the domain), never by slug —
+            // ON CONFLICT(namespace, slug) would blind-overwrite an unrelated atom
+            // that merely happens to share this slug.
+            let mirror_stmt = SqlStatement {
+                sql: "INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, properties, status, finalized, created_at, updated_at) \
+                      VALUES (?1,?2,?3,?4,?5,?6,?7,'reviewed',1,?8,?9) \
+                      ON CONFLICT(id) DO UPDATE SET slug=?3, name=?4, content=?5, tags=?6, properties=?7, status='reviewed', finalized=1, updated_at=?9".into(),
+                params: vec![
+                    SqlValue::Text(id.clone()),
+                    SqlValue::Text(ns.clone()),
+                    SqlValue::Text(slug.clone()),
+                    SqlValue::Text(name.clone()),
+                    SqlValue::Text(domain_in.description.clone().unwrap_or_default()),
+                    SqlValue::Text(tags_json.clone()),
+                    SqlValue::Text(properties_json.clone()),
+                    SqlValue::Integer(now),
+                    SqlValue::Integer(now),
+                ],
+                label: None,
+            };
+
             let mut writer = sql
                 .writer()
                 .await
                 .map_err(|e| sql_err("upsert_domains writer", e))?;
-            if let Some(row) = existing {
-                let id = row_str(&row, "id").ok_or_else(|| {
-                    RuntimeError::Internal("missing id in existing domain row".into())
-                })?;
+            if existing.is_some() {
+                let domain_stmt = SqlStatement {
+                    sql: "UPDATE knowledge_domains SET name=?1, description=?2, tags=?3, members=?4, updated_at=?5 WHERE id=?6 AND namespace=?7".into(),
+                    params: vec![
+                        SqlValue::Text(name.clone()),
+                        domain_in.description.as_ref().map_or(SqlValue::Null, |d| SqlValue::Text(d.clone())),
+                        SqlValue::Text(tags_json.clone()),
+                        SqlValue::Text(members_json.clone()),
+                        SqlValue::Integer(now),
+                        SqlValue::Text(id.clone()),
+                        SqlValue::Text(ns.clone()),
+                    ],
+                    label: None,
+                };
+                // Atomic: the canonical domain row and its FTS mirror atom are one
+                // logical record; a mirror-write failure must roll back the domain
+                // update too.
                 writer
-                    .execute(SqlStatement {
-                        sql: "UPDATE knowledge_domains SET name=?1, description=?2, tags=?3, members=?4, updated_at=?5 WHERE id=?6 AND namespace=?7".into(),
-                        params: vec![
-                            SqlValue::Text(name.clone()),
-                            domain_in.description.as_ref().map_or(SqlValue::Null, |d| SqlValue::Text(d.clone())),
-                            SqlValue::Text(tags_json.clone()),
-                            SqlValue::Text(members_json.clone()),
-                            SqlValue::Integer(now),
-                            SqlValue::Text(id.clone()),
-                            SqlValue::Text(ns.clone()),
-                        ],
-                        label: None,
-                    })
+                    .execute_batch(vec![domain_stmt, mirror_stmt])
                     .await
-                    .map_err(|e| sql_err("upsert_domains update", e))?;
-                // Dual-write: sync the mirror atom in knowledge_atoms for FTS.
-                // The domain's description text becomes the mirror atom's content.
-                writer
-                    .execute(SqlStatement {
-                        sql: "INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, properties, status, finalized, created_at, updated_at) \
-                              VALUES (?1,?2,?3,?4,?5,?6,?7,'reviewed',1,?8,?9) \
-                              ON CONFLICT(namespace, slug) DO UPDATE SET name=?4, content=?5, tags=?6, properties=?7, status='reviewed', updated_at=?9".into(),
-                        params: vec![
-                            SqlValue::Text(id),
-                            SqlValue::Text(ns.clone()),
-                            SqlValue::Text(slug.clone()),
-                            SqlValue::Text(name.clone()),
-                            SqlValue::Text(domain_in.description.clone().unwrap_or_default()),
-                            SqlValue::Text(tags_json.clone()),
-                            SqlValue::Text(properties_json.clone()),
-                            SqlValue::Integer(now),
-                            SqlValue::Integer(now),
-                        ],
-                        label: None,
-                    })
-                    .await
-                    .map_err(|e| sql_err("upsert_domains atom mirror update", e))?;
+                    .map_err(|e| sql_err("upsert_domains update batch", e))?;
                 updated += 1;
             } else {
-                let id = new_id();
+                let domain_stmt = SqlStatement {
+                    sql: "INSERT INTO knowledge_domains (id, namespace, slug, name, description, tags, members, created_at, updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)".into(),
+                    params: vec![
+                        SqlValue::Text(id.clone()),
+                        SqlValue::Text(ns.clone()),
+                        SqlValue::Text(slug.clone()),
+                        SqlValue::Text(name.clone()),
+                        domain_in.description.as_ref().map_or(SqlValue::Null, |d| SqlValue::Text(d.clone())),
+                        SqlValue::Text(tags_json.clone()),
+                        SqlValue::Text(members_json.clone()),
+                        SqlValue::Integer(now),
+                        SqlValue::Integer(now),
+                    ],
+                    label: None,
+                };
+                // Atomic: a mirror-insert failure must roll back the domain insert
+                // too, so no domain row is ever left committed without its mirror.
                 writer
-                    .execute(SqlStatement {
-                        sql: "INSERT INTO knowledge_domains (id, namespace, slug, name, description, tags, members, created_at, updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)".into(),
-                        params: vec![
-                            SqlValue::Text(id.clone()),
-                            SqlValue::Text(ns.clone()),
-                            SqlValue::Text(slug.clone()),
-                            SqlValue::Text(name.clone()),
-                            domain_in.description.as_ref().map_or(SqlValue::Null, |d| SqlValue::Text(d.clone())),
-                            SqlValue::Text(tags_json.clone()),
-                            SqlValue::Text(members_json.clone()),
-                            SqlValue::Integer(now),
-                            SqlValue::Integer(now),
-                        ],
-                        label: None,
-                    })
+                    .execute_batch(vec![domain_stmt, mirror_stmt])
                     .await
-                    .map_err(|e| sql_err("upsert_domains insert", e))?;
-                // Dual-write: mirror atom in knowledge_atoms for FTS indexing.
-                // The domain's description text becomes the mirror atom's content.
-                writer
-                    .execute(SqlStatement {
-                        sql: "INSERT INTO knowledge_atoms (id, namespace, slug, name, content, tags, properties, status, finalized, created_at, updated_at) \
-                              VALUES (?1,?2,?3,?4,?5,?6,?7,'reviewed',1,?8,?9)".into(),
-                        params: vec![
-                            SqlValue::Text(id),
-                            SqlValue::Text(ns.clone()),
-                            SqlValue::Text(slug.clone()),
-                            SqlValue::Text(name.clone()),
-                            SqlValue::Text(domain_in.description.clone().unwrap_or_default()),
-                            SqlValue::Text(tags_json.clone()),
-                            SqlValue::Text(properties_json.clone()),
-                            SqlValue::Integer(now),
-                            SqlValue::Integer(now),
-                        ],
-                        label: None,
-                    })
-                    .await
-                    .map_err(|e| sql_err("upsert_domains atom mirror insert", e))?;
+                    .map_err(|e| sql_err("upsert_domains insert batch", e))?;
                 created += 1;
             }
         }

--- a/crates/khive-pack-knowledge/src/knowledge/crud.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/crud.rs
@@ -593,6 +593,50 @@ impl KnowledgeHandlers {
         let now = now_us();
         let mut deleted = 0usize;
 
+        // Preflight the full request before mutating anything: knowledge.delete_atoms
+        // is documented as atom-only. A domain's canonical row and its FTS mirror
+        // atom share an id/slug, so deleting the mirror here would tombstone one
+        // half of the domain while leaving knowledge_domains live — a split-brain
+        // where direct lookup and search/suggest disagree. Domains must go through
+        // the generic delete verb, which deletes both halves together.
+        let mut reader = sql
+            .reader()
+            .await
+            .map_err(|e| sql_err("delete_atoms reader", e))?;
+        for id_or_slug in &p.ids {
+            let key = id_or_slug.trim().to_string();
+            let domain = reader
+                .query_row(SqlStatement {
+                    sql: "SELECT id FROM knowledge_domains WHERE namespace = ?1 AND (id = ?2 OR slug = ?2) AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(key.clone())],
+                    label: None,
+                })
+                .await
+                .map_err(|e| sql_err("delete_atoms domain preflight", e))?;
+            if domain.is_some() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "knowledge.delete_atoms cannot delete domain {key:?}; use the generic delete verb by domain UUID"
+                )));
+            }
+
+            let mirror = reader
+                .query_row(SqlStatement {
+                    sql: "SELECT tags FROM knowledge_atoms WHERE namespace = ?1 AND (id = ?2 OR slug = ?2) AND deleted_at IS NULL LIMIT 1".into(),
+                    params: vec![SqlValue::Text(ns.clone()), SqlValue::Text(key.clone())],
+                    label: None,
+                })
+                .await
+                .map_err(|e| sql_err("delete_atoms mirror preflight", e))?;
+            if let Some(row) = mirror {
+                let tags = row_str(&row, "tags").unwrap_or_default();
+                if tags.contains("type:domain") {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "knowledge.delete_atoms cannot delete domain mirror {key:?}; use the generic delete verb by domain UUID"
+                    )));
+                }
+            }
+        }
+
         let mut writer = sql
             .writer()
             .await

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -731,6 +731,62 @@ async fn upsert_domains_rejects_atom_slug_collision_without_partial_domain() {
     assert!(tags.iter().any(|t| t == "distinctive-tag"));
 }
 
+#[tokio::test]
+async fn upsert_atoms_rejects_domain_mirror_slug_collision_without_mutation() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{
+            "slug": "retrieval",
+            "name": "Retrieval",
+            "description": "Dense and sparse retrieval techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail —",
+        }] }),
+    )
+    .await
+    .expect("upsert domain");
+
+    // A plain upsert_atoms call targeting the domain's mirror slug must be
+    // rejected, not silently strip type:domain from the mirror's tags.
+    let err = f
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({ "atoms": [{
+                "slug": "retrieval",
+                "name": "Retrieval Atom Overwrite Attempt",
+                "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            }] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    // The domain mirror must be untouched: still classified as a domain by
+    // direct lookup and by search, with its original name intact.
+    let got = f
+        .dispatch("knowledge.get", json!({ "id": "retrieval" }))
+        .await
+        .expect("get must still resolve the domain");
+    assert_eq!(got["kind"], "domain");
+    assert_eq!(got["name"], "Retrieval");
+
+    let search = f
+        .dispatch(
+            "knowledge.search",
+            json!({ "query": "retrieval", "type": "domain", "rerank": false }),
+        )
+        .await
+        .expect("search ok");
+    let results = search["results"].as_array().expect("results array");
+    assert!(
+        results.iter().any(|r| r["slug"] == "retrieval"),
+        "search must still find the domain, not a demoted atom: {results:?}"
+    );
+}
+
 // ── knowledge.get ─────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -689,6 +689,44 @@ async fn get_returns_not_found_for_unknown_slug() {
     );
 }
 
+#[tokio::test]
+async fn get_by_domain_uuid_returns_canonical_domain_not_mirror_atom() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({
+            "domains": [
+                { "slug": "uuid-domain", "name": "UUID Domain", "description": "Retrieval techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques", "members": ["rag"] }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert_domains ok");
+
+    // Resolve the domain's UUID via the slug path (already correct).
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": "uuid-domain" }))
+        .await
+        .expect("get by slug ok");
+    assert_eq!(by_slug["kind"], "domain");
+    let uuid = by_slug["id"].as_str().expect("id string").to_string();
+
+    // The UUID path must agree with the slug path: canonical domain, not the mirror atom.
+    let by_uuid = f
+        .dispatch("knowledge.get", json!({ "id": uuid }))
+        .await
+        .expect("get by uuid ok");
+    assert_eq!(
+        by_uuid["kind"], "domain",
+        "UUID lookup must return the canonical domain, got: {by_uuid}"
+    );
+    let members = by_uuid["members"]
+        .as_array()
+        .expect("members must be present and an array");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0], "rag");
+}
+
 // ── knowledge.get + include_sections ─────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1198,6 +1198,128 @@ async fn delete_atoms_returns_zero_for_unknown_slug() {
     assert_eq!(resp["deleted"], 0);
 }
 
+#[tokio::test]
+async fn delete_atoms_rejects_domain_mirror_slug_without_mutation() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{ "slug": "retrieval", "name": "Retrieval", "description": "Dense and sparse retrieval techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail —" }] }),
+    )
+    .await
+    .expect("upsert domain");
+
+    let err = f
+        .dispatch("knowledge.delete_atoms", json!({ "ids": ["retrieval"] }))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    // Direct lookup and search must agree: the domain is present on both paths.
+    let got = f
+        .dispatch("knowledge.get", json!({ "id": "retrieval" }))
+        .await
+        .expect("get must still resolve the domain");
+    assert_eq!(got["kind"], "domain");
+    assert!(got["members"].is_array());
+
+    let search = f
+        .dispatch(
+            "knowledge.search",
+            json!({ "query": "retrieval", "type": "domain", "rerank": false }),
+        )
+        .await
+        .expect("search ok");
+    let results = search["results"].as_array().expect("results array");
+    assert!(
+        results.iter().any(|r| r["slug"] == "retrieval"),
+        "search must still find the domain: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_atoms_rejects_domain_mirror_uuid_without_mutation() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{ "slug": "embedding-theory", "name": "Embedding Theory", "description": "vector embedding concepts — covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts" }] }),
+    )
+    .await
+    .expect("upsert domain");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": "embedding-theory" }))
+        .await
+        .expect("get domain by slug");
+    let uuid = by_slug["id"].as_str().expect("id string").to_string();
+
+    let err = f
+        .dispatch("knowledge.delete_atoms", json!({ "ids": [uuid.clone()] }))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    // Direct lookup by UUID must agree with search: both say the domain is present.
+    let got = f
+        .dispatch("knowledge.get", json!({ "id": uuid }))
+        .await
+        .expect("get must still resolve the domain by uuid");
+    assert_eq!(got["kind"], "domain");
+
+    let search = f
+        .dispatch(
+            "knowledge.search",
+            json!({ "query": "embedding", "type": "domain", "rerank": false }),
+        )
+        .await
+        .expect("search ok");
+    let results = search["results"].as_array().expect("results array");
+    assert!(
+        results.iter().any(|r| r["slug"] == "embedding-theory"),
+        "search must still find the domain: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_atoms_mixed_request_with_domain_mirror_leaves_normal_atom_live() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "normal-atom", "name": "Normal Atom", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+    )
+    .await
+    .expect("seed atom");
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{ "slug": "mixed-domain", "name": "Mixed Domain", "description": "Mixed domain techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques" }] }),
+    )
+    .await
+    .expect("seed domain");
+
+    let err = f
+        .dispatch(
+            "knowledge.delete_atoms",
+            json!({ "ids": ["normal-atom", "mixed-domain"] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "normal-atom" }))
+        .await
+        .expect("normal atom must remain live after the rejected mixed request");
+    assert_eq!(atom["kind"], "atom");
+}
+
 // ── stats ──────────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -2226,6 +2226,107 @@ async fn upsert_domains_clean_slug_passes() {
     );
 }
 
+// ── #441: soft-deleted slugs cannot be upserted again ────────────────────────
+
+/// Soft-deleting an atom's slug and then upserting the same slug again must
+/// return a clean lifecycle error, never a raw SQLite unique-constraint error.
+#[tokio::test]
+async fn upsert_atoms_rejects_reuse_of_soft_deleted_slug_cleanly() {
+    let f = pack(rt());
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{ "slug": "draft-guide", "name": "Draft Guide", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+    )
+    .await
+    .expect("seed atom");
+
+    f.dispatch("knowledge.delete_atoms", json!({ "ids": ["draft-guide"] }))
+        .await
+        .expect("soft delete atom");
+
+    let err = f
+        .dispatch(
+            "knowledge.upsert_atoms",
+            json!({ "atoms": [{ "slug": "draft-guide", "name": "Draft Guide Reborn", "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("deleted") || msg.contains("previously deleted"),
+        "error should explain the slug was previously deleted: {msg}"
+    );
+    let lower = msg.to_lowercase();
+    assert!(
+        !lower.contains("unique") && !lower.contains("constraint") && !lower.contains("sqlite"),
+        "no raw SQLite unique-constraint wording may leak to the caller: {msg}"
+    );
+}
+
+/// Soft-deleting a domain (via the generic delete verb, which tombstones both
+/// the canonical domain row and its mirror atom) and then upserting the same
+/// slug again must return a clean lifecycle error, never a raw SQLite error.
+#[tokio::test]
+async fn upsert_domains_rejects_reuse_of_soft_deleted_slug_cleanly() {
+    let f = pack_via_registry(rt());
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({ "domains": [{ "slug": "draft-domain", "name": "Draft Domain", "description": "Draft domain techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques" }] }),
+    )
+    .await
+    .expect("seed domain");
+
+    let by_slug = f
+        .dispatch("knowledge.get", json!({ "id": "draft-domain" }))
+        .await
+        .expect("get domain before delete");
+    let uuid = by_slug["id"].as_str().expect("id string").to_string();
+
+    // Soft-delete via the generic delete verb, not knowledge.delete_atoms.
+    f.dispatch("delete", json!({ "id": uuid }))
+        .await
+        .expect("generic soft delete domain");
+
+    let err = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({ "domains": [{ "slug": "draft-domain", "name": "Draft Domain Reborn", "description": "Draft domain techniques — covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques" }] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("deleted") || msg.contains("previously deleted"),
+        "error should explain the slug was previously deleted: {msg}"
+    );
+    let lower = msg.to_lowercase();
+    assert!(
+        !lower.contains("unique")
+            && !lower.contains("constraint")
+            && !lower.contains("sqlite")
+            && !lower.contains("knowledge_domains")
+            && !lower.contains("knowledge_atoms"),
+        "no raw SQLite unique-constraint wording may leak to the caller: {msg}"
+    );
+
+    // The rejected reuse must not resurrect the tombstoned domain.
+    let not_found = f
+        .dispatch("knowledge.get", json!({ "id": "draft-domain" }))
+        .await;
+    assert!(
+        matches!(not_found, Err(RuntimeError::NotFound(_))),
+        "expected NotFound after rejected reuse, got: {not_found:?}"
+    );
+}
+
 // ── resolver e2e tests (ADR-061): registry wired via PackRegistry::register_packs ────────
 
 /// Build a VerbRegistry the same way the production MCP server does: via

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -654,6 +654,83 @@ async fn upsert_domains_rejects_empty_list() {
     assert!(err.to_string().contains("must not be empty"), "got: {err}");
 }
 
+#[tokio::test]
+async fn upsert_domains_rejects_atom_slug_collision_without_partial_domain() {
+    let f = pack(rt());
+
+    // Seed a normal atom that owns the slug the domain upsert will collide on.
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({ "atoms": [{
+            "slug": "shared-slug",
+            "name": "Original Atom Name",
+            "content": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+            "tags": ["distinctive-tag"],
+        }] }),
+    )
+    .await
+    .expect("seed atom");
+
+    let err = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({ "domains": [{
+                "slug": "shared-slug",
+                "name": "Colliding Domain",
+                "description": "covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques",
+            }] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    // No domain row must exist after the rejected upsert (no partial commit).
+    let domains = f
+        .dispatch("knowledge.list", json!({ "type": "domain" }))
+        .await
+        .expect("list domains ok");
+    let results = domains["results"].as_array().expect("results array");
+    assert!(
+        results
+            .iter()
+            .all(|d| d["slug"].as_str() != Some("shared-slug")),
+        "no domain with slug 'shared-slug' should exist after rejected collision: {results:?}"
+    );
+
+    // Retry — still rejected, and the original atom is untouched.
+    let err2 = f
+        .dispatch(
+            "knowledge.upsert_domains",
+            json!({ "domains": [{
+                "slug": "shared-slug",
+                "name": "Colliding Domain Retry",
+                "description": "covering concepts techniques algorithms implementations applications use cases and design patterns in detail — covering concepts techniques",
+            }] }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err2, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput on retry, got: {err2:?}"
+    );
+
+    let atom = f
+        .dispatch("knowledge.get", json!({ "id": "shared-slug" }))
+        .await
+        .expect("original atom still resolvable");
+    assert_eq!(atom["kind"], "atom");
+    assert_eq!(atom["name"], "Original Atom Name");
+    assert_eq!(
+        atom["content"],
+        "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+    );
+    let tags = atom["tags"].as_array().expect("tags array");
+    assert!(tags.iter().any(|t| t == "distinctive-tag"));
+}
+
 // ── knowledge.get ─────────────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes 4 audit findings in `khive-pack-knowledge` (#426, #427, #428, #441):

- **#426**: `get()` UUID branch queried `knowledge_atoms` before `knowledge_domains`, so a domain UUID resolved to its own mirror atom instead of the canonical domain. Reordered to match the slug branch + `PackByIdResolver`.
- **#427**: domain row + mirror atom were written as two separate non-atomic `execute()` calls, with a blind `ON CONFLICT(namespace, slug)` retry path. Now: preflight rejects any foreign-id slug collision before any write; domain+mirror written in one `execute_batch` (BEGIN IMMEDIATE/COMMIT, rolls back on failure); mirror conflict keyed by `id`, never `slug`.
- **#428**: `delete_atoms` could tombstone a domain's mirror atom directly, leaving `knowledge_domains` live (split-brain). Now: full-request preflight rejects the whole request if any target names a live domain or its mirror, with zero mutation on rejection.
- **#441**: soft-deleted slugs still owned the non-partial `(namespace, slug)` unique index, so reuse raised a raw SQLite unique-constraint error. Both `upsert_atoms`/`upsert_domains` now look up without the `deleted_at IS NULL` filter and return a clean `InvalidInput` before insert.

## Verification
- Adversarial source-grounded review: approved, 0 CRIT/MAJ/MIN — confirmed all 4 root causes against committed source (not reports), verified #427's atomicity via `khive-db/src/sql_bridge.rs` batch semantics, verified #428's get/search agreement, verified #441 leaks no raw SQLite text.
- `cargo test -p khive-pack-knowledge --all-targets`: 210 passed, 0 failed (60 unit + 1 bench-smoke + 6 feedback + 64 fixes + 79 integration).
- `cargo clippy -p khive-pack-knowledge --all-targets -- -D warnings`: clean.
- `cargo fmt -p khive-pack-knowledge -- --check`: clean.
- `cargo check --workspace`: clean.

Independent adversarial review is queued and will be reported before merge.

Note: `benches/search_latency.rs` panics on seed-fixture word-count validation (`InvalidInput("atom content must be at least 20 words (got 10)")) — confirmed **pre-existing on origin/main**, unrelated to this fix, and outside the standard gate (`cargo test -p <crate>` without `--all-targets` never runs it). Not fixed here; will file as a separate hygiene issue.
