### PR TITLE
fix(merge): entity_type diff parity, duplicate/swapped edge rejection, shortcut dangling-edge validation

### DIFF
--- a/crates/khive-merge/README.md
+++ b/crates/khive-merge/README.md
@@ -31,8 +31,9 @@ fn merge(base: &KgArchive, ours: &KgArchive, theirs: &KgArchive) {
 }
 ```
 
-`SnapshotMergeStrategy::Ours` / `Theirs` skip conflict detection entirely and apply a
-last-write-wins shortcut instead — always `Clean`. `SnapshotMergeStrategy::Auto` runs the
+`SnapshotMergeStrategy::Ours` / `Theirs` skip field conflict detection and apply a
+last-write-wins shortcut, then report `DanglingEdge` conflicts if the shortcut output
+would reference missing endpoints. `SnapshotMergeStrategy::Auto` runs the
 full three-way algorithm: entity pass, edge pass, dangling-edge validation, deterministic
 sort, and returns `MergeResult::Conflicts` if anything needs a human. The free function
 `khive_merge::three_way_merge(base, ours, theirs, strategy)` is the same algorithm without

--- a/crates/khive-merge/src/diff_local.rs
+++ b/crates/khive-merge/src/diff_local.rs
@@ -166,6 +166,7 @@ pub fn diff_edges(
 fn entities_equal(a: &ExportedEntity, b: &ExportedEntity) -> bool {
     a.id == b.id
         && a.kind == b.kind
+        && a.entity_type == b.entity_type
         && a.name == b.name
         && a.description == b.description
         && a.tags == b.tags
@@ -173,7 +174,10 @@ fn entities_equal(a: &ExportedEntity, b: &ExportedEntity) -> bool {
 }
 
 /// Property equality check; shared with entity.rs for duplicate-addition detection.
-pub(crate) fn properties_equal(a: &Option<serde_json::Value>, b: &Option<serde_json::Value>) -> bool {
+pub(crate) fn properties_equal(
+    a: &Option<serde_json::Value>,
+    b: &Option<serde_json::Value>,
+) -> bool {
     match (a, b) {
         (None, None) => true,
         (Some(av), Some(bv)) => av == bv,

--- a/crates/khive-merge/src/diff_local.rs
+++ b/crates/khive-merge/src/diff_local.rs
@@ -64,10 +64,20 @@ pub struct EdgeKey {
 
 impl EdgeKey {
     /// Construct an `EdgeKey` from a `ExportedEdge` by cloning its identity fields.
+    ///
+    /// Symmetric relations (e.g. `competes_with`, `composed_with`) canonicalize
+    /// endpoints to `min(source, target)`/`max(source, target)` (ADR-002) so that
+    /// a swapped-order duplicate collides with the original in the key's hash/eq.
     pub fn from_edge(e: &ExportedEdge) -> Self {
+        let (source, target) = if e.relation.is_symmetric() && e.target < e.source {
+            (e.target, e.source)
+        } else {
+            (e.source, e.target)
+        };
+
         Self {
-            source: e.source,
-            target: e.target,
+            source,
+            target,
             relation: e.relation.to_string(),
         }
     }

--- a/crates/khive-merge/src/entity.rs
+++ b/crates/khive-merge/src/entity.rs
@@ -186,6 +186,16 @@ fn field_level_merge(
         });
     }
 
+    // Entity type: governed subtype field; use the existing generic value conflict payload.
+    if ours.entity_type != theirs.entity_type {
+        conflicts.push(MergeConflict::PropertyMismatch {
+            entity_id: id,
+            key: "entity_type".into(),
+            ours: serde_json::json!(&ours.entity_type),
+            theirs: serde_json::json!(&theirs.entity_type),
+        });
+    }
+
     // Description: ours wins (annotation, not identity).
     if ours.description != theirs.description {
         // Auto-resolved: keep ours (no conflict).
@@ -280,6 +290,9 @@ fn detect_entity_diffs(ours: &ExportedEntity, theirs: &ExportedEntity) -> Vec<St
     }
     if ours.kind != theirs.kind {
         diffs.push("kind".into());
+    }
+    if ours.entity_type != theirs.entity_type {
+        diffs.push("entity_type".into());
     }
     if ours.description != theirs.description {
         diffs.push("description".into());

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -61,15 +61,26 @@ fn validate_archive(archive: &KgArchive) -> Result<(), MergeError> {
         }
     }
 
-    // Reject duplicate edge natural keys.
+    // Reject duplicate edge IDs.
+    let mut edge_ids: HashSet<Uuid> = HashSet::with_capacity(archive.edges.len());
+    for edge in &archive.edges {
+        if !edge_ids.insert(edge.edge_id) {
+            return Err(MergeError::Internal(format!(
+                "duplicate edge IDs in archive: {}",
+                edge.edge_id
+            )));
+        }
+    }
+
+    // Reject duplicate edge semantic keys.
     let mut edge_keys: HashSet<EdgeKey> = HashSet::with_capacity(archive.edges.len());
     for edge in &archive.edges {
         let key = EdgeKey::from_edge(edge);
         if !edge_keys.insert(key.clone()) {
             return Err(MergeError::DuplicateEdgeKey {
-                edge_source: edge.source,
-                edge_target: edge.target,
-                edge_relation: edge.relation.to_string(),
+                edge_source: key.source,
+                edge_target: key.target,
+                edge_relation: key.relation,
             });
         }
     }

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -112,7 +112,9 @@ fn deterministic_timestamp(ours: &KgArchive, theirs: &KgArchive) -> chrono::Date
 /// Perform a three-way merge.
 ///
 /// - `Auto`: validate → entity pass → edge pass → dangling validation → deterministic sort → `Conflicts` or `Clean`.
-/// - `Ours`/`Theirs`: validate → last-write-wins shortcut → deterministic sort → always returns `Clean`.
+/// - `Ours`/`Theirs`: validate → last-write-wins shortcut (skips field conflict detection) →
+///   deterministic sort → dangling-edge validation against the shortcut-composed entity set,
+///   returning `Conflicts` if the shortcut output would reference a missing endpoint, else `Clean`.
 pub fn three_way_merge(
     base: &KgArchive,
     ours: &KgArchive,

--- a/crates/khive-merge/src/merge.rs
+++ b/crates/khive-merge/src/merge.rs
@@ -123,20 +123,37 @@ pub fn three_way_merge(
 
     match strategy {
         SnapshotMergeStrategy::Ours => {
-            let mut merged = apply_ours(base, ours, theirs);
-            sort_entities(&mut merged);
-            sort_edges(&mut merged.edges);
-            merged.exported_at = deterministic_timestamp(ours, theirs);
-            Ok(MergeResult::Clean { merged })
+            let merged = apply_ours(base, ours, theirs);
+            finish_shortcut_merge(merged, ours, theirs)
         }
         SnapshotMergeStrategy::Theirs => {
-            let mut merged = apply_theirs(base, ours, theirs);
-            sort_entities(&mut merged);
-            sort_edges(&mut merged.edges);
-            merged.exported_at = deterministic_timestamp(ours, theirs);
-            Ok(MergeResult::Clean { merged })
+            let merged = apply_theirs(base, ours, theirs);
+            finish_shortcut_merge(merged, ours, theirs)
         }
         SnapshotMergeStrategy::Auto => three_way_merge_auto(base, ours, theirs),
+    }
+}
+
+/// Finish a last-write-wins shortcut merge: sort, stamp, then check that the
+/// shortcut-composed archive has no dangling edge endpoints before labeling
+/// the result `Clean`.
+fn finish_shortcut_merge(
+    mut merged: KgArchive,
+    ours: &KgArchive,
+    theirs: &KgArchive,
+) -> Result<MergeResult, MergeError> {
+    sort_entities(&mut merged);
+    sort_edges(&mut merged.edges);
+    merged.exported_at = deterministic_timestamp(ours, theirs);
+
+    let entity_id_set: HashSet<Uuid> = merged.entities.iter().map(|e| e.id).collect();
+    let dangling = validate_dangling_edges(&merged.edges, &entity_id_set);
+    if dangling.is_empty() {
+        Ok(MergeResult::Clean { merged })
+    } else {
+        Ok(MergeResult::Conflicts {
+            conflicts: dangling,
+        })
     }
 }
 

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -1009,6 +1009,110 @@ fn duplicate_uuid_different_entity_type_is_conflict() {
     }
 }
 
+// ── #455: duplicate edge_id and symmetric duplicate identity validation ────
+
+#[test]
+fn rejects_duplicate_edge_ids_in_archive() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    let d = Uuid::new_v4();
+    let dup_id = Uuid::new_v4();
+
+    let entities = vec![
+        entity(a, "A"),
+        entity(b, "B"),
+        entity(c, "C"),
+        entity(d, "D"),
+    ];
+    let base = archive_full(vec![], vec![]);
+    let mut ours = archive_full(entities, vec![]);
+    ours.edges = vec![
+        ExportedEdge {
+            edge_id: dup_id,
+            source: a,
+            target: b,
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+        },
+        ExportedEdge {
+            edge_id: dup_id,
+            source: c,
+            target: d,
+            relation: EdgeRelation::DependsOn,
+            weight: 1.0,
+        },
+    ];
+    let theirs = archive_full(vec![], vec![]);
+
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
+    match err {
+        MergeError::Internal(msg) => {
+            assert!(
+                msg.contains("duplicate edge IDs") && msg.contains(&dup_id.to_string()),
+                "expected message mentioning duplicate edge IDs and the UUID, got: {msg}"
+            );
+        }
+        other => panic!("expected MergeError::Internal, got: {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_swapped_symmetric_duplicate_edges_in_archive() {
+    let (lo, hi) = {
+        let x = Uuid::new_v4();
+        let y = Uuid::new_v4();
+        if x < y {
+            (x, y)
+        } else {
+            (y, x)
+        }
+    };
+
+    let entities = vec![entity(lo, "A"), entity(hi, "B")];
+    let base = archive_full(vec![], vec![]);
+    let ours = archive_full(
+        entities,
+        vec![
+            ExportedEdge {
+                edge_id: Uuid::new_v4(),
+                source: lo,
+                target: hi,
+                relation: EdgeRelation::CompetesWith,
+                weight: 1.0,
+            },
+            ExportedEdge {
+                edge_id: Uuid::new_v4(),
+                source: hi,
+                target: lo,
+                relation: EdgeRelation::CompetesWith,
+                weight: 1.0,
+            },
+        ],
+    );
+    let theirs = archive_full(vec![], vec![]);
+
+    let err = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap_err();
+    match err {
+        MergeError::DuplicateEdgeKey {
+            edge_source,
+            edge_target,
+            edge_relation,
+        } => {
+            assert_eq!(
+                edge_source, lo,
+                "canonical source must be min(source, target)"
+            );
+            assert_eq!(
+                edge_target, hi,
+                "canonical target must be max(source, target)"
+            );
+            assert_eq!(edge_relation, "competes_with");
+        }
+        other => panic!("expected MergeError::DuplicateEdgeKey, got: {other:?}"),
+    }
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 fn archive_with_entities(entities: Vec<ExportedEntity>) -> KgArchive {

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -37,6 +37,12 @@ fn entity(id: Uuid, name: &str) -> ExportedEntity {
     }
 }
 
+fn entity_with_type(id: Uuid, name: &str, entity_type: Option<&str>) -> ExportedEntity {
+    let mut e = entity(id, name);
+    e.entity_type = entity_type.map(|s| s.to_string());
+    e
+}
+
 fn edge(src: Uuid, tgt: Uuid) -> ExportedEdge {
     ExportedEdge {
         edge_id: Uuid::new_v4(),
@@ -922,6 +928,85 @@ fn diff_weight_modified_edge() {
         relation: "extends".into(),
     };
     assert!(matches!(diff[&key], EdgeChange::WeightModified { .. }));
+}
+
+// ── #454: entity_type must participate in diff and merge ───────────────────
+
+#[test]
+fn diff_entity_type_change_is_modified() {
+    use khive_merge::diff_local::{diff_entities, EntityChange};
+    let id = Uuid::new_v4();
+    let base = archive_with_entities(vec![entity_with_type(id, "FlashAttention", None)]);
+    let branch = archive_with_entities(vec![entity_with_type(
+        id,
+        "FlashAttention",
+        Some("algorithm"),
+    )]);
+    let diff = diff_entities(&base, &branch);
+    assert!(
+        matches!(diff[&id], EntityChange::Modified { .. }),
+        "entity_type-only change must be classified Modified, got: {:?}",
+        diff[&id]
+    );
+}
+
+#[test]
+fn auto_merge_preserves_single_sided_entity_type_change() {
+    let id = Uuid::new_v4();
+    let base = archive_with_entities(vec![entity_with_type(id, "U", None)]);
+    let ours = archive_with_entities(vec![entity_with_type(id, "U", Some("algorithm"))]);
+    let theirs = archive_with_entities(vec![entity_with_type(id, "U", None)]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+    if let MergeResult::Clean { merged } = result {
+        assert_eq!(
+            merged.entities[0].entity_type,
+            Some("algorithm".to_string()),
+            "single-sided entity_type change must survive the merge"
+        );
+    } else {
+        panic!("expected Clean, got Conflicts");
+    }
+}
+
+#[test]
+fn auto_merge_conflicts_on_divergent_entity_type_changes() {
+    let id = Uuid::new_v4();
+    let base = archive_with_entities(vec![entity_with_type(id, "U", None)]);
+    let ours = archive_with_entities(vec![entity_with_type(id, "U", Some("algorithm"))]);
+    let theirs = archive_with_entities(vec![entity_with_type(id, "U", Some("technique"))]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+    assert!(matches!(result, MergeResult::Conflicts { .. }));
+    if let MergeResult::Conflicts { conflicts } = result {
+        assert!(
+            conflicts.iter().any(
+                |c| matches!(c, MergeConflict::PropertyMismatch { key, .. } if key == "entity_type")
+            ),
+            "expected PropertyMismatch{{key: \"entity_type\"}}, got: {conflicts:?}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_uuid_different_entity_type_is_conflict() {
+    let id = Uuid::new_v4();
+    let base = archive_with_entities(vec![]);
+    let ours = archive_with_entities(vec![entity_with_type(id, "U", Some("algorithm"))]);
+    let theirs = archive_with_entities(vec![entity_with_type(id, "U", Some("technique"))]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Auto).unwrap();
+    assert!(matches!(result, MergeResult::Conflicts { .. }));
+    if let MergeResult::Conflicts { conflicts } = result {
+        assert!(
+            conflicts.iter().any(|c| matches!(
+                c,
+                MergeConflict::DuplicateAddition { differing_fields, .. }
+                    if differing_fields.contains(&"entity_type".to_string())
+            )),
+            "expected DuplicateAddition with entity_type in differing_fields, got: {conflicts:?}"
+        );
+    }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/crates/khive-merge/tests/three_way_merge.rs
+++ b/crates/khive-merge/tests/three_way_merge.rs
@@ -1113,6 +1113,60 @@ fn rejects_swapped_symmetric_duplicate_edges_in_archive() {
     }
 }
 
+// ── #456: shortcut strategies must not report dangling edges as Clean ──────
+
+#[test]
+fn ours_strategy_reports_dangling_edge_after_shortcut() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+
+    let base = archive_full(vec![entity(a, "A")], vec![]);
+    // ours deletes A and has no edges.
+    let ours = archive_full(vec![], vec![]);
+    // theirs retains A, adds B, and adds edge B -> A.
+    let theirs = archive_full(vec![entity(a, "A"), entity(b, "B")], vec![edge(b, a)]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Ours).unwrap();
+    assert!(
+        matches!(result, MergeResult::Conflicts { .. }),
+        "shortcut merge with a dangling edge must not be Clean"
+    );
+    if let MergeResult::Conflicts { conflicts } = result {
+        assert!(
+            conflicts.iter().any(
+                |c| matches!(c, MergeConflict::DanglingEdge { missing_endpoint, .. } if *missing_endpoint == a)
+            ),
+            "expected DanglingEdge for missing entity A, got: {conflicts:?}"
+        );
+    }
+}
+
+#[test]
+fn theirs_strategy_reports_dangling_edge_after_shortcut() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+
+    let base = archive_full(vec![entity(a, "A")], vec![]);
+    // theirs deletes A and has no edges.
+    let theirs = archive_full(vec![], vec![]);
+    // ours retains A, adds B, and adds edge B -> A.
+    let ours = archive_full(vec![entity(a, "A"), entity(b, "B")], vec![edge(b, a)]);
+
+    let result = three_way_merge(&base, &ours, &theirs, SnapshotMergeStrategy::Theirs).unwrap();
+    assert!(
+        matches!(result, MergeResult::Conflicts { .. }),
+        "shortcut merge with a dangling edge must not be Clean"
+    );
+    if let MergeResult::Conflicts { conflicts } = result {
+        assert!(
+            conflicts.iter().any(
+                |c| matches!(c, MergeConflict::DanglingEdge { missing_endpoint, .. } if *missing_endpoint == a)
+            ),
+            "expected DanglingEdge for missing entity A, got: {conflicts:?}"
+        );
+    }
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 fn archive_with_entities(entities: Vec<ExportedEntity>) -> KgArchive {


### PR DESCRIPTION
## Summary
Fixes 3 audit findings in `khive-merge` (#454, #455, #456):

- **#454**: entity diff/merge omitted `entity_type` from the compared/merged fields, so subtype changes (e.g. `theorem` -> `axiom`) were silently dropped across a merge.
- **#455**: duplicate `edge_id`s, and symmetric edges with swapped source/target representing the same logical edge, were not rejected — could double-count or silently collide.
- **#456**: the `Ours`/`Theirs` merge shortcuts could produce dangling edges (referencing a pruned-side entity) while still reporting `Clean`; now validated before the Clean verdict is returned.

## Verification
- Adversarial review: approved with fixes — 1 Low finding (a stale rustdoc comment on the Ours/Theirs shortcut's Clean claim), fixed in `3438406e` and re-verified.
- `cargo test` (standalone workspace): 83 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.

This branch was fully gated and pushed earlier but did not get a PR opened — landing it now as part of closing out untracked backlog work.
