### PR TITLE
fix(vcs): NDJSON validation, atomic remote-cache publish, RemoteName hardening, adapter field preservation

### DIFF
--- a/crates/khive-vcs-adapters/src/json_adapter.rs
+++ b/crates/khive-vcs-adapters/src/json_adapter.rs
@@ -69,7 +69,7 @@ impl JsonFormatAdapter {
             });
 
             if has_source && has_target {
-                edges.push(parse_edge(index, obj));
+                edges.push(parse_edge(index, obj, &mut warnings));
             } else {
                 entities.push(parse_entity(index, obj, &mut warnings));
             }
@@ -199,15 +199,49 @@ fn parse_entity(
 ) -> Result<EntityRecord, AdapterError> {
     let name = extract_required_string(&mut obj, index, "name")?;
 
-    let kind = {
-        let raw = extract_required_string(&mut obj, index, "kind")?;
-        EntityKind::from_str(&raw)
-            .map_err(|_| AdapterError::UnknownKind {
-                index,
-                kind: raw.clone(),
-            })?
-            .name()
-            .to_owned()
+    let raw_kind = extract_required_string(&mut obj, index, "kind")?;
+    let kind = EntityKind::from_str(&raw_kind)
+        .map_err(|_| AdapterError::UnknownKind {
+            index,
+            kind: raw_kind.clone(),
+        })?
+        .name()
+        .to_owned();
+
+    // ADR-020 subtype: prefer an explicit `entity_type`, else preserve a
+    // `kind="paper"`-style alias (which `EntityKind::from_str` canonicalizes
+    // to the base kind "document") as `entity_type="paper"`.
+    let entity_type = match remove_ci(&mut obj, "entity_type") {
+        Some((_, Value::String(s))) => Some(s),
+        Some(_) => {
+            warnings.push(format!(
+                "record {index}: 'entity_type' is not a string; ignored"
+            ));
+            None
+        }
+        None if raw_kind.trim().eq_ignore_ascii_case("paper") => Some("paper".to_string()),
+        None => None,
+    };
+
+    let created_at = match remove_ci(&mut obj, "created_at") {
+        Some((_, Value::String(s))) => Some(s),
+        Some(_) => {
+            warnings.push(format!(
+                "record {index}: 'created_at' is not a string; ignored"
+            ));
+            None
+        }
+        None => None,
+    };
+    let updated_at = match remove_ci(&mut obj, "updated_at") {
+        Some((_, Value::String(s))) => Some(s),
+        Some(_) => {
+            warnings.push(format!(
+                "record {index}: 'updated_at' is not a string; ignored"
+            ));
+            None
+        }
+        None => None,
     };
 
     let id = extract_uuid_field(&mut obj, index, "id")?;
@@ -259,16 +293,20 @@ fn parse_entity(
     Ok(EntityRecord {
         id,
         kind,
+        entity_type,
         name,
         description,
         properties: Value::Object(props_base),
         tags,
+        created_at,
+        updated_at,
     })
 }
 
 fn parse_edge(
     index: usize,
     mut obj: serde_json::Map<String, Value>,
+    warnings: &mut Vec<String>,
 ) -> Result<EdgeRecord, AdapterError> {
     let source = remove_ci(&mut obj, "source")
         .or_else(|| remove_ci(&mut obj, "from"))
@@ -317,6 +355,27 @@ fn parse_edge(
 
     let weight = extract_weight(&mut obj, index)?;
 
+    let created_at = match remove_ci(&mut obj, "created_at") {
+        Some((_, Value::String(s))) => Some(s),
+        Some(_) => {
+            warnings.push(format!(
+                "record {index}: edge 'created_at' is not a string; ignored"
+            ));
+            None
+        }
+        None => None,
+    };
+    let updated_at = match remove_ci(&mut obj, "updated_at") {
+        Some((_, Value::String(s))) => Some(s),
+        Some(_) => {
+            warnings.push(format!(
+                "record {index}: edge 'updated_at' is not a string; ignored"
+            ));
+            None
+        }
+        None => None,
+    };
+
     let mut properties = match remove_ci(&mut obj, "properties") {
         Some((_, Value::Object(m))) => m,
         Some(_) | None => serde_json::Map::new(),
@@ -332,6 +391,8 @@ fn parse_edge(
         relation,
         weight,
         properties: Value::Object(properties),
+        created_at,
+        updated_at,
     })
 }
 

--- a/crates/khive-vcs-adapters/src/json_adapter.rs
+++ b/crates/khive-vcs-adapters/src/json_adapter.rs
@@ -49,11 +49,11 @@ impl JsonFormatAdapter {
             let obj = match item {
                 Value::Object(m) => m,
                 other => {
-                    warnings.push(format!(
-                        "record {index}: expected an object, got {}; skipped",
-                        other.type_str()
-                    ));
-                    continue;
+                    return Err(AdapterError::InvalidField {
+                        index,
+                        field: "$record".into(),
+                        reason: format!("expected object, got {}", other.type_str()),
+                    })
                 }
             };
 
@@ -378,7 +378,14 @@ fn parse_edge(
 
     let mut properties = match remove_ci(&mut obj, "properties") {
         Some((_, Value::Object(m))) => m,
-        Some(_) | None => serde_json::Map::new(),
+        Some((_, other)) => {
+            warnings.push(format!(
+                "record {index}: edge 'properties' is not an object (got {}); ignored",
+                other.type_str()
+            ));
+            serde_json::Map::new()
+        }
+        None => serde_json::Map::new(),
     };
     for (k, v) in obj {
         properties.insert(k, v);

--- a/crates/khive-vcs-adapters/src/record.rs
+++ b/crates/khive-vcs-adapters/src/record.rs
@@ -13,6 +13,10 @@ use uuid::Uuid;
 pub struct EntityRecord {
     pub id: Uuid,
     pub kind: String,
+    /// ADR-020 pack-governed subtype token (e.g. `"paper"`). Reserved key
+    /// parsed before the unknown-key fold, so it never lands in `properties`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_type: Option<String>,
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -20,6 +24,12 @@ pub struct EntityRecord {
     pub properties: serde_json::Value,
     #[serde(default)]
     pub tags: Vec<String>,
+    /// ADR-020 RFC3339 creation timestamp. Reserved key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// ADR-020 RFC3339 last-update timestamp. Reserved key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
 }
 
 /// Raw deserialization target for [`EdgeRecord`].
@@ -33,6 +43,10 @@ struct EdgeRecordRaw {
     weight: f64,
     #[serde(default)]
     properties: serde_json::Value,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
 }
 
 impl TryFrom<EdgeRecordRaw> for EdgeRecord {
@@ -58,6 +72,8 @@ impl TryFrom<EdgeRecordRaw> for EdgeRecord {
             relation: raw.relation,
             weight: raw.weight,
             properties: raw.properties,
+            created_at: raw.created_at,
+            updated_at: raw.updated_at,
         })
     }
 }
@@ -74,6 +90,12 @@ pub struct EdgeRecord {
     pub weight: f64,
     #[serde(default)]
     pub properties: serde_json::Value,
+    /// ADR-020 RFC3339 creation timestamp. Reserved key; not folded into `properties`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// ADR-020 RFC3339 last-update timestamp. Reserved key; not folded into `properties`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
 }
 
 fn default_weight() -> f64 {
@@ -93,6 +115,8 @@ mod tests {
             relation: "extends".into(),
             weight: w,
             properties: serde_json::Value::Null,
+            created_at: None,
+            updated_at: None,
         }
     }
 
@@ -178,6 +202,8 @@ mod tests {
             relation: "extends".into(),
             weight: 0.7,
             properties: serde_json::Value::Null,
+            created_at: None,
+            updated_at: None,
         };
         let json = serde_json::to_string(&record).unwrap();
         let restored: EdgeRecord = serde_json::from_str(&json).unwrap();

--- a/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
+++ b/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
@@ -486,10 +486,13 @@ fn test_json_adapter_entity_byte_identical_roundtrip() {
     let original = EntityRecord {
         id,
         kind: "dataset".into(),
+        entity_type: None,
         name: "CIFAR-10".into(),
         description: Some("60k images, 10 classes".into()),
         properties: serde_json::json!({"num_classes": 10, "license": "MIT"}),
         tags: vec!["vision".into(), "benchmark".into()],
+        created_at: None,
+        updated_at: None,
     };
 
     // First serialization — this is the wire form the adapter will receive.
@@ -511,4 +514,89 @@ fn test_json_adapter_entity_byte_identical_roundtrip() {
         first_json, second_json,
         "entity serialize → parse → serialize must be byte-identical"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Test 14 — ADR-020 entity fields are reserved, not folded into properties (#472)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_adr020_entity_fields_are_reserved() {
+    let json = r#"[{
+        "id": "66666666-6666-6666-6666-666666666666",
+        "kind": "document",
+        "name": "Attention Is All You Need",
+        "entity_type": "paper",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-02-02T00:00:00Z"
+    }]"#;
+
+    let mut adapter = JsonFormatAdapter::new(json).expect("valid fixture");
+    let ents: Vec<EntityRecord> = adapter.entities().map(|r| r.expect("no errors")).collect();
+
+    assert_eq!(ents.len(), 1);
+    let e = &ents[0];
+    assert_eq!(e.entity_type.as_deref(), Some("paper"));
+    assert_eq!(e.created_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+    assert_eq!(e.updated_at.as_deref(), Some("2026-02-02T00:00:00Z"));
+
+    assert!(
+        e.properties.get("entity_type").is_none(),
+        "entity_type must not be folded into properties"
+    );
+    assert!(
+        e.properties.get("created_at").is_none(),
+        "created_at must not be folded into properties"
+    );
+    assert!(
+        e.properties.get("updated_at").is_none(),
+        "updated_at must not be folded into properties"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 15 — kind="paper" alias preserves entity_type="paper" (#472)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_kind_paper_alias_sets_entity_type() {
+    let mut adapter =
+        JsonFormatAdapter::new(r#"[{"kind":"paper","name":"Some Paper"}]"#).expect("valid JSON");
+    let first = adapter.entities().next().expect("one record");
+    let entity = first.expect("alias must parse as valid kind");
+
+    assert_eq!(
+        entity.kind, "document",
+        "alias 'paper' must canonicalize kind to 'document'"
+    );
+    assert_eq!(
+        entity.entity_type.as_deref(),
+        Some("paper"),
+        "alias 'paper' must be preserved as entity_type"
+    );
+    assert!(entity.properties.get("entity_type").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 16 — ADR-020 edge timestamp fields are reserved (#472)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_edge_timestamps_are_reserved() {
+    let json = r#"[{
+        "source": "11111111-1111-1111-1111-111111111111",
+        "target": "22222222-2222-2222-2222-222222222222",
+        "relation": "extends",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-02-02T00:00:00Z"
+    }]"#;
+
+    let mut adapter = JsonFormatAdapter::new(json).expect("valid");
+    let edges: Vec<EdgeRecord> = adapter.edges().map(|r| r.expect("no errors")).collect();
+
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].created_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+    assert_eq!(edges[0].updated_at.as_deref(), Some("2026-02-02T00:00:00Z"));
+    assert!(edges[0].properties.get("created_at").is_none());
+    assert!(edges[0].properties.get("updated_at").is_none());
 }

--- a/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
+++ b/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
@@ -600,3 +600,66 @@ fn test_json_adapter_edge_timestamps_are_reserved() {
     assert!(edges[0].properties.get("created_at").is_none());
     assert!(edges[0].properties.get("updated_at").is_none());
 }
+
+// ---------------------------------------------------------------------------
+// Test 17 — a non-object top-level array element is fatal, not skipped (#488a)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_non_object_array_element_is_fatal() {
+    // A bare string in the top-level array must abort construction with a
+    // fatal error identifying the offending record index, not be silently
+    // skipped with a warning.
+    let json = r#"[
+        {"kind":"concept","name":"Good"},
+        "not-a-record",
+        {"kind":"concept","name":"NeverParsed"}
+    ]"#;
+
+    let err = match JsonFormatAdapter::new(json) {
+        Err(e) => e,
+        Ok(_) => panic!("a non-object array element must be a fatal construction error"),
+    };
+    match &err {
+        AdapterError::InvalidField { index, field, .. } => {
+            assert_eq!(*index, 1, "error must point at the non-object element");
+            assert_eq!(field, "$record");
+        }
+        other => panic!("expected InvalidField at index 1, got: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 18 — non-object edge properties warns, never silently becomes {} (#488b)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_edge_properties_non_object_warns() {
+    let json = r#"[{
+        "source": "11111111-1111-1111-1111-111111111111",
+        "target": "22222222-2222-2222-2222-222222222222",
+        "relation": "extends",
+        "properties": "not-an-object"
+    }]"#;
+
+    let mut adapter = JsonFormatAdapter::new(json).expect("structurally valid JSON");
+    let edges: Vec<EdgeRecord> = adapter
+        .edges()
+        .map(|r| r.expect("no parse errors"))
+        .collect();
+
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].properties,
+        Value::Object(serde_json::Map::new()),
+        "non-object properties must fall back to an empty object"
+    );
+    assert!(
+        adapter
+            .warnings()
+            .iter()
+            .any(|w| w.contains("properties") && w.contains("not an object")),
+        "non-object edge properties must be reported as a warning, got: {:?}",
+        adapter.warnings()
+    );
+}

--- a/crates/khive-vcs/src/error.rs
+++ b/crates/khive-vcs/src/error.rs
@@ -36,6 +36,13 @@ pub enum VcsError {
     #[error("invalid branch name: {0:?}")]
     InvalidBranchName(String),
 
+    /// A remote name failed validation (must be a single path segment
+    /// matching `[A-Za-z0-9._-]+`, and not `.` or `..`). Rejected before any
+    /// filesystem path is built from it, to prevent path traversal into
+    /// `.khive/kg/remotes/`.
+    #[error("invalid remote name {0:?}: must be one path segment [A-Za-z0-9._-]+ and not . or ..")]
+    InvalidRemoteName(String),
+
     /// An underlying storage operation failed.
     #[error("storage: {0}")]
     Storage(String),

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -291,48 +291,170 @@ pub async fn run_sync_remote(
         }
     }
 
-    // ── 5. Atomically publish to cache ────────────────────────────────────────
-    let cache_dir = repo_root
-        .join(".khive/kg/remotes")
-        .join(remote.name.as_str());
-    std::fs::create_dir_all(&cache_dir)
-        .with_context(|| format!("creating cache dir {}", cache_dir.display()))?;
-
-    // Write files into staging first, then rename into place atomically.
-    let tmp_entities = cache_dir.with_extension("entities.tmp");
-    let tmp_edges = cache_dir.with_extension("edges.tmp");
-
-    write_sorted_entities(&tmp_entities, &entities_ndjson)
-        .context("writing staged entities.ndjson")?;
-    write_sorted_edges(&tmp_edges, &edges_ndjson).context("writing staged edges.ndjson")?;
-
-    std::fs::rename(&tmp_entities, cache_dir.join("entities.ndjson"))
-        .context("renaming entities.ndjson into cache")?;
-    std::fs::rename(&tmp_edges, cache_dir.join("edges.ndjson"))
-        .context("renaming edges.ndjson into cache")?;
-
-    // ── 6. Write meta.json ────────────────────────────────────────────────────
+    // ── 5. Build meta and atomically publish to cache ─────────────────────────
     let meta = MetaJson {
         fetched_at: Utc::now().to_rfc3339(),
         git_ref: remote.git_ref.clone(),
         commit_sha,
         content_hash: actual_hash.as_str().to_string(),
     };
-    let meta_path = cache_dir.join("meta.json");
-    let meta_json = serde_json::to_string_pretty(&meta).context("serializing meta.json")?;
-    std::fs::write(&meta_path, meta_json.as_bytes()).context("writing meta.json")?;
 
-    // staging tempdir is dropped here, cleaning up the clone.
+    let remotes_root = repo_root.join(".khive/kg/remotes");
+    let cache_dir = remotes_root.join(remote.name.as_str());
+    let published = publish_remote_cache(
+        &remotes_root,
+        remote.name.as_str(),
+        &entities_ndjson,
+        &edges_ndjson,
+        &meta,
+        #[cfg(test)]
+        None,
+    )
+    .with_context(|| format!("publishing cache for remote {:?}", remote.name))?;
+    debug_assert_eq!(published, cache_dir);
+
+    // staging tempdir (the git clone) is dropped here, cleaning up the clone.
     drop(staging);
 
     Ok(RemoteSyncReport {
         entities: entities_ndjson.len(),
         edges: edges_ndjson.len(),
         cache_dir: cache_dir.to_string_lossy().into_owned(),
-        meta_path: meta_path.to_string_lossy().into_owned(),
+        meta_path: cache_dir.join("meta.json").to_string_lossy().into_owned(),
         content_hash: actual_hash.as_str().to_string(),
         repinned: repin,
     })
+}
+
+/// Injection points for #475 failure-injection tests: simulate a crash at each
+/// publish step so tests can assert readers never observe a mixed cache state.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishFailAt {
+    AfterEntities,
+    AfterEdges,
+    AfterMeta,
+    BeforeSwap,
+}
+
+/// Publish a complete `{entities.ndjson, edges.ndjson, meta.json}` triple to
+/// `<remotes_root>/<name>/` as a single atomic unit.
+///
+/// Builds a complete staging directory (a sibling of the cache directory,
+/// under `remotes_root`) containing all three files, then switches visibility
+/// with one directory-rename swap ([`atomic_replace_dir`]). A crash or error
+/// at any point before the swap leaves the existing cache untouched; a crash
+/// or error during the swap either leaves the old cache in place or completes
+/// to the new cache — a reader never observes a mix of old and new files.
+fn publish_remote_cache(
+    remotes_root: &Path,
+    name: &str,
+    entities: &[NdjsonEntity],
+    edges: &[NdjsonEdge],
+    meta: &MetaJson,
+    #[cfg(test)] fail_at: Option<PublishFailAt>,
+) -> Result<PathBuf> {
+    std::fs::create_dir_all(remotes_root)
+        .with_context(|| format!("creating {}", remotes_root.display()))?;
+    let staging = tempfile::TempDir::new_in(remotes_root).context("creating staging dir")?;
+
+    write_sorted_entities(&staging.path().join("entities.ndjson"), entities)
+        .context("writing staged entities.ndjson")?;
+    #[cfg(test)]
+    if fail_at == Some(PublishFailAt::AfterEntities) {
+        anyhow::bail!("injected failure after staged entities write");
+    }
+
+    write_sorted_edges(&staging.path().join("edges.ndjson"), edges)
+        .context("writing staged edges.ndjson")?;
+    #[cfg(test)]
+    if fail_at == Some(PublishFailAt::AfterEdges) {
+        anyhow::bail!("injected failure after staged edges write");
+    }
+
+    let meta_json = serde_json::to_string_pretty(meta).context("serializing meta.json")?;
+    std::fs::write(staging.path().join("meta.json"), meta_json.as_bytes())
+        .context("writing staged meta.json")?;
+    fsync_dir_best_effort(staging.path());
+    #[cfg(test)]
+    if fail_at == Some(PublishFailAt::AfterMeta) {
+        anyhow::bail!("injected failure after staged meta write, before swap");
+    }
+
+    let cache_dir = remotes_root.join(name);
+    #[cfg(test)]
+    if fail_at == Some(PublishFailAt::BeforeSwap) {
+        anyhow::bail!("injected failure before swap");
+    }
+    atomic_replace_dir(staging.path(), &cache_dir)?;
+    fsync_dir_best_effort(remotes_root);
+
+    Ok(cache_dir)
+}
+
+/// Atomically replace `target_dir` with `new_dir` (a complete, ready-to-serve
+/// directory). If `target_dir` does not exist yet, `new_dir` is simply renamed
+/// into place. If `target_dir` already exists, the existing directory is first
+/// renamed to a sibling backup path, then `new_dir` is renamed into
+/// `target_dir`'s place; the backup is removed only after the swap succeeds.
+/// If the second rename fails, the backup is restored so the old cache is
+/// never lost. Both renames are single filesystem rename(2) calls, each of
+/// which is atomic — at every instant `target_dir` resolves to either the
+/// complete old directory, is briefly absent, or resolves to the complete new
+/// directory; it never contains a mix of old and new files.
+fn atomic_replace_dir(new_dir: &Path, target_dir: &Path) -> Result<()> {
+    if !target_dir.exists() {
+        std::fs::rename(new_dir, target_dir).with_context(|| {
+            format!("renaming {} -> {}", new_dir.display(), target_dir.display())
+        })?;
+        return Ok(());
+    }
+
+    let backup = target_dir.with_file_name(format!(
+        "{}.replaced-{}",
+        target_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("cache"),
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&backup);
+
+    std::fs::rename(target_dir, &backup).with_context(|| {
+        format!(
+            "backing up existing cache {} -> {}",
+            target_dir.display(),
+            backup.display()
+        )
+    })?;
+
+    match std::fs::rename(new_dir, target_dir) {
+        Ok(()) => {
+            let _ = std::fs::remove_dir_all(&backup);
+            Ok(())
+        }
+        Err(e) => {
+            // Restore the old cache so a failed swap never leaves the target missing.
+            let _ = std::fs::rename(&backup, target_dir);
+            Err(e).with_context(|| {
+                format!(
+                    "renaming {} -> {} (old cache restored)",
+                    new_dir.display(),
+                    target_dir.display()
+                )
+            })
+        }
+    }
+}
+
+/// Best-effort `fsync` of a directory's entries, where the platform supports
+/// opening a directory as a file handle (Unix). Errors are ignored: this is a
+/// durability improvement, not a correctness requirement for the atomicity
+/// guarantee above (which relies on rename(2) semantics, not fsync).
+fn fsync_dir_best_effort(dir: &Path) {
+    if let Ok(f) = std::fs::File::open(dir) {
+        let _ = f.sync_all();
+    }
 }
 
 /// Redact URLs and embedded credentials from git stderr before surfacing in errors.
@@ -1306,6 +1428,196 @@ mod tests {
             !outside_target.exists(),
             "nothing must be written outside the repo root"
         );
+    }
+
+    // ── #475 atomic publish failure-injection tests (VCS-AUD-003) ───────────────
+
+    fn sample_entity(id: &str, name: &str) -> NdjsonEntity {
+        NdjsonEntity {
+            id: id.parse().unwrap(),
+            kind: "concept".to_string(),
+            entity_type: None,
+            name: name.to_string(),
+            description: None,
+            properties: Some(serde_json::json!({})),
+            tags: vec![],
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_meta(tag: &str) -> MetaJson {
+        MetaJson {
+            fetched_at: "2026-01-01T00:00:00Z".to_string(),
+            git_ref: "main".to_string(),
+            commit_sha: "deadbeef".to_string(),
+            content_hash: format!("sha256:{tag}"),
+        }
+    }
+
+    /// Publish an "old" cache generation successfully, used as the baseline
+    /// state that a subsequent failed publish must leave untouched.
+    fn publish_old_generation(remotes_root: &Path, name: &str) -> PathBuf {
+        let entities = vec![sample_entity(
+            "11111111-1111-1111-1111-111111111111",
+            "OldEntity",
+        )];
+        publish_remote_cache(
+            remotes_root,
+            name,
+            &entities,
+            &[],
+            &sample_meta("old"),
+            None,
+        )
+        .expect("baseline publish must succeed")
+    }
+
+    fn assert_cache_is_old_generation(cache_dir: &Path) {
+        let entities = std::fs::read_to_string(cache_dir.join("entities.ndjson")).unwrap();
+        assert!(
+            entities.contains("OldEntity"),
+            "cache entities must still be the old generation, got: {entities}"
+        );
+        let meta: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(cache_dir.join("meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta["content_hash"], "sha256:old");
+    }
+
+    #[test]
+    fn remote_cache_publish_failure_after_entities_keeps_old_cache() {
+        let tmp = TempDir::new().unwrap();
+        let remotes_root = tmp.path().join(".khive/kg/remotes");
+        let cache_dir = publish_old_generation(&remotes_root, "upstream");
+
+        let new_entities = vec![sample_entity(
+            "22222222-2222-2222-2222-222222222222",
+            "NewEntity",
+        )];
+        let err = publish_remote_cache(
+            &remotes_root,
+            "upstream",
+            &new_entities,
+            &[],
+            &sample_meta("new"),
+            Some(PublishFailAt::AfterEntities),
+        )
+        .expect_err("injected failure must surface as an error");
+        assert!(err.to_string().contains("injected failure"));
+
+        assert_cache_is_old_generation(&cache_dir);
+    }
+
+    #[test]
+    fn remote_cache_publish_failure_after_edges_keeps_old_cache() {
+        let tmp = TempDir::new().unwrap();
+        let remotes_root = tmp.path().join(".khive/kg/remotes");
+        let cache_dir = publish_old_generation(&remotes_root, "upstream");
+
+        let new_entities = vec![sample_entity(
+            "22222222-2222-2222-2222-222222222222",
+            "NewEntity",
+        )];
+        let err = publish_remote_cache(
+            &remotes_root,
+            "upstream",
+            &new_entities,
+            &[],
+            &sample_meta("new"),
+            Some(PublishFailAt::AfterEdges),
+        )
+        .expect_err("injected failure must surface as an error");
+        assert!(err.to_string().contains("injected failure"));
+
+        assert_cache_is_old_generation(&cache_dir);
+    }
+
+    #[test]
+    fn remote_cache_publish_failure_after_meta_keeps_old_cache() {
+        let tmp = TempDir::new().unwrap();
+        let remotes_root = tmp.path().join(".khive/kg/remotes");
+        let cache_dir = publish_old_generation(&remotes_root, "upstream");
+
+        let new_entities = vec![sample_entity(
+            "22222222-2222-2222-2222-222222222222",
+            "NewEntity",
+        )];
+        let err = publish_remote_cache(
+            &remotes_root,
+            "upstream",
+            &new_entities,
+            &[],
+            &sample_meta("new"),
+            Some(PublishFailAt::AfterMeta),
+        )
+        .expect_err("injected failure must surface as an error");
+        assert!(err.to_string().contains("injected failure"));
+
+        assert_cache_is_old_generation(&cache_dir);
+    }
+
+    /// Failure injected immediately before the directory swap: the staged
+    /// directory is fully built but never made visible, so the reader-visible
+    /// cache must still be exactly the old generation.
+    #[test]
+    fn remote_cache_publish_failure_before_swap_keeps_old_cache() {
+        let tmp = TempDir::new().unwrap();
+        let remotes_root = tmp.path().join(".khive/kg/remotes");
+        let cache_dir = publish_old_generation(&remotes_root, "upstream");
+
+        let new_entities = vec![sample_entity(
+            "22222222-2222-2222-2222-222222222222",
+            "NewEntity",
+        )];
+        let err = publish_remote_cache(
+            &remotes_root,
+            "upstream",
+            &new_entities,
+            &[],
+            &sample_meta("new"),
+            Some(PublishFailAt::BeforeSwap),
+        )
+        .expect_err("injected failure must surface as an error");
+        assert!(err.to_string().contains("injected failure"));
+
+        assert_cache_is_old_generation(&cache_dir);
+    }
+
+    /// A successful publish exposes the complete new entities+edges+meta
+    /// together — never a partial mix with the previous generation.
+    #[test]
+    fn remote_cache_publish_success_exposes_complete_new_cache() {
+        let tmp = TempDir::new().unwrap();
+        let remotes_root = tmp.path().join(".khive/kg/remotes");
+        let cache_dir = publish_old_generation(&remotes_root, "upstream");
+        assert_cache_is_old_generation(&cache_dir);
+
+        let new_entities = vec![sample_entity(
+            "22222222-2222-2222-2222-222222222222",
+            "NewEntity",
+        )];
+        let published = publish_remote_cache(
+            &remotes_root,
+            "upstream",
+            &new_entities,
+            &[],
+            &sample_meta("new"),
+            None,
+        )
+        .expect("publish must succeed");
+        assert_eq!(published, cache_dir);
+
+        let entities = std::fs::read_to_string(cache_dir.join("entities.ndjson")).unwrap();
+        assert!(entities.contains("NewEntity"));
+        assert!(
+            !entities.contains("OldEntity"),
+            "old generation entity must not linger after a successful publish"
+        );
+        let meta: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(cache_dir.join("meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta["content_hash"], "sha256:new");
     }
 
     // ── F201 tests ────────────────────────────────────────────────────────────

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -26,6 +26,8 @@ use crate::types::SnapshotId;
 struct NdjsonEntity {
     id: Uuid,
     kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    entity_type: Option<String>,
     name: String,
     #[serde(default)]
     description: Option<String>,
@@ -421,7 +423,7 @@ fn build_kg_archive(
         .map(|e| ExportedEntity {
             id: e.id,
             kind: e.kind.clone(),
-            entity_type: None,
+            entity_type: e.entity_type.clone(),
             name: e.name.clone(),
             description: e.description.clone(),
             properties: e.properties.clone(),
@@ -678,7 +680,7 @@ async fn upsert_entities(
                 id: r.id,
                 namespace: namespace.to_string(),
                 kind: r.kind.clone(),
-                entity_type: None,
+                entity_type: r.entity_type.clone(),
                 name: r.name.clone(),
                 description: r.description.clone(),
                 properties: r.properties.clone(),
@@ -1060,6 +1062,70 @@ mod tests {
         let report = run_sync(repo, &db_path, "test-ns").await.unwrap();
         assert_eq!(report.entities, 0);
         assert_eq!(report.edges, 0);
+    }
+
+    /// #473: `run_sync` must preserve `entity_type` from NDJSON into the
+    /// SQLite-backed entity store so subtype-filtered reads see it.
+    #[tokio::test]
+    async fn sync_preserves_entity_type() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+
+        let id_a = "44444444-4444-4444-4444-444444444444";
+        let line_a = format!(
+            r#"{{"id":"{id_a}","kind":"document","entity_type":"paper","name":"Attention Is All You Need","properties":{{}},"tags":[]}}"#
+        );
+        write_repo(repo, &line_a, "");
+
+        let report = run_sync(repo, &db_path, "test-ns").await.unwrap();
+        assert_eq!(report.entities, 1);
+
+        let ns = khive_types::Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path.clone()),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..RuntimeConfig::default()
+        };
+        let rt = KhiveRuntime::new(config).unwrap();
+        let token = rt.authorize(ns).unwrap();
+        let entity = rt
+            .entities(&token)
+            .unwrap()
+            .get_entity(id_a.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("entity must be retrievable after sync");
+        assert_eq!(
+            entity.entity_type.as_deref(),
+            Some("paper"),
+            "entity_type must survive NDJSON sync, not be stored as NULL"
+        );
+    }
+
+    /// #473: two archives differing ONLY by `entity_type` must hash to
+    /// different `SnapshotId`s — the pin must be injective over entity_type,
+    /// not collide with the untyped archive.
+    #[test]
+    fn remote_hash_includes_ndjson_entity_type() {
+        let id_a = "55555555-5555-5555-5555-555555555555";
+        let untyped = format!(
+            r#"{{"id":"{id_a}","kind":"document","name":"Some Doc","properties":{{}},"tags":[]}}"#
+        );
+        let typed = format!(
+            r#"{{"id":"{id_a}","kind":"document","entity_type":"paper","name":"Some Doc","properties":{{}},"tags":[]}}"#
+        );
+
+        let untyped_pin = compute_pin(&untyped, "", "test-ns");
+        let typed_pin = compute_pin(&typed, "", "test-ns");
+
+        assert_ne!(
+            untyped_pin.as_str(),
+            typed_pin.as_str(),
+            "entity_type must be part of the canonical hash input; a pin for the \
+             untyped archive must not validate typed content"
+        );
     }
 
     /// F195: verify that FTS5 is populated during sync so text search works

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -86,13 +86,67 @@ pub struct SyncReport {
 
 // ── F201: Remote archive fetch ────────────────────────────────────────────────
 
+/// A validated remote cache name: a single path segment safe to join under
+/// `.khive/kg/remotes/` without escaping that directory.
+///
+/// Construct via [`RemoteName::parse`]. There is no public way to build a
+/// `RemoteName` that fails validation, so a `RemoteConfig` can never carry an
+/// unsafe name into [`run_sync_remote`] (VCS-AUD-002).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct RemoteName(String);
+
+/// Renders exactly like a plain `String`'s `Debug` (quoted), so existing
+/// `{:?}`-formatted error messages that embedded `remote.name` keep the same
+/// shape after the `String` -> `RemoteName` migration.
+impl std::fmt::Debug for RemoteName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl RemoteName {
+    /// Validate `raw` as a safe single-path-segment remote name.
+    ///
+    /// Rejects: empty strings, `.`, `..`, any name containing `/` or `\`, and
+    /// any character outside `[A-Za-z0-9._-]`. Because path separators are
+    /// rejected outright, an absolute path (Unix `/root`, Windows `C:\root`)
+    /// can never pass — `:` is also outside the allowed character set.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, VcsError> {
+        let raw = raw.into();
+        let valid = !raw.is_empty()
+            && raw != "."
+            && raw != ".."
+            && raw
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+            && !raw.contains('/')
+            && !raw.contains('\\');
+        if !valid {
+            return Err(VcsError::InvalidRemoteName(raw));
+        }
+        Ok(Self(raw))
+    }
+
+    /// The validated name as a `&str`, safe to join onto a cache directory path.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for RemoteName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Configuration for a remote KG archive (maps to one entry in `schema.yaml`
 /// `remotes:` list).
 #[derive(Debug, Clone)]
 pub struct RemoteConfig {
-    /// Human-readable name for this remote (used in error messages and cache
-    /// directory paths).
-    pub name: String,
+    /// Validated name for this remote (used in error messages and cache
+    /// directory paths). Constructed via [`RemoteName::parse`], so a
+    /// `RemoteConfig` can never carry a path-traversal or absolute-path name.
+    pub name: RemoteName,
     /// Git remote URL (e.g. `https://github.com/org/kg-data.git`).
     pub url: String,
     /// Git ref to check out (branch or tag, e.g. `main`).
@@ -238,7 +292,9 @@ pub async fn run_sync_remote(
     }
 
     // ── 5. Atomically publish to cache ────────────────────────────────────────
-    let cache_dir = repo_root.join(".khive/kg/remotes").join(&remote.name);
+    let cache_dir = repo_root
+        .join(".khive/kg/remotes")
+        .join(remote.name.as_str());
     std::fs::create_dir_all(&cache_dir)
         .with_context(|| format!("creating cache dir {}", cache_dir.display()))?;
 
@@ -1184,6 +1240,74 @@ mod tests {
         );
     }
 
+    // ── #474 RemoteName tests (VCS-AUD-002) ─────────────────────────────────────
+
+    /// #474: `RemoteName::parse` must reject every path-traversal / absolute
+    /// / separator-containing shape before it can reach `run_sync_remote`.
+    #[test]
+    fn remote_name_rejects_path_traversal_cases() {
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../evil",
+            "../../outside",
+            "/tmp/evil",
+            "safe/name",
+            "safe\\name",
+            "safe/../evil",
+        ] {
+            assert!(
+                RemoteName::parse(bad).is_err(),
+                "expected RemoteName::parse to reject {bad:?}"
+            );
+        }
+    }
+
+    /// #474: safe single-segment names must be accepted and preserved verbatim.
+    #[test]
+    fn remote_name_accepts_single_safe_segment() {
+        for good in ["upstream", "team.data-1", "remote_2"] {
+            let parsed = RemoteName::parse(good).expect("expected safe name to be accepted");
+            assert_eq!(parsed.as_str(), good);
+        }
+    }
+
+    /// #474: `run_sync_remote("../evil" | "/tmp/evil" | "safe/name")` must be
+    /// impossible to even construct — `RemoteConfig::name` is a `RemoteName`,
+    /// and `RemoteName::parse` is its only constructor — so these names never
+    /// reach `run_sync_remote`'s cache-directory join. Confirm both the
+    /// construction-time rejection AND (via filesystem check) that nothing
+    /// was created at the traversal targets or under `.khive/kg/remotes/`.
+    #[tokio::test]
+    async fn run_sync_remote_cannot_be_constructed_with_invalid_name() {
+        let repo_dir = TempDir::new().unwrap();
+        let outside_target = repo_dir.path().parent().unwrap().join("evil-outside-probe");
+        let _ = std::fs::remove_file(&outside_target);
+
+        for bad in ["../evil", "/tmp/evil", "safe/name"] {
+            assert!(
+                RemoteName::parse(bad).is_err(),
+                "RemoteName::parse must reject {bad:?} before any RemoteConfig can be built"
+            );
+        }
+
+        // No RemoteConfig could be built from these names, so run_sync_remote was
+        // never called: the cache tree and any traversal target are both absent.
+        assert!(
+            !repo_dir.path().join(".khive/kg/remotes").exists(),
+            "cache tree must not exist — no sync ever ran"
+        );
+        assert!(
+            !std::path::Path::new("/tmp/evil").exists(),
+            "/tmp/evil must not have been created by this test run"
+        );
+        assert!(
+            !outside_target.exists(),
+            "nothing must be written outside the repo root"
+        );
+    }
+
     // ── F201 tests ────────────────────────────────────────────────────────────
 
     /// F201-1: `run_sync_remote` with a correct pin succeeds and writes the
@@ -1203,7 +1327,7 @@ mod tests {
         let expected_pin = compute_pin(&entities, edges, "remote-ns");
 
         let remote = RemoteConfig {
-            name: "upstream".to_string(),
+            name: RemoteName::parse("upstream").unwrap(),
             url: remote_url,
             git_ref: "main".to_string(),
             namespace: "remote-ns".to_string(),
@@ -1275,7 +1399,7 @@ mod tests {
         let wrong_pin = SnapshotId::from_hash(&"0".repeat(64)).unwrap();
 
         let remote = RemoteConfig {
-            name: "upstream".to_string(),
+            name: RemoteName::parse("upstream").unwrap(),
             url: remote_url,
             git_ref: "main".to_string(),
             namespace: "remote-ns".to_string(),
@@ -1319,7 +1443,7 @@ mod tests {
         let remote_url = make_git_remote(remote_dir.path(), &entities, "");
 
         let remote = RemoteConfig {
-            name: "no-pin-remote".to_string(),
+            name: RemoteName::parse("no-pin-remote").unwrap(),
             url: remote_url,
             git_ref: "main".to_string(),
             namespace: "remote-ns".to_string(),
@@ -1362,7 +1486,7 @@ mod tests {
         let stale_pin = SnapshotId::from_hash(&"f".repeat(64)).unwrap();
 
         let remote = RemoteConfig {
-            name: "repinned".to_string(),
+            name: RemoteName::parse("repinned").unwrap(),
             url: remote_url,
             git_ref: "main".to_string(),
             namespace: "repin-ns".to_string(),
@@ -1518,7 +1642,7 @@ mod tests {
         let repo_dir = tempfile::TempDir::new().unwrap();
         // Use a credential-bearing HTTPS URL that will fail immediately.
         let remote = RemoteConfig {
-            name: "cred-test".to_string(),
+            name: RemoteName::parse("cred-test").unwrap(),
             url: "https://user:secret_token@nonexistent.example.invalid/org/repo.git".to_string(),
             git_ref: "main".to_string(),
             namespace: "test-ns".to_string(),
@@ -1568,7 +1692,7 @@ mod tests {
     async fn public_error_redacts_scp_style_remote() {
         let repo_dir = tempfile::TempDir::new().unwrap();
         let remote = RemoteConfig {
-            name: "scp-test".to_string(),
+            name: RemoteName::parse("scp-test").unwrap(),
             url: "git@nonexistent.example.invalid:org/private-repo.git".to_string(),
             git_ref: "main".to_string(),
             namespace: "test-ns".to_string(),
@@ -1658,7 +1782,7 @@ mod tests {
     async fn public_error_redacts_user_pass_at_host_scp() {
         let repo_dir = tempfile::TempDir::new().unwrap();
         let remote = RemoteConfig {
-            name: "userpass-scp".to_string(),
+            name: RemoteName::parse("userpass-scp").unwrap(),
             url: "deploy@nonexistent.example.invalid:infra/secret-repo.git".to_string(),
             git_ref: "main".to_string(),
             namespace: "test-ns".to_string(),

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -4,16 +4,18 @@
 //! Builds atomically into a `.tmp` file then renames. Also supports remote archive
 //! fetch with SHA-256 pin verification via [`run_sync_remote`].
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::FromStr;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::Utc;
 use khive_runtime::portability::{ExportedEdge, ExportedEntity, KgArchive};
 use khive_runtime::{entity_fts_document, KhiveRuntime, RuntimeConfig};
 use khive_storage::types::Edge;
 use khive_storage::LinkId;
-use khive_types::EdgeRelation;
+use khive_types::{EdgeRelation, EntityKind};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -694,6 +696,119 @@ fn write_sorted_edges(path: &Path, records: &[NdjsonEdge]) -> Result<()> {
     Ok(())
 }
 
+/// Full ADR-020 structural validation of parsed NDJSON records (#476).
+///
+/// Checks entity kind validity, entity/edge timestamp validity, entity/edge
+/// sort order (matching `write_sorted_entities`/`write_sorted_edges`), duplicate
+/// entity ids, duplicate edge ids, duplicate semantic edge triples
+/// (source, target, relation), dangling edge endpoints, and edge relation/weight
+/// validity. Called before any temp DB is created so a violation here leaves
+/// the existing target DB completely untouched.
+fn validate_ndjson_records(entities: &[NdjsonEntity], edges: &[NdjsonEdge]) -> Result<()> {
+    let mut entity_ids: HashSet<Uuid> = HashSet::with_capacity(entities.len());
+    let mut prev_entity_key: Option<String> = None;
+    for (i, e) in entities.iter().enumerate() {
+        EntityKind::from_str(&e.kind)
+            .map_err(|_| anyhow!("entity {i} ({}): unknown kind {:?}", e.id, e.kind))?;
+
+        if !entity_ids.insert(e.id) {
+            bail!("entity {i}: duplicate entity id {}", e.id);
+        }
+
+        for (field, value) in [("created_at", &e.created_at), ("updated_at", &e.updated_at)] {
+            if let Some(s) = value {
+                chrono::DateTime::parse_from_rfc3339(s)
+                    .with_context(|| format!("entity {i} ({}): invalid {field} {s:?}", e.id))?;
+            }
+        }
+
+        let key = e.id.to_string().to_ascii_lowercase();
+        if let Some(prev) = &prev_entity_key {
+            if key < *prev {
+                bail!(
+                    "entities.ndjson is not sorted: entity {i} ({}) is out of order",
+                    e.id
+                );
+            }
+        }
+        prev_entity_key = Some(key);
+    }
+
+    let mut edge_ids: HashSet<Uuid> = HashSet::with_capacity(edges.len());
+    let mut triples: HashSet<(Uuid, Uuid, EdgeRelation)> = HashSet::with_capacity(edges.len());
+    let mut prev_edge_key: Option<(String, String, String)> = None;
+    for (i, r) in edges.iter().enumerate() {
+        let relation = r.relation.parse::<EdgeRelation>().with_context(|| {
+            format!(
+                "invalid edge relation {:?} at record {} — sync aborted before any DB write",
+                r.relation,
+                i + 1
+            )
+        })?;
+
+        if !r.weight.is_finite() || !(0.0..=1.0).contains(&r.weight) {
+            bail!(
+                "edge {i} ({}): weight {} out of range; must be finite and in [0.0, 1.0]",
+                r.edge_id,
+                r.weight
+            );
+        }
+
+        if !edge_ids.insert(r.edge_id) {
+            bail!("edge {i}: duplicate edge id {}", r.edge_id);
+        }
+
+        if !triples.insert((r.source, r.target, relation)) {
+            bail!(
+                "edge {i} ({}): duplicate edge triple (source={}, target={}, relation={:?})",
+                r.edge_id,
+                r.source,
+                r.target,
+                relation
+            );
+        }
+
+        if !entity_ids.contains(&r.source) {
+            bail!(
+                "edge {i} ({}): dangling source {} — no matching entity",
+                r.edge_id,
+                r.source
+            );
+        }
+        if !entity_ids.contains(&r.target) {
+            bail!(
+                "edge {i} ({}): dangling target {} — no matching entity",
+                r.edge_id,
+                r.target
+            );
+        }
+
+        for (field, value) in [("created_at", &r.created_at), ("updated_at", &r.updated_at)] {
+            if let Some(s) = value {
+                chrono::DateTime::parse_from_rfc3339(s)
+                    .with_context(|| format!("edge {i} ({}): invalid {field} {s:?}", r.edge_id))?;
+            }
+        }
+
+        let key = (
+            r.source.to_string(),
+            r.target.to_string(),
+            r.relation.clone(),
+        );
+        if let Some(prev) = &prev_edge_key {
+            if key < *prev {
+                bail!(
+                    "edges.ndjson is not sorted: edge {i} ({}) is out of order",
+                    r.edge_id
+                );
+            }
+        }
+        prev_edge_key = Some(key);
+    }
+
+    Ok(())
+}
+
 /// Rebuild `db_path` from `.khive/kg/{entities,edges}.ndjson` under `repo_root`.
 ///
 /// The operation is atomic: the database is built in a `.tmp` sibling file and
@@ -713,18 +828,12 @@ pub async fn run_sync(repo_root: &Path, db_path: &Path, namespace: &str) -> Resu
     let edge_records =
         read_edges(&edges_path).with_context(|| format!("reading {}", edges_path.display()))?;
 
-    // ── Validate-first gate ──────────────────────────────────────────────────────
-    // Parse every edge relation before creating the temp DB so that an invalid
-    // relation causes a clean error that leaves the existing DB intact.
-    for (i, r) in edge_records.iter().enumerate() {
-        r.relation.parse::<EdgeRelation>().with_context(|| {
-            format!(
-                "invalid edge relation {:?} at record {} — sync aborted before any DB write",
-                r.relation,
-                i + 1
-            )
-        })?;
-    }
+    // ── Validate-first gate (#476) ────────────────────────────────────────────
+    // Run the full ADR-020 structural validation before creating the temp DB,
+    // so any violation leaves the existing DB completely untouched.
+    validate_ndjson_records(&entity_records, &edge_records).context(
+        "validating ADR-020 KG NDJSON before DB rebuild — sync aborted before any DB write",
+    )?;
 
     let tmp_path = with_extension_suffix(db_path, ".tmp");
     let _ = std::fs::remove_file(&tmp_path);
@@ -1114,31 +1223,56 @@ mod tests {
 
         // Generate N synthetic entity lines with predictable UUIDs.
         let ids: Vec<uuid::Uuid> = (0..N).map(|_| uuid::Uuid::new_v4()).collect();
-        let entity_lines: Vec<String> = ids
+        // #476 requires entities.ndjson to be in canonical ascending-by-id
+        // order (matching `write_sorted_entities`), so sort the lines below
+        // even though `ids` itself stays in generation order (used to build
+        // the wrap-around edges and to spot-check the last-generated entity).
+        let mut entity_lines: Vec<(uuid::Uuid, String)> = ids
             .iter()
             .enumerate()
             .map(|(i, id)| {
-                format!(
-                    r#"{{"id":"{id}","kind":"concept","name":"SyntheticEntity{i}","description":"Synthetic test entity {i} for chunk-boundary coverage","properties":{{}},"tags":["bench","synthetic"]}}"#
+                (
+                    *id,
+                    format!(
+                        r#"{{"id":"{id}","kind":"concept","name":"SyntheticEntity{i}","description":"Synthetic test entity {i} for chunk-boundary coverage","properties":{{}},"tags":["bench","synthetic"]}}"#
+                    ),
                 )
             })
             .collect();
-        let entities_ndjson = entity_lines.join("\n");
+        entity_lines.sort_by(|a, b| {
+            a.0.to_string()
+                .to_ascii_lowercase()
+                .cmp(&b.0.to_string().to_ascii_lowercase())
+        });
+        let entities_ndjson = entity_lines
+            .into_iter()
+            .map(|(_, line)| line)
+            .collect::<Vec<_>>()
+            .join("\n");
 
         // Generate N synthetic edges: each entity points at the next one via
-        // "extends". The last entity wraps back to the first.
-        let edge_lines: Vec<String> = ids
+        // "extends". The last entity wraps back to the first. #476 requires
+        // edges.ndjson sorted by (source, target, relation), matching
+        // `write_sorted_edges`.
+        let mut edge_lines: Vec<((String, String, String), String)> = ids
             .iter()
             .enumerate()
             .map(|(i, &src)| {
                 let tgt = ids[(i + 1) % N];
                 let eid = uuid::Uuid::new_v4();
-                format!(
+                let key = (src.to_string(), tgt.to_string(), "extends".to_string());
+                let line = format!(
                     r#"{{"edge_id":"{eid}","source":"{src}","target":"{tgt}","relation":"extends","weight":0.9,"properties":{{}}}}"#
-                )
+                );
+                (key, line)
             })
             .collect();
-        let edges_ndjson = edge_lines.join("\n");
+        edge_lines.sort_by(|a, b| a.0.cmp(&b.0));
+        let edges_ndjson = edge_lines
+            .into_iter()
+            .map(|(_, line)| line)
+            .collect::<Vec<_>>()
+            .join("\n");
 
         write_repo(repo, &entities_ndjson, &edges_ndjson);
 
@@ -1240,6 +1374,291 @@ mod tests {
         let report = run_sync(repo, &db_path, "test-ns").await.unwrap();
         assert_eq!(report.entities, 0);
         assert_eq!(report.edges, 0);
+    }
+
+    // ── #476: validate-first gate — one test per violation type ─────────────────
+    //
+    // Each test writes a sentinel DB file, runs `run_sync` against NDJSON that
+    // violates exactly one structural rule, asserts `run_sync` returns `Err`,
+    // and asserts the sentinel DB file is byte-unchanged: the violation must be
+    // caught before the temp DB is even created, let alone renamed over the
+    // target.
+
+    async fn assert_sync_rejected_before_db_write(
+        repo: &Path,
+        db_path: &Path,
+        entities_ndjson: &str,
+        edges_ndjson: &str,
+        expected_substr: &str,
+    ) {
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        std::fs::write(db_path, b"SENTINEL").unwrap();
+        write_repo(repo, entities_ndjson, edges_ndjson);
+
+        let err = run_sync(repo, db_path, "test-ns")
+            .await
+            .expect_err("run_sync must reject invalid NDJSON");
+        assert!(
+            err.chain().any(|e| e.to_string().contains(expected_substr)),
+            "error must mention {expected_substr:?}, got: {err:#}"
+        );
+
+        let after = std::fs::read(db_path).unwrap();
+        assert_eq!(
+            after, b"SENTINEL",
+            "rejected sync must leave the target DB completely untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_unknown_entity_kind_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id = "11111111-1111-1111-1111-111111111111";
+        let entities = format!(
+            r#"{{"id":"{id}","kind":"not-a-real-kind","name":"Bad","properties":{{}},"tags":[]}}"#
+        );
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, "", "unknown kind").await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_out_of_range_edge_weight_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let edges = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":1.5,"properties":{{}}}}"#
+        );
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, &edges, "out of range")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_duplicate_entity_ids_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id = "11111111-1111-1111-1111-111111111111";
+        let entities = [
+            format!(r#"{{"id":"{id}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id}","kind":"concept","name":"A2","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, "", "duplicate entity id")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_duplicate_edge_ids_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let id_c = "33333333-3333-3333-3333-333333333333";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_c}","kind":"concept","name":"C","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edge_id = "44444444-4444-4444-4444-444444444444";
+        let edges = [
+            format!(r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{}}}}"#),
+            format!(r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{id_c}","relation":"extends","weight":0.5,"properties":{{}}}}"#),
+        ]
+        .join("\n");
+
+        assert_sync_rejected_before_db_write(
+            repo,
+            &db_path,
+            &entities,
+            &edges,
+            "duplicate edge id",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_duplicate_edge_triples_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edge_id_1 = "33333333-3333-3333-3333-333333333333";
+        let edge_id_2 = "44444444-4444-4444-4444-444444444444";
+        let edges = [
+            format!(r#"{{"edge_id":"{edge_id_1}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{}}}}"#),
+            format!(r#"{{"edge_id":"{edge_id_2}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.9,"properties":{{}}}}"#),
+        ]
+        .join("\n");
+
+        assert_sync_rejected_before_db_write(
+            repo,
+            &db_path,
+            &entities,
+            &edges,
+            "duplicate edge triple",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_dangling_edge_source_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let missing_source = "99999999-9999-9999-9999-999999999999";
+        let entities =
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#);
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let edges = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{missing_source}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{}}}}"#
+        );
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, &edges, "dangling source")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_dangling_edge_target_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let missing_target = "99999999-9999-9999-9999-999999999999";
+        let entities =
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#);
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let edges = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{missing_target}","relation":"extends","weight":0.5,"properties":{{}}}}"#
+        );
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, &edges, "dangling target")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_invalid_entity_timestamp_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id = "11111111-1111-1111-1111-111111111111";
+        let entities = format!(
+            r#"{{"id":"{id}","kind":"concept","name":"A","properties":{{}},"tags":[],"created_at":"not-a-timestamp"}}"#
+        );
+
+        assert_sync_rejected_before_db_write(repo, &db_path, &entities, "", "invalid created_at")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_invalid_edge_timestamp_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edge_id = "33333333-3333-3333-3333-333333333333";
+        let edges = format!(
+            r#"{{"edge_id":"{edge_id}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{}},"updated_at":"not-a-timestamp"}}"#
+        );
+
+        assert_sync_rejected_before_db_write(
+            repo,
+            &db_path,
+            &entities,
+            &edges,
+            "invalid updated_at",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_unsorted_entities_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        // "b..." sorts after "a...", so writing it first violates the
+        // ascending-by-lowercase-id order that `write_sorted_entities` enforces.
+        let id_hi = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+        let id_lo = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let entities = [
+            format!(
+                r#"{{"id":"{id_hi}","kind":"concept","name":"Hi","properties":{{}},"tags":[]}}"#
+            ),
+            format!(
+                r#"{{"id":"{id_lo}","kind":"concept","name":"Lo","properties":{{}},"tags":[]}}"#
+            ),
+        ]
+        .join("\n");
+
+        assert_sync_rejected_before_db_write(
+            repo,
+            &db_path,
+            &entities,
+            "",
+            "entities.ndjson is not sorted",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sync_rejects_unsorted_edges_before_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let db_path = repo.join(".khive/state/working.db");
+        let id_a = "11111111-1111-1111-1111-111111111111";
+        let id_b = "22222222-2222-2222-2222-222222222222";
+        let id_c = "33333333-3333-3333-3333-333333333333";
+        let entities = [
+            format!(r#"{{"id":"{id_a}","kind":"concept","name":"A","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_b}","kind":"concept","name":"B","properties":{{}},"tags":[]}}"#),
+            format!(r#"{{"id":"{id_c}","kind":"concept","name":"C","properties":{{}},"tags":[]}}"#),
+        ]
+        .join("\n");
+        let edge_id_1 = "44444444-4444-4444-4444-444444444444";
+        let edge_id_2 = "55555555-5555-5555-5555-555555555555";
+        // (source=c, target=a) sorts after (source=a, target=b) lexicographically
+        // by UUID string, so writing it first violates edge sort order.
+        let edges = [
+            format!(r#"{{"edge_id":"{edge_id_1}","source":"{id_c}","target":"{id_a}","relation":"extends","weight":0.5,"properties":{{}}}}"#),
+            format!(r#"{{"edge_id":"{edge_id_2}","source":"{id_a}","target":"{id_b}","relation":"extends","weight":0.5,"properties":{{}}}}"#),
+        ]
+        .join("\n");
+
+        assert_sync_rejected_before_db_write(
+            repo,
+            &db_path,
+            &entities,
+            &edges,
+            "edges.ndjson is not sorted",
+        )
+        .await;
     }
 
     /// #473: `run_sync` must preserve `entity_type` from NDJSON into the

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -168,7 +168,7 @@ fn adapter_records_to_archive(
             Ok(ExportedEntity {
                 id: e.id,
                 kind: e.kind,
-                entity_type: None,
+                entity_type: e.entity_type,
                 name: e.name,
                 description: e.description,
                 properties: if e.properties.is_null() {
@@ -177,8 +177,8 @@ fn adapter_records_to_archive(
                     Some(e.properties)
                 },
                 tags: e.tags,
-                created_at: now,
-                updated_at: now,
+                created_at: parse_dt(e.created_at.as_deref(), now),
+                updated_at: parse_dt(e.updated_at.as_deref(), now),
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -638,6 +638,79 @@ mod tests {
             err.to_string().contains("not finite"),
             "expected 'not finite' in error: {err}"
         );
+    }
+
+    /// #472: `adapter_records_to_archive` must preserve ADR-020 `entity_type`
+    /// and timestamp fields from adapter-parsed `EntityRecord`s instead of
+    /// forcing `entity_type: None` and `Utc::now()`.
+    #[test]
+    fn adapter_records_to_archive_preserves_entity_adr020_fields() {
+        let id = Uuid::new_v4();
+        let record = EntityRecord {
+            id,
+            kind: "document".to_string(),
+            entity_type: Some("paper".to_string()),
+            name: "Attention Is All You Need".to_string(),
+            description: None,
+            properties: serde_json::Value::Null,
+            tags: vec![],
+            created_at: Some("2026-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2026-02-02T00:00:00Z".to_string()),
+        };
+
+        let archive = adapter_records_to_archive("test-ns", vec![record], vec![]).unwrap();
+        assert_eq!(archive.entities.len(), 1);
+        let e = &archive.entities[0];
+        assert_eq!(e.entity_type.as_deref(), Some("paper"));
+        assert_eq!(e.created_at.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+        assert_eq!(e.updated_at.to_rfc3339(), "2026-02-02T00:00:00+00:00");
+    }
+
+    /// #472: importing adapter JSON with `entity_type`/timestamps end-to-end
+    /// through `cmd_import` must land those fields in the runtime, not `None`
+    /// + import-time `Utc::now()`.
+    #[tokio::test]
+    async fn import_json_adapter_preserves_entity_type_and_timestamps() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("adapter-adr020.db");
+        let entity_id = "77777777-7777-7777-7777-777777777777";
+
+        let json_input = format!(
+            r#"[{{"id":"{entity_id}","kind":"paper","name":"Some Paper","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-02-02T00:00:00Z"}}]"#
+        );
+        let source_path = tmp.path().join("records.json");
+        std::fs::write(&source_path, &json_input).unwrap();
+
+        let args = ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        };
+        cmd_import(args).await.unwrap();
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let rt2 = KhiveRuntime::new(config).unwrap();
+        let tok2 = rt2.authorize(ns).unwrap();
+        let entity_uuid: Uuid = entity_id.parse().unwrap();
+        let entity = rt2.get_entity(&tok2, entity_uuid).await.unwrap();
+        assert_eq!(entity.kind, "document");
+        assert_eq!(entity.entity_type.as_deref(), Some("paper"));
+        let expected_created = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .timestamp_micros();
+        let expected_updated = chrono::DateTime::parse_from_rfc3339("2026-02-02T00:00:00Z")
+            .unwrap()
+            .timestamp_micros();
+        assert_eq!(entity.created_at, expected_created);
+        assert_eq!(entity.updated_at, expected_updated);
     }
 
     #[test]

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -274,6 +274,8 @@ pub(super) fn archive_from_ndjson_repo(repo: &Path, namespace: &str) -> Result<K
     struct NdjsonEntity {
         id: Uuid,
         kind: String,
+        #[serde(default)]
+        entity_type: Option<String>,
         name: String,
         #[serde(default)]
         description: Option<String>,
@@ -311,7 +313,7 @@ pub(super) fn archive_from_ndjson_repo(repo: &Path, namespace: &str) -> Result<K
         .map(|e| ExportedEntity {
             id: e.id,
             kind: e.kind,
-            entity_type: None,
+            entity_type: e.entity_type,
             name: e.name,
             description: e.description,
             properties: e.properties,

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -713,6 +713,80 @@ mod tests {
         assert_eq!(entity.updated_at, expected_updated);
     }
 
+    /// #488a: a non-object element anywhere in the top-level JSON array must
+    /// abort the whole import — including entities before AND after it in the
+    /// array — before anything is written to the target DB. Previously this
+    /// was a warning that skipped just the bad element and kept going.
+    #[tokio::test]
+    async fn import_json_adapter_rejects_non_object_array_element_without_db_write() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("adapter-488.db");
+        let baseline_id = "88888888-8888-8888-8888-888888888888";
+
+        // Establish a baseline DB state via a first, valid import.
+        let baseline_json =
+            format!(r#"[{{"id":"{baseline_id}","kind":"concept","name":"Baseline"}}]"#);
+        let baseline_source = tmp.path().join("baseline.json");
+        std::fs::write(&baseline_source, &baseline_json).unwrap();
+        cmd_import(ImportArgs {
+            source: baseline_source,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        })
+        .await
+        .unwrap();
+
+        // A second import mixes a well-formed entity with a bare string
+        // element. The whole import must be rejected — the well-formed
+        // entity must NOT be written even though it appears before the
+        // malformed element in the array.
+        let never_imported_id = "99999999-9999-9999-9999-999999999999";
+        let bad_json = format!(
+            r#"[{{"id":"{never_imported_id}","kind":"concept","name":"NeverImported"}},"not-a-record"]"#
+        );
+        let bad_source = tmp.path().join("bad.json");
+        std::fs::write(&bad_source, &bad_json).unwrap();
+
+        let err = cmd_import(ImportArgs {
+            source: bad_source,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        })
+        .await
+        .expect_err("non-object array element must fail the whole import");
+        assert!(
+            err.chain().any(|e| e.to_string().contains("$record")),
+            "error must identify the malformed record, got: {err:#}"
+        );
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let rt2 = KhiveRuntime::new(config).unwrap();
+        let tok2 = rt2.authorize(ns).unwrap();
+
+        let baseline_uuid: Uuid = baseline_id.parse().unwrap();
+        let baseline = rt2
+            .get_entity(&tok2, baseline_uuid)
+            .await
+            .expect("baseline entity must still be present, untouched by the failed import");
+        assert_eq!(baseline.name, "Baseline");
+
+        let never_imported_uuid: Uuid = never_imported_id.parse().unwrap();
+        assert!(
+            rt2.get_entity(&tok2, never_imported_uuid).await.is_err(),
+            "entity preceding the malformed element in the array must not have been imported"
+        );
+    }
+
     #[test]
     fn validate_edge_weight_out_of_range_is_rejected() {
         let err = validate_edge_weight(1.5, "edge-z").unwrap_err();

--- a/crates/kkernel/src/kg/fetch.rs
+++ b/crates/kkernel/src/kg/fetch.rs
@@ -1,24 +1,12 @@
 //! `kkernel kg fetch` — fetch a remote KG archive.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use super::types::FetchArgs;
-
-pub(super) fn is_safe_remote_name(s: &str) -> bool {
-    !s.is_empty()
-        && s != "."
-        && s != ".."
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-}
+use crate::sync::RemoteName;
 
 pub(super) async fn cmd_fetch(args: FetchArgs) -> Result<()> {
-    if !is_safe_remote_name(&args.remote) {
-        bail!(
-            "invalid remote name {:?}: must be [A-Za-z0-9._-]+ and not . or ..",
-            args.remote
-        );
-    }
+    let name = RemoteName::parse(args.remote).context("invalid --remote")?;
 
     let pin = args
         .pin
@@ -28,7 +16,7 @@ pub(super) async fn cmd_fetch(args: FetchArgs) -> Result<()> {
         .context("invalid --pin")?;
 
     let remote = crate::sync::RemoteConfig {
-        name: args.remote,
+        name,
         url: args.url,
         git_ref: args.git_ref,
         namespace: args.namespace,

--- a/crates/kkernel/src/kg/status.rs
+++ b/crates/kkernel/src/kg/status.rs
@@ -80,4 +80,52 @@ mod tests {
         let ndjson_hash = khive_vcs::hash::snapshot_id_for_archive(&ndjson_archive).unwrap();
         assert_eq!(db_hash, ndjson_hash, "hashes must match after sync");
     }
+
+    /// #473 exposed a sibling gap: `run_sync` now preserves `entity_type` into
+    /// the DB, but `archive_from_ndjson_repo` (the status command's NDJSON-side
+    /// reader) hardcoded `entity_type: None`, so a repo with typed entities
+    /// reported dirty immediately after a clean sync. Mirrors
+    /// `status_hashes_clean_after_sync` but with a real `entity_type` set.
+    #[tokio::test]
+    async fn status_hashes_clean_after_sync_with_entity_type() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path();
+        let entity_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+        let entity_ndjson = format!(
+            r#"{{"id":"{entity_id}","kind":"document","entity_type":"paper","name":"Attention Is All You Need","properties":{{}},"tags":[]}}"#
+        );
+        let kg_dir = repo.join(".khive/kg");
+        std::fs::create_dir_all(&kg_dir).unwrap();
+        std::fs::write(kg_dir.join("entities.ndjson"), &entity_ndjson).unwrap();
+        std::fs::write(kg_dir.join("edges.ndjson"), "").unwrap();
+
+        let db = repo.join(".khive/state/working.db");
+        crate::sync::run_sync(repo, &db, "test-ns").await.unwrap();
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let runtime = KhiveRuntime::new(config).unwrap();
+        let token = runtime.authorize(ns).unwrap();
+
+        let db_archive = runtime.export_kg(&token).await.unwrap();
+        let ndjson_archive = archive_from_ndjson_repo(repo, "test-ns").unwrap();
+
+        assert_eq!(
+            ndjson_archive.entities[0].entity_type.as_deref(),
+            Some("paper"),
+            "NDJSON-side archive must preserve entity_type, not hardcode None"
+        );
+
+        let db_hash = khive_vcs::hash::snapshot_id_for_archive(&db_archive).unwrap();
+        let ndjson_hash = khive_vcs::hash::snapshot_id_for_archive(&ndjson_archive).unwrap();
+        assert_eq!(
+            db_hash, ndjson_hash,
+            "hashes must match after sync even when entities carry entity_type"
+        );
+    }
 }

--- a/crates/kkernel/src/sync.rs
+++ b/crates/kkernel/src/sync.rs
@@ -4,4 +4,6 @@
 //! This module re-exports the types and function so the `kkernel` binary CLI
 //! layer can call them with minimal indirection.
 
-pub use khive_vcs::sync::{run_sync, run_sync_remote, RemoteConfig, RemoteSyncReport, SyncReport};
+pub use khive_vcs::sync::{
+    run_sync, run_sync_remote, RemoteConfig, RemoteName, RemoteSyncReport, SyncReport,
+};


### PR DESCRIPTION
Resolves 6 defect findings from an internal audit sweep in `khive-vcs`/`khive-vcs-adapters`:
- #472: preserve ADR-020 adapter fields (entity_type, timestamps) through NDJSON round-trip
- #473: preserve `entity_type` through NDJSON sync and remote hash (was hardcoded to `None`, breaking hash + import)
- #474: validate remote-cache names via a `RemoteName` newtype (path-traversal hardening)
- #475: publish the remote cache atomically (staged dir + single rename swap; no old/new/meta interleaving)
- #476: full structural validation (kind, timestamps, sort order, dup IDs/triples, dangling endpoints, weight range) before any temp DB is built — old DB is byte-unchanged on rejection
- #488: adapters fail closed on malformed records (non-object array elements fatal; non-object edge `properties` warns instead of silently becoming `{}`)

## Verification
- **Adversarial review**: independently re-verified every fix against source, `git show`, and a live gate re-run (not just trusting prior implementer/tester reports) — **approved**, `CRIT:0 | MAJ:0 | MIN:2 (documented escalations, non-blocking)`.
  - MIN-1: `#472` edge-timestamp DB persistence needs a further `khive-runtime` schema change beyond this PR's 2-crate scope — escalation, not a gap in this PR.
  - MIN-2: `#475`'s crash window (backup-rename to new-rename) can leave an existing cache **absent** post-crash — availability-only, never torn/corrupt. Documented, not gating.
- **Independent re-run**: `cargo test -p khive-vcs -p khive-vcs-adapters -p kkernel` — 72+9+9+19+156+2+2 = all green, 0 failed; `clippy --all-targets -D warnings` clean; `fmt --check` clean.
- Additional independent review pending. This PR stays in draft until that review fully approves — not marked ready or auto-merged on this review alone.

## Test plan
- [x] `cargo test --workspace` (targeted: khive-vcs, khive-vcs-adapters, kkernel) — all green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Additional independent review (pending)
