### PR TITLE
fix(pack-brain): durable profile mutations, fail-closed feedback persistence, namespaced recall dispatch hook

### DIFF
--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -38,6 +38,11 @@ lattice-router = ["dep:lattice-fann"]
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+# Dev-only: exercises the real memory.recall -> BrainPack dispatch-hook path
+# (issue #459 regression). khive-pack-memory already carries khive-pack-brain
+# as a dev-dependency for its own tests; Cargo permits cyclic dev-dependencies
+# since neither crate's normal (non-dev) dependency graph is affected.
+khive-pack-memory = { version = "0.3.0", path = "../khive-pack-memory" }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/khive-pack-brain/src/event.rs
+++ b/crates/khive-pack-brain/src/event.rs
@@ -15,10 +15,14 @@ use khive_brain_core::{FeedbackEventKind, FeedbackSignal, SectionType};
 /// Any `brain.emit` event that predates this rename is treated as Irrelevant so
 /// that old event log entries do not cause spurious feedback updates.
 ///
+/// The runtime dispatch hook (`khive-runtime`) emits the namespaced verb
+/// (e.g. `"memory.recall"`) as the verb it actually dispatched. `"recall"` is
+/// retained as a legacy alias for event-log rows predating namespacing.
+///
 /// To add a new signal source: add one match arm to this function.
 pub fn interpret(event: &Event) -> BrainSignal {
     match event.verb.as_str() {
-        "recall" => match event.outcome {
+        "memory.recall" | "recall" => match event.outcome {
             EventOutcome::Success => match event.target_id {
                 Some(tid) => BrainSignal::RecallHit {
                     target_id: tid,
@@ -126,6 +130,18 @@ mod tests {
     fn recall_success_with_target_is_hit() {
         let id = Uuid::new_v4();
         let e = make_event("recall", EventOutcome::Success, Some(id));
+        match interpret(&e) {
+            BrainSignal::RecallHit { target_id, .. } => assert_eq!(target_id, id),
+            other => panic!("expected RecallHit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_recall_success_with_target_is_hit() {
+        // Namespaced verb, as actually dispatched by the runtime's VerbRegistry
+        // for `memory.recall` — see khive-runtime/src/pack.rs's dispatch hook.
+        let id = Uuid::new_v4();
+        let e = make_event("memory.recall", EventOutcome::Success, Some(id));
         match interpret(&e) {
             BrainSignal::RecallHit { target_id, .. } => assert_eq!(target_id, id),
             other => panic!("expected RecallHit, got {other:?}"),

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1328,7 +1328,8 @@ impl BrainPack {
 
         // ADR-081 §6: "the fold... backfills the ledger row's grade." Runs after
         // the fold itself so a ledger-write failure never blocks the feedback
-        // event from landing; non-fatal like the persistence call above.
+        // event from landing — intentionally non-fatal, unlike the fail-closed
+        // brain-state persistence above (#458).
         if let (Some(scorer_run_id), Some(serve_ledger_id)) =
             (p.scorer_run_id.as_deref(), p.serve_ledger_id.as_deref())
         {

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -738,20 +738,40 @@ impl BrainPack {
 
     // ── brain.activate / deactivate / archive ─────────────────────────────
 
-    pub(crate) async fn handle_activate(&self, params: Value) -> Result<Value, RuntimeError> {
-        self.set_lifecycle(params, ProfileLifecycle::Active).await
+    pub(crate) async fn handle_activate(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        self.set_lifecycle(token, params, ProfileLifecycle::Active)
+            .await
     }
 
-    pub(crate) async fn handle_deactivate(&self, params: Value) -> Result<Value, RuntimeError> {
-        self.set_lifecycle(params, ProfileLifecycle::Inactive).await
+    pub(crate) async fn handle_deactivate(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        self.set_lifecycle(token, params, ProfileLifecycle::Inactive)
+            .await
     }
 
-    pub(crate) async fn handle_archive(&self, params: Value) -> Result<Value, RuntimeError> {
-        self.set_lifecycle(params, ProfileLifecycle::Archived).await
+    pub(crate) async fn handle_archive(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        self.set_lifecycle(token, params, ProfileLifecycle::Archived)
+            .await
     }
 
+    /// Route a profile lifecycle transition through the durable-write helper
+    /// (issue #457): the transition is validated and applied against a
+    /// proposed state copy, and only takes effect in `self.state` after the
+    /// brain event-log append + snapshot upsert commit in one transaction.
     pub(crate) async fn set_lifecycle(
         &self,
+        token: &NamespaceToken,
         params: Value,
         lifecycle: ProfileLifecycle,
     ) -> Result<Value, RuntimeError> {
@@ -763,45 +783,76 @@ impl BrainPack {
         let p: LifecycleParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        let mut state = self.state.lock().unwrap();
-        let record = state
-            .profiles
-            .get_mut(&p.profile_id)
-            .ok_or_else(|| RuntimeError::NotFound(format!("profile {:?}", p.profile_id)))?;
+        let event_kind = match lifecycle {
+            ProfileLifecycle::Active => "brain.activate",
+            ProfileLifecycle::Inactive => "brain.deactivate",
+            ProfileLifecycle::Archived => "brain.archive",
+            // set_lifecycle is only ever invoked (via handle_activate /
+            // handle_deactivate / handle_archive) with one of the three
+            // targets above; other lifecycle values are registry-only states
+            // that no handler transitions to here.
+            ProfileLifecycle::Defined | ProfileLifecycle::Registered => "brain.set_lifecycle",
+        };
+        let profile_id = p.profile_id;
+        let event_payload = json!({ "profile_id": profile_id, "lifecycle": lifecycle.clone() });
 
-        // Lifecycle DAG: defined → registered → active ⟷ inactive → archived
-        // Terminal state: archived is read-only/audit-retained.
-        // No transition OUT of archived is legal.
-        // Active → archived is also illegal; must deactivate first.
-        match (&record.lifecycle, &lifecycle) {
-            // archived is terminal — nothing leaves it
-            (ProfileLifecycle::Archived, _) => {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "profile {:?} is archived; archive is terminal and no transition is permitted",
-                    p.profile_id
-                )));
-            }
-            // active → archived is illegal (must go through inactive first)
-            (ProfileLifecycle::Active, ProfileLifecycle::Archived) => {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "profile {:?} is active; deactivate it before archiving",
-                    p.profile_id
-                )));
-            }
-            // all other transitions are permitted
-            _ => {}
-        }
+        crate::persist::persist_brain_state_mutation(
+            &self.runtime,
+            token,
+            &self.persistence,
+            &self.state,
+            crate::persist::BrainMutationEvent {
+                profile_id: profile_id.clone(),
+                event_kind: event_kind.to_string(),
+                payload: event_payload,
+            },
+            ENTITY_CACHE_CAPACITY,
+            move |state: &mut khive_brain_core::BrainState| -> Result<Value, RuntimeError> {
+                let record = state
+                    .profiles
+                    .get_mut(&profile_id)
+                    .ok_or_else(|| RuntimeError::NotFound(format!("profile {:?}", profile_id)))?;
 
-        record.lifecycle = lifecycle.clone();
-        Ok(json!({
-            "profile_id": p.profile_id,
-            "lifecycle": lifecycle,
-        }))
+                // Lifecycle DAG: defined → registered → active ⟷ inactive → archived
+                // Terminal state: archived is read-only/audit-retained.
+                // No transition OUT of archived is legal.
+                // Active → archived is also illegal; must deactivate first.
+                match (&record.lifecycle, &lifecycle) {
+                    // archived is terminal — nothing leaves it
+                    (ProfileLifecycle::Archived, _) => {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "profile {:?} is archived; archive is terminal and no transition is permitted",
+                            profile_id
+                        )));
+                    }
+                    // active → archived is illegal (must go through inactive first)
+                    (ProfileLifecycle::Active, ProfileLifecycle::Archived) => {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "profile {:?} is active; deactivate it before archiving",
+                            profile_id
+                        )));
+                    }
+                    // all other transitions are permitted
+                    _ => {}
+                }
+
+                record.lifecycle = lifecycle.clone();
+                Ok(json!({
+                    "profile_id": profile_id,
+                    "lifecycle": lifecycle,
+                }))
+            },
+        )
+        .await
     }
 
     // ── brain.reset ───────────────────────────────────────────────────────
 
-    pub(crate) async fn handle_reset(&self, params: Value) -> Result<Value, RuntimeError> {
+    pub(crate) async fn handle_reset(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
         // profile_id is optional; defaults to "balanced-recall-v1".
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
@@ -813,51 +864,69 @@ impl BrainPack {
         let profile_id = p
             .profile_id
             .unwrap_or_else(|| "balanced-recall-v1".to_string());
-        let mut state = self.state.lock().unwrap();
+        let event_payload = json!({ "profile_id": profile_id });
 
-        // Validate profile exists.
-        let lifecycle = state
-            .profiles
-            .get(&profile_id)
-            .ok_or_else(|| RuntimeError::NotFound(format!("profile {:?}", profile_id)))?
-            .lifecycle
-            .clone();
+        // Route through the durable-write helper (issue #457): reset is
+        // applied to a proposed state copy and only takes effect after the
+        // brain event-log append + snapshot upsert commit.
+        crate::persist::persist_brain_state_mutation(
+            &self.runtime,
+            token,
+            &self.persistence,
+            &self.state,
+            crate::persist::BrainMutationEvent {
+                profile_id: profile_id.clone(),
+                event_kind: "brain.reset".to_string(),
+                payload: event_payload,
+            },
+            ENTITY_CACHE_CAPACITY,
+            move |state: &mut khive_brain_core::BrainState| -> Result<Value, RuntimeError> {
+                // Validate profile exists.
+                let lifecycle = state
+                    .profiles
+                    .get(&profile_id)
+                    .ok_or_else(|| RuntimeError::NotFound(format!("profile {:?}", profile_id)))?
+                    .lifecycle
+                    .clone();
 
-        // Reject archived profiles — archive is terminal and read-only.
-        if lifecycle == ProfileLifecycle::Archived {
-            return Err(RuntimeError::InvalidInput(format!(
-                "profile {:?} is archived; archive is terminal and reset is not permitted",
-                profile_id
-            )));
-        }
+                // Reject archived profiles — archive is terminal and read-only.
+                if lifecycle == ProfileLifecycle::Archived {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "profile {:?} is archived; archive is terminal and reset is not permitted",
+                        profile_id
+                    )));
+                }
 
-        if profile_id == "balanced-recall-v1" {
-            state.reset_posteriors();
-            // Sync profile record after reset so brain.profile reflects the restored
-            // domain-informed priors, not stale pre-reset values.
-            sync_balanced_recall_record(&mut state);
-        } else if state.profile_states.contains_key(&profile_id) {
-            // User-created Bayesian profile — reset its own posteriors.
-            state.reset_profile_posteriors(&profile_id);
-        } else {
-            // Profile exists in registry but has no live state (e.g. non-Bayesian).
-            // Increment exploration_epoch on the record to mark the reset event.
-            if let Some(record) = state.profiles.get_mut(&profile_id) {
-                record.exploration_epoch += 1;
-            }
-        }
+                if profile_id == "balanced-recall-v1" {
+                    state.reset_posteriors();
+                    // Sync profile record after reset so brain.profile reflects the restored
+                    // domain-informed priors, not stale pre-reset values.
+                    sync_balanced_recall_record(state);
+                } else if state.profile_states.contains_key(&profile_id) {
+                    // User-created Bayesian profile — reset its own posteriors.
+                    state.reset_profile_posteriors(&profile_id);
+                } else {
+                    // Profile exists in registry but has no live state (e.g. non-Bayesian).
+                    // Increment exploration_epoch on the record to mark the reset event.
+                    if let Some(record) = state.profiles.get_mut(&profile_id) {
+                        record.exploration_epoch += 1;
+                    }
+                }
 
-        let epoch = if profile_id == "balanced-recall-v1" {
-            state.balanced_recall.exploration_epoch
-        } else {
-            state.profiles[&profile_id].exploration_epoch
-        };
+                let epoch = if profile_id == "balanced-recall-v1" {
+                    state.balanced_recall.exploration_epoch
+                } else {
+                    state.profiles[&profile_id].exploration_epoch
+                };
 
-        Ok(json!({
-            "reset": true,
-            "profile_id": profile_id,
-            "exploration_epoch": epoch,
-        }))
+                Ok(json!({
+                    "reset": true,
+                    "profile_id": profile_id,
+                    "exploration_epoch": epoch,
+                }))
+            },
+        )
+        .await
     }
 
     // ── brain.feedback ────────────────────────────────────────────────────
@@ -1365,7 +1434,11 @@ impl BrainPack {
 
     // ── brain.bind ────────────────────────────────────────────────────────
 
-    pub(crate) async fn handle_bind(&self, params: Value) -> Result<Value, RuntimeError> {
+    pub(crate) async fn handle_bind(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct BindParams {
@@ -1377,25 +1450,6 @@ impl BrainPack {
         }
         let p: BindParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
-
-        let mut state = self.state.lock().unwrap();
-
-        // Verify the profile exists and is not archived (archived = terminal, no new bindings).
-        match state.profiles.get(&p.profile_id) {
-            None => {
-                return Err(RuntimeError::NotFound(format!(
-                    "profile {:?}",
-                    p.profile_id
-                )));
-            }
-            Some(record) if record.lifecycle == ProfileLifecycle::Archived => {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "profile {:?} is archived; bindings to archived profiles are not permitted",
-                    p.profile_id
-                )));
-            }
-            Some(_) => {}
-        }
 
         let actor = p.actor.unwrap_or_else(|| "*".into());
         let namespace = p.namespace.unwrap_or_else(|| "*".into());
@@ -1426,32 +1480,80 @@ impl BrainPack {
             khive_runtime::secret_gate::check(&consumer_kind)?;
         }
 
-        // Remove any existing binding for the same (actor, namespace, consumer_kind)
-        state.bindings.retain(|b| {
-            !(b.actor == actor && b.namespace == namespace && b.consumer_kind == consumer_kind)
-        });
-
-        state.bindings.push(ProfileBinding {
-            actor: actor.clone(),
-            namespace: namespace.clone(),
-            consumer_kind: consumer_kind.clone(),
-            profile_id: p.profile_id.clone(),
-            priority: p.priority.unwrap_or(0),
-            created_at: Utc::now(),
-        });
-
-        Ok(json!({
-            "bound": true,
-            "profile_id": p.profile_id,
+        let profile_id = p.profile_id;
+        let priority = p.priority.unwrap_or(0);
+        let event_payload = json!({
+            "profile_id": profile_id,
             "actor": actor,
             "namespace": namespace,
             "consumer_kind": consumer_kind,
-        }))
+            "priority": priority,
+        });
+
+        // Route through the durable-write helper (issue #457): the binding
+        // change is applied to a proposed state copy and only takes effect
+        // after the brain event-log append + snapshot upsert commit.
+        crate::persist::persist_brain_state_mutation(
+            &self.runtime,
+            token,
+            &self.persistence,
+            &self.state,
+            crate::persist::BrainMutationEvent {
+                profile_id: profile_id.clone(),
+                event_kind: "brain.bind".to_string(),
+                payload: event_payload,
+            },
+            ENTITY_CACHE_CAPACITY,
+            move |state: &mut khive_brain_core::BrainState| -> Result<Value, RuntimeError> {
+                // Verify the profile exists and is not archived (archived = terminal, no new bindings).
+                match state.profiles.get(&profile_id) {
+                    None => {
+                        return Err(RuntimeError::NotFound(format!("profile {:?}", profile_id)));
+                    }
+                    Some(record) if record.lifecycle == ProfileLifecycle::Archived => {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "profile {:?} is archived; bindings to archived profiles are not permitted",
+                            profile_id
+                        )));
+                    }
+                    Some(_) => {}
+                }
+
+                // Remove any existing binding for the same (actor, namespace, consumer_kind)
+                state.bindings.retain(|b| {
+                    !(b.actor == actor
+                        && b.namespace == namespace
+                        && b.consumer_kind == consumer_kind)
+                });
+
+                state.bindings.push(ProfileBinding {
+                    actor: actor.clone(),
+                    namespace: namespace.clone(),
+                    consumer_kind: consumer_kind.clone(),
+                    profile_id: profile_id.clone(),
+                    priority,
+                    created_at: Utc::now(),
+                });
+
+                Ok(json!({
+                    "bound": true,
+                    "profile_id": profile_id,
+                    "actor": actor,
+                    "namespace": namespace,
+                    "consumer_kind": consumer_kind,
+                }))
+            },
+        )
+        .await
     }
 
     // ── brain.unbind ──────────────────────────────────────────────────────
 
-    pub(crate) async fn handle_unbind(&self, params: Value) -> Result<Value, RuntimeError> {
+    pub(crate) async fn handle_unbind(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct UnbindParams {
@@ -1474,25 +1576,50 @@ impl BrainPack {
             ));
         }
 
-        let mut state = self.state.lock().unwrap();
-        let before = state.bindings.len();
-
-        state.bindings.retain(|b| {
-            let pid_match = p.profile_id.as_ref().is_none_or(|id| &b.profile_id == id);
-            let actor_match = p.actor.as_ref().is_none_or(|a| &b.actor == a);
-            let ns_match = p.namespace.as_ref().is_none_or(|n| &b.namespace == n);
-            let kind_match = p
-                .consumer_kind
-                .as_ref()
-                .is_none_or(|k| &b.consumer_kind == k);
-            // Retain if this binding does NOT match ALL of the provided filters.
-            // A filter that is absent (None) matches everything — only bindings
-            // satisfying every supplied criterion are removed.
-            !(pid_match && actor_match && ns_match && kind_match)
+        let event_payload = json!({
+            "profile_id": p.profile_id,
+            "actor": p.actor,
+            "namespace": p.namespace,
+            "consumer_kind": p.consumer_kind,
         });
+        let event_profile_id = p.profile_id.clone().unwrap_or_else(|| "*".to_string());
 
-        let removed = before - state.bindings.len();
-        Ok(json!({ "unbound": removed }))
+        // Route through the durable-write helper (issue #457): the binding
+        // removal is applied to a proposed state copy and only takes effect
+        // after the brain event-log append + snapshot upsert commit.
+        crate::persist::persist_brain_state_mutation(
+            &self.runtime,
+            token,
+            &self.persistence,
+            &self.state,
+            crate::persist::BrainMutationEvent {
+                profile_id: event_profile_id,
+                event_kind: "brain.unbind".to_string(),
+                payload: event_payload,
+            },
+            ENTITY_CACHE_CAPACITY,
+            move |state: &mut khive_brain_core::BrainState| -> Result<Value, RuntimeError> {
+                let before = state.bindings.len();
+
+                state.bindings.retain(|b| {
+                    let pid_match = p.profile_id.as_ref().is_none_or(|id| &b.profile_id == id);
+                    let actor_match = p.actor.as_ref().is_none_or(|a| &b.actor == a);
+                    let ns_match = p.namespace.as_ref().is_none_or(|n| &b.namespace == n);
+                    let kind_match = p
+                        .consumer_kind
+                        .as_ref()
+                        .is_none_or(|k| &b.consumer_kind == k);
+                    // Retain if this binding does NOT match ALL of the provided filters.
+                    // A filter that is absent (None) matches everything — only bindings
+                    // satisfying every supplied criterion are removed.
+                    !(pid_match && actor_match && ns_match && kind_match)
+                });
+
+                let removed = before - state.bindings.len();
+                Ok(json!({ "unbound": removed }))
+            },
+        )
+        .await
     }
 
     // ── brain.bindings ────────────────────────────────────────────────────
@@ -1538,7 +1665,11 @@ impl BrainPack {
 
     // ── brain.create_profile ──────────────────────────────────────────────
 
-    pub(crate) async fn handle_create_profile(&self, params: Value) -> Result<Value, RuntimeError> {
+    pub(crate) async fn handle_create_profile(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
         // Allow external agents to create new profiles via MCP.
         // seed_priors: optional object for seeding section priors, or null for defaults.
         #[derive(Deserialize)]
@@ -1592,89 +1723,117 @@ impl BrainPack {
         if let Some(ref seed) = p.seed_priors {
             khive_runtime::secret_gate::check_json(seed)?;
         }
+        let seed_priors = p.seed_priors;
 
-        let mut state = self.state.lock().unwrap();
-
-        if state.profiles.contains_key(&p_name) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "profile {:?} already exists",
-                p_name
-            )));
-        }
-
-        // Initialize live BalancedRecallState for this profile so that reset and
-        // feedback can route to its actual posteriors rather than a metadata-only record.
-        let ps = khive_brain_core::BalancedRecallState::new(ENTITY_CACHE_CAPACITY);
-        let snap = serde_json::to_value(ps.to_snapshot()).ok();
-
-        let record = ProfileRecord {
-            id: p_name.clone(),
-            description: description.clone(),
-            consumer_kind: consumer_kind.clone(),
-            state_class: "Bayesian".into(),
-            lifecycle: ProfileLifecycle::Inactive,
-            created_at: Utc::now(),
-            state_snapshot: snap,
-            total_events: 0,
-            exploration_epoch: 0,
-        };
-
-        // Seed section posteriors: parse explicit section_posteriors object if provided,
-        // else use default informative priors.
-        let section_state = if let Some(ref seed) = p.seed_priors {
-            if let Some(sp_obj) = seed.get("section_posteriors").and_then(|v| v.as_object()) {
-                let mut priors = std::collections::HashMap::new();
-                for (key, val) in sp_obj {
-                    let st: SectionType = key.parse().map_err(|_| {
-                        RuntimeError::InvalidInput(format!("unknown section type: {key:?}"))
-                    })?;
-                    let alpha = val.get("alpha").and_then(|v| v.as_f64()).ok_or_else(|| {
-                        RuntimeError::InvalidInput(format!(
-                            "missing or invalid alpha for section {key:?}"
-                        ))
-                    })?;
-                    let beta = val.get("beta").and_then(|v| v.as_f64()).ok_or_else(|| {
-                        RuntimeError::InvalidInput(format!(
-                            "missing or invalid beta for section {key:?}"
-                        ))
-                    })?;
-                    let posterior =
-                        khive_brain_core::BetaPosterior::try_new(alpha, beta).map_err(|e| {
-                            RuntimeError::InvalidInput(format!(
-                                "invalid seed_priors for section {key:?}: {e}"
-                            ))
-                        })?;
-                    let ess = posterior.effective_sample_size();
-                    if ess > DEFAULT_ESS_CAP {
-                        return Err(RuntimeError::InvalidInput(format!(
-                            "seed_priors for section {key:?}: alpha+beta ({ess}) exceeds \
-                             maximum allowed ESS ({DEFAULT_ESS_CAP}); use values where \
-                             alpha + beta <= {DEFAULT_ESS_CAP}"
-                        )));
-                    }
-                    priors.insert(st, posterior);
-                }
-                SectionPosteriorState::from_priors(priors)
-            } else {
-                return Err(RuntimeError::InvalidInput(
-                    "seed_priors must contain a 'section_posteriors' object".into(),
-                ));
-            }
-        } else {
-            SectionPosteriorState::new()
-        };
-
-        state.profiles.insert(p_name.clone(), record);
-        state.profile_states.insert(p_name.clone(), ps);
-        state.section_states.insert(p_name.clone(), section_state);
-
-        Ok(json!({
-            "created": true,
+        let event_payload = json!({
             "profile_id": p_name,
             "consumer_kind": consumer_kind,
-            "lifecycle": "inactive",
             "description": description,
-        }))
+        });
+
+        // Route through the durable-write helper (issue #457): the new
+        // profile/state/section rows are applied to a proposed state copy
+        // and only take effect after the brain event-log append + snapshot
+        // upsert commit — so a persistence failure never leaves a phantom
+        // profile that vanishes on restart.
+        crate::persist::persist_brain_state_mutation(
+            &self.runtime,
+            token,
+            &self.persistence,
+            &self.state,
+            crate::persist::BrainMutationEvent {
+                profile_id: p_name.clone(),
+                event_kind: "brain.create_profile".to_string(),
+                payload: event_payload,
+            },
+            ENTITY_CACHE_CAPACITY,
+            move |state: &mut khive_brain_core::BrainState| -> Result<Value, RuntimeError> {
+                if state.profiles.contains_key(&p_name) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "profile {:?} already exists",
+                        p_name
+                    )));
+                }
+
+                // Initialize live BalancedRecallState for this profile so that reset and
+                // feedback can route to its actual posteriors rather than a metadata-only record.
+                let ps = khive_brain_core::BalancedRecallState::new(ENTITY_CACHE_CAPACITY);
+                let snap = serde_json::to_value(ps.to_snapshot()).ok();
+
+                let record = ProfileRecord {
+                    id: p_name.clone(),
+                    description: description.clone(),
+                    consumer_kind: consumer_kind.clone(),
+                    state_class: "Bayesian".into(),
+                    lifecycle: ProfileLifecycle::Inactive,
+                    created_at: Utc::now(),
+                    state_snapshot: snap,
+                    total_events: 0,
+                    exploration_epoch: 0,
+                };
+
+                // Seed section posteriors: parse explicit section_posteriors object if provided,
+                // else use default informative priors.
+                let section_state = if let Some(ref seed) = seed_priors {
+                    if let Some(sp_obj) = seed.get("section_posteriors").and_then(|v| v.as_object())
+                    {
+                        let mut priors = std::collections::HashMap::new();
+                        for (key, val) in sp_obj {
+                            let st: SectionType = key.parse().map_err(|_| {
+                                RuntimeError::InvalidInput(format!("unknown section type: {key:?}"))
+                            })?;
+                            let alpha =
+                                val.get("alpha").and_then(|v| v.as_f64()).ok_or_else(|| {
+                                    RuntimeError::InvalidInput(format!(
+                                        "missing or invalid alpha for section {key:?}"
+                                    ))
+                                })?;
+                            let beta =
+                                val.get("beta").and_then(|v| v.as_f64()).ok_or_else(|| {
+                                    RuntimeError::InvalidInput(format!(
+                                        "missing or invalid beta for section {key:?}"
+                                    ))
+                                })?;
+                            let posterior = khive_brain_core::BetaPosterior::try_new(alpha, beta)
+                                .map_err(|e| {
+                                RuntimeError::InvalidInput(format!(
+                                    "invalid seed_priors for section {key:?}: {e}"
+                                ))
+                            })?;
+                            let ess = posterior.effective_sample_size();
+                            if ess > DEFAULT_ESS_CAP {
+                                return Err(RuntimeError::InvalidInput(format!(
+                                    "seed_priors for section {key:?}: alpha+beta ({ess}) exceeds \
+                                     maximum allowed ESS ({DEFAULT_ESS_CAP}); use values where \
+                                     alpha + beta <= {DEFAULT_ESS_CAP}"
+                                )));
+                            }
+                            priors.insert(st, posterior);
+                        }
+                        SectionPosteriorState::from_priors(priors)
+                    } else {
+                        return Err(RuntimeError::InvalidInput(
+                            "seed_priors must contain a 'section_posteriors' object".into(),
+                        ));
+                    }
+                } else {
+                    SectionPosteriorState::new()
+                };
+
+                state.profiles.insert(p_name.clone(), record);
+                state.profile_states.insert(p_name.clone(), ps);
+                state.section_states.insert(p_name.clone(), section_state);
+
+                Ok(json!({
+                    "created": true,
+                    "profile_id": p_name,
+                    "consumer_kind": consumer_kind,
+                    "lifecycle": "inactive",
+                    "description": description,
+                }))
+            },
+        )
+        .await
     }
 
     // ── brain.register_adapter ────────────────────────────────────────────
@@ -1950,16 +2109,16 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.resolve" => self.handle_resolve(params).await,
             "brain.bindings" => self.handle_bindings(params).await,
             // Commissive
-            "brain.activate" => self.handle_activate(params).await,
-            "brain.deactivate" => self.handle_deactivate(params).await,
-            "brain.archive" => self.handle_archive(params).await,
-            "brain.reset" => self.handle_reset(params).await,
+            "brain.activate" => self.handle_activate(token, params).await,
+            "brain.deactivate" => self.handle_deactivate(token, params).await,
+            "brain.archive" => self.handle_archive(token, params).await,
+            "brain.reset" => self.handle_reset(token, params).await,
             "brain.feedback" => self.handle_feedback(token, params).await,
             "brain.auto_feedback" => self.handle_auto_feedback(token, params).await,
             // Declaration
-            "brain.bind" => self.handle_bind(params).await,
-            "brain.unbind" => self.handle_unbind(params).await,
-            "brain.create_profile" => self.handle_create_profile(params).await,
+            "brain.bind" => self.handle_bind(token, params).await,
+            "brain.unbind" => self.handle_unbind(token, params).await,
+            "brain.create_profile" => self.handle_create_profile(token, params).await,
             "brain.register_adapter" => self.handle_register_adapter(token, params).await,
             // Legacy
             "brain.emit" => self.handle_emit(token, params).await,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1224,108 +1224,106 @@ impl BrainPack {
             .unwrap_or("balanced-recall-v1")
             .to_string();
 
-        // Posteriors snapshotted while the lock is held; routing runs after the lock drops
-        // so the mutex scope is not widened across fann inference.
-        // Declared uninitialized: definitely assigned inside the lock scope below (in
-        // the feature-on build the cfg block always executes, so the compiler can verify
-        // definite initialization without a dead initial-value assignment).
-        #[cfg(feature = "lattice-router")]
-        #[allow(clippy::type_complexity)]
-        let router_inputs: Option<(
-            BetaPosterior,
-            BetaPosterior,
-            BetaPosterior,
-            Option<std::collections::HashMap<SectionType, BetaPosterior>>,
-        )>;
+        let brain_signal = interpret(&event);
 
-        {
-            let signal = interpret(&event);
-            let mut state = self.state.lock().unwrap();
-            let serving_profile = serving_profile_owned.as_str();
-
-            if serving_profile == "balanced-recall-v1" {
-                state.balanced_recall.apply_signal(&signal);
-                sync_balanced_recall_record(&mut state);
-            } else if state.profile_states.contains_key(serving_profile) {
-                let ps = state
-                    .profile_states
-                    .get_mut(serving_profile)
-                    .expect("key checked above");
-                ps.apply_signal(&signal);
-                let snap = serde_json::to_value(ps.to_snapshot()).ok();
-                let total = ps.total_events;
-                if let Some(record) = state.profiles.get_mut(serving_profile) {
-                    record.total_events = total;
-                    record.state_snapshot = snap;
-                }
-            } else {
-                state.balanced_recall.apply_signal(&signal);
-                sync_balanced_recall_record(&mut state);
-            }
-
-            // Seed and backfill section posteriors, then apply the signal.
-            // Shared contract with the replay path — see `ensure_section_state_seeded`.
-            {
-                let section_state = crate::ensure_section_state_seeded(
-                    &mut state.section_states,
-                    &serving_profile_owned,
-                );
-                section_state.apply_signal(&signal);
-            }
-
-            // Snapshot posteriors for lattice-router while the lock is still held.
-            // BetaPosterior is two f64s — cloning is cheap.
-            #[cfg(feature = "lattice-router")]
-            {
-                let (rel, sal, temp) = if serving_profile == "balanced-recall-v1" {
-                    (
-                        state.balanced_recall.relevance.clone(),
-                        state.balanced_recall.salience.clone(),
-                        state.balanced_recall.temporal.clone(),
-                    )
-                } else if let Some(ps) = state.profile_states.get(serving_profile) {
-                    (
-                        ps.relevance.clone(),
-                        ps.salience.clone(),
-                        ps.temporal.clone(),
-                    )
-                } else {
-                    (
-                        state.balanced_recall.relevance.clone(),
-                        state.balanced_recall.salience.clone(),
-                        state.balanced_recall.temporal.clone(),
-                    )
-                };
-                let sec = state
-                    .section_states
-                    .get(serving_profile)
-                    .map(|ss| ss.posteriors.clone());
-                router_inputs = Some((rel, sal, temp, sec));
-            }
-        }
-
-        // lattice-router: build the context vector from snapshotted posteriors and forward
-        // through the fann network. Lock is already released here.
-        // Consumption of routed weights lands with the engine route() seam (#343) and the
-        // compose value-gate (#346); no per-event stdout/stderr spam.
-        #[cfg(feature = "lattice-router")]
-        if let Some((rel, sal, temp, sec)) = router_inputs {
-            let ctx = build_context_vector(&rel, &sal, &temp, sec.as_ref());
-            let _routed = route_via_fann(&ctx);
-        }
-
-        // Persist feedback to brain_event_log; batch-upsert snapshot when dirty threshold reached.
-        if let Err(e) = crate::persist::persist_after_feedback(
+        // Issue #458: apply the posterior mutation and make its durability
+        // part of the success contract. `persist_brain_state_mutation` runs
+        // this closure against a *proposed* state copy, then commits the
+        // brain event-log append + snapshot upsert in one transaction —
+        // `self.state` is only replaced with the proposed copy after that
+        // commit succeeds. If persistence fails, this returns `Err` and
+        // `self.state` is left completely untouched (no phantom in-memory
+        // posterior update that vanishes on restart).
+        crate::persist::persist_brain_state_mutation(
             &self.runtime,
             token,
             &self.persistence,
             &self.state,
-            &event,
-            &serving_profile_owned,
+            crate::persist::BrainMutationEvent {
+                profile_id: serving_profile_owned.clone(),
+                event_kind: event.verb.clone(),
+                payload: serde_json::to_value(&event)
+                    .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?,
+            },
+            ENTITY_CACHE_CAPACITY,
+            {
+                let brain_signal = brain_signal.clone();
+                let serving_profile_owned = serving_profile_owned.clone();
+                move |state: &mut khive_brain_core::BrainState| -> Result<(), RuntimeError> {
+                    let serving_profile = serving_profile_owned.as_str();
+
+                    if serving_profile == "balanced-recall-v1" {
+                        state.balanced_recall.apply_signal(&brain_signal);
+                        sync_balanced_recall_record(state);
+                    } else if state.profile_states.contains_key(serving_profile) {
+                        let ps = state
+                            .profile_states
+                            .get_mut(serving_profile)
+                            .expect("key checked above");
+                        ps.apply_signal(&brain_signal);
+                        let snap = serde_json::to_value(ps.to_snapshot()).ok();
+                        let total = ps.total_events;
+                        if let Some(record) = state.profiles.get_mut(serving_profile) {
+                            record.total_events = total;
+                            record.state_snapshot = snap;
+                        }
+                    } else {
+                        state.balanced_recall.apply_signal(&brain_signal);
+                        sync_balanced_recall_record(state);
+                    }
+
+                    // Seed and backfill section posteriors, then apply the signal.
+                    // Shared contract with the replay path — see `ensure_section_state_seeded`.
+                    {
+                        let section_state = crate::ensure_section_state_seeded(
+                            &mut state.section_states,
+                            &serving_profile_owned,
+                        );
+                        section_state.apply_signal(&brain_signal);
+                    }
+
+                    Ok(())
+                }
+            },
         )
-        .await
+        .await?;
+
+        // lattice-router: build the context vector from the now-published live
+        // state and forward through the fann network. This is a best-effort
+        // routing computation independent of durability, so it reads from
+        // `self.state` only after the mutation above has durably committed.
+        // Consumption of routed weights lands with the engine route() seam (#343) and the
+        // compose value-gate (#346); no per-event stdout/stderr spam.
+        #[cfg(feature = "lattice-router")]
         {
-            eprintln!("[brain] persistence failed (non-fatal): {e}");
+            let state = self.state.lock().unwrap();
+            let serving_profile = serving_profile_owned.as_str();
+            let (rel, sal, temp) = if serving_profile == "balanced-recall-v1" {
+                (
+                    state.balanced_recall.relevance.clone(),
+                    state.balanced_recall.salience.clone(),
+                    state.balanced_recall.temporal.clone(),
+                )
+            } else if let Some(ps) = state.profile_states.get(serving_profile) {
+                (
+                    ps.relevance.clone(),
+                    ps.salience.clone(),
+                    ps.temporal.clone(),
+                )
+            } else {
+                (
+                    state.balanced_recall.relevance.clone(),
+                    state.balanced_recall.salience.clone(),
+                    state.balanced_recall.temporal.clone(),
+                )
+            };
+            let sec = state
+                .section_states
+                .get(serving_profile)
+                .map(|ss| ss.posteriors.clone());
+            drop(state);
+            let ctx = build_context_vector(&rel, &sal, &temp, sec.as_ref());
+            let _routed = route_via_fann(&ctx);
         }
 
         // ADR-081 §6: "the fold... backfills the ledger row's grade." Runs after

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -41,7 +41,7 @@ use serde_json::Value;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
-use khive_storage::SqlAccess;
+use khive_storage::{SqlAccess, SqlWriter};
 
 use khive_brain_core::{
     validate_brain_state_snapshot, BrainSignal, BrainState, BrainStateSnapshot,
@@ -221,8 +221,10 @@ fn sql_err(context: &str, e: impl std::fmt::Display) -> RuntimeError {
     RuntimeError::Internal(format!("brain persistence {context}: {e}"))
 }
 
-pub async fn append_brain_event(
-    sql: &dyn SqlAccess,
+/// Append one `brain_event_log` row using an already-acquired writer (plain
+/// writer or an open transaction — both implement `SqlWriter`).
+async fn append_brain_event_on_writer(
+    writer: &mut dyn SqlWriter,
     namespace: &str,
     profile_id: &str,
     event_kind: &str,
@@ -231,7 +233,6 @@ pub async fn append_brain_event(
 ) -> Result<(), RuntimeError> {
     let payload_str = serde_json::to_string(payload).map_err(|e| sql_err("serialize event", e))?;
 
-    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
     writer
         .execute(SqlStatement {
             sql: "INSERT INTO brain_event_log (profile_id, namespace, event_kind, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5)".into(),
@@ -250,8 +251,10 @@ pub async fn append_brain_event(
     Ok(())
 }
 
-pub async fn upsert_snapshot(
-    sql: &dyn SqlAccess,
+/// Upsert the namespace's `brain_profile_snapshots` row using an
+/// already-acquired writer (plain writer or an open transaction).
+async fn upsert_snapshot_on_writer(
+    writer: &mut dyn SqlWriter,
     namespace: &str,
     snapshot: &BrainStateSnapshot,
     updated_at_us: i64,
@@ -259,7 +262,6 @@ pub async fn upsert_snapshot(
     let snapshot_json =
         serde_json::to_string(snapshot).map_err(|e| sql_err("serialize snapshot", e))?;
 
-    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
     writer
         .execute(SqlStatement {
             sql: "INSERT INTO brain_profile_snapshots (profile_id, namespace, snapshot_json, updated_at) VALUES (?1, ?2, ?3, ?4) ON CONFLICT(profile_id, namespace) DO UPDATE SET snapshot_json = excluded.snapshot_json, updated_at = excluded.updated_at".into(),
@@ -275,6 +277,144 @@ pub async fn upsert_snapshot(
         .map_err(|e| sql_err("upsert snapshot", e))?;
 
     Ok(())
+}
+
+pub async fn append_brain_event(
+    sql: &dyn SqlAccess,
+    namespace: &str,
+    profile_id: &str,
+    event_kind: &str,
+    payload: &Value,
+    created_at_us: i64,
+) -> Result<(), RuntimeError> {
+    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+    append_brain_event_on_writer(
+        writer.as_mut(),
+        namespace,
+        profile_id,
+        event_kind,
+        payload,
+        created_at_us,
+    )
+    .await
+}
+
+pub async fn upsert_snapshot(
+    sql: &dyn SqlAccess,
+    namespace: &str,
+    snapshot: &BrainStateSnapshot,
+    updated_at_us: i64,
+) -> Result<(), RuntimeError> {
+    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+    upsert_snapshot_on_writer(writer.as_mut(), namespace, snapshot, updated_at_us).await
+}
+
+/// Descriptor for a single durable `BrainState` mutation (issues #457/#458):
+/// which brain-event-log row to append alongside the snapshot upsert.
+pub struct BrainMutationEvent {
+    pub profile_id: String,
+    pub event_kind: String,
+    pub payload: Value,
+}
+
+async fn exec_raw(writer: &mut dyn SqlWriter, sql: &str, label: &str) -> Result<(), RuntimeError> {
+    writer
+        .execute(SqlStatement {
+            sql: sql.to_string(),
+            params: Vec::new(),
+            label: Some(label.to_string()),
+        })
+        .await
+        .map_err(|e| sql_err(label, e))?;
+    Ok(())
+}
+
+/// Apply a `BrainState` mutation with durability as part of the success
+/// contract (issues #457/#458).
+///
+/// `mutate` runs against a *proposed* copy of the state (never the live
+/// `state` mutex) built via a snapshot round-trip. Its result and the
+/// resulting snapshot are then persisted — brain event-log append AND
+/// snapshot upsert — inside ONE `BEGIN IMMEDIATE` transaction held on a
+/// single `SqlWriter` connection. Only after that transaction commits does
+/// the proposed state replace the live state and the tracker get marked
+/// clean.
+///
+/// This deliberately does NOT use `SqlAccess::begin_tx` — per `fold_gate.rs`'s
+/// module doc, that API requires a file-backed database and errors for
+/// in-memory pools (used throughout this crate's test suite and by
+/// `KhiveRuntime::memory()`). Issuing `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` as
+/// ordinary statements on a plain `SqlWriter` handle gives the same
+/// all-or-nothing guarantee on both backends.
+///
+/// If `mutate` fails, or the transaction fails to begin, append, upsert, or
+/// commit, this returns `Err` and the live state is left completely
+/// untouched — there is no in-memory mutation to roll back because it was
+/// never applied to the shared state in the first place.
+pub async fn persist_brain_state_mutation<R>(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    tracker: &Mutex<PersistenceTracker>,
+    state: &Mutex<BrainState>,
+    event: BrainMutationEvent,
+    entity_capacity: usize,
+    mutate: impl FnOnce(&mut BrainState) -> Result<R, RuntimeError>,
+) -> Result<R, RuntimeError> {
+    let namespace = token.namespace().as_str().to_string();
+    let now_us = chrono::Utc::now().timestamp_micros();
+
+    let mut proposed = {
+        let current = state.lock().unwrap();
+        BrainState::from_snapshot(current.to_snapshot(), entity_capacity)
+    };
+
+    let result = mutate(&mut proposed)?;
+    let snapshot = proposed.to_snapshot();
+
+    let sql = runtime.sql();
+    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+
+    exec_raw(writer.as_mut(), "BEGIN IMMEDIATE", "begin mutation tx").await?;
+
+    let write_result: Result<(), RuntimeError> = async {
+        append_brain_event_on_writer(
+            writer.as_mut(),
+            &namespace,
+            &event.profile_id,
+            &event.event_kind,
+            &event.payload,
+            now_us,
+        )
+        .await?;
+        upsert_snapshot_on_writer(writer.as_mut(), &namespace, &snapshot, now_us).await?;
+        Ok(())
+    }
+    .await;
+
+    match write_result {
+        Ok(()) => {
+            if let Err(e) = exec_raw(writer.as_mut(), "COMMIT", "commit mutation tx").await {
+                let _ = exec_raw(writer.as_mut(), "ROLLBACK", "rollback mutation tx").await;
+                return Err(e);
+            }
+        }
+        Err(e) => {
+            let _ = exec_raw(writer.as_mut(), "ROLLBACK", "rollback mutation tx").await;
+            return Err(e);
+        }
+    }
+
+    {
+        let mut live = state.lock().unwrap();
+        *live = proposed;
+    }
+    {
+        let mut t = tracker.lock().unwrap();
+        t.reset_dirty(&namespace);
+        t.mark_loaded(namespace);
+    }
+
+    Ok(result)
 }
 
 pub async fn load_latest_snapshot(

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -779,51 +779,6 @@ pub async fn ensure_loaded(
     Ok(())
 }
 
-pub async fn persist_after_feedback(
-    runtime: &KhiveRuntime,
-    token: &NamespaceToken,
-    tracker: &Mutex<PersistenceTracker>,
-    state: &Mutex<BrainState>,
-    event: &khive_storage::event::Event,
-    serving_profile: &str,
-) -> Result<(), RuntimeError> {
-    let namespace = token.namespace().as_str().to_string();
-    let now_us = chrono::Utc::now().timestamp_micros();
-
-    let sql = runtime.sql();
-
-    let event_payload = serde_json::to_value(event).map_err(|e| sql_err("serialize event", e))?;
-
-    append_brain_event(
-        sql.as_ref(),
-        &namespace,
-        serving_profile,
-        &event.verb,
-        &event_payload,
-        now_us,
-    )
-    .await?;
-
-    let should_snapshot = {
-        let mut t = tracker.lock().unwrap();
-        t.increment_dirty(&namespace)
-    };
-
-    if should_snapshot {
-        let snapshot = {
-            let s = state.lock().unwrap();
-            s.to_snapshot()
-        };
-
-        upsert_snapshot(sql.as_ref(), &namespace, &snapshot, now_us).await?;
-
-        let mut t = tracker.lock().unwrap();
-        t.reset_dirty(&namespace);
-    }
-
-    Ok(())
-}
-
 // ── BRAIN-007: event-log replay quarantine diagnostics ────────────────────────
 
 #[cfg(test)]

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4901,7 +4901,7 @@ mod adr081_retune_driver_tests {
     }
 }
 
-// ── issue #457: durable-write helper regressions ────────────────────────────
+// ── issues #457 / #458: durable-write helper regressions ─────────────────────
 
 mod durable_write_tests {
     use super::*;
@@ -5073,6 +5073,98 @@ mod durable_write_tests {
             bindings["count"],
             json!(0u64),
             "brain.unbind must survive restart — no bob binding should remain"
+        );
+    }
+
+    /// #458 success path: `brain.feedback`'s posterior update must survive a
+    /// restart via the same durable-write helper used by #457, instead of the
+    /// old best-effort `persist_after_feedback` that ran after the in-memory
+    /// mutation and was logged (not surfaced) on failure.
+    #[tokio::test]
+    async fn feedback_posteriors_survive_restart() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        pack.dispatch(
+            "brain.feedback",
+            json!({"target_id": target, "signal": "useful"}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.feedback");
+
+        let live_total = pack.snapshot().balanced_recall.total_events;
+
+        drop(pack);
+        let pack2 = crate::BrainPack::new(rt.clone());
+        pack2
+            .ensure_loaded(&token)
+            .await
+            .expect("ensure_loaded on fresh pack");
+
+        assert_eq!(
+            pack2.snapshot().balanced_recall.total_events,
+            live_total,
+            "brain.feedback's posterior update must survive restart"
+        );
+    }
+
+    /// #458 fail-closed path: if the brain-specific persistence (event append
+    /// + snapshot upsert) fails, `brain.feedback` must return an error and
+    /// leave the in-memory state untouched — not log the failure as
+    /// non-fatal and still report `emitted: true`.
+    ///
+    /// The failure is injected by dropping the real `brain_profile_snapshots`
+    /// table to simulate genuine schema drift, so this exercises the actual
+    /// SQL failure path rather than a test-only mock hook.
+    #[tokio::test]
+    async fn feedback_fails_closed_when_brain_persistence_fails() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let before_us = chrono::Utc::now().timestamp_micros();
+        let total_before = pack.snapshot().balanced_recall.total_events;
+
+        {
+            let sql = rt.sql();
+            let mut writer = sql.writer().await.expect("writer");
+            writer
+                .execute_script("DROP TABLE brain_profile_snapshots;".to_string())
+                .await
+                .expect("drop brain_profile_snapshots to simulate schema drift");
+        }
+
+        let err = pack
+            .dispatch(
+                "brain.feedback",
+                json!({"target_id": target, "signal": "useful"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect_err("brain.feedback must fail when brain-specific persistence fails");
+        let _ = err;
+
+        let total_after = pack.snapshot().balanced_recall.total_events;
+        assert_eq!(
+            total_after, total_before,
+            "a failed brain-persistence write must leave in-memory state untouched"
+        );
+
+        // No brain_event_log row must have been committed for this call either
+        // — the append and the (failing) snapshot upsert share one transaction.
+        let sql = rt.sql();
+        let replay = crate::persist::load_events_since(sql.as_ref(), "local", before_us)
+            .await
+            .expect("load_events_since must still work (brain_event_log untouched)");
+        assert!(
+            replay.events.is_empty(),
+            "no brain_event_log row must be committed when the snapshot upsert fails"
         );
     }
 }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -3556,8 +3556,9 @@ async fn concurrent_cold_load_does_not_clobber_live_state() {
 /// ensure_loaded + handler steps in the exact order that a scheduler can
 /// produce, giving a deterministic reproduction of the race.
 ///
-/// Expected: A's brain.bind writes into the ns-b slot (wrong namespace).
-/// bindings(gate-ns-a) == 0  →  demonstrates the race.
+/// Expected: A's brain.bind lands in the wrong namespace's bookkeeping.
+/// See the comment at the assertions below for the exact (durability-fix-era)
+/// shape of the corruption this produces.
 ///
 /// This test runs against the PRODUCTION code (not a simulated removal)
 /// by calling ensure_loaded and the handler directly, bypassing the gate.
@@ -3587,36 +3588,49 @@ async fn dispatch_gate_race_is_observable_without_gate() {
     // Step 3: A's handler now runs (binding for ns-a). But the slot is ns-b.
     // WITHOUT the gate, dispatch() lets this happen after a concurrent swap.
     // We reproduce it by calling handle_bind directly.
-    pack.handle_bind(json!({
-        "profile_id": "balanced-recall-v1",
-        "actor": "racer-a",
-        "namespace": "bare-ns-a",
-        "consumer_kind": "recall",
-    }))
+    pack.handle_bind(
+        &token_a,
+        json!({
+            "profile_id": "balanced-recall-v1",
+            "actor": "racer-a",
+            "namespace": "bare-ns-a",
+            "consumer_kind": "recall",
+        }),
+    )
     .await
     .expect("handle_bind for a");
 
-    // Step 4: Assert the binding landed in the WRONG namespace (ns-b slot).
-    // This is the race: ns-a has 0 bindings, ns-b has 1 (A's write went there).
+    // Step 4: Assert the binding landed in the WRONG namespace slot.
+    //
+    // Since #457/#458, `handle_bind` durably persists through
+    // `persist_brain_state_mutation`, which also republishes
+    // `tracker.active_namespace` as `token.namespace()` (`bare-ns-a`) on
+    // success — even though the live state it mutated was actually ns-b's
+    // (loaded in step 2). That mislabels the save-restore bookkeeping, so
+    // the corruption now surfaces on the OPPOSITE side from before the
+    // durability fix: ns-b's slot comes back empty (its live content, plus
+    // A's leaked write, gets saved under the wrong namespace key), and A's
+    // leaked binding resurfaces under ns-a instead. The exact shape of the
+    // corruption changed; the underlying point — that bypassing the gate
+    // corrupts namespace isolation — still holds.
     let bindings_b_now = pack
         .dispatch("brain.bindings", json!({}), &registry, &token_b)
         .await
         .expect("bindings ns-b");
     assert_eq!(
         bindings_b_now["count"],
-        json!(1u64),
-        "race reproduced: A's bind wrote into the ns-b slot (WRONG namespace)"
+        json!(0u64),
+        "race reproduced: ns-b's slot lost its content to the mislabeled save-restore"
     );
 
-    // ns-a's saved state was saved before any binding was added, so it has 0.
     let bindings_a_now = pack
         .dispatch("brain.bindings", json!({}), &registry, &token_a)
         .await
         .expect("bindings ns-a");
     assert_eq!(
         bindings_a_now["count"],
-        json!(0u64),
-        "race reproduced: ns-a has 0 bindings because A's write went to ns-b"
+        json!(1u64),
+        "race reproduced: A's leaked bind resurfaces under ns-a's slot instead"
     );
 }
 
@@ -4883,6 +4897,182 @@ mod adr081_retune_driver_tests {
             (replayed_sal_beta - live_sal_beta).abs() < 1e-9,
             "replay must reproduce the live gated outcome exactly; \
              live={live_sal_beta}, replayed={replayed_sal_beta}"
+        );
+    }
+}
+
+// ── issue #457: durable-write helper regressions ────────────────────────────
+
+mod durable_write_tests {
+    use super::*;
+
+    /// #457: `brain.create_profile`, `brain.activate`, and `brain.bind` must
+    /// all survive a restart. Before the fix these mutated `ProfileRecord` /
+    /// `bindings` in memory only — `ensure_loaded` on a fresh `BrainPack`
+    /// replayed only `brain_event_log` since the last snapshot, so the
+    /// profile and binding vanished and `brain.resolve` fell back to
+    /// `balanced-recall-v1`.
+    ///
+    /// This test uses ONE backing store (`rt`) and a genuinely FRESH
+    /// `BrainPack` instance (`pack2`) to simulate a restart, per the issue's
+    /// verification criteria — not a peek at the first pack's in-memory state.
+    #[tokio::test]
+    async fn profile_management_mutations_survive_restart() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        pack.dispatch(
+            "brain.create_profile",
+            json!({"name": "tenant-recall", "consumer_kind": "recall"}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.create_profile");
+
+        pack.dispatch(
+            "brain.activate",
+            json!({"profile_id": "tenant-recall"}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.activate");
+
+        pack.dispatch(
+            "brain.bind",
+            json!({
+                "profile_id": "tenant-recall",
+                "actor": "alice",
+                "namespace": "local",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.bind");
+
+        // Simulate a restart: drop the first pack entirely and construct a
+        // brand new one over the same backing store.
+        drop(pack);
+        let pack2 = crate::BrainPack::new(rt.clone());
+
+        let profiles = pack2
+            .dispatch("brain.profiles", json!({}), &registry, &token)
+            .await
+            .expect("brain.profiles on fresh pack");
+        let tenant = profiles["profiles"]
+            .as_array()
+            .expect("profiles array")
+            .iter()
+            .find(|p| p["id"] == json!("tenant-recall"))
+            .expect("tenant-recall profile must survive restart");
+        assert_eq!(
+            tenant["lifecycle"],
+            json!("active"),
+            "brain.activate must survive restart"
+        );
+
+        let bindings = pack2
+            .dispatch(
+                "brain.bindings",
+                json!({"profile_id": "tenant-recall"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.bindings on fresh pack");
+        assert_eq!(
+            bindings["count"],
+            json!(1u64),
+            "brain.bind must survive restart"
+        );
+
+        let resolved = pack2
+            .dispatch(
+                "brain.resolve",
+                json!({"actor": "alice", "namespace": "local", "consumer_kind": "recall"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.resolve on fresh pack");
+        assert_eq!(
+            resolved["resolved_profile_id"],
+            json!("tenant-recall"),
+            "resolve must use the durably-bound profile, not fall back to balanced-recall-v1"
+        );
+    }
+
+    /// #457: `brain.reset` and `brain.unbind` must also survive a restart —
+    /// same durable-write helper, different mutations.
+    #[tokio::test]
+    async fn reset_and_unbind_survive_restart() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        // Advance balanced-recall-v1's posteriors, then reset — the reset
+        // itself must be durable.
+        pack.dispatch(
+            "brain.feedback",
+            json!({"target_id": target, "signal": "useful"}),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.feedback");
+        pack.dispatch("brain.reset", json!({}), &registry, &token)
+            .await
+            .expect("brain.reset");
+        let epoch_after_reset = pack.snapshot().balanced_recall.exploration_epoch;
+
+        pack.dispatch(
+            "brain.bind",
+            json!({
+                "profile_id": "balanced-recall-v1",
+                "actor": "bob",
+                "namespace": "local",
+                "consumer_kind": "recall",
+            }),
+            &registry,
+            &token,
+        )
+        .await
+        .expect("brain.bind");
+        pack.dispatch("brain.unbind", json!({"actor": "bob"}), &registry, &token)
+            .await
+            .expect("brain.unbind");
+
+        drop(pack);
+        let pack2 = crate::BrainPack::new(rt.clone());
+
+        let profile = pack2
+            .dispatch(
+                "brain.profile",
+                json!({"profile_id": "balanced-recall-v1"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.profile on fresh pack");
+        assert_eq!(
+            profile["exploration_epoch"],
+            json!(epoch_after_reset),
+            "brain.reset's exploration_epoch bump must survive restart"
+        );
+
+        let bindings = pack2
+            .dispatch("brain.bindings", json!({"actor": "bob"}), &registry, &token)
+            .await
+            .expect("brain.bindings on fresh pack");
+        assert_eq!(
+            bindings["count"],
+            json!(0u64),
+            "brain.unbind must survive restart — no bob binding should remain"
         );
     }
 }

--- a/crates/khive-pack-brain/tests/dispatch_hook.rs
+++ b/crates/khive-pack-brain/tests/dispatch_hook.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use khive_pack_brain::BrainPack;
 use khive_pack_kg::KgPack;
+use khive_pack_memory::MemoryPack;
 use khive_runtime::{DispatchHook, KhiveRuntime, Namespace, PackRuntime, VerbRegistryBuilder};
 use serde_json::json;
 
@@ -404,5 +405,122 @@ async fn brain_feedback_accepts_foreign_namespace_target_id() {
     assert!(
         err.to_string().to_lowercase().contains("not found"),
         "brain.feedback on an absent target_id must return NotFound; got: {err}"
+    );
+}
+
+// ---- issue #459 regression: real memory.recall through the real VerbRegistry ----
+
+/// #459: a genuine `memory.recall` dispatch — through the real `VerbRegistry`,
+/// with `BrainPack` installed only as the post-dispatch `DispatchHook` (not
+/// constructed as a hand-built bare `"recall"` event) — must move both the
+/// temporal posterior and the hit entity's posterior.
+///
+/// Before the fix, `interpret()` in `event.rs` recognized only the bare
+/// legacy verb `"recall"`. The runtime hook (`khive-runtime/src/pack.rs`
+/// around line 1044) fires with `verb = "memory.recall"` (the verb it
+/// actually dispatched) and attaches the first hit's id as `target_id`
+/// (`:1055-1063`). `interpret` returned `Irrelevant` for the namespaced verb,
+/// so `on_dispatch` applied no signal at all and real production recall
+/// traffic never taught the brain anything. The old regression in
+/// `src/tests.rs` masked this because it built a bare `"recall"` `Event`
+/// directly instead of dispatching through a registry.
+///
+/// This test seeds one real memory via `memory.remember`, recalls it via
+/// `memory.recall` dispatched through `VerbRegistry::dispatch` (the exact
+/// namespaced verb the runtime uses), and asserts:
+///   - the recall actually hit the seeded memory (sanity: proves the signal
+///     path fires on a *real* hit, not a miss);
+///   - `balanced_recall.temporal` moved off its `BetaPosterior::new(1.0, 9.0)`
+///     prior;
+///   - `balanced_recall.entity_posteriors` gained an entry for the hit's id,
+///     and that entry moved off the `BetaPosterior::new(1.0, 1.0)` default.
+#[tokio::test]
+async fn memory_recall_through_real_registry_updates_brain_posteriors() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let brain = Arc::new(BrainPack::new(rt.clone()));
+
+    // BrainPack is installed ONLY as the dispatch hook here — it is not
+    // registered as a verb-serving pack in this registry. The hook fires
+    // purely off the runtime's real post-dispatch machinery.
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(MemoryPack::new(rt.clone()));
+    let hook: Arc<dyn DispatchHook> = brain.clone();
+    builder.with_dispatch_hook(hook);
+    let registry = builder.build().expect("registry builds");
+
+    // Seed one real, recallable memory.
+    let remembered = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "The attention mechanism in transformers uses Q K V matrices",
+                "memory_type": "semantic",
+                "salience": 0.8,
+                "decay": 0.01
+            }),
+        )
+        .await
+        .expect("memory.remember succeeds");
+    let note_id = remembered["id"]
+        .as_str()
+        .expect("remembered note has id")
+        .to_string();
+
+    // Snapshot BEFORE the real recall dispatch — baseline for the delta assertions.
+    let before = brain.snapshot().balanced_recall;
+
+    // Real memory.recall through the real registry — the exact verb
+    // (`"memory.recall"`, namespaced) and entrypoint (`VerbRegistry::dispatch`,
+    // not a hand-built Event) that production traffic uses.
+    let recall_result = registry
+        .dispatch(
+            "memory.recall",
+            json!({ "query": "attention mechanism transformers", "limit": 1 }),
+        )
+        .await
+        .expect("memory.recall succeeds");
+
+    let hits = recall_result.as_array().expect("recall returns an array");
+    assert!(
+        !hits.is_empty(),
+        "recall must produce a real hit, not a miss"
+    );
+    let hit_id = hits[0]["id"].as_str().expect("hit has id").to_string();
+    assert_eq!(
+        hit_id, note_id,
+        "recall must hit the memory just remembered (sanity check before asserting learning)"
+    );
+
+    // Promote "local" via the production dispatch path so the hook-queued
+    // signal (which landed in PersistenceTracker, cold or active) is drained
+    // into the live BrainState we're about to inspect.
+    promote_namespace(&brain, &rt, "local").await;
+
+    let after = brain.snapshot().balanced_recall;
+
+    assert_ne!(
+        (after.temporal.alpha(), after.temporal.beta()),
+        (before.temporal.alpha(), before.temporal.beta()),
+        "temporal posterior must move on a real memory.recall hit dispatched \
+         through the real VerbRegistry; before={:?} after={:?}",
+        (before.temporal.alpha(), before.temporal.beta()),
+        (after.temporal.alpha(), after.temporal.beta())
+    );
+
+    let hit_uuid: uuid::Uuid = hit_id.parse().expect("hit id is a valid uuid");
+    let entity_posterior = after
+        .entity_posteriors
+        .get(&hit_uuid)
+        .expect("hit entity must have a posterior entry after a real recall hit");
+    assert_ne!(
+        (entity_posterior.alpha(), entity_posterior.beta()),
+        (1.0, 1.0),
+        "hit entity posterior must move off the BetaPosterior::new(1.0, 1.0) default; got {:?}",
+        (entity_posterior.alpha(), entity_posterior.beta())
+    );
+    assert!(
+        !before.entity_posteriors.contains_key(&hit_uuid),
+        "sanity: the hit entity must not have had a posterior before this recall"
     );
 }


### PR DESCRIPTION
Resolves 3 defect findings from an internal audit sweep in `khive-pack-brain`:
- #457: profile-management mutations (create/lifecycle/reset/bind/unbind) now durable across restart via a shared `persist_brain_state_mutation` helper (mutate-proposed-clone -> `BEGIN IMMEDIATE` append+upsert -> COMMIT -> publish-live, ROLLBACK+Err on failure)
- #458: `brain.feedback` fails closed on unbacked persistence failure instead of returning success (`.await?`s the shared helper; `emitted:true` only after commit)
- #459: `interpret()` recognized only the bare legacy `"recall"` verb — real production dispatch fires `"memory.recall"` (namespaced), so real recall traffic never taught the brain anything. Fixed to match both.

## Verification
- **Adversarial review**: independently re-verified against live source and git state — approved with fixes, `CRIT:0 | MAJ:1 | MIN:1`. The one MAJ finding: the regression test that actually satisfies the acceptance criterion for #459 (a real `memory.recall` dispatched through the real `VerbRegistry`, with `BrainPack` installed only as a `DispatchHook` — proving real production traffic teaches the brain, not just a hand-built `Event`) was **not included** in the committed changes; the committed state shipped only a weaker hand-built-`Event` unit test.
- **Fixed before opening this PR**: amended `f57fc603` to include the two uncommitted files (`Cargo.toml` dev-dep on `khive-pack-memory`, `tests/dispatch_hook.rs`'s `memory_recall_through_real_registry_updates_brain_posteriors`). Verified the new test fails deterministically when the `event.rs` fix is reverted (real regression test, not a tautology), then confirmed the fix restores it.
- **Independent re-run post-amend**: `cargo test -p khive-pack-brain` — 186 + 6 + 4 = 196 passed, 0 failed; `clippy --all-targets -D warnings` clean; `fmt --check` clean. The MAJ finding above is resolved — this is now effectively a clean approval.
- Additional independent review pending. This PR stays in draft until that review fully approves — not marked ready or auto-merged on this review alone.

## Test plan
- [x] `cargo test -p khive-pack-brain` — 196 passed, 0 failed (post-amend, independently re-run)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Additional independent review (pending)