### PR TITLE
fix(pack-kg): compound-proposal atomicity, apply-path validation parity, namespace-agnostic event get, graph direction defaults

### DIFF
--- a/crates/khive-pack-kg/src/apply_worker/budget.rs
+++ b/crates/khive-pack-kg/src/apply_worker/budget.rs
@@ -43,3 +43,16 @@ pub(crate) fn count_new_entries(changeset: &ProposalChangeset) -> u64 {
         _ => 0,
     }
 }
+
+/// Return true when a proposal changeset contains a Compound with more than one
+/// step. Multi-step Compound cannot be applied atomically with the current
+/// runtime/storage APIs, so pack-kg rejects it until an atomic apply primitive
+/// exists.
+pub(crate) fn has_multi_step_compound(changeset: &ProposalChangeset) -> bool {
+    match changeset {
+        ProposalChangeset::Compound { steps } => {
+            steps.len() > 1 || steps.iter().any(has_multi_step_compound)
+        }
+        _ => false,
+    }
+}

--- a/crates/khive-pack-kg/src/apply_worker/mod.rs
+++ b/crates/khive-pack-kg/src/apply_worker/mod.rs
@@ -7,6 +7,8 @@ pub use worker::ProposalApplyWorker;
 
 #[cfg(test)]
 pub(crate) use crate::projection_worker::ProposalsProjectionWorker;
+pub(crate) use budget::has_multi_step_compound;
+
 #[cfg(test)]
 pub(crate) use budget::{count_new_entries, WriteBudget};
 #[cfg(test)]

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -428,6 +428,115 @@ async fn apply_worker_rejects_invalid_note_kind() {
     );
 }
 
+/// #423 regression: a legacy queued multi-step Compound (AddEntity then an
+/// AddEdge with a phantom target) must not leak the entity write — the whole
+/// compound is rejected before any step is applied.
+#[tokio::test]
+async fn apply_worker_rejects_legacy_multi_step_compound_without_partial_entity_write() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::Compound {
+        steps: vec![
+            ProposalChangeset::AddEntity {
+                entity: make_entity_draft("AtomicLeak"),
+            },
+            ProposalChangeset::AddEdge {
+                source: Id128::from_u128(Uuid::new_v4().as_u128()),
+                target: Id128::from_u128(Uuid::new_v4().as_u128()),
+                relation: khive_types::EdgeRelation::Extends,
+                weight: Some(1.0),
+            },
+        ],
+    };
+
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("maybe_apply must succeed (rejection emitted as ProposalApplied{Failed})");
+
+    // No entity leaked from the first (successful-looking) step.
+    let entities = rt
+        .list_entities(&tok, None, None, 100, 0)
+        .await
+        .expect("list_entities");
+    assert!(
+        !entities.iter().any(|e| e.name == "AtomicLeak"),
+        "#423: multi-step Compound must not leak the AddEntity write"
+    );
+
+    // Exactly one ProposalApplied{Failed} event, applied_step_count == 0.
+    let event_store = rt.events(&tok).expect("event store");
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query events");
+    assert_eq!(
+        applied_events.items.len(),
+        1,
+        "#423: exactly one ProposalApplied event must be emitted"
+    );
+    let payload_str = applied_events.items[0].payload.to_string();
+    assert!(
+        payload_str.contains("multi-step Compound"),
+        "#423: failure payload must mention multi-step Compound; got: {payload_str}"
+    );
+    assert!(
+        payload_str.contains("\"applied_step_count\":0"),
+        "#423: failure payload must report zero applied steps; got: {payload_str}"
+    );
+}
+
+/// #423 regression: `propose` itself must reject multi-step Compound changesets
+/// up front, before a proposal is even created.
+#[tokio::test]
+async fn propose_rejects_multi_step_compound_until_atomic_apply() {
+    let (rt, _tok) = setup();
+    ensure_schema(&rt).await;
+
+    let registry = build_registry(&rt);
+    let params = serde_json::json!({
+        "title": "Multi-step compound",
+        "description": "should be rejected",
+        "changeset": {
+            "kind": "compound",
+            "steps": [
+                {"kind": "add_entity", "entity": {"kind": "concept", "name": "A"}},
+                {"kind": "add_entity", "entity": {"kind": "concept", "name": "B"}}
+            ]
+        }
+    });
+    let err = registry
+        .dispatch("propose", params)
+        .await
+        .expect_err("multi-step Compound propose must fail");
+    match err {
+        RuntimeError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("multi-step Compound"),
+                "unexpected message: {msg}"
+            );
+        }
+        other => panic!("unexpected error variant: {other}"),
+    }
+}
+
 // ---- Write-budget tests ------------------------------------------------
 
 fn make_entity_draft(name: &str) -> EntityDraft {
@@ -498,11 +607,16 @@ async fn budget_exceeded_flat_compound_creates_zero_rows() {
         1,
         "budget: ProposalApplied event must be emitted on over-budget"
     );
+    // #423: multi-step Compound is now rejected for containment before the
+    // budget check ever runs, so the failure reason is the containment
+    // message rather than WriteBudgetExceeded. The all-or-nothing outcome
+    // (zero new entity rows) is what this test actually guards.
     let payload_str = applied_events.items[0].payload.to_string();
     assert!(
         payload_str.contains("WriteBudgetExceeded")
-            || payload_str.contains("write budget exceeded"),
-        "budget: failure payload must mention WriteBudgetExceeded; got: {payload_str}"
+            || payload_str.contains("write budget exceeded")
+            || payload_str.contains("multi-step Compound"),
+        "budget: failure payload must mention WriteBudgetExceeded or multi-step Compound; got: {payload_str}"
     );
 
     // Verify: zero new entity rows (all-or-nothing guarantee).
@@ -517,10 +631,12 @@ async fn budget_exceeded_flat_compound_creates_zero_rows() {
     );
 }
 
-/// In-budget flat Compound: 2 AddEntity steps, budget=Some(2).
-/// Expects: ProposalApplied{Success}, two new entities.
+/// #423 superseded this scenario: a 2-step Compound (previously "in-budget,
+/// applies fully") is now rejected outright as a multi-step Compound before
+/// the budget check runs, regardless of budget. Renamed from
+/// `budget_in_budget_flat_compound_applies_fully` to reflect the new contract.
 #[tokio::test]
-async fn budget_in_budget_flat_compound_applies_fully() {
+async fn budget_in_budget_flat_compound_is_rejected_as_multi_step() {
     let (rt, tok) = setup();
     ensure_schema(&rt).await;
 
@@ -544,24 +660,25 @@ async fn budget_in_budget_flat_compound_applies_fully() {
     worker
         .maybe_apply(&tok, proposal_id, &registry, Some(2))
         .await
-        .expect("maybe_apply must succeed");
+        .expect("maybe_apply must succeed (rejection emitted as ProposalApplied{Failed})");
 
     let entities = rt
         .list_entities(&tok, None, None, 100, 0)
         .await
         .expect("list_entities");
     assert!(
-        entities.iter().any(|e| e.name == "InBudgetA"),
-        "budget: InBudgetA must be created"
+        !entities.iter().any(|e| e.name == "InBudgetA"),
+        "#423: multi-step Compound must not apply any step, including InBudgetA"
     );
     assert!(
-        entities.iter().any(|e| e.name == "InBudgetB"),
-        "budget: InBudgetB must be created"
+        !entities.iter().any(|e| e.name == "InBudgetB"),
+        "#423: multi-step Compound must not apply any step, including InBudgetB"
     );
 }
 
 /// Nested Compound: outer has 1 AddEntity + inner Compound with 2 AddEntity.
-/// Total = 3. budget=Some(2) → fail before any write.
+/// Now rejected as multi-step Compound (#423) before the budget check runs;
+/// zero-write invariant still holds either way.
 #[tokio::test]
 async fn budget_nested_compound_counts_recursively() {
     let (rt, tok) = setup();

--- a/crates/khive-pack-kg/src/apply_worker/tests.rs
+++ b/crates/khive-pack-kg/src/apply_worker/tests.rs
@@ -537,6 +537,114 @@ async fn propose_rejects_multi_step_compound_until_atomic_apply() {
     }
 }
 
+/// #424 regression: `AddEntity` proposals must accept pack-local entity kinds
+/// (e.g. `resource`) even though `khive_types::EntityKind` does not know them.
+#[tokio::test]
+async fn apply_add_entity_accepts_pack_local_resource_kind() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::AddEntity {
+        entity: EntityDraft {
+            kind: "resource".to_string(),
+            name: "ProposedResource".to_string(),
+            description: None,
+            properties: None,
+            tags: vec![],
+        },
+    };
+
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("maybe_apply must succeed");
+
+    let entities = rt
+        .list_entities(&tok, None, None, 100, 0)
+        .await
+        .expect("list_entities");
+    let created = entities
+        .iter()
+        .find(|e| e.name == "ProposedResource")
+        .expect("#424: ProposedResource must be created");
+    assert_eq!(
+        created.kind, "resource",
+        "#424: kind must resolve to resource"
+    );
+}
+
+/// #424 regression: `AddEntity` proposals must reject whitespace-only names the
+/// same way the normal `create` handler does, with zero net writes.
+#[tokio::test]
+async fn apply_add_entity_rejects_whitespace_name_without_write() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::AddEntity {
+        entity: EntityDraft {
+            kind: "concept".to_string(),
+            name: "   ".to_string(),
+            description: None,
+            properties: None,
+            tags: vec![],
+        },
+    };
+
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let entities_before = rt
+        .list_entities(&tok, None, None, 100, 0)
+        .await
+        .expect("list_entities");
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("maybe_apply must succeed (errors emitted as ProposalApplied{Failed})");
+
+    let entities_after = rt
+        .list_entities(&tok, None, None, 100, 0)
+        .await
+        .expect("list_entities");
+    assert_eq!(
+        entities_before.len(),
+        entities_after.len(),
+        "#424: whitespace-only name must result in zero net writes"
+    );
+
+    let event_store = rt.events(&tok).expect("event store");
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query events");
+    assert_eq!(applied_events.items.len(), 1);
+    let payload_str = applied_events.items[0].payload.to_string();
+    assert!(
+        payload_str.contains("name must not be empty"),
+        "#424: failure payload must mention the empty-name guard; got: {payload_str}"
+    );
+}
+
 // ---- Write-budget tests ------------------------------------------------
 
 fn make_entity_draft(name: &str) -> EntityDraft {

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -15,7 +15,7 @@ use khive_types::{
     ProposalChangeset, ProposalCreatedPayload, ProposalEntityPatch, Timestamp,
 };
 
-use super::budget::{count_new_entries, WriteBudget};
+use super::budget::{count_new_entries, has_multi_step_compound, WriteBudget};
 use crate::projection_worker::ProposalsProjectionWorker;
 
 /// Worker that applies approved proposal changesets.
@@ -59,6 +59,18 @@ impl ProposalApplyWorker {
                 return Ok(());
             }
         };
+
+        if has_multi_step_compound(&changeset) {
+            self.emit_apply_failed(
+                token,
+                proposal_id,
+                "multi-step Compound proposals are not supported until atomic proposal apply is available"
+                    .to_string(),
+                0,
+            )
+            .await;
+            return Ok(());
+        }
 
         if let Some(max) = max_new_entries {
             let needed = count_new_entries(&changeset);

--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -1,7 +1,5 @@
 //! ProposalApplyWorker implementation.
 
-use std::str::FromStr;
-
 use uuid::Uuid;
 
 use khive_runtime::{
@@ -11,7 +9,7 @@ use khive_runtime::{
 use khive_storage::types::PageRequest;
 use khive_storage::{EdgeRelation, EventFilter};
 use khive_types::{
-    ApplyResult, EntityDraft, EntityKind, EventKind, Id128, NoteDraft, ProposalAppliedPayload,
+    ApplyResult, EntityDraft, EventKind, Id128, NoteDraft, ProposalAppliedPayload,
     ProposalChangeset, ProposalCreatedPayload, ProposalEntityPatch, Timestamp,
 };
 
@@ -212,7 +210,7 @@ impl ProposalApplyWorker {
         Box::pin(async move {
             match changeset {
                 ProposalChangeset::AddEntity { entity } => {
-                    self.apply_add_entity(token, entity, budget).await
+                    self.apply_add_entity(token, entity, registry, budget).await
                 }
                 ProposalChangeset::UpdateEntity { id, patch } => {
                     self.apply_update_entity(token, *id, patch).await?;
@@ -257,22 +255,19 @@ impl ProposalApplyWorker {
         &self,
         token: &NamespaceToken,
         draft: &EntityDraft,
+        registry: &VerbRegistry,
         budget: &mut WriteBudget,
     ) -> Result<Vec<Uuid>, RuntimeError> {
-        let kind = draft.kind.as_str();
-        EntityKind::from_str(kind).map_err(|_| {
-            let valid: Vec<&str> = EntityKind::ALL.iter().map(|k| k.name()).collect();
-            RuntimeError::InvalidInput(format!(
-                "AddEntity: unknown entity_kind {kind:?}; valid: {}",
-                valid.join(" | ")
-            ))
-        })?;
+        let kind = crate::handlers::canonical_entity_kind(draft.kind.as_str(), registry)?;
+        if draft.name.trim().is_empty() {
+            return Err(RuntimeError::InvalidInput("name must not be empty".into()));
+        }
         budget.consume_new_entry()?;
         let entity = self
             .runtime
             .create_entity(
                 token,
-                kind,
+                kind.as_str(),
                 None,
                 draft.name.as_str(),
                 draft.description.as_deref(),

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -364,12 +364,14 @@ pub(crate) fn remap_note_status(mut note_value: Value) -> Value {
     note_value
 }
 
-pub(crate) fn parse_direction(s: Option<&str>) -> Direction {
+pub(crate) fn parse_direction(s: Option<&str>) -> Result<Direction, RuntimeError> {
     match s {
-        Some("in") | Some("incoming") => Direction::In,
-        Some("both") => Direction::Both,
-        Some("out") | Some("outgoing") | None => Direction::Out,
-        Some(_) => Direction::Out,
+        Some("in") | Some("incoming") => Ok(Direction::In),
+        Some("both") | None => Ok(Direction::Both),
+        Some("out") | Some("outgoing") => Ok(Direction::Out),
+        Some(raw) => Err(RuntimeError::InvalidInput(format!(
+            "unknown direction {raw:?}; valid: out | outgoing | in | incoming | both"
+        ))),
     }
 }
 

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -6,12 +6,14 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use khive_runtime::{NamespaceToken, Resolved, RuntimeError, VerbRegistry};
-use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::event::Event;
+use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
 use khive_types::EventKind;
 
 use super::common::{
     deser, flatten_get_result, normalize_entity_timestamps, normalize_event_timestamps,
-    remap_note_status, resolve_uuid_unfiltered, to_json, GetParams,
+    parse_event_kind, parse_event_outcome, parse_event_substrate, remap_note_status,
+    resolve_uuid_unfiltered, to_json, GetParams,
 };
 use crate::KgPack;
 
@@ -83,19 +85,8 @@ impl KgPack {
             return flatten_get_result("edge", to_json(&edge)?);
         }
 
-        if let Some(event) = self
-            .runtime
-            .events(token)?
-            .get_event(id)
-            .await
-            .map_err(RuntimeError::Storage)?
-        {
-            if token
-                .visible_namespace_strs()
-                .contains(&event.namespace.as_str())
-            {
-                return flatten_get_result("event", normalize_event_timestamps(to_json(&event)?));
-            }
+        if let Some(event) = self.get_event_unfiltered_by_id(id).await? {
+            return flatten_get_result("event", normalize_event_timestamps(to_json(&event)?));
         }
 
         // Pack-resolver probe: ask each registered resolver for pack-private records
@@ -113,6 +104,64 @@ impl KgPack {
         }
 
         Err(RuntimeError::NotFound(format!("not found: {}", p.id)))
+    }
+
+    /// Fetch an event by ID without a namespace predicate (ADR-007 Rev 6 pattern).
+    /// Only for by-ID `get`; event `list`/`query` surfaces must keep namespace scoping.
+    async fn get_event_unfiltered_by_id(&self, id: Uuid) -> Result<Option<Event>, RuntimeError> {
+        let sql = self.runtime.sql();
+        let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
+        let row = reader
+            .query_row(SqlStatement {
+                sql: "SELECT id, namespace, verb, substrate, actor, kind, outcome, payload, \
+                      payload_schema_version, profile_state_version, duration_us, target_id, \
+                      session_id, aggregate_kind, aggregate_id, created_at \
+                      FROM events WHERE id = ?1 LIMIT 1"
+                    .to_string(),
+                params: vec![SqlValue::Text(id.to_string())],
+                label: Some("events.get_unfiltered_by_id".into()),
+            })
+            .await
+            .map_err(RuntimeError::Storage)?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        Ok(Some(Event {
+            id: parse_uuid_column(&row, "id")?,
+            namespace: sql_text(&row, "namespace")?,
+            verb: sql_text(&row, "verb")?,
+            substrate: parse_event_substrate(&sql_text(&row, "substrate")?)
+                .map_err(|_| RuntimeError::Internal("stored event substrate is invalid".into()))?,
+            actor: sql_text(&row, "actor")?,
+            kind: parse_event_kind(&sql_text(&row, "kind")?)
+                .map_err(|_| RuntimeError::Internal("stored event kind is invalid".into()))?,
+            outcome: parse_event_outcome(&sql_text(&row, "outcome")?)
+                .map_err(|_| RuntimeError::Internal("stored event outcome is invalid".into()))?,
+            payload: serde_json::from_str(&sql_text(&row, "payload")?).map_err(|e| {
+                RuntimeError::Internal(format!("stored event payload is invalid JSON: {e}"))
+            })?,
+            payload_schema_version: u32::try_from(sql_i64(&row, "payload_schema_version")?)
+                .map_err(|_| {
+                    RuntimeError::Internal("stored event payload_schema_version is invalid".into())
+                })?,
+            profile_state_version: sql_optional_i64(&row, "profile_state_version")?
+                .map(|v| {
+                    u64::try_from(v).map_err(|_| {
+                        RuntimeError::Internal(
+                            "stored event profile_state_version is invalid".into(),
+                        )
+                    })
+                })
+                .transpose()?,
+            duration_us: sql_i64(&row, "duration_us")?,
+            target_id: sql_optional_uuid(&row, "target_id")?,
+            session_id: sql_optional_uuid(&row, "session_id")?,
+            aggregate_kind: sql_optional_text(&row, "aggregate_kind")?,
+            aggregate_id: sql_optional_uuid(&row, "aggregate_id")?,
+            created_at: sql_i64(&row, "created_at")?,
+        }))
     }
 
     pub(crate) async fn try_get_proposal_payload(
@@ -237,4 +286,58 @@ impl KgPack {
 
         Ok(Some(result))
     }
+}
+
+fn sql_text(row: &SqlRow, name: &str) -> Result<String, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Text(v)) => Ok(v.clone()),
+        Some(other) => Err(RuntimeError::Internal(format!(
+            "events.{name} has unexpected SQL value {other:?}"
+        ))),
+        None => Err(RuntimeError::Internal(format!("events row missing {name}"))),
+    }
+}
+
+fn sql_optional_text(row: &SqlRow, name: &str) -> Result<Option<String>, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Null) | None => Ok(None),
+        Some(SqlValue::Text(v)) => Ok(Some(v.clone())),
+        Some(other) => Err(RuntimeError::Internal(format!(
+            "events.{name} has unexpected SQL value {other:?}"
+        ))),
+    }
+}
+
+fn sql_i64(row: &SqlRow, name: &str) -> Result<i64, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Integer(v)) => Ok(*v),
+        Some(other) => Err(RuntimeError::Internal(format!(
+            "events.{name} has unexpected SQL value {other:?}"
+        ))),
+        None => Err(RuntimeError::Internal(format!("events row missing {name}"))),
+    }
+}
+
+fn sql_optional_i64(row: &SqlRow, name: &str) -> Result<Option<i64>, RuntimeError> {
+    match row.get(name) {
+        Some(SqlValue::Null) | None => Ok(None),
+        Some(SqlValue::Integer(v)) => Ok(Some(*v)),
+        Some(other) => Err(RuntimeError::Internal(format!(
+            "events.{name} has unexpected SQL value {other:?}"
+        ))),
+    }
+}
+
+fn parse_uuid_column(row: &SqlRow, name: &str) -> Result<Uuid, RuntimeError> {
+    Uuid::from_str(&sql_text(row, name)?)
+        .map_err(|e| RuntimeError::Internal(format!("events.{name} is not a UUID: {e}")))
+}
+
+fn sql_optional_uuid(row: &SqlRow, name: &str) -> Result<Option<Uuid>, RuntimeError> {
+    sql_optional_text(row, name)?
+        .map(|v| {
+            Uuid::from_str(&v)
+                .map_err(|e| RuntimeError::Internal(format!("events.{name} is not a UUID: {e}")))
+        })
+        .transpose()
 }

--- a/crates/khive-pack-kg/src/handlers/graph.rs
+++ b/crates/khive-pack-kg/src/handlers/graph.rs
@@ -19,7 +19,7 @@ impl KgPack {
     ) -> Result<Value, RuntimeError> {
         let p: NeighborsParams = deser(params)?;
         let node_id = resolve_uuid_async(&p.id, &self.runtime, token).await?;
-        let direction = parse_direction(p.direction.as_deref());
+        let direction = parse_direction(p.direction.as_deref())?;
         let relations = p
             .relations
             .map(|v| {
@@ -62,7 +62,7 @@ impl KgPack {
         for s in &p.roots {
             roots.push(resolve_uuid_async(s, &self.runtime, token).await?);
         }
-        let direction = parse_direction(p.direction.as_deref());
+        let direction = parse_direction(p.direction.as_deref())?;
         let relations = p
             .relations
             .map(|v| {

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -13,7 +13,7 @@ mod search;
 mod stats;
 mod update;
 
-pub(crate) use common::{canonical_note_kind, parse_relation};
+pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relation};
 
 #[cfg(test)]
 pub(crate) use common::{

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -16,6 +16,7 @@ use khive_types::{
 use super::common::{
     deser, to_json, ListProposalsParams, ProposeParams, ReviewParams, WithdrawParams,
 };
+use crate::apply_worker::has_multi_step_compound;
 use crate::KgPack;
 
 use khive_runtime::micros_to_iso;
@@ -98,8 +99,14 @@ impl KgPack {
         khive_runtime::secret_gate::check_tags(&p.reviewers)?;
         khive_runtime::secret_gate::check_json(&p.changeset)?;
 
-        let _changeset: ProposalChangeset = serde_json::from_value(p.changeset.clone())
+        let changeset: ProposalChangeset = serde_json::from_value(p.changeset.clone())
             .map_err(|e| RuntimeError::InvalidInput(format!("invalid changeset: {e}")))?;
+        if has_multi_step_compound(&changeset) {
+            return Err(RuntimeError::InvalidInput(
+                "multi-step Compound proposals are not supported until atomic proposal apply is available"
+                    .into(),
+            ));
+        }
 
         let proposal_id = Uuid::new_v4();
         let actor = token.actor().id.clone();
@@ -146,7 +153,7 @@ impl KgPack {
             proposer: actor.clone(),
             title: p.title.clone(),
             description: p.description.clone(),
-            changeset: _changeset,
+            changeset,
             reviewers: p.reviewers.clone(),
             expiry: p
                 .expiry

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -2002,6 +2002,69 @@ async fn get_event_uuid_returns_event_wrapper() {
     );
 }
 
+/// #425 regression: `get(id=<event_uuid>)` from a caller in a DIFFERENT
+/// namespace than the event must succeed, matching the ADR-007 Rev 6 pattern
+/// #393 already established for entity/note/edge. Guards against the residual
+/// event-UUID resolver path #393 did not cover.
+#[tokio::test]
+async fn get_event_uuid_cross_namespace_succeeds() {
+    let pack = pack_with_events();
+    pack.dispatch(
+        "create",
+        json!({"kind": "concept", "name": "CrossNsEventTarget"}),
+    )
+    .await
+    .expect("create must succeed");
+
+    let list_result = pack
+        .dispatch(
+            "list",
+            json!({"kind": "event", "verb": "create", "limit": 1}),
+        )
+        .await
+        .expect("list must succeed");
+    let events = list_result.as_array().expect("list must be array");
+    assert!(!events.is_empty(), "must have at least one create event");
+    let event_id = events[0]
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("event must have id field")
+        .to_string();
+    let stored_namespace = events[0]
+        .get("namespace")
+        .and_then(Value::as_str)
+        .expect("event must have namespace field")
+        .to_string();
+    assert_ne!(
+        stored_namespace, "ns-caller",
+        "event must be stored in a namespace other than the cross-namespace caller"
+    );
+
+    let get_result = pack
+        .dispatch("get", json!({"id": event_id, "namespace": "ns-caller"}))
+        .await;
+    assert!(
+        get_result.is_ok(),
+        "#425: get(id=<event_uuid>) from a different namespace must succeed; got: {get_result:?}"
+    );
+    let get_result = get_result.unwrap();
+    assert_eq!(
+        get_result.get("kind").and_then(Value::as_str),
+        Some("event"),
+        "#425: get must have kind=event at top level"
+    );
+    assert_eq!(
+        get_result.get("id").and_then(Value::as_str),
+        Some(event_id.as_str()),
+        "#425: id must match the requested event UUID"
+    );
+    assert_eq!(
+        get_result.get("namespace").and_then(Value::as_str),
+        Some(stored_namespace.as_str()),
+        "#425: returned event's namespace must be preserved, not overwritten by the caller's"
+    );
+}
+
 // ADR-045 §5: event `created_at` must be an ISO-8601 string at the MCP boundary,
 // not a raw microsecond integer (round-4 blocker fix).
 

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3513,6 +3513,166 @@ async fn neighbors_direction_filter_incoming_outgoing() {
     }
 }
 
+/// #445 regression: omitted `direction` must default to "both" (per the
+/// advertised `help=true` contract), not outgoing-only. On an incoming-only
+/// graph (A --extends--> B, no outgoing edges from B), `neighbors(B)` with no
+/// `direction` must still surface the incoming edge from A.
+#[tokio::test]
+async fn neighbors_default_direction_includes_incoming_edges() {
+    let pack = pack();
+
+    let a = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "DefaultDir_A", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create A");
+    let a_id = a.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    let b = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "DefaultDir_B", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create B");
+    let b_id = b.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    // A --extends--> B; B has no outgoing edges.
+    pack.dispatch(
+        "link",
+        json!({"source_id": a_id, "target_id": b_id, "relation": "extends"}),
+    )
+    .await
+    .expect("link A->B");
+
+    let result = pack
+        .dispatch("neighbors", json!({"id": b_id}))
+        .await
+        .expect("neighbors with omitted direction must succeed");
+    let items = result.as_array().expect("must be array");
+    let node_ids: Vec<&str> = items
+        .iter()
+        .filter_map(|v| v.get("id").and_then(Value::as_str))
+        .collect();
+    assert!(
+        node_ids
+            .iter()
+            .any(|&id| id == a_id || a_id.starts_with(id) || id.starts_with(&a_id[..8])),
+        "#445: neighbors(B) with omitted direction must default to both and surface A; got: {node_ids:?}"
+    );
+}
+
+/// #480 regression: an unrecognized `direction` string (e.g. a plausible typo
+/// like "inbound") must be rejected with a descriptive error, not silently
+/// coerced to outgoing-only.
+#[tokio::test]
+async fn neighbors_invalid_direction_is_rejected() {
+    let pack = pack();
+
+    let b = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "InvalidDir_B", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create B");
+    let b_id = b.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    let result = pack
+        .dispatch("neighbors", json!({"id": b_id, "direction": "inbound"}))
+        .await;
+    assert!(
+        result.is_err(),
+        "#480: neighbors with direction=\"inbound\" must be rejected, not silently coerced"
+    );
+    let err = result.unwrap_err();
+    assert!(is_invalid_input(&err), "must be InvalidInput; got: {err:?}");
+    let msg = invalid_input_message(&err);
+    assert!(
+        msg.contains("unknown direction") && msg.contains("out | outgoing | in | incoming | both"),
+        "#480: error must list valid direction values; got: {msg}"
+    );
+}
+
+/// #445 regression (traverse variant): omitted `direction` must default to
+/// "both", so traversing from an incoming-only node still expands via the
+/// incoming edge.
+#[tokio::test]
+async fn traverse_default_direction_includes_incoming_edges() {
+    let pack = pack();
+
+    let a = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "TraverseDefaultDir_A", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create A");
+    let a_id = a.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    let b = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "TraverseDefaultDir_B", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create B");
+    let b_id = b.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    pack.dispatch(
+        "link",
+        json!({"source_id": a_id, "target_id": b_id, "relation": "extends"}),
+    )
+    .await
+    .expect("link A->B");
+
+    let result = pack
+        .dispatch(
+            "traverse",
+            json!({"roots": [b_id], "max_depth": 1, "include_roots": false}),
+        )
+        .await
+        .expect("traverse with omitted direction must succeed");
+    let items = result.as_array().expect("must be array");
+    assert!(
+        !items.is_empty(),
+        "#445: traverse(roots=[B]) with omitted direction must default to both and expand via the incoming edge from A"
+    );
+}
+
+/// #480 regression (traverse variant): an unrecognized `direction` string must
+/// be rejected with a descriptive error.
+#[tokio::test]
+async fn traverse_invalid_direction_is_rejected() {
+    let pack = pack();
+
+    let b = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "TraverseInvalidDir_B", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create B");
+    let b_id = b.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    let result = pack
+        .dispatch("traverse", json!({"roots": [b_id], "direction": "inbound"}))
+        .await;
+    assert!(
+        result.is_err(),
+        "#480: traverse with direction=\"inbound\" must be rejected, not silently coerced"
+    );
+    let err = result.unwrap_err();
+    assert!(is_invalid_input(&err), "must be InvalidInput; got: {err:?}");
+    let msg = invalid_input_message(&err);
+    assert!(
+        msg.contains("unknown direction") && msg.contains("out | outgoing | in | incoming | both"),
+        "#480: error must list valid direction values; got: {msg}"
+    );
+}
+
 // ── verbs() dispatch-level tests (codex review Medium: H5 not covered) ────────
 //
 // A fake pack with one public verb and one subhandler so we can verify that


### PR DESCRIPTION
Resolves 4 defect findings (5 issues) from an internal audit sweep in `khive-pack-kg`:
- #423: reject multi-step `Compound` proposals at both propose-time and legacy apply-time, since no caller-controlled transaction spans khive-runtime/khive-db's per-call-commit mutation APIs yet (real cross-crate architectural gap — contained locally, not silently half-fixed; see Escalations below)
- #424: `apply_add_entity` now validates kind + name the same way normal `create` does (pack-vocab kind resolution via `canonical_entity_kind()`, whitespace-only name rejected) instead of a weaker base-type-only check
- #425: added a namespace-agnostic event-by-ID getter — PR #393 made entity/note/edge by-ID `get` namespace-agnostic per ADR-007 Rev 6, but the event-UUID resolver is a separate code path #393 didn't touch (event `list`/`query` correctly keep namespace scoping; only by-ID `get` changes)
- #445 + #480 (same root cause, one commit): `parse_direction` now returns `Result` — `None` defaults to `Direction::Both` (matching the advertised `help=true` contract, previously silently defaulted to `Out`), and unrecognized direction strings are rejected instead of silently coerced to `Out`

## Verification
- **Independent reviewer pass** (separate from the implementer): re-verified all 4 fixes against source + re-ran every gate independently — approved with suggestions, `0 Critical / 0 High / 0 Medium / 1 Low`. The one Low: the #424 regression test doesn't assert the failure payload's `created_ids`/`applied_step_count` fields, only the error message — the implementation guard is correct (verified at `apply_worker/worker.rs:261-265`), just the test could be more thorough. Non-blocking, tracked, not fixed in this draft.
- **Independent re-run**: `cargo test -p khive-pack-kg` — 135+5+3+171+11 = 325 passed, 0 failed; `clippy --all-targets -D warnings` clean; `fmt --check` clean. Matches the reviewer's numbers exactly.
- Additional independent review pending. This PR stays in draft until that review fully approves.

## Escalation (documented, not gating this PR)
`#423`: a real fix needs a caller-controlled transaction primitive spanning `khive-runtime`/`khive-db` entity, note, edge, merge, and event mutation APIs (each currently commits its own transaction per call — `khive-db/src/stores/entity.rs:325,372`). Cross-crate, out of `khive-pack-kg` scope. This PR contains the bug (reject multi-step `Compound` until that primitive exists) rather than attempting a partial fix.

## Test plan
- [x] `cargo test -p khive-pack-kg` — 325 passed, 0 failed (independently re-run, matches reviewer)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Additional independent review (pending)
