### PR TITLE
fix(kkernel): serialize namespace_absent_defaults_to_none against KHIVE_NAMESPACE races

### DIFF
--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -1391,7 +1391,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn namespace_absent_defaults_to_none() {
+        std::env::remove_var("KHIVE_NAMESPACE");
         let args = ReindexArgs::parse_from(["reindex"]);
         assert!(
             args.namespace.is_none(),


### PR DESCRIPTION
## Summary
- Main's CI went red on `a24e51a3`: `kkernel::reindex::tests::namespace_absent_defaults_to_none` panicked ("omitted --namespace must be None (not a String default)").
- Root cause: this test is the only one of four tests touching the `KHIVE_NAMESPACE` env var in this file that lacked `#[serial]`. Rust runs `#[test]`s in parallel threads within one process; `std::env::set_var`/`remove_var` are process-global with no synchronization. This test could race against `namespace_env_var_sets_explicit_flag` (which sets `KHIVE_NAMESPACE=env-ns` mid-test) and pick up the leaked value via clap's `env = "KHIVE_NAMESPACE"` binding on `ReindexArgs::namespace`.
- Not a regression from recent merges — `reindex.rs` wasn't touched by any of the just-landed PRs (#507/#508/#509/#510/#513). Pre-existing flaky test that happened to lose the race on this CI run.

## Fix
Add `#[serial]` (matching the other three tests in this file that mutate `KHIVE_NAMESPACE`/`KHIVE_DB`/`KHIVE_CONFIG`) plus a defensive `remove_var` at the top of the test body.

## Test plan
- [x] `cargo test -p kkernel --lib` — 153/153 passing (was 152/153, 1 flaky failure), repeated 3x clean
- [x] `cargo clippy -p kkernel --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p kkernel -- --check` — clean