### PR TITLE
docs: fix stale verb/pack counts across all docs (72 verbs, 8 packs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,10 @@ khive gives your agent:
 7. **Scheduling** — time-triggered reminders and future verb dispatch
 8. **Knowledge corpus** — atom/domain CRUD, FTS + embedding search, compose briefings
 9. **Brain** — Bayesian profile tuning from feedback signals
+10. **Session** — persist and resume agent-session records
 
-All 7 packs load by default. **67 public verbs** across the packs.
+All 8 packs load by default. **72 public verbs** across the packs (regenerate via
+`request(ops="verbs()")` before editing this line).
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 
@@ -95,23 +97,24 @@ false, id, full_id, from, to, note: "already in target status"}` — the task fi
 `memory.recall` supports `tags` and `tag_mode` ("any"|"all") for tag-based post-filtering.
 Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 
-### Brain pack — 13 verbs (`brain.` prefix)
+### Brain pack — 14 verbs (`brain.` prefix)
 
-| Verb                   | What it does                                         | When to use                                     |
-| ---------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| `brain.profiles`       | List profiles (optionally filtered by lifecycle)     | See what profiles exist                         |
-| `brain.profile`        | Full detail: metadata, snapshot, state summary       | Inspect a specific profile                      |
-| `brain.create_profile` | Create a new profile with optional seed priors       | Custom tuning for a new consumer                |
-| `brain.resolve`        | Which profile serves a given consumer context?       | Before recall — check active tuning             |
-| `brain.activate`       | Start live update loop for a profile                 | Enable feedback-driven tuning                   |
-| `brain.deactivate`     | Stop live updates, retain state                      | Pause tuning without losing progress            |
-| `brain.archive`        | Read-only, audit-retained                            | Retire a profile permanently                    |
-| `brain.reset`          | Reset posteriors to priors (preserves event history) | Start tuning fresh                              |
-| `brain.feedback`       | Emit explicit feedback event                         | Rate a recall result as useful/not_useful/wrong |
-| `brain.auto_feedback`  | Emit implicit feedback for recall results            | Convenience: agents call after memory.recall    |
-| `brain.bind`           | Bind a profile to an actor + consumer                | Route a specific caller to a specific profile   |
-| `brain.unbind`         | Remove a binding                                     | Stop routing                                    |
-| `brain.bindings`       | List binding rows                                    | Audit profile routing                           |
+| Verb                     | What it does                                         | When to use                                                |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------- |
+| `brain.profiles`         | List profiles (optionally filtered by lifecycle)     | See what profiles exist                                    |
+| `brain.profile`          | Full detail: metadata, snapshot, state summary       | Inspect a specific profile                                 |
+| `brain.create_profile`   | Create a new profile with optional seed priors       | Custom tuning for a new consumer                           |
+| `brain.resolve`          | Which profile serves a given consumer context?       | Before recall — check active tuning                        |
+| `brain.activate`         | Start live update loop for a profile                 | Enable feedback-driven tuning                              |
+| `brain.deactivate`       | Stop live updates, retain state                      | Pause tuning without losing progress                       |
+| `brain.archive`          | Read-only, audit-retained                            | Retire a profile permanently                               |
+| `brain.reset`            | Reset posteriors to priors (preserves event history) | Start tuning fresh                                         |
+| `brain.feedback`         | Emit explicit feedback event                         | Rate a recall result as useful/not_useful/wrong            |
+| `brain.auto_feedback`    | Emit implicit feedback for recall results            | Convenience: agents call after memory.recall               |
+| `brain.bind`             | Bind a profile to an actor + consumer                | Route a specific caller to a specific profile              |
+| `brain.unbind`           | Remove a binding                                     | Stop routing                                               |
+| `brain.bindings`         | List binding rows                                    | Audit profile routing                                      |
+| `brain.register_adapter` | Register an adapter integrity record                 | Gate adapter composition to the active base-model revision |
 
 ### Comm pack — 5 verbs (`comm.` prefix)
 
@@ -178,6 +181,15 @@ is a **closed enum** — valid values: `overview` | `core_model` | `boundary_con
 `formalism` | `operational_guidance` | `examples` | `failure_modes` | `expert_lens` |
 `references` | `other`. Content must be **at least 80 characters**. Shorter content or an
 unrecognized `section_type` returns a validation error listing the valid values.
+
+### Session pack — 4 verbs (`session.` prefix)
+
+| Verb             | What it does                                      | When to use                              |
+| ---------------- | ------------------------------------------------- | ---------------------------------------- |
+| `session.store`  | Persist an agent-session record as a session note | Checkpoint/save a completed session      |
+| `session.list`   | List stored sessions, newest first                | "What sessions have I run?"              |
+| `session.resume` | Fetch one session's full content by UUID/prefix   | Continue or reference a specific session |
+| `session.export` | Serialize one session as JSON or markdown         | Share or archive a session outside khive |
 
 ### How to call a verb
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,9 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 ```
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
-loads all 7 production packs: kg, gtd, memory, brain, comm, schedule, knowledge
-(67 verbs total).
+loads all 8 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session
+(72 verbs total — verified against the live `verbs()` registry, 2026-07-03; regenerate via
+`request(ops="verbs()")` before editing this line).
 
 ### KG pack verbs (16 — ADR-017, ADR-046)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ No Neo4j. No SPARQL endpoint to deploy. SQLite on disk, MCP over stdio, `cargo t
 
 | Capability                  | How                                                                                                                                                |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **67 verbs, 7 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge — all load by default                                                                            |
+| **72 verbs, 8 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge, session — all load by default                                                                   |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                      |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                |
@@ -58,17 +58,20 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 7 packs load by default — **67 verbs** out of the box:
+All 8 packs load by default — **72 verbs** out of the box (verified against the live
+`verbs()` registry, 2026-07-03 — regenerate with `request(ops="verbs()")` before editing
+this table):
 
-| Pack          | Prefix       | Verbs | What it does                                     |
-| ------------- | ------------ | ----- | ------------------------------------------------ |
-| **kg**        | _(bare)_     | 16    | Entities, edges, notes, graph queries            |
-| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)    |
-| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall |
-| **brain**     | `brain.`     | 13    | Bayesian user profiles + feedback loop           |
-| **comm**      | `comm.`      | 5     | Threaded messaging                               |
-| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution           |
-| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search       |
+| Pack          | Prefix       | Verbs | What it does                                          |
+| ------------- | ------------ | ----- | ----------------------------------------------------- |
+| **kg**        | _(bare)_     | 16    | Entities, edges, notes, graph queries                 |
+| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)         |
+| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall      |
+| **brain**     | `brain.`     | 14    | Bayesian user profiles + feedback loop                |
+| **comm**      | `comm.`      | 5     | Threaded messaging                                    |
+| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution                |
+| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search            |
+| **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export) |
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only — they auto-detect the record type.
@@ -93,10 +96,11 @@ No language SDK to learn.
 │  khive-pack-kg         — KG vocabulary + 16 verb handlers    │
 │  khive-pack-gtd        — task lifecycle (5 verbs)            │
 │  khive-pack-memory     — salience + decay recall (5 verbs)   │
-│  khive-pack-brain      — Bayesian profiles (13 verbs)        │
+│  khive-pack-brain      — Bayesian profiles (14 verbs)        │
 │  khive-pack-comm       — threaded messaging (5 verbs)        │
 │  khive-pack-schedule   — reminders + scheduled ops (4 verbs) │
 │  khive-pack-knowledge  — atom KB + embedding rerank (19 verbs)│
+│  khive-pack-session    — session record persistence (4 verbs)│
 └──────────────────────────────────────────────────────────────┘
                             ↕ in-process
 ┌──────────────────────────────────────────────────────────────┐
@@ -191,8 +195,8 @@ global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-**That's it.** All 7 packs load by default, a background daemon auto-spawns to keep the runtime
-warm, and Claude Code discovers the `request` tool with the full 67-verb catalog.
+**That's it.** All 8 packs load by default, a background daemon auto-spawns to keep the runtime
+warm, and Claude Code discovers the `request` tool with the full 72-verb catalog.
 
 ### Alternative: install via Cargo
 
@@ -285,7 +289,7 @@ Deno 2.x (for the TypeScript CLI layer — optional)
 
 ## Status
 
-**v0.3.0 — published on [crates.io](https://crates.io/crates/khive-mcp).** 67 verbs across 7
+**v0.3.0 — published on [crates.io](https://crates.io/crates/khive-mcp).** 72 verbs across 8
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -38,7 +38,7 @@ This is the production entrypoint. The deno/npm distribution invokes it:
 # stdio MCP server (default transport) — what MCP clients spawn
 kkernel mcp --db ~/.khive/khive.db
 
-# pick packs explicitly (default loads all 7 production packs)
+# pick packs explicitly (default loads all 8 production packs)
 kkernel mcp --pack kg --pack gtd --pack knowledge
 
 # warm Unix-socket daemon (owns ANN indexes; stdio clients auto-spawn + forward to it)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 63 verbs across 7 packs, dispatched through a single MCP tool.
+through 72 verbs across 8 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 67 verbs across 7 packs.
+exposing one tool — `request` — that dispatches 72 verbs across 8 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the
@@ -50,7 +50,9 @@ Once installed, invoke them as `khive:digester`, `khive:polisher`, and so on.
 ## Requirements
 
 The `kg` pack is the base (entities, edges, notes); every other pack builds on it. The default
-server config loads all seven (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`).
+server config loads all eight (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
+`session`) — this plugin currently ships pattern skills for the first seven; `session` has no
+skill yet (see the Pattern skills table above).
 See [INSTALL.md](../INSTALL.md) for setup, the actor config, and per-pack smoke tests.
 
 ## Links

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 67 verbs, 7 packs, one MCP tool.
+A research knowledge graph runtime — 72 verbs, 8 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -19,7 +19,7 @@ Add to `.mcp.json` (project-level or `~/.claude/mcp.json` for global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-All 7 packs load by default. A background daemon auto-spawns to keep the runtime warm.
+All 8 packs load by default. A background daemon auto-spawns to keep the runtime warm.
 
 ## What you get
 
@@ -28,10 +28,11 @@ All 7 packs load by default. A background daemon auto-spawns to keep the runtime
 | **kg**        | 16    | Entities, edges, notes, graph queries, proposals |
 | **gtd**       | 5     | Task lifecycle (inbox → next → active → done)    |
 | **memory**    | 5     | Salience-weighted remember / decay-ranked recall |
-| **brain**     | 13    | Bayesian user profiles + feedback loop           |
+| **brain**     | 14    | Bayesian user profiles + feedback loop           |
 | **comm**      | 5     | Threaded messaging                               |
 | **schedule**  | 4     | Reminders and scheduled verb execution           |
 | **knowledge** | 19    | Atom-based KB with embedding rerank search       |
+| **session**   | 4     | Session record persistence (store/list/resume/export) |
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Live registry (`request(ops="verbs()")`) confirms **72 verbs across 8 packs** (kg=16, gtd=5, memory=5, brain=14, comm=5, schedule=4, knowledge=19, session=4).
- The `session` pack shipped as a genuine 8th production-default pack but several docs still cited pre-session counts (67/63 verbs, 7 packs).
- `AGENTS.md` was missing the Session pack section entirely, plus the `brain.register_adapter` verb (14th brain verb, docs said 13).

## Changes
- `README.md`, `CLAUDE.md`, `npm/README.md`, `marketplace/khive/README.md`, `docs/guide/getting-started.md`: verb/pack counts corrected to 72 verbs / 8 packs.
- `AGENTS.md`: added missing Session pack table (4 verbs: store/list/resume/export); added missing `brain.register_adapter` row; fixed brain count 13 → 14.
- `marketplace/khive/README.md`: clarified the plugin ships pattern skills for 7 of the 8 loaded packs (session has none yet), rather than implying only 7 packs load.

Docs-only change, no code/schema touched.

## Test plan
- [x] Grep sweep across all `.md` files in the repository for stale verb/pack-count patterns — clean.
- [x] `deno fmt` clean (table alignment fixed).
- [x] Pre-commit hooks passed on final commit.