### PR TITLE
docs: bump CLAUDE.md version banner 0.2.8 -> 0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **What this is**: A research knowledge graph runtime. Typed entities, closed edge ontology,
 hybrid search, GQL/SPARQL queries — all in a single 7.7MB Rust binary over MCP stdio.
 
-**v0.2.8** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
+**v0.3.0** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
 
 ---
 


### PR DESCRIPTION
## Summary
Resolves the version-posture half of the #206-deferred decision (issue #206, closed).

Verified facts (2026-07-03):
- Workspace `Cargo.toml`: `version = "0.3.0"`
- crates.io published `max_version`/`newest_version` for `khive-mcp`: `0.3.0` (checked via the crates.io API)
- `README.md`: already correctly says "v0.3.0 — published on crates.io"
- `CLAUDE.md`: top-of-file banner still said `v0.2.8` — the sole holdout

## Changes
- `CLAUDE.md`: version banner `v0.2.8` → `v0.3.0`.

Repo-wide sweep confirmed no other genuine staleness — remaining `v0.2.x` references elsewhere (crate `docs/benchmarks.md` "Last reviewed: v0.2.8" entries, a "deprecated since v0.2.3" note, a "(pre-v0.2.8)" behavior-boundary note, `CHANGELOG.md` compare-links) are all dated historical snapshots, correctly left untouched.

## Test plan
- [x] Verified crates.io published version via API before editing.
- [x] Verified workspace Cargo.toml version matches.
- [x] Repo-wide grep confirmed no other current-version-banner staleness.