### PR TITLE
feat(session): ChatGPT export mirror source for khive-pack-session (#463)

### DIFF
--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -1,7 +1,7 @@
 //! Idempotent file tail + upsert into the session mirror tables.
 //!
 //! `mirror_file` reads new bytes from a JSONL file starting at `start_offset`,
-//! parses complete lines using the parser selected by `MirrorSource`, and writes
+//! parses complete lines using the parser selected by `LineTailSource`, and writes
 //! them to the session mirror tables in a single transaction.  It is safe to call
 //! repeatedly on the same file; `INSERT OR IGNORE` keyed by the event UUID ensures
 //! idempotency.
@@ -16,22 +16,22 @@ use khive_storage::SqlTransaction;
 
 use super::parse;
 
-/// The `sessions.source` value written by [`mirror_chatgpt_export_file`].
+/// The full ADR-080 mirror-source contract — the closed set of sources
+/// `sessions.source` can hold (`docs/adr/ADR-080-session-pack-oss-storage-mechanism.md`,
+/// "Mirror sources — closed set"). Adding a source requires amending that ADR
+/// section and this enum together.
 ///
-/// Not a `MirrorSource` variant: ChatGPT export ingestion is whole-file, not
-/// line-tail, so it does not share `mirror_file`'s per-line dispatch and does
-/// not need a place in that closed enum.
-const CHATGPT_EXPORT_SOURCE: &str = "chatgpt_export";
-
-/// Identifies which CLI produced the JSONL file being mirrored.
-///
-/// The value is written to `sessions.source` and selects the line parser.
+/// This is a superset of [`LineTailSource`]: `ChatGptExport` ingests via
+/// whole-file re-parse (`mirror_chatgpt_export_file`), not the per-line
+/// dispatch `LineTailSource` selects, so it has no `LineTailSource` variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MirrorSource {
     /// Claude Code (`~/.claude/projects/<slug>/<uuid>.jsonl`).
     ClaudeCode,
     /// Codex CLI (`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`).
     Codex,
+    /// ChatGPT data export (`<exports dir>/**/conversations.json`).
+    ChatGptExport,
 }
 
 impl MirrorSource {
@@ -40,8 +40,33 @@ impl MirrorSource {
         match self {
             MirrorSource::ClaudeCode => "claude_code",
             MirrorSource::Codex => "codex",
+            MirrorSource::ChatGptExport => "chatgpt_export",
         }
     }
+}
+
+impl From<LineTailSource> for MirrorSource {
+    fn from(source: LineTailSource) -> Self {
+        match source {
+            LineTailSource::ClaudeCode => MirrorSource::ClaudeCode,
+            LineTailSource::Codex => MirrorSource::Codex,
+        }
+    }
+}
+
+/// Identifies which CLI produced the JSONL file being mirrored, for the
+/// purpose of selecting `mirror_file`'s per-line parser.
+///
+/// This is narrower than [`MirrorSource`]: it covers only the line-tail
+/// sources (append-only JSONL, tailed by byte offset). ChatGPT export
+/// ingestion is whole-file re-parse, not line-tail, so it has no variant
+/// here — see [`mirror_chatgpt_export_file`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineTailSource {
+    /// Claude Code (`~/.claude/projects/<slug>/<uuid>.jsonl`).
+    ClaudeCode,
+    /// Codex CLI (`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`).
+    Codex,
 }
 
 /// Statistics returned by a single `mirror_file` call.
@@ -59,10 +84,10 @@ pub struct MirrorStats {
 /// using the parser selected by `source`, and upsert them idempotently into the
 /// session mirror tables.
 ///
-/// For `MirrorSource::Codex`, `codex_session_id` must be the session UUID
+/// For `LineTailSource::Codex`, `codex_session_id` must be the session UUID
 /// derived from the filename; it is used both to key the `sessions` row and to
 /// synthesise per-line event UUIDs (`"{session_id}:{abs_byte_offset}"`).
-/// For `MirrorSource::ClaudeCode`, `codex_session_id` is ignored (the session
+/// For `LineTailSource::ClaudeCode`, `codex_session_id` is ignored (the session
 /// UUID is embedded in each line).
 ///
 /// Returns stats including the advanced byte offset.  A partial trailing line
@@ -76,7 +101,7 @@ pub async fn mirror_file(
     runtime: &KhiveRuntime,
     path: &Path,
     start_offset: u64,
-    source: MirrorSource,
+    source: LineTailSource,
     codex_session_id: Option<&str>,
 ) -> Result<MirrorStats, RuntimeError> {
     // ── read new bytes ────────────────────────────────────────────────────────
@@ -128,12 +153,12 @@ pub async fn mirror_file(
     // the synthesised event UUID is stable across re-tails.  Compute line
     // boundaries once, then iterate with offsets.
     let events: Vec<parse::ParsedEvent> = match source {
-        MirrorSource::ClaudeCode => complete_content
+        LineTailSource::ClaudeCode => complete_content
             .split('\n')
             .filter(|l| !l.is_empty())
             .filter_map(parse::parse_cc_line)
             .collect(),
-        MirrorSource::Codex => {
+        LineTailSource::Codex => {
             let sid = codex_session_id.unwrap_or("");
             let mut line_start: u64 = start_offset;
             let mut evs = Vec::new();
@@ -168,7 +193,15 @@ pub async fn mirror_file(
 
     // ── write in one transaction ──────────────────────────────────────────────
 
-    write_events_and_cursor(runtime, path, source.as_str(), &events, scanned, new_offset).await
+    write_events_and_cursor(
+        runtime,
+        path,
+        MirrorSource::from(source).as_str(),
+        &events,
+        scanned,
+        new_offset,
+    )
+    .await
 }
 
 /// Read the whole ChatGPT export `conversations.json` at `path`, parse every
@@ -220,7 +253,7 @@ pub async fn mirror_chatgpt_export_file(
     write_events_and_cursor(
         runtime,
         path,
-        CHATGPT_EXPORT_SOURCE,
+        MirrorSource::ChatGptExport.as_str(),
         &events,
         scanned,
         file_len,
@@ -649,7 +682,7 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // First call: should insert all 3 rows.
-        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let stats = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .expect("mirror_file first call");
         assert_eq!(stats.inserted, 3, "should insert 3 new messages");
@@ -663,16 +696,22 @@ mod tests {
         assert_eq!(session_count, 1, "1 session row");
 
         // Idempotency: second call over the SAME range inserts 0 rows.
-        let stats2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let stats2 = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .expect("mirror_file second call");
         assert_eq!(stats2.inserted, 0, "second pass must insert 0 rows");
         assert_eq!(count_rows(&rt, "session_messages").await, 3);
 
         // Offset-aware: calling from the advanced offset finds nothing new.
-        let stats3 = mirror_file(&rt, &path, stats.new_offset, MirrorSource::ClaudeCode, None)
-            .await
-            .expect("mirror_file from new_offset");
+        let stats3 = mirror_file(
+            &rt,
+            &path,
+            stats.new_offset,
+            LineTailSource::ClaudeCode,
+            None,
+        )
+        .await
+        .expect("mirror_file from new_offset");
         assert_eq!(stats3.inserted, 0, "no new data past advanced offset");
         assert_eq!(stats3.new_offset, stats.new_offset);
 
@@ -697,7 +736,7 @@ mod tests {
         let path = file.path().to_path_buf();
         let full_len = std::fs::metadata(&path).unwrap().len();
 
-        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let stats = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .expect("mirror_file partial");
 
@@ -710,9 +749,15 @@ mod tests {
         );
 
         // The partial bytes remain; calling again from new_offset finds no complete lines.
-        let stats2 = mirror_file(&rt, &path, stats.new_offset, MirrorSource::ClaudeCode, None)
-            .await
-            .expect("second call");
+        let stats2 = mirror_file(
+            &rt,
+            &path,
+            stats.new_offset,
+            LineTailSource::ClaudeCode,
+            None,
+        )
+        .await
+        .expect("second call");
         assert_eq!(
             stats2.inserted, 0,
             "partial line must not be consumed on re-poll"
@@ -735,7 +780,7 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // First call inserts.
-        let s1 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let s1 = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(s1.inserted, 1);
@@ -744,14 +789,14 @@ mod tests {
         writeln!(file, "{line}").unwrap();
 
         // Second call from offset 0 should see both lines but insert 0 new rows.
-        let s2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let s2 = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(s2.inserted, 0, "duplicate uuid must not be re-inserted");
         assert_eq!(count_rows(&rt, "session_messages").await, 1);
 
         // Incremental: call from first call's new_offset; the second line is the dup.
-        let s3 = mirror_file(&rt, &path, s1.new_offset, MirrorSource::ClaudeCode, None)
+        let s3 = mirror_file(&rt, &path, s1.new_offset, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(s3.inserted, 0, "incremental dup must also insert 0");
@@ -770,7 +815,7 @@ mod tests {
         writeln!(file, "{line}").unwrap();
         let path = file.path().to_path_buf();
 
-        let s1 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let s1 = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(s1.inserted, 1);
@@ -780,7 +825,7 @@ mod tests {
 
         // Replay from offset 0: re-scans the same line, inserts 0, and must
         // leave last_seen_at byte-identical even though now_us has advanced.
-        let s2 = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let s2 = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(s2.inserted, 0, "replay must insert 0 rows");
@@ -798,7 +843,7 @@ mod tests {
         let file = NamedTempFile::new().expect("tmpfile");
         let path = file.path().to_path_buf();
 
-        let stats = mirror_file(&rt, &path, 0, MirrorSource::ClaudeCode, None)
+        let stats = mirror_file(&rt, &path, 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
         assert_eq!(stats.inserted, 0);
@@ -810,7 +855,7 @@ mod tests {
     async fn test_missing_file_returns_error() {
         let (rt, _dir) = setup().await;
         let bad_path = std::path::PathBuf::from("/nonexistent/path/session.jsonl");
-        let result = mirror_file(&rt, &bad_path, 0, MirrorSource::ClaudeCode, None).await;
+        let result = mirror_file(&rt, &bad_path, 0, LineTailSource::ClaudeCode, None).await;
         assert!(
             matches!(result, Err(RuntimeError::Internal(_))),
             "missing file should return Internal error"
@@ -864,7 +909,7 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // Mirror the file as Codex source.
-        let stats = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+        let stats = mirror_file(&rt, &path, 0, LineTailSource::Codex, Some(session_id))
             .await
             .expect("codex mirror_file");
 
@@ -949,7 +994,7 @@ mod tests {
         let path = file.path().to_path_buf();
 
         // First pass.
-        let s1 = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+        let s1 = mirror_file(&rt, &path, 0, LineTailSource::Codex, Some(session_id))
             .await
             .unwrap();
         assert_eq!(s1.inserted, 1);
@@ -978,7 +1023,7 @@ mod tests {
         );
 
         // Second pass from offset 0: same lines, 0 new rows (idempotent).
-        let s2 = mirror_file(&rt, &path, 0, MirrorSource::Codex, Some(session_id))
+        let s2 = mirror_file(&rt, &path, 0, LineTailSource::Codex, Some(session_id))
             .await
             .unwrap();
         assert_eq!(s2.inserted, 0, "second pass must be idempotent");
@@ -989,7 +1034,7 @@ mod tests {
             &rt,
             &path,
             s1.new_offset,
-            MirrorSource::Codex,
+            LineTailSource::Codex,
             Some(session_id),
         )
         .await
@@ -1011,7 +1056,7 @@ mod tests {
         let mut cdx_file = NamedTempFile::new().expect("cdx tmpfile");
         writeln!(cdx_file, "{cdx_msg}").unwrap();
 
-        mirror_file(&rt, cc_file.path(), 0, MirrorSource::ClaudeCode, None)
+        mirror_file(&rt, cc_file.path(), 0, LineTailSource::ClaudeCode, None)
             .await
             .unwrap();
 
@@ -1019,7 +1064,7 @@ mod tests {
             &rt,
             cdx_file.path(),
             0,
-            MirrorSource::Codex,
+            LineTailSource::Codex,
             Some(cdx_session_id),
         )
         .await

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -12,8 +12,16 @@ use std::path::Path;
 use chrono::Utc;
 use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlTxOptions, SqlValue};
+use khive_storage::SqlTransaction;
 
 use super::parse;
+
+/// The `sessions.source` value written by [`mirror_chatgpt_export_file`].
+///
+/// Not a `MirrorSource` variant: ChatGPT export ingestion is whole-file, not
+/// line-tail, so it does not share `mirror_file`'s per-line dispatch and does
+/// not need a place in that closed enum.
+const CHATGPT_EXPORT_SOURCE: &str = "chatgpt_export";
 
 /// Identifies which CLI produced the JSONL file being mirrored.
 ///
@@ -160,18 +168,93 @@ pub async fn mirror_file(
 
     // ── write in one transaction ──────────────────────────────────────────────
 
+    write_events_and_cursor(runtime, path, source.as_str(), &events, scanned, new_offset).await
+}
+
+/// Read the whole ChatGPT export `conversations.json` at `path`, parse every
+/// conversation's mapping tree via [`parse::parse_chatgpt_export`], and upsert
+/// every message-bearing event idempotently into the session mirror tables in
+/// a single transaction.
+///
+/// Unlike `mirror_file` (append-only line-tail), a ChatGPT export is a single
+/// static JSON array with no stable "new bytes" boundary to tail, so this
+/// function always re-reads and re-parses the whole file. `start_offset` is
+/// used only as a cheap re-poll guard: if the file has not grown past it,
+/// nothing is read or parsed. `new_offset` is set to the whole file's byte
+/// length only after a successful parse and commit — any IO, parse, or DB
+/// error leaves the persisted cursor untouched, so a partially-downloaded
+/// export is retried whole on the next tick, never half-consumed.
+pub async fn mirror_chatgpt_export_file(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    start_offset: u64,
+) -> Result<MirrorStats, RuntimeError> {
+    let file_len = std::fs::metadata(path).map(|m| m.len()).map_err(|e| {
+        RuntimeError::Internal(format!(
+            "mirror_chatgpt_export_file: failed to stat {path:?}: {e}"
+        ))
+    })?;
+
+    if file_len <= start_offset {
+        return Ok(MirrorStats {
+            inserted: 0,
+            scanned: 0,
+            new_offset: start_offset,
+        });
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        RuntimeError::Internal(format!(
+            "mirror_chatgpt_export_file: failed to read {path:?}: {e}"
+        ))
+    })?;
+
+    let events = parse::parse_chatgpt_export(&content).ok_or_else(|| {
+        RuntimeError::Internal(format!(
+            "mirror_chatgpt_export_file: {path:?} is not a valid ChatGPT export (expected a top-level JSON array)"
+        ))
+    })?;
+
+    let scanned = events.len() as u64;
+
+    write_events_and_cursor(
+        runtime,
+        path,
+        CHATGPT_EXPORT_SOURCE,
+        &events,
+        scanned,
+        file_len,
+    )
+    .await
+}
+
+/// Upsert `events` and the mirror cursor for `path` in one transaction.
+///
+/// Shared by `mirror_file`'s eventful line-tail path and
+/// `mirror_chatgpt_export_file`'s whole-file path, so the session/message row
+/// construction and cursor semantics (create-only sessions, `INSERT OR
+/// IGNORE` message dedup, monotonic `last_seen_at`, cursor advances only on
+/// success) live in exactly one place.
+async fn write_events_and_cursor(
+    runtime: &KhiveRuntime,
+    path: &Path,
+    source_value: &'static str,
+    events: &[parse::ParsedEvent],
+    scanned: u64,
+    new_offset: u64,
+) -> Result<MirrorStats, RuntimeError> {
     let now_us = Utc::now().timestamp_micros();
     let sql = runtime.sql();
 
     let mut tx = sql
         .begin_tx(SqlTxOptions::default())
         .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror_file: begin_tx: {e}")))?;
+        .map_err(|e| RuntimeError::Internal(format!("mirror: begin_tx: {e}")))?;
 
     let mut inserted: u64 = 0;
     let mut last_session_id: Option<String> = None;
 
-    for ev in &events {
+    for ev in events {
         let created_at = if ev.created_at_micros != 0 {
             ev.created_at_micros
         } else {
@@ -192,7 +275,7 @@ pub async fn mirror_file(
                    message_count, first_seen_at, last_seen_at, namespace) \
                   VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
                   ON CONFLICT(id) DO NOTHING",
-                source.as_str()
+                source_value
             ),
             params: vec![
                 SqlValue::Text(ev.session_id.clone()),
@@ -213,7 +296,7 @@ pub async fn mirror_file(
             label: Some("session_mirror_create_session".into()),
         })
         .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror_file: session create: {e}")))?;
+        .map_err(|e| RuntimeError::Internal(format!("mirror: session create: {e}")))?;
 
         // ── session_messages insert (idempotent) ──────────────────────────────
         let affected = tx
@@ -248,7 +331,7 @@ pub async fn mirror_file(
                 label: Some("session_mirror_insert_message".into()),
             })
             .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror_file: message insert: {e}")))?;
+            .map_err(|e| RuntimeError::Internal(format!("mirror: message insert: {e}")))?;
 
         // ── advance session metadata ONLY when a new message landed ────────────
         //
@@ -284,7 +367,7 @@ pub async fn mirror_file(
                 label: Some("session_mirror_touch_session".into()),
             })
             .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror_file: session touch: {e}")))?;
+            .map_err(|e| RuntimeError::Internal(format!("mirror: session touch: {e}")))?;
         }
 
         inserted += affected;
@@ -293,7 +376,7 @@ pub async fn mirror_file(
 
     // ── refresh message_count for each distinct session ───────────────────────
     //
-    // In practice one JSONL file maps to one session_id, but we refresh every
+    // In practice one file maps to one session_id, but we refresh every
     // session_id we touched to stay correct even if that changes. Skipped
     // entirely on a pure replay (`inserted == 0`): the counts cannot have
     // changed, so writing them would be needless churn.
@@ -316,11 +399,39 @@ pub async fn mirror_file(
                 label: Some("session_mirror_refresh_count".into()),
             })
             .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror_file: count refresh: {e}")))?;
+            .map_err(|e| RuntimeError::Internal(format!("mirror: count refresh: {e}")))?;
         }
     }
 
-    // ── cursor upsert ─────────────────────────────────────────────────────────
+    upsert_cursor_in_tx(
+        &mut *tx,
+        path,
+        last_session_id.as_deref(),
+        new_offset,
+        now_us,
+    )
+    .await?;
+
+    // ── commit ────────────────────────────────────────────────────────────────
+    tx.commit()
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("mirror: commit: {e}")))?;
+
+    Ok(MirrorStats {
+        inserted,
+        scanned,
+        new_offset,
+    })
+}
+
+/// Upsert the `session_mirror_cursor` row for `path` inside an open transaction.
+async fn upsert_cursor_in_tx(
+    tx: &mut dyn SqlTransaction,
+    path: &Path,
+    session_id: Option<&str>,
+    new_offset: u64,
+    now_us: i64,
+) -> Result<(), RuntimeError> {
     let path_str = path.to_string_lossy().into_owned();
     tx.execute(SqlStatement {
         sql: "INSERT INTO session_mirror_cursor(file_path, session_id, byte_offset, updated_at) \
@@ -332,8 +443,7 @@ pub async fn mirror_file(
             .into(),
         params: vec![
             SqlValue::Text(path_str),
-            last_session_id
-                .as_deref()
+            session_id
                 .map(|s| SqlValue::Text(s.to_string()))
                 .unwrap_or(SqlValue::Null),
             SqlValue::Integer(new_offset as i64),
@@ -342,18 +452,8 @@ pub async fn mirror_file(
         label: Some("session_mirror_cursor_upsert".into()),
     })
     .await
-    .map_err(|e| RuntimeError::Internal(format!("mirror_file: cursor upsert: {e}")))?;
-
-    // ── commit ────────────────────────────────────────────────────────────────
-    tx.commit()
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror_file: commit: {e}")))?;
-
-    Ok(MirrorStats {
-        inserted,
-        scanned,
-        new_offset,
-    })
+    .map_err(|e| RuntimeError::Internal(format!("mirror: cursor upsert: {e}")))?;
+    Ok(())
 }
 
 /// Read bytes from `path` starting at `offset` to EOF.
@@ -947,5 +1047,513 @@ mod tests {
             })
             .collect();
         assert_eq!(sources, vec!["claude_code", "codex"]);
+    }
+
+    // ── ChatGPT export whole-file ingest tests ────────────────────────────────
+    //
+    // All fixtures below are hand-authored synthetic JSON, not real export
+    // content. Node ids are set equal to their own `message.id` so that
+    // `parent_uuid` (which threads through the mapping node id, per
+    // `parse::build_chatgpt_event`) resolves to the expected message uuid.
+
+    use serde_json::json;
+
+    fn write_export_file(content: &str) -> (NamedTempFile, std::path::PathBuf) {
+        let mut file = NamedTempFile::new().expect("tmpfile");
+        write!(file, "{content}").unwrap();
+        let path = file.path().to_path_buf();
+        (file, path)
+    }
+
+    fn chatgpt_happy_export_json() -> String {
+        let conv = json!({
+            "id": "conv-happy",
+            "title": "Synthetic Happy",
+            "create_time": 1_751_462_400.0,
+            "current_node": "msg-happy-assistant",
+            "mapping": {
+                "root-happy": {
+                    "id": "root-happy",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-happy-user"]
+                },
+                "msg-happy-user": {
+                    "id": "msg-happy-user",
+                    "parent": "root-happy",
+                    "children": ["msg-happy-assistant"],
+                    "message": {
+                        "id": "msg-happy-user",
+                        "author": {"role": "user"},
+                        "create_time": 1_751_462_400.0,
+                        "content": {"content_type": "text", "parts": ["Hello synthetic"]}
+                    }
+                },
+                "msg-happy-assistant": {
+                    "id": "msg-happy-assistant",
+                    "parent": "msg-happy-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-happy-assistant",
+                        "author": {"role": "assistant"},
+                        "create_time": 1_751_462_401.0,
+                        "content": {"content_type": "text", "parts": ["Hi synthetic"]}
+                    }
+                }
+            }
+        });
+        serde_json::to_string(&json!([conv])).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_chatgpt_happy_conversations_json() {
+        let (rt, _dir) = setup().await;
+        let (_file, path) = write_export_file(&chatgpt_happy_export_json());
+        let file_len = std::fs::metadata(&path).unwrap().len();
+
+        let stats = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("happy path ingest");
+        assert_eq!(stats.inserted, 2, "2 message-bearing nodes");
+        assert_eq!(stats.scanned, 2, "2 events parsed");
+        assert_eq!(stats.new_offset, file_len, "whole-file cursor-at-length");
+
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let row = r
+            .query_row(SqlStatement {
+                sql: "SELECT source, slug, cwd, git_branch FROM sessions WHERE id='conv-happy'"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("session row must exist");
+        match row.get("source") {
+            Some(SqlValue::Text(s)) => assert_eq!(s, "chatgpt_export"),
+            other => panic!("unexpected source: {other:?}"),
+        }
+        match row.get("slug") {
+            Some(SqlValue::Text(s)) => assert_eq!(s, "Synthetic Happy"),
+            other => panic!("unexpected slug: {other:?}"),
+        }
+        assert!(
+            matches!(row.get("cwd"), Some(SqlValue::Null) | None),
+            "chatgpt export never carries a cwd"
+        );
+        assert!(
+            matches!(row.get("git_branch"), Some(SqlValue::Null) | None),
+            "chatgpt export never carries a git branch"
+        );
+
+        let mut r2 = sql.reader().await.expect("reader");
+        let rows = r2
+            .query_all(SqlStatement {
+                sql: "SELECT seq, role FROM session_messages \
+                      WHERE session_id='conv-happy' ORDER BY seq"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok");
+        let roles: Vec<(i64, String)> = rows
+            .iter()
+            .map(|row| {
+                let seq = match row.get("seq") {
+                    Some(SqlValue::Integer(n)) => *n,
+                    other => panic!("unexpected seq: {other:?}"),
+                };
+                let role = match row.get("role") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => panic!("unexpected role: {other:?}"),
+                };
+                (seq, role)
+            })
+            .collect();
+        assert_eq!(
+            roles,
+            vec![(0, "user".to_string()), (1, "assistant".to_string())]
+        );
+    }
+
+    fn chatgpt_idempotency_export_json() -> String {
+        let conv = json!({
+            "id": "conv-idem",
+            "title": "Synthetic Idempotency",
+            "current_node": "msg-idem-assistant",
+            "mapping": {
+                "root-idem": {
+                    "id": "root-idem",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-idem-user"]
+                },
+                "msg-idem-user": {
+                    "id": "msg-idem-user",
+                    "parent": "root-idem",
+                    "children": ["msg-idem-assistant"],
+                    "message": {
+                        "id": "msg-idem-user",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Same question again"]}
+                    }
+                },
+                "msg-idem-assistant": {
+                    "id": "msg-idem-assistant",
+                    "parent": "msg-idem-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-idem-assistant",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Same answer again"]}
+                    }
+                }
+            }
+        });
+        serde_json::to_string(&json!([conv])).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_chatgpt_reingest_idempotency_conversations_json() {
+        let (rt, _dir) = setup().await;
+        let (_file, path) = write_export_file(&chatgpt_idempotency_export_json());
+
+        let s1 = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("first ingest");
+        assert_eq!(s1.inserted, 2);
+
+        let seen_after_first = last_seen_at(&rt, "conv-idem")
+            .await
+            .expect("session row exists");
+
+        // Re-ingest from offset 0 (the service always re-reads the whole file
+        // for this source): same event uuids, INSERT OR IGNORE must dedup.
+        let s2 = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("second ingest");
+        assert_eq!(s2.inserted, 0, "re-ingest must insert 0 new rows");
+
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let count = r
+            .query_row(SqlStatement {
+                sql: "SELECT COUNT(*) FROM session_messages WHERE session_id='conv-idem'".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("count row");
+        match count.columns.first().map(|c| &c.value) {
+            Some(SqlValue::Integer(n)) => assert_eq!(*n, 2, "message count stays at 2"),
+            other => panic!("unexpected count: {other:?}"),
+        }
+
+        let seen_after_replay = last_seen_at(&rt, "conv-idem")
+            .await
+            .expect("session row still exists");
+        assert_eq!(
+            seen_after_first, seen_after_replay,
+            "pure replay must not advance last_seen_at"
+        );
+    }
+
+    fn chatgpt_branch_sidechain_export_json() -> String {
+        let conv = json!({
+            "id": "conv-branch",
+            "title": "Synthetic Branch",
+            "current_node": "msg-branch-main",
+            "mapping": {
+                "root-branch": {
+                    "id": "root-branch",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-branch-user"]
+                },
+                "msg-branch-user": {
+                    "id": "msg-branch-user",
+                    "parent": "root-branch",
+                    "children": ["msg-branch-main", "msg-branch-alt"],
+                    "message": {
+                        "id": "msg-branch-user",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Branch question"]}
+                    }
+                },
+                "msg-branch-main": {
+                    "id": "msg-branch-main",
+                    "parent": "msg-branch-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-branch-main",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Main answer"]}
+                    }
+                },
+                "msg-branch-alt": {
+                    "id": "msg-branch-alt",
+                    "parent": "msg-branch-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-branch-alt",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Alternate answer"]}
+                    }
+                }
+            }
+        });
+        serde_json::to_string(&json!([conv])).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_chatgpt_branch_sidechain_conversations_json() {
+        let (rt, _dir) = setup().await;
+        let (_file, path) = write_export_file(&chatgpt_branch_sidechain_export_json());
+
+        let stats = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("branch ingest");
+        assert_eq!(stats.inserted, 3, "user + main + alt all stored");
+
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT id, is_sidechain, text FROM session_messages \
+                      WHERE session_id='conv-branch' ORDER BY id"
+                    .into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok");
+        assert_eq!(rows.len(), 3);
+
+        for row in &rows {
+            let id = match row.get("id") {
+                Some(SqlValue::Text(s)) => s.clone(),
+                other => panic!("unexpected id: {other:?}"),
+            };
+            let is_sidechain = match row.get("is_sidechain") {
+                Some(SqlValue::Integer(n)) => *n,
+                other => panic!("unexpected is_sidechain: {other:?}"),
+            };
+            let text = match row.get("text") {
+                Some(SqlValue::Text(s)) => s.clone(),
+                other => panic!("unexpected text: {other:?}"),
+            };
+            match id.as_str() {
+                "msg-branch-user" | "msg-branch-main" => {
+                    assert_eq!(is_sidechain, 0, "{id} is on the current-node path")
+                }
+                "msg-branch-alt" => {
+                    assert_eq!(is_sidechain, 1, "alt branch is off the current-node path");
+                    assert_eq!(
+                        text, "Alternate answer",
+                        "sidechain content must be preserved, not dropped"
+                    );
+                }
+                other => panic!("unexpected message id: {other}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chatgpt_malformed_conversations_json_cursor_does_not_advance() {
+        let (rt, _dir) = setup().await;
+
+        // Seed the path with a valid (if empty) export and record its cursor.
+        let (mut file, path) = write_export_file("[]");
+        let seeded_stats = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("seeding with an empty array is a valid parse");
+        assert_eq!(seeded_stats.inserted, 0);
+        let seeded_offset = seeded_stats.new_offset;
+
+        let seeded_sessions = count_rows(&rt, "sessions").await;
+        let seeded_messages = count_rows(&rt, "session_messages").await;
+
+        // Overwrite with a longer, malformed (valid-JSON-but-not-an-array) body.
+        let malformed = r#"{"oops": "not a chatgpt export array"}"#;
+        file.as_file_mut().set_len(0).expect("truncate");
+        std::io::Seek::seek(file.as_file_mut(), std::io::SeekFrom::Start(0)).unwrap();
+        write!(file, "{malformed}").unwrap();
+
+        let result = mirror_chatgpt_export_file(&rt, &path, seeded_offset).await;
+        assert!(
+            matches!(result, Err(RuntimeError::Internal(_))),
+            "malformed export must return Internal error, got {result:?}"
+        );
+
+        let stored_offset = cursor_offset(&rt, &path.to_string_lossy()).await;
+        assert_eq!(
+            stored_offset,
+            Some(seeded_offset as i64),
+            "cursor must remain at the pre-error value"
+        );
+        assert_eq!(
+            count_rows(&rt, "sessions").await,
+            seeded_sessions,
+            "no new session rows on parse failure"
+        );
+        assert_eq!(
+            count_rows(&rt, "session_messages").await,
+            seeded_messages,
+            "no new message rows on parse failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chatgpt_secret_bearing_conversations_json_is_masked() {
+        // Assembled from fragments at runtime so no credential-shaped literal
+        // is committed to the repo; matches the AWS-key shape already covered
+        // by `khive_runtime::secret_gate`'s own detector tests.
+        let secret_fragment_a = "AKIA";
+        let secret_fragment_b = "FAKEKEY1234567890";
+        let secret = format!("{secret_fragment_a}{secret_fragment_b}");
+        let user_text = format!("here is my key: {secret}");
+
+        let conv = json!({
+            "id": "conv-secret",
+            "title": "Synthetic Secret",
+            "current_node": "msg-secret-user",
+            "mapping": {
+                "root-secret": {
+                    "id": "root-secret",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-secret-user"]
+                },
+                "msg-secret-user": {
+                    "id": "msg-secret-user",
+                    "parent": "root-secret",
+                    "children": [],
+                    "message": {
+                        "id": "msg-secret-user",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": [user_text]}
+                    }
+                }
+            }
+        });
+        let content = serde_json::to_string(&json!([conv])).unwrap();
+        let (_file, path) = write_export_file(&content);
+
+        let (rt, _dir) = setup().await;
+        let stats = mirror_chatgpt_export_file(&rt, &path, 0)
+            .await
+            .expect("secret-bearing content must still ingest, only masked");
+        assert_eq!(stats.inserted, 1);
+
+        let sql = rt.sql();
+        let mut r = sql.reader().await.expect("reader");
+        let row = r
+            .query_row(SqlStatement {
+                sql: "SELECT text, raw FROM session_messages WHERE session_id='conv-secret'".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query ok")
+            .expect("message row must exist");
+        let (stored_text, stored_raw) = match (row.get("text"), row.get("raw")) {
+            (Some(SqlValue::Text(t)), Some(SqlValue::Text(r))) => (t.clone(), r.clone()),
+            other => panic!("unexpected text/raw shape: {other:?}"),
+        };
+
+        assert!(
+            !stored_text.contains(&secret),
+            "stored text must not contain the raw secret"
+        );
+        assert!(
+            !stored_raw.contains(&secret),
+            "stored raw must not contain the raw secret"
+        );
+        assert!(
+            stored_text.contains("***MASKED***"),
+            "stored text must carry the secret_gate redaction marker"
+        );
+        assert!(
+            stored_raw.contains("***MASKED***"),
+            "stored raw must carry the secret_gate redaction marker"
+        );
+    }
+
+    /// SS6 invariants #4 ("an ingest error never advances the cursor") and #5
+    /// ("one transaction per file pass") both rest on the same underlying
+    /// contract that `write_events_and_cursor` depends on: a `begin_tx()`
+    /// transaction that hits an error before `commit()` is called must leave
+    /// no visible trace of ANY write it made in that pass — including the
+    /// cursor upsert, which runs last, right before `commit()`.
+    ///
+    /// The real ingest loop can't be driven into a mid-loop DB error through
+    /// crafted event data: the `sessions` insert uses `ON CONFLICT(id) DO
+    /// NOTHING` and the `session_messages` insert uses `INSERT OR IGNORE`,
+    /// both of which swallow constraint violations by design (that's what
+    /// makes re-ingest idempotent). So this test exercises the same
+    /// `begin_tx`/`execute`/drop-without-commit path directly — the exact
+    /// machinery `mirror_chatgpt_export_file`'s `?`-propagated errors rely
+    /// on — and forces a genuine, non-suppressed SQL error (a `prepare()`
+    /// failure on a nonexistent table) after a session write AND a cursor
+    /// advance have already succeeded within the same open transaction.
+    #[tokio::test]
+    async fn test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced() {
+        let (rt, _dir) = setup().await;
+        let sql = rt.sql();
+        let path = std::path::Path::new("/synthetic/mid-tx-probe.json");
+
+        let mut tx = sql
+            .begin_tx(SqlTxOptions::default())
+            .await
+            .expect("begin_tx");
+
+        // First write succeeds — mirrors event 1's session row in a
+        // multi-event file pass.
+        tx.execute(SqlStatement {
+            sql: "INSERT INTO sessions \
+                  (id, provider_session_id, source, message_count, first_seen_at, last_seen_at, namespace) \
+                  VALUES('mid-tx-session', 'mid-tx-session', 'chatgpt_export', 0, 1, 1, 'local')"
+                .into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .expect("first write in transaction must succeed");
+
+        // Cursor advance succeeds too — mirrors `upsert_cursor_in_tx` running
+        // near the end of `write_events_and_cursor`, before `commit()`.
+        upsert_cursor_in_tx(&mut *tx, path, Some("mid-tx-session"), 999, 1)
+            .await
+            .expect("cursor upsert in transaction must succeed");
+
+        // Third write fails with a genuine (non-suppressed) SQL error —
+        // mirrors a mid-loop DB failure on a later event in the same file.
+        let err = tx
+            .execute(SqlStatement {
+                sql: "INSERT INTO no_such_table_mid_tx_probe(a) VALUES(1)".into(),
+                params: vec![],
+                label: None,
+            })
+            .await;
+        assert!(err.is_err(), "forced third write must fail");
+
+        // No `commit()` is ever called — `tx` is dropped here, exactly as
+        // `write_events_and_cursor` drops its `tx` when an earlier `?`
+        // returns `Err` before reaching its own `tx.commit()` call.
+        drop(tx);
+
+        assert_eq!(
+            count_rows(&rt, "sessions").await,
+            0,
+            "session write must not survive a later error in the same transaction"
+        );
+        assert_eq!(
+            cursor_offset(&rt, &path.to_string_lossy()).await,
+            None,
+            "cursor must not advance when a later write in the same transaction fails"
+        );
     }
 }

--- a/crates/khive-pack-session/src/mirror/mod.rs
+++ b/crates/khive-pack-session/src/mirror/mod.rs
@@ -7,6 +7,6 @@ pub mod ingest;
 pub mod parse;
 pub mod service;
 
-pub use ingest::{MirrorSource, MirrorStats};
+pub use ingest::{LineTailSource, MirrorSource, MirrorStats};
 pub use parse::{parse_cc_line, parse_codex_line};
 pub use service::{run_mirror_service, MirrorConfig};

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -913,4 +913,181 @@ mod tests {
         let ev = parse_cc_line(line).expect("CC text block must parse");
         assert_eq!(ev.text.as_deref(), Some("CC still works"));
     }
+
+    // ── parse_chatgpt_export: direct unit tests ─────────────────────────────
+    //
+    // Unlike the end-to-end mirror_chatgpt_export_file tests in ingest.rs
+    // (which go through file I/O + SQL), these exercise the pure JSON-tree
+    // parsing seam directly with no runtime or DB setup.
+
+    #[test]
+    fn test_chatgpt_export_minimal_valid_export() {
+        let export = serde_json::json!([{
+            "id": "conv-min",
+            "title": "Minimal Export",
+            "current_node": "msg-assistant",
+            "create_time": 1_700_000_000.0,
+            "mapping": {
+                "root": {
+                    "id": "root",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-user"]
+                },
+                "msg-user": {
+                    "id": "msg-user",
+                    "parent": "root",
+                    "children": ["msg-assistant"],
+                    "message": {
+                        "id": "msg-user",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Hello"]}
+                    }
+                },
+                "msg-assistant": {
+                    "id": "msg-assistant",
+                    "parent": "msg-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-assistant",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Hi there"]}
+                    }
+                }
+            }
+        }]);
+        let content = serde_json::to_string(&export).unwrap();
+
+        let events = parse_chatgpt_export(&content).expect("valid export must parse");
+        assert_eq!(events.len(), 2, "root has no message, 2 nodes carry one");
+
+        assert_eq!(events[0].uuid, "msg-user");
+        assert_eq!(events[0].session_id, "conv-min");
+        assert_eq!(events[0].role.as_deref(), Some("user"));
+        assert_eq!(events[0].text.as_deref(), Some("Hello"));
+        assert_eq!(events[0].parent_uuid, None, "root carries no message");
+        assert!(!events[0].is_sidechain);
+        assert_eq!(events[0].slug.as_deref(), Some("Minimal Export"));
+
+        assert_eq!(events[1].uuid, "msg-assistant");
+        assert_eq!(events[1].role.as_deref(), Some("assistant"));
+        assert_eq!(events[1].text.as_deref(), Some("Hi there"));
+        assert_eq!(events[1].parent_uuid.as_deref(), Some("msg-user"));
+        assert!(!events[1].is_sidechain);
+    }
+
+    #[test]
+    fn test_chatgpt_export_multi_branch_tree_dfs_order_and_sidechain() {
+        // root -> user -> {main (current path), alt (regenerated/abandoned)}
+        let export = serde_json::json!([{
+            "id": "conv-branch",
+            "title": "Branching Conversation",
+            "current_node": "msg-main",
+            "mapping": {
+                "root": {
+                    "id": "root",
+                    "message": null,
+                    "parent": null,
+                    "children": ["msg-user"]
+                },
+                "msg-user": {
+                    "id": "msg-user",
+                    "parent": "root",
+                    "children": ["msg-main", "msg-alt"],
+                    "message": {
+                        "id": "msg-user",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["Question"]}
+                    }
+                },
+                "msg-main": {
+                    "id": "msg-main",
+                    "parent": "msg-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-main",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Main answer"]}
+                    }
+                },
+                "msg-alt": {
+                    "id": "msg-alt",
+                    "parent": "msg-user",
+                    "children": [],
+                    "message": {
+                        "id": "msg-alt",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["Alternate answer"]}
+                    }
+                }
+            }
+        }]);
+        let content = serde_json::to_string(&export).unwrap();
+
+        let events = parse_chatgpt_export(&content).expect("branch export must parse");
+        assert_eq!(events.len(), 3);
+
+        // DFS preorder must follow the mapping's `children` array order, not
+        // JSON object key order: user, then main, then alt.
+        let uuids: Vec<&str> = events.iter().map(|e| e.uuid.as_str()).collect();
+        assert_eq!(uuids, vec!["msg-user", "msg-main", "msg-alt"]);
+
+        let by_uuid = |id: &str| events.iter().find(|e| e.uuid == id).unwrap();
+        assert!(!by_uuid("msg-user").is_sidechain);
+        assert!(
+            !by_uuid("msg-main").is_sidechain,
+            "current_node's own path must not be flagged"
+        );
+        assert!(
+            by_uuid("msg-alt").is_sidechain,
+            "branch off current_node path must be flagged sidechain"
+        );
+        assert_eq!(by_uuid("msg-alt").text.as_deref(), Some("Alternate answer"));
+    }
+
+    #[test]
+    fn test_chatgpt_export_malformed_inputs() {
+        // Top level not valid JSON at all -> None (caller must not advance cursor).
+        assert!(parse_chatgpt_export("not json").is_none());
+
+        // Valid JSON but not an array -> None.
+        assert!(parse_chatgpt_export(r#"{"oops": "not an array"}"#).is_none());
+
+        // Valid array, but individual malformed conversations (missing
+        // mapping, missing id, non-object entry) must be skipped
+        // individually rather than sinking the whole file.
+        let export = serde_json::json!([
+            {"id": "no-mapping"},
+            {"mapping": {}},
+            "not-an-object",
+            {
+                "id": "conv-good",
+                "current_node": "msg-good",
+                "mapping": {
+                    "root": {"id": "root", "message": null, "parent": null, "children": ["msg-good"]},
+                    "msg-good": {
+                        "id": "msg-good",
+                        "parent": "root",
+                        "children": [],
+                        "message": {
+                            "id": "msg-good",
+                            "author": {"role": "user"},
+                            "content": {"content_type": "text", "parts": ["Still works"]}
+                        }
+                    }
+                }
+            }
+        ]);
+        let content = serde_json::to_string(&export).unwrap();
+
+        let events = parse_chatgpt_export(&content)
+            .expect("array with some malformed conversations still parses");
+        assert_eq!(
+            events.len(),
+            1,
+            "malformed conversations skipped, valid one still yields its event"
+        );
+        assert_eq!(events[0].uuid, "msg-good");
+        assert_eq!(events[0].session_id, "conv-good");
+    }
 }

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -3,9 +3,11 @@
 //! Every function here is deterministic and side-effect-free so the unit tests
 //! can run without any runtime or DB setup.
 
+use std::collections::HashSet;
+
 use chrono::DateTime;
 use khive_runtime::secret_gate;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// A single parsed event, source-agnostic.
 #[derive(Debug, Clone, PartialEq)]
@@ -15,6 +17,7 @@ pub struct ParsedEvent {
     /// For Claude Code events this is the top-level `uuid` field.
     /// For Codex events (which carry no per-message uuid) this is synthesised
     /// as `"{session_id}:{abs_byte_offset}"`.
+    /// For ChatGPT export events this is the mapping node's `message.id`.
     pub uuid: String,
     /// Session UUID.
     pub session_id: String,
@@ -36,7 +39,8 @@ pub struct ParsedEvent {
     pub cwd: Option<String>,
     /// `gitBranch` (CC) or `payload.git.branch` (Codex) if present.
     pub git_branch: Option<String>,
-    /// `slug` if present (CC-only; Codex files carry no slug concept).
+    /// `slug` if present (CC: project slug; ChatGPT export: conversation
+    /// title; Codex files carry no slug concept).
     pub slug: Option<String>,
 }
 
@@ -252,6 +256,39 @@ pub fn parse_codex_line(line: &str, session_id: &str, abs_byte_offset: u64) -> O
     }
 }
 
+/// Parse a ChatGPT data-export `conversations.json` file.
+///
+/// Unlike `parse_cc_line`/`parse_codex_line` (one JSONL line in, one event
+/// out), a ChatGPT export is a single static JSON array of conversation
+/// objects — this function parses the whole file at once and returns every
+/// message-bearing event across every conversation it contains.
+///
+/// Returns `None` when `content` is not valid JSON or the top level is not a
+/// JSON array. The caller treats that as a per-file error so the mirror
+/// cursor does not advance: a partially-downloaded export is retried whole
+/// on the next tick, never half-consumed. A malformed *conversation* inside
+/// an otherwise-valid array is skipped individually (see `parse_conversation`)
+/// so one bad entry cannot sink the rest of the file.
+///
+/// Each conversation's `mapping` forms a tree; events are emitted in
+/// deterministic DFS preorder from the root, following each node's
+/// `children` array order (never JSON object key order). Nodes off the
+/// `current_node` root-to-tip path are flagged `is_sidechain`, mirroring how
+/// Claude Code flags abandoned/regenerated branches.
+///
+/// The returned `raw` and `text` fields have secrets masked, exactly like
+/// `parse_cc_line`/`parse_codex_line`.
+pub fn parse_chatgpt_export(content: &str) -> Option<Vec<ParsedEvent>> {
+    let value: Value = serde_json::from_str(content).ok()?;
+    let conversations = value.as_array()?;
+
+    let mut events = Vec::new();
+    for conv in conversations {
+        parse_conversation(conv, &mut events);
+    }
+    Some(events)
+}
+
 /// Extract a display-friendly text string from a message `content` value.
 ///
 /// Handles both the string form and the structured-block array form.
@@ -314,6 +351,245 @@ fn truncate(s: &str, max_chars: usize) -> String {
         let mut out: String = s.chars().take(max_chars).collect();
         out.push('…');
         out
+    }
+}
+
+/// Context threaded through node visitation for one conversation — the
+/// pieces that don't change as the DFS walks the mapping tree.
+struct ConvContext<'a> {
+    mapping: &'a Map<String, Value>,
+    current_path: &'a HashSet<String>,
+    session_id: &'a str,
+    /// Conversation-level `create_time` in micros (0 if absent) — the
+    /// fallback used when a message's own `create_time` is null/absent.
+    conv_created_at_micros: i64,
+    slug: Option<&'a str>,
+}
+
+/// Parse one ChatGPT export conversation object, appending its
+/// message-bearing nodes (deterministic DFS preorder from the mapping root)
+/// to `out`.
+///
+/// Skips the whole conversation on a missing/empty `id` or missing `mapping`
+/// so one malformed entry cannot sink the rest of the file.
+fn parse_conversation(conv: &Value, out: &mut Vec<ParsedEvent>) {
+    let Some(conv_obj) = conv.as_object() else {
+        return;
+    };
+    let Some(session_id) = conv_obj
+        .get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    else {
+        return;
+    };
+    let Some(mapping) = conv_obj.get("mapping").and_then(|v| v.as_object()) else {
+        return;
+    };
+
+    let slug = conv_obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let conv_created_at_micros = conv_obj
+        .get("create_time")
+        .and_then(|v| v.as_f64())
+        .map(|secs| (secs * 1_000_000.0) as i64)
+        .unwrap_or(0);
+
+    // ── current-path set: walk current_node -> parent -> ... -> root ────────
+    //
+    // Off-path nodes (abandoned/regenerated branches) are flagged
+    // is_sidechain, mirroring how Claude Code flags sidechains.
+    let mut current_path: HashSet<String> = HashSet::new();
+    if let Some(current_node) = conv_obj.get("current_node").and_then(|v| v.as_str()) {
+        let mut cursor = Some(current_node.to_string());
+        while let Some(node_id) = cursor {
+            if !current_path.insert(node_id.clone()) {
+                break; // cycle guard against malformed mapping data
+            }
+            cursor = mapping
+                .get(&node_id)
+                .and_then(|n| n.as_object())
+                .and_then(|n| n.get("parent"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+    }
+
+    let root_id = mapping.iter().find_map(|(id, node)| {
+        let node_obj = node.as_object()?;
+        let parent_is_null = node_obj.get("parent").map(|v| v.is_null()).unwrap_or(true);
+        parent_is_null.then(|| id.clone())
+    });
+    let Some(root_id) = root_id else {
+        return;
+    };
+
+    let ctx = ConvContext {
+        mapping,
+        current_path: &current_path,
+        session_id,
+        conv_created_at_micros,
+        slug: slug.as_deref(),
+    };
+
+    // ── deterministic DFS preorder from the root, following `children` order ─
+    //
+    // Explicit stack, not recursion — a long linear conversation can nest
+    // thousands of turns deep and would risk overflowing a worker-thread stack.
+    let mut stack: Vec<String> = vec![root_id];
+    let mut visited: HashSet<String> = HashSet::new();
+
+    while let Some(node_id) = stack.pop() {
+        if !visited.insert(node_id.clone()) {
+            continue; // cycle guard
+        }
+        let Some(node) = mapping.get(&node_id).and_then(|n| n.as_object()) else {
+            continue;
+        };
+
+        if let Some(message) = node.get("message").filter(|m| !m.is_null()) {
+            if let Some(message_obj) = message.as_object() {
+                if let Some(ev) = build_chatgpt_event(&node_id, node, message_obj, &ctx) {
+                    out.push(ev);
+                }
+            }
+        }
+
+        if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
+            // Push in reverse so the first child in the array is popped (and
+            // thus visited) first — preorder must follow children order.
+            for child in children.iter().rev() {
+                if let Some(child_id) = child.as_str() {
+                    stack.push(child_id.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// Build a `ParsedEvent` for a single message-bearing mapping node.
+///
+/// Returns `None` when the message carries no `id`, or when the extracted
+/// text is empty/whitespace-only (ChatGPT scaffolding nodes, e.g. system
+/// prompts with `parts: [""]`).
+fn build_chatgpt_event(
+    node_id: &str,
+    node: &Map<String, Value>,
+    message: &Map<String, Value>,
+    ctx: &ConvContext,
+) -> Option<ParsedEvent> {
+    let uuid = message
+        .get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())?
+        .to_string();
+
+    let role = message
+        .get("author")
+        .and_then(|a| a.as_object())
+        .and_then(|a| a.get("role"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let content = message.get("content").and_then(|c| c.as_object());
+    let content_type = content
+        .and_then(|c| c.get("content_type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let text = extract_chatgpt_text(&content_type, content)?;
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    let created_at_micros = message
+        .get("create_time")
+        .and_then(|v| v.as_f64())
+        .map(|secs| (secs * 1_000_000.0) as i64)
+        .unwrap_or(ctx.conv_created_at_micros);
+
+    // Some(parent_node_id) only when that parent node itself carries a
+    // (non-null) message — the ChatGPT root is normally message=null, so its
+    // children correctly get parent_uuid=None. A parent that DOES carry a
+    // message but was itself skipped as an event (e.g. empty-parts
+    // scaffolding) still counts — this is provenance linkage, matching how
+    // CC parent chains can reference events that were never mirrored.
+    let parent_uuid = node
+        .get("parent")
+        .and_then(|v| v.as_str())
+        .filter(|pid| {
+            ctx.mapping
+                .get(*pid)
+                .and_then(|p| p.as_object())
+                .and_then(|p| p.get("message"))
+                .map(|m| !m.is_null())
+                .unwrap_or(false)
+        })
+        .map(str::to_string);
+
+    let is_sidechain = !ctx.current_path.contains(node_id);
+
+    let raw_json = serde_json::to_string(node).unwrap_or_default();
+    let raw = secret_gate::mask_secrets(&raw_json).into_owned();
+    let text = secret_gate::mask_secrets(&text).into_owned();
+
+    Some(ParsedEvent {
+        uuid,
+        session_id: ctx.session_id.to_string(),
+        parent_uuid,
+        is_sidechain,
+        role,
+        msg_type: content_type,
+        text: Some(text),
+        raw,
+        created_at_micros,
+        cwd: None,
+        git_branch: None,
+        slug: ctx.slug.map(str::to_string),
+    })
+}
+
+/// Extract display text from a ChatGPT message `content` object per its
+/// `content_type`.
+///
+/// - `"text"` — join string `parts` with `"\n"` (non-string parts ignored
+///   defensively).
+/// - anything else (`"code"`, `"execution_output"`, …) — `content.text` if
+///   present, else joined string `parts`, else `None`.
+fn extract_chatgpt_text(content_type: &str, content: Option<&Map<String, Value>>) -> Option<String> {
+    let content = content?;
+
+    if content_type == "text" {
+        let parts = content.get("parts")?.as_array()?;
+        let joined: Vec<String> = parts
+            .iter()
+            .filter_map(|p| p.as_str().map(str::to_string))
+            .collect();
+        return if joined.is_empty() {
+            None
+        } else {
+            Some(joined.join("\n"))
+        };
+    }
+
+    if let Some(text) = content.get("text").and_then(|v| v.as_str()) {
+        return Some(text.to_string());
+    }
+
+    let parts = content.get("parts")?.as_array()?;
+    let joined: Vec<String> = parts
+        .iter()
+        .filter_map(|p| p.as_str().map(str::to_string))
+        .collect();
+    if joined.is_empty() {
+        None
+    } else {
+        Some(joined.join("\n"))
     }
 }
 

--- a/crates/khive-pack-session/src/mirror/parse.rs
+++ b/crates/khive-pack-session/src/mirror/parse.rs
@@ -561,7 +561,10 @@ fn build_chatgpt_event(
 ///   defensively).
 /// - anything else (`"code"`, `"execution_output"`, …) — `content.text` if
 ///   present, else joined string `parts`, else `None`.
-fn extract_chatgpt_text(content_type: &str, content: Option<&Map<String, Value>>) -> Option<String> {
+fn extract_chatgpt_text(
+    content_type: &str,
+    content: Option<&Map<String, Value>>,
+) -> Option<String> {
     let content = content?;
 
     if content_type == "text" {

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -20,13 +20,24 @@ use khive_storage::types::{SqlStatement, SqlValue};
 
 use super::ingest::{self, MirrorSource};
 
-/// A discovered JSONL file together with its source type and (for Codex) the
-/// session UUID derived from the filename.
+/// How a discovered file should be ingested.
+///
+/// `ChatGptExport` is deliberately not a `MirrorSource` variant: ChatGPT
+/// export ingestion is whole-file (`mirror_chatgpt_export_file`), not
+/// line-tail, so it does not belong in that closed line-tail dispatch enum.
+enum DiscoveredKind {
+    LineTail {
+        source: MirrorSource,
+        /// Set for `MirrorSource::Codex`; `None` for `MirrorSource::ClaudeCode`.
+        session_id: Option<String>,
+    },
+    ChatGptExport,
+}
+
+/// A discovered file together with how it should be ingested.
 struct DiscoveredFile {
     path: PathBuf,
-    source: MirrorSource,
-    /// Set for `MirrorSource::Codex`; `None` for `MirrorSource::ClaudeCode`.
-    session_id: Option<String>,
+    kind: DiscoveredKind,
 }
 
 /// Configuration for the mirror service.
@@ -46,6 +57,13 @@ pub struct MirrorConfig {
     ///
     /// Defaults to `$HOME/.codex/sessions`.
     pub codex_sessions_dir: PathBuf,
+    /// Whether the ChatGPT export mirror is enabled (default: false — opt-in,
+    /// independent of `enabled` and `codex_enabled`).
+    pub chatgpt_enabled: bool,
+    /// Root directory scanned (recursively) for `conversations.json` export files.
+    ///
+    /// Defaults to `$HOME/.chatgpt/exports`.
+    pub chatgpt_exports_dir: PathBuf,
     /// How long to sleep between polling ticks (default: 2 seconds).
     pub poll_interval: Duration,
     /// When true (default), existing files are mirrored from byte offset 0.
@@ -62,6 +80,8 @@ impl MirrorConfig {
     /// | `KHIVE_MIRROR_PROJECTS_DIR`    | `$HOME/.claude/projects`       |
     /// | `KHIVE_MIRROR_CODEX_ENABLED`   | `false`                        |
     /// | `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`        |
+    /// | `KHIVE_MIRROR_CHATGPT_ENABLED` | `false`                        |
+    /// | `KHIVE_MIRROR_CHATGPT_DIR`     | `$HOME/.chatgpt/exports`       |
     /// | `KHIVE_MIRROR_POLL_SECS`       | `2`                            |
     /// | `KHIVE_MIRROR_BACKFILL`        | `true`                         |
     pub fn from_env() -> Self {
@@ -83,6 +103,14 @@ impl MirrorConfig {
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from(&home).join(".codex").join("sessions"));
 
+        let chatgpt_enabled = std::env::var("KHIVE_MIRROR_CHATGPT_ENABLED")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let chatgpt_exports_dir = std::env::var("KHIVE_MIRROR_CHATGPT_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(&home).join(".chatgpt").join("exports"));
+
         let poll_secs = std::env::var("KHIVE_MIRROR_POLL_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -97,6 +125,8 @@ impl MirrorConfig {
             projects_dir,
             codex_enabled,
             codex_sessions_dir,
+            chatgpt_enabled,
+            chatgpt_exports_dir,
             poll_interval: Duration::from_secs(poll_secs),
             backfill,
         }
@@ -140,14 +170,22 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
             for path in scan_cc_jsonl_files(&config.projects_dir) {
                 discovered.push(DiscoveredFile {
                     path,
-                    source: MirrorSource::ClaudeCode,
-                    session_id: None,
+                    kind: DiscoveredKind::LineTail {
+                        source: MirrorSource::ClaudeCode,
+                        session_id: None,
+                    },
                 });
             }
         }
 
         if config.codex_enabled {
             for item in scan_codex_jsonl_files(&config.codex_sessions_dir) {
+                discovered.push(item);
+            }
+        }
+
+        if config.chatgpt_enabled {
+            for item in scan_chatgpt_conversations_files(&config.chatgpt_exports_dir) {
                 discovered.push(item);
             }
         }
@@ -182,16 +220,24 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 continue;
             }
 
-            // Tail the new bytes.
-            match ingest::mirror_file(
-                &runtime,
-                &item.path,
-                offset,
-                item.source,
-                item.session_id.as_deref(),
-            )
-            .await
-            {
+            // Tail (line-tail sources) or whole-file re-read (ChatGPT export).
+            let result = match &item.kind {
+                DiscoveredKind::LineTail { source, session_id } => {
+                    ingest::mirror_file(
+                        &runtime,
+                        &item.path,
+                        offset,
+                        *source,
+                        session_id.as_deref(),
+                    )
+                    .await
+                }
+                DiscoveredKind::ChatGptExport => {
+                    ingest::mirror_chatgpt_export_file(&runtime, &item.path, offset).await
+                }
+            };
+
+            match result {
                 Ok(stats) => {
                     offsets.insert(item.path.clone(), stats.new_offset);
                     if stats.inserted > 0 || stats.new_offset > offset {
@@ -199,7 +245,6 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                         rows_inserted += stats.inserted;
                         tracing::debug!(
                             path = %item.path.display(),
-                            source = ?item.source,
                             inserted = stats.inserted,
                             scanned = stats.scanned,
                             new_offset = stats.new_offset,
@@ -332,10 +377,51 @@ fn scan_codex_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>
             if let Some(session_id) = extract_codex_session_id(&path) {
                 out.push(DiscoveredFile {
                     path,
-                    source: MirrorSource::Codex,
-                    session_id: Some(session_id),
+                    kind: DiscoveredKind::LineTail {
+                        source: MirrorSource::Codex,
+                        session_id: Some(session_id),
+                    },
                 });
             }
+        }
+    }
+}
+
+/// Find `conversations.json` ChatGPT export files under `path`.
+///
+/// If `path` is itself a file, it is accepted only when its basename is
+/// exactly `conversations.json`; otherwise `path` is scanned recursively.
+/// Silently skips unreadable directories, like the other scanners.
+fn scan_chatgpt_conversations_files(path: &std::path::Path) -> Vec<DiscoveredFile> {
+    let mut files = Vec::new();
+    if path.is_file() {
+        if path.file_name().and_then(|n| n.to_str()) == Some("conversations.json") {
+            files.push(DiscoveredFile {
+                path: path.to_path_buf(),
+                kind: DiscoveredKind::ChatGptExport,
+            });
+        }
+        return files;
+    }
+    scan_chatgpt_dir_recursive(path, &mut files);
+    files
+}
+
+/// Recursive helper for `scan_chatgpt_conversations_files`.
+fn scan_chatgpt_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_chatgpt_dir_recursive(&path, out);
+        } else if path.file_name().and_then(|n| n.to_str()) == Some("conversations.json") {
+            out.push(DiscoveredFile {
+                path,
+                kind: DiscoveredKind::ChatGptExport,
+            });
         }
     }
 }

--- a/crates/khive-pack-session/src/mirror/service.rs
+++ b/crates/khive-pack-session/src/mirror/service.rs
@@ -18,17 +18,18 @@ use std::time::Duration;
 use khive_runtime::{KhiveRuntime, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 
-use super::ingest::{self, MirrorSource};
+use super::ingest::{self, LineTailSource};
 
 /// How a discovered file should be ingested.
 ///
-/// `ChatGptExport` is deliberately not a `MirrorSource` variant: ChatGPT
-/// export ingestion is whole-file (`mirror_chatgpt_export_file`), not
-/// line-tail, so it does not belong in that closed line-tail dispatch enum.
+/// `ChatGptExport` is a `MirrorSource` variant (ADR-080's closed mirror-source
+/// set) but deliberately not a `LineTailSource` variant: ChatGPT export
+/// ingestion is whole-file (`mirror_chatgpt_export_file`), not line-tail, so
+/// it does not belong in that narrower per-line dispatch enum.
 enum DiscoveredKind {
     LineTail {
-        source: MirrorSource,
-        /// Set for `MirrorSource::Codex`; `None` for `MirrorSource::ClaudeCode`.
+        source: LineTailSource,
+        /// Set for `LineTailSource::Codex`; `None` for `LineTailSource::ClaudeCode`.
         session_id: Option<String>,
     },
     ChatGptExport,
@@ -171,7 +172,7 @@ pub async fn run_mirror_service(runtime: KhiveRuntime, config: MirrorConfig) {
                 discovered.push(DiscoveredFile {
                     path,
                     kind: DiscoveredKind::LineTail {
-                        source: MirrorSource::ClaudeCode,
+                        source: LineTailSource::ClaudeCode,
                         session_id: None,
                     },
                 });
@@ -378,7 +379,7 @@ fn scan_codex_dir_recursive(dir: &std::path::Path, out: &mut Vec<DiscoveredFile>
                 out.push(DiscoveredFile {
                     path,
                     kind: DiscoveredKind::LineTail {
-                        source: MirrorSource::Codex,
+                        source: LineTailSource::Codex,
                         session_id: Some(session_id),
                     },
                 });

--- a/crates/khive-pack-session/src/pack.rs
+++ b/crates/khive-pack-session/src/pack.rs
@@ -88,7 +88,7 @@ impl PackRuntime for SessionPack {
 
     async fn warm(&self) {
         let config = crate::mirror::MirrorConfig::from_env();
-        if !config.enabled && !config.codex_enabled {
+        if !config.enabled && !config.codex_enabled && !config.chatgpt_enabled {
             return;
         }
         let runtime = self.runtime().clone();


### PR DESCRIPTION
## Summary

Implements a ChatGPT-export mirror source for `khive-pack-session` per ADR-080 §6. Closes/tracks **#463**.

Rebased the stalled `feat-chatgpt-export-mirror` branch (was 2 ahead / 33 behind) onto current `origin/main` (`1fd87402`) and added direct parser unit tests.

## Rebase outcome — clean

- Rebased onto `origin/main` with **zero conflicts**. Merge-base(HEAD, origin/main) == `origin/main` tip.
- Verified via **patch-id equivalence**: both feature commits are byte-identical pre/post rebase (no hunk dropped, no silent force-resolution). Only `pack.rs` moved upstream (PR #411) and its touched hunk did not collide.
- The prior low-risk assessment reproduced under the actual rebase — no surprise semantic conflicts.

## New tests — 3 direct parser unit tests

Added to `crates/khive-pack-session/src/mirror/parse.rs` (`mod tests`), targeting `parse_chatgpt_export` directly (pure JSON-tree seam, no DB/I/O) — a different seam than the existing SQL-backed `ingest.rs` integration tests:

1. `test_chatgpt_export_minimal_valid_export` — minimal valid export; asserts event count and per-event uuid/session_id/role/text/**parent_uuid linkage**/slug/sidechain.
2. `test_chatgpt_export_multi_branch_tree_dfs_order_and_sidechain` — multi-branch tree; asserts exact DFS preorder and that only the off-`current_node` branch is flagged `is_sidechain`.
3. `test_chatgpt_export_malformed_inputs` — non-JSON → None, valid-JSON-non-array → None, and per-entry skip of malformed entries while still emitting the one valid event.

## Verification (post-rebase HEAD `fb64e0fe`)

- `cargo test -p khive-pack-session` — **86 passed, 0 failed** (63 unit incl. 3 new + 23 integration)
- `cargo clippy -p khive-pack-session --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## ⚠️ Known file-overlap with `fix/audit-session` (#482) — REAL

This branch **does** substantially edit `ingest.rs`'s `mirror_file` (ingest.rs:75) and `read_from_offset` (ingest.rs:462). The in-flight `fix/audit-session` branch (issue #482: zero-poll-interval hot loop + unbounded backfill reads) targets the **same** helpers.

- The shared-code overlap is **real, not a false positive** — both helpers are edited here.
- However `fix/audit-session` currently has **zero landed commits** (it sits at `origin/main`), so there is **no active merge conflict yet**.
- **Whoever merges second should expect a real conflict on `mirror_file` / `read_from_offset`** and resolve deliberately (do not blind-take either side).

## Notes for reviewer

- Draft intentionally: the maintainers own the review + merge decision. Not marking ready, no auto-merge.
