### PR TITLE
fix(pack-comm,request): dual-write rollback atomicity, ingest thread validation, bulk-link conflict keys, $prev path validation

### DIFF
--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2159,6 +2159,134 @@ async fn link_is_always_verbose_returns_full_uuids_in_agent_mode() -> anyhow::Re
     Ok(())
 }
 
+// ── #469 regression: bulk/symmetric link write-key conflict preflight ────────
+
+/// #469: a bulk `link(links=[...])` op and a singleton `link` op that target
+/// the same natural edge key must both be rejected with per-op conflict
+/// errors by MCP preflight (`khive_request::write_keys_for_op_pub`) before
+/// either dispatches, instead of racing through storage where SQLite's
+/// `ON CONFLICT DO UPDATE` would let the last write silently win.
+#[tokio::test]
+async fn parallel_link_bulk_conflict_is_rejected_before_storage_race() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let a = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="BulkConflictA")"#,
+    )
+    .await?;
+    let b = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="BulkConflictB")"#,
+    )
+    .await?;
+    let a_id = a["id"].as_str().unwrap().to_string();
+    let b_id = b["id"].as_str().unwrap().to_string();
+
+    let ops = format!(
+        r#"[link(links=[{{"source_id":"{a_id}","target_id":"{b_id}","relation":"extends","weight":0.1}}]), link(source_id="{a_id}", target_id="{b_id}", relation="extends", weight=0.9)]"#
+    );
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+
+    assert_eq!(body["summary"]["total"], json!(2));
+    assert_eq!(
+        body["summary"]["failed"],
+        json!(2),
+        "both conflicting link ops must fail preflight: {body}"
+    );
+    for i in 0..2 {
+        let entry = &body["results"][i];
+        assert_eq!(entry["ok"], json!(false), "op #{i} must fail: {entry}");
+        let err = entry["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("conflict"),
+            "op #{i} error must mention conflict: {entry}"
+        );
+    }
+
+    // No edge should have been written — neither op reached storage.
+    let get_result = call(
+        &client,
+        "request",
+        json!({
+            "ops": format!(r#"list(kind="entity_edge", source_id="{a_id}", target_id="{b_id}")"#),
+            "presentation": "verbose"
+        }),
+    )
+    .await;
+    if let Ok(get_result) = get_result {
+        if let Ok(get_body) = serde_json::from_str::<Value>(&first_text(&get_result)) {
+            if get_body["results"][0]["ok"] == json!(true) {
+                let items = get_body["results"][0]["result"]["items"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                assert!(
+                    items.is_empty(),
+                    "no edge should have been written from conflicting preflight-rejected ops: {items:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// #469: reversed singleton symmetric links (`link(A,B,competes_with)` and
+/// `link(B,A,competes_with)`) must canonicalize to the same natural edge key
+/// and be rejected as conflicting, matching storage's own endpoint-order
+/// canonicalization for symmetric relations.
+#[tokio::test]
+async fn parallel_reversed_symmetric_link_conflict_is_rejected() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    let a = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="SymConflictA")"#,
+    )
+    .await?;
+    let b = ok_one(
+        &client,
+        r#"create(kind="entity", entity_kind="concept", name="SymConflictB")"#,
+    )
+    .await?;
+    let a_id = a["id"].as_str().unwrap().to_string();
+    let b_id = b["id"].as_str().unwrap().to_string();
+
+    let ops = format!(
+        r#"[link(source_id="{a_id}", target_id="{b_id}", relation="competes_with"), link(source_id="{b_id}", target_id="{a_id}", relation="competes_with")]"#
+    );
+    let result = call(
+        &client,
+        "request",
+        json!({"ops": ops, "presentation": "verbose"}),
+    )
+    .await?;
+    let body: Value = serde_json::from_str(&first_text(&result))?;
+
+    assert_eq!(body["summary"]["total"], json!(2));
+    assert_eq!(
+        body["summary"]["failed"],
+        json!(2),
+        "reversed symmetric link ops must both fail preflight: {body}"
+    );
+    for i in 0..2 {
+        let entry = &body["results"][i];
+        assert_eq!(entry["ok"], json!(false), "op #{i} must fail: {entry}");
+        let err = entry["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("conflict"),
+            "op #{i} error must mention conflict: {entry}"
+        );
+    }
+    Ok(())
+}
+
 // ── ADR-046 regression: get(id=proposal_id) returns ProposalCreated payload ──
 
 /// ADR-046:299 — get(id=<proposal_id>) must return the full ProposalCreated

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -11,7 +11,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
-use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
+use khive_storage::note::{FilterOp, Note, NoteFilter, PropertyFilter};
 use khive_storage::types::{PageRequest, SqlValue};
 
 use crate::message::{dual_write_message, note_to_message_json, resolve_id, short_id};
@@ -457,7 +457,7 @@ pub(crate) async fn handle_thread(
     // Resolve and validate the passed ID.
     let passed_uuid = resolve_id(runtime, token, &p.id, "thread").await?;
 
-    let canonical_thread_id: String = {
+    let (canonical_thread_id, root_note): (String, Note) = {
         let store = runtime.notes(token)?;
         let note = store
             .get_note(passed_uuid)
@@ -484,7 +484,12 @@ pub(crate) async fn handle_thread(
         // canonical thread_id.  This handles the case where the caller holds an
         // inbound copy UUID (id_B) but the canonical root is the outbound UUID (id_A).
         // Both copies were written with the same canonical thread_id by dual_write_message.
-        match note
+        //
+        // Missing/invalid `thread_id` (issue #479b -- e.g. a legacy/imported root
+        // written before the canonical field existed) falls back to the passed
+        // note's own UUID, matching ADR-040: a target with no `thread_id` becomes
+        // the root for its chain.
+        let canonical = match note
             .properties
             .as_ref()
             .and_then(|p| p.get("thread_id"))
@@ -496,7 +501,8 @@ pub(crate) async fn handle_thread(
                 stored_root.as_hyphenated().to_string()
             }
             _ => passed_uuid.as_hyphenated().to_string(),
-        }
+        };
+        (canonical, note)
     };
 
     // Push thread_id predicate into SQL so idx_comm_message_thread can be used.
@@ -536,6 +542,21 @@ pub(crate) async fn handle_thread(
             break;
         }
         db_offset += PAGE_SIZE;
+    }
+
+    // Practical equivalent of `id == root OR properties.thread_id == root`
+    // (issue #479b): the SQL filter above only matches `properties.thread_id ==
+    // canonical_thread_id`, which misses a root note that lacks a `thread_id`
+    // property at all (e.g. legacy/imported data). Explicitly include the
+    // already-validated root note when the query didn't already return it, so
+    // `comm.thread(id=root)` never reports an empty/incomplete thread for a
+    // root that exists but predates the canonical `thread_id` field.
+    let root_full_id = root_note.id.as_hyphenated().to_string();
+    let root_already_present = messages
+        .iter()
+        .any(|m| m.get("full_id").and_then(Value::as_str) == Some(root_full_id.as_str()));
+    if !root_already_present {
+        messages.push(note_to_message_json(&root_note));
     }
 
     // Sort chronologically ascending (earliest first).
@@ -596,6 +617,23 @@ pub(crate) async fn handle_ingest(
             "ingest: `content` must not be empty".into(),
         ));
     }
+    // Reject a malformed caller-supplied thread_id at the boundary (issue #479a):
+    // a present, non-empty `thread_id` that is not a valid UUID must fail closed
+    // rather than being silently dropped and replaced with a fresh UUID, which
+    // would split the message into the wrong conversation. A blank/absent value
+    // is not an error -- it just means "no caller-supplied thread_id".
+    if let Some(tid) = p
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if tid.parse::<Uuid>().is_err() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "ingest: `thread_id` must be a valid UUID, got: {tid:?}"
+            )));
+        }
+    }
 
     let ns = token.namespace().as_str();
     let store = runtime.notes(token)?;
@@ -646,19 +684,31 @@ pub(crate) async fn handle_ingest(
                         },
                     )
                     .await?;
-                pass1 = corr_page.items.first().and_then(|n| {
-                    let props = n.properties.as_ref()?;
-                    let thread_id = props
-                        .get("thread_id")
+                pass1 = corr_page.items.first().map(|n| {
+                    // Fall back to the matched note's own UUID as the canonical
+                    // root (issue #479b) when it carries no valid `thread_id` --
+                    // e.g. a legacy/imported outbound row written before the
+                    // canonical `thread_id` field existed. Per ADR-040, a
+                    // target message with no `thread_id` becomes the root for
+                    // the new chain, so replies stay attached to the right
+                    // conversation/actor instead of splitting into a fresh
+                    // thread routed to the default inbound actor.
+                    let thread_id = n
+                        .properties
+                        .as_ref()
+                        .and_then(|props| props.get("thread_id"))
                         .and_then(Value::as_str)
                         .filter(|s| s.parse::<Uuid>().is_ok())
-                        .map(|s| s.to_string())?;
-                    let from_actor = props
-                        .get("from_actor")
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| n.id.as_hyphenated().to_string());
+                    let from_actor = n
+                        .properties
+                        .as_ref()
+                        .and_then(|props| props.get("from_actor"))
                         .and_then(Value::as_str)
                         .unwrap_or("")
                         .to_string();
-                    Some((thread_id, from_actor))
+                    (thread_id, from_actor)
                 });
                 if pass1.is_some() {
                     break;
@@ -716,10 +766,12 @@ pub(crate) async fn handle_ingest(
     };
 
     // Determine thread_id: caller-supplied > resolved from correlation > new root.
+    // `p.thread_id` was already validated above (present+non-empty implies valid UUID).
     let thread_id: String = p
         .thread_id
         .as_deref()
-        .filter(|s| s.parse::<Uuid>().is_ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .or_else(|| resolved.as_ref().map(|(tid, _)| tid.clone()))
         .unwrap_or_else(|| Uuid::new_v4().as_hyphenated().to_string());

--- a/crates/khive-pack-comm/src/message.rs
+++ b/crates/khive-pack-comm/src/message.rs
@@ -36,6 +36,31 @@ pub(crate) async fn resolve_id(
     )))
 }
 
+/// Roll back a partially-written outbound note after a later `dual_write_message`
+/// step fails (issue #460). Uses a row-first compensating delete so that a
+/// cleanup failure cannot leave the outbound row (and thus the failed send's
+/// live message) behind. Returns `original` unchanged when rollback fully
+/// succeeds; returns a composite `RuntimeError::Internal` naming both the
+/// original failure and the rollback cleanup failure when the row was removed
+/// but cleanup did not complete.
+async fn rollback_outbound(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    outbound_id: Uuid,
+    context: &str,
+    original: RuntimeError,
+) -> RuntimeError {
+    match runtime
+        .delete_note_row_first_for_compensation(token, outbound_id)
+        .await
+    {
+        Ok(()) => original,
+        Err(rollback_err) => RuntimeError::Internal(format!(
+            "{context}: original error: {original}; outbound rollback failed after row removal attempt for {outbound_id}: {rollback_err}"
+        )),
+    }
+}
+
 pub(crate) fn note_to_message_json(note: &Note) -> Value {
     let props = note.properties.as_ref();
 
@@ -240,12 +265,17 @@ pub(crate) async fn dual_write_message(
         patched.properties = Some(props);
         patched.updated_at = chrono::Utc::now().timestamp_micros();
         if let Err(patch_err) = store.upsert_note(patched).await {
-            let _ = runtime
-                .delete_note(caller_token, outbound_note.id, true)
-                .await;
-            return Err(RuntimeError::Internal(format!(
+            let original = RuntimeError::Internal(format!(
                 "dual_write: patch outbound thread_id: {patch_err}"
-            )));
+            ));
+            return Err(rollback_outbound(
+                runtime,
+                caller_token,
+                outbound_note.id,
+                "dual_write: patch outbound thread_id rollback",
+                original,
+            )
+            .await);
         }
     }
 
@@ -305,10 +335,14 @@ pub(crate) async fn dual_write_message(
             .await;
 
         if let Err(inbound_err) = inbound_result {
-            let _ = runtime
-                .delete_note(caller_token, outbound_note.id, true)
-                .await;
-            return Err(inbound_err);
+            return Err(rollback_outbound(
+                runtime,
+                caller_token,
+                outbound_note.id,
+                "dual_write: inbound write rollback",
+                inbound_err,
+            )
+            .await);
         }
     }
 
@@ -320,6 +354,90 @@ mod tests {
     use super::*;
     use khive_storage::note::Note;
     use serde_json::json;
+
+    // Issue #460: dual_write_message must not leave a live outbound note behind
+    // when the inbound write fails AND the rollback's compensation cleanup also
+    // fails. Forces outbound creation to succeed (sender_ns), the inbound create
+    // to fail (recipient_ns, via `arm_fts_fail`), and the rollback's post-row-
+    // removal cleanup to fail (sender_ns, via `arm_rollback_cleanup_fail`). Row-
+    // first ordering in `delete_note_row_first_for_compensation` means the
+    // outbound row is gone before cleanup runs, so it must stay gone even though
+    // cleanup errors; the caller must see that cleanup failure surfaced in the
+    // returned error rather than silently discarded.
+    #[tokio::test]
+    async fn dual_write_inbound_failure_rollback_delete_failure_removes_outbound_or_reports_composite(
+    ) {
+        use khive_runtime::{
+            arm_fts_fail, arm_rollback_cleanup_fail, AllowAllGate, BackendId, RuntimeConfig,
+        };
+
+        let sender_ns = format!("t460-sender-{}", Uuid::new_v4().simple());
+        let recipient_ns = format!("t460-recipient-{}", Uuid::new_v4().simple());
+
+        let runtime = KhiveRuntime::new(RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::parse(&sender_ns).unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(AllowAllGate),
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            backend_id: BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![Namespace::parse(&recipient_ns).unwrap()],
+            actor_id: None,
+        })
+        .expect("in-memory runtime");
+
+        let caller_token = runtime
+            .authorize(Namespace::parse(&sender_ns).unwrap())
+            .expect("authorize sender");
+
+        // Outbound (1st create_note call) targets sender_ns and is unaffected.
+        // Inbound (2nd create_note call) targets recipient_ns and fails.
+        arm_fts_fail(&recipient_ns);
+        // The rollback compensation's post-row-removal cleanup also fails.
+        arm_rollback_cleanup_fail(&sender_ns);
+
+        let result = dual_write_message(
+            &runtime,
+            &caller_token,
+            &sender_ns,
+            &recipient_ns,
+            None,
+            "F1 regression content",
+            None,
+            "2026-07-03T00:00:00Z",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "dual_write_message must fail when the inbound create fails; got {result:?}"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("rollback") || err_msg.contains("cleanup"),
+            "error must explicitly surface the rollback/cleanup failure, not discard it; got: {err_msg}"
+        );
+
+        let alive = runtime
+            .list_notes(&caller_token, Some("message"), 100, 0)
+            .await
+            .expect("list_notes")
+            .into_iter()
+            .filter(|n| n.deleted_at.is_none())
+            .count();
+        assert_eq!(
+            alive, 0,
+            "no live outbound note may remain after rollback, even though the \
+             compensation cleanup itself failed; got {alive}"
+        );
+    }
 
     fn make_note(namespace: &str, content: &str, props: Option<Value>) -> Note {
         let mut n = Note::new(namespace, "message", content);

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -4896,3 +4896,284 @@ async fn ingest_metadata_cannot_override_stamped_identity_fields() {
         "metadata must never override the handler-stamped direction; got props={props}"
     );
 }
+
+// ── Issue #479a: comm.ingest must reject malformed thread_id ─────────────────
+
+/// `comm.ingest` with a malformed `thread_id` must return `InvalidInput` and
+/// must not write any note (issue #479a). Before the fix, an invalid thread_id
+/// was silently filtered out and replaced with a fresh UUID, splitting the
+/// message into the wrong conversation while still reporting success.
+#[tokio::test]
+async fn ingest_rejects_malformed_thread_id_without_writing_note() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let result = registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "thread_id": "not-a-uuid",
+                "from": "email:a@example.com",
+                "to": "email:b@example.com",
+                "content": "reply",
+                "namespace": "local",
+            }),
+        )
+        .await;
+
+    let err = result.expect_err("ingest with malformed thread_id must fail");
+    let err_msg = err.to_string();
+    assert!(
+        matches!(err, khive_runtime::RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+    assert!(
+        err_msg.contains("thread_id"),
+        "error must mention thread_id; got: {err_msg}"
+    );
+
+    let token = rt
+        .authorize(khive_runtime::Namespace::parse("local").unwrap())
+        .expect("authorize local");
+    let notes = rt
+        .list_notes(&token, Some("message"), 100, 0)
+        .await
+        .expect("list_notes");
+    let alive = notes.iter().filter(|n| n.deleted_at.is_none()).count();
+    assert_eq!(
+        alive, 0,
+        "no note may be written when thread_id validation fails; got {alive}"
+    );
+}
+
+/// `comm.ingest` with a valid UUID `thread_id` must succeed and persist it verbatim.
+#[tokio::test]
+async fn ingest_accepts_valid_uuid_thread_id() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let supplied_thread_id = uuid::Uuid::new_v4().as_hyphenated().to_string();
+    let result = registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "thread_id": supplied_thread_id,
+                "from": "email:a@example.com",
+                "to": "email:b@example.com",
+                "content": "reply",
+                "namespace": "local",
+            }),
+        )
+        .await
+        .expect("ingest with valid UUID thread_id must succeed");
+
+    assert_eq!(
+        result["thread_id"].as_str(),
+        Some(supplied_thread_id.as_str()),
+        "response thread_id must equal the supplied UUID; got {result}"
+    );
+
+    let full_id = result["full_id"].as_str().expect("full_id present");
+    let uuid = full_id.parse::<uuid::Uuid>().expect("valid UUID");
+    let token = rt
+        .authorize(khive_runtime::Namespace::parse("local").unwrap())
+        .expect("authorize local");
+    let store = rt.notes(&token).expect("notes store");
+    let note = store
+        .get_note(uuid)
+        .await
+        .expect("get_note ok")
+        .expect("note exists");
+    assert_eq!(
+        note.properties
+            .as_ref()
+            .and_then(|p| p.get("thread_id"))
+            .and_then(|v| v.as_str()),
+        Some(supplied_thread_id.as_str()),
+        "stored note properties.thread_id must equal the supplied UUID"
+    );
+}
+
+// ── Issue #479b: missing thread roots fall back to the matched message's own UUID ──
+
+/// A reply correlated to an outbound message that has no `thread_id` property
+/// (e.g. a legacy/imported row) must reuse the outbound note's own UUID as the
+/// canonical root and route to the original `from_actor`, instead of being
+/// treated as unmatched and split into a fresh thread routed to the default
+/// inbound actor.
+#[tokio::test]
+async fn ingest_correlation_without_thread_id_uses_matched_message_id_as_root() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let outbound_external_id = "<legacy@khive.ai>";
+    let outbound_id = uuid::Uuid::new_v4();
+    {
+        use khive_storage::note::Note;
+        let token = rt
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize");
+        let store = rt.notes(&token).expect("notes store");
+        let now = chrono::Utc::now().timestamp_micros();
+        let note = Note {
+            id: outbound_id,
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "legacy outbound".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "email:mailbox@example.com",
+                "to": "email:user@example.com",
+                "from_actor": "lambda:khive",
+                "to_actor": "email:user@example.com",
+                "external_id": outbound_external_id,
+                // No `thread_id` -- simulates a legacy/imported root row written
+                // before the canonical thread_id field existed.
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.upsert_note(note).await.expect("upsert outbound note");
+    }
+
+    let result = registry
+        .dispatch(
+            "comm.ingest",
+            serde_json::json!({
+                "from": "email:user@example.com",
+                "to": "email:mailbox@example.com",
+                "content": "reply to legacy root",
+                "correlation_external_id": outbound_external_id,
+                "external_id": "imap:mail:legacy:1",
+                "default_inbound_actor": "lambda:leo",
+                "namespace": "local",
+            }),
+        )
+        .await
+        .expect("ingest succeeds");
+
+    let expected_thread_id = outbound_id.as_hyphenated().to_string();
+    assert_eq!(
+        result["thread_id"].as_str(),
+        Some(expected_thread_id.as_str()),
+        "reply must use the matched outbound note's own UUID as the canonical root; got {result}"
+    );
+
+    let full_id = result["full_id"].as_str().expect("full_id present");
+    let uuid = full_id.parse::<uuid::Uuid>().expect("valid UUID");
+    let token = rt
+        .authorize(khive_runtime::Namespace::local())
+        .expect("authorize local");
+    let store = rt.notes(&token).expect("notes store");
+    let note = store
+        .get_note(uuid)
+        .await
+        .expect("get_note ok")
+        .expect("note exists");
+    let props = note.properties.expect("note has properties");
+    assert_eq!(
+        props["thread_id"].as_str(),
+        Some(expected_thread_id.as_str()),
+        "stored reply properties.thread_id must equal the outbound note's own UUID"
+    );
+    assert_eq!(
+        props["to_actor"].as_str(),
+        Some("lambda:khive"),
+        "reply must route to the original from_actor, not default_inbound_actor; got props={props}"
+    );
+}
+
+/// `comm.thread` must include a root message that has no `thread_id` property
+/// at all (issue #479b) -- the SQL query only matches `properties.thread_id ==
+/// root`, which a thread-id-less root can never satisfy on its own.
+#[tokio::test]
+async fn thread_includes_root_message_without_thread_id_property() {
+    let (registry, rt) = build_registry_for_ns("local");
+
+    let root_id = uuid::Uuid::new_v4();
+    {
+        use khive_storage::note::Note;
+        let token = rt
+            .authorize(khive_runtime::Namespace::local())
+            .expect("authorize");
+        let store = rt.notes(&token).expect("notes store");
+        let now = chrono::Utc::now().timestamp_micros();
+        let root_note = Note {
+            id: root_id,
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "legacy root, no thread_id".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "outbound",
+                "from": "local",
+                "to": "local",
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        store.upsert_note(root_note).await.expect("upsert root");
+
+        let child_note = Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".into(),
+            kind: "message".into(),
+            status: "active".into(),
+            name: None,
+            content: "child reply".into(),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(serde_json::json!({
+                "direction": "inbound",
+                "from": "local",
+                "to": "local",
+                "thread_id": root_id.as_hyphenated().to_string(),
+                "sent_at": chrono::Utc::now().to_rfc3339(),
+            })),
+            created_at: now + 1,
+            updated_at: now + 1,
+            deleted_at: None,
+        };
+        store.upsert_note(child_note).await.expect("upsert child");
+    }
+
+    let thread_result = registry
+        .dispatch(
+            "comm.thread",
+            serde_json::json!({ "id": root_id.as_hyphenated().to_string() }),
+        )
+        .await
+        .expect("thread dispatch succeeds");
+
+    assert_eq!(
+        thread_result["thread_id"].as_str(),
+        Some(root_id.as_hyphenated().to_string().as_str()),
+        "canonical thread_id must be the root's own UUID; got {thread_result}"
+    );
+    let messages = thread_result["messages"]
+        .as_array()
+        .expect("messages is an array");
+    let root_full_id = root_id.as_hyphenated().to_string();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.get("full_id").and_then(|v| v.as_str()) == Some(root_full_id.as_str())),
+        "thread must include the root message even though it has no thread_id property; got {thread_result}"
+    );
+    let count = thread_result["count"].as_u64().expect("count present");
+    assert!(
+        count >= 2,
+        "thread must include root + child (at least 2); got count={count}"
+    );
+}

--- a/crates/khive-request/src/conflict.rs
+++ b/crates/khive-request/src/conflict.rs
@@ -25,21 +25,86 @@ pub fn write_keys_for_op_pub(op: &ParsedOp) -> Vec<String> {
             // `link` writes an edge, not an entity. Use a natural-key format so
             // update(id="X") + link(source_id="X", ...) do NOT conflict (they target
             // different substrates).
-            let src = op.args.get("source_id");
-            let tgt = op.args.get("target_id");
-            let rel = op.args.get("relation");
             if let (
                 Some(ArgValue::Value(Value::String(s))),
                 Some(ArgValue::Value(Value::String(t))),
                 Some(ArgValue::Value(Value::String(r))),
-            ) = (src, tgt, rel)
-            {
-                keys.push(format!("edge-natural:{s}:{t}:{r}"));
+            ) = (
+                op.args.get("source_id"),
+                op.args.get("target_id"),
+                op.args.get("relation"),
+            ) {
+                push_link_key(&mut keys, s, t, r);
+            }
+
+            // Bulk form: `link(links=[{source_id, target_id, relation, ...}, ...])`.
+            // Each contained natural edge must contribute its own key so a bulk
+            // entry conflicts with a colliding singleton `link` (or another bulk
+            // entry) instead of silently racing through storage.
+            if let Some(ArgValue::Value(Value::Array(links))) = op.args.get("links") {
+                for link in links {
+                    let Some(obj) = link.as_object() else {
+                        continue;
+                    };
+                    let (Some(s), Some(t), Some(r)) = (
+                        obj.get("source_id").and_then(Value::as_str),
+                        obj.get("target_id").and_then(Value::as_str),
+                        obj.get("relation").and_then(Value::as_str),
+                    ) else {
+                        continue;
+                    };
+                    push_link_key(&mut keys, s, t, r);
+                }
             }
         }
         _ => {}
     }
     keys
+}
+
+/// Build the substrate-prefixed natural-edge write key for one link entry,
+/// canonicalizing endpoint order for statically-known symmetric relations so
+/// reversed singleton links (e.g. `link(A,B,competes_with)` vs
+/// `link(B,A,competes_with)`) collide on the same key.
+fn push_link_key(keys: &mut Vec<String>, source: &str, target: &str, relation: &str) {
+    let relation_key = canonical_relation_key(relation);
+    let (source_key, target_key) = if is_static_symmetric_relation(&relation_key) && target < source
+    {
+        (target, source)
+    } else {
+        (source, target)
+    };
+    keys.push(format!(
+        "edge-natural:{source_key}:{target_key}:{relation_key}"
+    ));
+}
+
+/// Normalize relation spelling (case/hyphen variants) without depending on
+/// `khive-types`, so bulk and singleton entries produce identical keys.
+fn canonical_relation_key(relation: &str) -> String {
+    let normalized: String = relation
+        .chars()
+        .map(|c| {
+            if c == '-' {
+                '_'
+            } else {
+                c.to_ascii_lowercase()
+            }
+        })
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    match normalized.as_str() {
+        "competeswith" => "competes_with".to_string(),
+        "composedwith" => "composed_with".to_string(),
+        _ => normalized,
+    }
+}
+
+/// Relations known to be symmetric (endpoint order does not matter) without
+/// consulting the full relation registry. Kept conservative and local to
+/// avoid coupling `khive-request` to `khive-types`.
+fn is_static_symmetric_relation(relation: &str) -> bool {
+    matches!(relation, "competes_with" | "composed_with")
 }
 
 /// Scan a parsed batch for write-key conflicts; skips chain mode (sequential by design).
@@ -173,5 +238,62 @@ mod tests {
         let r = parse_request(r#"delete(id="solo-id")"#).unwrap();
         assert_eq!(r.mode, ExecutionMode::Single);
         check_write_key_conflicts(&r).unwrap();
+    }
+
+    #[test]
+    fn bulk_link_and_singleton_same_natural_key_conflict() {
+        // A bulk `links=[...]` entry must contribute the same write key as an
+        // equivalent singleton `link` op so they are detected as conflicting.
+        let r = parse_request(
+            r#"[link(links=[{"source_id":"a","target_id":"b","relation":"extends","weight":0.1}]), link(source_id="a", target_id="b", relation="extends", weight=0.9)]"#,
+        )
+        .unwrap();
+        let err = check_write_key_conflicts(&r).unwrap_err();
+        assert!(
+            matches!(&err, DslError::WriteKeyConflict { id, .. }
+                if id == "edge-natural:a:b:extends"),
+            "expected WriteKeyConflict on edge-natural key, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reversed_symmetric_links_conflict() {
+        // competes_with is symmetric: A->B and B->A must collide on one key.
+        let r = parse_request(
+            r#"[link(source_id="b", target_id="a", relation="competes_with"), link(source_id="a", target_id="b", relation="competes_with")]"#,
+        )
+        .unwrap();
+        let err = check_write_key_conflicts(&r).unwrap_err();
+        assert!(
+            matches!(&err, DslError::WriteKeyConflict { id, .. }
+                if id == "edge-natural:a:b:competes_with"),
+            "expected WriteKeyConflict on canonicalized symmetric key, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reversed_non_symmetric_links_do_not_conflict() {
+        // `extends` is directional: reversed endpoints must NOT collide.
+        let r = parse_request(
+            r#"[link(source_id="b", target_id="a", relation="extends"), link(source_id="a", target_id="b", relation="extends")]"#,
+        )
+        .unwrap();
+        check_write_key_conflicts(&r).unwrap();
+    }
+
+    #[test]
+    fn write_keys_for_op_pub_bulk_link_extracts_all_edges() {
+        let r = parse_request(
+            r#"link(links=[{"source_id":"a","target_id":"b","relation":"extends"},{"source_id":"c","target_id":"d","relation":"extends"}])"#,
+        )
+        .unwrap();
+        let keys = write_keys_for_op_pub(&r.ops[0]);
+        assert_eq!(
+            keys,
+            vec![
+                "edge-natural:a:b:extends".to_string(),
+                "edge-natural:c:d:extends".to_string(),
+            ]
+        );
     }
 }

--- a/crates/khive-request/src/parser/parser_impl.rs
+++ b/crates/khive-request/src/parser/parser_impl.rs
@@ -375,19 +375,22 @@ impl<'a> Parser<'a> {
             });
         }
         if let Some(rest) = s.strip_prefix("$prev.") {
-            if !rest.is_empty() {
+            if !rest.is_empty() && quoted_prev_path_is_valid(rest) {
                 return Some(ArgValue::PrevRef {
                     path: rest.to_owned(),
                 });
             }
+            return None;
         }
         if let Some(after_bracket) = s.strip_prefix("$prev[") {
             if let Some(close) = after_bracket.find(']') {
                 let index_str = &after_bracket[..close];
                 if !index_str.is_empty() && index_str.chars().all(|c| c.is_ascii_digit()) {
                     let tail = &after_bracket[close + 1..];
-                    let path = format!("[{index_str}]{tail}");
-                    return Some(ArgValue::PrevRef { path });
+                    if quoted_prev_path_is_valid(tail) {
+                        let path = format!("[{index_str}]{tail}");
+                        return Some(ArgValue::PrevRef { path });
+                    }
                 }
             }
             return None;
@@ -454,4 +457,33 @@ impl<'a> Parser<'a> {
         }
         Ok(i)
     }
+}
+
+/// Validate a quoted `$prev` path tail (everything after `$prev.` or after the
+/// first `[N]` of a root `$prev[N]...` form) using the same bracket grammar as
+/// unquoted refs: every `[...]` segment must be non-empty digits followed by
+/// `]`, and a bare `]` outside a bracket is invalid. Malformed segments
+/// anywhere in the path must keep the whole string a literal `ArgValue::Value`
+/// rather than being promoted to `ArgValue::PrevRef`.
+fn quoted_prev_path_is_valid(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => {
+                i += 1;
+                let start = i;
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i == start || i >= bytes.len() || bytes[i] != b']' {
+                    return false;
+                }
+                i += 1;
+            }
+            b']' => return false,
+            _ => i += 1,
+        }
+    }
+    true
 }

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -867,6 +867,70 @@ fn quoted_prev_ref_non_numeric_index_treated_as_literal() {
     );
 }
 
+// ── #484 regression: nested malformed bracket paths in a quoted dotted ref ────
+
+#[test]
+fn quoted_prev_ref_nested_negative_index_treated_as_literal() {
+    // #484: `"$prev.items[-1].id"` — malformed bracket after a field segment
+    // must stay a literal Value, not be promoted to PrevRef.
+    let r = req(r#"list(kind="concept") | get(id="$prev.items[-1].id")"#);
+    assert_eq!(r.mode, ExecutionMode::Chain);
+    assert_eq!(
+        r.ops[1].args["id"],
+        ArgValue::Value(json!("$prev.items[-1].id"))
+    );
+}
+
+#[test]
+fn quoted_prev_ref_nested_non_numeric_index_treated_as_literal() {
+    // #484: `"$prev.items[abc].id"` — non-numeric nested index is malformed.
+    let r = req(r#"list(kind="concept") | get(id="$prev.items[abc].id")"#);
+    assert_eq!(r.mode, ExecutionMode::Chain);
+    assert_eq!(
+        r.ops[1].args["id"],
+        ArgValue::Value(json!("$prev.items[abc].id"))
+    );
+}
+
+#[test]
+fn quoted_prev_ref_nested_missing_close_bracket_treated_as_literal() {
+    // #484: `"$prev.items[0.id"` — unclosed nested bracket is malformed.
+    let r = req(r#"list(kind="concept") | get(id="$prev.items[0.id")"#);
+    assert_eq!(r.mode, ExecutionMode::Chain);
+    assert_eq!(
+        r.ops[1].args["id"],
+        ArgValue::Value(json!("$prev.items[0.id"))
+    );
+}
+
+#[test]
+fn quoted_prev_ref_nested_valid_index_still_promotes_and_resolves() {
+    // #484 non-regression: a well-formed nested bracket path must still
+    // promote to PrevRef and resolve correctly.
+    let r = req(r#"list(kind="concept") | get(id="$prev.items[0].id")"#);
+    assert_eq!(r.mode, ExecutionMode::Chain);
+    assert_eq!(
+        r.ops[1].args["id"],
+        ArgValue::PrevRef {
+            path: "items[0].id".into()
+        }
+    );
+    let prev = json!({"items": [{"id": "ok"}]});
+    assert_eq!(r.ops[1].args["id"].resolve_prev(&prev), Some(&json!("ok")));
+}
+
+#[test]
+fn quoted_prev_ref_root_bracket_with_malformed_nested_tail_treated_as_literal() {
+    // #484 risk flag: the root `$prev[N]...` branch must also validate
+    // malformed brackets in its tail, e.g. `"$prev[0].items[-1].id"`.
+    let r = req(r#"list(kind="concept") | get(id="$prev[0].items[-1].id")"#);
+    assert_eq!(r.mode, ExecutionMode::Chain);
+    assert_eq!(
+        r.ops[1].args["id"],
+        ArgValue::Value(json!("$prev[0].items[-1].id"))
+    );
+}
+
 #[test]
 fn unquoted_negative_index_rejected_at_parse_time() {
     // Regression: unquoted `$prev[-1].id` — the `-` is not a digit, so the

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -57,8 +57,8 @@ pub use objectives::{
 };
 #[cfg(any(test, feature = "fault-injection"))]
 pub use operations::{
-    arm_fts_fail, arm_fts_fail_many, arm_fts_fail_many_partial, arm_vector_fail,
-    arm_vector_fail_after,
+    arm_fts_fail, arm_fts_fail_many, arm_fts_fail_many_partial, arm_rollback_cleanup_fail,
+    arm_vector_fail, arm_vector_fail_after,
 };
 pub use operations::{EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved};
 pub use pack::{

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -153,6 +153,24 @@ pub fn arm_vector_fail(ns: &str) {
     *VECTOR_FAIL_NS.lock().unwrap() = Some(ns.to_string());
 }
 
+/// Failure injection for `delete_note_row_first_for_compensation`'s post-row-removal
+/// cleanup step (issue #460) — distinct from `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, which
+/// target `create_note_inner`. Lets tests prove that a rollback compensation's
+/// cleanup failure still leaves the note row (and thus the live message) gone.
+#[cfg(any(test, feature = "fault-injection"))]
+static ROLLBACK_CLEANUP_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Arm the rollback-compensation cleanup failure injection targeting `ns`.
+///
+/// The next `delete_note_row_first_for_compensation` call whose note namespace
+/// equals `ns` removes the row as usual, then returns an injected cleanup error
+/// instead of running the real graph/FTS/vector cleanup, then disarms.
+/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+#[cfg(any(test, feature = "fault-injection"))]
+pub fn arm_rollback_cleanup_fail(ns: &str) {
+    *ROLLBACK_CLEANUP_FAIL_NS.lock().unwrap() = Some(ns.to_string());
+}
+
 /// A note search result with UUID, salience-weighted RRF score, and display text.
 #[derive(Clone, Debug)]
 pub struct NoteSearchHit {
@@ -3141,6 +3159,83 @@ impl KhiveRuntime {
             })?;
         }
         Ok(deleted)
+    }
+
+    /// Row-first compensating delete for rolling back a partially-written note
+    /// (issue #460 — `dual_write_message` rollback after a later delivery step
+    /// fails). Unlike [`KhiveRuntime::delete_note`], which cleans up graph/FTS/
+    /// vector indexes *before* removing the row, this removes the row first so
+    /// that a cleanup failure afterward cannot leave the compensated note live.
+    ///
+    /// Returns `Ok(())` once the row is gone (whether or not cleanup fully
+    /// succeeded). Returns `Err(RuntimeError::Internal)` naming the failed
+    /// cleanup legs when row removal succeeded but cleanup did not — the
+    /// message is gone, but stale index entries may remain and should be
+    /// surfaced to the caller rather than silently discarded.
+    ///
+    /// Returns `Ok(())` immediately, with no cleanup attempted, if the note
+    /// does not exist (nothing to compensate).
+    ///
+    /// Not a general-purpose replacement for `delete_note(..., hard=true)`:
+    /// normal hard delete still needs cleanup-first semantics (ADR-002
+    /// no-dangling-references) since a caller-visible error there should not
+    /// remove the row.
+    pub async fn delete_note_row_first_for_compensation(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+    ) -> RuntimeResult<()> {
+        let note_store = self.notes(token)?;
+        let Some(note) = note_store.get_note_including_deleted(id).await? else {
+            return Ok(());
+        };
+        let record_tok = NamespaceToken::for_namespace(
+            khive_types::Namespace::parse(&note.namespace)
+                .map_err(|e| RuntimeError::Internal(format!("note namespace invalid: {e}")))?,
+        );
+        let record_ns = note.namespace.clone();
+
+        // Critical ordering: remove the row before any cleanup that can fail.
+        note_store.delete_note(id, DeleteMode::Hard).await?;
+
+        #[cfg(any(test, feature = "fault-injection"))]
+        {
+            let armed = ROLLBACK_CLEANUP_FAIL_NS.lock().unwrap().take();
+            if armed.as_deref() == Some(record_ns.as_str()) {
+                return Err(RuntimeError::Internal(
+                    "row removed but compensation cleanup failed: injected=true".to_string(),
+                ));
+            }
+        }
+
+        let mut cleanup_errors = Vec::new();
+        if let Err(e) = self.graph(&record_tok)?.purge_incident_edges(id).await {
+            cleanup_errors.push(format!("graph={e}"));
+        }
+        if let Err(e) = self
+            .text_for_notes(&record_tok)?
+            .delete_document(&record_ns, id)
+            .await
+        {
+            cleanup_errors.push(format!("fts={e}"));
+        }
+        for model_name in self.registered_embedding_model_names() {
+            if let Err(e) = self
+                .vectors_for_model(&record_tok, &model_name)?
+                .delete(id)
+                .await
+            {
+                cleanup_errors.push(format!("vector[{model_name}]={e}"));
+            }
+        }
+        if cleanup_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(RuntimeError::Internal(format!(
+                "row removed but compensation cleanup failed: {}",
+                cleanup_errors.join("; ")
+            )))
+        }
     }
 }
 


### PR DESCRIPTION
Audit-sweep batch (audit-20260702), issue-sweep wave-3a `comm-request` batch.

Closes #460
Closes #479
Closes #469
Closes #484

- **#460 (high)**: `dual_write_message` rollback silently discarded cleanup errors (`let _ =`), violating ADR-040 atomicity. Now uses a row-first compensating delete (`delete_note_row_first_for_compensation`) — outbound note row removed before best-effort index cleanup; composite error surfaced if cleanup still fails. Regression: two-namespace fault-injection test proving no live outbound note survives a failed rollback cleanup.
- **#479 (medium, 2 findings)**: `comm.ingest` now rejects malformed `thread_id` at the boundary (`InvalidInput`, no write); correlation matching + `comm.thread` fall back to a matched/root message's own UUID when `thread_id` is absent (legacy/imported messages thread correctly).
- **#469 (high)**: bulk `links=[...]` entries now contribute conflict keys, with symmetric-relation (`competes_with`/`composed_with`) endpoint canonicalization so reversed links collide at MCP preflight (ADR-038). `conflict_ops` error shape deliberately untouched (out of scope, ADR-038 known gap).
- **#484 (medium)**: `string_as_prev_ref` validates the entire quoted `$prev` path before promotion — malformed nested bracket segments stay literal per ADR-016.

Gates: cargo test -p khive-pack-comm -p khive-request (250 pass) + khive-mcp dispatch regressions (109 pass), clippy -D warnings clean, fmt clean, check --workspace clean. Independent adversarial review re-ran tests against the diff: 0 critical, 0 major, 0 minor findings.