### PR TITLE
test(hnsw): end-to-end deserialize regression coverage for snapshot count-wrap (#415)

### DIFF
--- a/crates/khive-hnsw/src/checkpoint/tests.rs
+++ b/crates/khive-hnsw/src/checkpoint/tests.rs
@@ -853,3 +853,58 @@ fn verify_rejects_duplicate_tombstoned_ids() {
         "verify() must reject duplicate tombstoned_ids, got {result:?}"
     );
 }
+
+/// Regression for #415: the full `serde_json::from_str::<HnswSnapshot>` path
+/// (manual `Deserialize` -> `RawHnswSnapshot` -> `TryFrom`) must return `Err`
+/// for a legacy snapshot whose `tombstoned_ids` exceeds `indexed_ids`,
+/// instead of panicking on unchecked subtraction.
+#[test]
+fn deserialize_rejects_legacy_tombstones_exceed_indexed_without_panic() {
+    let bad_json = r#"{
+        "max_layer": 0,
+        "entry_point": "01010101010101010101010101010101",
+        "config": {"m": 16, "ef_construction": 200, "metric": "cosine"},
+        "indexed_ids": ["01010101010101010101010101010101"],
+        "tombstoned_ids": [
+            "01010101010101010101010101010101",
+            "02020202020202020202020202020202"
+        ],
+        "layers": [[["01010101010101010101010101010101", []]]]
+    }"#;
+
+    let result = serde_json::from_str::<HnswSnapshot>(bad_json);
+    assert!(
+        result.is_err(),
+        "malformed legacy snapshot with more tombstones than indexed ids must deserialize as Err, got {result:?}"
+    );
+}
+
+/// Regression for #415/#416: the full `serde_json::from_str::<HnswSnapshot>`
+/// path must return `Err` when `tombstoned_ids` contains duplicate entries,
+/// so duplicate membership can't be used to satisfy the count check.
+#[test]
+fn deserialize_rejects_duplicate_tombstoned_ids_without_panic() {
+    let bad_json = r#"{
+        "max_layer": 0,
+        "entry_point": "01010101010101010101010101010101",
+        "config": {"m": 16, "ef_construction": 200, "metric": "cosine"},
+        "indexed_ids": [
+            "01010101010101010101010101010101",
+            "02020202020202020202020202020202"
+        ],
+        "tombstoned_ids": [
+            "01010101010101010101010101010101",
+            "01010101010101010101010101010101"
+        ],
+        "layers": [[
+            ["01010101010101010101010101010101", []],
+            ["02020202020202020202020202020202", []]
+        ]]
+    }"#;
+
+    let result = serde_json::from_str::<HnswSnapshot>(bad_json);
+    assert!(
+        result.is_err(),
+        "duplicate tombstoned_ids must deserialize as Err, got {result:?}"
+    );
+}


### PR DESCRIPTION
Audit-sweep wave-3a `hnsw-kg-tail` batch (audit-20260702).

Closes #415

The substantive checked-arithmetic + duplicate-tombstone fixes for #415 already landed via #508/`c623f7d`; what was missing (and why #415 stayed open when #508 silently dropped it) was end-to-end coverage through the public `serde_json::from_str::<HnswSnapshot>` deserialize path. This adds the two regression tests, each landing on a distinct rejecting branch (legacy `checked_sub` cardinality; `verify()` duplicate-tombstone check), both confirmed to fail against pre-fix source.

Note on #445 (same batch's scope): verified already fully resolved by #517/`1fd87402` including all four requested direction-regression tests — nothing to commit; #445 will be closed by comment referencing #517 rather than by this PR.

Gates: cargo test -p khive-hnsw -p khive-pack-kg green, clippy -D warnings clean, fmt clean. Independent adversarial review: 0 critical, 0 major, 3 minor non-blocking findings (MIN-2 traverse help-schema drift -> follow-up docs issue).