### PR TITLE
fix(pack-gtd): task property normalization, resolver parity, audit-table namespace upgrade

### DIFF
--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -50,6 +50,41 @@ async fn ensure_audit_schema(runtime: &KhiveRuntime) {
             tracing::warn!(error = %e, stmt, "gtd: failed to apply lifecycle_audit schema stmt (non-fatal)");
         }
     }
+
+    // `CREATE TABLE IF NOT EXISTS` above is a no-op on databases that already
+    // have `gtd_lifecycle_audit` from before the `namespace` column existed.
+    // Guard-check and upgrade those tables in place so `write_audit_record`'s
+    // `INSERT ... namespace` doesn't silently fail on legacy schemas.
+    let rows = match w
+        .query_all(SqlStatement {
+            sql: "PRAGMA table_info(gtd_lifecycle_audit)".into(),
+            params: vec![],
+            label: Some("gtd_audit_schema_info".into()),
+        })
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(error = %e, "gtd: failed to inspect lifecycle_audit schema (non-fatal)");
+            return;
+        }
+    };
+
+    let has_namespace = rows
+        .iter()
+        .any(|row| matches!(row.get("name"), Some(SqlValue::Text(name)) if name == "namespace"));
+
+    if !has_namespace {
+        if let Err(e) = w
+            .execute_script("ALTER TABLE gtd_lifecycle_audit ADD COLUMN namespace TEXT".into())
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                "gtd: failed to add lifecycle_audit.namespace column (non-fatal)"
+            );
+        }
+    }
 }
 
 /// Append one row to `gtd_lifecycle_audit`.

--- a/crates/khive-pack-gtd/src/hook.rs
+++ b/crates/khive-pack-gtd/src/hook.rs
@@ -58,9 +58,38 @@ impl KindHook for TaskHook {
             )));
         }
 
+        let token = args
+            .get("namespace")
+            .and_then(Value::as_str)
+            .and_then(|s| Namespace::parse(s).ok())
+            .map(|ns| runtime.authorize(ns))
+            .unwrap_or_else(|| runtime.authorize(Namespace::local()))?;
+
+        // Start from any user-supplied `properties` (object only) so foreign
+        // keys survive; task-controlled keys are overwritten with normalized
+        // values. If `properties` is present but not an object, replace it.
+        // Set up `props` before extracting priority/depends_on so both
+        // top-level args and nested `properties` fields are considered —
+        // the ADR-019 generic `create(kind="note", note_kind="task", ...)`
+        // form must accept task-controlled fields nested under `properties`
+        // the same way `gtd.assign` accepts them at the top level.
+        let mut props = args
+            .get("properties")
+            .cloned()
+            .filter(|v| v.is_object())
+            .unwrap_or_else(|| json!({}));
+        let obj = props
+            .as_object_mut()
+            .expect("props is object by construction");
+
+        // Precedence: top-level wins if present, else nested `properties`,
+        // else the field's default. This matches the documented top-level
+        // API surface taking priority while still letting the generic
+        // properties-only form round-trip without being silently defaulted.
         let priority = args
             .get("priority")
             .and_then(Value::as_str)
+            .or_else(|| obj.get("priority").and_then(Value::as_str))
             .map(str::to_string);
         if let Some(ref p) = priority {
             if !is_valid_priority(p) {
@@ -71,27 +100,32 @@ impl KindHook for TaskHook {
         }
         let salience = priority.as_deref().map(priority_to_salience).unwrap_or(0.5);
 
-        let token = args
-            .get("namespace")
-            .and_then(Value::as_str)
-            .and_then(|s| Namespace::parse(s).ok())
-            .map(|ns| runtime.authorize(ns))
-            .unwrap_or_else(|| runtime.authorize(Namespace::local()))?;
-
         // Resolve depends_on entries (full UUID or 8+ hex prefix) to canonical
         // UUID strings — matches the shape gtd's `assign` produces. Also
-        // pre-validate each target is a task note before the storage write so
-        // the kg-create path matches GTD `assign` and never leaves a task
-        // persisted with a `properties.depends_on` pointing at a non-task
-        // (the GTD pack edge rule only legalises task→task `depends_on`).
+        // pre-validate each target is a task note in the primary namespace
+        // before the storage write, using the same `resolve_primary`
+        // resolver as `gtd.assign` and runtime link-mutation validation, so
+        // this create path never leaves a task persisted with a
+        // `properties.depends_on` pointing at a non-task or a visible-only
+        // (non-primary-namespace) note that runtime link creation would
+        // reject (the GTD pack edge rule only legalises task→task
+        // `depends_on` within the primary namespace).
+        let depends_on_source = args
+            .get("depends_on")
+            .cloned()
+            .or_else(|| obj.get("depends_on").cloned());
+        let depends_on_present = depends_on_source.is_some();
         let mut resolved_deps: Vec<String> = Vec::new();
-        if let Some(arr) = args.get("depends_on").and_then(Value::as_array) {
+        if let Some(value) = depends_on_source {
+            let arr = value.as_array().ok_or_else(|| {
+                RuntimeError::InvalidInput("depends_on must be an array of strings".into())
+            })?;
             for entry in arr {
                 let raw = entry.as_str().ok_or_else(|| {
                     RuntimeError::InvalidInput("depends_on entries must be strings".into())
                 })?;
                 let uuid = resolve_uuid(raw, runtime, &token).await?;
-                match runtime.resolve(&token, uuid).await? {
+                match runtime.resolve_primary(&token, uuid).await? {
                     Some(Resolved::Note(n)) if n.kind == "task" => {}
                     Some(Resolved::Note(n)) => {
                         return Err(RuntimeError::InvalidInput(format!(
@@ -116,17 +150,6 @@ impl KindHook for TaskHook {
             }
         }
 
-        // Start from any user-supplied `properties` (object only) so foreign
-        // keys survive; task-controlled keys are overwritten with normalized
-        // values. If `properties` is present but not an object, replace it.
-        let mut props = args
-            .get("properties")
-            .cloned()
-            .filter(|v| v.is_object())
-            .unwrap_or_else(|| json!({}));
-        let obj = props
-            .as_object_mut()
-            .expect("props is object by construction");
         obj.insert("status".into(), json!(status.to_string()));
         let description = args
             .get("description")
@@ -154,8 +177,15 @@ impl KindHook for TaskHook {
         if let Some(v) = args.get("end").and_then(Value::as_str) {
             obj.insert("end".into(), json!(v));
         }
-        if !resolved_deps.is_empty() {
-            obj.insert("depends_on".into(), json!(resolved_deps));
+        // Write back only the canonicalized dependency list (or clear a
+        // stale/invalid nested value) so `after_create` always consumes
+        // validated data regardless of which input location supplied it.
+        if depends_on_present {
+            if resolved_deps.is_empty() {
+                obj.remove("depends_on");
+            } else {
+                obj.insert("depends_on".into(), json!(resolved_deps));
+            }
         }
         if let Some(tags) = args.get("tags").cloned() {
             obj.insert("tags".into(), tags);

--- a/crates/khive-pack-gtd/src/vocab.rs
+++ b/crates/khive-pack-gtd/src/vocab.rs
@@ -68,11 +68,11 @@ pub(crate) static GTD_NOTE_KIND_SPECS: [NoteKindSpec; 1] = [NoteKindSpec {
 /// IF NOT EXISTS`) and is NOT part of the core versioned migration chain.
 ///
 /// Every statement must be idempotent so the generic boot applier can call them
-/// on any database (fresh or pre-existing) without error. The `namespace` column
-/// is included in the `CREATE TABLE` definition, so no separate `ALTER TABLE`
-/// is needed. Databases that predate the `namespace` column are handled by the
-/// `ensure_audit_schema` lazy-init path in `handlers.rs`, which swallows the
-/// duplicate-column error produced by the in-process `ALTER` on those older DBs.
+/// on any database (fresh or pre-existing) without error. The fresh-table DDL
+/// includes `namespace`. Older databases that already have
+/// `gtd_lifecycle_audit` without that column are upgraded by the guarded
+/// `ensure_audit_schema` path in `handlers.rs` (`PRAGMA table_info` check
+/// followed by `ALTER TABLE ... ADD COLUMN namespace` only when missing).
 pub(crate) static GTD_SCHEMA_PLAN_STMTS: [&str; 2] = [
     "CREATE TABLE IF NOT EXISTS gtd_lifecycle_audit (\
         note_id    TEXT NOT NULL,\

--- a/crates/khive-pack-gtd/tests/audit.rs
+++ b/crates/khive-pack-gtd/tests/audit.rs
@@ -185,6 +185,89 @@ async fn noop_transition_does_not_write_audit_record() {
     );
 }
 
+/// F3 regression: a `gtd_lifecycle_audit` table created by an older pack
+/// version (no `namespace` column) must be upgraded in place on the next
+/// `ensure_audit_schema` call, and the transition must still write an audit row.
+#[tokio::test]
+async fn transition_upgrades_namespace_less_audit_table_and_writes_row() {
+    let rt = rt();
+
+    {
+        let mut writer = rt.sql().writer().await.expect("sql writer");
+        writer
+            .execute_script(
+                "CREATE TABLE gtd_lifecycle_audit (\
+                    note_id TEXT NOT NULL,\
+                    from_state TEXT NOT NULL,\
+                    to_state TEXT NOT NULL,\
+                    note TEXT,\
+                    at INTEGER NOT NULL\
+                )"
+                .into(),
+            )
+            .await
+            .expect("old audit table");
+    }
+
+    let fixture = pack(rt.clone());
+
+    let resp = assign(
+        &fixture,
+        json!({"title": "legacy audit table task", "status": "inbox"}),
+    )
+    .await;
+    let task_id = resp["full_id"].as_str().unwrap().to_string();
+
+    fixture
+        .dispatch("gtd.transition", json!({"id": task_id, "status": "next"}))
+        .await
+        .expect("transition should succeed against upgraded legacy table");
+
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.expect("sql reader");
+
+    let cols = reader
+        .query_all(SqlStatement {
+            sql: "PRAGMA table_info(gtd_lifecycle_audit)".into(),
+            params: vec![],
+            label: None,
+        })
+        .await
+        .expect("table_info query");
+    assert!(
+        cols.iter().any(|row| matches!(
+            row.get("name"),
+            Some(SqlValue::Text(name)) if name == "namespace"
+        )),
+        "gtd_lifecycle_audit must be upgraded with a namespace column; got columns {cols:?}"
+    );
+
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT namespace FROM gtd_lifecycle_audit WHERE note_id = ?1".into(),
+            params: vec![SqlValue::Text(task_id.clone())],
+            label: None,
+        })
+        .await
+        .expect("audit query");
+    assert_eq!(
+        rows.len(),
+        1,
+        "transition against an upgraded legacy table must write exactly one audit row; got {rows:?}"
+    );
+    assert_eq!(
+        rows[0].get("namespace").and_then(|v| {
+            if let SqlValue::Text(s) = v {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        }),
+        Some("local"),
+        "audit row namespace must be 'local'"
+    );
+}
+
 #[tokio::test]
 async fn cc1_complete_cancelled_writes_audit_record() {
     let rt = rt();

--- a/crates/khive-pack-gtd/tests/dependencies.rs
+++ b/crates/khive-pack-gtd/tests/dependencies.rs
@@ -409,6 +409,150 @@ async fn assign_rejects_malformed_context_entity_id() {
     );
 }
 
+// ---- Finding 1 regression: generic create must normalize nested properties ----
+
+#[tokio::test]
+async fn create_task_normalizes_nested_priority_and_depends_on_before_write() {
+    use khive_storage::types::{Direction, NeighborQuery};
+    use khive_storage::EdgeRelation;
+
+    let rt = rt();
+    let pack = pack(rt.clone());
+
+    let blocker = assign(&pack, json!({"title": "write spec"})).await;
+    let blocker_full = blocker["full_id"].as_str().unwrap().to_string();
+
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "generic dependent",
+                "properties": {"priority": "p1", "depends_on": [blocker_full.clone()]}
+            }),
+        )
+        .await
+        .expect("generic create with nested properties must succeed");
+
+    assert_eq!(
+        created["properties"]["priority"].as_str(),
+        Some("p1"),
+        "nested properties.priority must be preserved, not overwritten with default p2; got {created:?}"
+    );
+    let deps = created["properties"]["depends_on"]
+        .as_array()
+        .expect("depends_on must be an array");
+    assert_eq!(
+        deps.iter().map(|v| v.as_str().unwrap()).collect::<Vec<_>>(),
+        vec![blocker_full.as_str()],
+        "nested depends_on must be canonicalized to hyphenated UUID form; got {created:?}"
+    );
+
+    let dep_uuid = uuid::Uuid::parse_str(created["id"].as_str().unwrap()).unwrap();
+    let blocker_uuid = uuid::Uuid::parse_str(&blocker_full).unwrap();
+    let graph = rt
+        .graph(&rt.authorize(khive_runtime::Namespace::local()).unwrap())
+        .expect("graph store");
+    let neighbors = graph
+        .neighbors(
+            dep_uuid,
+            NeighborQuery {
+                direction: Direction::Out,
+                relations: Some(vec![EdgeRelation::DependsOn]),
+                limit: Some(16),
+                min_weight: None,
+            },
+        )
+        .await
+        .expect("neighbors query");
+    let targets: Vec<_> = neighbors.iter().map(|hit| hit.node_id).collect();
+    assert!(
+        targets.contains(&blocker_uuid),
+        "generic create with nested depends_on must also create the graph edge; got targets {targets:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_task_top_level_priority_wins_over_nested_priority() {
+    let pack = pack(rt());
+
+    let created = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "conflicting priority",
+                "priority": "p0",
+                "properties": {"priority": "p3"}
+            }),
+        )
+        .await
+        .expect("generic create must succeed");
+
+    assert_eq!(
+        created["properties"]["priority"].as_str(),
+        Some("p0"),
+        "top-level priority must win over nested properties.priority when both are present; got {created:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_task_rejects_nested_depends_on_non_task_without_persisting() {
+    use khive_storage::types::PageRequest;
+
+    let rt = rt();
+    let pack = pack(rt.clone());
+
+    let entity = pack
+        .dispatch("create", json!({"kind": "concept", "name": "Not A Task"}))
+        .await
+        .expect("entity create must succeed");
+    let entity_id = entity["id"].as_str().unwrap().to_string();
+
+    let err = pack
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "bad nested dep",
+                "properties": {"depends_on": [entity_id]}
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("must be a task note"),
+        "expected rejection of non-task nested depends_on target; got: {msg}"
+    );
+
+    let local_token = rt.authorize(khive_runtime::Namespace::local()).unwrap();
+    let notes = rt.notes(&local_token).expect("note store");
+    let task_page = notes
+        .query_notes(
+            "local",
+            Some("task"),
+            PageRequest {
+                offset: 0,
+                limit: 64,
+            },
+        )
+        .await
+        .expect("query task notes");
+    assert!(
+        task_page.items.is_empty(),
+        "rejected generic create must not persist a task; found {:?}",
+        task_page
+            .items
+            .iter()
+            .filter_map(|n| n.name.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
 // ---- Finding 2 regression: depends_on and context_entity_id must be primary-only ----
 
 /// A task in a visible (non-primary) namespace must be treated as NotFound
@@ -507,5 +651,115 @@ async fn resolve_primary_rejects_visible_only_entity() {
         resolved_primary.is_none(),
         "resolve_primary must return None for a visible-only entity; \
          context_entity_id validation uses resolve_primary and must reject it as NotFound"
+    );
+}
+
+/// Documents current KG-create-path behavior for a visible-only `depends_on`
+/// target — NOT a discriminating regression test for the F2 `resolve` vs
+/// `resolve_primary` fix. The KG create dispatch only forwards the token's
+/// primary namespace string to `TaskHook` (`khive-pack-kg/src/handlers/create.rs`
+/// builds `args["namespace"]` from `token.namespace()` alone, discarding any
+/// wider visible set), and `TaskHook::prepare_create` always re-derives its
+/// own token via `runtime.authorize(ns)`, which mints a primary-namespace-only
+/// token (`KhiveRuntime::authorize` -> `mint_with_visibility(ns, vec![], ..)`).
+/// So `TaskHook` can never hold a token that sees a foreign namespace on this
+/// path today, and `resolve`/`resolve_primary` are indistinguishable here —
+/// this test would pass identically with the F2 fix reverted. It is kept to
+/// pin the current (safe) end-to-end behavior — reject + persist nothing —
+/// as defensive parity with `gtd.assign`. The test that actually proves the
+/// `resolve_primary` fix matters is `resolve_primary_rejects_visible_only_task`
+/// above, which hand-builds a widened (`authorize_with_visibility`) token and
+/// shows `resolve` finds the foreign task while `resolve_primary` does not —
+/// the exact distinction `TaskHook`'s dependency validator now relies on.
+#[tokio::test]
+async fn create_task_with_visible_only_dependency_is_rejected_and_persists_no_local_task() {
+    use khive_pack_gtd::GtdPack;
+    use khive_pack_kg::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_storage::types::PageRequest;
+
+    let rt = KhiveRuntime::memory().unwrap();
+
+    let ns_foreign = Namespace::parse("dep-foreign-ns-create").unwrap();
+    let tok_foreign = rt.authorize(ns_foreign.clone()).unwrap();
+    let foreign_task = rt
+        .create_note(
+            &tok_foreign,
+            "task",
+            Some("foreign blocker"),
+            "foreign blocker",
+            Some(0.5),
+            Some(json!({"status": "inbox", "priority": "p2"})),
+            vec![],
+        )
+        .await
+        .expect("create foreign blocker task");
+
+    let tok_visible = rt
+        .authorize_with_visibility(Namespace::local(), vec![ns_foreign.clone()])
+        .unwrap();
+    assert!(
+        rt.resolve(&tok_visible, foreign_task.id)
+            .await
+            .unwrap()
+            .is_some(),
+        "visible-aware resolve must find the foreign task"
+    );
+    assert!(
+        rt.resolve_primary(&tok_visible, foreign_task.id)
+            .await
+            .unwrap()
+            .is_none(),
+        "resolve_primary must not find the foreign task"
+    );
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GtdPack::new(rt.clone()));
+    builder.with_visible_namespaces(vec![ns_foreign.clone()]);
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let foreign_full = foreign_task.id.as_hyphenated().to_string();
+    let err = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "note",
+                "note_kind": "task",
+                "title": "local dependent",
+                "depends_on": [foreign_full]
+            }),
+        )
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        matches!(err, khive_runtime::RuntimeError::NotFound(_))
+            || msg.contains("not found in namespace"),
+        "visible-only depends_on target must be rejected as NotFound; got: {msg}"
+    );
+
+    let local_token = rt.authorize(Namespace::local()).unwrap();
+    let notes = rt.notes(&local_token).expect("note store");
+    let task_page = notes
+        .query_notes(
+            "local",
+            Some("task"),
+            PageRequest {
+                offset: 0,
+                limit: 64,
+            },
+        )
+        .await
+        .expect("query local task notes");
+    assert!(
+        task_page.items.is_empty(),
+        "rejected create must not persist a local task; found {:?}",
+        task_page
+            .items
+            .iter()
+            .filter_map(|n| n.name.clone())
+            .collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
Audit-sweep wave-3a `gtd` batch (audit-20260702).

Closes #420
Closes #421
Closes #422

- **#420 (high)**: `TaskHook::prepare_create` read `priority`/`depends_on` from top-level args only — overwrote nested `properties.priority` with the default and never validated nested `depends_on` before write. Now normalizes both fields (precedence: top-level → nested → default), validates and canonicalizes every dep as a primary-namespace task before the write. Revert-confirmed genuine regressions.
- **#421 (medium)**: swapped visible-aware `resolve` → `resolve_primary` in dep validation for parity with `gtd.assign` and link mutation. Honest-coverage note: the stated reproduction is structurally unreachable through the KG-create path today (dispatch collapses the token to primary-namespace before the hook), so the end-to-end test is documented as behavior-pinning, not fix-discriminating; the discriminating proof is the pre-existing `resolve_primary_rejects_visible_only_task` primitive test.
- **#422 (medium)**: `ensure_audit_schema` never upgraded legacy namespace-less `gtd_lifecycle_audit` tables (audit rows silently swallowed). Now a `PRAGMA table_info`-guarded idempotent `ALTER TABLE ... ADD COLUMN namespace`. Revert-confirmed genuine regression.

Gates: cargo test -p khive-pack-gtd (149 pass), clippy -D warnings clean, fmt clean, check --workspace clean. Internal review caught and fixed a vacuous regression test before commit. Review findings were resolved before merge readiness.