### PR TITLE
fix(kkernel): SQLite identifier quoting, fail-closed validate, merged-registry import kinds, registry-driven search routing

### DIFF
--- a/crates/kkernel/src/coordinator/service.rs
+++ b/crates/kkernel/src/coordinator/service.rs
@@ -2,7 +2,7 @@
 //! trait defined in `khive-mcp`. Wraps `SubstrateCoordinator` and adapts its types
 //! to the trait interface used by `KhiveMcpServer`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -24,17 +24,34 @@ use super::dispatch::SubstrateCoordinator;
 /// for single-backend deployments (zero-change invariant).
 pub struct SubstrateCoordinatorService {
     inner: SubstrateCoordinator,
+    /// Merged note-kind vocabulary from every pack loaded onto the multi-backend
+    /// `VerbRegistry` (see `khive_runtime::pack::VerbRegistry::all_note_kinds`).
+    /// Drives `fan_out_search`'s note-vs-entity substrate classification so a
+    /// granular kind registered by any loaded pack (e.g. `session`) routes to
+    /// note FTS instead of falling through to a hardcoded list.
+    note_kinds: HashSet<String>,
 }
 
 impl SubstrateCoordinatorService {
-    /// Wrap an existing [`SubstrateCoordinator`].
-    pub fn new(coordinator: SubstrateCoordinator) -> Self {
-        Self { inner: coordinator }
+    /// Wrap an existing [`SubstrateCoordinator`], classifying granular search
+    /// kinds against `note_kinds` (the merged pack/runtime note-kind registry).
+    pub fn new(coordinator: SubstrateCoordinator, note_kinds: HashSet<String>) -> Self {
+        Self {
+            inner: coordinator,
+            note_kinds,
+        }
     }
 
     /// The primary backend id, if any.
     pub fn primary_backend_id_inner(&self) -> Option<BackendId> {
         self.inner.primary_runtime().map(|_| BackendId::main())
+    }
+
+    /// Classify `kind` as note-substrate vs entity-substrate for fan-out
+    /// routing. `"note"` is always note-substrate; any other kind is
+    /// note-substrate iff it is a member of the merged pack note-kind registry.
+    fn is_note_substrate(&self, kind: &str) -> bool {
+        kind == "note" || self.note_kinds.contains(kind)
     }
 }
 
@@ -101,7 +118,7 @@ impl CoordinatorService for SubstrateCoordinatorService {
         props_filter: Option<&serde_json::Value>,
         tags: &[String],
     ) -> CoordSearchResult {
-        let search_notes = is_note_substrate(kind);
+        let search_notes = self.is_note_substrate(kind);
         let (entity_hits, note_hits, per_backend) = self
             .inner
             .fan_out_search(
@@ -185,24 +202,4 @@ impl CoordinatorService for SubstrateCoordinatorService {
     fn is_single_backend(&self) -> bool {
         self.inner.is_single_backend()
     }
-}
-
-/// Classify `kind` as note-substrate vs entity-substrate for fan-out routing.
-///
-/// Entity substrate: `"entity"` or any granular entity kind name.
-/// Note substrate: `"note"` or any granular note kind name (including pack-extended kinds).
-fn is_note_substrate(kind: &str) -> bool {
-    matches!(
-        kind,
-        "note"
-            | "observation"
-            | "insight"
-            | "question"
-            | "decision"
-            | "reference"
-            | "task"
-            | "memory"
-            | "message"
-            | "scheduled_event"
-    )
 }

--- a/crates/kkernel/src/coordinator/tests.rs
+++ b/crates/kkernel/src/coordinator/tests.rs
@@ -14,8 +14,8 @@ fn memory_runtime() -> Arc<KhiveRuntime> {
     Arc::new(KhiveRuntime::memory().expect("memory runtime"))
 }
 
-/// Build a VerbRegistry with the `kg` pack loaded, using the given runtime.
-fn kg_registry(runtime: Arc<KhiveRuntime>) -> khive_runtime::VerbRegistry {
+/// Build a VerbRegistry with the given packs loaded, using the given runtime.
+fn packs_registry(runtime: Arc<KhiveRuntime>, pack_names: &[&str]) -> khive_runtime::VerbRegistry {
     let gate = runtime.config().gate.clone();
     let default_ns = runtime.config().default_namespace.clone();
     let actor_id = runtime.config().actor_id.clone();
@@ -23,8 +23,9 @@ fn kg_registry(runtime: Arc<KhiveRuntime>) -> khive_runtime::VerbRegistry {
     builder.with_gate(gate);
     builder.with_default_namespace(default_ns.as_str());
     builder.with_actor_id(actor_id);
-    PackRegistry::register_packs(&["kg".to_string()], (*runtime).clone(), &mut builder)
-        .expect("register kg");
+    let names: Vec<String> = pack_names.iter().map(|s| s.to_string()).collect();
+    PackRegistry::register_packs(&names, (*runtime).clone(), &mut builder)
+        .unwrap_or_else(|n| panic!("pack {n:?} declared in inventory but factory missing"));
     let registry = builder.build().expect("build registry");
     runtime.install_edge_rules(registry.all_edge_rules());
     registry
@@ -951,14 +952,31 @@ fn two_backend_server(
     rt_a: Arc<KhiveRuntime>,
     rt_b: Arc<KhiveRuntime>,
 ) -> khive_mcp::server::KhiveMcpServer {
-    // Build the VerbRegistry from rt_a (single runtime, kg pack).
-    let registry = kg_registry(Arc::clone(&rt_a));
+    two_backend_server_with_packs(rt_a, rt_b, &["kg"])
+}
+
+/// Helper: build a two-backend server whose `VerbRegistry` (and the
+/// coordinator's note-kind substrate classification, #439) includes the given
+/// packs.
+fn two_backend_server_with_packs(
+    rt_a: Arc<KhiveRuntime>,
+    rt_b: Arc<KhiveRuntime>,
+    pack_names: &[&str],
+) -> khive_mcp::server::KhiveMcpServer {
+    // Build the VerbRegistry from rt_a (single runtime, given packs).
+    let registry = packs_registry(Arc::clone(&rt_a), pack_names);
+    let note_kinds: std::collections::HashSet<String> = registry
+        .all_note_kinds()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
 
     // Build a two-backend coordinator.
     let mut backend_reg = BackendRegistry::new();
     backend_reg.register(BackendId::new("alpha"), Arc::clone(&rt_a));
     backend_reg.register(BackendId::new("beta"), Arc::clone(&rt_b));
-    let coordinator = SubstrateCoordinatorService::new(SubstrateCoordinator::new(backend_reg));
+    let coordinator =
+        SubstrateCoordinatorService::new(SubstrateCoordinator::new(backend_reg), note_kinds);
 
     khive_mcp::server::KhiveMcpServer::from_registry_with_meta(
         registry,
@@ -1184,4 +1202,74 @@ async fn t7c_multi_backend_search_min_score_applied() {
         "T7c: min_score=1.0 must filter all hits, got {} hit(s)",
         hits.len()
     );
+}
+
+/// T7d (#439): multi-backend search for the `session` note kind must route to
+/// note FTS through the coordinator, not fall through to entity search.
+///
+/// RED before fix: `is_note_substrate` was a hardcoded list omitting `session`,
+/// so `search(kind="session")` searched entity FTS with an entity-kind filter
+/// and never found the seeded session note.
+/// GREEN after fix: substrate classification is driven by the merged
+/// `VerbRegistry` note-kind set (installed on `SubstrateCoordinatorService`),
+/// so `session` (registered by `khive-pack-session`) routes to note FTS.
+#[tokio::test]
+async fn t7d_multi_backend_search_session_kind_routes_to_note_substrate() {
+    let rt_a = memory_runtime();
+    let rt_b = memory_runtime();
+    let ns = RuntimeNamespace::local();
+
+    let tok_a = rt_a.authorize(ns.clone()).unwrap();
+    rt_a.create_note(
+        &tok_a,
+        "session",
+        Some("Daily standup"),
+        "standup notes for the team",
+        None,
+        None,
+        vec![],
+    )
+    .await
+    .expect("T7d: create session note on alpha");
+
+    let _ = rt_b.authorize(ns.clone()).unwrap();
+
+    let server =
+        two_backend_server_with_packs(Arc::clone(&rt_a), Arc::clone(&rt_b), &["kg", "session"]);
+
+    let result_str = server
+        .dispatch_request_local(khive_mcp::tools::request::RequestParams {
+            ops: r#"search(kind="session", query="standup")"#.to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            save_to: None,
+            format: None,
+            format_per_op: None,
+        })
+        .await
+        .expect("T7d: dispatch");
+
+    let response: serde_json::Value = serde_json::from_str(&result_str).expect("T7d: parse");
+    let results = response["results"].as_array().expect("T7d: results");
+    let op = &results[0];
+    assert!(
+        op["ok"].as_bool() == Some(true),
+        "T7d: search op must succeed, got: {op}"
+    );
+    let hits = op["result"].as_array().expect("T7d: result array");
+    assert!(
+        !hits.is_empty(),
+        "T7d: session note must be found through the coordinator path"
+    );
+    for hit in hits {
+        assert_eq!(
+            hit.get("note_kind").and_then(|v| v.as_str()),
+            Some("session"),
+            "T7d: hit must be note-shaped with note_kind='session', got: {hit}"
+        );
+        assert!(
+            hit.get("entity_kind").map(|v| v.is_null()).unwrap_or(true),
+            "T7d: note-substrate hit must not carry an entity_kind, got: {hit}"
+        );
+    }
 }

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
+use khive_runtime::pack::{PackRegistry, VerbRegistryBuilder};
 use khive_runtime::portability::{ExportedEdge, ExportedEntity, KgArchive};
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
 use khive_storage::EdgeRelation;
-use khive_types::EntityKind;
 use khive_vcs_adapters::{EdgeRecord, EntityRecord, FormatAdapter, JsonFormatAdapter};
 use uuid::Uuid;
 
@@ -90,6 +90,7 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
         ..Default::default()
     };
     let runtime = KhiveRuntime::new(config)?;
+    install_import_kind_registry(&runtime)?;
     let token = runtime.authorize(ns)?;
 
     let source = std::fs::read_to_string(&args.source)
@@ -99,7 +100,7 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
         ImportFormat::Archive => {
             let archive: KgArchive = serde_json::from_str(&source)
                 .with_context(|| format!("parse archive {}", args.source.display()))?;
-            validate_archive_entity_kinds(&archive)?;
+            validate_archive_edge_weights(&archive)?;
             runtime
                 .import_kg(&archive, &token)
                 .await
@@ -162,9 +163,9 @@ fn adapter_records_to_archive(
     let exported_entities: Vec<ExportedEntity> = entities
         .into_iter()
         .map(|e| {
-            let _: EntityKind = e.kind.parse().map_err(|_| {
-                anyhow::anyhow!("unknown entity kind {:?} on entity {}", e.kind, e.id)
-            })?;
+            // Entity kind is validated against the merged pack/runtime kind
+            // registry inside `runtime.import_kg`, not here — a bare base-enum
+            // parse would reject valid pack-registered kinds like `resource`.
             Ok(ExportedEntity {
                 id: e.id,
                 kind: e.kind,
@@ -215,16 +216,41 @@ pub(super) fn validate_edge_weight(weight: f64, edge_id: impl std::fmt::Display)
     Ok(())
 }
 
-pub(super) fn validate_archive_entity_kinds(archive: &KgArchive) -> Result<()> {
-    for e in &archive.entities {
-        let _: EntityKind = e
-            .kind
-            .parse()
-            .map_err(|_| anyhow::anyhow!("unknown entity kind {:?} on entity {}", e.kind, e.id))?;
-    }
+/// Pre-import validation that does not require entity-kind knowledge.
+/// Entity-kind validation happens inside `runtime.import_kg` against the
+/// merged pack/runtime kind registry installed by `install_import_kind_registry`.
+pub(super) fn validate_archive_edge_weights(archive: &KgArchive) -> Result<()> {
     for edge in &archive.edges {
         validate_edge_weight(edge.weight, edge.edge_id)?;
     }
+    Ok(())
+}
+
+/// Install the merged pack/runtime entity- and note-kind registry on `runtime`
+/// so that `runtime.import_kg` (and any other runtime-layer kind validation)
+/// accepts pack-registered kinds such as `resource`, not just the eight base
+/// `khive_types::EntityKind` variants.
+fn install_import_kind_registry(runtime: &KhiveRuntime) -> Result<()> {
+    let mut builder = VerbRegistryBuilder::new();
+    let names: Vec<String> = PackRegistry::discovered_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    PackRegistry::register_packs(&names, runtime.clone(), &mut builder)
+        .map_err(|n| anyhow::anyhow!("pack {n:?} declared in inventory but factory missing"))?;
+    let registry = builder.build().context("building import VerbRegistry")?;
+    runtime.install_kind_registry(
+        registry
+            .all_entity_kinds()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        registry
+            .all_note_kinds()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    );
     Ok(())
 }
 
@@ -540,6 +566,81 @@ mod tests {
         let entity_uuid: Uuid = entity_id.parse().unwrap();
         let entity = rt2.get_entity(&tok2, entity_uuid).await.unwrap();
         assert_eq!(entity.name, "Imported");
+    }
+
+    #[tokio::test]
+    async fn import_archive_accepts_resource_kind() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("import-resource.db");
+        let entity_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+
+        let archive_json = format!(
+            r#"{{"format":"khive-kg","version":"0.1","namespace":"test-ns","exported_at":"2026-01-01T00:00:00Z","entities":[{{"id":"{entity_id}","kind":"resource","name":"ImportedResource","tags":[],"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}],"edges":[]}}"#
+        );
+        let source_path = tmp.path().join("archive.json");
+        std::fs::write(&source_path, &archive_json).unwrap();
+
+        let args = ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Archive,
+            verbose: false,
+        };
+        cmd_import(args)
+            .await
+            .expect("archive import must accept pack-registered `resource` kind");
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let rt2 = KhiveRuntime::new(config).unwrap();
+        let tok2 = rt2.authorize(ns).unwrap();
+        let entity_uuid: Uuid = entity_id.parse().unwrap();
+        let entity = rt2.get_entity(&tok2, entity_uuid).await.unwrap();
+        assert_eq!(entity.kind, "resource");
+        assert_eq!(entity.name, "ImportedResource");
+    }
+
+    // NOTE: the JSON/NDJSON adapter import path (`ImportFormat::Json` /
+    // `ImportFormat::Ndjson`) goes through `khive_vcs_adapters::JsonFormatAdapter`,
+    // which independently gates entity kind through the base
+    // `khive_types::EntityKind::from_str` in `parse_entity` — before an
+    // `ExportedEntity`/`KgArchive` is even constructed, and before this module's
+    // `install_import_kind_registry` fix has any effect. Making that path accept
+    // pack-registered kinds like `resource` requires an API change to the shared
+    // `khive-vcs-adapters` crate (also consumed by `khive-vcs` sync) to accept an
+    // injected valid-kind set — architecture work beyond this issue's scope
+    // (archive.rs kind validation, per #438's evidence). Only the archive-format
+    // round-trip path (the issue's reported failure scenario) is fixed here; see
+    // `import_archive_accepts_resource_kind` above.
+
+    #[tokio::test]
+    async fn import_rejects_unregistered_entity_kind() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("import-unknown-kind.db");
+        let entity_id = "12345678-1234-1234-1234-123456789012";
+
+        let json_input =
+            format!(r#"[{{"id":"{entity_id}","kind":"not_a_registered_kind","name":"Bad"}}]"#);
+        let source_path = tmp.path().join("records.json");
+        std::fs::write(&source_path, &json_input).unwrap();
+
+        let args = ImportArgs {
+            source: source_path,
+            db: db_path,
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        };
+        assert!(
+            cmd_import(args).await.is_err(),
+            "import must still reject entity kinds unknown to every registered pack"
+        );
     }
 
     #[tokio::test]

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -162,6 +162,7 @@ fn structural_checks(
     taxonomy: &KgTaxonomy,
 ) -> Vec<RuleResult> {
     let mut results = vec![
+        check_schema_compliance(entities_path, edges_path, notes_path),
         check_no_duplicate_uuids(entities_path),
         check_sort_order(entities_path, edges_path),
         check_referential_integrity(entities_path, notes_path, edges_path),
@@ -172,6 +173,136 @@ fn structural_checks(
         results.push(check_valid_note_kinds(notes_path, &taxonomy.note_kinds));
     }
     results
+}
+
+fn schema_violation(file: &str, line_no: usize, message: impl std::fmt::Display) -> Violation {
+    Violation {
+        entity_id: None,
+        entity_name: None,
+        entity_kind: None,
+        rule_id: "schema-compliance".into(),
+        severity: "error",
+        message: format!("{file} line {line_no}: {message}"),
+        fixable: false,
+    }
+}
+
+/// Fail-closed schema-compliance check: every non-empty NDJSON line in
+/// entities.ndjson, edges.ndjson, and (if present) notes.ndjson must parse as
+/// JSON and carry the minimal required fields for its record type. Unlike the
+/// other structural checks, malformed lines here are reported as violations
+/// instead of being silently skipped, so corrupt NDJSON cannot pass `kg
+/// validate` only to fail later in `kkernel sync` / `kg import`.
+fn check_schema_compliance(
+    entities_path: &Path,
+    edges_path: &Path,
+    notes_path: &Path,
+) -> RuleResult {
+    let mut violations = Vec::new();
+
+    if let Ok(content) = std::fs::read_to_string(entities_path) {
+        for (idx, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let line_no = idx + 1;
+            match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(v) => {
+                    let missing: Vec<&str> = ["id", "kind", "name"]
+                        .into_iter()
+                        .filter(|f| v.get(f).and_then(|x| x.as_str()).is_none())
+                        .collect();
+                    if !missing.is_empty() {
+                        violations.push(schema_violation(
+                            "entities.ndjson",
+                            line_no,
+                            format!("missing required field(s): {}", missing.join(", ")),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    violations.push(schema_violation(
+                        "entities.ndjson",
+                        line_no,
+                        format!("invalid JSON: {e}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Ok(content) = std::fs::read_to_string(edges_path) {
+        for (idx, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let line_no = idx + 1;
+            match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(v) => {
+                    let missing: Vec<&str> = ["source_id", "target_id", "relation"]
+                        .into_iter()
+                        .filter(|f| v.get(f).and_then(|x| x.as_str()).is_none())
+                        .collect();
+                    if !missing.is_empty() {
+                        violations.push(schema_violation(
+                            "edges.ndjson",
+                            line_no,
+                            format!("missing required field(s): {}", missing.join(", ")),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    violations.push(schema_violation(
+                        "edges.ndjson",
+                        line_no,
+                        format!("invalid JSON: {e}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    // notes.ndjson is optional: an absent file is fine, a present-but-malformed
+    // file is not.
+    if notes_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(notes_path) {
+            for (idx, line) in content.lines().enumerate() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let line_no = idx + 1;
+                match serde_json::from_str::<serde_json::Value>(line) {
+                    Ok(v) => {
+                        let missing: Vec<&str> = ["id", "kind"]
+                            .into_iter()
+                            .filter(|f| v.get(f).and_then(|x| x.as_str()).is_none())
+                            .collect();
+                        if !missing.is_empty() {
+                            violations.push(schema_violation(
+                                "notes.ndjson",
+                                line_no,
+                                format!("missing required field(s): {}", missing.join(", ")),
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        violations.push(schema_violation(
+                            "notes.ndjson",
+                            line_no,
+                            format!("invalid JSON: {e}"),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    RuleResult {
+        id: "schema-compliance".into(),
+        severity: "error",
+        passed: violations.is_empty(),
+        violations,
+    }
 }
 
 /// Format a record identifier prefix from the available violation fields.
@@ -770,11 +901,21 @@ pub(super) fn fix_sort_order(path: &Path, sort_key: &str) -> Result<()> {
     }
     let content =
         std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    let mut lines: Vec<serde_json::Value> = content
+    let mut lines: Vec<serde_json::Value> = Vec::new();
+    for (idx, l) in content
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter_map(|l| serde_json::from_str(l).ok())
-        .collect();
+        .enumerate()
+        .filter(|(_, l)| !l.trim().is_empty())
+    {
+        let v = serde_json::from_str(l).with_context(|| {
+            format!(
+                "{} line {}: refusing to apply --fix over malformed JSON; run `kg validate` for details",
+                path.display(),
+                idx + 1
+            )
+        })?;
+        lines.push(v);
+    }
     lines.sort_by(|a, b| {
         let ak = a.get(sort_key).and_then(|v| v.as_str()).unwrap_or("");
         let bk = b.get(sort_key).and_then(|v| v.as_str()).unwrap_or("");
@@ -794,11 +935,21 @@ fn fix_sort_order_edges(path: &Path) -> Result<()> {
     }
     let content =
         std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    let mut lines: Vec<serde_json::Value> = content
+    let mut lines: Vec<serde_json::Value> = Vec::new();
+    for (idx, l) in content
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter_map(|l| serde_json::from_str(l).ok())
-        .collect();
+        .enumerate()
+        .filter(|(_, l)| !l.trim().is_empty())
+    {
+        let v = serde_json::from_str(l).with_context(|| {
+            format!(
+                "{} line {}: refusing to apply --fix over malformed JSON; run `kg validate` for details",
+                path.display(),
+                idx + 1
+            )
+        })?;
+        lines.push(v);
+    }
     lines.sort_by(|a, b| {
         let ak = (
             a.get("source_id").and_then(|v| v.as_str()).unwrap_or(""),
@@ -949,6 +1100,78 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         std::fs::write(kg_dir.join("notes.ndjson"), content + "\n").unwrap();
+    }
+
+    // ── Schema-compliance tests (#437) ────────────────────────────────────────
+
+    #[test]
+    fn schema_compliance_rejects_malformed_entities_ndjson() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        std::fs::write(kg_dir.join("entities.ndjson"), "not-valid-json\n").unwrap();
+        std::fs::write(kg_dir.join("edges.ndjson"), "").unwrap();
+
+        let taxonomy = KgTaxonomy {
+            entity_kinds: base_entity_kinds(),
+            note_kinds: base_note_kinds(),
+        };
+        let results = structural_checks(
+            &kg_dir.join("entities.ndjson"),
+            &kg_dir.join("edges.ndjson"),
+            &kg_dir.join("notes.ndjson"),
+            &taxonomy,
+        );
+
+        let schema_rule = results
+            .iter()
+            .find(|r| r.id == "schema-compliance")
+            .expect("schema-compliance rule must always run");
+        assert!(
+            !schema_rule.passed,
+            "malformed NDJSON must fail schema-compliance"
+        );
+        assert!(
+            schema_rule.violations[0]
+                .message
+                .contains("entities.ndjson line 1"),
+            "violation must point at the malformed line: {}",
+            schema_rule.violations[0].message
+        );
+    }
+
+    #[test]
+    fn schema_compliance_passes_well_formed_kg_and_absent_notes() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        write_entities(
+            &kg_dir,
+            &[("aaaaaaaa-0000-0000-0000-000000000001", "concept", "A")],
+        );
+        write_edges(&kg_dir, &[]);
+
+        let result = check_schema_compliance(
+            &kg_dir.join("entities.ndjson"),
+            &kg_dir.join("edges.ndjson"),
+            &kg_dir.join("notes.ndjson"),
+        );
+        assert!(
+            result.passed,
+            "well-formed KG with absent notes.ndjson must pass: {:?}",
+            result.violations
+        );
+    }
+
+    #[test]
+    fn fix_sort_order_refuses_malformed_json() {
+        let tmp = TempDir::new().unwrap();
+        let kg_dir = make_kg_dir(&tmp);
+        let path = kg_dir.join("entities.ndjson");
+        std::fs::write(&path, "not-valid-json\n").unwrap();
+
+        let err = fix_sort_order(&path, "id").expect_err("fix must refuse malformed JSON");
+        assert!(err.to_string().contains("line 1"));
+        // The file must be left untouched, not truncated/dropped.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "not-valid-json\n");
     }
 
     // ── Entity kind tests ─────────────────────────────────────────────────────

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -279,8 +279,16 @@ async fn main() -> Result<()> {
                     backend_reg.register(backend_id, Arc::clone(rt));
                 }
 
-                let coord =
-                    SubstrateCoordinatorService::new(SubstrateCoordinator::new(backend_reg));
+                let note_kinds: std::collections::HashSet<String> = multi
+                    .registry
+                    .all_note_kinds()
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect();
+                let coord = SubstrateCoordinatorService::new(
+                    SubstrateCoordinator::new(backend_reg),
+                    note_kinds,
+                );
                 // Resolve the ADR-078 output-format default (env > [runtime] TOML >
                 // builtin json) for this serve path too — the single-backend branch
                 // does this inside `serve::run`, but this multi-backend branch builds

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -958,8 +958,15 @@ async fn sweep_stale_fts_partitions(rt: &KhiveRuntime, covered_ns: &str) {
         return;
     };
     for table in &to_drop {
-        let ddl = format!("DROP TABLE IF EXISTS \"{table}\"");
-        match writer.execute_script(ddl).await {
+        let ddl = format!("DROP TABLE IF EXISTS {}", quote_sqlite_identifier(table));
+        match writer
+            .execute(SqlStatement {
+                sql: ddl,
+                params: vec![],
+                label: Some("sweep_stale_fts_partitions_drop".into()),
+            })
+            .await
+        {
             Ok(_) => {
                 tracing::info!(table, "dropped stale FTS partition table");
             }
@@ -968,6 +975,13 @@ async fn sweep_stale_fts_partitions(rt: &KhiveRuntime, covered_ns: &str) {
             }
         }
     }
+}
+
+/// Quote a SQLite identifier for safe interpolation into generated DDL,
+/// doubling any embedded double quotes so the identifier cannot terminate
+/// early and inject additional statements.
+fn quote_sqlite_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 async fn count_notes(rt: &KhiveRuntime, ns: &str) -> u64 {
@@ -1156,6 +1170,70 @@ mod tests {
         assert!(
             !remaining.contains(&"local::vamana::model-b".to_string()),
             "local vamana model-b must be deleted: {remaining:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_fts_sweep_quotes_malicious_table_name_and_preserves_entities() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize");
+
+        // Seed a base row so `distinct_base_namespaces` returns only `local`
+        // and the sweep guard does not skip the drop loop.
+        rt.create_entity(&token, "concept", None, "seed", None, None, vec![])
+            .await
+            .expect("seed entity");
+
+        let sql = rt.sql();
+        let malicious = "fts_entities_x\"; DROP TABLE entities; --";
+        {
+            let mut w = sql.writer().await.expect("writer");
+            let ddl = format!(
+                "CREATE TABLE {} (rowid INTEGER)",
+                quote_sqlite_identifier(malicious)
+            );
+            w.execute(SqlStatement {
+                sql: ddl,
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("create malicious stale table");
+        }
+
+        sweep_stale_fts_partitions(&rt, "local").await;
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT COUNT(*) AS c FROM entities".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("entities table must still exist and be queryable");
+        let count = rows
+            .first()
+            .and_then(|row| row.get("c"))
+            .map(|v| matches!(v, SqlValue::Integer(n) if *n >= 1))
+            .unwrap_or(false);
+        assert!(
+            count,
+            "entities table must survive the sweep with its seeded row intact"
+        );
+
+        let survivors = r
+            .query_all(SqlStatement {
+                sql: "SELECT name FROM sqlite_master WHERE name = ?1".into(),
+                params: vec![SqlValue::Text(malicious.to_string())],
+                label: None,
+            })
+            .await
+            .expect("query sqlite_master");
+        assert!(
+            survivors.is_empty(),
+            "malicious stale table should have been dropped"
         );
     }
 


### PR DESCRIPTION
Audit-sweep wave-3a `kkernel` batch (audit-20260702).

Closes #436
Closes #437
Closes #439

Refs #438 — **partial fix, deliberately not closed by this PR** (see below).

- **#436 (high, security)**: SQLite identifier injection in `reindex.rs`'s stale-FTS sweep — discovered table names flowed unquoted into `execute_script`. Now `quote_sqlite_identifier` (quote-doubling) + single-statement `execute` (defense in depth). Adversarial regression plants the exact payload `fts_entities_x"; DROP TABLE entities; --` and asserts `entities` survives with its row AND the malicious table was actually dropped (sweep ran, neutralized).
- **#437 (high)**: `kg validate` silently passed malformed NDJSON (parse failures dropped via `if let Ok`/`filter_map`). New fail-closed `schema-compliance` structural rule; CLI exits nonzero; `--fix` refuses malformed input rather than sorting-by-dropping.
- **#438 (high, PARTIAL)**: `kg import` now installs the merged pack/runtime kind registry before delegating, so archive-format import accepts `resource`. JSON/NDJSON **adapter** imports still hard-reject `resource` at `khive-vcs-adapters/json_adapter.rs:202-208` — a second validation gate one crate below, requiring a cross-crate API change (threading the merged registry into `JsonFormatAdapter`). Independently reproduced via CLI on two separate passes. Follow-up issue to be filed; this PR does not claim full resolution.
- **#439 (high)**: multi-backend coordinator search misrouted the `session` note kind — substrate classification was a hardcoded list. Now driven from the merged `VerbRegistry` note-kind set; hardcoded classifier deleted.

Gates: cargo test -p kkernel (168 pass), clippy -D warnings clean, fmt clean, check --workspace clean. Adversarial review: approved with fixes (CRIT:0 MAJ:1 = the acknowledged #438 partial, judged safe to land: fails closed, never corrupts).