### PR TITLE
docs(adr): ADR-086/087/088 — doc/file modeling, workspace mirror, git-lifecycle pack

### DIFF
--- a/docs/adr/ADR-086-doc-file-pack.md
+++ b/docs/adr/ADR-086-doc-file-pack.md
@@ -1,0 +1,195 @@
+# ADR-086: Document/File Modeling — Content on the Existing `document` Entity Kind
+
+**Status**: Proposed\
+**Date**: 2026-07-03\
+**Authors**: Ocean, lambda:khive\
+**Depends on**: ADR-001 (Entity Kind Taxonomy — `document` is a base kind; `entity_type`
+subtype registration), ADR-002 (Edge Ontology — `annotates`, `supersedes`), ADR-013 (Note
+Kind Taxonomy), ADR-017 (Pack Standard — `EntityTypeRegistry`, `KindHook`), ADR-021 (Memory
+Pack — decay/salience precedent for pack-scoped auxiliary data)\
+**Related**: ADR-010 (KG Versioning — NDJSON snapshot scope), ADR-080 (Session Pack — OSS
+storage mechanism; sibling background-ingestion precedent for ADR-087), ADR-085 (Code
+Pack — `EntityTypeRegistry` Modify precedent, `KindHook` validation precedent)
+
+## Context
+
+Ocean's request: documents and files (specs, research notes, meeting artifacts, reports)
+should be "on record and kept" — first-class, graph-queryable, versioned — rather than
+opaque files agents happen to read from disk. The `document` entity kind has existed since
+ADR-001 as one of the 8 base `EntityKind` variants, but nothing in the codebase specifies
+how document _content_ is meant to be stored, retained, or versioned. In practice, agents
+either paste excerpts into `description` ad hoc or don't model documents in the graph at
+all.
+
+Two facts about the current substrate shape drive this ADR's design directly:
+
+- `Entity` (`crates/khive-types/src/entity.rs`) has `name: String`, `description:
+  Option<String>`, and `properties: BTreeMap<String, PropertyValue>` — no dedicated content
+  field, but `description` is an unconstrained free-text field with no length limit at the
+  SQLite layer.
+- `fts_entities` (`crates/khive-db/sql/004-fts-consolidation.sql`) already indexes a
+  `title`/`body` pair (name/description) via FTS5 trigram tokenization for every entity,
+  regardless of kind. Any text placed in `description` is automatically part of the
+  existing hybrid FTS5 + vector search fusion — no new indexing path required.
+
+This is a different shape than the knowledge pack's `knowledge_atoms` table (`content TEXT
+NOT NULL DEFAULT ''`, its own primary key, its own FTS5 table `fts_knowledge`) — atoms are
+a wholly separate pack-owned corpus, not KG entities. Modeling document/file content is not
+the same problem as modeling knowledge atoms, and this ADR does not touch `knowledge_atoms`.
+
+## Decision
+
+Documents and files are modeled as `document`-kind entities using the substrate that
+already exists. No new pack, no new table, no new verb surface ships in v1.
+
+1. **Content placement.** `description` holds the document's textual body (markdown,
+   plain text, or extracted text) directly, inline. This is the only storage decision this
+   ADR makes for text content — it is a usage convention, not a schema change.
+
+2. **Metadata placement.** `properties` carries `source_uri` (where the canonical
+   bytes live, if not fully inline — a local path, an object-store URI, or a location
+   under the Global Asset Store per the root CLAUDE.md's Resource & Scope Governance
+   section), `source_type` (a MIME-ish string, e.g. `text/markdown`, `application/pdf`),
+   and optionally `checksum` / `size_bytes` for dedup and integrity checks. This mirrors
+   `knowledge_atoms.source_uri` / `source_type` exactly, without importing that table.
+
+3. **`entity_type` governed vocabulary (Modify, not Create).** Register a small subtype
+   token set for `document` in `khive-pack-kg`'s existing `EntityTypeRegistry` — the same
+   mechanism ADR-085 used for code declaration subtypes, and an explicit Modify per
+   `PI_AEP`, not a new pack:
+
+   ```text
+   entity_type ∈ {spec, note, summary, handoff, report, reference, adr, transcript, other}
+   ```
+
+   These map directly onto the existing `.khive/` workspace convention (root CLAUDE.md
+   Workspace Convention: `notes/summaries/`, `notes/handoffs/`, `reports/`, etc.), so
+   `entity_type` becomes a queryable filter (`entity_type="handoff"`) instead of a tag
+   convention only. This registration is optional at the KindHook-validation level — an
+   entity may omit `entity_type` — but recommended for anything created via the
+   workspace mirror (ADR-087).
+
+4. **Retention: soft-delete + `supersedes`, never mutate-in-place for a new version.**
+   A document that changes (a spec gets revised, a report gets a v2) is a NEW `document`
+   entity linked to the prior one via `supersedes` (document→document, already legal in
+   the ADR-002 base endpoint contract — no new relation). The old entity is never deleted,
+   overwritten, or content-transferred; view-layer queries filter superseded records
+   (root CLAUDE.md's `feedback-data-vs-view-not-mutation` principle, and khive's own
+   `docs/adr/README.md` "Data vs view" cross-cutting principle). Hard-delete stays
+   available via the existing `delete(id, hard=true)` curation verb for deliberate removal
+   only (ADR-014), never as part of normal versioning.
+
+5. **Decisions/annotations use existing note kinds.** A `decision` note (or `observation`,
+   `insight`, `question`, `reference`) `annotates` a `document` entity to record review
+   outcomes, corrections, or commentary. `annotates` is note→any-substrate-UUID and already
+   universally legal (ADR-002) — no new relation, matching the same pattern ADR-085 D4 used
+   for `finding`→`project`.
+
+6. **No new verb surface.** `create(kind="document", name=..., description=..., properties=
+   {...})`, `update`, `get`, `search(kind="document", query=...)`, `link` all already do the
+   job. There is no `doc.*` verb family in v1.
+
+## Rationale
+
+### Why not a new pack + content table
+
+The obvious alternative — a dedicated `khive-pack-doc` crate with its own content table,
+modeled on `knowledge_atoms` — was the original framing this ADR started from. It is
+strictly more machinery than the actual requirement needs: `Entity.description` is already
+unconstrained free text, already FTS5-indexed, already versionable via `supersedes`, and
+already annotatable via existing notes. `PI_AEP` (`FindExisting > Modify(≤5 files, ≤100
+LOC) > Create`) resolves cleanly to Modify — one `EntityTypeRegistry` addition — once the
+substrate is read carefully rather than assumed. A new pack crate would duplicate
+`fts_entities` coverage in a second FTS5 table for no query benefit, and would need its own
+`get`-path wiring to make content visible at all, which is exactly the new-verb-surface
+outcome this ADR avoids.
+
+### Why this does not collide with the knowledge pack
+
+`knowledge_atoms` serves a different consumer: curated, rerank-composed corpus content
+(`knowledge.compose`), sectioned, dispute/adjudication-tracked, with its own domain
+taxonomy. Document/file entities serve "this specific artifact is on record" — a
+project-history and provenance concern, not a composable-corpus concern. Nothing here
+proposes migrating knowledge atoms to entities, or vice versa; the two remain separate,
+matching the "Atoms canonical, not project inventory" standing distinction already in
+practice.
+
+### The blob-ready seam, deliberately not built
+
+`StorageCapability` (`crates/khive-storage/src/capability.rs`) is a closed 8-variant enum
+(`Sql, Notes, Entities, Graph, Events, Vectors, Sparse, Text`) with no blob/binary variant.
+There is currently no storage capability anywhere in khive for large binary content. This
+ADR does not add one. Binary or very large content stays out of `description` and is
+referenced only via `properties.source_uri` pointing at wherever the bytes actually live
+(local disk, the Global Asset Store on LaCie per the Resource & Scope Governance directive,
+or an eventual object store). If a real consumer needs inline binary storage, that is a
+`StorageCapability::Blob` v2 amendment with its own ADR — the same "defer until a real
+consumer needs it" discipline ADR-085's A7 alternative used for commit/PR entities.
+
+As a soft operational guideline (not a hard technical limit — SQLite TEXT columns have no
+practical size ceiling here): prefer inline `description` for content under roughly 200KB;
+larger text should live at `properties.source_uri` with an excerpt or summary inline, so
+that entity list/search responses stay a reasonable size. This is guidance for ingesters
+(notably ADR-087's workspace mirror), not a validated constraint.
+
+## Alternatives Considered
+
+**A1: New `khive-pack-doc` crate with a dedicated content table.** Rejected — see
+Rationale above. More machinery than the requirement needs; `description` already covers
+the v1 need with zero schema change.
+
+**A2: Store content in `properties.content` instead of `description`.** Rejected.
+`properties` values are `PropertyValue` (structured metadata), not indexed by
+`fts_entities`'s `body` column — using it for large text content would silently lose
+search coverage. `description` is the field the existing FTS5/hybrid-search machinery
+already treats as the entity's body text.
+
+**A3: A `doc.*` verb family (`doc.write`, `doc.read`) mirroring `knowledge.*`.** Rejected
+for v1. Generic `create`/`update`/`get` already suffice for a plain-text-in-`description`
+model; a bespoke verb family would only be justified once binary/blob content exists,
+which this ADR explicitly defers.
+
+## Consequences
+
+- Documents become queryable via the same `search`/`get`/`neighbors`/`traverse` verbs as
+  every other entity, with zero new indexing infrastructure.
+- Version history is a linked chain of `supersedes` edges, consistent with how `document`
+  already behaves per the base ADR-002 endpoint contract — no new consumer-side logic
+  needed to understand "this document has prior versions."
+- `entity_type` registration is a small, additive change to `khive-pack-kg`'s
+  `EntityTypeRegistry`, reviewed and shipped like any other subtype-token addition.
+- The workspace mirror (ADR-087) and the git-lifecycle pack (ADR-088) both build directly
+  on this ADR: ADR-087 populates `document` entities using exactly this shape; ADR-088
+  deliberately does NOT use this shape (commit/issue are note kinds, not `document`
+  entities) — see ADR-088 Rationale for why that's the better fit for that content class.
+
+## Open Questions
+
+1. Should very large inline `description` values (multi-MB text) get a soft warning or
+   rejection at the `KindHook` layer, or is the `properties.source_uri` guideline
+   sufficient as pure convention? Deferred to implementation experience — no consumer has
+   hit this yet.
+2. Is a `prepare_create` `KindHook` for `document` (validating `entity_type` against the
+   governed vocabulary, defaulting `source_type` if omitted) worth adding in v1, or should
+   the vocabulary be advisory-only until a real validation need appears? Recommend
+   advisory-only for v1, matching this ADR's minimal-machinery posture; add a hook only if
+   ingesters start writing invalid `entity_type` values in practice.
+
+## Implementation
+
+- `crates/khive-pack-kg/src/vocab.rs` (or wherever `EntityTypeRegistry` tokens are
+  declared): add the `document` subtype token set.
+- No migration required — `description` and `properties` already exist on every entity.
+- No new crate.
+
+## References
+
+- `crates/khive-types/src/entity.rs` — `Entity` struct (no content field; `description:
+  Option<String>`, `properties: BTreeMap<String, PropertyValue>`)
+- `crates/khive-db/sql/004-fts-consolidation.sql` — `fts_entities` (title/body FTS5,
+  trigram tokenizer)
+- `crates/khive-storage/src/capability.rs` — `StorageCapability` (8 variants, no blob)
+- `crates/khive-db/sql/schema.sql` — `knowledge_atoms` (contrast: separate pack-owned
+  table, not reused here)
+- ADR-085 §D4, §Rationale ("Why a new pack crate at all") — the `EntityTypeRegistry` Modify
+  precedent this ADR follows

--- a/docs/adr/ADR-086-doc-file-pack.md
+++ b/docs/adr/ADR-086-doc-file-pack.md
@@ -27,7 +27,9 @@ Two facts about the current substrate shape drive this ADR's design directly:
   Option<String>`, and `properties: BTreeMap<String, PropertyValue>` — no dedicated content
   field, but `description` is an unconstrained free-text field with no length limit at the
   SQLite layer.
-- `fts_entities` (`crates/khive-db/sql/004-fts-consolidation.sql`) already indexes a
+- `fts_entities` (`crates/khive-db/sql/004-fts-consolidation.sql`; at runtime each
+  namespace additionally owns a suffixed variant, `fts_entities_{ns}` — e.g.
+  `fts_entities_local` — per `crates/khive-runtime/src/retrieval.rs`) already indexes a
   `title`/`body` pair (name/description) via FTS5 trigram tokenization for every entity,
   regardless of kind. Any text placed in `description` is automatically part of the
   existing hybrid FTS5 + vector search fusion — no new indexing path required.
@@ -187,7 +189,7 @@ which this ADR explicitly defers.
 - `crates/khive-types/src/entity.rs` — `Entity` struct (no content field; `description:
   Option<String>`, `properties: BTreeMap<String, PropertyValue>`)
 - `crates/khive-db/sql/004-fts-consolidation.sql` — `fts_entities` (title/body FTS5,
-  trigram tokenizer)
+  trigram tokenizer; live databases also carry per-namespace `fts_entities_{ns}` variants)
 - `crates/khive-storage/src/capability.rs` — `StorageCapability` (8 variants, no blob)
 - `crates/khive-db/sql/schema.sql` — `knowledge_atoms` (contrast: separate pack-owned
   table, not reused here)

--- a/docs/adr/ADR-087-workspace-mirror.md
+++ b/docs/adr/ADR-087-workspace-mirror.md
@@ -1,0 +1,177 @@
+# ADR-087: Workspace Mirror — Folding `.khive/` Into the Graph Substrate
+
+**Status**: Proposed\
+**Date**: 2026-07-03\
+**Authors**: Ocean, lambda:khive\
+**Depends on**: ADR-086 (Document/File Modeling — the `document`-entity shape this mirror
+populates), ADR-080 (Session Pack — OSS Storage Mechanism, §6 session mirror — the
+operational pattern this ADR reuses), ADR-002 (Edge Ontology — `supersedes`), ADR-017
+(Pack Standard)\
+**Related**: ADR-010 (KG Versioning — NDJSON snapshot scope; explains why `.khive/kg/*`
+is excluded from this mirror's scope), ADR-021 (Memory Pack)
+
+## Context
+
+Ocean's request, verbatim intent: fold the `.khive/` filesystem convention (workspaces,
+notes, summaries, handoffs, reports, `codex_reviews/`) into khive itself, "on record and
+kept," explicitly drawing the analogy to `khive-pack-session`'s session mirror
+architecture. `.khive/` today is the root CLAUDE.md's documented Workspace Convention — a
+directory tree of markdown artifacts that exist only as files, invisible to
+`search`/`neighbors`/`traverse`.
+
+ADR-080 §6 already ships exactly this shape of thing once: a background poller that mirrors
+external content (ChatGPT export files, session JSONL transcripts) into khive on a
+warm()-spawned loop, with cursor-based idempotent progression and unconditional secret
+masking via `crates/khive-runtime/src/secret_gate.rs`'s `mask_secrets(text: &str) ->
+Cow<'_, str>` (the redact-in-place function, distinct from the hard-blocking `check(content:
+&str) -> RuntimeResult<()>` that verb-driven writes use — passive ingestion of pre-existing
+external content cannot reject a whole file over one matched line, so it must mask and
+continue, exactly as the session mirror already does).
+
+**The critical divergence this ADR must state explicitly.** The session mirror's actual
+shipped implementation writes into pack-`khive-pack-session`-private auxiliary tables,
+entirely outside the graph substrate (entities/notes/edges) — appropriate for session
+transcripts, which are recall-only raw material, not meant to be graph nodes. Ocean's ask
+for `.khive/` is different in kind: the content must be "on record" in the sense of
+graph-queryable (`search`, `neighbors`, `traverse`), linkable, and versioned via
+`supersedes` — not merely recallable. Copying the session mirror's storage target verbatim
+would satisfy the operational-pattern analogy Ocean drew but miss the actual requirement.
+This ADR reuses the OPERATIONAL PATTERN and deliberately changes the STORAGE TARGET.
+
+## Decision
+
+A background mirror service — architecturally identical to ADR-080 §6's session mirror —
+walks configured `.khive/` subpaths and, for each file, creates or updates a `document`
+entity per ADR-086's shape (`description`=file content, `properties`={`source_uri`,
+`source_type`, `checksum`}, `entity_type` set from the governed vocabulary where the path
+maps cleanly, e.g. `notes/handoffs/*` → `entity_type="handoff"`).
+
+1. **Reused operational pattern (from ADR-080 §6, unchanged):**
+   - `warm()`-spawned poller, config-driven interval (`KHIVE_MIRROR_WORKSPACE_POLL_SECS`,
+     validated nonzero per the PACKSESSION-AUD-002 fix precedent — reject or clamp zero,
+     do not repeat the hot-loop defect).
+   - Cursor-based idempotent progression via a small pack-owned tracking table (outside
+     the graph substrate — this is the one piece that stays auxiliary, since a cursor is
+     bookkeeping, not content): `workspace_mirror_cursor(path TEXT PRIMARY KEY, last_mtime
+     INTEGER, last_hash TEXT, last_synced_at INTEGER)`.
+   - Never advance the cursor on error — a failed mask/write/parse leaves the file to be
+     retried on the next pass, matching the session mirror's failure posture.
+   - One transaction per file pass (bounded work per commit, matching the PACKSESSION-
+     AUD-003 fix precedent for bounded resource use — this mirror processes whole files,
+     which are markdown/text and small by construction, so the unbounded-read concern
+     that applied to JSONL transcript deltas does not recur here, but the one-txn-per-item
+     discipline is kept regardless).
+   - Unconditional `secret_gate::mask_secrets` on every file's content before it is written
+     to `description` — never `check()`, since this is passive ingestion, not a rejectable
+     agent-authored write.
+
+2. **Diverged storage target (the actual change from ADR-080 §6):** content lands in the
+   PRIMARY graph substrate — real `document` entities, created/updated through the same
+   internal path an agent's `create`/`update` call would use — not a pack-private
+   auxiliary table. This is what makes the mirrored content genuinely queryable.
+
+3. **Retention follows ADR-086 exactly.** A file's content changing between polls produces
+   a NEW `document` entity version + a `supersedes` edge to the prior version (matched by
+   `properties.source_uri`, the stable identity key across versions) — never an
+   in-place content overwrite. This is Ocean's confirmed resolution: kept means
+   version-history-via-supersedes, not a single mutable row.
+
+4. **Scope: explicit include/exclude, not "everything under `.khive/`."** Config-driven
+   glob lists (`KHIVE_MIRROR_WORKSPACE_INCLUDE` / `_EXCLUDE`, matching the session mirror's
+   own env-var configuration convention), with a recommended default:
+   - **Include**: `.khive/notes/**`, `.khive/reports/**`, `.khive/codex_reviews/**` (local,
+     gitignored, but valuable review history worth having "on record" in the local graph —
+     mirroring is orthogonal to what gets committed to the public repo), workspace
+     `artifacts/`/completion-report markdown under `.khive/workspaces/*/`.
+   - **Exclude**: `.khive/kg/*.ndjson` and `schema.yaml` (already graph-versioned via
+     ADR-010's git-native snapshot mechanism — mirroring the graph's own export back into
+     itself would be circular), `.khive/scripts/` (executable code, not document content —
+     belongs in the `project`/code-pack world if modeled at all), any build-cache or
+     binary paths.
+
+5. **Explicit non-goals.**
+   - **Not a live sync.** Poll-based, bounded staleness is acceptable — matching the
+     session mirror's own tolerance.
+   - **Not write-through.** khive never writes back to `.khive/` files. One-directional:
+     disk → graph, always.
+   - **Not a git-history importer.** This mirror captures file content as it currently
+     exists on disk at poll time, not commit-by-commit file history — that concern, for
+     actual git commits, is ADR-088's job.
+
+## Rationale
+
+### Why reuse the session mirror's pattern instead of designing a new one
+
+The operational hard parts of any filesystem-to-graph mirror are the same regardless of
+target: safe polling intervals, idempotent resumption after a crash, and secret handling
+on untrusted pre-existing content. ADR-080 §6 already solved these, including two
+production-audit-confirmed defect classes (hot-loop on a misconfigured poll interval;
+unbounded in-memory reads on large deltas) that a from-scratch design would be at real risk
+of reintroducing. Reusing the pattern is a direct `PI_AEP` Modify-over-Create call:
+the poller shape, cursor discipline, and secret-masking call are copied; only the
+write target changes.
+
+### Why the write target must not also be copied
+
+Session transcripts are recall-only by design (ADR-080's own scope statement: the
+mirror stores raw material for `session.recall`, not curated graph content). `.khive/`
+notes, handoffs, and reports are exactly the kind of content Ocean's directive says
+should be linkable and traversable — decisions annotate documents, documents get
+superseded, agents `neighbors()` out from a report to the project it concerns. None of
+that is possible if the content sits in a pack-private table the graph substrate doesn't
+see. The requirement, not just the analogy, decides the storage target.
+
+## Alternatives Considered
+
+**A1: Copy the session mirror's auxiliary-table storage verbatim ("similar architecture"
+taken literally).** Rejected. Satisfies the literal analogy Ocean drew but not the
+"on record, kept, queryable" requirement — the whole point of folding `.khive/` in.
+
+**A2: A new dedicated pack crate for the mirror.** Rejected. The mirror is a service that
+calls ADR-086's existing `document`-entity write path; it needs no verbs, no new entity or
+note kinds, and no edge rules of its own. A thin mirror module (mirroring
+`khive-pack-session/src/mirror/`'s module shape) inside `khive-mcp`'s daemon warm() path,
+or a small submodule of whichever crate owns the `document` pattern, is sufficient —
+consistent with ADR-086 itself introducing no new pack.
+
+**A3: Mirror everything under `.khive/` unconditionally, no include/exclude config.**
+Rejected. `.khive/kg/*.ndjson` mirrored back into the graph it was exported from is
+circular and wasteful; build/scratch paths add noise with no query value. Explicit scope
+config, defaulting to the high-value subpaths, avoids both.
+
+## Consequences
+
+- `.khive/notes/`, `.khive/reports/`, and `.khive/codex_reviews/` content becomes
+  queryable, linkable, and versioned the same way any agent-authored document would be.
+- The mirror inherits ADR-080 §6's operational risk profile (a misconfigured poll interval
+  or an unbounded read) but also inherits its already-fixed defenses — no new defect class
+  is introduced by construction.
+- A future consumer wanting to browse "every handoff note for project X" gets it via
+  ordinary `search(kind="document", query=...)` / `traverse` — no new query mechanism.
+
+## Open Questions
+
+1. Exact default include/exclude glob list — proposed above as a starting point, but
+   should be validated against real `.khive/` directory contents before the mirror ships,
+   not fixed permanently in this ADR text.
+2. Should `codex_reviews/` mirroring be gated behind a separate opt-in flag, given it's
+   explicitly local-only/gitignored content, distinct in sensitivity from notes/reports?
+   Recommend: mirror it (it's local-graph-only too, not re-exported anywhere), but keep it
+   toggleable via the same include/exclude config.
+
+## Implementation
+
+- New `mirror` submodule (module shape mirrors `khive-pack-session/src/mirror/`), wired
+  into the same `warm()` daemon startup path as the session mirror.
+- New pack-owned `workspace_mirror_cursor` table (migration under
+  `crates/khive-db/sql/`), outside the entity/note/edge substrate.
+- No new pack crate; no new verbs.
+
+## References
+
+- ADR-080 §6 — session mirror operational pattern (poller, cursor, secret masking)
+- `crates/khive-runtime/src/secret_gate.rs` — `mask_secrets` vs `check`/`check_json`
+- ADR-086 — `document`-entity shape this mirror populates
+- ADR-010 — NDJSON snapshot scope (why `.khive/kg/*` is excluded)
+- `docs/adr/feedback-data-vs-view-not-mutation` principle (khive `docs/adr/README.md`
+  "Data vs view" cross-cutting principle) — governs the supersedes-not-overwrite behavior

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -1,0 +1,218 @@
+# ADR-088: Git-Lifecycle Pack — Commit and Issue Note Kinds
+
+**Status**: Proposed\
+**Date**: 2026-07-03\
+**Authors**: Ocean, lambda:khive\
+**Depends on**: ADR-001 (Entity Kind Taxonomy — `project` as the repo anchor), ADR-002
+(Edge Ontology — `annotates`), ADR-013 (Note Kind Taxonomy — pack-declared note kinds),
+ADR-017 (Pack Standard — `NOTE_KINDS`, `NoteKindSpec`, `KindHook`), ADR-085 (Code Pack —
+`finding` note kind and its Alternative A7, directly reconciled below)\
+**Related**: ADR-010 (KG Versioning — "khive does not build a GitHub replacement"),
+ADR-087 (Workspace Mirror — sibling background-ingestion pattern this pack's ingester
+reuses)
+
+## Context
+
+Ocean's direct correction (relayed via lambda:leo, superseding an earlier
+properties-only framing this workstream had proposed): commits and issues should be
+first-class, pack-registered **note kinds** — not entity subtypes, not bare properties on
+another record — carrying canonical edge relations to code-pack `finding` notes and to
+`project` entities. Population is via a background git-ingester modeled on the mirror
+pattern already established (ADR-080 §6, ADR-087), not through new agent-facing verbs.
+
+This directly engages ADR-085's own Alternative A7, decided one day earlier in this same
+repository:
+
+> **A7: Commit/PR provenance entities in v1.** Deferred. Entity-per-commit is graph bloat
+> at exactly the granularity the D6.1 fence exists to prevent; findings carry `refs`
+> (pr/commit/issue) as properties, which serves the audit lane's resolution-tracking need.
+> If a real consumer needs commit-graph traversal, that is a v2 amendment with `artifact`
+> subtypes and `introduced_by`/`derived_from` rules.
+
+A7 correctly anticipated that commit/PR provenance would eventually need first-class
+representation once a real consumer needed commit-graph traversal — and correctly rejected
+entity-per-commit as bloat at the D6.1 granularity fence. It also **guessed a specific
+shape** for that eventual v2 amendment: `artifact` entity subtypes linked via
+`introduced_by`/`derived_from`. Ocean's actual resolution takes a different shape: note
+kinds, linked via `annotates`. This ADR is that v2 amendment, and it explains, not just
+asserts, why the note-kind shape is the better fit than the artifact-entity shape A7
+guessed at.
+
+## Decision
+
+New pack crate `khive-pack-git`, `REQUIRES = ["kg"]`, following `khive-pack-formal`'s and
+`khive-pack-code`'s established shape (`crates/khive-pack-formal/src/pack.rs`,
+`crates/khive-pack-code`).
+
+1. **`NOTE_KINDS = ["commit", "issue"]`.** Both reuse the Note substrate's existing
+   `content: String` field for body text — `commit.content` = the commit message,
+   `issue.content` = the issue body — no new content table, unlike ADR-086's `document`
+   entities, which needed a usage convention over `description` precisely because `Entity`
+   has no content field. Notes already carry one; this is a structural argument for the
+   note-kind choice, not just a naming one.
+
+2. **`commit` properties** (validated by a `prepare_create` `KindHook`, same mechanism as
+   `finding`'s): `sha` (required, full 40-char, the natural identity key), `short_sha`,
+   `author`, `author_email` (plain — email addresses are PII, not secrets, per the root
+   CLAUDE.md's "Scope = secrets only, not general PII" rule; no masking required),
+   `committed_at`, `parents` (array of parent SHA strings — a plain property, not a graph
+   edge; see Alternatives A2 for why commit-to-commit lineage is deliberately not an edge
+   in v1). No lifecycle — commits are immutable once created, so `commit` carries no
+   `kind_status`.
+
+3. **`issue` properties**: `number`, `title`, `author`, `created_at`, `closed_at`
+   (optional), `labels` (array), `state_reason` (optional: `completed` / `not_planned`).
+   `NoteKindSpec` lifecycle (declared now, enforced when the generic Phase-2 lifecycle
+   layer lands — same posture as `finding`'s): `kind_status`, initial `open`, terminal
+   `closed`. `pull_request` is explicitly NOT in v1 — see Open Questions.
+
+4. **Edges: `annotates` only, no new relation.** `commit` and `issue` notes `annotates`
+   (note → any-substrate-UUID, already universally legal per ADR-002 and already the
+   mechanism `finding` uses for its own `project`/decision links) the `project` entity that
+   is the repo anchor, and, where applicable, a code-pack `finding` note the commit fixes
+   or the issue tracks. This directly answers the delegated question of whether a new edge
+   relation is warranted: **it is not.** `annotates` already covers note→entity and
+   note→note in exactly the shape needed.
+
+5. **Population: background git-ingester, same operational pattern as ADR-087.**
+   Cursor-based (per-repo, per-kind: last-ingested commit SHA per branch; last-synced
+   issue `updated_at` per repo), reading local `.git` history and, for issues, whatever
+   GitHub API access the fleet already uses (`gh` / the GitHub App per the standing
+   `project_leo_github_app` context) — not a live poll of the GitHub API on a tight
+   interval, and not a new API client. Unconditional `secret_gate::mask_secrets` on commit
+   messages and issue bodies before write (external, less-trusted content, same posture as
+   ADR-087's file mirroring). No new agent-facing verbs — `create`/`update`/`get`/`search`
+   already suffice for anything an agent needs to do with a `commit`/`issue` note once it
+   exists.
+
+6. **Explicit non-goals**, matching Ocean's own framing and ADR-010's established
+   principle:
+   - **Not a GitHub API mirror or replacement.** ADR-010: "khive does not build a GitHub
+     replacement... add semantic enrichment instead." This pack structures git/GitHub
+     lifecycle events the fleet already cares about; it does not attempt to reproduce
+     GitHub's UI, review threads, or CI state.
+   - **Not first-class git entities.** Commits/issues are notes, per Decision §1 — deliberately
+     lighter-weight than entities, matching their high-cardinality, event-like nature.
+   - **No commit-to-commit lineage edges in v1** — see Alternatives A2.
+   - **No write-back.** khive never pushes commits, comments, or state changes to GitHub;
+     one-directional, git/GitHub → graph only.
+
+## Rationale
+
+### Why note kinds, not artifact-entity subtypes (the A7 divergence, explained)
+
+A7 assumed the eventual v2 amendment would take the shape of every other "first-class
+provenance record" this codebase has modeled so far: an entity subtype with typed edges
+(`artifact` + `introduced_by`/`derived_from`), because that is the pattern ADR-069 and
+ADR-085 both used for code declarations and papers. But entities are for curated, named,
+referenceable concepts — the D6.1 granularity fence A7 itself invoked exists precisely to
+keep the shared production graph from being overrun by high-cardinality, non-curated
+records. Commits arrive in the thousands per active repo; issues, in the hundreds. That
+cardinality and event-like character is exactly the profile khive already reserves for
+**notes**, not entities — `task`, `memory`, and `finding` are all note kinds for the same
+reason: numerous, time-bound, evidence-bearing records that reference curated entities
+rather than being curated entities themselves. Modeling `commit`/`issue` as note kinds is
+more consistent with khive's own existing note-vs-entity split than A7's tentative
+artifact-subtype guess would have been — it satisfies the granularity fence more
+conservatively, not less.
+
+### Why `annotates` and not a new relation
+
+The 17-relation edge ontology (ADR-002, extended by ADR-055) is closed by design; adding a
+relation requires demonstrating that no existing relation fits. `annotates` was designed
+for exactly this shape — a note commenting on, or providing evidence about, an entity or
+another note — and `finding` already uses it for the identical purpose (annotating
+`project` and other notes). A commit fixing a finding, or an issue tracking one, is not
+semantically different from a finding annotating the project it concerns; it is the same
+relation with a different note kind on the source side. No new relation clears the bar.
+
+### Reconciling with `finding.refs.*` — the two mechanisms coexist
+
+ADR-085 D4's `finding` properties contract already includes `refs` (`github_issue`, `pr`,
+`commit` as plain string references) explicitly for the audit lane's lightweight
+resolution-tracking need — "this finding was fixed by commit abc123" without requiring the
+commit to be a graph citizen. This ADR does not remove or change that. `finding.refs.commit`
+remains valid for the case where a single finding needs to point at a SHA and nothing more.
+The new `commit`/`issue` note kinds are for the different, additional case Ocean has now
+supplied a real consumer for: when the commit or issue itself needs identity, and needs to
+be a target other records can `annotates` or be `annotates`-ed by. Both can point at the
+same SHA without conflict — a `finding.refs.commit` string and a `commit` note's `sha`
+property are simply two independent references to the same real-world commit; nothing
+forces them to be reconciled, though a future enrichment pass could optionally resolve
+`finding.refs.commit` into an `annotates` edge to the matching `commit` note once one
+exists. That resolution step is optional polish, not required by this ADR, and needs no
+ADR-085 amendment.
+
+## Alternatives Considered
+
+**A1: Model commits/issues as `artifact` entity subtypes with `introduced_by`/
+`derived_from` (A7's literal suggestion).** Rejected — see Rationale. Wrong cardinality
+profile for the entity substrate; the note substrate already exists for exactly this shape
+of record and gets body-text storage for free.
+
+**A2: Commit-to-commit lineage as a note→note edge (extending `precedes` or a new
+relation) instead of a plain `parents` property.** Rejected for v1. Only two target
+relations were named in the governing directive — commit/issue → `finding`, and → `project`
+— not commit-to-commit history traversal. Adding a third edge use beyond what was actually
+asked is scope creep; `parents` as a plain SHA-array property serves any consumer that
+needs to walk lineage today (resolve via a follow-up `get`/`search` by SHA). If a real
+consumer needs graph-native commit-history traversal, that is its own future amendment —
+the same "defer until needed" discipline A7 itself used.
+
+**A3: `finding.refs.*` alone, no new note kinds — reject Ocean's correction and keep
+ADR-085's v1 scope as final.** Rejected. This is precisely the resolution Ocean's direct
+correction superseded; `refs` properties do not give a commit/issue independent identity,
+annotatability, or traversal, which is the explicit ask.
+
+**A4: Include `pull_request` as a third note kind in v1** (a PR is structurally
+issue-like — `merged_at`, `base`, `head` — plus everything `issue` has). Deferred, not
+rejected — see Open Questions.
+
+## Consequences
+
+- Commit/issue history relevant to the fleet's own work (fixes, tracked audit findings)
+  becomes queryable and linkable, closing the exact gap A7 flagged as a future amendment
+  trigger.
+- The audit pipeline's existing `finding.refs.*` properties are unaffected — no migration,
+  no ADR-085 amendment.
+- `khive-pack-git` is a genuinely new, small pack crate (two note kinds, one `KindHook`,
+  zero new edge rules beyond what `annotates` already licenses) — low ongoing maintenance
+  surface, matching `khive-pack-formal`'s demonstrated cost profile.
+- The ingester reuses ADR-087's operational pattern rather than inventing a third mirror
+  design in as many ADRs.
+
+## Open Questions
+
+1. **`pull_request` note kind** — same shape as `issue` plus `merged_at`/`base`/`head`.
+   Not requested explicitly in the governing directive; recommend deferring to a
+   follow-up, severable addition once `commit`/`issue` are shipped and a real PR-tracking
+   consumer exists, mirroring ADR-085's own "severable" discipline for `finding`.
+2. **Per-repo cursor granularity** — commit ingestion cursors naturally key off branch tip
+   SHAs; issue ingestion cursors key off `updated_at`. Exact schema for the shared cursor
+   table is an implementation detail, not fixed here.
+3. **GitHub API access path for issues** — whether the ingester uses `gh` CLI, the
+   `khive-leo[bot]` GitHub App, or direct REST calls is an implementation choice deferred
+   to whoever builds the ingester; this ADR only requires that it not become a live,
+   tight-interval GitHub API poller (rate-limit and "GitHub replacement" concerns both
+   argue for batch/cursor-based sync, matching ADR-087's own poll cadence discipline).
+
+## Implementation
+
+- New crate `crates/khive-pack-git`, `NAME = "git"`, `REQUIRES = ["kg"]`.
+- `NOTE_KINDS = ["commit", "issue"]`, `NoteKindSpec` lifecycle for `issue` only.
+- One `prepare_create` `KindHook` validating `commit.sha` shape and `issue.state_reason`
+  against a governed value set (fail-closed, no silent coercion — matching `finding`'s
+  hook precedent).
+- Ingester submodule reusing ADR-087's cursor/secret-masking pattern; a shared
+  `git_mirror_cursor(project_id, kind, cursor_value, updated_at)` table.
+- No new edge relations; no new top-level verbs.
+
+## References
+
+- ADR-085 §D4, §Alternatives (A7) — the deferred commit/PR provenance question this ADR
+  resolves, and the shape divergence from A7's own guess
+- ADR-002 — `annotates` (note → any substrate UUID, source always a note)
+- ADR-010 — "khive does not build a GitHub replacement"
+- ADR-087 — background ingestion operational pattern reused here
+- `crates/khive-types/src/note.rs` — `Note.content: String` (free body-text storage this
+  ADR relies on)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,6 +111,9 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-083](ADR-083-session-pack-t1-verbs.md)                  | Session Pack T1 Verb Surface (Accepted)                                                                         |
 | [ADR-084](ADR-084-verb-surface-consistency.md)               | Verb-Surface Consistency Contract and Live Ontology Introspection (Proposed)                                    |
 | [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary (Proposed)                                        |
+| [ADR-086](ADR-086-doc-file-pack.md)                          | Document/File Modeling — Content on the Existing `document` Entity Kind (Proposed)                              |
+| [ADR-087](ADR-087-workspace-mirror.md)                       | Workspace Mirror — Folding `.khive/` Into the Graph Substrate (Proposed)                                        |
+| [ADR-088](ADR-088-git-lifecycle-pack.md)                     | Git-Lifecycle Pack — Commit and Issue Note Kinds (Proposed)                                                     |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Three related ADRs, routed through maintainer review per project convention, drafted to fold `.khive/` content and document/file artifacts into the graph, plus a git commit/issue lifecycle pack. This is docs-only — no implementation in this PR.

- **ADR-086 (Doc/File Modeling)**: documents modeled as existing `document`-kind entities (`description`=content, `properties`=source metadata). No new pack, table, or verb surface — `Entity.description` is already unconstrained free text and already covered by `fts_entities`' FTS5 indexing. Retention via soft-delete + `supersedes` (confirmed: kept = version-history-via-supersedes).
- **ADR-087 (Workspace Mirror)**: background mirror folding `.khive/` into ADR-086's document shape. Reuses ADR-080 §6's session-mirror operational pattern (poller, cursor, `secret_gate::mask_secrets`) but — the key divergence from that template — writes into the **primary graph substrate**, not a pack-private auxiliary table, since the requirement is queryability (`search`/`neighbors`/`traverse`), not just recall.
- **ADR-088 (Git-Lifecycle Pack)**: new `khive-pack-git` crate registering `commit`/`issue` as **note kinds** (a correction superseding an earlier properties-only framing this workstream had proposed), linked via existing `annotates` edges to `project` entities and code-pack `finding` notes — no new edge relation. Explicitly reconciles with ADR-085's Alternative A7 (deferred commit/PR provenance): A7 anticipated the need but guessed `artifact` entity subtypes; this ADR explains why note kinds fit the cardinality/event-like profile better, and confirms `finding.refs.*` properties remain valid and unaffected.

All three were drafted after direct verification against current source (not assumption): `Entity`/`Note` struct shapes in `crates/khive-types`, `fts_entities`' FTS5 coverage, `StorageCapability`'s 8 variants (no blob), `secret_gate`'s `check()` vs `mask_secrets()` split, and ADR-085's exact A7 text — cited verbatim in ADR-088.

## Test plan
- [ ] maintainer review (routed on PR open per standing convention)
- [ ] additional review pass (docs-only PR; still routed through the standard gate)
- [ ] `docs/adr/README.md` index renders correctly (added 3 rows under "New v1 Surfaces")
- [ ] No implementation follows until review lands