### PR TITLE
fix(fold,bm25,brain-core): ranking precision, snapshot validation, ordered restore (#446 #447 #450 #478)

### DIFF
--- a/crates/khive-bm25/src/index/core.rs
+++ b/crates/khive-bm25/src/index/core.rs
@@ -201,17 +201,83 @@ impl<'de> serde::Deserialize<'de> for Bm25Index {
             .validate()
             .map_err(|e| D::Error::custom(format!("invalid config: {e}")))?;
 
-        // Validate: PostingList doc_ids must reference valid internal IDs.
-        // Each doc_id in a posting list must exist in doc_lengths.
+        // Validate: every live doc_id (a doc_lengths key) must be in range and have a
+        // consistent internal_to_id / id_to_internal mapping; accumulate a checked sum
+        // of doc_lengths so total_tokens can be cross-checked below.
+        let mut checked_total: usize = 0;
+        for (&internal_id, &len) in &wire.doc_lengths {
+            if internal_id == u32::MAX || internal_id >= wire.next_internal_id {
+                return Err(D::Error::custom(format!(
+                    "doc_lengths contains invalid live doc_id {internal_id} (next_internal_id={})",
+                    wire.next_internal_id
+                )));
+            }
+            let external = wire
+                .internal_to_id
+                .get(internal_id as usize)
+                .ok_or_else(|| {
+                    D::Error::custom(format!(
+                        "missing internal_to_id entry for live doc_id {internal_id}"
+                    ))
+                })?;
+            match wire.id_to_internal.get(external.as_ref() as &str) {
+                Some(&mapped) if mapped == internal_id => {}
+                _ => {
+                    return Err(D::Error::custom(format!(
+                        "id_to_internal does not map '{external}' back to live doc_id {internal_id}"
+                    )));
+                }
+            }
+            checked_total = checked_total.checked_add(len).ok_or_else(|| {
+                D::Error::custom("total_tokens overflow while summing doc_lengths")
+            })?;
+        }
+
+        // Validate: every id_to_internal entry must point at a live, in-range doc that
+        // reverse-maps back through internal_to_id to the same external ID.
+        for (external_id, &internal_id) in &wire.id_to_internal {
+            if internal_id == u32::MAX
+                || internal_id >= wire.next_internal_id
+                || !wire.doc_lengths.contains_key(&internal_id)
+            {
+                return Err(D::Error::custom(format!(
+                    "id_to_internal maps '{external_id}' to non-live doc_id {internal_id}"
+                )));
+            }
+            let reverse = wire
+                .internal_to_id
+                .get(internal_id as usize)
+                .ok_or_else(|| {
+                    D::Error::custom(format!("missing internal_to_id entry for '{external_id}'"))
+                })?;
+            if reverse.as_ref() != external_id.as_str() {
+                return Err(D::Error::custom(format!(
+                    "internal_to_id[{internal_id}] does not reverse-map to '{external_id}'"
+                )));
+            }
+        }
+
+        // Validate: PostingList doc_ids must reference only live, in-range doc IDs.
         for (term, postings) in &wire.inverted_index {
             for &doc_id in &postings.doc_ids {
-                if !wire.doc_lengths.contains_key(&doc_id) {
+                if doc_id == u32::MAX
+                    || doc_id >= wire.next_internal_id
+                    || !wire.doc_lengths.contains_key(&doc_id)
+                {
                     return Err(D::Error::custom(format!(
-                        "PostingList for term '{}' references doc_id {} not in doc_lengths",
+                        "PostingList for term '{}' references non-live doc_id {}",
                         term, doc_id
                     )));
                 }
             }
+        }
+
+        // Validate: total_tokens must equal the checked sum of doc_lengths.
+        if wire.total_tokens != checked_total {
+            return Err(D::Error::custom(format!(
+                "total_tokens {} does not match doc_lengths sum {}",
+                wire.total_tokens, checked_total
+            )));
         }
 
         // Build the derived caches from the persisted data.
@@ -853,6 +919,119 @@ mod regression_tests {
             results.len(),
             4,
             "all documents must be found in clone after block_max_state lock was poisoned"
+        );
+    }
+
+    /// A schema-valid single-live-doc wire snapshot: doc "doc0" -> internal id 0,
+    /// one posting for term "alpha". Tests corrupt one field at a time from this base.
+    fn valid_single_doc_json() -> serde_json::Value {
+        serde_json::json!({
+            "inverted_index": {
+                "alpha": { "doc_ids": [0], "term_freqs": [1] }
+            },
+            "doc_lengths": { "0": 1 },
+            "id_to_internal": { "doc0": 0 },
+            "internal_to_id": ["doc0"],
+            "next_internal_id": 1,
+            "total_tokens": 1,
+            "postings_epoch": 0,
+            "block_size": 128,
+            "config": { "k1": 1.2, "b": 0.75, "memory_budget": null }
+        })
+    }
+
+    #[test]
+    fn deserialize_rejects_doc_length_id_at_u32_max() {
+        let json = serde_json::json!({
+            "inverted_index": {},
+            "doc_lengths": { "4294967295": 1 },
+            "id_to_internal": {},
+            "internal_to_id": [],
+            "next_internal_id": 0,
+            "total_tokens": 1,
+            "postings_epoch": 0,
+            "block_size": 128,
+            "config": { "k1": 1.2, "b": 0.75, "memory_budget": null }
+        });
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid live doc_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_live_doc_id_at_or_above_next_internal_id() {
+        let mut json = valid_single_doc_json();
+        // doc_lengths key 0 is fine, but shift next_internal_id below it.
+        json["next_internal_id"] = serde_json::json!(0);
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid live doc_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_posting_id_at_or_above_next_internal_id() {
+        let mut json = valid_single_doc_json();
+        json["doc_lengths"] = serde_json::json!({ "0": 1, "5": 1 });
+        json["inverted_index"] = serde_json::json!({
+            "alpha": { "doc_ids": [0, 5], "term_freqs": [1, 1] }
+        });
+        json["total_tokens"] = serde_json::json!(2);
+        // next_internal_id stays 1, so doc_id 5 is out of range for both doc_lengths and postings.
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid live doc_id")
+                || err.to_string().contains("non-live doc_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_missing_internal_to_id_for_live_doc() {
+        let mut json = valid_single_doc_json();
+        json["internal_to_id"] = serde_json::json!([]);
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("missing internal_to_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_mismatched_internal_to_id_reverse_mapping() {
+        let mut json = valid_single_doc_json();
+        json["internal_to_id"] = serde_json::json!(["wrong"]);
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("does not map")
+                || err.to_string().contains("does not reverse-map"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_stale_id_to_internal_value() {
+        let mut json = valid_single_doc_json();
+        // "stale" points at internal id 7, which is neither live nor in range.
+        json["id_to_internal"] = serde_json::json!({ "doc0": 0, "stale": 7 });
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("non-live doc_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_bad_total_tokens() {
+        let mut json = valid_single_doc_json();
+        json["total_tokens"] = serde_json::json!(4);
+        let err = serde_json::from_value::<Bm25Index>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match doc_lengths sum"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -303,6 +303,17 @@ pub fn validate_brain_state_snapshot(snapshot: &BrainStateSnapshot) -> Result<()
 /// ids absent from `entity_posteriors`. This is the capacity-aware
 /// counterpart used at the persistence load boundary, so a crafted or legacy
 /// oversized snapshot is rejected outright rather than silently truncated.
+///
+/// `entity_posteriors_version` gates how strictly `entity_posterior_order` is
+/// checked:
+/// - version `0` (legacy, pre-ordering snapshots) — order is expected empty;
+///   restore falls back to the deterministic ascending-`Uuid` compatibility
+///   path in [`crate::posterior::EntityPosteriors::from_snapshot`].
+/// - version `1` (current) — order MUST cover every `entity_posteriors` key
+///   exactly (same length, no duplicates, no unknown ids). A partial order on
+///   a current-format snapshot is corruption, not a compatibility case, and is
+///   rejected here rather than silently normalized at restore.
+/// - any other version — rejected outright as unknown.
 pub fn validate_brain_state_snapshot_with_capacity(
     snapshot: &BrainStateSnapshot,
     entity_capacity: usize,
@@ -320,6 +331,14 @@ pub fn validate_brain_state_snapshot_with_capacity(
                 br.entity_posteriors.len()
             ));
         }
+
+        if br.entity_posteriors_version > 1 {
+            return Err(format!(
+                "{label}.entity_posteriors_version: unknown version {}",
+                br.entity_posteriors_version
+            ));
+        }
+
         if !br.entity_posterior_order.is_empty() {
             let mut seen =
                 std::collections::HashSet::with_capacity(br.entity_posterior_order.len());
@@ -334,6 +353,23 @@ pub fn validate_brain_state_snapshot_with_capacity(
                 }
             }
         }
+
+        // Non-legacy (version >= 1) snapshots must have an order entry for
+        // every entity_posteriors key. Combined with the duplicate/unknown-id
+        // checks above (which already guarantee every order id is a distinct,
+        // valid map key), an equal length here proves the id sets are
+        // identical — no entity_posteriors key is missing from the order.
+        if br.entity_posteriors_version >= 1
+            && br.entity_posterior_order.len() != br.entity_posteriors.len()
+        {
+            return Err(format!(
+                "{label}.entity_posterior_order: length {} does not cover all {} entity_posteriors entries (version {} requires full order coverage)",
+                br.entity_posterior_order.len(),
+                br.entity_posteriors.len(),
+                br.entity_posteriors_version,
+            ));
+        }
+
         Ok(())
     }
 
@@ -592,6 +628,171 @@ mod tests {
         assert!(
             result.is_err(),
             "profile_states entry with entity_posteriors.len() > capacity must be rejected"
+        );
+    }
+
+    // ── entity_posterior_order strict coverage (PR #535 codex round-1) ────────
+
+    /// Build a fresh version-1 `BalancedRecallSnapshot` with `n` entity
+    /// posteriors and a fully-covering order, for mutation in the tests below.
+    fn make_versioned_recall_snapshot(capacity: usize, n: usize) -> BalancedRecallSnapshot {
+        let mut state = BalancedRecallState::new(capacity);
+        for _ in 0..n {
+            state.entity_posteriors.get_or_insert(
+                uuid::Uuid::new_v4(),
+                crate::posterior::BetaPosterior::default,
+            );
+        }
+        state.to_snapshot()
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_missing_order_ids() {
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
+        assert_eq!(snapshot.entity_posteriors_version, 1);
+        assert_eq!(snapshot.entity_posterior_order.len(), 2);
+
+        // Drop one id from the order — partial coverage on a current-format
+        // (version 1) snapshot must be rejected, not silently normalized.
+        snapshot.entity_posterior_order.truncate(1);
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "version-1 snapshot with order shorter than entity_posteriors must be rejected"
+        );
+        assert!(
+            result.unwrap_err().contains("does not cover all"),
+            "error must name the missing-coverage reason"
+        );
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_duplicate_order_ids() {
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
+        let dup = snapshot.entity_posterior_order[0];
+        snapshot.entity_posterior_order[1] = dup;
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "duplicate entity_posterior_order ids must be rejected"
+        );
+        assert!(result.unwrap_err().contains("duplicate id"));
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_unknown_order_ids() {
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
+        snapshot.entity_posterior_order.push(uuid::Uuid::new_v4());
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "entity_posterior_order id absent from entity_posteriors must be rejected"
+        );
+        assert!(result
+            .unwrap_err()
+            .contains("not present in entity_posteriors"));
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_unknown_version() {
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 1);
+        snapshot.entity_posteriors_version = 2;
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "unknown entity_posteriors_version must be rejected"
+        );
+        assert!(result.unwrap_err().contains("unknown version"));
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_accepts_legacy_empty_order() {
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
+        // Explicitly-legacy version 0 with no order metadata must still pass —
+        // restore falls back to the deterministic ascending-Uuid path.
+        snapshot.entity_posteriors_version = 0;
+        snapshot.entity_posterior_order.clear();
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_ok(),
+            "legacy version-0 snapshot with empty order must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_accepts_full_order_current_version() {
+        let capacity = 4;
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = make_versioned_recall_snapshot(capacity, 3);
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_ok(),
+            "version-1 snapshot with a fully-covering order must be accepted: {result:?}"
+        );
+    }
+
+    /// A validated snapshot must restore→re-snapshot→restore to the same
+    /// state — the validation gate must not itself introduce drift, and a
+    /// snapshot that passes validation once must keep passing after a
+    /// round-trip through `BrainState`.
+    #[test]
+    fn restore_to_snapshot_restore_idempotency() {
+        let capacity = 4;
+        let mut state = BrainState::new(capacity);
+        for _ in 0..3 {
+            state.balanced_recall.entity_posteriors.get_or_insert(
+                uuid::Uuid::new_v4(),
+                crate::posterior::BetaPosterior::default,
+            );
+        }
+
+        let snapshot_1 = state.to_snapshot();
+        validate_brain_state_snapshot_with_capacity(&snapshot_1, capacity)
+            .expect("first snapshot must validate");
+
+        let restored_1 = BrainState::from_snapshot(snapshot_1, capacity);
+        let snapshot_2 = restored_1.to_snapshot();
+        validate_brain_state_snapshot_with_capacity(&snapshot_2, capacity)
+            .expect("round-tripped snapshot must still validate");
+
+        let restored_2 = BrainState::from_snapshot(snapshot_2.clone(), capacity);
+        let snapshot_3 = restored_2.to_snapshot();
+
+        assert_eq!(
+            snapshot_2.balanced_recall.entity_posteriors,
+            snapshot_3.balanced_recall.entity_posteriors,
+            "entity_posteriors must be stable across a second restore/snapshot cycle"
+        );
+        assert_eq!(
+            snapshot_2.balanced_recall.entity_posterior_order,
+            snapshot_3.balanced_recall.entity_posterior_order,
+            "entity_posterior_order must be stable across a second restore/snapshot cycle"
         );
     }
 }

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -306,9 +306,12 @@ pub fn validate_brain_state_snapshot(snapshot: &BrainStateSnapshot) -> Result<()
 ///
 /// `entity_posteriors_version` gates how strictly `entity_posterior_order` is
 /// checked:
-/// - version `0` (legacy, pre-ordering snapshots) — order is expected empty;
+/// - version `0` (legacy, pre-ordering snapshots) — order MUST be empty;
 ///   restore falls back to the deterministic ascending-`Uuid` compatibility
-///   path in [`crate::posterior::EntityPosteriors::from_snapshot`].
+///   path in [`crate::posterior::EntityPosteriors::from_snapshot`]. A
+///   version-0 snapshot with a non-empty order is not legacy compatibility
+///   data — it is partial order metadata that `serde(default)` let through
+///   (an omitted or explicit-zero version field) and is rejected here.
 /// - version `1` (current) — order MUST cover every `entity_posteriors` key
 ///   exactly (same length, no duplicates, no unknown ids). A partial order on
 ///   a current-format snapshot is corruption, not a compatibility case, and is
@@ -352,6 +355,22 @@ pub fn validate_brain_state_snapshot_with_capacity(
                     ));
                 }
             }
+        }
+
+        // Version 0 is the legacy, pre-ordering compatibility case and is
+        // only valid with an EMPTY order — restore falls back to the
+        // deterministic ascending-`Uuid` order in that case. A version-0
+        // snapshot with a non-empty (necessarily partial, since full coverage
+        // is only ever written under version 1) order is not legacy
+        // compatibility data; it is corruption that `serde(default)` would
+        // otherwise let through unnoticed (a snapshot with an omitted or
+        // explicit-zero version field), and restore would silently normalize
+        // it by appending the missing keys (posterior.rs `from_snapshot`).
+        // Reject it outright rather than let it round-trip.
+        if br.entity_posteriors_version == 0 && !br.entity_posterior_order.is_empty() {
+            return Err(format!(
+                "{label}.entity_posterior_order: non-empty order requires entity_posteriors_version >= 1 (got version 0, the legacy empty-order compatibility version)",
+            ));
         }
 
         // Non-legacy (version >= 1) snapshots must have an order entry for
@@ -741,6 +760,35 @@ mod tests {
         assert!(
             result.is_ok(),
             "legacy version-0 snapshot with empty order must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_version_zero_with_partial_order() {
+        // PR #535 codex round-2 finding 2: a version-0 snapshot with a
+        // non-empty (here: partial) order is NOT the legacy empty-order
+        // compatibility case. `serde(default)` lets `entity_posteriors_version`
+        // silently resolve to 0 on an omitted field, so this must be rejected
+        // outright rather than passed through to `restore`, which would
+        // silently normalize `[A]` order over `{A, B}` posteriors to `[A, B]`.
+        let capacity = 4;
+        let mut snapshot = make_versioned_recall_snapshot(capacity, 2);
+        snapshot.entity_posteriors_version = 0;
+        snapshot.entity_posterior_order.truncate(1);
+
+        let mut full_snapshot = BrainState::new(capacity).to_snapshot();
+        full_snapshot.balanced_recall = snapshot;
+
+        let result = validate_brain_state_snapshot_with_capacity(&full_snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "version-0 snapshot with non-empty partial order must be rejected"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .contains("requires entity_posteriors_version >= 1"),
+            "error must name the version-0-with-non-empty-order reason"
         );
     }
 

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -294,6 +294,61 @@ pub fn validate_brain_state_snapshot(snapshot: &BrainStateSnapshot) -> Result<()
     Ok(())
 }
 
+/// Validate posterior numerics (via [`validate_brain_state_snapshot`]) plus
+/// entity-posterior cache-capacity bounds for a persisted snapshot.
+///
+/// Rejects a snapshot whose `balanced_recall` or any `profile_states` entry
+/// holds more entity posteriors than `entity_capacity`, and rejects
+/// `entity_posterior_order` values that contain duplicate ids or reference
+/// ids absent from `entity_posteriors`. This is the capacity-aware
+/// counterpart used at the persistence load boundary, so a crafted or legacy
+/// oversized snapshot is rejected outright rather than silently truncated.
+pub fn validate_brain_state_snapshot_with_capacity(
+    snapshot: &BrainStateSnapshot,
+    entity_capacity: usize,
+) -> Result<(), String> {
+    validate_brain_state_snapshot(snapshot)?;
+
+    fn check_recall(
+        label: &str,
+        br: &BalancedRecallSnapshot,
+        entity_capacity: usize,
+    ) -> Result<(), String> {
+        if br.entity_posteriors.len() > entity_capacity {
+            return Err(format!(
+                "{label}.entity_posteriors: {} entries exceeds capacity {entity_capacity}",
+                br.entity_posteriors.len()
+            ));
+        }
+        if !br.entity_posterior_order.is_empty() {
+            let mut seen =
+                std::collections::HashSet::with_capacity(br.entity_posterior_order.len());
+            for id in &br.entity_posterior_order {
+                if !seen.insert(*id) {
+                    return Err(format!("{label}.entity_posterior_order: duplicate id {id}"));
+                }
+                if !br.entity_posteriors.contains_key(id) {
+                    return Err(format!(
+                        "{label}.entity_posterior_order: id {id} not present in entity_posteriors"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    check_recall(
+        "balanced_recall",
+        &snapshot.balanced_recall,
+        entity_capacity,
+    )?;
+    for (pid, ps) in &snapshot.profile_states {
+        check_recall(&format!("profile_states[{pid}]"), ps, entity_capacity)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -476,6 +531,67 @@ mod tests {
         assert!(
             restored.adapter_set.is_empty(),
             "adapter_set must default to empty map when absent from JSON"
+        );
+    }
+
+    /// BRAINCORE-AUD-001 regression: oversized-snapshot restore is rejected
+    /// (bounded/rejected) at the capacity-aware validation boundary.
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_entity_posteriors_over_capacity() {
+        use uuid::Uuid;
+
+        let capacity = 2;
+        let mut state = BrainState::new(capacity);
+        for _ in 0..(capacity + 1) {
+            state
+                .balanced_recall
+                .entity_posteriors
+                .get_or_insert(Uuid::new_v4(), crate::posterior::BetaPosterior::default);
+        }
+        // Force an over-capacity snapshot directly, since live inserts already
+        // enforce the bound — this simulates a crafted/legacy oversized snapshot.
+        let mut snapshot = state.to_snapshot();
+        snapshot
+            .balanced_recall
+            .entity_posteriors
+            .insert(Uuid::new_v4(), crate::posterior::BetaPosterior::default());
+
+        let result = validate_brain_state_snapshot_with_capacity(&snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "snapshot with entity_posteriors.len() > capacity must be rejected"
+        );
+    }
+
+    /// BRAINCORE-AUD-001 regression: capacity violation in a named
+    /// `profile_states` entry (not just the default profile) must also be
+    /// rejected.
+    #[test]
+    fn validate_brain_state_snapshot_with_capacity_rejects_profile_state_over_capacity() {
+        use uuid::Uuid;
+
+        let capacity = 1;
+        let mut state = BrainState::new(capacity);
+        let mut extra = BalancedRecallState::new(capacity);
+        extra
+            .entity_posteriors
+            .get_or_insert(Uuid::new_v4(), crate::posterior::BetaPosterior::default);
+        state
+            .profile_states
+            .insert("extra-profile".to_owned(), extra);
+
+        let mut snapshot = state.to_snapshot();
+        snapshot
+            .profile_states
+            .get_mut("extra-profile")
+            .unwrap()
+            .entity_posteriors
+            .insert(Uuid::new_v4(), crate::posterior::BetaPosterior::default());
+
+        let result = validate_brain_state_snapshot_with_capacity(&snapshot, capacity);
+        assert!(
+            result.is_err(),
+            "profile_states entry with entity_posteriors.len() > capacity must be rejected"
         );
     }
 }

--- a/crates/khive-brain-core/src/lib.rs
+++ b/crates/khive-brain-core/src/lib.rs
@@ -10,7 +10,10 @@ pub mod signal;
 pub mod tunable;
 
 pub use brain_signal::{entity_signal, is_recall_positive, BrainSignal};
-pub use brain_state::{validate_brain_state_snapshot, BrainState, BrainStateSnapshot};
+pub use brain_state::{
+    validate_brain_state_snapshot, validate_brain_state_snapshot_with_capacity, BrainState,
+    BrainStateSnapshot,
+};
 pub use posterior::{BetaPosterior, EntityPosteriors};
 pub use profile::{
     BalancedRecallSnapshot, BalancedRecallState, ProfileBinding, ProfileLifecycle, ProfileRecord,

--- a/crates/khive-brain-core/src/posterior.rs
+++ b/crates/khive-brain-core/src/posterior.rs
@@ -218,11 +218,50 @@ impl EntityPosteriors {
         self.map.clone()
     }
 
-    pub fn from_snapshot(snapshot: HashMap<Uuid, BetaPosterior>, capacity: usize) -> Self {
+    /// Current eviction order, oldest (next to evict) first.
+    pub fn order(&self) -> Vec<Uuid> {
+        self.order.iter().copied().collect()
+    }
+
+    /// Rebuild from a persisted map plus an explicit eviction order.
+    ///
+    /// `order` lists ids from least- to most-recently-used, as produced by
+    /// [`Self::order`]. Ids in `order` that are absent from `map` are dropped;
+    /// map entries missing from `order` (legacy snapshots with no order
+    /// metadata, or partially-ordered snapshots) are appended afterward in
+    /// ascending `Uuid` order so restore is deterministic across processes.
+    /// The combined id list is then truncated to `capacity`, so a snapshot
+    /// with more entries than the configured cache capacity restores bounded
+    /// rather than exceeding it.
+    pub fn from_snapshot(
+        map: HashMap<Uuid, BetaPosterior>,
+        order: Vec<Uuid>,
+        capacity: usize,
+    ) -> Self {
+        let mut seen = std::collections::HashSet::with_capacity(map.len());
+        let mut ids: Vec<Uuid> = Vec::with_capacity(map.len());
+
+        for id in order {
+            if map.contains_key(&id) && seen.insert(id) {
+                ids.push(id);
+            }
+        }
+
+        let mut remaining: Vec<Uuid> = map
+            .keys()
+            .copied()
+            .filter(|id| !seen.contains(id))
+            .collect();
+        remaining.sort();
+        ids.extend(remaining);
+        ids.truncate(capacity);
+
         let mut ep = Self::new(capacity);
-        for (id, posterior) in snapshot {
-            ep.map.insert(id, posterior);
-            ep.order.push_back(id);
+        for id in ids {
+            if let Some(posterior) = map.get(&id).cloned() {
+                ep.map.insert(id, posterior);
+                ep.order.push_back(id);
+            }
         }
         ep
     }
@@ -447,5 +486,60 @@ mod tests {
         assert!(ep.get(&id1).is_none());
         assert!(ep.get(&id2).is_some());
         assert!(ep.get(&id3).is_some());
+    }
+
+    /// BRAINCORE-AUD-001 regression: snapshot/restore must be eviction-equivalent
+    /// to uninterrupted execution. Capacity 2, observe A then B, snapshot, restore,
+    /// then observe C — the restored path must evict A (the oldest), not B, exactly
+    /// like the live in-memory path would.
+    #[test]
+    fn snapshot_restore_eviction_equivalence() {
+        let capacity = 2;
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let id_c = Uuid::new_v4();
+
+        let mut live = EntityPosteriors::new(capacity);
+        live.get_or_insert(id_a, BetaPosterior::default);
+        live.get_or_insert(id_b, BetaPosterior::default);
+
+        let map = live.to_snapshot();
+        let order = live.order();
+        let mut restored = EntityPosteriors::from_snapshot(map, order, capacity);
+
+        restored.get_or_insert(id_c, BetaPosterior::default);
+
+        assert_eq!(restored.len(), 2);
+        assert!(
+            restored.get(&id_a).is_none(),
+            "A must be evicted after restore, matching uninterrupted execution"
+        );
+        assert!(restored.get(&id_b).is_some(), "B must survive eviction");
+        assert!(
+            restored.get(&id_c).is_some(),
+            "C must be present after insert"
+        );
+    }
+
+    /// BRAINCORE-AUD-001 regression: a snapshot with more entries than the
+    /// configured capacity must restore bounded, not exceed it.
+    #[test]
+    fn oversized_snapshot_restore_is_bounded_by_capacity() {
+        let capacity = 2;
+        let mut map = HashMap::new();
+        let mut ids = Vec::new();
+        for _ in 0..5 {
+            let id = Uuid::new_v4();
+            map.insert(id, BetaPosterior::default());
+            ids.push(id);
+        }
+        // No order metadata supplied — exercises the legacy/deterministic path.
+        let restored = EntityPosteriors::from_snapshot(map, Vec::new(), capacity);
+
+        assert_eq!(
+            restored.len(),
+            capacity,
+            "restore must truncate to capacity, not accept all 5 entries"
+        );
     }
 }

--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -102,6 +102,8 @@ impl BalancedRecallState {
             salience: self.salience.clone(),
             temporal: self.temporal.clone(),
             entity_posteriors: self.entity_posteriors.to_snapshot(),
+            entity_posteriors_version: 1,
+            entity_posterior_order: self.entity_posteriors.order(),
             total_events: self.total_events,
             exploration_epoch: self.exploration_epoch,
         }
@@ -114,6 +116,7 @@ impl BalancedRecallState {
             temporal: snapshot.temporal,
             entity_posteriors: EntityPosteriors::from_snapshot(
                 snapshot.entity_posteriors,
+                snapshot.entity_posterior_order,
                 entity_capacity,
             ),
             total_events: snapshot.total_events,
@@ -222,6 +225,16 @@ pub struct BalancedRecallSnapshot {
     pub salience: BetaPosterior,
     pub temporal: BetaPosterior,
     pub entity_posteriors: HashMap<Uuid, BetaPosterior>,
+    /// Snapshot schema version for `entity_posteriors`/`entity_posterior_order`.
+    /// `0` (the serde default) marks a legacy snapshot with no order metadata;
+    /// `1` marks a snapshot written with `entity_posterior_order` populated.
+    #[serde(default)]
+    pub entity_posteriors_version: u32,
+    /// Eviction order (oldest first) for `entity_posteriors`, as of the write.
+    /// Empty on legacy snapshots — restore falls back to a deterministic
+    /// ascending-`Uuid` compatibility order in that case.
+    #[serde(default)]
+    pub entity_posterior_order: Vec<Uuid>,
     pub total_events: u64,
     pub exploration_epoch: u64,
 }
@@ -288,5 +301,52 @@ mod tests {
             shift >= 0.3,
             "ESS cap convergence: mean shift {shift:.4} < 0.3 (positive={mean_after_positive:.4}, opposing={mean_after_opposing:.4})"
         );
+    }
+
+    /// BRAINCORE-AUD-001 regression: a legacy snapshot (version 0, no order
+    /// metadata) with more entries than the configured capacity must restore
+    /// bounded, using a deterministic ascending-`Uuid` compatibility order.
+    #[test]
+    fn legacy_entity_posteriors_restore_uses_deterministic_order_and_capacity() {
+        let capacity = 2;
+        let mut ids = vec![
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        ];
+        ids.sort();
+
+        let mut entity_posteriors = HashMap::new();
+        for id in &ids {
+            entity_posteriors.insert(*id, BetaPosterior::default());
+        }
+
+        let legacy = BalancedRecallSnapshot {
+            relevance: BetaPosterior::default(),
+            salience: BetaPosterior::default(),
+            temporal: BetaPosterior::default(),
+            entity_posteriors,
+            entity_posteriors_version: 0,
+            entity_posterior_order: Vec::new(),
+            total_events: 0,
+            exploration_epoch: 0,
+        };
+
+        let restored = BalancedRecallState::from_snapshot(legacy, capacity);
+
+        assert_eq!(restored.entity_posteriors.len(), capacity);
+        for id in ids.iter().take(capacity) {
+            assert!(
+                restored.entity_posteriors.get(id).is_some(),
+                "deterministic sort prefix id {id} must be retained"
+            );
+        }
+        for id in ids.iter().skip(capacity) {
+            assert!(
+                restored.entity_posteriors.get(id).is_none(),
+                "id {id} beyond the deterministic sort prefix must be dropped"
+            );
+        }
     }
 }

--- a/crates/khive-fold/benches/fold_bench.rs
+++ b/crates/khive-fold/benches/fold_bench.rs
@@ -27,6 +27,7 @@ fn make_selector_inputs(n: usize) -> Vec<SelectorInput<()>> {
             score: lcg_next(&mut state),
             category: Some(format!("cat-{}", i % 8)),
             information_gain: None,
+            rank_score: None,
         })
         .collect()
 }

--- a/crates/khive-fold/src/objective/builtin.rs
+++ b/crates/khive-fold/src/objective/builtin.rs
@@ -134,6 +134,9 @@ where
 
         for (i, candidate) in candidates.iter().take(limit).enumerate() {
             if (self.predicate)(candidate) {
+                if !self.passes_score(1.0, context) {
+                    return Vec::new();
+                }
                 return vec![Selection::new(candidate, 1.0, i)
                     .with_considered(i + 1)
                     .with_passed(1)];
@@ -345,6 +348,17 @@ mod tests {
 
         assert_eq!(*selection.item, 7);
         assert_eq!(selection.index, 2);
+    }
+
+    #[test]
+    fn test_first_match_respects_min_score() {
+        let objective = FirstMatchObjective::new(|n: &i32| *n > 5);
+
+        let candidates = vec![7];
+        let context = ObjectiveContext::new().with_min_score(2.0);
+
+        assert!(!objective.passes(&7, &context));
+        assert!(objective.select(&candidates, &context).is_empty());
     }
 
     #[test]

--- a/crates/khive-fold/src/pipeline.rs
+++ b/crates/khive-fold/src/pipeline.rs
@@ -25,13 +25,119 @@ impl<T: Clone + Send + Sync + 'static> ComposePipeline<T> {
         weights: &SelectorWeights,
         context: &ObjectiveContext,
     ) -> Result<SelectorOutput<T>, FoldError> {
-        let scored = candidates
-            .into_iter()
-            .map(|mut candidate| {
-                candidate.score = self.objective.score(&candidate.content, context) as f32;
-                candidate
-            })
-            .collect();
+        let mut scored = Vec::with_capacity(candidates.len());
+        for mut candidate in candidates {
+            let score = self.objective.score(&candidate.content, context);
+            if !self.objective.passes_score(score, context) {
+                continue;
+            }
+
+            let precision = self.objective.precision(&candidate.content, context);
+            let precision = if precision.is_finite() {
+                precision
+            } else {
+                1.0
+            };
+            let effective = score * precision;
+
+            if !effective.is_finite() || effective < f32::MIN as f64 || effective > f32::MAX as f64
+            {
+                return Err(FoldError::InvalidInput(format!(
+                    "objective effective score for '{}' is outside finite f32 range",
+                    candidate.id
+                )));
+            }
+
+            candidate.score = effective as f32;
+            scored.push(candidate);
+        }
         self.selector.select(scored, budget, weights)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::objective::Objective;
+
+    struct TupleObjective;
+
+    impl Objective<(f64, f64)> for TupleObjective {
+        fn score(&self, candidate: &(f64, f64), _context: &ObjectiveContext) -> f64 {
+            candidate.0
+        }
+
+        fn precision(&self, candidate: &(f64, f64), _context: &ObjectiveContext) -> f64 {
+            candidate.1
+        }
+    }
+
+    fn input(id: &str, score: f64, precision: f64) -> SelectorInput<(f64, f64)> {
+        SelectorInput {
+            id: id.to_string(),
+            content: (score, precision),
+            size: 1,
+            score: 0.0,
+            category: None,
+            information_gain: None,
+        }
+    }
+
+    fn pipeline() -> ComposePipeline<(f64, f64)> {
+        ComposePipeline {
+            anchor: Box::new(crate::anchor::BfsAnchor),
+            objective: Box::new(TupleObjective),
+            selector: Box::new(crate::selector::GreedySelector),
+        }
+    }
+
+    #[test]
+    fn compose_pipeline_ranks_by_precision_weighted_score() {
+        let pipeline = pipeline();
+        let candidates = vec![input("a", 10.0, 0.1), input("b", 2.0, 1.0)];
+        let out = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                1,
+                &SelectorWeights::default(),
+                &ObjectiveContext::new(),
+            )
+            .unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(out.selected[0].id, "b");
+    }
+
+    #[test]
+    fn compose_pipeline_applies_objective_min_score_before_selector() {
+        let pipeline = pipeline();
+        let candidates = vec![input("a", 1.0, 1.0)];
+        let context = ObjectiveContext::new().with_min_score(2.0);
+        let out = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                10,
+                &SelectorWeights::default(),
+                &context,
+            )
+            .unwrap();
+        assert!(out.selected.is_empty());
+    }
+
+    #[test]
+    fn compose_pipeline_rejects_effective_score_outside_f32_range() {
+        let pipeline = pipeline();
+        let candidates = vec![input("a", f64::MAX, 1.0)];
+        let err = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                10,
+                &SelectorWeights::default(),
+                &ObjectiveContext::new(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, FoldError::InvalidInput(_)));
     }
 }

--- a/crates/khive-fold/src/pipeline.rs
+++ b/crates/khive-fold/src/pipeline.rs
@@ -89,6 +89,18 @@ mod tests {
         }
     }
 
+    fn input_cat(
+        id: &str,
+        score: f64,
+        precision: f64,
+        category: &str,
+    ) -> SelectorInput<(f64, f64)> {
+        SelectorInput {
+            category: Some(category.to_string()),
+            ..input(id, score, precision)
+        }
+    }
+
     fn pipeline() -> ComposePipeline<(f64, f64)> {
         ComposePipeline {
             anchor: Box::new(crate::anchor::BfsAnchor),
@@ -172,6 +184,44 @@ mod tests {
         assert_eq!(out.selected.len(), 2);
         assert_eq!(out.selected[0].id, "a");
         assert_eq!(out.selected[1].id, "z");
+    }
+
+    #[test]
+    fn compose_pipeline_category_weights_still_reorder_with_rank_score() {
+        // Mirrors selector.rs's `category_weights_boost_preferred_category`,
+        // but drives it through `ComposePipeline::execute`, which always sets
+        // `rank_score` (see the `execute` comment above). Before the fix,
+        // `ComposePipeline` candidates carrying `rank_score` were immune to
+        // `SelectorWeights.category_weights`: the comparator read the
+        // unweighted `rank_score` while the weight only touched `score`. "a"
+        // (raw effective 0.9, "low") would beat "b" (raw effective 0.5,
+        // "high", weight 2.0) despite the weight. The fix scales `rank_score`
+        // by the category weight too, so "b" must win.
+        let pipeline = pipeline();
+        let candidates = vec![
+            input_cat("a", 0.9, 1.0, "low"),
+            input_cat("b", 0.5, 1.0, "high"),
+        ];
+        let weights = SelectorWeights {
+            category_weights: [("high".to_string(), 2.0f32), ("low".to_string(), 1.0f32)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let out = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                1,
+                &weights,
+                &ObjectiveContext::new(),
+            )
+            .unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(
+            out.selected[0].id, "b",
+            "category weight must still reorder ComposePipeline candidates carrying rank_score"
+        );
     }
 
     #[test]

--- a/crates/khive-fold/src/pipeline.rs
+++ b/crates/khive-fold/src/pipeline.rs
@@ -49,6 +49,11 @@ impl<T: Clone + Send + Sync + 'static> ComposePipeline<T> {
             }
 
             candidate.score = effective as f32;
+            // Carry the full f64 precision into selector ranking so rank
+            // comparisons go through the khive-score fixed-point comparators
+            // instead of re-deriving from the narrowed f32 `score` field —
+            // mirrors the RankedIndex pattern in objective/traits.rs.
+            candidate.rank_score = Some(effective);
             scored.push(candidate);
         }
         self.selector.select(scored, budget, weights)
@@ -80,6 +85,7 @@ mod tests {
             score: 0.0,
             category: None,
             information_gain: None,
+            rank_score: None,
         }
     }
 
@@ -123,6 +129,49 @@ mod tests {
             )
             .unwrap();
         assert!(out.selected.is_empty());
+    }
+
+    #[test]
+    fn compose_pipeline_ranks_correctly_within_f32_ulp_around_one() {
+        // 1.0 and 1.00000004 collapse to the identical f32 bit pattern (delta is
+        // below the f32 ulp at magnitude 1.0), but are distinct at the
+        // khive-score 2^32 fixed-point scale. Without carrying the f64
+        // `rank_score` into the selector, both candidates would tie on `score`
+        // and fall back to id ordering (picking "a"); the fix must still rank
+        // "b" ahead since its true effective score is higher.
+        let pipeline = pipeline();
+        let candidates = vec![input("a", 1.0, 1.0), input("b", 1.000_000_04, 1.0)];
+        let out = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                1,
+                &SelectorWeights::default(),
+                &ObjectiveContext::new(),
+            )
+            .unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(out.selected[0].id, "b");
+    }
+
+    #[test]
+    fn compose_pipeline_ranks_score_zero_ties_deterministically() {
+        // Equal effective scores of exactly zero must still tie-break
+        // deterministically (id ascending), same as any other tie.
+        let pipeline = pipeline();
+        let candidates = vec![input("z", 0.0, 1.0), input("a", 0.0, 1.0)];
+        let out = pipeline
+            .execute(
+                &AnchorGraph::new(),
+                candidates,
+                10,
+                &SelectorWeights::default(),
+                &ObjectiveContext::new(),
+            )
+            .unwrap();
+        assert_eq!(out.selected.len(), 2);
+        assert_eq!(out.selected[0].id, "a");
+        assert_eq!(out.selected[1].id, "z");
     }
 
     #[test]

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -128,6 +128,32 @@ fn effective_score<T>(
     base * (1.0 - bias * count as f32 / (count as f32 + 1.0))
 }
 
+fn validate_selector_weights(weights: &SelectorWeights) -> Result<(), FoldError> {
+    if !weights.min_score.is_finite() {
+        return Err(FoldError::InvalidInput(
+            "SelectorWeights.min_score must be finite".to_string(),
+        ));
+    }
+    if !weights.diversity_bias.is_finite() {
+        return Err(FoldError::InvalidInput(
+            "SelectorWeights.diversity_bias must be finite".to_string(),
+        ));
+    }
+    if !weights.epistemic_weight.is_finite() {
+        return Err(FoldError::InvalidInput(
+            "SelectorWeights.epistemic_weight must be finite".to_string(),
+        ));
+    }
+    for (category, weight) in &weights.category_weights {
+        if !weight.is_finite() {
+            return Err(FoldError::InvalidInput(format!(
+                "SelectorWeights.category_weights['{category}'] must be finite"
+            )));
+        }
+    }
+    Ok(())
+}
+
 impl<T: Clone> Selector<T> for GreedySelector {
     fn select(
         &self,
@@ -135,6 +161,18 @@ impl<T: Clone> Selector<T> for GreedySelector {
         budget: usize,
         weights: &SelectorWeights,
     ) -> Result<SelectorOutput<T>, FoldError> {
+        validate_selector_weights(weights)?;
+        for input in &inputs {
+            if let Some(gain) = input.information_gain {
+                if !gain.is_finite() {
+                    return Err(FoldError::InvalidInput(format!(
+                        "information_gain for '{}' must be finite",
+                        input.id
+                    )));
+                }
+            }
+        }
+
         // Filter non-finite and below min_score.
         inputs.retain(|i| i.score.is_finite() && i.score >= weights.min_score);
 
@@ -153,15 +191,26 @@ impl<T: Clone> Selector<T> for GreedySelector {
         let ew = weights.epistemic_weight;
 
         // Initial sort: effective score (pragmatic + epistemic bonus) desc, size asc, id asc —
-        // deterministic across platforms.
-        inputs.sort_by(|a, b| {
-            let a_eff = pragmatic_plus_epistemic(a, ew);
-            let b_eff = pragmatic_plus_epistemic(b, ew);
+        // deterministic across platforms. Non-finite effective scores are rejected rather
+        // than silently sorted, since a checked score can still overflow to non-finite.
+        let mut ranked = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let effective = pragmatic_plus_epistemic(&input, ew);
+            if !effective.is_finite() {
+                return Err(FoldError::InvalidInput(format!(
+                    "effective score for '{}' must be finite",
+                    input.id
+                )));
+            }
+            ranked.push((input, effective));
+        }
+        ranked.sort_by(|(a, a_eff), (b, b_eff)| {
             b_eff
-                .total_cmp(&a_eff)
+                .total_cmp(a_eff)
                 .then_with(|| a.size.cmp(&b.size))
                 .then_with(|| a.id.cmp(&b.id))
         });
+        let inputs: Vec<_> = ranked.into_iter().map(|(input, _)| input).collect();
 
         let mut selected = Vec::new();
         let mut total_size = 0usize;
@@ -181,19 +230,28 @@ impl<T: Clone> Selector<T> for GreedySelector {
                 std::collections::BTreeMap::new();
 
             while !remaining.is_empty() && total_size < budget {
-                let best_idx = remaining
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, item)| item.size <= budget.saturating_sub(total_size))
-                    .max_by(|(_, a), (_, b)| {
-                        let a_eff =
-                            effective_score(a, &category_counts, weights.diversity_bias, ew);
-                        let b_eff =
-                            effective_score(b, &category_counts, weights.diversity_bias, ew);
+                let mut candidates = Vec::with_capacity(remaining.len());
+                for (i, item) in remaining.iter().enumerate() {
+                    if item.size > budget.saturating_sub(total_size) {
+                        continue;
+                    }
+                    let eff = effective_score(item, &category_counts, weights.diversity_bias, ew);
+                    if !eff.is_finite() {
+                        return Err(FoldError::InvalidInput(format!(
+                            "effective score for '{}' must be finite",
+                            item.id
+                        )));
+                    }
+                    candidates.push((i, eff));
+                }
+
+                let best_idx = candidates
+                    .into_iter()
+                    .max_by(|&(i, a_eff), &(j, b_eff)| {
                         a_eff
                             .total_cmp(&b_eff)
-                            .then_with(|| b.size.cmp(&a.size))
-                            .then_with(|| a.id.cmp(&b.id))
+                            .then_with(|| remaining[j].size.cmp(&remaining[i].size))
+                            .then_with(|| remaining[i].id.cmp(&remaining[j].id))
                     })
                     .map(|(i, _)| i);
 
@@ -619,5 +677,69 @@ mod tests {
         assert_eq!(out.selected[0].id, "a");
         // b (eff=0.8*0.75=0.6) > c (eff=0.3) after a is placed in category x.
         assert_eq!(out.selected[1].id, "b");
+    }
+
+    // ── non-finite validation tests (FOLD-AUD-003) ─────────────────────────────
+
+    #[test]
+    fn greedy_selector_rejects_nan_information_gain() {
+        let inputs = vec![
+            input_with_gain("a", 100, 0.1, f32::NAN),
+            input_with_gain("b", 100, 0.9, 0.0),
+        ];
+        let w = SelectorWeights {
+            epistemic_weight: 1.0,
+            ..Default::default()
+        };
+        let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+        assert!(matches!(err, FoldError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn greedy_selector_rejects_non_finite_epistemic_weight() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let inputs = vec![input("a", 100, 0.5)];
+            let w = SelectorWeights {
+                epistemic_weight: bad,
+                ..Default::default()
+            };
+            let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+            assert!(matches!(err, FoldError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn greedy_selector_rejects_non_finite_diversity_bias() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let inputs = vec![input("a", 100, 0.5)];
+            let w = SelectorWeights {
+                diversity_bias: bad,
+                ..Default::default()
+            };
+            let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+            assert!(matches!(err, FoldError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn greedy_selector_rejects_non_finite_category_weight() {
+        let inputs = vec![input_cat("a", 100, 0.5, "x")];
+        let w = SelectorWeights {
+            category_weights: [("x".to_string(), f32::NAN)].into_iter().collect(),
+            ..Default::default()
+        };
+        let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+        assert!(matches!(err, FoldError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn greedy_selector_rejects_non_finite_effective_score_before_compare() {
+        let inputs = vec![input_with_gain("a", 100, f32::MAX, f32::MAX)];
+        let w = SelectorWeights {
+            epistemic_weight: f32::MAX,
+            ..Default::default()
+        };
+        let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
+        assert!(matches!(err, FoldError::InvalidInput(_)));
     }
 }

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -43,8 +43,10 @@ pub struct SelectorInput<T> {
     /// `None`, but two `f64` scores that differ by less than an `f32` ulp would
     /// otherwise collapse to the same `f32` bit pattern before the selector
     /// ever compares them (khive-score contract: ADR fixed-point ranking).
-    /// Does not affect `min_score` filtering or `category_weights`
-    /// multipliers, which continue to operate on `score`.
+    /// Does not affect `min_score` filtering, which continues to operate on
+    /// `score`. `category_weights` multipliers DO scale `rank_score` (by the
+    /// same weight applied to `score`) so a caller-supplied high-precision
+    /// rank base still reflects category weighting during rank comparisons.
     #[cfg_attr(feature = "serde", serde(default))]
     pub rank_score: Option<f64>,
 }
@@ -216,12 +218,21 @@ impl<T: Clone> Selector<T> for GreedySelector {
         // Filter non-finite and below min_score.
         inputs.retain(|i| i.score.is_finite() && i.score >= weights.min_score);
 
-        // Apply category_weights multipliers.
+        // Apply category_weights multipliers. `rank_score`, when present, is
+        // the caller's higher-precision f64 rank base (see `rank_base` doc) —
+        // it must be scaled by the same weight or rank comparisons would see
+        // the unweighted value while `min_score` filtering sees the weighted
+        // one, silently defeating `category_weights` for any candidate that
+        // set `rank_score` (khive/PR#535 codex round-2 finding 1).
         if !weights.category_weights.is_empty() {
             for item in &mut inputs {
                 if let Some(ref cat) = item.category {
                     if let Some(&w) = weights.category_weights.get(cat.as_str()) {
-                        item.score *= w.max(0.0);
+                        let w = w.max(0.0);
+                        item.score *= w;
+                        if let Some(rank_score) = item.rank_score {
+                            item.rank_score = Some(rank_score * w as f64);
+                        }
                     }
                 }
             }
@@ -858,6 +869,33 @@ mod tests {
         assert_eq!(
             out.selected[0].id, "b",
             "higher rank_score must win despite tied f32 score"
+        );
+    }
+
+    #[test]
+    fn category_weights_reorder_candidates_when_rank_score_present() {
+        // Same shape as `category_weights_boost_preferred_category`, but both
+        // candidates carry an explicit `rank_score` equal to `score` widened
+        // to f64. Before the fix, rank comparisons read the unweighted
+        // `rank_score` (weights only ever touched `score`), so "a" (raw 0.9,
+        // "low") would win despite "high" carrying a 2.0x weight. The fix
+        // must scale `rank_score` by the same weight so "b" still wins.
+        let mut a = input_cat("a", 100, 0.9, "low");
+        a.rank_score = Some(0.9);
+        let mut b = input_cat("b", 100, 0.5, "high");
+        b.rank_score = Some(0.5);
+
+        let w = SelectorWeights {
+            category_weights: [("high".to_string(), 2.0f32), ("low".to_string(), 1.0f32)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let out = GreedySelector.select(vec![a, b], 100, &w).unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(
+            out.selected[0].id, "b",
+            "category weight must still reorder candidates when rank_score is present"
         );
     }
 

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -6,6 +6,8 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use khive_score::DeterministicScore;
+
 use crate::error::FoldError;
 
 /// A single input item to a selector operation.
@@ -31,6 +33,20 @@ pub struct SelectorInput<T> {
     /// when `SelectorWeights.epistemic_weight > 0.0`.
     #[cfg_attr(feature = "serde", serde(default))]
     pub information_gain: Option<f32>,
+    /// Higher-precision pre-conversion effective score used for rank
+    /// comparisons, when available.
+    ///
+    /// Callers that compute the score in `f64` (e.g. `ComposePipeline`, which
+    /// multiplies an objective score by a precision weight) should set this
+    /// instead of relying solely on the narrowed `score: f32` field — ranking
+    /// widens `score` back through `DeterministicScore::from_f32` when this is
+    /// `None`, but two `f64` scores that differ by less than an `f32` ulp would
+    /// otherwise collapse to the same `f32` bit pattern before the selector
+    /// ever compares them (khive-score contract: ADR fixed-point ranking).
+    /// Does not affect `min_score` filtering or `category_weights`
+    /// multipliers, which continue to operate on `score`.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub rank_score: Option<f64>,
 }
 
 /// Result of a selector operation.
@@ -97,16 +113,32 @@ pub trait Selector<T>: Send + Sync {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GreedySelector;
 
-/// Compute the base pragmatic score adjusted for epistemic weight.
+/// Widen `score` (and any `rank_score` override) into the `f64` domain used
+/// for rank-comparison arithmetic.
 ///
-/// `base` is the pragmatic score (after category-weight multipliers).
-/// `epistemic_weight * information_gain` is the epistemic bonus.
+/// `rank_score`, when present, carries the caller's full-precision effective
+/// score (e.g. `ComposePipeline`'s `objective_score * precision` in `f64`
+/// before it was narrowed to `f32` for the `score` field). Falling back to
+/// `score as f64` for plain callers (e.g. `khive-pack-knowledge`'s direct
+/// JSON-supplied candidates) is lossless — those scores were never more
+/// precise than `f32` to begin with.
 #[inline]
-fn pragmatic_plus_epistemic<T>(item: &SelectorInput<T>, epistemic_weight: f32) -> f32 {
+fn rank_base<T>(item: &SelectorInput<T>) -> f64 {
+    item.rank_score.unwrap_or(item.score as f64)
+}
+
+/// Compute the base pragmatic score adjusted for epistemic weight, in `f64`.
+///
+/// `base` is the pragmatic score (after category-weight multipliers, which
+/// still apply to `score` before this is called). `epistemic_weight *
+/// information_gain` is the epistemic bonus.
+#[inline]
+fn pragmatic_plus_epistemic<T>(item: &SelectorInput<T>, epistemic_weight: f32) -> f64 {
+    let base = rank_base(item);
     if epistemic_weight == 0.0 {
-        return item.score;
+        return base;
     }
-    item.score + epistemic_weight * item.information_gain.unwrap_or(0.0)
+    base + epistemic_weight as f64 * item.information_gain.unwrap_or(0.0) as f64
 }
 
 fn effective_score<T>(
@@ -114,7 +146,7 @@ fn effective_score<T>(
     counts: &std::collections::BTreeMap<String, usize>,
     bias: f32,
     epistemic_weight: f32,
-) -> f32 {
+) -> f64 {
     let base = pragmatic_plus_epistemic(item, epistemic_weight);
     if bias == 0.0 {
         return base;
@@ -125,7 +157,7 @@ fn effective_score<T>(
         .and_then(|c| counts.get(c))
         .copied()
         .unwrap_or(0);
-    base * (1.0 - bias * count as f32 / (count as f32 + 1.0))
+    base * (1.0 - bias as f64 * count as f64 / (count as f64 + 1.0))
 }
 
 fn validate_selector_weights(weights: &SelectorWeights) -> Result<(), FoldError> {
@@ -171,6 +203,14 @@ impl<T: Clone> Selector<T> for GreedySelector {
                     )));
                 }
             }
+            if let Some(rank_score) = input.rank_score {
+                if !rank_score.is_finite() {
+                    return Err(FoldError::InvalidInput(format!(
+                        "rank_score for '{}' must be finite",
+                        input.id
+                    )));
+                }
+            }
         }
 
         // Filter non-finite and below min_score.
@@ -193,6 +233,10 @@ impl<T: Clone> Selector<T> for GreedySelector {
         // Initial sort: effective score (pragmatic + epistemic bonus) desc, size asc, id asc —
         // deterministic across platforms. Non-finite effective scores are rejected rather
         // than silently sorted, since a checked score can still overflow to non-finite.
+        // Comparisons run through `DeterministicScore` (khive-score's i64 fixed-point
+        // contract), not raw `f32::total_cmp` — matches the objective-path ranking
+        // pattern in `objective::traits::RankedIndex` and preserves precision that a
+        // caller-supplied `rank_score` (f64) carries past what `f32` can hold.
         let mut ranked = Vec::with_capacity(inputs.len());
         for input in inputs {
             let effective = pragmatic_plus_epistemic(&input, ew);
@@ -202,11 +246,12 @@ impl<T: Clone> Selector<T> for GreedySelector {
                     input.id
                 )));
             }
-            ranked.push((input, effective));
+            let det_score = DeterministicScore::from_f64(effective);
+            ranked.push((input, det_score));
         }
-        ranked.sort_by(|(a, a_eff), (b, b_eff)| {
-            b_eff
-                .total_cmp(a_eff)
+        ranked.sort_by(|(a, a_det), (b, b_det)| {
+            b_det
+                .cmp(a_det)
                 .then_with(|| a.size.cmp(&b.size))
                 .then_with(|| a.id.cmp(&b.id))
         });
@@ -242,14 +287,14 @@ impl<T: Clone> Selector<T> for GreedySelector {
                             item.id
                         )));
                     }
-                    candidates.push((i, eff));
+                    candidates.push((i, DeterministicScore::from_f64(eff)));
                 }
 
                 let best_idx = candidates
                     .into_iter()
-                    .max_by(|&(i, a_eff), &(j, b_eff)| {
-                        a_eff
-                            .total_cmp(&b_eff)
+                    .max_by(|&(i, a_det), &(j, b_det)| {
+                        a_det
+                            .cmp(&b_det)
                             .then_with(|| remaining[j].size.cmp(&remaining[i].size))
                             .then_with(|| remaining[i].id.cmp(&remaining[j].id))
                     })
@@ -293,6 +338,7 @@ mod tests {
             score,
             category: None,
             information_gain: None,
+            rank_score: None,
         }
     }
 
@@ -304,6 +350,7 @@ mod tests {
             score,
             category: Some(cat.to_string()),
             information_gain: None,
+            rank_score: None,
         }
     }
 
@@ -530,6 +577,7 @@ mod tests {
                 score: 0.9,
                 category: None,
                 information_gain: None,
+                rank_score: None,
             },
             SelectorInput {
                 id: "b".to_string(),
@@ -538,6 +586,7 @@ mod tests {
                 score: 0.8,
                 category: None,
                 information_gain: None,
+                rank_score: None,
             },
         ];
         // Budget is 100 — only item "b" fits.
@@ -573,6 +622,7 @@ mod tests {
             score,
             category: None,
             information_gain: Some(gain),
+            rank_score: None,
         }
     }
 
@@ -733,13 +783,96 @@ mod tests {
     }
 
     #[test]
-    fn greedy_selector_rejects_non_finite_effective_score_before_compare() {
+    fn greedy_selector_handles_extreme_f32_products_without_overflow() {
+        // Ranking now runs in f64/DeterministicScore rather than raw f32
+        // arithmetic: `f32::MAX * f32::MAX` (~1.15e77) no longer overflows to
+        // `f32::INFINITY` the way it did under the old f32-only computation —
+        // it's a large-but-finite f64 value, saturated into DeterministicScore
+        // rather than rejected. This is exactly the precision upgrade FOLD-AUD
+        // (khive-score fixed-point contract) requires: a real magnitude, not a
+        // spurious f32 rounding artifact, decides the outcome.
         let inputs = vec![input_with_gain("a", 100, f32::MAX, f32::MAX)];
         let w = SelectorWeights {
             epistemic_weight: f32::MAX,
             ..Default::default()
         };
-        let err = GreedySelector.select(inputs, 100, &w).unwrap_err();
-        assert!(matches!(err, FoldError::InvalidInput(_)));
+        let out = GreedySelector.select(inputs, 100, &w).unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(out.selected[0].id, "a");
+    }
+
+    // ── DeterministicScore rank-comparator tests (fold PR #535 codex round-1) ──
+
+    #[test]
+    fn rejects_non_finite_rank_score() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut item = input("a", 100, 0.5);
+            item.rank_score = Some(bad);
+            let err = GreedySelector
+                .select(vec![item], 100, &weights(0.0))
+                .unwrap_err();
+            assert!(matches!(err, FoldError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn rank_score_saturates_at_deterministic_score_max_without_panic() {
+        // Two candidates whose rank_score both exceed DeterministicScore's
+        // i64/2^32 representable range must both saturate to MAX rather than
+        // panicking or overflowing, then fall back to the deterministic
+        // size/id tie-break — same contract as DeterministicScore's own
+        // saturating arithmetic (khive-score score.rs `from_rounded_arithmetic`).
+        let mut big = input("big", 200, 0.0);
+        big.rank_score = Some(f64::MAX);
+        let mut small = input("small", 50, 0.0);
+        small.rank_score = Some(f64::MAX / 2.0);
+
+        let out = GreedySelector
+            .select(vec![big, small], 1000, &weights(0.0))
+            .unwrap();
+        assert_eq!(out.selected.len(), 2);
+        // Both saturate to DeterministicScore::MAX and tie; size-ascending wins.
+        assert_eq!(out.selected[0].id, "small");
+        assert_eq!(out.selected[1].id, "big");
+    }
+
+    #[test]
+    fn rank_score_distinguishes_values_within_f32_ulp_of_one() {
+        // 1.0 and 1.00000004 collapse to the identical f32 bit pattern (delta
+        // is below the f32 ulp at magnitude 1.0) but are distinct at the
+        // khive-score 2^32 fixed-point scale — `rank_score` must be the value
+        // that decides ranking, not the narrowed `score` field.
+        let a_score = 1.0_f32;
+        let b_score = 1.0_f32; // identical f32 bits to a after narrowing
+        assert_eq!(a_score.to_bits(), b_score.to_bits());
+
+        let mut a = input("a", 100, a_score);
+        a.rank_score = Some(1.0);
+        let mut b = input("b", 100, b_score);
+        b.rank_score = Some(1.000_000_04);
+
+        let out = GreedySelector
+            .select(vec![a, b], 100, &weights(0.0))
+            .unwrap();
+        assert_eq!(out.selected.len(), 1);
+        assert_eq!(
+            out.selected[0].id, "b",
+            "higher rank_score must win despite tied f32 score"
+        );
+    }
+
+    #[test]
+    fn rank_score_zero_ties_break_deterministically() {
+        let mut a = input("z", 100, 0.0);
+        a.rank_score = Some(0.0);
+        let mut b = input("a", 100, 0.0);
+        b.rank_score = Some(0.0);
+
+        let out = GreedySelector
+            .select(vec![a, b], 1000, &weights(0.0))
+            .unwrap();
+        assert_eq!(out.selected.len(), 2);
+        assert_eq!(out.selected[0].id, "a");
+        assert_eq!(out.selected[1].id, "z");
     }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -44,7 +44,7 @@ use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::{SqlAccess, SqlWriter};
 
 use khive_brain_core::{
-    validate_brain_state_snapshot, BrainSignal, BrainState, BrainStateSnapshot,
+    validate_brain_state_snapshot_with_capacity, BrainSignal, BrainState, BrainStateSnapshot,
 };
 
 use crate::event::interpret;
@@ -420,6 +420,7 @@ pub async fn persist_brain_state_mutation<R>(
 pub async fn load_latest_snapshot(
     sql: &dyn SqlAccess,
     namespace: &str,
+    entity_capacity: usize,
 ) -> Result<Option<(BrainStateSnapshot, i64)>, RuntimeError> {
     let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
     let row = reader
@@ -447,7 +448,7 @@ pub async fn load_latest_snapshot(
             };
             let snapshot: BrainStateSnapshot =
                 serde_json::from_str(&json_str).map_err(|e| sql_err("deserialize snapshot", e))?;
-            validate_brain_state_snapshot(&snapshot)
+            validate_brain_state_snapshot_with_capacity(&snapshot, entity_capacity)
                 .map_err(|e| sql_err("snapshot invariant violation", e))?;
             Ok(Some((snapshot, updated_at)))
         }
@@ -612,7 +613,8 @@ pub async fn ensure_loaded(
         None
     } else {
         let sql = runtime.sql();
-        let snapshot_result = load_latest_snapshot(sql.as_ref(), &namespace).await?;
+        let snapshot_result =
+            load_latest_snapshot(sql.as_ref(), &namespace, entity_capacity).await?;
 
         let bs = if let Some((snapshot, updated_at)) = snapshot_result {
             let replay_result = load_events_since(sql.as_ref(), &namespace, updated_at).await?;
@@ -1285,5 +1287,78 @@ mod brain_007_replay_quarantine {
             "snippet body must contain only '日' chars; got: {:?}",
             snippet_body
         );
+    }
+}
+
+// ── BRAINCORE-AUD-001: entity-posterior cache-capacity enforcement on load ────
+
+#[cfg(test)]
+mod braincore_aud_001_capacity {
+    use uuid::Uuid;
+
+    use super::*;
+    use khive_brain_core::BetaPosterior;
+    use khive_runtime::{KhiveRuntime, Namespace};
+
+    /// Oversized persisted snapshot restore is bounded/rejected: a snapshot
+    /// with more entity posteriors than `ENTITY_CACHE_CAPACITY` must fail
+    /// capacity-aware validation at the load boundary rather than silently
+    /// restoring past the configured bound.
+    #[tokio::test]
+    async fn oversized_brain_snapshot_load_returns_runtime_error() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        let capacity = 2;
+        let mut state = BrainState::new(capacity);
+        for _ in 0..capacity {
+            state
+                .balanced_recall
+                .entity_posteriors
+                .get_or_insert(Uuid::new_v4(), BetaPosterior::default);
+        }
+        let mut snapshot = state.to_snapshot();
+        // Force one entry past the configured capacity — simulates a crafted
+        // or legacy oversized snapshot that live inserts could never produce.
+        snapshot
+            .balanced_recall
+            .entity_posteriors
+            .insert(Uuid::new_v4(), BetaPosterior::default());
+
+        upsert_snapshot(sql.as_ref(), ns, &snapshot, 500_000)
+            .await
+            .expect("seed oversized snapshot");
+
+        let result = load_latest_snapshot(sql.as_ref(), ns, capacity).await;
+        assert!(
+            result.is_err(),
+            "snapshot with entity_posteriors.len() > capacity must be rejected at load"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("snapshot invariant violation"),
+            "error must name the invariant-violation load boundary, got: {err}"
+        );
+    }
+
+    /// A snapshot within the configured capacity restores without error.
+    #[tokio::test]
+    async fn in_capacity_brain_snapshot_load_succeeds() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        let capacity = 2;
+        let state = BrainState::new(capacity);
+        let snapshot = state.to_snapshot();
+        upsert_snapshot(sql.as_ref(), ns, &snapshot, 500_000)
+            .await
+            .expect("seed snapshot");
+
+        let result = load_latest_snapshot(sql.as_ref(), ns, capacity).await;
+        assert!(result.is_ok(), "in-capacity snapshot must load cleanly");
     }
 }

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -1361,4 +1361,124 @@ mod braincore_aud_001_capacity {
         let result = load_latest_snapshot(sql.as_ref(), ns, capacity).await;
         assert!(result.is_ok(), "in-capacity snapshot must load cleanly");
     }
+
+    /// PR #535 codex round-2 finding 2: a persisted snapshot with `{A, B}`
+    /// entity_posteriors, `entity_posterior_order = [A]`, and an EXPLICIT
+    /// `entity_posteriors_version = 0` must be rejected at the
+    /// `load_latest_snapshot` boundary rather than silently normalized by
+    /// `restore` to `[A, B]`. Version 0 with a non-empty order is not the
+    /// legacy empty-order compatibility case.
+    #[tokio::test]
+    async fn version_zero_snapshot_with_explicit_partial_order_rejected_at_load() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        let capacity = 10;
+        let mut state = BrainState::new(capacity);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        state
+            .balanced_recall
+            .entity_posteriors
+            .get_or_insert(a, BetaPosterior::default);
+        state
+            .balanced_recall
+            .entity_posteriors
+            .get_or_insert(b, BetaPosterior::default);
+
+        let mut snapshot = state.to_snapshot();
+        snapshot.balanced_recall.entity_posteriors_version = 0;
+        snapshot.balanced_recall.entity_posterior_order = vec![a];
+
+        upsert_snapshot(sql.as_ref(), ns, &snapshot, 500_000)
+            .await
+            .expect("seed corrupt version-0 snapshot");
+
+        let result = load_latest_snapshot(sql.as_ref(), ns, capacity).await;
+        assert!(
+            result.is_err(),
+            "version-0 snapshot with non-empty partial order must be rejected at load, not normalized"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("snapshot invariant violation"),
+            "error must name the load-boundary invariant violation, got: {err}"
+        );
+    }
+
+    /// Same corruption as above, but with `entity_posteriors_version` OMITTED
+    /// from the stored JSON entirely (rather than set to an explicit `0`) —
+    /// the `#[serde(default)]` path that made this reachable in the first
+    /// place. Inserted as a raw row (bypassing the typed `upsert_snapshot`,
+    /// which always serializes the full struct) to reproduce exactly what a
+    /// pre-versioning writer, or a hand-crafted snapshot, would have stored.
+    #[tokio::test]
+    async fn version_omitted_snapshot_with_partial_order_rejected_at_load() {
+        let rt = KhiveRuntime::memory().expect("memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("token");
+        let ns = token.namespace().as_str();
+        let sql = rt.sql();
+
+        let capacity = 10;
+        let mut state = BrainState::new(capacity);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        state
+            .balanced_recall
+            .entity_posteriors
+            .get_or_insert(a, BetaPosterior::default);
+        state
+            .balanced_recall
+            .entity_posteriors
+            .get_or_insert(b, BetaPosterior::default);
+
+        let mut snapshot = state.to_snapshot();
+        snapshot.balanced_recall.entity_posterior_order = vec![a];
+
+        let mut json = serde_json::to_value(&snapshot).expect("serialize snapshot");
+        json["balanced_recall"]
+            .as_object_mut()
+            .expect("balanced_recall is an object")
+            .remove("entity_posteriors_version");
+        let json_str = serde_json::to_string(&json).expect("re-serialize snapshot");
+
+        // Round-trip through the typed struct to confirm the omitted field
+        // really does serde-default to 0 before we bypass the typed insert
+        // path — this is the precondition the fix closes.
+        let reparsed: BrainStateSnapshot =
+            serde_json::from_str(&json_str).expect("deserialize snapshot with omitted version");
+        assert_eq!(
+            reparsed.balanced_recall.entity_posteriors_version, 0,
+            "omitted entity_posteriors_version must serde-default to 0"
+        );
+
+        let mut writer = sql.writer().await.expect("writer");
+        writer
+            .execute(SqlStatement {
+                sql: "INSERT INTO brain_profile_snapshots (profile_id, namespace, snapshot_json, updated_at) VALUES (?1, ?2, ?3, ?4)".into(),
+                params: vec![
+                    SqlValue::Text(SNAPSHOT_PROFILE_ID.to_string()),
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(json_str),
+                    SqlValue::Integer(500_000),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert raw snapshot row with omitted version");
+        drop(writer);
+
+        let result = load_latest_snapshot(sql.as_ref(), ns, capacity).await;
+        assert!(
+            result.is_err(),
+            "snapshot with omitted entity_posteriors_version and non-empty partial order must be rejected at load"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("snapshot invariant violation"),
+            "error must name the load-boundary invariant violation, got: {err}"
+        );
+    }
 }

--- a/crates/khive-pack-knowledge/src/knowledge/fold_handler.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/fold_handler.rs
@@ -82,6 +82,7 @@ impl KnowledgeHandlers {
                 category: c.category.clone(),
                 information_gain: c.information_gain,
                 content: c,
+                rank_score: None,
             })
             .collect();
 

--- a/crates/khive-retrieval/src/persist/tests.rs
+++ b/crates/khive-retrieval/src/persist/tests.rs
@@ -436,6 +436,54 @@ async fn test_valid_json_wrong_schema_bm25() {
 }
 
 #[tokio::test]
+async fn test_schema_valid_bad_bm25_snapshot_returns_deserialize() {
+    let persist = setup_test_persistence().await;
+
+    // Schema-valid BM25 JSON (all required fields present with correct types),
+    // but internally inconsistent: doc_lengths has a live doc_id (0) that is
+    // out of range because next_internal_id is 0. This must be rejected by
+    // Bm25Index's cross-field validation (issue #446), not just its shape.
+    {
+        let conn = persist.conn.clone();
+        let namespace = "test".to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let bad_snapshot = br#"{
+                "inverted_index": {},
+                "doc_lengths": {"0": 1},
+                "id_to_internal": {},
+                "internal_to_id": [],
+                "next_internal_id": 0,
+                "total_tokens": 1,
+                "postings_epoch": 0,
+                "block_size": 128,
+                "config": {"k1": 1.2, "b": 0.75, "memory_budget": null}
+            }"#;
+            conn.execute(
+                r#"
+                INSERT OR REPLACE INTO retrieval_snapshots
+                    (namespace, index_type, snapshot, created_at)
+                VALUES
+                    (?1, 'bm25', ?2, strftime('%s', 'now'))
+                "#,
+                rusqlite::params![namespace, bad_snapshot.as_slice()],
+            )
+            .expect("insert schema-valid but inconsistent snapshot");
+        })
+        .await
+        .expect("spawn");
+    }
+
+    let result = persist.load_bm25_index().await;
+    assert!(
+        result.is_err(),
+        "loading a schema-valid but invariant-broken snapshot should fail"
+    );
+    let err = result.unwrap_err();
+    assert!(matches!(err, PersistError::Deserialize(_)));
+}
+
+#[tokio::test]
 async fn test_valid_json_wrong_schema_hnsw() {
     let persist = setup_test_persistence().await;
 


### PR DESCRIPTION
Resolves fold/bm25/brain-core cluster findings from audit-20260702.

Closes #446
Closes #447
Closes #450
Closes #478

## Changes
- `khive-fold`: precision-weighted ComposePipeline ranking + finite-guards in the selector (#450, #478).
- `khive-bm25`: post-wire snapshot cross-field validation (#446).
- `khive-brain-core`: ordered `from_snapshot` + truncate + capacity validator; additive `#[serde(default)]` wire change only, no migration (#447).

## Gates
- `cargo test -p khive-fold -p khive-bm25 -p khive-brain-core`: 343 passed post-rebase onto main; clippy `-D warnings` clean; fmt clean.
- Review verdict: approved (tests verified non-vacuous — error paths fail pre-fix; ranking tests assert membership AND set size).
- Additional review fires next.