### PR TITLE
fix(mcp,template,text,db): fail-closed backends, save_to sink, unicode gates, read-only enforcement (#419 #440 #464 #486 #413)

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -56,19 +56,15 @@ impl StorageBackend {
         let resolved = path.as_ref().to_path_buf();
         let config = PoolConfig {
             path: Some(resolved.clone()),
+            read_only: true,
             ..PoolConfig::default()
         };
+        // `ConnectionPool::new` opens the writer slot with `SQLITE_OPEN_READ_ONLY`
+        // (no `SQLITE_OPEN_CREATE`) and sets `PRAGMA query_only = ON` on it, so a
+        // missing path is rejected instead of created, and any write attempt is
+        // rejected at the SQLite level regardless of which code path reaches the
+        // writer.
         let pool = ConnectionPool::new(config)?;
-        // Set PRAGMA query_only = ON on the writer connection so that any write
-        // attempt is rejected at the SQLite level regardless of which code path
-        // reaches the writer.
-        {
-            let writer = pool.try_writer()?;
-            writer
-                .conn()
-                .pragma_update(None, "query_only", "ON")
-                .map_err(SqliteError::Rusqlite)?;
-        }
         Ok(Self {
             pool: Arc::new(pool),
             is_file_backed: true,
@@ -687,6 +683,87 @@ mod tests {
             SqlValue::Text(s) => assert_eq!(s, "world"),
             other => panic!("expected Text, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn sqlite_read_only_missing_path_does_not_create_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing_ro.db");
+        assert!(!path.exists());
+
+        let result = StorageBackend::sqlite_read_only(&path);
+        assert!(
+            result.is_err(),
+            "opening a missing path read-only must fail"
+        );
+        assert!(
+            !path.exists(),
+            "opening a missing path read-only must not create the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_read_only_sql_writer_rejects_ddl_and_insert() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_writer.db");
+
+        // Create the database and a table while writable.
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            let sql = writable.sql();
+            let mut writer = sql.writer().await.unwrap();
+            writer
+                .execute_script("CREATE TABLE ro_existing (id INTEGER PRIMARY KEY)".into())
+                .await
+                .unwrap();
+        }
+
+        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
+        let sql = ro.sql();
+
+        // Writer acquisition itself must fail for a read-only backend.
+        let writer_result = sql.writer().await;
+        assert!(
+            writer_result.is_err(),
+            "sql().writer() must be rejected on a read-only backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_read_only_default_transaction_rejects_writes() {
+        use khive_storage::types::SqlTxOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_tx.db");
+
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            let sql = writable.sql();
+            let mut writer = sql.writer().await.unwrap();
+            writer
+                .execute_script("CREATE TABLE ro_tx_test (id INTEGER PRIMARY KEY)".into())
+                .await
+                .unwrap();
+        }
+
+        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
+        let sql = ro.sql();
+
+        // `SqlTxOptions::default()` has `read_only: false`; the read-only
+        // backend must still force the transaction to reject writes.
+        let mut tx = sql.begin_tx(SqlTxOptions::default()).await.unwrap();
+        let result = tx
+            .execute(SqlStatement {
+                sql: "INSERT INTO ro_tx_test (id) VALUES (?1)".into(),
+                params: vec![SqlValue::Integer(1)],
+                label: None,
+            })
+            .await;
+        assert!(
+            result.is_err(),
+            "INSERT inside a default tx on a read-only backend must fail"
+        );
+        tx.rollback().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -907,6 +907,121 @@ mod tests {
         assert!(backend.text("").is_err());
     }
 
+    #[tokio::test]
+    async fn sqlite_read_only_graph_store_rejects_upsert_edge() {
+        use khive_storage::types::Edge;
+        use khive_types::EdgeRelation;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_graph.db");
+
+        // Create the database and the graph schema while writable.
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable.graph().unwrap();
+        }
+
+        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
+        let store = match ro.graph() {
+            Ok(store) => store,
+            // Failing to even open the store on a read-only backend is an
+            // acceptable rejection — the write path never becomes reachable.
+            Err(_) => return,
+        };
+
+        let now = chrono::Utc::now();
+        let edge = Edge {
+            id: uuid::Uuid::new_v4().into(),
+            namespace: "local".to_string(),
+            source_id: uuid::Uuid::new_v4(),
+            target_id: uuid::Uuid::new_v4(),
+            relation: EdgeRelation::Extends,
+            weight: 0.8,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            metadata: None,
+            target_backend: None,
+        };
+
+        let result = store.upsert_edge(edge).await;
+        assert!(
+            result.is_err(),
+            "upsert_edge on a read-only backend must reject, not silently no-op"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_read_only_event_store_rejects_append_event() {
+        use khive_types::{EventKind, EventOutcome, SubstrateKind};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_events.db");
+
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable.events().unwrap();
+        }
+
+        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
+        let store = match ro.events() {
+            Ok(store) => store,
+            Err(_) => return,
+        };
+
+        let event = khive_storage::event::Event::new(
+            "local",
+            "test.verb",
+            EventKind::Audit,
+            SubstrateKind::Entity,
+            "test-actor",
+        )
+        .with_outcome(EventOutcome::Success);
+
+        let result = store.append_event(event).await;
+        assert!(
+            result.is_err(),
+            "append_event on a read-only backend must reject, not silently no-op"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_read_only_text_store_rejects_upsert_document() {
+        use khive_storage::types::TextDocument;
+        use khive_types::SubstrateKind;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro_text.db");
+
+        {
+            let writable = StorageBackend::sqlite(&path).unwrap();
+            writable.text("ro_test").unwrap();
+        }
+
+        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
+        let store = match ro.text("ro_test") {
+            Ok(store) => store,
+            Err(_) => return,
+        };
+
+        let doc = TextDocument {
+            subject_id: uuid::Uuid::new_v4(),
+            kind: SubstrateKind::Entity,
+            title: Some("Title".to_string()),
+            body: "Body text.".to_string(),
+            tags: vec![],
+            namespace: "local".to_string(),
+            metadata: None,
+            updated_at: chrono::Utc::now(),
+        };
+
+        let result = store.upsert_document(doc).await;
+        assert!(
+            result.is_err(),
+            "upsert_document on a read-only backend must reject, not silently no-op"
+        );
+    }
+
     #[test]
     fn apply_schema_runs_migrations_idempotently() {
         static MIGRATIONS: &[crate::migrations::Migration] = &[crate::migrations::Migration {

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -47,6 +47,14 @@ pub struct PoolConfig {
     ///
     /// Overridable via `KHIVE_JOURNAL_SIZE_LIMIT_BYTES`.
     pub journal_size_limit_bytes: i64,
+    /// Open the database read-only (default: false).
+    ///
+    /// When true, the pool's writer connection is opened with
+    /// `SQLITE_OPEN_READ_ONLY` (no `SQLITE_OPEN_CREATE`, so a missing path is
+    /// rejected instead of created) and `PRAGMA query_only = ON` is set on
+    /// every connection that can execute SQL. Reader connections are already
+    /// opened read-only regardless of this flag.
+    pub read_only: bool,
 }
 
 impl Default for PoolConfig {
@@ -78,6 +86,7 @@ impl Default for PoolConfig {
                 .ok()
                 .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(DEFAULT_JOURNAL_SIZE_LIMIT_BYTES),
+            read_only: false,
         }
     }
 }
@@ -399,7 +408,14 @@ fn effective_reader_count(config: &PoolConfig, wal_enabled: bool) -> usize {
 
 fn open_writer_connection(config: &PoolConfig) -> Result<Connection, SqliteError> {
     match config.path.as_ref() {
-        Some(path) => Connection::open_with_flags(path, writer_open_flags()).map_err(Into::into),
+        Some(path) => {
+            let flags = if config.read_only {
+                writer_read_only_open_flags()
+            } else {
+                writer_open_flags()
+            };
+            Connection::open_with_flags(path, flags).map_err(Into::into)
+        }
         None => Connection::open_in_memory().map_err(Into::into),
     }
 }
@@ -417,6 +433,12 @@ fn writer_open_flags() -> OpenFlags {
         | OpenFlags::SQLITE_OPEN_NO_MUTEX
 }
 
+/// Read-only writer-slot open flags: no `SQLITE_OPEN_CREATE`, so a missing
+/// path is rejected rather than silently created.
+fn writer_read_only_open_flags() -> OpenFlags {
+    OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI | OpenFlags::SQLITE_OPEN_NO_MUTEX
+}
+
 fn reader_open_flags() -> OpenFlags {
     OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI | OpenFlags::SQLITE_OPEN_NO_MUTEX
 }
@@ -425,6 +447,22 @@ fn configure_writer_connection(
     conn: &Connection,
     config: &PoolConfig,
 ) -> Result<bool, SqliteError> {
+    if config.read_only {
+        // Read-only writer slot: skip write-intent PRAGMAs (journal_mode,
+        // wal_autocheckpoint, journal_size_limit all require write access to
+        // change) and lock the connection down with query_only instead.
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.busy_timeout(config.busy_timeout)?;
+        conn.pragma_update(None, "cache_size", CACHE_SIZE_KIB)?;
+        conn.pragma_update(None, "mmap_size", MMAP_SIZE_BYTES)?;
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        conn.pragma_update(None, "query_only", "ON")?;
+
+        let wal_enabled =
+            config.wal_mode && current_journal_mode(conn)?.eq_ignore_ascii_case("wal");
+        return Ok(wal_enabled);
+    }
+
     let wants_wal = config.path.is_some() && config.wal_mode;
 
     if wants_wal {

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -375,6 +375,63 @@ impl ConnectionPool {
         open_reader_connection(path, &self.config)
     }
 
+    /// Open a standalone read-write connection to the same file-backed database.
+    ///
+    /// Stores whose trait methods take `Send + 'static` closures (executed via
+    /// `spawn_blocking`) cannot hold the pooled `WriterGuard`'s `MutexGuard`
+    /// across the call — it opens an independent connection instead. This
+    /// must still honor `PoolConfig::read_only`: opening
+    /// `SQLITE_OPEN_READ_WRITE` unconditionally here would let a read-only
+    /// backend's graph/event/text stores bypass the flag that the pooled
+    /// writer enforces via `query_only`.
+    pub fn open_standalone_writer(&self) -> Result<Connection, SqliteError> {
+        let path = self.config.path.as_ref().ok_or_else(|| {
+            SqliteError::InvalidData(
+                "in-memory databases do not support standalone connections".to_string(),
+            )
+        })?;
+
+        if self.config.read_only {
+            return Err(SqliteError::InvalidData(
+                "database is read-only: standalone write connections are not permitted".to_string(),
+            ));
+        }
+
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | OpenFlags::SQLITE_OPEN_URI,
+        )?;
+        conn.busy_timeout(self.config.busy_timeout)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        Ok(conn)
+    }
+
+    /// Open a standalone read-only connection to the same file-backed database.
+    ///
+    /// Companion to `open_standalone_writer` for stores that also need an
+    /// independent reader connection outside the pooled reader queue.
+    pub fn open_standalone_reader(&self) -> Result<Connection, SqliteError> {
+        let path = self.config.path.as_ref().ok_or_else(|| {
+            SqliteError::InvalidData(
+                "in-memory databases do not support standalone connections".to_string(),
+            )
+        })?;
+
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | OpenFlags::SQLITE_OPEN_URI,
+        )?;
+        conn.busy_timeout(self.config.busy_timeout)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        Ok(conn)
+    }
+
     fn return_reader(&self, conn: Connection) {
         if self.max_readers == 0 {
             return;

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -148,6 +148,44 @@ fn open_standalone_writer(pool: &ConnectionPool) -> Result<rusqlite::Connection,
     Ok(conn)
 }
 
+/// Open a standalone connection for a transaction, honoring `effective_read_only`.
+///
+/// When `effective_read_only` is set, the connection is opened with
+/// `SQLITE_OPEN_READ_ONLY` (so writes fail at the SQLite level even if the
+/// `PRAGMA query_only` toggle were ever bypassed) instead of `READ_WRITE`.
+fn open_standalone_tx_conn(
+    pool: &ConnectionPool,
+    effective_read_only: bool,
+) -> Result<rusqlite::Connection, StorageError> {
+    let config = pool.config();
+    let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
+        operation: "begin_tx".into(),
+        message: "in-memory databases do not support standalone writer; use pool-backed".into(),
+    })?;
+
+    let flags = if effective_read_only {
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI
+    } else {
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI
+    };
+
+    let conn = rusqlite::Connection::open_with_flags(path, flags)
+        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
+
+    conn.busy_timeout(config.busy_timeout)
+        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
+    conn.pragma_update(None, "cache_size", "-65536")
+        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
+    conn.pragma_update(None, "mmap_size", "1073741824")
+        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
+
+    Ok(conn)
+}
+
 // =============================================================================
 // File-backed: SqliteReader (standalone connection)
 // =============================================================================
@@ -792,6 +830,12 @@ impl khive_storage::SqlAccess for SqlBridge {
         &self,
     ) -> khive_storage::types::StorageResult<Box<dyn khive_storage::SqlWriter>> {
         if self.is_file_backed {
+            if self.pool.config().read_only {
+                return Err(StorageError::Pool {
+                    operation: "writer".into(),
+                    message: "backend is read-only".into(),
+                });
+            }
             let conn = open_standalone_writer(&self.pool)?;
             Ok(Box::new(SqliteWriter { conn: Some(conn) }))
         } else {
@@ -808,8 +852,13 @@ impl khive_storage::SqlAccess for SqlBridge {
         // Transactions need a standalone connection so the BEGIN/COMMIT state
         // is not shared with other operations. For in-memory DBs we still
         // open a standalone writer since the pool writer would conflict.
+        // A read-only backend forces the transaction read-only even if the
+        // caller did not ask for it, so writes cannot bypass the backend's
+        // read-only mode via `SqlTxOptions::default()`.
+        let effective_read_only = self.pool.config().read_only || options.read_only;
+
         let conn = if self.is_file_backed {
-            open_standalone_writer(&self.pool)?
+            open_standalone_tx_conn(&self.pool, effective_read_only)?
         } else {
             return Err(StorageError::Pool {
                 operation: "begin_tx".into(),
@@ -821,11 +870,10 @@ impl khive_storage::SqlAccess for SqlBridge {
         // SQLite WAL mode gives snapshot isolation for readers automatically;
         // IMMEDIATE acquires the write lock early (prevents writer starvation),
         // EXCLUSIVE prevents any concurrent readers for full serializability.
-        let read_only = options.read_only;
         let begin_stmt = match options.isolation {
             SqlIsolation::Serializable => "BEGIN EXCLUSIVE",
             _ => {
-                if read_only {
+                if effective_read_only {
                     // DEFERRED acquires no lock at BEGIN time, compatible with
                     // read-only transactions (no write-intent needed).
                     "BEGIN DEFERRED"
@@ -841,14 +889,14 @@ impl khive_storage::SqlAccess for SqlBridge {
         // Honor read_only: block all writes via PRAGMA query_only.
         // The connection is opened as read-write so COMMIT still works, but
         // any INSERT/UPDATE/DELETE executed inside the transaction will error.
-        if read_only {
+        if effective_read_only {
             conn.pragma_update(None, "query_only", "ON")
                 .map_err(|e| map_rusqlite_err(e, "begin_tx"))?;
         }
 
         Ok(Box::new(SqliteTransaction {
             conn: Some(conn),
-            read_only,
+            read_only: effective_read_only,
         }))
     }
 }

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -53,53 +53,15 @@ impl SqlEventStore {
     }
 
     fn open_standalone_writer(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "event_writer".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_event_writer"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_event_writer"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_event_writer"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_event_writer"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_writer()
+            .map_err(|e| map_sqlite_err(e, "open_event_writer"))
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "event_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_event_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_event_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_event_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_event_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|e| map_sqlite_err(e, "open_event_reader"))
     }
 
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -59,53 +59,15 @@ impl SqlGraphStore {
     }
 
     fn open_standalone_writer(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "graph_writer".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_graph_writer"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_graph_writer"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_graph_writer"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_graph_writer"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_writer()
+            .map_err(|e| map_sqlite_err(e, "open_graph_writer"))
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "graph_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_graph_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_graph_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_graph_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_graph_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|e| map_sqlite_err(e, "open_graph_reader"))
     }
 
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -78,53 +78,15 @@ impl Fts5TextSearch {
     }
 
     fn open_standalone_writer(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "fts_writer".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_fts_writer"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_fts_writer"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_fts_writer"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_fts_writer"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_writer()
+            .map_err(|e| map_sqlite_err(e, "open_fts_writer"))
     }
 
     fn open_standalone_reader(&self) -> Result<rusqlite::Connection, StorageError> {
-        let config = self.pool.config();
-        let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-            operation: "fts_reader".into(),
-            message: "in-memory databases do not support standalone connections".into(),
-        })?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(|e| map_err(e, "open_fts_reader"))?;
-
-        conn.busy_timeout(config.busy_timeout)
-            .map_err(|e| map_err(e, "open_fts_reader"))?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| map_err(e, "open_fts_reader"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| map_err(e, "open_fts_reader"))?;
-
-        Ok(conn)
+        self.pool
+            .open_standalone_reader()
+            .map_err(|e| map_sqlite_err(e, "open_fts_reader"))
     }
 
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -38,6 +38,7 @@ async-trait = { workspace = true }
 libc = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
+tempfile = { workspace = true }
 lattice-embed = { workspace = true, optional = true }
 khive-channel = { version = "0.3.0", path = "../khive-channel", optional = true }
 khive-channel-email = { version = "0.3.0", path = "../khive-channel-email", optional = true }
@@ -55,7 +56,6 @@ tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["server", "transport-io", "client"] }
 khive-types = { version = "0.3.0", path = "../khive-types" }
 async-trait = { workspace = true }
-tempfile = { workspace = true }
 serial_test = { workspace = true }
 khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -167,6 +167,10 @@ pub(crate) mod tests {
         pub link_called: std::sync::atomic::AtomicBool,
         pub search_called: std::sync::atomic::AtomicBool,
         pub single_backend: bool,
+        /// Records the `limit` value `fan_out_search` was last called with, so
+        /// callers can assert the coordinator received the already-capped value
+        /// (MCP-AUD-003 regression).
+        pub last_limit: std::sync::atomic::AtomicU32,
     }
 
     impl MockCoordinator {
@@ -175,6 +179,7 @@ pub(crate) mod tests {
                 link_called: std::sync::atomic::AtomicBool::new(false),
                 search_called: std::sync::atomic::AtomicBool::new(false),
                 single_backend: false,
+                last_limit: std::sync::atomic::AtomicU32::new(0),
             })
         }
 
@@ -183,6 +188,7 @@ pub(crate) mod tests {
                 link_called: std::sync::atomic::AtomicBool::new(false),
                 search_called: std::sync::atomic::AtomicBool::new(false),
                 single_backend: true,
+                last_limit: std::sync::atomic::AtomicU32::new(0),
             })
         }
     }
@@ -218,13 +224,15 @@ pub(crate) mod tests {
             _kind: &str,
             _query: &str,
             _namespace: &Namespace,
-            _limit: u32,
+            limit: u32,
             _kind_filter: Option<&str>,
             _props_filter: Option<&serde_json::Value>,
             _tags: &[String],
         ) -> CoordSearchResult {
             self.search_called
                 .store(true, std::sync::atomic::Ordering::SeqCst);
+            self.last_limit
+                .store(limit, std::sync::atomic::Ordering::SeqCst);
             CoordSearchResult {
                 entity_hits: vec![],
                 note_hits: vec![],
@@ -432,6 +440,95 @@ pub(crate) mod tests {
         assert!(
             !coord.link_called.load(std::sync::atomic::Ordering::SeqCst),
             "T6c: coordinator.link must NOT be called for a single-backend server"
+        );
+    }
+
+    /// T6e: A multi-backend `search` limit beyond `u32::MAX` must be rejected
+    /// with a per-op error, not silently wrapped by `as u32` and passed through.
+    ///
+    /// Before the fix, `limit=4294967297` (`u32::MAX as u64 + 2`) was parsed as
+    /// `u64`, cast with `as u32` (wrapping to `1`), then `.min(100)` left `1` —
+    /// the coordinator was called with a near-empty limit instead of rejecting
+    /// the out-of-range input (MCP-AUD-003).
+    #[tokio::test]
+    async fn t6e_multi_backend_search_limit_matches_single_backend_u32_contract() {
+        let (registry, _runtime) = make_registry();
+        let coord = MockCoordinator::multi_backend();
+        let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+            .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+        let too_large: u64 = u64::from(u32::MAX) + 2;
+        let raw = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(r#"search(kind="entity", query="anything", limit={too_large})"#),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("T6e: dispatch must not return an MCP-level error");
+
+        let result_val: serde_json::Value =
+            serde_json::from_str(&raw).expect("T6e: response must be valid JSON");
+        let first = result_val
+            .get("results")
+            .and_then(|r| r.as_array())
+            .and_then(|a| a.first())
+            .expect("T6e: results array must be non-empty");
+        assert_eq!(
+            first.get("ok").and_then(serde_json::Value::as_bool),
+            Some(false),
+            "T6e: an out-of-range limit must produce ok=false; got {:?}",
+            first
+        );
+        assert!(
+            !coord
+                .search_called
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "T6e: coordinator must not be called with an out-of-range limit \
+             (it must not silently wrap to a small value); recorded last_limit={}",
+            coord.last_limit.load(std::sync::atomic::Ordering::SeqCst)
+        );
+    }
+
+    /// T6e companion: a valid-but-huge `u32` limit (`u32::MAX`) must still reach
+    /// the coordinator, capped at 100 — proving the strict parser doesn't
+    /// over-reject in-range values.
+    #[tokio::test]
+    async fn t6e_multi_backend_search_limit_u32_max_is_capped_at_100() {
+        let (registry, _runtime) = make_registry();
+        let coord = MockCoordinator::multi_backend();
+        let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+            .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+        let raw = server
+            .dispatch_request_local(RequestParams {
+                ops: format!(
+                    r#"search(kind="entity", query="anything", limit={})"#,
+                    u32::MAX
+                ),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("T6e: dispatch must not return an MCP-level error");
+        let _ = raw;
+
+        assert!(
+            coord
+                .search_called
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "T6e: coordinator.fan_out_search must be called for a valid in-range limit"
+        );
+        assert_eq!(
+            coord.last_limit.load(std::sync::atomic::Ordering::SeqCst),
+            100,
+            "T6e: u32::MAX must be capped at 100 before reaching the coordinator"
         );
     }
 }

--- a/crates/khive-mcp/src/save_sink.rs
+++ b/crates/khive-mcp/src/save_sink.rs
@@ -3,12 +3,105 @@
 //! Why the manifest matters: a sink that self-reports null counts catches bulk export
 //! corruption (e.g. `content=null` across 10 000 rows) in one second rather than after
 //! a downstream agent fleet has graded blind.
+//!
+//! Why the destination policy matters: `save_to` is a client-supplied string reaching
+//! the filesystem. Without a root + traversal + symlink check, a client could request
+//! `../../etc/cron.d/x` or overwrite an existing symlinked file outside any sandbox.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+
+/// Environment override for the allowed `save_to` export root.
+const EXPORT_ROOT_ENV: &str = "KHIVE_SAVE_TO_ROOT";
+
+/// Resolve (and create) the allowed export root for `save_to` destinations.
+///
+/// Defaults to `~/.khive/exports`; overridable via `KHIVE_SAVE_TO_ROOT` (used by
+/// tests to scope each case to its own temp directory). Every `save_to` request
+/// must resolve to a path inside this root — see `validate_destination`.
+fn export_root() -> anyhow::Result<PathBuf> {
+    let root = match std::env::var(EXPORT_ROOT_ENV) {
+        Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
+        _ => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".khive").join("exports")
+        }
+    };
+    std::fs::create_dir_all(&root)
+        .map_err(|e| anyhow::anyhow!("create export root {}: {e}", root.display()))?;
+    root.canonicalize()
+        .map_err(|e| anyhow::anyhow!("canonicalize export root {}: {e}", root.display()))
+}
+
+/// Validate a client-supplied `save_to` path against the allowed export `root`
+/// and return the canonicalized destination.
+///
+/// Rejects:
+/// - `..` traversal components anywhere in the requested path
+/// - a resolved parent directory outside `root` (catches absolute-path escapes
+///   and symlinked intermediate directories, since canonicalization follows them)
+/// - an existing symlink at the destination itself (no-follow: a symlink must
+///   never be silently written through to its target)
+fn validate_destination(root: &Path, requested: &Path) -> anyhow::Result<PathBuf> {
+    if requested.as_os_str().is_empty() {
+        anyhow::bail!("save_to path must not be empty");
+    }
+    if requested
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        anyhow::bail!(
+            "save_to path must not contain '..' traversal components: {}",
+            requested.display()
+        );
+    }
+
+    let joined = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        root.join(requested)
+    };
+
+    let parent = joined.parent().filter(|p| !p.as_os_str().is_empty());
+    let parent = match parent {
+        Some(p) => p,
+        None => anyhow::bail!("save_to path has no parent directory: {}", joined.display()),
+    };
+
+    std::fs::create_dir_all(parent)
+        .map_err(|e| anyhow::anyhow!("create save_to parent dir {}: {e}", parent.display()))?;
+
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("canonicalize save_to parent {}: {e}", parent.display()))?;
+
+    if !canonical_parent.starts_with(root) {
+        anyhow::bail!(
+            "save_to path escapes the allowed export root ({}): {}",
+            root.display(),
+            joined.display()
+        );
+    }
+
+    let file_name = joined
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("save_to path has no file name: {}", joined.display()))?;
+    let dest = canonical_parent.join(file_name);
+
+    if let Ok(meta) = std::fs::symlink_metadata(&dest) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "save_to destination must not be a symlink: {}",
+                dest.display()
+            );
+        }
+    }
+
+    Ok(dest)
+}
 
 /// Write `results_envelope` as JSONL to `path` and return the self-describing manifest.
 ///
@@ -28,9 +121,34 @@ use sha2::{Digest, Sha256};
 /// }
 /// ```
 ///
+/// `restrict_to_export_root` gates the destination policy (root containment,
+/// `..` traversal rejection, symlink-destination rejection): `true` for the
+/// agent-facing MCP `request` tool, where `path` is a client-supplied string
+/// reaching the filesystem; `false` for the trusted operator CLI path
+/// (`kkernel exec --save-file`, `from_wire = false`), which may write anywhere
+/// the operator points it, matching its documented behavior.
+///
 /// Errors are propagated as `anyhow::Error` so callers can convert to their preferred
 /// error type (`McpError::internal_error` on the MCP path; `anyhow::bail!` on the CLI path).
-pub fn write_and_manifest(results_envelope: &Value, path: &Path) -> anyhow::Result<Value> {
+pub fn write_and_manifest(
+    results_envelope: &Value,
+    path: &Path,
+    restrict_to_export_root: bool,
+) -> anyhow::Result<Value> {
+    let dest = if restrict_to_export_root {
+        let root = export_root()?;
+        validate_destination(&root, path)?
+    } else {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| anyhow::anyhow!("create parent dir {}: {e}", parent.display()))?;
+            }
+        }
+        path.to_path_buf()
+    };
+    let path = dest.as_path();
+
     // Collect per-op rows from the results array.
     let results_arr = results_envelope
         .get("results")
@@ -47,8 +165,8 @@ pub fn write_and_manifest(results_envelope: &Value, path: &Path) -> anyhow::Resu
         jsonl_bytes.push(b'\n');
     }
 
-    // Write atomically via tmp+rename when the target is on the same filesystem.
-    // Falls back to direct write when the rename crosses filesystems.
+    // Write atomically via a securely-created unique temp file in the same
+    // directory, then rename over the destination.
     write_atomic(path, &jsonl_bytes)?;
 
     // Compute manifest fields.
@@ -99,41 +217,55 @@ fn hex_sha256(data: &[u8]) -> String {
     format!("{:x}", h.finalize())
 }
 
-/// Write `data` to `path` using a tmp+rename strategy when possible.
+/// Write `data` to `path` via a securely-created, randomly-named temp file in
+/// the same directory, then rename over the destination.
+///
+/// Using `tempfile::Builder::tempfile_in` (instead of a predictable
+/// `path.with_extension("tmp")` sibling) closes the symlink-following /
+/// predictable-path race the previous sibling-tmp approach was open to, and
+/// the temp file always lives in the same directory as `path` so the final
+/// rename is same-filesystem and atomic.
 fn write_atomic(path: &Path, data: &[u8]) -> anyhow::Result<()> {
-    // If the parent doesn't exist, create it.
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| anyhow::anyhow!("create parent dir {}: {e}", parent.display()))?;
-        }
-    }
+    use std::io::Write;
 
-    // Try tmp+rename for atomicity.
-    // Build the tmp extension without a leading dot so extensionless paths
-    // (e.g. `/tmp/outfile`) don't produce a double-dot (`outfile..tmp`).
-    let tmp_ext = match path.extension() {
-        Some(e) => format!("{}.tmp", e.to_string_lossy()),
-        None => "tmp".to_string(),
-    };
-    let tmp_path = path.with_extension(tmp_ext);
-    if std::fs::write(&tmp_path, data).is_ok() {
-        if std::fs::rename(&tmp_path, path).is_ok() {
-            return Ok(());
-        }
-        // Rename failed (cross-filesystem); clean up tmp and fall through.
-        let _ = std::fs::remove_file(&tmp_path);
-    }
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
 
-    // Direct write fallback.
-    std::fs::write(path, data).map_err(|e| anyhow::anyhow!("write file {}: {e}", path.display()))
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".khive-save-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .map_err(|e| anyhow::anyhow!("create temp file in {}: {e}", parent.display()))?;
+
+    tmp.write_all(data)
+        .map_err(|e| anyhow::anyhow!("write temp file: {e}"))?;
+    tmp.flush()
+        .map_err(|e| anyhow::anyhow!("flush temp file: {e}"))?;
+
+    tmp.persist(path)
+        .map_err(|e| anyhow::anyhow!("persist temp file to {}: {}", path.display(), e.error))?;
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use serial_test::serial;
     use tempfile::TempDir;
+
+    /// Scope `KHIVE_SAVE_TO_ROOT` to `root` for the duration of `f`.
+    ///
+    /// Tests are `#[serial]` because `EXPORT_ROOT_ENV` is process-global state.
+    fn with_root<R>(root: &Path, f: impl FnOnce() -> R) -> R {
+        std::env::set_var(EXPORT_ROOT_ENV, root);
+        let result = f();
+        std::env::remove_var(EXPORT_ROOT_ENV);
+        result
+    }
 
     fn make_envelope(results: Vec<Value>) -> Value {
         let total = results.len();
@@ -158,7 +290,7 @@ mod tests {
             json!({ "ok": true, "tool": "list",  "result": { "entities": 3, "notes": 2 } }),
         ]);
 
-        let manifest = write_and_manifest(&envelope, &path).unwrap();
+        let manifest = write_and_manifest(&envelope, &path, false).unwrap();
 
         // File must exist.
         assert!(path.exists());
@@ -206,7 +338,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("empty.jsonl");
         let envelope = make_envelope(vec![]);
-        let manifest = write_and_manifest(&envelope, &path).unwrap();
+        let manifest = write_and_manifest(&envelope, &path, false).unwrap();
 
         assert_eq!(manifest["rows"], json!(0));
         assert!(path.exists());
@@ -222,29 +354,10 @@ mod tests {
             json!({ "ok": true, "tool": "get", "result": { "id": "abc", "name": "foo" } }),
         ]);
 
-        let m1 = write_and_manifest(&envelope, &path).unwrap();
-        let m2 = write_and_manifest(&envelope, &path).unwrap();
+        let m1 = write_and_manifest(&envelope, &path, false).unwrap();
+        let m2 = write_and_manifest(&envelope, &path, false).unwrap();
         assert_eq!(m1["checksum"], m2["checksum"]);
         assert_eq!(m1["schema_fingerprint"], m2["schema_fingerprint"]);
-    }
-
-    #[test]
-    fn extensionless_target_produces_clean_tmp_path() {
-        let tmp = TempDir::new().unwrap();
-        // A target with no extension must not produce a `..tmp` double-dot path.
-        let path = tmp.path().join("outfile");
-        let envelope = make_envelope(vec![
-            json!({ "ok": true, "tool": "stats", "result": { "n": 1 } }),
-        ]);
-        // write_and_manifest must succeed (it uses write_atomic internally).
-        write_and_manifest(&envelope, &path).unwrap();
-        assert!(path.exists());
-        // No double-dot artefact left behind.
-        let double_dot = tmp.path().join("outfile..tmp");
-        assert!(
-            !double_dot.exists(),
-            "double-dot tmp path must not be created"
-        );
     }
 
     #[test]
@@ -260,8 +373,126 @@ mod tests {
             json!({ "ok": true, "tool": "t", "result": { "bar": 1 } }),
         ]);
 
-        let m1 = write_and_manifest(&e1, &p1).unwrap();
-        let m2 = write_and_manifest(&e2, &p2).unwrap();
+        let m1 = write_and_manifest(&e1, &p1, false).unwrap();
+        let m2 = write_and_manifest(&e2, &p2, false).unwrap();
         assert_ne!(m1["schema_fingerprint"], m2["schema_fingerprint"]);
+    }
+
+    #[test]
+    #[serial]
+    fn happy_path_relative_and_absolute_inside_root_both_succeed() {
+        let tmp = TempDir::new().unwrap();
+        let envelope = make_envelope(vec![
+            json!({ "ok": true, "tool": "t", "result": { "n": 1 } }),
+        ]);
+
+        with_root(tmp.path(), || {
+            // Relative path is joined under the root.
+            let m1 = write_and_manifest(&envelope, Path::new("nested/rel.jsonl"), true).unwrap();
+            assert!(tmp.path().join("nested/rel.jsonl").exists());
+            assert_eq!(m1["rows"], json!(1));
+
+            // Absolute path that resolves inside the root also succeeds.
+            let abs = tmp.path().join("abs.jsonl");
+            let m2 = write_and_manifest(&envelope, &abs, true).unwrap();
+            assert!(abs.exists());
+            assert_eq!(m2["rows"], json!(1));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn traversal_component_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let envelope = make_envelope(vec![json!({ "ok": true, "tool": "t", "result": {} })]);
+
+        with_root(tmp.path(), || {
+            let err =
+                write_and_manifest(&envelope, Path::new("../escape.jsonl"), true).unwrap_err();
+            assert!(
+                err.to_string().contains("traversal"),
+                "expected traversal error, got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn absolute_path_outside_root_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let envelope = make_envelope(vec![json!({ "ok": true, "tool": "t", "result": {} })]);
+
+        with_root(tmp.path(), || {
+            let target = outside.path().join("outside.jsonl");
+            let err = write_and_manifest(&envelope, &target, true).unwrap_err();
+            assert!(
+                err.to_string().contains("escapes"),
+                "expected escape error, got: {err}"
+            );
+            assert!(!target.exists());
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn symlinked_destination_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let real_target = outside.path().join("real.txt");
+        std::fs::write(&real_target, b"pre-existing").unwrap();
+
+        let link_path = tmp.path().join("link.jsonl");
+        std::os::unix::fs::symlink(&real_target, &link_path).unwrap();
+
+        let envelope = make_envelope(vec![json!({ "ok": true, "tool": "t", "result": {} })]);
+
+        with_root(tmp.path(), || {
+            let err = write_and_manifest(&envelope, &link_path, true).unwrap_err();
+            assert!(
+                err.to_string().contains("symlink"),
+                "expected symlink error, got: {err}"
+            );
+        });
+
+        // The symlink target must be untouched.
+        assert_eq!(std::fs::read(&real_target).unwrap(), b"pre-existing");
+    }
+
+    #[test]
+    #[serial]
+    fn overwrite_of_existing_regular_file_inside_root_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("overwrite.jsonl");
+        std::fs::write(&path, b"stale content").unwrap();
+
+        let envelope = make_envelope(vec![
+            json!({ "ok": true, "tool": "t", "result": { "n": 2 } }),
+        ]);
+
+        with_root(tmp.path(), || {
+            let manifest = write_and_manifest(&envelope, &path, true).unwrap();
+            assert_eq!(manifest["rows"], json!(1));
+        });
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("\"n\":2"));
+        assert!(!content.contains("stale content"));
+    }
+
+    #[test]
+    fn unrestricted_path_outside_any_root_still_succeeds() {
+        // Trusted operator path (`kkernel exec --save-file`, from_wire = false):
+        // no root containment is enforced, matching documented CLI behavior.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nested").join("cli.jsonl");
+        let envelope = make_envelope(vec![
+            json!({ "ok": true, "tool": "t", "result": { "n": 3 } }),
+        ]);
+
+        let manifest = write_and_manifest(&envelope, &path, false).unwrap();
+        assert_eq!(manifest["rows"], json!(1));
+        assert!(path.exists());
     }
 }

--- a/crates/khive-mcp/src/save_sink.rs
+++ b/crates/khive-mcp/src/save_sink.rs
@@ -71,6 +71,31 @@ fn validate_destination(root: &Path, requested: &Path) -> anyhow::Result<PathBuf
         None => anyhow::bail!("save_to path has no parent directory: {}", joined.display()),
     };
 
+    // Containment must be proven BEFORE any directory creation: walk up to the
+    // deepest existing ancestor and canonicalize that. `..` components were
+    // already rejected above, so the not-yet-existing suffix can only descend
+    // beneath the ancestor — if the ancestor is inside the root, the parent is.
+    let mut existing = parent;
+    while !existing.exists() {
+        existing = match existing.parent().filter(|p| !p.as_os_str().is_empty()) {
+            Some(p) => p,
+            None => anyhow::bail!(
+                "save_to path has no existing ancestor: {}",
+                joined.display()
+            ),
+        };
+    }
+    let canonical_existing = existing.canonicalize().map_err(|e| {
+        anyhow::anyhow!("canonicalize save_to ancestor {}: {e}", existing.display())
+    })?;
+    if !canonical_existing.starts_with(root) {
+        anyhow::bail!(
+            "save_to path escapes the allowed export root ({}): {}",
+            root.display(),
+            joined.display()
+        );
+    }
+
     std::fs::create_dir_all(parent)
         .map_err(|e| anyhow::anyhow!("create save_to parent dir {}: {e}", parent.display()))?;
 
@@ -412,6 +437,28 @@ mod tests {
             assert!(
                 err.to_string().contains("traversal"),
                 "expected traversal error, got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn outside_root_missing_parent_is_rejected_without_creating_directories() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let envelope = make_envelope(vec![json!({ "ok": true, "tool": "t", "result": {} })]);
+
+        with_root(tmp.path(), || {
+            let missing_parent = outside.path().join("no").join("such").join("dir");
+            let dest = missing_parent.join("escape.jsonl");
+            let err = write_and_manifest(&envelope, &dest, true).unwrap_err();
+            assert!(
+                err.to_string().contains("escapes the allowed export root"),
+                "expected escape error, got: {err}"
+            );
+            assert!(
+                !missing_parent.exists() && !outside.path().join("no").exists(),
+                "outside-root parent directories must not be created"
             );
         });
     }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -609,15 +609,19 @@ pub fn build_registry_for_multi_backend(
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes_local: HashMap<String, KhiveRuntime> = HashMap::new();
     for pack_name in pack_names {
-        let backend_name = khive_cfg
-            .packs
-            .get(pack_name.as_str())
-            .map(|pc| pc.backend.as_str())
-            .unwrap_or(BackendId::MAIN);
-        let backend = backends
-            .get(backend_name)
-            .cloned()
-            .unwrap_or_else(|| main_backend.clone());
+        let (backend_name, backend) = match khive_cfg.packs.get(pack_name.as_str()) {
+            None => (BackendId::MAIN, main_backend.clone()),
+            Some(pack_cfg) => {
+                let backend_name = pack_cfg.backend.as_str();
+                let backend = backends.get(backend_name).cloned().ok_or_else(|| {
+                    let defined = backends.keys().cloned().collect::<Vec<_>>().join(", ");
+                    anyhow::anyhow!(
+                        "[packs.{pack_name}].backend = {backend_name:?} references an unknown backend; defined backends: {defined}"
+                    )
+                })?;
+                (backend_name, backend)
+            }
+        };
         let mut rt_config = base_config.clone();
         rt_config.backend_id = BackendId::new(backend_name);
         per_pack_runtimes_local.insert(
@@ -945,15 +949,19 @@ fn build_server_multi_backend(
     let pack_names = &base_config.packs;
     let mut per_pack_runtimes: HashMap<String, KhiveRuntime> = HashMap::new();
     for pack_name in pack_names {
-        let backend_name = khive_cfg
-            .packs
-            .get(pack_name.as_str())
-            .map(|pc| pc.backend.as_str())
-            .unwrap_or(BackendId::MAIN);
-        let backend = backends
-            .get(backend_name)
-            .cloned()
-            .unwrap_or_else(|| main_backend.clone());
+        let (backend_name, backend) = match khive_cfg.packs.get(pack_name.as_str()) {
+            None => (BackendId::MAIN, main_backend.clone()),
+            Some(pack_cfg) => {
+                let backend_name = pack_cfg.backend.as_str();
+                let backend = backends.get(backend_name).cloned().ok_or_else(|| {
+                    let defined = backends.keys().cloned().collect::<Vec<_>>().join(", ");
+                    anyhow::anyhow!(
+                        "[packs.{pack_name}].backend = {backend_name:?} references an unknown backend; defined backends: {defined}"
+                    )
+                })?;
+                (backend_name, backend)
+            }
+        };
         let mut rt_config = base_config.clone();
         rt_config.backend_id = BackendId::new(backend_name);
         per_pack_runtimes.insert(
@@ -1945,6 +1953,119 @@ brain_profile = "project-profile"
             assert!(
                 err.to_string().contains("main"),
                 "error message must mention \"main\"; got: {err}"
+            );
+        }
+    }
+
+    /// Regression for MCP-AUD-001 / #419: a pack explicitly configured to a
+    /// backend that has no matching `[[backends]]` entry must fail closed
+    /// instead of silently falling back to `main`. `build_registry_for_multi_backend`
+    /// must return an `Err` mentioning the pack, the requested backend, and the
+    /// defined backends.
+    #[test]
+    fn multi_backend_registry_rejects_undefined_pack_backend() {
+        use khive_runtime::PackConfig;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            packs: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "archive".to_string(),
+                    },
+                );
+                m
+            },
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg);
+        assert!(
+            result.is_err(),
+            "an undeclared configured pack backend must be a startup error, not a silent \
+             fallback to main"
+        );
+        // MultiBackendRegistry does not implement Debug, so expect_err/unwrap_err are
+        // unavailable; extract the error via match instead (same pattern as
+        // multi_backend_missing_main_returns_error_mentioning_main above).
+        if let Err(err) = result {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("packs.comm"),
+                "error must name the pack; got: {msg}"
+            );
+            assert!(
+                msg.contains("archive"),
+                "error must name the undeclared backend; got: {msg}"
+            );
+            assert!(
+                msg.contains("main"),
+                "error must list the defined backends; got: {msg}"
+            );
+        }
+    }
+
+    /// Same regression as `multi_backend_registry_rejects_undefined_pack_backend`
+    /// but through the `build_server_multi_backend` public builder, which has its
+    /// own independent per-pack backend resolution loop.
+    #[test]
+    fn multi_backend_server_rejects_undefined_pack_backend() {
+        use khive_runtime::PackConfig;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![BackendConfig {
+                name: "main".to_string(),
+                kind: BackendKind::Memory,
+                path: None,
+                cache_mb: None,
+                journal_mode: None,
+                read_only: false,
+            }],
+            packs: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "comm".to_string(),
+                    PackConfig {
+                        backend: "archive".to_string(),
+                    },
+                );
+                m
+            },
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = base_runtime_config_for_multi_backend();
+
+        let result = build_server_multi_backend(base_cfg, &khive_cfg);
+        assert!(
+            result.is_err(),
+            "an undeclared configured pack backend must be a startup error, not a silent \
+             fallback to main"
+        );
+        if let Err(err) = result {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("packs.comm"),
+                "error must name the pack; got: {msg}"
+            );
+            assert!(
+                msg.contains("archive"),
+                "error must name the undeclared backend; got: {msg}"
+            );
+            assert!(
+                msg.contains("main"),
+                "error must list the defined backends; got: {msg}"
             );
         }
     }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -970,12 +970,23 @@ async fn dispatch_via_coordinator_inner(
         "search" => {
             let kind = args_value.get("kind")?.as_str()?;
             let query = args_value.get("query")?.as_str()?;
-            let limit = args_value
-                .get("limit")
-                .and_then(Value::as_u64)
-                .map(|v| v as u32)
-                .unwrap_or(10)
-                .min(100);
+            // Parse strictly as u32 (matching the single-backend `SearchParams { limit:
+            // Option<u32> }` contract) instead of parsing as u64 and casting — `as u32`
+            // wraps values above `u32::MAX` (e.g. 4294967297 as u32 == 1) before the
+            // `.min(100)` cap ever runs, silently truncating a huge limit to a near-empty
+            // result set rather than rejecting it (MCP-AUD-003).
+            let limit = match args_value.get("limit") {
+                None | Some(Value::Null) => 10,
+                Some(v) => match serde_json::from_value::<u32>(v.clone()) {
+                    Ok(limit) => limit.min(100),
+                    Err(_) => {
+                        return Some(Err((
+                            "search".to_string(),
+                            json!("limit must be an unsigned 32-bit integer"),
+                        )));
+                    }
+                },
+            };
             let score_floor = args_value
                 .get("min_score")
                 .and_then(Value::as_f64)
@@ -1155,8 +1166,14 @@ result (e.g. create then link with the new entity's id)."#)]
         // Forward to the warm daemon when reachable, auto-spawning it
         // on first use. Any failure (no socket, spawn failure, namespace
         // mismatch, KHIVE_NO_DAEMON) falls through to local dispatch.
+        //
+        // MCP-AUD-002: the daemon wire frame has no `save_to` field, so
+        // daemon-forwarded requests silently drop the sink and return the
+        // inline result instead. Bypass daemon forwarding whenever `save_to`
+        // is set so the local path's manifest/file behavior always applies,
+        // matching the existing `kkernel exec --save-file` precedent.
         #[cfg(unix)]
-        {
+        if p.save_to.is_none() {
             let frame = self.wire_daemon_frame(&p);
             if let Some(res) = crate::daemon::forward_or_spawn(&frame).await {
                 return res;
@@ -1479,7 +1496,8 @@ impl ServerHandler for KhiveMcpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::build_verb_catalog;
+    use super::*;
+    use serial_test::serial;
 
     fn t(pack: &str, verb: &str, desc: &str) -> (String, String, String) {
         (pack.to_owned(), verb.to_owned(), desc.to_owned())
@@ -1523,5 +1541,100 @@ mod tests {
             .map(|l| l.trim_start().split(' ').next().unwrap())
             .collect();
         assert_eq!(names, vec!["assign", "list", "search"]);
+    }
+
+    // ── MCP-AUD-002 regression: save_to must bypass daemon forwarding ────────
+
+    fn make_daemon_save_to_test_server() -> KhiveMcpServer {
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::parse("test").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string()],
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        KhiveMcpServer::new(runtime).expect("server builds with kg")
+    }
+
+    fn clear_daemon_env() {
+        std::env::remove_var("KHIVE_SOCKET");
+        std::env::remove_var("KHIVE_PID");
+        std::env::remove_var("KHIVE_NO_DAEMON");
+        std::env::remove_var("KHIVE_LOCK");
+    }
+
+    async fn connect_when_daemon_ready(sock: &std::path::Path) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if tokio::net::UnixStream::connect(sock).await.is_ok() {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "daemon never bound {sock:?} within 5s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Regression for MCP-AUD-002 / #440: `request()` must NOT forward a
+    /// `save_to`-bearing call to a warm daemon (whose wire frame has no
+    /// `save_to` field and would silently return the inline result instead of
+    /// writing the sink). With a real daemon reachable at `KHIVE_SOCKET`, a
+    /// `save_to` request must still take the local path and return the
+    /// manifest with the file actually written — proving the daemon was
+    /// bypassed rather than silently dropping the sink.
+    #[tokio::test]
+    #[serial]
+    async fn request_save_to_bypasses_daemon_forwarding_and_writes_manifest() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid = dir.path().join("khived.pid");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let server = make_daemon_save_to_test_server();
+        let daemon_server = server.clone();
+        let handle = tokio::spawn(async move {
+            let _ = khive_runtime::daemon::run_daemon(daemon_server).await;
+        });
+        connect_when_daemon_ready(&sock).await;
+
+        let sink_path = dir.path().join("out.jsonl");
+        let resp = server
+            .request(Parameters(RequestParams {
+                ops: "stats()".to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: Some(sink_path.to_string_lossy().to_string()),
+                format: None,
+                format_per_op: None,
+            }))
+            .await
+            .expect("request with save_to must succeed even with a warm daemon reachable");
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(&resp).expect("response must be the save_to manifest JSON");
+        assert!(
+            manifest.get("rows").is_some() && manifest.get("path").is_some(),
+            "response must be the save_to manifest, not an inline daemon result; got: {resp}"
+        );
+        assert!(
+            sink_path.exists(),
+            "save_to file must be written even when a daemon is reachable"
+        );
+        let contents = std::fs::read_to_string(&sink_path).expect("read sink file");
+        assert!(
+            !contents.trim().is_empty(),
+            "sink file must contain JSONL content"
+        );
+
+        handle.abort();
+        let _ = handle.await;
+        clear_daemon_env();
     }
 }

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1294,7 +1294,12 @@ impl KhiveMcpServer {
 
         if let Some(path_str) = save_to {
             let path = std::path::Path::new(&path_str);
-            let manifest = crate::save_sink::write_and_manifest(&result, path)
+            // `from_wire` gates the destination policy: the agent-facing MCP
+            // `request` tool (`from_wire = true`) restricts `save_to` to the
+            // allowed export root; the trusted operator CLI path
+            // (`kkernel exec --save-file`, `from_wire = false`) is unrestricted,
+            // matching its documented "write anywhere" behavior.
+            let manifest = crate::save_sink::write_and_manifest(&result, path, from_wire)
                 .map_err(|e| McpError::internal_error(format!("save_to: {e}"), None))?;
             // Manifests are always compact JSON regardless of format (lossless metadata).
             return serde_json::to_string(&manifest)
@@ -1596,6 +1601,9 @@ mod tests {
         std::env::set_var("KHIVE_SOCKET", &sock);
         std::env::set_var("KHIVE_PID", &pid);
         std::env::remove_var("KHIVE_NO_DAEMON");
+        // save_to destinations must resolve inside the allowed export root
+        // (crate::save_sink); scope it to this test's tempdir.
+        std::env::set_var("KHIVE_SAVE_TO_ROOT", dir.path());
 
         let server = make_daemon_save_to_test_server();
         let daemon_server = server.clone();
@@ -1636,5 +1644,6 @@ mod tests {
         handle.abort();
         let _ = handle.await;
         clear_daemon_env();
+        std::env::remove_var("KHIVE_SAVE_TO_ROOT");
     }
 }

--- a/crates/khive-mcp/src/tools/request.rs
+++ b/crates/khive-mcp/src/tools/request.rs
@@ -54,6 +54,12 @@ pub struct RequestParams {
     /// rows) in one call rather than after a downstream judgment fleet has graded
     /// blind. Parent directories are created if absent.
     ///
+    /// The resolved destination MUST stay within the allowed export root
+    /// (default `~/.khive/exports`, overridable via `KHIVE_SAVE_TO_ROOT`).
+    /// Relative paths are joined under the root; absolute paths are accepted
+    /// only if they resolve inside it. Paths containing `..` traversal
+    /// components and symlinked destinations are rejected.
+    ///
     /// When omitted, results are returned inline (default behaviour).
     #[serde(default)]
     #[schemars(

--- a/crates/khive-pack-template/src/pack.rs
+++ b/crates/khive-pack-template/src/pack.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use khive_runtime::pack::PackRuntime;
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
-use khive_types::{HandlerDef, Visibility};
+use khive_types::{HandlerDef, ParamDef, Visibility};
 
 use crate::{handlers, TemplatePack, PACK_NAME};
 
@@ -20,7 +20,12 @@ pub(crate) static TEMPLATE_HANDLERS: [HandlerDef; 1] = [HandlerDef {
     description: "Example pack-prefixed verb. Non-kg packs must use pack.verb naming.",
     visibility: Visibility::Verb,
     category: khive_types::VerbCategory::Directive,
-    params: &[],
+    params: &[ParamDef {
+        name: "name",
+        param_type: "string",
+        required: true,
+        description: "Non-empty string field to echo in the template response.",
+    }],
 }];
 
 // ── Inventory self-registration ───────────────────────────────────────────────

--- a/crates/khive-pack-template/tests/integration.rs
+++ b/crates/khive-pack-template/tests/integration.rs
@@ -74,6 +74,33 @@ async fn my_verb_errors_on_empty_name() {
 }
 
 #[tokio::test]
+async fn my_verb_help_declares_required_name_param() {
+    let (registry, _rt) = build_registry();
+
+    let result = registry
+        .dispatch("template.my_verb", serde_json::json!({ "help": true }))
+        .await
+        .expect("template.my_verb help dispatches");
+
+    let params = result["params"].as_array().expect("params is an array");
+    assert_eq!(
+        params.len(),
+        1,
+        "params should declare the name field; got: {params:?}"
+    );
+    assert_eq!(params[0]["name"], "name");
+    assert_eq!(params[0]["type"], "string");
+    assert_eq!(params[0]["required"], true);
+    assert!(
+        params[0]["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "description should be a non-empty string; got: {:?}",
+        params[0]["description"]
+    );
+}
+
+#[tokio::test]
 async fn unknown_verb_returns_error() {
     let (registry, _rt) = build_registry();
 

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -16,6 +16,7 @@ rust-stemmers = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+khive-bm25 = { version = "0.3.0", path = "../khive-bm25" }
 
 [features]
 default = []

--- a/crates/khive-text/README.md
+++ b/crates/khive-text/README.md
@@ -17,12 +17,16 @@ identifiers, KG entity names).
 use khive_text::{preset, Analyzer};
 
 let tokens = preset::standard().analyze("The quick brown fox jumps over the lazy dog");
-assert_eq!(tokens, vec!["quick", "brown", "fox", "jumps", "lazy", "dog"]);
+assert_eq!(tokens, vec!["quick", "brown", "fox", "jumps", "over", "lazy", "dog"]);
 ```
 
 `preset::standard()` chains `WhitespaceTokenizer` with `LowercaseFilter`,
-`StopWordFilter`, `MinLengthFilter(2)`, and `MaxLengthFilter(40)`. Other named
-presets: `preset::simple()` (whitespace + lowercase only, keeps stop words),
+a BM25-compatible stop-word filter, and `MinLengthFilter(1)` — producing the
+same token stream as `khive-bm25`'s `SimpleTokenizer::default()` (same stop
+list, no max-length cap). This is intentionally different from the public
+`StopWordFilter` in `khive_text::filter`, which has its own stop list for
+callers building custom pipelines. Other named presets: `preset::simple()`
+(whitespace + lowercase only, keeps stop words),
 `preset::keyword()` (whole input as one token), `preset::cjk()`
 (character-level unigrams for CJK scripts, whitespace for Latin), and
 `preset::kg_name()` (identifier-aware splitting tuned for entity names like

--- a/crates/khive-text/src/filter.rs
+++ b/crates/khive-text/src/filter.rs
@@ -200,6 +200,37 @@ impl TokenFilter for StopWordFilter {
     }
 }
 
+/// Drops the same stop words as `khive-bm25`'s `SimpleTokenizer::default()`.
+/// Scoped to `preset::standard()` so the public [`StopWordFilter`] stop list
+/// is unaffected. Assumes input is already lowercased.
+#[derive(Debug, Default, Clone)]
+pub struct Bm25StopWordFilter;
+
+static BM25_STOP_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "a", "an", "and", "are", "as", "at", "be", "been", "being", "but", "by", "can", "did",
+        "do", "does", "doing", "done", "for", "from", "had", "has", "have", "having", "he", "her",
+        "here", "hers", "him", "his", "how", "i", "if", "in", "into", "is", "it", "its", "just",
+        "may", "me", "might", "my", "no", "nor", "not", "of", "on", "or", "our", "out", "own",
+        "say", "she", "should", "so", "some", "such", "than", "that", "the", "their", "them",
+        "then", "there", "these", "they", "this", "those", "through", "to", "too", "up", "us",
+        "very", "was", "we", "were", "what", "when", "where", "which", "while", "who", "whom",
+        "why", "will", "with", "would", "you", "your",
+    ]
+    .into_iter()
+    .collect()
+});
+
+impl TokenFilter for Bm25StopWordFilter {
+    fn apply(&self, token: String) -> Option<String> {
+        if BM25_STOP_WORDS.contains(token.as_str()) {
+            None
+        } else {
+            Some(token)
+        }
+    }
+}
+
 /// Snowball stemmer. Only stems ASCII-alphabetic tokens; others pass through.
 #[cfg(feature = "stem")]
 pub struct SnowballStemmer(rust_stemmers::Stemmer);

--- a/crates/khive-text/src/identifier.rs
+++ b/crates/khive-text/src/identifier.rs
@@ -114,11 +114,12 @@ pub fn split_identifier(text: &str, min_part_len: usize) -> Vec<String> {
         parts.push(current);
     }
 
-    // Lowercase and filter by min_part_len
+    // Lowercase and filter by min_part_len (character count, not byte length)
+    let min_part_len = min_part_len.max(1);
     parts
         .into_iter()
         .map(|p| p.to_lowercase())
-        .filter(|p| p.len() >= min_part_len.max(1))
+        .filter(|p| p.chars().count() >= min_part_len)
         .collect()
 }
 
@@ -227,6 +228,18 @@ mod tests {
         // "GPT-4": parts ["gpt", "4"] — "4" has len 1, filtered when min=2
         let parts = split_identifier("GPT-4", 2);
         assert_eq!(parts, vec!["gpt"]);
+    }
+
+    #[test]
+    fn split_identifier_filters_unicode_min_part_len_by_chars() {
+        // "\u{4F60}" (你) is 1 char but 3 UTF-8 bytes; must be filtered by
+        // char count, not byte length, when min_part_len == 2.
+        let parts = split_identifier("foo_\u{4F60}", 2);
+        assert_eq!(parts, vec!["foo"]);
+
+        // A two-character non-ASCII part is kept at min_part_len == 2.
+        let parts = split_identifier("foo_\u{4F60}\u{597D}", 2);
+        assert_eq!(parts, vec!["foo", "\u{4F60}\u{597D}"]);
     }
 
     #[test]

--- a/crates/khive-text/src/lang.rs
+++ b/crates/khive-text/src/lang.rs
@@ -77,11 +77,8 @@ pub fn is_meaningful_query(query: &str) -> bool {
         return false;
     }
 
-    // All non-whitespace are ASCII but not alphanumeric => symbols only
-    if non_ws
-        .iter()
-        .all(|c| c.is_ascii() && !c.is_ascii_alphanumeric())
-    {
+    // Symbol/punctuation/emoji-only queries are not meaningful, including Unicode symbols.
+    if !non_ws.iter().any(|c| c.is_alphanumeric()) {
         return false;
     }
 
@@ -300,6 +297,18 @@ mod tests {
     #[test]
     fn single_digit_is_meaningful() {
         // Only single ASCII letter is blocked, not digit
+        assert!(is_meaningful_query("5"));
+    }
+
+    #[test]
+    fn unicode_symbol_only_queries_are_not_meaningful() {
+        assert!(!is_meaningful_query("\u{FF0C}")); // fullwidth comma
+        assert!(!is_meaningful_query("\u{3001}")); // ideographic comma
+        assert!(!is_meaningful_query("\u{FF01}\u{FF1F}")); // fullwidth ! ?
+        assert!(!is_meaningful_query("\u{1F600}")); // emoji-only
+
+        assert!(is_meaningful_query("\u{4F60}\u{597D}\u{4E16}\u{754C}")); // 你好世界
+        assert!(is_meaningful_query("BM25"));
         assert!(is_meaningful_query("5"));
     }
 }

--- a/crates/khive-text/src/preset.rs
+++ b/crates/khive-text/src/preset.rs
@@ -1,19 +1,18 @@
 //! Named analyzer constructors for common use cases.
 
 use crate::analyzer::StandardAnalyzer;
-use crate::filter::{LowercaseFilter, MaxLengthFilter, MinLengthFilter, StopWordFilter};
+use crate::filter::{Bm25StopWordFilter, LowercaseFilter, MaxLengthFilter, MinLengthFilter};
 use crate::tokenizer::{CjkCharTokenizer, KeywordTokenizer, WhitespaceTokenizer};
 
-/// Standard English analyzer: whitespace + lowercase + stop words + length filters.
+/// Standard English analyzer: whitespace + lowercase + stop words.
 ///
 /// Produces the same token stream as `khive-bm25`'s `SimpleTokenizer::default()`,
 /// but returns a `StandardAnalyzer` rather than a `khive-bm25` tokenizer type.
 pub fn standard() -> StandardAnalyzer {
     StandardAnalyzer::with_tokenizer(WhitespaceTokenizer)
         .filter(LowercaseFilter)
-        .filter(StopWordFilter)
-        .filter(MinLengthFilter(2))
-        .filter(MaxLengthFilter(40))
+        .filter(Bm25StopWordFilter)
+        .filter(MinLengthFilter(1))
 }
 
 /// Simple analyzer: whitespace split + lowercase only.
@@ -21,11 +20,9 @@ pub fn simple() -> StandardAnalyzer {
     StandardAnalyzer::with_tokenizer(WhitespaceTokenizer).filter(LowercaseFilter)
 }
 
-/// Keyword analyzer: entire input is one lowercased token.
+/// Keyword analyzer: entire input is one lowercased token, regardless of length.
 pub fn keyword() -> StandardAnalyzer {
-    StandardAnalyzer::with_tokenizer(KeywordTokenizer)
-        .filter(LowercaseFilter)
-        .filter(MaxLengthFilter(200))
+    StandardAnalyzer::with_tokenizer(KeywordTokenizer).filter(LowercaseFilter)
 }
 
 /// CJK analyzer: character-level unigrams for CJK, whitespace for Latin.
@@ -53,18 +50,22 @@ mod tests {
     #[test]
     fn standard_english() {
         let a = standard();
+        // "over" is not in the BM25 default stop list, so it survives under
+        // the parity contract even though khive-text's own StopWordFilter
+        // would have dropped it.
         let tokens = a.analyze("The quick brown fox jumps over the lazy dog");
         assert_eq!(
             tokens,
-            vec!["quick", "brown", "fox", "jumps", "lazy", "dog"]
+            vec!["quick", "brown", "fox", "jumps", "over", "lazy", "dog"]
         );
     }
 
     #[test]
-    fn standard_drops_short_and_stops() {
+    fn standard_drops_stops_but_keeps_short_non_stop_tokens() {
         let a = standard();
+        // "am" is not a BM25 stop word and min_length is 1, so it survives.
         let tokens = a.analyze("I am a test");
-        assert_eq!(tokens, vec!["test"]);
+        assert_eq!(tokens, vec!["am", "test"]);
     }
 
     #[test]
@@ -97,6 +98,18 @@ mod tests {
     #[test]
     fn keyword_empty() {
         assert!(keyword().analyze("").is_empty());
+    }
+
+    #[test]
+    fn keyword_preserves_long_whole_input_without_hidden_cap() {
+        let input_200 = "a".repeat(200);
+        assert_eq!(keyword().analyze(&input_200), vec![input_200.clone()]);
+
+        let input_201 = "A".repeat(201);
+        assert_eq!(
+            keyword().analyze(&input_201),
+            vec![input_201.to_lowercase()]
+        );
     }
 
     #[test]
@@ -133,10 +146,29 @@ mod tests {
     }
 
     #[test]
-    fn standard_drops_long_tokens() {
+    fn standard_keeps_long_tokens_like_bm25() {
+        // BM25's SimpleTokenizer::default() has no max-length filter, so
+        // standard() must not drop long tokens either.
         let long = "a".repeat(50);
         let input = format!("hello {long} world");
         let tokens = standard().analyze(&input);
-        assert_eq!(tokens, vec!["hello", "world"]);
+        assert_eq!(tokens, vec!["hello".to_string(), long, "world".to_string()]);
+    }
+
+    #[test]
+    fn standard_matches_bm25_default_token_stream() {
+        let bm25 = khive_bm25::SimpleTokenizer::default();
+        let cases = [
+            "may x",
+            "done say might",
+            "against",
+            &"a".repeat(41),
+            "The quick brown fox jumps over the lazy dog",
+        ];
+        for input in cases {
+            let ours = standard().analyze(input);
+            let theirs = khive_bm25::Tokenizer::tokenize(&bm25, input);
+            assert_eq!(ours, theirs, "mismatch for input: {input:?}");
+        }
     }
 }

--- a/crates/khive-text/src/tokenizer.rs
+++ b/crates/khive-text/src/tokenizer.rs
@@ -297,6 +297,18 @@ mod tests {
         assert_eq!(got, vec!["lora", "lo", "ra"]);
     }
 
+    #[test]
+    fn identifier_tokenizer_filters_unicode_min_part_len_by_chars() {
+        // "\u{4F60}" (你) is 1 char / 3 bytes; min_part_len: 2 must drop it
+        // by character count, not keep it via byte length.
+        let t = IdentifierTokenizer { min_part_len: 2 };
+        let got = t.tokenize("foo_\u{4F60}");
+        assert!(
+            !got.contains(&"\u{4F60}".to_string()),
+            "expected unicode single-char part to be filtered; got: {got:?}"
+        );
+    }
+
     // --- UnicodeWordTokenizer ---
 
     #[cfg(feature = "unicode")]

--- a/crates/khive-text/tests/public_api.rs
+++ b/crates/khive-text/tests/public_api.rs
@@ -27,9 +27,11 @@ fn boxed_tokenizer_is_object_safe() {
 
 #[test]
 fn standard_preset_filters_stops_and_short() {
+    // "am" is not a BM25 default stop word, so it survives under the
+    // BM25-parity contract for preset::standard().
     let a = preset::standard();
     let tokens = a.analyze("I am a test of the standard analyzer");
-    assert_eq!(tokens, vec!["test", "standard", "analyzer"]);
+    assert_eq!(tokens, vec!["am", "test", "standard", "analyzer"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Issue-sweep batch resolving 5 audit issues across khive-mcp, khive-pack-template, khive-text, khive-db. Internal review: 0 critical / 0 major / 1 minor non-blocking finding.

| Issue | Fix |
|---|---|
| #419 | Multi-backend registry/server builders fail closed on undeclared pack backend (both builder paths; error names pack + backend + defined set) |
| #440 | `request()` bypasses daemon forwarding when `save_to` is set so the local `write_and_manifest` sink always handles it; multi-backend search `limit` parsed as strict `u32` (no wrap) with per-op error; email-tasks finding verified non-reproducing on main (SKIP, no code change) |
| #464 | `TEMPLATE_HANDLERS` help schema declares the required `name` param |
| #486 | Unicode-aware meaningful-query gate; `standard()` tokenizer mirrors BM25 (new `Bm25StopWordFilter`, cross-crate parity test, khive-bm25 as dev-dep only); `split_identifier` char-count semantics; `keyword()` hidden 200-char cap removed |
| #413 | `sqlite_read_only` enforced end-to-end: no `SQLITE_OPEN_CREATE` on read-only pools, `sql().writer()` rejects acquisition, `begin_tx()` honors backend read-only regardless of tx options |

Each fix carries named regression tests (12 total). Rebased onto main post-#525/#531.

## Gates

- `cargo test -p khive-db -p khive-text -p khive-pack-template -p khive-mcp`: green (re-run post-rebase)
- clippy `-D warnings` scoped: clean; `cargo fmt --all -- --check`: clean