### PR TITLE
fix(runtime,storage,types): namespace fail-closed, bounds validation, edge-token hardening (#433 #443 #470 #471 #485 #487)

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -437,6 +437,15 @@ impl EntityStore for SqlEntityStore {
         page: PageRequest,
     ) -> Result<Page<Entity>, StorageError> {
         let namespace = namespace.to_string();
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Entities,
+            operation: "query_entities".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
 
         self.with_reader("query_entities", move |conn| {
             let (count_sql, count_params) = build_entity_where(&namespace, &filter);
@@ -449,8 +458,8 @@ impl EntityStore for SqlEntityStore {
             };
 
             let (where_sql, mut data_params) = build_entity_where(&namespace, &filter);
-            data_params.push(Box::new(page.limit as i64));
-            data_params.push(Box::new(page.offset as i64));
+            data_params.push(Box::new(limit_i64));
+            data_params.push(Box::new(offset_i64));
 
             let limit_idx = data_params.len() - 1;
             let offset_idx = data_params.len();

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -473,3 +473,30 @@ async fn test_same_id_upsert_replaces_row() {
     assert_eq!(count_a, 0);
     assert_eq!(count_b, 1);
 }
+
+/// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
+/// InvalidInput instead of silently narrowing to a negative i64 offset.
+#[tokio::test]
+async fn page_offset_over_i64max_rejected() {
+    let store = setup_memory_store_ns("ns1");
+    store
+        .upsert_entity(make_entity("ns1", "concept", "Alpha"))
+        .await
+        .unwrap();
+
+    let result = store
+        .query_entities(
+            "ns1",
+            EntityFilter::default(),
+            PageRequest {
+                offset: (i64::MAX as u64) + 1,
+                limit: 10,
+            },
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "expected InvalidInput, got {result:?}"
+    );
+}

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -805,6 +805,15 @@ impl EventStore for SqlEventStore {
         page: PageRequest,
     ) -> Result<Page<Event>, StorageError> {
         let namespace = self.namespace.clone();
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Events,
+            operation: "query_events".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
 
         self.with_reader("query_events", move |conn| {
             let (where_clause, filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
@@ -819,8 +828,8 @@ impl EventStore for SqlEventStore {
 
             let (_, data_filter_params) = build_event_filter_sql(conn, &namespace, &filter)?;
             let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
-            all_params.push(Box::new(page.limit as i64));
-            all_params.push(Box::new(page.offset as i64));
+            all_params.push(Box::new(limit_i64));
+            all_params.push(Box::new(offset_i64));
 
             let limit_idx = all_params.len() - 1;
             let offset_idx = all_params.len();

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -554,3 +554,26 @@ async fn read_event_rejects_payload_schema_version_u32_max_plus_one() {
         "payload_schema_version = u32::MAX + 1 ({overflow_version}) must be rejected"
     );
 }
+
+/// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
+/// InvalidInput instead of silently narrowing to a negative i64 offset.
+#[tokio::test]
+async fn page_offset_over_i64max_rejected() {
+    let store = setup_memory_store();
+    store.append_event(make_event("default")).await.unwrap();
+
+    let result = store
+        .query_events(
+            EventFilter::default(),
+            PageRequest {
+                offset: (i64::MAX as u64) + 1,
+                limit: 10,
+            },
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "expected InvalidInput, got {result:?}"
+    );
+}

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -810,6 +810,15 @@ impl GraphStore for SqlGraphStore {
         page: PageRequest,
     ) -> Result<Page<Edge>, StorageError> {
         let namespace = self.namespace.clone();
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Graph,
+            operation: "query_edges".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
         self.with_reader("query_edges", move |conn| {
             let (where_clause, filter_params) = build_edge_filter_sql(&namespace, &filter);
 
@@ -839,8 +848,8 @@ impl GraphStore for SqlGraphStore {
 
             let (_, data_filter_params) = build_edge_filter_sql(&namespace, &filter);
             let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = data_filter_params;
-            all_params.push(Box::new(page.limit as i64));
-            all_params.push(Box::new(page.offset as i64));
+            all_params.push(Box::new(limit_i64));
+            all_params.push(Box::new(offset_i64));
 
             let limit_idx = all_params.len() - 1;
             let offset_idx = all_params.len();
@@ -1008,6 +1017,15 @@ impl GraphStore for SqlGraphStore {
         let opts = request.options.clone();
         let include_roots = request.include_roots;
         let namespace = self.namespace.clone();
+        let max_depth_i64 =
+            i64::try_from(opts.max_depth).map_err(|_| StorageError::InvalidInput {
+                capability: StorageCapability::Graph,
+                operation: "traverse".into(),
+                message: format!(
+                    "TraversalOptions: max_depth must be <= i64::MAX, got {}",
+                    opts.max_depth
+                ),
+            })?;
 
         self.with_reader("traverse", move |conn| {
             // Two SQLite limits apply to the seed VALUES clause:
@@ -1147,7 +1165,7 @@ impl GraphStore for SqlGraphStore {
                     all_params.push(Box::new(root_id.to_string()));
                 }
                 all_params.push(Box::new(namespace.clone()));
-                all_params.push(Box::new(opts.max_depth as i64));
+                all_params.push(Box::new(max_depth_i64));
                 all_params.extend(extra_params);
 
                 let param_refs: Vec<&dyn rusqlite::types::ToSql> =

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1726,3 +1726,59 @@ async fn traverse_chunks_root_binds_over_host_param_limit() {
         );
     }
 }
+
+/// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
+/// InvalidInput instead of silently narrowing to a negative i64 offset.
+#[tokio::test]
+async fn page_offset_over_i64max_rejected() {
+    let store = setup_memory_store();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    store
+        .upsert_edge(make_edge(a, b, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let result = store
+        .query_edges(
+            EdgeFilter::default(),
+            vec![],
+            PageRequest {
+                offset: (i64::MAX as u64) + 1,
+                limit: 10,
+            },
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "expected InvalidInput, got {result:?}"
+    );
+}
+
+/// STORAGE-AUD-003 / #485: TraversalOptions.max_depth > i64::MAX must return
+/// InvalidInput from the backend instead of silently narrowing to a negative
+/// i64 depth and returning an empty/wrong traversal.
+#[tokio::test]
+async fn traverse_max_depth_over_i64max_rejected() {
+    let store = setup_memory_store();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    store
+        .upsert_edge(make_edge(a, b, EdgeRelation::Extends, 1.0))
+        .await
+        .unwrap();
+
+    let request = TraversalRequest {
+        roots: vec![a],
+        options: TraversalOptions::new((i64::MAX as usize) + 1).with_direction(Direction::Out),
+        include_roots: false,
+        include_properties: false,
+    };
+
+    let result = store.traverse(request).await;
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "expected InvalidInput, got {result:?}"
+    );
+}

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -591,6 +591,15 @@ impl NoteStore for SqlNoteStore {
     ) -> Result<Page<Note>, StorageError> {
         let namespace = namespace.to_string();
         let kind = kind.map(|k| k.to_string());
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Notes,
+            operation: "query_notes".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
 
         self.with_reader("query_notes", move |conn| {
             let (count_sql, count_params) = build_note_where(&namespace, kind.as_deref());
@@ -603,8 +612,8 @@ impl NoteStore for SqlNoteStore {
             };
 
             let (where_sql, mut data_params) = build_note_where(&namespace, kind.as_deref());
-            data_params.push(Box::new(page.limit as i64));
-            data_params.push(Box::new(page.offset as i64));
+            data_params.push(Box::new(limit_i64));
+            data_params.push(Box::new(offset_i64));
 
             let limit_idx = data_params.len() - 1;
             let offset_idx = data_params.len();
@@ -650,6 +659,15 @@ impl NoteStore for SqlNoteStore {
 
         let namespace = namespace.to_string();
         let filter = filter.clone();
+        let limit_i64 = i64::from(page.limit);
+        let offset_i64 = i64::try_from(page.offset).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Notes,
+            operation: "query_notes_filtered".into(),
+            message: format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                page.offset
+            ),
+        })?;
 
         self.with_reader("query_notes_filtered", move |conn| {
             let (count_sql, count_params) = build_note_filter_where(&namespace, &filter)?;
@@ -662,8 +680,8 @@ impl NoteStore for SqlNoteStore {
             };
 
             let (where_sql, mut data_params) = build_note_filter_where(&namespace, &filter)?;
-            data_params.push(Box::new(page.limit as i64));
-            data_params.push(Box::new(page.offset as i64));
+            data_params.push(Box::new(limit_i64));
+            data_params.push(Box::new(offset_i64));
 
             let order_clause = match &filter.order_by {
                 Some((path, dir)) => {

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -385,3 +385,34 @@ async fn test_try_insert_note_pk_collision_returns_error_not_dedup() {
         "PK collision without external_id must return StorageError, not Ok(false)"
     );
 }
+
+/// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
+/// InvalidInput for both list paths instead of silently narrowing to a
+/// negative i64 offset.
+#[tokio::test]
+async fn page_offset_over_i64max_rejected() {
+    let store = setup_memory_store();
+    store
+        .upsert_note(make_note("ns1", "observation", "Hello world"))
+        .await
+        .unwrap();
+
+    let oversized = PageRequest {
+        offset: (i64::MAX as u64) + 1,
+        limit: 10,
+    };
+
+    let result = store.query_notes("ns1", None, oversized.clone()).await;
+    assert!(
+        matches!(result, Err(StorageError::InvalidInput { .. })),
+        "query_notes: expected InvalidInput, got {result:?}"
+    );
+
+    let filtered_result = store
+        .query_notes_filtered("ns1", &NoteFilter::default(), oversized)
+        .await;
+    assert!(
+        matches!(filtered_result, Err(StorageError::InvalidInput { .. })),
+        "query_notes_filtered: expected InvalidInput, got {filtered_result:?}"
+    );
+}

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -331,6 +331,14 @@ impl SqliteSparseStore {
         &self,
         request: SparseSearchRequest,
     ) -> Result<Vec<SparseSearchHit>, StorageError> {
+        request
+            .validate()
+            .map_err(|message| StorageError::InvalidInput {
+                capability: StorageCapability::Sparse,
+                operation: "sparse_search".into(),
+                message,
+            })?;
+
         let table = self.table_name.clone();
         let ns = request
             .namespace
@@ -338,7 +346,18 @@ impl SqliteSparseStore {
             .unwrap_or_else(|| self.namespace.clone());
         let kind_filter = request.kind.map(|k| k.to_string());
         let query = request.query;
-        let top_k = request.top_k as usize;
+        let top_k = usize::try_from(request.top_k).map_err(|_| StorageError::InvalidInput {
+            capability: StorageCapability::Sparse,
+            operation: "sparse_search".into(),
+            message: "SparseSearchRequest: top_k does not fit usize".into(),
+        })?;
+        let heap_capacity = top_k
+            .checked_add(1)
+            .ok_or_else(|| StorageError::InvalidInput {
+                capability: StorageCapability::Sparse,
+                operation: "sparse_search".into(),
+                message: "SparseSearchRequest: top_k capacity overflow".into(),
+            })?;
 
         self.with_reader("sparse_search", move |conn| {
             // Load candidate rows for namespace (and optional kind).
@@ -378,7 +397,7 @@ impl SqliteSparseStore {
 
             // Bounded min-heap for top-k selection (KDB-AUD-003).
             let mut heap: BinaryHeap<Reverse<ScoredCandidate>> =
-                BinaryHeap::with_capacity(top_k + 1);
+                BinaryHeap::with_capacity(heap_capacity);
 
             for row_result in rows {
                 let (id_str, indices_json, values_blob) = row_result?;
@@ -685,6 +704,38 @@ mod tests {
         assert!(!hits.is_empty());
         assert_eq!(hits[0].subject_id, id1, "id1 should rank first");
         assert_eq!(hits[0].rank, 1);
+    }
+
+    /// STORAGE-AUD-002 / #470: top_k = u32::MAX must return InvalidInput
+    /// without allocating a multi-hundred-GB heap.
+    #[tokio::test]
+    async fn sparse_top_k_u32_max_rejected() {
+        let store = make_store("test_top_k_max");
+        let id = Uuid::new_v4();
+        store
+            .insert_sparse(
+                id,
+                SubstrateKind::Entity,
+                "ns:test",
+                "body",
+                sv(vec![0], vec![1.0]),
+            )
+            .await
+            .unwrap();
+
+        let result = store
+            .search_sparse(SparseSearchRequest {
+                query: sv(vec![0], vec![1.0]),
+                top_k: u32::MAX,
+                namespace: Some("ns:test".into()),
+                kind: None,
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(StorageError::InvalidInput { .. })),
+            "expected InvalidInput, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-mcp/src/coordinator.rs
+++ b/crates/khive-mcp/src/coordinator.rs
@@ -392,6 +392,135 @@ pub(crate) mod tests {
         );
     }
 
+    /// T6e / PR #549 blocker: a multi-backend `search` with a present-but-malformed
+    /// `namespace` (null/number/bool/array/object) must fail closed — `ok: false`,
+    /// an error naming the namespace — and the coordinator must NEVER be invoked
+    /// under the server's default namespace.
+    ///
+    /// Before the fix, `dispatch_via_coordinator_inner` never inspected
+    /// `args_value["namespace"]` at all: it always parsed the server's
+    /// `default_namespace` and called `coord.fan_out_search` under it, silently
+    /// substituting the default for a caller value that failed to parse. This
+    /// test FAILS against that code (coordinator IS called, `ok: true`) and
+    /// PASSES once the coordinator intercept shares `resolve_explicit_namespace`
+    /// with `VerbRegistry::dispatch` (RUNTIME-AUD-002 / #433).
+    #[tokio::test]
+    async fn t6e_multi_backend_search_malformed_namespace_fails_closed() {
+        let cases: [(&str, &str); 5] = [
+            ("null", "null"),
+            ("number", "42"),
+            ("boolean", "true"),
+            ("array", r#"["local"]"#),
+            ("object", r#"{"ns":"local"}"#),
+        ];
+
+        for (label, ns_literal) in cases {
+            let (registry, _runtime) = make_registry();
+            let coord = MockCoordinator::multi_backend();
+            let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+                .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+            let ops = format!(r#"search(kind="entity", query="anything", namespace={ns_literal})"#);
+            let raw = server
+                .dispatch_request_local(RequestParams {
+                    ops,
+                    presentation: None,
+                    presentation_per_op: None,
+                    save_to: None,
+                    format: None,
+                    format_per_op: None,
+                })
+                .await
+                .unwrap_or_else(|e| panic!("T6e case {label}: dispatch must not MCP-error: {e}"));
+
+            let result_val: serde_json::Value =
+                serde_json::from_str(&raw).expect("T6e: response must be valid JSON");
+            let first = result_val
+                .get("results")
+                .and_then(|r| r.as_array())
+                .and_then(|a| a.first())
+                .unwrap_or_else(|| panic!("T6e case {label}: results array must be non-empty"));
+
+            assert_eq!(
+                first.get("ok").and_then(serde_json::Value::as_bool),
+                Some(false),
+                "T6e case {label}: malformed namespace must fail closed; got {first:?}"
+            );
+            let err_text = first.get("error").map(|e| e.to_string().to_lowercase());
+            assert!(
+                err_text.as_deref().is_some_and(|e| e.contains("namespace")),
+                "T6e case {label}: error must name the namespace; got {first:?}"
+            );
+            assert!(
+                !coord
+                    .search_called
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                "T6e case {label}: coordinator.fan_out_search must NOT be called for a malformed namespace"
+            );
+        }
+    }
+
+    /// T6f / PR #549 blocker: a multi-backend UUID-form `link` with a
+    /// present-but-malformed `namespace` must fail closed the same way T6e does
+    /// for `search`, and the coordinator must never be invoked.
+    #[tokio::test]
+    async fn t6f_multi_backend_link_malformed_namespace_fails_closed() {
+        let cases: [(&str, &str); 5] = [
+            ("null", "null"),
+            ("number", "42"),
+            ("boolean", "true"),
+            ("array", r#"["local"]"#),
+            ("object", r#"{"ns":"local"}"#),
+        ];
+
+        for (label, ns_literal) in cases {
+            let (registry, _runtime) = make_registry();
+            let coord = MockCoordinator::multi_backend();
+            let server = KhiveMcpServer::from_registry_with_meta(registry, "local", "test-cfg")
+                .with_coordinator(Arc::clone(&coord) as Arc<dyn CoordinatorService>);
+
+            let src_id = Uuid::new_v4();
+            let tgt_id = Uuid::new_v4();
+            let ops = format!(
+                r#"link(source_id="{src_id}", target_id="{tgt_id}", relation="implements", namespace={ns_literal})"#
+            );
+            let raw = server
+                .dispatch_request_local(RequestParams {
+                    ops,
+                    presentation: None,
+                    presentation_per_op: None,
+                    save_to: None,
+                    format: None,
+                    format_per_op: None,
+                })
+                .await
+                .unwrap_or_else(|e| panic!("T6f case {label}: dispatch must not MCP-error: {e}"));
+
+            let result_val: serde_json::Value =
+                serde_json::from_str(&raw).expect("T6f: response must be valid JSON");
+            let first = result_val
+                .get("results")
+                .and_then(|r| r.as_array())
+                .and_then(|a| a.first())
+                .unwrap_or_else(|| panic!("T6f case {label}: results array must be non-empty"));
+
+            assert_eq!(
+                first.get("ok").and_then(serde_json::Value::as_bool),
+                Some(false),
+                "T6f case {label}: malformed namespace must fail closed; got {first:?}"
+            );
+            let err_text = first.get("error").map(|e| e.to_string().to_lowercase());
+            assert!(
+                err_text.as_deref().is_some_and(|e| e.contains("namespace")),
+                "T6f case {label}: error must name the namespace; got {first:?}"
+            );
+            assert!(
+                !coord.link_called.load(std::sync::atomic::Ordering::SeqCst),
+                "T6f case {label}: coordinator.link must NOT be called for a malformed namespace"
+            );
+        }
+    }
+
     /// T6c: A single-backend server must NOT route through the coordinator.
     ///
     /// When the coordinator reports `is_single_backend() == true`, the zero-change

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -23,9 +23,9 @@ use serde_json::{json, Value};
 use khive_db::ConnectionPool;
 use khive_request::{parse_request, ArgValue, DslError, ExecutionMode, ParsedOp};
 use khive_runtime::{
-    present, render_format, KhiveRuntime, Namespace, OutputFormat, PackLoadError, PackRegistry,
-    PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy, VerbRegistry,
-    VerbRegistryBuilder,
+    present, render_format, resolve_explicit_namespace, KhiveRuntime, OutputFormat, PackLoadError,
+    PackRegistry, PresentationMode, RuntimeConfig, RuntimeError, VerbPresentationPolicy,
+    VerbRegistry, VerbRegistryBuilder,
 };
 
 use khive_storage::EdgeRelation;
@@ -897,15 +897,44 @@ impl KhiveMcpServer {
 /// function so closures that don't have access to `&self` can call it.
 ///
 /// Returns `Some(Ok(Value))` when the coordinator handled the op successfully.
-/// Returns `Some(Err((tool, error_value)))` when the coordinator returned an error.
+/// Returns `Some(Err((tool, error_value)))` when the coordinator returned an error,
+/// including when a caller-supplied `namespace` argument fails fail-closed
+/// validation (see below).
 /// Returns `None` to indicate fall-through (caller should dispatch through the registry).
+///
+/// RUNTIME-AUD-002 (#433, PR #549 blocker): this coordinator intercept runs
+/// *before* `VerbRegistry::dispatch`, so it must apply the exact same
+/// fail-closed namespace rule `dispatch` applies — a present-but-non-string
+/// `namespace` (null/number/bool/array/object) must be rejected, never
+/// silently substituted with the server default. Both call sites route
+/// through `resolve_explicit_namespace` (the same chokepoint `dispatch` uses)
+/// so this can't drift out of sync again.
 async fn dispatch_via_coordinator_inner(
     coord: &dyn CoordinatorService,
     tool: &str,
     args_value: &Value,
-    namespace_str: &str,
+    default_namespace_str: &str,
 ) -> Option<Result<Value, (String, Value)>> {
-    let namespace = Namespace::parse(namespace_str).unwrap_or_else(|_| Namespace::local());
+    // Only link/search are ever intercepted here — resolve/validate the
+    // namespace only for those verbs so unrelated verbs (which always
+    // fall through to `None` below) don't pay for a parse they don't need.
+    if !matches!(tool, "link" | "search") {
+        return None;
+    }
+
+    let namespace = match resolve_explicit_namespace(args_value, default_namespace_str) {
+        Ok(ns) => ns,
+        Err(e) => {
+            return Some(Err(match e {
+                RuntimeError::Khive(k) => {
+                    let error_payload = serde_json::to_value(&k)
+                        .unwrap_or_else(|_| json!({"kind": "internal", "message": k.to_string()}));
+                    (tool.to_string(), error_payload)
+                }
+                other => (tool.to_string(), json!(other.to_string())),
+            }));
+        }
+    };
 
     match tool {
         "link" => {

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -470,6 +470,63 @@ async fn json_form_request_works_identically() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// RUNTIME-AUD-002 (#433): a present-but-malformed `namespace` value entering
+/// through the MCP JSON-form wire boundary must fail closed with a per-op
+/// invalid-input error — never be silently coerced to the default namespace and
+/// written. The JSON parser preserves the non-string value verbatim (it is not
+/// dropped or treated as absent), so `VerbRegistry::dispatch` sees it and
+/// rejects it before any gate Allow / storage write. This is the end-to-end
+/// ingress counterpart to the runtime-layer `namespace_null_rejected_not_coerced`
+/// gate-spy test.
+#[tokio::test]
+async fn json_form_namespace_non_string_returns_invalid_input() -> anyhow::Result<()> {
+    let client = connect().await?;
+
+    // Every non-string JSON type the finding enumerates, embedded in a real
+    // JSON-form `create` op exactly as an MCP client would send it.
+    let cases: [(&str, &str); 5] = [
+        ("null", "null"),
+        ("number", "42"),
+        ("boolean", "true"),
+        ("array", r#"["local"]"#),
+        ("object", r#"{"ns":"local"}"#),
+    ];
+
+    for (label, ns_json) in cases {
+        let ops = format!(
+            r#"[{{"tool":"create","args":{{"kind":"entity","entity_kind":"concept","name":"aud002-{label}","namespace":{ns_json}}}}}]"#
+        );
+        let result = call(&client, "request", json!({ "ops": ops })).await?;
+        let body: Value = serde_json::from_str(&first_text(&result))?;
+
+        // Malformed namespace is a per-op validation failure, NOT a protocol
+        // error — the JSON parses fine, so the batch is not aborted.
+        let first = &body["results"][0];
+        assert_eq!(
+            first["ok"],
+            json!(false),
+            "case {label}: op must fail closed, got: {body}"
+        );
+        let err = first["error"].as_str().unwrap_or_default().to_lowercase();
+        assert!(
+            err.contains("namespace"),
+            "case {label}: error must name the namespace, got: {first}"
+        );
+
+        // No local write may have slipped through under a coerced default.
+        assert_eq!(
+            body["summary"]["succeeded"], 0,
+            "case {label}: no op may succeed, got: {body}"
+        );
+        assert_eq!(
+            body["summary"]["failed"], 1,
+            "case {label}: the malformed op must be counted as failed, got: {body}"
+        );
+    }
+
+    Ok(())
+}
+
 // ── Kind hooks (ADR-030) — shared CRUD reaches gtd-owned `task` via TaskHook ──
 
 #[tokio::test]

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -765,6 +765,61 @@ async fn link_two_entities_visible_via_neighbors() {
     );
 }
 
+/// Regression for #471: `link` must reject relation strings with punctuation
+/// (`supports!`, `part/of`, `depends.on`, `competes with`) as InvalidInput
+/// instead of silently normalizing them into a canonical relation.
+#[tokio::test]
+async fn link_edge_relation_bang_returns_invalid_input() {
+    let pack = pack();
+
+    let src = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "Alpha", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create source must succeed");
+    let src_id = src
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("must have id")
+        .to_string();
+
+    let tgt = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "Beta", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create target must succeed");
+    let tgt_id = tgt
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("must have id")
+        .to_string();
+
+    for bad_relation in ["supports!", "part/of", "depends.on", "competes with"] {
+        let err = pack
+            .dispatch(
+                "link",
+                json!({
+                    "source_id": src_id,
+                    "target_id": tgt_id,
+                    "relation": bad_relation,
+                    "weight": 0.5
+                }),
+            )
+            .await
+            .expect_err(&format!(
+                "relation {bad_relation:?} must be rejected as InvalidInput"
+            ));
+        assert!(
+            is_invalid_input(&err),
+            "relation {bad_relation:?} must be InvalidInput, got: {err:?}"
+        );
+    }
+}
+
 /// Regression for #160: search response includes `entity_kind` so agents can
 /// distinguish hit kinds without an extra `get()` call.
 #[tokio::test]
@@ -1316,6 +1371,59 @@ async fn traverse_from_root_with_depth_one_returns_linked_node() {
         !arr.is_empty(),
         "traverse must find the child node at depth 1"
     );
+}
+
+/// STORAGE-AUD-003 / #485: an oversized max_depth (> i64::MAX) must reject at
+/// the storage boundary, not silently narrow to a negative i64 depth and
+/// return an empty or wrong traversal.
+#[tokio::test]
+async fn traverse_max_depth_over_i64max_rejected() {
+    let pack = pack();
+
+    let root = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "RootConcept", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create root must succeed");
+    let root_id = root.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    let child = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "ChildConcept", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create child must succeed");
+    let child_id = child.get("id").and_then(Value::as_str).unwrap().to_string();
+
+    pack.dispatch(
+        "link",
+        json!({"source_id": root_id, "target_id": child_id, "relation": "contains"}),
+    )
+    .await
+    .expect("link must succeed");
+
+    let oversized_max_depth = (i64::MAX as u64) + 1;
+    let err = pack
+        .dispatch(
+            "traverse",
+            json!({
+                "roots": [root_id],
+                "max_depth": oversized_max_depth,
+                "direction": "out",
+                "include_roots": false
+            }),
+        )
+        .await
+        .expect_err("traverse with max_depth > i64::MAX must not succeed");
+
+    match err {
+        RuntimeError::Storage(khive_storage::StorageError::InvalidInput { .. }) => {}
+        RuntimeError::InvalidInput(_) => {}
+        other => panic!("expected InvalidInput (directly or via Storage), got {other:?}"),
+    }
 }
 
 // ---- include_entity_type / include_properties optional enrichment ----

--- a/crates/khive-query/src/validate_tests.rs
+++ b/crates/khive-query/src/validate_tests.rs
@@ -103,6 +103,24 @@ fn rejects_unknown_relation_in_where() {
     assert!(err.to_string().contains("related_to"), "msg: {err}");
 }
 
+#[test]
+fn query_edge_relation_bang_rejected() {
+    // Regression for #471: relation filters with punctuation must be
+    // rejected as Validation errors, not silently normalised into a
+    // canonical relation.
+    for bad in ["supports!", "part/of", "depends.on", "competes with"] {
+        let mut q = gql::parse(&format!(
+            "MATCH (a)-[e:extends]->(b) WHERE e.relation = '{bad}' RETURN a"
+        ))
+        .unwrap();
+        let err = validate(&mut q).unwrap_err();
+        assert!(
+            matches!(err, QueryError::Validation(_)),
+            "relation {bad:?} must be QueryError::Validation, got: {err:?}"
+        );
+    }
+}
+
 fn first_condition_string_value(q: &GqlQuery) -> String {
     match q.where_clause.conditions().next().unwrap().value {
         ConditionValue::String(ref s) => s.clone(),

--- a/crates/khive-request/tests/parser.rs
+++ b/crates/khive-request/tests/parser.rs
@@ -1052,3 +1052,35 @@ fn non_reserved_presentation_like_arg_accepted() {
     assert_eq!(r.mode, ExecutionMode::Single);
     assert_eq!(val(&r.ops[0].args["present"]), &json!("yes"));
 }
+
+/// RUNTIME-AUD-002 (#433): the JSON-form parser must preserve a present-but
+/// non-string `namespace` verbatim (as `ArgValue::Value`), never dropping or
+/// coercing it. This is the ingress link that carries the malformed value into
+/// `VerbRegistry::dispatch`, where `namespace_null_rejected_not_coerced` proves
+/// it is rejected with `InvalidInput` before the gate is ever consulted.
+/// Together the two tests cover the full MCP JSON-form path end to end.
+#[test]
+fn json_form_namespace_non_string_preserved_for_dispatch_rejection() {
+    let cases = [
+        json!(null),
+        json!(42),
+        json!(true),
+        json!(["local"]),
+        json!({ "ns": "local" }),
+    ];
+    for ns in cases {
+        let body = json!([{
+            "tool": "create",
+            "args": { "kind": "entity", "entity_kind": "concept", "name": "N", "namespace": ns },
+        }]);
+        let r = req(&body.to_string());
+        assert_eq!(r.ops.len(), 1, "namespace={ns} should parse to one op");
+        // `namespace` is NOT a reserved envelope arg — it survives parsing as a
+        // raw Value and reaches the runtime dispatch chokepoint unchanged.
+        assert_eq!(
+            val(&r.ops[0].args["namespace"]),
+            &ns,
+            "namespace={ns} must be preserved verbatim, not dropped or coerced"
+        );
+    }
+}

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -60,7 +60,7 @@
 - `merge_entity` enforces same-kind constraint at the runtime layer, not storage
 - Merge is a same-namespace curation constraint: only records in the caller namespace can be
   merged (this is the one by-ID operation with a namespace check — see ADR-007 below; it is
-  not general namespace isolation)
+  not a general by-ID access rule)
 - Symmetric relations are canonicalized (source_uuid < target_uuid) before merge conflict checks
 - Soft-delete preserves existing edges; queries filter by `deleted_at IS NULL`
 - Entity tombstone records preserve provenance for audit

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -18,12 +18,20 @@
 - The audit payload field holds the full `AuditEvent` envelope (not a bare verb result)
 - Top-level event fields follow the ADR-004/ADR-005 schema
 
-### ADR-007: Namespace Strategy
+### ADR-007: Namespace Strategy (Rev 6)
 
-- Every ID-based operation (get, delete, update, merge) verifies `record.namespace == caller_namespace`
-- Wrong-namespace and absent IDs return the same `NotFound` error to prevent timing-oracle attacks
+- Namespace is attribution and gate-policy input, not a storage partition; it is not a
+  by-ID access control boundary
+- By-ID operations (get, delete, update) resolve globally unique UUIDs directly — no
+  `record.namespace == caller_namespace` check at the runtime layer (rule 2; see
+  `operations.rs::get_entity`)
+- `merge_entity` is the one by-ID operation that still requires a namespace match on
+  both sides (it is a same-namespace curation operation, not a generic lookup); it
+  rejects the merge when a record's namespace differs from the caller's token namespace
 - `actor.id` in config must be a valid namespace string; an invalid value is a startup error
-- `NamespaceToken` is the runtime trust boundary; storage is ID-only
+- `NamespaceToken` carries dispatch attribution and the visible-namespace read/write
+  scope produced at the gate boundary; it is not a by-ID access guard (historical:
+  earlier ADR-007 revisions described it as the storage trust boundary — superseded)
 
 ### ADR-009 / ADR-028: Multi-Backend Deployment
 
@@ -165,7 +173,9 @@
 ### ADR-050: Namespace Token Contract
 
 - `NamespaceToken` is sealed to prevent external construction without gate authorization
-- Namespace authority is checked at the runtime layer on every ID-based operation
+- Namespace authority governs which namespace(s) a dispatch can read/write (minted at
+  the gate boundary); it is not consulted again per-record on by-ID operations (ADR-007
+  Rev 6), except `merge_entity`/`merge_note`, which still require a namespace match
 
 ## Consistency Notes
 

--- a/crates/khive-runtime/docs/design.md
+++ b/crates/khive-runtime/docs/design.md
@@ -4,10 +4,12 @@
 
 ### ADR-002: Edge Ontology
 
-- 15 closed edge relations; endpoint contract enforced at the runtime layer in `operations.rs`
+- 17 closed edge relations (15 base relations plus 2 epistemic relations added by ADR-055);
+  endpoint contract enforced at the runtime layer in `operations.rs`
 - Symmetric relations (`competes_with`, `composed_with`) are stored with `source_uuid < target_uuid`
 - `annotates` is the only cross-substrate relation: source must be a note, target may be anything
-- All 13 base relations require entity→entity; notes cannot be source/target except via `annotates`
+- All base relations other than `annotates` require entity→entity; notes cannot be source/target
+  except via `annotates`
 - `supersedes` is same-substrate only: entity→entity or note→note, never cross-substrate
 - `dependency_kind` metadata key is only valid on `depends_on` edges
 - Pack-declared edge endpoint rules are additive only; packs cannot tighten the base contract
@@ -56,7 +58,9 @@
 ### ADR-014: Curation Operations
 
 - `merge_entity` enforces same-kind constraint at the runtime layer, not storage
-- Namespace isolation is enforced during merge: only records in the caller namespace can be merged
+- Merge is a same-namespace curation constraint: only records in the caller namespace can be
+  merged (this is the one by-ID operation with a namespace check — see ADR-007 below; it is
+  not general namespace isolation)
 - Symmetric relations are canonicalized (source_uuid < target_uuid) before merge conflict checks
 - Soft-delete preserves existing edges; queries filter by `deleted_at IS NULL`
 - Entity tombstone records preserve provenance for audit

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -4,7 +4,8 @@
 
 The runtime protocol defines how verb dispatches are routed from the MCP `request` surface
 through the `VerbRegistry` to individual pack handlers, and how security, auditing, and
-namespace isolation are enforced at each step.
+namespace attribution are enforced at each step (ADR-007 Rev 6: namespace is gate-policy
+input, not a storage isolation boundary).
 
 ## ADR Links
 
@@ -33,8 +34,12 @@ MCP request(ops=...) → khive_request::parse_request → Vec<ParsedOp>
 ## Verb Visibility Contract
 
 - `Visibility::Verb` — callable via MCP `request` surface, advertised in `help=true` envelopes.
-- `Visibility::Subhandler` — internal only; `dispatch` returns `PermissionDenied`. `help=true`
-  returns an envelope with `callable_via_mcp: false`.
+- `Visibility::Subhandler` — internal / operator-only. `help=true` returns an envelope with
+  `callable_via_mcp: false`.
+- Subhandler blocking is enforced at the **MCP wire boundary** (`khive-mcp`'s request
+  handling rejects non-help `Visibility::Subhandler` calls before they reach the runtime).
+  `VerbRegistry::dispatch` itself does not block on visibility — direct/operator dispatch
+  (e.g. `khived` local calls, tests) may invoke internal subhandlers.
 
 ## Request Schema
 
@@ -59,17 +64,27 @@ For subhandlers, the envelope additionally carries `"visibility": "internal"` an
 
 - One pack per verb at boot: duplicate verb names across packs produce `RuntimeError::VerbCollision`.
 - Gate is consulted before every dispatch. Gate infrastructure errors are fail-open (ADR-018).
-- Namespace token authority is checked in every ID-based operation at the runtime layer.
-  Storage is ID-only; the runtime is the trust boundary (ADR-007, ADR-050).
+- Namespace is attribution and gate-policy input (ADR-007 Rev 6, ADR-050): it is minted into
+  the dispatch `NamespaceToken`'s read/write scope, not re-checked per record. By-ID
+  operations (get, delete, update) resolve globally unique UUIDs without a namespace
+  equality check; `merge_entity`/`merge_note` are the exception and still require a
+  namespace match.
+- A present but non-string `namespace` request param (`null`, number, boolean, array,
+  object) is rejected with `RuntimeError::InvalidInput` before the gate is consulted —
+  it is never coerced to the default namespace (RUNTIME-AUD-002 / #433, ADR-018 fail-closed).
 
 ## Failure Modes
 
-| Condition          | Error                                                              |
-| ------------------ | ------------------------------------------------------------------ |
-| Unknown verb       | `RuntimeError::InvalidInput("unknown verb ...")`                   |
-| Gate deny          | `RuntimeError::PermissionDenied { verb, reason }`                  |
-| Pack not loaded    | `RuntimeError::InvalidInput` (unknown verb path)                   |
-| Namespace mismatch | `RuntimeError::NamespaceMismatch` (reported as NotFound to caller) |
+| Condition                        | Error                                              |
+| --------------------------------- | --------------------------------------------------- |
+| Unknown verb                      | `RuntimeError::InvalidInput("unknown verb ...")`   |
+| Gate deny                         | `RuntimeError::PermissionDenied { verb, reason }`  |
+| Pack not loaded                   | `RuntimeError::InvalidInput` (unknown verb path)   |
+| Malformed explicit namespace      | `RuntimeError::InvalidInput` (non-string `namespace`, rejected before gate) |
+
+`RuntimeError::NamespaceMismatch` is a historical/rejected variant from a pre-Rev-6
+design where by-ID lookups compared `record.namespace == caller_namespace`; it is not
+part of the current by-ID contract described above.
 
 ## Extension Points
 

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -5,7 +5,7 @@
 The runtime protocol defines how verb dispatches are routed from the MCP `request` surface
 through the `VerbRegistry` to individual pack handlers, and how security, auditing, and
 namespace attribution are enforced at each step (ADR-007 Rev 6: namespace is gate-policy
-input, not a storage isolation boundary).
+input, not a storage access boundary).
 
 ## ADR Links
 

--- a/crates/khive-runtime/docs/protocol.md
+++ b/crates/khive-runtime/docs/protocol.md
@@ -13,7 +13,7 @@ input, not a storage isolation boundary).
 - [ADR-023](../../../docs/adr/ADR-023-declarative-pack-format.md) — Declarative pack format and verb visibility
 - [ADR-027](../../../docs/adr/ADR-027-dynamic-pack-loading.md) — Dynamic pack loading via self-registration
 - [ADR-028](../../../docs/adr/ADR-028-pack-scoped-backends.md) — Pack-scoped backends and schema declaration
-- [ADR-007](../../../docs/adr/ADR-007-namespace.md) — Namespace strategy and isolation requirements
+- [ADR-007](../../../docs/adr/ADR-007-namespace.md) — Namespace attribution and read visibility
 - [ADR-050](../../../docs/adr/ADR-050-kg-token-namespace-contract.md) — NamespaceToken authority contract
 
 ## Dispatch Flow

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -62,10 +62,10 @@ pub use operations::{
 };
 pub use operations::{EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved};
 pub use pack::{
-    DispatchHook, HandlerDef, KindHook, NoteKindSpec, NoteLifecycleSpec, PackByIdResolver,
-    PackFactory, PackLoadError, PackRegistration, PackRegistry, PackRuntime,
-    PackSchemaCollisionError, PackSchemaPlan, ParamDef, SchemaPlan, VerbCategory,
-    VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder, Visibility,
+    resolve_explicit_namespace, DispatchHook, HandlerDef, KindHook, NoteKindSpec,
+    NoteLifecycleSpec, PackByIdResolver, PackFactory, PackLoadError, PackRegistration,
+    PackRegistry, PackRuntime, PackSchemaCollisionError, PackSchemaPlan, ParamDef, SchemaPlan,
+    VerbCategory, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder, Visibility,
 };
 pub use portability::{ImportSummary, KgArchive};
 pub use presentation::{

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -880,15 +880,32 @@ impl VerbRegistry {
         if params.get("help").and_then(Value::as_bool) == Some(true) {
             return self.describe_verb(verb);
         }
-        // Resolve namespace as an owned String before `params` is moved into
-        // pack.dispatch, so the post-dispatch hook can reference it.
-        let ns_str: String = params
-            .get("namespace")
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .unwrap_or_else(|| self.default_namespace.clone());
-        let ns = Namespace::parse(&ns_str)
-            .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
+        // Resolve namespace before `params` is moved into pack.dispatch, so the
+        // post-dispatch hook can reference it.
+        //
+        // RUNTIME-AUD-002 (#433): absent `namespace` and a present-but-malformed
+        // `namespace` are different cases. A present non-string value (null,
+        // number, bool, array, object) is explicit caller input that failed to
+        // parse — ADR-018 requires it fail closed, not silently coerce to the
+        // default namespace. Only a genuinely absent key defaults.
+        let (ns, explicit_namespace) = match params.get("namespace") {
+            None => {
+                let ns = Namespace::parse(&self.default_namespace)
+                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
+                (ns, false)
+            }
+            Some(Value::String(ns_str)) => {
+                let ns = Namespace::parse(ns_str)
+                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
+                (ns, true)
+            }
+            Some(other) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "invalid namespace: expected string when present, got {}",
+                    json_type_name(other),
+                )));
+            }
+        };
         // ADR-057: thread the configured actor identity into the gate request so
         // the gate can distinguish human vs agent callers at the dispatch seam.
         // Mirrors the actor resolution used by the token-minting path below.
@@ -896,7 +913,7 @@ impl VerbRegistry {
             Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
             _ => ActorRef::anonymous(),
         };
-        let gate_req = GateRequest::new(gate_actor, ns, verb, params.clone());
+        let gate_req = GateRequest::new(gate_actor, ns.clone(), verb, params.clone());
 
         // Consult the gate.
         //
@@ -994,20 +1011,18 @@ impl VerbRegistry {
         // included (mint_with_visibility deduplicates). Writes remain pinned to
         // `'local'`. Per-actor distinctions use view-layer tag filters
         // (assignee, actor_id, from/to), not namespace partitions.
-        let token = match params.get("namespace").and_then(Value::as_str) {
-            Some(ns) => {
-                // Rule 3 explicit escape: precise single-namespace scope, read+write. NOT widened.
-                let primary = Namespace::parse(ns)
-                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
-                NamespaceToken::mint_with_visibility(primary, vec![], configured_actor)
-            }
-            None => {
-                // Rule 3b: default path. Write namespace = local; read scope = ['local'] ∪ visible_namespaces.
-                let primary = Namespace::local();
-                let mut extra_visible = self.visible_namespaces.clone();
-                extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
-                NamespaceToken::mint_with_visibility(primary, extra_visible, configured_actor)
-            }
+        // `ns`/`explicit_namespace` were already validated above (RUNTIME-AUD-002 /
+        // #433) — reuse them instead of re-reading `params["namespace"]` with
+        // `as_str()`, which would silently drop malformed non-string values again.
+        let token = if explicit_namespace {
+            // Rule 3 explicit escape: precise single-namespace scope, read+write. NOT widened.
+            NamespaceToken::mint_with_visibility(ns.clone(), vec![], configured_actor)
+        } else {
+            // Rule 3b: default path. Write namespace = local; read scope = ['local'] ∪ visible_namespaces.
+            let primary = Namespace::local();
+            let mut extra_visible = self.visible_namespaces.clone();
+            extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
+            NamespaceToken::mint_with_visibility(primary, extra_visible, configured_actor)
         };
 
         for pack in self.packs.iter() {
@@ -1040,7 +1055,7 @@ impl VerbRegistry {
                 // Post-dispatch hook: fires on success, opt-in (Issue #158).
                 if let (Ok(ref ok_val), Some(hook)) = (&result, &self.dispatch_hook) {
                     let mut dispatch_event = Event::new(
-                        ns_str.as_str(),
+                        ns.as_str(),
                         verb,
                         EventKind::Audit,
                         SubstrateKind::Event,
@@ -1652,6 +1667,19 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
         .and_then(|s| s.parse::<uuid::Uuid>().ok())
 }
 
+/// JSON type name for error messages (RUNTIME-AUD-002 / #433): describes a
+/// present-but-malformed `namespace` value without echoing its contents.
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
 // INLINE TEST JUSTIFICATION: tests here exercise VerbRegistry collision detection,
 // gate enforcement, and dispatch ordering that depend on direct access to the
 // registry's private `packs` Vec and gate field. Moving them to tests/ would
@@ -2182,6 +2210,49 @@ mod tests {
         reg.dispatch("list", Value::Null).await.unwrap();
         let seen = gate.seen.lock().unwrap().clone();
         assert_eq!(seen, vec!["local"]);
+    }
+
+    /// RUNTIME-AUD-002 (#433): a present-but-malformed `namespace` value must
+    /// never reach the gate as the default namespace. Table-driven over every
+    /// non-string JSON type; the gate-spy proves no call is ever recorded (the
+    /// dispatch must short-circuit with `InvalidInput` before `GateRequest` is
+    /// built), so the default namespace can never appear as a coerced stand-in.
+    #[tokio::test]
+    async fn namespace_null_rejected_not_coerced() {
+        let cases: Vec<(&str, Value)> = vec![
+            ("null", Value::Null),
+            ("number", serde_json::json!(42)),
+            ("boolean", serde_json::json!(true)),
+            ("array", serde_json::json!(["local"])),
+            ("object", serde_json::json!({"ns": "local"})),
+        ];
+
+        for (label, ns_value) in cases {
+            let gate = Arc::new(NamespaceCapturingGate::default());
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(AlphaPack);
+            builder.with_gate(gate.clone());
+            builder.with_default_namespace("tenant-x");
+            let reg = builder.build().expect("registry builds");
+
+            let err = reg
+                .dispatch("list", serde_json::json!({"namespace": ns_value}))
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, RuntimeError::InvalidInput(_)),
+                "case {label}: expected InvalidInput, got {err:?}"
+            );
+
+            // The gate must never have been consulted for this malformed input —
+            // proves no Allow decision (and therefore no default-namespace write)
+            // can ever be reached for it.
+            let seen = gate.seen.lock().unwrap().clone();
+            assert!(
+                seen.is_empty(),
+                "case {label}: gate must not be consulted for malformed namespace, saw {seen:?}"
+            );
+        }
     }
 
     // ---- Audit event emission ----

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -887,25 +887,11 @@ impl VerbRegistry {
         // `namespace` are different cases. A present non-string value (null,
         // number, bool, array, object) is explicit caller input that failed to
         // parse — ADR-018 requires it fail closed, not silently coerce to the
-        // default namespace. Only a genuinely absent key defaults.
-        let (ns, explicit_namespace) = match params.get("namespace") {
-            None => {
-                let ns = Namespace::parse(&self.default_namespace)
-                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
-                (ns, false)
-            }
-            Some(Value::String(ns_str)) => {
-                let ns = Namespace::parse(ns_str)
-                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}")))?;
-                (ns, true)
-            }
-            Some(other) => {
-                return Err(RuntimeError::InvalidInput(format!(
-                    "invalid namespace: expected string when present, got {}",
-                    json_type_name(other),
-                )));
-            }
-        };
+        // default namespace. Only a genuinely absent key defaults. Shared with
+        // the multi-backend coordinator intercept via `resolve_explicit_namespace`
+        // so every MCP ingress path applies the same fail-closed rule.
+        let explicit_namespace = params.get("namespace").is_some_and(Value::is_string);
+        let ns = resolve_explicit_namespace(&params, &self.default_namespace)?;
         // ADR-057: thread the configured actor identity into the gate request so
         // the gate can distinguish human vs agent callers at the dispatch seam.
         // Mirrors the actor resolution used by the token-minting path below.
@@ -1667,9 +1653,39 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
         .and_then(|s| s.parse::<uuid::Uuid>().ok())
 }
 
+/// Resolve and validate a caller-supplied `namespace` argument the same way
+/// on every MCP ingress path (RUNTIME-AUD-002 / #433).
+///
+/// - Absent `namespace` key → parse `default_namespace`.
+/// - Present `namespace: "<string>"` → parse the caller's value.
+/// - Present non-string `namespace` (null, number, bool, array, object) →
+///   fail closed with `RuntimeError::InvalidInput`. ADR-018 requires this:
+///   a malformed explicit value must never be silently coerced to the
+///   default namespace.
+///
+/// This is the single chokepoint both `VerbRegistry::dispatch` (single-backend
+/// and JSON-form ingress) and the multi-backend coordinator intercept
+/// (`dispatch_via_coordinator_inner` in `khive-mcp`) call into, so no ingress
+/// path can bypass the fail-closed rule by routing around `dispatch`.
+pub fn resolve_explicit_namespace(
+    params: &Value,
+    default_namespace: &str,
+) -> Result<Namespace, RuntimeError> {
+    match params.get("namespace") {
+        None => Namespace::parse(default_namespace)
+            .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}"))),
+        Some(Value::String(ns_str)) => Namespace::parse(ns_str)
+            .map_err(|e| RuntimeError::InvalidInput(format!("invalid namespace: {e}"))),
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "invalid namespace: expected string when present, got {}",
+            json_type_name(other),
+        ))),
+    }
+}
+
 /// JSON type name for error messages (RUNTIME-AUD-002 / #433): describes a
 /// present-but-malformed `namespace` value without echoing its contents.
-fn json_type_name(v: &Value) -> &'static str {
+pub fn json_type_name(v: &Value) -> &'static str {
     match v {
         Value::Null => "null",
         Value::Bool(_) => "boolean",

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -36,7 +36,7 @@ pub use types::{
     TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
     TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest, VectorIndexKind,
     VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
-    VectorStoreCapabilities, VectorStoreInfo,
+    VectorStoreCapabilities, VectorStoreInfo, MAX_SPARSE_SEARCH_TOP_K,
 };
 
 pub use khive_types::{EdgeCategory, EdgeRelation, EventOutcome, SubstrateKind};

--- a/crates/khive-storage/src/types/graph.rs
+++ b/crates/khive-storage/src/types/graph.rs
@@ -313,6 +313,12 @@ impl TryFrom<TraversalOptionsRaw> for TraversalOptions {
                 ));
             }
         }
+        if raw.max_depth > i64::MAX as usize {
+            return Err(format!(
+                "TraversalOptions: max_depth must be <= i64::MAX, got {}",
+                raw.max_depth
+            ));
+        }
         Ok(Self {
             max_depth: raw.max_depth,
             direction: raw.direction,
@@ -436,5 +442,39 @@ mod tests {
     #[test]
     fn traversal_options_default_max_depth_is_three() {
         assert_eq!(TraversalOptions::default().max_depth, 3);
+    }
+
+    /// STORAGE-AUD-003 / #485: max_depth > i64::MAX must be rejected by serde
+    /// deserialization instead of silently narrowing to a negative i64 at the
+    /// SQLite traversal boundary.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn traverse_max_depth_over_i64max_rejected() {
+        let raw = serde_json::json!({
+            "max_depth": (i64::MAX as u64) + 1,
+            "direction": "out",
+            "relations": null,
+            "min_weight": null,
+            "limit": null,
+        });
+        let result: Result<TraversalOptions, _> = serde_json::from_value(raw);
+        assert!(
+            result.is_err(),
+            "max_depth > i64::MAX must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn traverse_max_depth_at_i64max_accepted() {
+        let raw = serde_json::json!({
+            "max_depth": i64::MAX as u64,
+            "direction": "out",
+            "relations": null,
+            "min_weight": null,
+            "limit": null,
+        });
+        let result: Result<TraversalOptions, _> = serde_json::from_value(raw);
+        assert!(result.is_ok(), "max_depth == i64::MAX must be accepted");
     }
 }

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -17,7 +17,9 @@ pub use graph::{
     PathNode, SortDirection, SortOrder, TimeRange, TraversalOptions, TraversalRequest,
 };
 pub use pagination::{Page, PageRequest};
-pub use sparse::{SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector};
+pub use sparse::{
+    SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, MAX_SPARSE_SEARCH_TOP_K,
+};
 pub use sql::{SqlColumn, SqlIsolation, SqlRow, SqlStatement, SqlTxOptions, SqlValue};
 pub use text::{
     IndexRebuildScope, TextDocument, TextFilter, TextGatherMode, TextIndexStats, TextQueryMode,

--- a/crates/khive-storage/src/types/pagination.rs
+++ b/crates/khive-storage/src/types/pagination.rs
@@ -2,8 +2,35 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Offset-based pagination cursor for list operations.
+/// Raw deserialization target for [`PageRequest`].
+#[derive(Deserialize)]
+struct PageRequestRaw {
+    offset: u64,
+    limit: u32,
+}
+
+impl TryFrom<PageRequestRaw> for PageRequest {
+    type Error = String;
+
+    fn try_from(raw: PageRequestRaw) -> Result<Self, Self::Error> {
+        if raw.offset > i64::MAX as u64 {
+            return Err(format!(
+                "PageRequest: offset must be <= i64::MAX, got {}",
+                raw.offset
+            ));
+        }
+        Ok(Self {
+            offset: raw.offset,
+            limit: raw.limit,
+        })
+    }
+}
+
+/// Offset-based pagination cursor for list operations. Deserialization rejects
+/// `offset > i64::MAX` (STORAGE-AUD-003), since SQLite backends narrow offset
+/// to `i64`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(try_from = "PageRequestRaw")]
 pub struct PageRequest {
     pub offset: u64,
     pub limit: u32,
@@ -23,4 +50,35 @@ impl Default for PageRequest {
 pub struct Page<T> {
     pub items: Vec<T>,
     pub total: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// STORAGE-AUD-003 / #485: offset > i64::MAX must be rejected by serde
+    /// deserialization instead of silently narrowing to a negative i64 at the
+    /// SQLite boundary.
+    #[test]
+    fn page_offset_over_i64max_rejected() {
+        let raw = serde_json::json!({
+            "offset": (i64::MAX as u64) + 1,
+            "limit": 50,
+        });
+        let result: Result<PageRequest, _> = serde_json::from_value(raw);
+        assert!(
+            result.is_err(),
+            "offset > i64::MAX must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn page_offset_at_i64max_accepted() {
+        let raw = serde_json::json!({
+            "offset": i64::MAX as u64,
+            "limit": 50,
+        });
+        let result: Result<PageRequest, _> = serde_json::from_value(raw);
+        assert!(result.is_ok(), "offset == i64::MAX must be accepted");
+    }
 }

--- a/crates/khive-storage/src/types/sparse.rs
+++ b/crates/khive-storage/src/types/sparse.rs
@@ -91,23 +91,27 @@ struct SparseSearchRequestRaw {
     kind: Option<SubstrateKind>,
 }
 
+/// Upper bound on `SparseSearchRequest::top_k` to prevent request-sized heap
+/// allocation in first-party backends (STORAGE-AUD-002).
+pub const MAX_SPARSE_SEARCH_TOP_K: u32 = 10_000;
+
 impl TryFrom<SparseSearchRequestRaw> for SparseSearchRequest {
     type Error = String;
 
     fn try_from(raw: SparseSearchRequestRaw) -> Result<Self, Self::Error> {
-        if raw.top_k == 0 {
-            return Err("SparseSearchRequest: top_k must be > 0".into());
-        }
-        Ok(Self {
+        let request = Self {
             query: raw.query,
             top_k: raw.top_k,
             namespace: raw.namespace,
             kind: raw.kind,
-        })
+        };
+        request.validate()?;
+        Ok(request)
     }
 }
 
-/// Parameters for a sparse nearest-neighbor similarity search. Deserialization rejects top_k = 0.
+/// Parameters for a sparse nearest-neighbor similarity search. Deserialization
+/// rejects top_k = 0 and top_k > [`MAX_SPARSE_SEARCH_TOP_K`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(try_from = "SparseSearchRequestRaw")]
 pub struct SparseSearchRequest {
@@ -117,10 +121,90 @@ pub struct SparseSearchRequest {
     pub kind: Option<SubstrateKind>,
 }
 
+impl SparseSearchRequest {
+    /// Validate `top_k` bounds. Backends must call this even when the request
+    /// is constructed directly (bypassing serde), since the fields are public.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.top_k == 0 {
+            return Err("SparseSearchRequest: top_k must be > 0".into());
+        }
+        if self.top_k > MAX_SPARSE_SEARCH_TOP_K {
+            return Err(format!(
+                "SparseSearchRequest: top_k must be <= {MAX_SPARSE_SEARCH_TOP_K}, got {}",
+                self.top_k
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// A single ranked result from a sparse similarity search.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SparseSearchHit {
     pub subject_id: Uuid,
     pub score: khive_score::DeterministicScore,
     pub rank: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_query() -> SparseVector {
+        SparseVector {
+            indices: vec![0],
+            values: vec![1.0],
+        }
+    }
+
+    /// STORAGE-AUD-002 / #470: top_k = u32::MAX must be rejected by serde
+    /// deserialization instead of reaching a backend that would allocate a
+    /// multi-hundred-GB heap.
+    #[test]
+    fn sparse_top_k_u32_max_rejected() {
+        let raw = serde_json::json!({
+            "query": {"indices": [0], "values": [1.0]},
+            "top_k": u32::MAX,
+            "namespace": null,
+            "kind": null,
+        });
+        let result: Result<SparseSearchRequest, _> = serde_json::from_value(raw);
+        assert!(
+            result.is_err(),
+            "top_k = u32::MAX must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sparse_top_k_at_max_accepted() {
+        let request = SparseSearchRequest {
+            query: sample_query(),
+            top_k: MAX_SPARSE_SEARCH_TOP_K,
+            namespace: None,
+            kind: None,
+        };
+        assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn sparse_top_k_over_max_rejected_direct_construction() {
+        let request = SparseSearchRequest {
+            query: sample_query(),
+            top_k: MAX_SPARSE_SEARCH_TOP_K + 1,
+            namespace: None,
+            kind: None,
+        };
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn sparse_top_k_zero_still_rejected() {
+        let request = SparseSearchRequest {
+            query: sample_query(),
+            top_k: 0,
+            namespace: None,
+            kind: None,
+        };
+        assert!(request.validate().is_err());
+    }
 }

--- a/crates/khive-storage/src/vectors.rs
+++ b/crates/khive-storage/src/vectors.rs
@@ -12,7 +12,7 @@ use crate::capability::StorageCapability;
 use crate::error::StorageError;
 use crate::types::{
     BatchWriteSummary, IndexRebuildScope, OrphanSweepConfig, OrphanSweepResult, StorageResult,
-    VectorIndexKind, VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
+    VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
     VectorStoreCapabilities, VectorStoreInfo,
 };
 
@@ -47,10 +47,12 @@ pub trait VectorStore: Send + Sync + 'static {
 
     /// Declare what this backend supports (called at runtime policy construction).
     ///
-    /// Default returns a conservative baseline with all optional features disabled,
-    /// preserving backward compatibility for existing implementations. Backends that
-    /// support filter pushdown, batch search, quantization, or in-place update should
-    /// override this and return their own `&'static VectorStoreCapabilities`.
+    /// Default returns a conservative, backend-neutral baseline with all optional
+    /// features disabled and no advertised dimension ceiling or index kind
+    /// (STORAGE-AUD-001, ADR-044, ADR-071 Phase 1). Backends that support filter
+    /// pushdown, batch search, quantization, in-place update, or that have a known
+    /// dimension ceiling or index kind should override this and return their own
+    /// `&'static VectorStoreCapabilities`.
     fn capabilities(&self) -> &'static VectorStoreCapabilities {
         static BASELINE: OnceLock<VectorStoreCapabilities> = OnceLock::new();
         BASELINE.get_or_init(|| VectorStoreCapabilities {
@@ -60,11 +62,11 @@ pub trait VectorStore: Send + Sync + 'static {
             supports_update: false,
             supports_orphan_sweep: false,
             supports_multi_field: false,
-            // sqlite-vec 0.1.9 enforces SQLITE_VEC_VEC0_MAX_DIMENSIONS = 8192.
-            // The baseline uses the same value so generic callers that have not
-            // overridden capabilities() report the correct ceiling.
-            max_dimensions: Some(8192),
-            index_kinds: vec![VectorIndexKind::SqliteVec],
+            // Backend-neutral baseline: unknown dimension ceiling and no
+            // advertised index kind. Backends with a concrete limit (e.g.
+            // SqliteVecStore) must override capabilities().
+            max_dimensions: None,
+            index_kinds: vec![],
         })
     }
 

--- a/crates/khive-storage/tests/vectors.rs
+++ b/crates/khive-storage/tests/vectors.rs
@@ -131,8 +131,12 @@ impl VectorStore for TestVectorStore {
 // Test cases — capabilities
 // ---------------------------------------------------------------------------
 
+/// STORAGE-AUD-001 / #485: the backend-neutral trait default must not
+/// advertise sqlite-vec-specific capabilities. A minimal `VectorStore` that
+/// does not override `capabilities()` must report an unknown dimension
+/// ceiling and no advertised index kind.
 #[tokio::test]
-async fn capabilities_returns_baseline_defaults() {
+async fn capabilities_default_is_neutral() {
     let store = TestVectorStore::new();
     let caps = store.capabilities();
     assert!(!caps.supports_filter);
@@ -140,24 +144,13 @@ async fn capabilities_returns_baseline_defaults() {
     assert!(!caps.supports_quantization);
     assert!(!caps.supports_update);
     assert!(!caps.supports_orphan_sweep);
-    // Baseline reports the sqlite-vec hard limit (SQLITE_VEC_VEC0_MAX_DIMENSIONS = 8192).
-    assert_eq!(caps.max_dimensions, Some(8192));
-    assert_eq!(caps.index_kinds, vec![VectorIndexKind::SqliteVec]);
-}
-
-/// Regression: baseline max_dimensions must be 8192 (SQLITE_VEC_VEC0_MAX_DIMENSIONS),
-/// not 4096 (SQLITE_VEC_VEC0_K_MAX). Callers with 5000-dim embeddings must not be
-/// falsely told the default backend is incapable.
-#[tokio::test]
-async fn baseline_max_dimensions_is_sqlite_vec_hard_limit() {
-    let store = TestVectorStore::new();
-    let caps = store.capabilities();
-    let max = caps
-        .max_dimensions
-        .expect("baseline must declare a finite dimension limit");
+    assert_eq!(
+        caps.max_dimensions, None,
+        "backend-neutral default must not advertise a dimension ceiling"
+    );
     assert!(
-        max >= 8192,
-        "baseline max_dimensions ({max}) must be at least 8192 — SQLITE_VEC_VEC0_MAX_DIMENSIONS"
+        caps.index_kinds.is_empty(),
+        "backend-neutral default must not advertise an index kind"
     );
 }
 

--- a/crates/khive-types/src/edge.rs
+++ b/crates/khive-types/src/edge.rs
@@ -177,17 +177,20 @@ impl FromStr for EdgeRelation {
     /// DSL entry; they are **not** stored on the wire, which always uses the
     /// canonical snake_case form produced by [`EdgeRelation::as_str`].
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let normalised: String = s
-            .chars()
-            .map(|c| {
-                if c == '-' {
-                    '_'
-                } else {
-                    c.to_ascii_lowercase()
+        let mut normalised = String::with_capacity(s.len());
+        for c in s.chars() {
+            match c {
+                '-' | '_' => normalised.push('_'),
+                c if c.is_ascii_alphanumeric() => normalised.push(c.to_ascii_lowercase()),
+                _ => {
+                    return Err(crate::error::UnknownVariant::new(
+                        "edge_relation",
+                        s,
+                        Self::VALID_NAMES,
+                    ));
                 }
-            })
-            .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
-            .collect();
+            }
+        }
 
         match normalised.as_str() {
             "contains" => Ok(Self::Contains),
@@ -306,6 +309,17 @@ mod tests {
         );
         assert!(msg.contains("precedes"), "error should list precedes");
         assert!(msg.contains("annotates"), "error should list all 17");
+    }
+
+    #[test]
+    fn edge_relation_bang_rejected() {
+        for bad in ["supports!", "part/of", "depends.on", "competes with"] {
+            let err = bad
+                .parse::<EdgeRelation>()
+                .expect_err("malformed punctuation/whitespace must be rejected");
+            assert_eq!(err.domain, "edge_relation");
+            assert_eq!(err.value, bad);
+        }
     }
 
     #[test]

--- a/crates/khive-types/src/khive_error.rs
+++ b/crates/khive-types/src/khive_error.rs
@@ -253,10 +253,9 @@ impl<'de> Deserialize<'de> for Details {
                 let mut entries: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
                     alloc::vec::Vec::new();
                 while let Some((k, v)) = map.next_entry::<String, String>()? {
-                    if entries.len() >= 8 {
-                        break;
+                    if entries.len() < 8 {
+                        entries.push((Cow::Owned(k), Cow::Owned(v)));
                     }
-                    entries.push((Cow::Owned(k), Cow::Owned(v)));
                 }
                 Ok(Details { entries })
             }

--- a/crates/khive-types/src/khive_error.rs
+++ b/crates/khive-types/src/khive_error.rs
@@ -199,11 +199,23 @@ pub const DETAILS_TRUNCATED_KEY: &str = "details_truncated";
 /// When the source supplies more than 8 pairs, the wire shape stays bounded
 /// at 8 entries, but the truncation is observable: the first 7 pairs are
 /// retained and the 8th slot becomes [`DETAILS_TRUNCATED_KEY`] mapped to the
-/// dropped-pair count. Callers that need the drop count without guessing the
-/// reserved key can use [`Details::dropped_count`].
+/// dropped-pair count. [`DETAILS_TRUNCATED_KEY`] is a *reserved* key: a
+/// client-supplied pair using that name is never retained as an ordinary
+/// entry (PR #549 round-2 review) — it is stripped and folded into the
+/// drop count instead, so a client can neither fake truncation on a small
+/// map nor shadow the real indicator on an oversized one. The drop count
+/// itself is tracked in an internal, non-serialized field
+/// ([`Details::dropped_count`]) rather than parsed back out of the entry
+/// list, so a same-shaped client map can't spoof it either.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Details {
     entries: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)>,
+    /// Internal truncation flag — `Some(dropped_count)` when this instance
+    /// was built by dropping pairs (8-entry overflow and/or a reserved-key
+    /// collision), `None` otherwise. Not serialized directly; the wire
+    /// shape communicates truncation via the [`DETAILS_TRUNCATED_KEY`]
+    /// entry, this field is the trusted, non-spoofable read side.
+    dropped: Option<usize>,
 }
 
 impl Details {
@@ -212,7 +224,10 @@ impl Details {
     /// Up to 8 pairs are kept as-is. When more than 8 are supplied, the first
     /// 7 client pairs are kept and the 8th slot is replaced with
     /// [`DETAILS_TRUNCATED_KEY`] carrying the dropped-pair count, so the
-    /// truncation is observable rather than silent.
+    /// truncation is observable rather than silent. A client-supplied pair
+    /// named [`DETAILS_TRUNCATED_KEY`] is always treated as reserved: it is
+    /// dropped (never stored as an ordinary entry) and counted, even when
+    /// the remaining pairs fit within the 8-entry bound.
     pub fn new<I>(pairs: I) -> Self
     where
         I: IntoIterator<Item = (&'static str, &'static str)>,
@@ -224,25 +239,57 @@ impl Details {
         )
     }
 
-    /// Shared bounding/truncation logic for both the constructor and the
-    /// deserializer: keep the first 8 pairs verbatim, or — when more than 8
-    /// are supplied — keep the first 7 and append a `details_truncated`
-    /// indicator carrying the dropped-pair count.
+    /// Shared bounding/truncation logic for the constructor: partition the
+    /// source into ordinary pairs and reserved-key collisions, then hand
+    /// off to [`Details::build`] for the bound + indicator logic.
     fn from_owned<I>(pairs: I) -> Self
     where
         I: IntoIterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
     {
-        let all: alloc::vec::Vec<_> = pairs.into_iter().collect();
-        if all.len() <= 8 {
-            return Self { entries: all };
+        let mut ordinary: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
+            alloc::vec::Vec::new();
+        let mut total_ordinary: usize = 0;
+        let mut collisions: usize = 0;
+        for (k, v) in pairs {
+            if k.as_ref() == DETAILS_TRUNCATED_KEY {
+                collisions += 1;
+            } else {
+                total_ordinary += 1;
+                if ordinary.len() < 8 {
+                    ordinary.push((k, v));
+                }
+            }
         }
-        let dropped = all.len() - 7;
-        let mut entries: alloc::vec::Vec<_> = all.into_iter().take(7).collect();
+        Self::build(ordinary, total_ordinary, collisions)
+    }
+
+    /// Bound `ordinary` (already capped at 8 entries, `total_ordinary` the
+    /// true count before capping) plus a reserved-key `collisions` count to
+    /// the wire shape: at most 8 entries, with a [`DETAILS_TRUNCATED_KEY`]
+    /// indicator appended whenever anything was dropped (either overflow
+    /// past 7 ordinary pairs, or a stripped reserved-key collision).
+    fn build(
+        ordinary: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)>,
+        total_ordinary: usize,
+        collisions: usize,
+    ) -> Self {
+        if total_ordinary <= 8 && collisions == 0 {
+            return Self {
+                entries: ordinary,
+                dropped: None,
+            };
+        }
+        let keep = total_ordinary.min(7);
+        let dropped = (total_ordinary - keep) + collisions;
+        let mut entries: alloc::vec::Vec<_> = ordinary.into_iter().take(keep).collect();
         entries.push((
             Cow::Borrowed(DETAILS_TRUNCATED_KEY),
             Cow::Owned(alloc::format!("{dropped}")),
         ));
-        Self { entries }
+        Self {
+            entries,
+            dropped: Some(dropped),
+        }
     }
 
     /// Look up a value by key.
@@ -258,13 +305,16 @@ impl Details {
         self.entries.iter().map(|(k, v)| (k.as_ref(), v.as_ref()))
     }
 
-    /// Number of pairs dropped due to the 8-entry bound, if any were.
+    /// Number of pairs dropped due to the 8-entry bound and/or a
+    /// reserved-key collision, if any were.
     ///
-    /// Returns `None` when the source supplied 8 or fewer pairs (no
-    /// truncation occurred). Returns `Some(dropped_count)` when truncation
-    /// occurred, parsed from the [`DETAILS_TRUNCATED_KEY`] indicator entry.
+    /// Returns `None` when nothing was dropped. Returns
+    /// `Some(dropped_count)` otherwise, read from the internal truncation
+    /// flag set at construction/deserialization time — never re-parsed from
+    /// the entry list, so a client-supplied `details_truncated` pair can't
+    /// spoof this value.
     pub fn dropped_count(&self) -> Option<usize> {
-        self.get(DETAILS_TRUNCATED_KEY)?.parse().ok()
+        self.dropped
     }
 }
 
@@ -298,29 +348,59 @@ impl<'de> Deserialize<'de> for Details {
                 // Drain to completion regardless of size (#487: a naive early-exit
                 // once 8 entries are collected leaves trailing map bytes unconsumed
                 // and corrupts the surrounding deserializer). Only the first 8
-                // pairs are retained in memory as they arrive; entries beyond that
-                // are counted, not stored, so an adversarially large map can't
-                // inflate memory. Bounding + the observable-truncation indicator
-                // (RUNTIME-AUD-002 / #487 follow-up) are applied afterward via the
-                // same logic `Details::new` uses.
-                let mut entries: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
+                // ordinary pairs are retained in memory as they arrive; pairs
+                // beyond that are counted, not stored, so an adversarially
+                // large map can't inflate memory.
+                //
+                // `DETAILS_TRUNCATED_KEY` is reserved (PR #549 round-2 review):
+                // it is never stored as an ordinary entry. Instead we track
+                // whether the wire map looks exactly like our own truncated
+                // serialization — the reserved key appears exactly once, as
+                // the very last pair, immediately after exactly 7 ordinary
+                // pairs, with a value that parses as a count — and if so,
+                // restore that as the trusted drop count (round-trip of a
+                // `Details` we truncated ourselves). Any other occurrence
+                // (wrong position, duplicated, or paired with an ordinary
+                // count that isn't 7) is treated as a client-supplied
+                // collision: stripped and folded into `Details::build`'s
+                // drop accounting like any other reserved-key collision.
+                let mut ordinary: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
                     alloc::vec::Vec::new();
-                let mut total: usize = 0;
+                let mut total_ordinary: usize = 0;
+                let mut reserved_count: usize = 0;
+                let mut reserved_is_trailing = false;
+                let mut reserved_follows_seven = false;
+                let mut last_reserved_value: Option<String> = None;
                 while let Some((k, v)) = map.next_entry::<String, String>()? {
-                    total += 1;
-                    if entries.len() < 8 {
-                        entries.push((Cow::Owned(k), Cow::Owned(v)));
+                    if k == DETAILS_TRUNCATED_KEY {
+                        reserved_count += 1;
+                        reserved_is_trailing = true;
+                        reserved_follows_seven = total_ordinary == 7;
+                        last_reserved_value = Some(v);
+                    } else {
+                        reserved_is_trailing = false;
+                        total_ordinary += 1;
+                        if ordinary.len() < 8 {
+                            ordinary.push((Cow::Owned(k), Cow::Owned(v)));
+                        }
                     }
                 }
-                if total > 8 {
-                    let dropped = total - 7;
-                    entries.truncate(7);
-                    entries.push((
-                        Cow::Borrowed(DETAILS_TRUNCATED_KEY),
-                        Cow::Owned(alloc::format!("{dropped}")),
-                    ));
+                if reserved_count == 1 && reserved_is_trailing && reserved_follows_seven {
+                    if let Some(dropped) =
+                        last_reserved_value.as_deref().and_then(|s| s.parse().ok())
+                    {
+                        let mut entries = ordinary;
+                        entries.push((
+                            Cow::Borrowed(DETAILS_TRUNCATED_KEY),
+                            Cow::Owned(alloc::format!("{dropped}")),
+                        ));
+                        return Ok(Details {
+                            entries,
+                            dropped: Some(dropped),
+                        });
+                    }
                 }
-                Ok(Details { entries })
+                Ok(Details::build(ordinary, total_ordinary, reserved_count))
             }
         }
 

--- a/crates/khive-types/src/khive_error.rs
+++ b/crates/khive-types/src/khive_error.rs
@@ -184,11 +184,23 @@ pub enum RetryHint {
 
 // ---- Details ----
 
+/// Reserved key inserted in place of the 8th slot when a `Details` source
+/// (constructor input or a deserialized wire map) supplies more than 8 pairs.
+/// Its value is the count of dropped pairs, so truncation is observable
+/// instead of silently discarding data (RUNTIME-AUD-002 / #487 follow-up).
+pub const DETAILS_TRUNCATED_KEY: &str = "details_truncated";
+
 /// Bounded key/value metadata attached to a `KhiveError` (max 8 pairs).
 ///
 /// Stored as `Cow<'static, str>` pairs: zero-alloc for static string literals
 /// (the common construction path) and owned strings on deserialization (no
 /// memory leak). Both paths are `no_std` + `alloc` compatible.
+///
+/// When the source supplies more than 8 pairs, the wire shape stays bounded
+/// at 8 entries, but the truncation is observable: the first 7 pairs are
+/// retained and the 8th slot becomes [`DETAILS_TRUNCATED_KEY`] mapped to the
+/// dropped-pair count. Callers that need the drop count without guessing the
+/// reserved key can use [`Details::dropped_count`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Details {
     entries: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)>,
@@ -196,16 +208,40 @@ pub struct Details {
 
 impl Details {
     /// Build `Details` from an iterable of `(&'static str, &'static str)` pairs.
-    /// Silently truncates to 8 entries.
+    ///
+    /// Up to 8 pairs are kept as-is. When more than 8 are supplied, the first
+    /// 7 client pairs are kept and the 8th slot is replaced with
+    /// [`DETAILS_TRUNCATED_KEY`] carrying the dropped-pair count, so the
+    /// truncation is observable rather than silent.
     pub fn new<I>(pairs: I) -> Self
     where
         I: IntoIterator<Item = (&'static str, &'static str)>,
     {
-        let entries: alloc::vec::Vec<_> = pairs
-            .into_iter()
-            .take(8)
-            .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
-            .collect();
+        let all: alloc::vec::Vec<(&'static str, &'static str)> = pairs.into_iter().collect();
+        Self::from_owned(
+            all.into_iter()
+                .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v))),
+        )
+    }
+
+    /// Shared bounding/truncation logic for both the constructor and the
+    /// deserializer: keep the first 8 pairs verbatim, or — when more than 8
+    /// are supplied — keep the first 7 and append a `details_truncated`
+    /// indicator carrying the dropped-pair count.
+    fn from_owned<I>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
+    {
+        let all: alloc::vec::Vec<_> = pairs.into_iter().collect();
+        if all.len() <= 8 {
+            return Self { entries: all };
+        }
+        let dropped = all.len() - 7;
+        let mut entries: alloc::vec::Vec<_> = all.into_iter().take(7).collect();
+        entries.push((
+            Cow::Borrowed(DETAILS_TRUNCATED_KEY),
+            Cow::Owned(alloc::format!("{dropped}")),
+        ));
         Self { entries }
     }
 
@@ -220,6 +256,15 @@ impl Details {
     /// Iterate over (key, value) pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> + '_ {
         self.entries.iter().map(|(k, v)| (k.as_ref(), v.as_ref()))
+    }
+
+    /// Number of pairs dropped due to the 8-entry bound, if any were.
+    ///
+    /// Returns `None` when the source supplied 8 or fewer pairs (no
+    /// truncation occurred). Returns `Some(dropped_count)` when truncation
+    /// occurred, parsed from the [`DETAILS_TRUNCATED_KEY`] indicator entry.
+    pub fn dropped_count(&self) -> Option<usize> {
+        self.get(DETAILS_TRUNCATED_KEY)?.parse().ok()
     }
 }
 
@@ -250,12 +295,30 @@ impl<'de> Deserialize<'de> for Details {
             }
 
             fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Details, A::Error> {
+                // Drain to completion regardless of size (#487: a naive early-exit
+                // once 8 entries are collected leaves trailing map bytes unconsumed
+                // and corrupts the surrounding deserializer). Only the first 8
+                // pairs are retained in memory as they arrive; entries beyond that
+                // are counted, not stored, so an adversarially large map can't
+                // inflate memory. Bounding + the observable-truncation indicator
+                // (RUNTIME-AUD-002 / #487 follow-up) are applied afterward via the
+                // same logic `Details::new` uses.
                 let mut entries: alloc::vec::Vec<(Cow<'static, str>, Cow<'static, str>)> =
                     alloc::vec::Vec::new();
+                let mut total: usize = 0;
                 while let Some((k, v)) = map.next_entry::<String, String>()? {
+                    total += 1;
                     if entries.len() < 8 {
                         entries.push((Cow::Owned(k), Cow::Owned(v)));
                     }
+                }
+                if total > 8 {
+                    let dropped = total - 7;
+                    entries.truncate(7);
+                    entries.push((
+                        Cow::Borrowed(DETAILS_TRUNCATED_KEY),
+                        Cow::Owned(alloc::format!("{dropped}")),
+                    ));
                 }
                 Ok(Details { entries })
             }

--- a/crates/khive-types/tests/khive_error.rs
+++ b/crates/khive-types/tests/khive_error.rs
@@ -242,9 +242,13 @@ mod serde_tests {
     }
 
     /// Regression for #487: a details map with 9-10 entries must deserialize
-    /// successfully (the visitor must keep draining MapAccess until None,
-    /// not stop reading once 8 entries have been retained), and must retain
-    /// exactly the first 8 insertion-order pairs.
+    /// successfully (the visitor must keep draining MapAccess until None, not
+    /// stop reading once 8 entries have been retained).
+    ///
+    /// Follow-up (PR #549 review): truncation must be observable, not silent.
+    /// The bounded wire shape stays at 8 entries, but the 8th slot is now the
+    /// `details_truncated` indicator carrying the dropped-pair count, so only
+    /// the first 7 insertion-order client pairs are retained verbatim.
     #[test]
     fn details_drains_oversized_map_retains_8() {
         let json = serde_json::json!({
@@ -256,15 +260,24 @@ mod serde_tests {
         let details: Details =
             serde_json::from_str(&json).expect("oversized map must deserialize successfully");
         let pairs: Vec<(&str, &str)> = details.iter().collect();
-        assert_eq!(pairs.len(), 8, "must retain exactly 8 pairs");
-        for i in 0..8 {
+        assert_eq!(
+            pairs.len(),
+            8,
+            "must retain exactly 8 pairs (7 client + indicator)"
+        );
+        for i in 0..7 {
             let key = format!("k{i}");
             assert_eq!(
                 details.get(&key),
                 Some(format!("v{i}").as_str()),
-                "entry {key} must be one of the first 8 insertion-order pairs"
+                "entry {key} must be one of the first 7 insertion-order pairs"
             );
         }
+        assert_eq!(
+            details.dropped_count(),
+            Some(3),
+            "10 supplied pairs - 7 retained = 3 dropped, must be observable"
+        );
     }
 
     /// Nine-pair variant embedded inside a full `KhiveError` envelope, proving
@@ -284,6 +297,15 @@ mod serde_tests {
         let deserialized: KhiveError =
             serde_json::from_str(&json).expect("envelope with 9 details pairs must deserialize");
         let got = deserialized.details().unwrap();
-        assert_eq!(got.iter().count(), 8, "must retain exactly 8 pairs");
+        assert_eq!(
+            got.iter().count(),
+            8,
+            "must retain exactly 8 pairs (7 client + truncation indicator)"
+        );
+        assert_eq!(
+            got.dropped_count(),
+            Some(2),
+            "9 supplied pairs - 7 retained = 2 dropped, must be observable"
+        );
     }
 }

--- a/crates/khive-types/tests/khive_error.rs
+++ b/crates/khive-types/tests/khive_error.rs
@@ -240,4 +240,50 @@ mod serde_tests {
         assert_eq!(got.get("resource"), Some("entity"));
         assert_eq!(got.get("id"), Some("x1"));
     }
+
+    /// Regression for #487: a details map with 9-10 entries must deserialize
+    /// successfully (the visitor must keep draining MapAccess until None,
+    /// not stop reading once 8 entries have been retained), and must retain
+    /// exactly the first 8 insertion-order pairs.
+    #[test]
+    fn details_drains_oversized_map_retains_8() {
+        let json = serde_json::json!({
+            "k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3",
+            "k4": "v4", "k5": "v5", "k6": "v6", "k7": "v7",
+            "k8": "v8", "k9": "v9"
+        })
+        .to_string();
+        let details: Details =
+            serde_json::from_str(&json).expect("oversized map must deserialize successfully");
+        let pairs: Vec<(&str, &str)> = details.iter().collect();
+        assert_eq!(pairs.len(), 8, "must retain exactly 8 pairs");
+        for i in 0..8 {
+            let key = format!("k{i}");
+            assert_eq!(
+                details.get(&key),
+                Some(format!("v{i}").as_str()),
+                "entry {key} must be one of the first 8 insertion-order pairs"
+            );
+        }
+    }
+
+    /// Nine-pair variant embedded inside a full `KhiveError` envelope, proving
+    /// the outer struct also deserializes successfully when details overflow.
+    #[test]
+    fn khive_error_with_nine_details_pairs_deserializes() {
+        let json = serde_json::json!({
+            "kind": "not_found",
+            "message": "missing",
+            "code": null,
+            "details": {
+                "a": "1", "b": "2", "c": "3", "d": "4",
+                "e": "5", "f": "6", "g": "7", "h": "8", "i": "9"
+            }
+        })
+        .to_string();
+        let deserialized: KhiveError =
+            serde_json::from_str(&json).expect("envelope with 9 details pairs must deserialize");
+        let got = deserialized.details().unwrap();
+        assert_eq!(got.iter().count(), 8, "must retain exactly 8 pairs");
+    }
 }

--- a/crates/khive-types/tests/khive_error.rs
+++ b/crates/khive-types/tests/khive_error.rs
@@ -3,7 +3,9 @@
 //! Covers: Display, Error trait, serde wire shape stability, RetryHint,
 //! Details, and the ErrorCode domain-scoped code model.
 
-use khive_types::khive_error::{Details, ErrorCode, ErrorDomain, ErrorKind, KhiveError, RetryHint};
+use khive_types::khive_error::{
+    Details, ErrorCode, ErrorDomain, ErrorKind, KhiveError, RetryHint, DETAILS_TRUNCATED_KEY,
+};
 
 // ---- ErrorKind Display ----
 
@@ -307,5 +309,100 @@ mod serde_tests {
             Some(2),
             "9 supplied pairs - 7 retained = 2 dropped, must be observable"
         );
+    }
+
+    /// PR #549 round-2 Medium finding: a client-supplied `details_truncated`
+    /// pair must never be retained as an ordinary entry, even when the total
+    /// pair count is within the 8-entry bound. Retaining it verbatim let a
+    /// client-controlled value flow straight into `dropped_count()` via
+    /// first-match `get()` and falsely report truncation that never
+    /// happened. The fix reserves the key unconditionally: the colliding
+    /// pair is dropped and counted, never stored and never trusted as-is.
+    #[test]
+    fn details_client_collision_within_bound_is_dropped_not_trusted() {
+        let details = Details::new([("a", "1"), (DETAILS_TRUNCATED_KEY, "not_a_real_count")]);
+        // The collision is stripped, not stored verbatim — the client's
+        // bogus value never appears as the indicator's value.
+        assert_eq!(details.get(DETAILS_TRUNCATED_KEY), Some("1"));
+        assert_eq!(details.get("a"), Some("1"));
+        // Exactly one pair was dropped (the collision) — a true report,
+        // not a spoofed one derived from the client's supplied value.
+        assert_eq!(details.dropped_count(), Some(1));
+        assert_eq!(details.iter().count(), 2);
+    }
+
+    /// Companion to the above: a `details_truncated` collision supplied
+    /// alongside more than 8 ordinary pairs must not shadow the real
+    /// indicator (first-match `get()` previously could return the client's
+    /// pair instead of ours) and must not serialize as a duplicate JSON key.
+    #[test]
+    fn details_client_collision_with_overflow_not_shadowed_no_duplicate_keys() {
+        let details = Details::new([
+            ("k0", "v0"),
+            ("k1", "v1"),
+            ("k2", "v2"),
+            ("k3", "v3"),
+            ("k4", "v4"),
+            ("k5", "v5"),
+            ("k6", "v6"),
+            (DETAILS_TRUNCATED_KEY, "not_a_real_count"),
+            ("k7", "v7"),
+        ]);
+        // 8 ordinary pairs (k0..k7) + 1 reserved-key collision supplied by
+        // the client = 2 dropped: k7 (past the 7-pair keep bound) and the
+        // collision itself.
+        assert_eq!(details.dropped_count(), Some(2));
+        assert_eq!(details.iter().count(), 8);
+        for i in 0..7 {
+            let key = format!("k{i}");
+            assert_eq!(details.get(&key), Some(format!("v{i}").as_str()));
+        }
+        assert_eq!(details.get("k7"), None, "8th ordinary pair must be dropped");
+
+        let serialized = serde_json::to_value(&details).unwrap();
+        let obj = serialized.as_object().unwrap();
+        assert_eq!(
+            obj.keys()
+                .filter(|k| k.as_str() == DETAILS_TRUNCATED_KEY)
+                .count(),
+            1,
+            "must serialize exactly one details_truncated key, never a duplicate"
+        );
+        assert_eq!(
+            obj.get(DETAILS_TRUNCATED_KEY).and_then(|v| v.as_str()),
+            Some("2")
+        );
+    }
+
+    /// Serde round-trip of a truncated `Details`: serializing our own
+    /// truncation output and reading it back must restore the same drop
+    /// count via the internal flag, not silently lose it because the
+    /// reserved key on the wire looks like a fresh client collision.
+    #[test]
+    fn details_truncated_serde_roundtrip_restores_dropped_count() {
+        let details = Details::new([
+            ("k0", "v0"),
+            ("k1", "v1"),
+            ("k2", "v2"),
+            ("k3", "v3"),
+            ("k4", "v4"),
+            ("k5", "v5"),
+            ("k6", "v6"),
+            ("k7", "v7"),
+            ("k8", "v8"),
+        ]);
+        assert_eq!(details.dropped_count(), Some(2));
+
+        let serialized = serde_json::to_string(&details).unwrap();
+        let roundtripped: Details = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            roundtripped.dropped_count(),
+            Some(2),
+            "truncation state must survive a serialize/deserialize round trip"
+        );
+        for i in 0..7 {
+            let key = format!("k{i}");
+            assert_eq!(roundtripped.get(&key), Some(format!("v{i}").as_str()));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Issue-sweep batch resolving 6 audit issues across khive-runtime, khive-storage, khive-types (ripple into khive-db; one end-to-end regression test in khive-mcp — the only crate depending on both request + runtime). Internal review: 0 critical / 2 major findings, both resolved before commit; the branch stayed blocked until the required test landed.

| Issue | Fix |
|---|---|
| #433 | Runtime rejects non-string `namespace` values, fail closed; end-to-end JSON-form regression test (null/number/bool/array/object → `ok:false`, `succeeded:0`) |
| #443 | Runtime namespace docs aligned to ADR-007 Rev 6 (attribution, not isolation) |
| #470 | Sparse `top_k` bounded; `VectorStore` capabilities default neutralized |
| #485 | Out-of-range page offset and traversal `max_depth` rejected at the storage boundary |
| #471 | Malformed edge relation tokens rejected |
| #487 | Oversized `Details` maps drained |

## Gates

- `cargo test -p khive-runtime -p khive-storage -p khive-types -p khive-db -p khive-mcp`: 17 suites green, verified under pipefail post-rebase
- clippy `-D warnings` scoped: clean; `cargo fmt --all -- --check`: clean
- Rebased onto main (6 commits, no conflicts)