### PR TITLE
fix(kg,knowledge,docs): audit reopens — bench fixture word count, ADR labels, person→project endpoints (#26 #32 #60)

### DIFF
--- a/crates/khive-merge/docs/design.md
+++ b/crates/khive-merge/docs/design.md
@@ -21,7 +21,7 @@ integration layer is extended to expose snapshot ancestry for LCA walks.
 - `khive-merge` is not yet registered in any pack; the VCS integration surface must be extended
   before the `ThreeWayMergeEngine` can be wired into production.
 
-### ADR-043: Three-Way Merge Conflict Taxonomy
+### Three-Way Merge Conflict Taxonomy
 
 - The `MergeConflict` enum (in `types.rs`) enumerates the six conflict kinds defined for
   the three-way merge: `NameConflict`, `KindConflict`, `ModifyDelete`, `PropertyMismatch`,
@@ -30,7 +30,7 @@ integration layer is extended to expose snapshot ancestry for LCA walks.
   take that side) are implemented in `entity::merge_properties`.
 - Auto-merge for duplicate-UUID additions uses scalars-ours-wins + tags-union logic.
 
-### ADR-048: Edge Identity
+### Edge Identity
 
 - `edge_id` must be stable across merge/diff cycles; merged edges must not receive a fresh UUID
   when the originating branch's edge is identifiable.

--- a/crates/khive-pack-gtd/docs/design.md
+++ b/crates/khive-pack-gtd/docs/design.md
@@ -56,7 +56,7 @@
   the pack registry by name (`"gtd"`) without a hard compile-time dependency in the MCP binary.
 - Requires `"kg"` pack as a dependency (`REQUIRES = &["kg"]`).
 
-### ADR-030: Non-propagating after_create failures
+### ADR-019: Non-propagating after_create failures
 
 - If `depends_on` edge creation fails after the task note is successfully written,
   the error is logged and swallowed. A `properties["depends_on"]` key captures the same

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -472,6 +472,8 @@ pub(crate) fn valid_relations_for_entity_pair(src_kind: &str, tgt_kind: &str) ->
         ("artifact", "refutes", "concept"),
         ("person", "part_of", "org"),
         ("person", "instance_of", "org"),
+        ("person", "part_of", "project"),
+        ("person", "instance_of", "project"),
         ("org", "depends_on", "org"),
         ("org", "enables", "org"),
         ("org", "contains", "org"),

--- a/crates/khive-pack-kg/src/pack.rs
+++ b/crates/khive-pack-kg/src/pack.rs
@@ -4,8 +4,11 @@ use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind, HandlerDef, Pack
 
 use crate::handler_defs::KG_HANDLERS;
 
-/// Pack-extensible edge endpoint rules — adds person→org and org→org pairs to the base allowlist.
-pub(crate) static KG_EDGE_RULES: [EdgeEndpointRule; 7] = [
+/// Pack-extensible edge endpoint rules — adds person→org, person→project, and org→org
+/// pairs to the base allowlist. The person→project rows mirror person→org (issue #60):
+/// a person is a member of a project the same way they are a member of an org, so the
+/// same member-not-component semantic stretch accepted for person→org is extended here.
+pub(crate) static KG_EDGE_RULES: [EdgeEndpointRule; 9] = [
     EdgeEndpointRule {
         relation: EdgeRelation::PartOf,
         source: EndpointKind::EntityOfKind("person"),
@@ -15,6 +18,16 @@ pub(crate) static KG_EDGE_RULES: [EdgeEndpointRule; 7] = [
         relation: EdgeRelation::InstanceOf,
         source: EndpointKind::EntityOfKind("person"),
         target: EndpointKind::EntityOfKind("org"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::PartOf,
+        source: EndpointKind::EntityOfKind("person"),
+        target: EndpointKind::EntityOfKind("project"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::InstanceOf,
+        source: EndpointKind::EntityOfKind("person"),
+        target: EndpointKind::EntityOfKind("project"),
     },
     EdgeEndpointRule {
         relation: EdgeRelation::DependsOn,

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -5998,6 +5998,78 @@ async fn link_person_to_org_part_of_succeeds() {
     assert_eq!(edge["relation"], "part_of");
 }
 
+/// person→project with part_of must succeed after edge rules are installed (#60).
+#[tokio::test]
+async fn link_person_to_project_part_of_succeeds() {
+    let (f, _rt) = pack_with_edge_rules();
+
+    let person = f
+        .dispatch(
+            "create",
+            json!({ "kind": "person", "name": "Alice Researcher" }),
+        )
+        .await
+        .expect("create person");
+    let project = f
+        .dispatch("create", json!({ "kind": "project", "name": "khive" }))
+        .await
+        .expect("create project");
+
+    let result = f
+        .dispatch(
+            "link",
+            json!({
+                "source_id": person["id"],
+                "target_id": project["id"],
+                "relation": "part_of",
+            }),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "person→project part_of must succeed with KG edge rules installed; got: {result:?}"
+    );
+    let edge = result.unwrap();
+    assert_eq!(edge["relation"], "part_of");
+}
+
+/// person→project with instance_of must succeed after edge rules are installed (#60).
+#[tokio::test]
+async fn link_person_to_project_instance_of_succeeds() {
+    let (f, _rt) = pack_with_edge_rules();
+
+    let person = f
+        .dispatch(
+            "create",
+            json!({ "kind": "person", "name": "Bob Engineer" }),
+        )
+        .await
+        .expect("create person");
+    let project = f
+        .dispatch("create", json!({ "kind": "project", "name": "lattice" }))
+        .await
+        .expect("create project");
+
+    let result = f
+        .dispatch(
+            "link",
+            json!({
+                "source_id": person["id"],
+                "target_id": project["id"],
+                "relation": "instance_of",
+            }),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "person→project instance_of must succeed with KG edge rules installed; got: {result:?}"
+    );
+    let edge = result.unwrap();
+    assert_eq!(edge["relation"], "instance_of");
+}
+
 /// org→org with depends_on must succeed after edge rules are installed.
 #[tokio::test]
 async fn link_org_to_org_depends_on_succeeds() {

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -5949,7 +5949,7 @@ async fn withdraw_cas_divergence_after_approval() {
 
 // ---- KG pack edge endpoint extensions (ADR-002 v0.2.4) ----
 //
-// These tests verify the 7 new endpoint pairs declared in KG_EDGE_RULES.
+// These tests verify the 9 new endpoint pairs declared in KG_EDGE_RULES.
 // Each test constructs a fixture with edge rules installed (mirroring what the
 // MCP transport does at startup per ADR-031) before calling link().
 

--- a/crates/khive-pack-knowledge/benches/search_latency.rs
+++ b/crates/khive-pack-knowledge/benches/search_latency.rs
@@ -73,8 +73,9 @@ fn main() {
                     "description": format!(
                         "knowledge retrieval embedding reranking benchmark atom {i} tensor neural"
                     ),
+                    // Content must satisfy MIN_ATOM_CONTENT_WORDS = 20 enforced by the knowledge pack.
                     "content": format!(
-                        "dense sparse retrieval corpus benchmark search latency atom {i} gradient"
+                        "dense sparse retrieval corpus benchmark search latency atom {i} gradient neural transformer embedding semantic index query score rank precision recall vector"
                     ),
                 })
             })
@@ -93,7 +94,7 @@ fn main() {
             .await
             .expect("cold rerank dispatch");
         let cold_us = t_cold.elapsed().as_micros();
-        assert_eq!(cold_resp["status"], "ok");
+        assert!(cold_resp["results"].is_array());
         println!("[#595] cold_rerank_first_query_us: {cold_us}");
 
         const N: usize = 20;
@@ -109,7 +110,7 @@ fn main() {
                 .await
                 .expect("rerank=false dispatch");
             rerank_false_us.push(t.elapsed().as_micros());
-            assert_eq!(resp["status"], "ok");
+            assert!(resp["results"].is_array());
         }
         rerank_false_us.sort_unstable();
 
@@ -124,7 +125,7 @@ fn main() {
                 .await
                 .expect("rerank=true dispatch");
             rerank_true_us.push(t.elapsed().as_micros());
-            assert_eq!(resp["status"], "ok");
+            assert!(resp["results"].is_array());
         }
         rerank_true_us.sort_unstable();
 
@@ -136,7 +137,7 @@ fn main() {
                 .await
                 .expect("default dispatch");
             default_us.push(t.elapsed().as_micros());
-            assert_eq!(resp["status"], "ok");
+            assert!(resp["results"].is_array());
         }
         default_us.sort_unstable();
 

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -304,20 +304,28 @@ Event and edge endpoints are invalid for `supports`/`refutes`.
 The KG pack extends the base endpoint contract via `EDGE_RULES` to cover
 person→org and org→org relationships common in research KGs:
 
-| Source   | Relation      | Target | Added  |
-| -------- | ------------- | ------ | ------ |
-| `Person` | `part_of`     | `Org`  | v0.2.4 |
-| `Person` | `instance_of` | `Org`  | v0.2.4 |
-| `Org`    | `depends_on`  | `Org`  | v0.2.4 |
-| `Org`    | `enables`     | `Org`  | v0.2.4 |
-| `Org`    | `contains`    | `Org`  | v0.2.4 |
-| `Org`    | `part_of`     | `Org`  | v0.2.4 |
-| `Org`    | `precedes`    | `Org`  | v0.2.4 |
+| Source   | Relation      | Target    | Added      |
+| -------- | ------------- | --------- | ---------- |
+| `Person` | `part_of`     | `Org`     | v0.2.4     |
+| `Person` | `instance_of` | `Org`     | v0.2.4     |
+| `Person` | `part_of`     | `Project` | unreleased |
+| `Person` | `instance_of` | `Project` | unreleased |
+| `Org`    | `depends_on`  | `Org`     | v0.2.4     |
+| `Org`    | `enables`     | `Org`     | v0.2.4     |
+| `Org`    | `contains`    | `Org`     | v0.2.4     |
+| `Org`    | `part_of`     | `Org`     | v0.2.4     |
+| `Org`    | `precedes`    | `Org`     | v0.2.4     |
 
 These are additive — the base contract is unchanged. Semantics:
 
 - `Person part_of Org` — a person is a member or employee of an org
 - `Person instance_of Org` — a person represents or embodies an org (e.g. a founder)
+- `Person part_of Project` — a person is a member or contributor of a project (issue #60);
+  the same member-not-component semantic stretch accepted for `Person part_of Org` is extended
+  here — a person is not a structural component of a project, but the closest base relation is
+  `part_of`, mirroring the org row.
+- `Person instance_of Project` — a person represents or embodies a project (e.g. a founder or
+  maintainer), mirroring `Person instance_of Org`.
 - `Org depends_on Org` — one org depends on another (e.g. subsidiary dependency)
 - `Org enables Org` — one org enables another (e.g. incubator → startup)
 - `Org contains Org` — org hierarchy (e.g. parent company contains subsidiary)

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -302,7 +302,7 @@ Event and edge endpoints are invalid for `supports`/`refutes`.
 #### KG pack extensions (added v0.2.4)
 
 The KG pack extends the base endpoint contract via `EDGE_RULES` to cover
-person→org and org→org relationships common in research KGs:
+person→org, person→project, and org→org relationships common in research KGs:
 
 | Source   | Relation      | Target    | Added      |
 | -------- | ------------- | --------- | ---------- |


### PR DESCRIPTION
## Summary

Fixes three reopened audit issues with small, scoped changes.

| Issue | Problem | Fix |
|---|---|---|
| #26 | `khive-pack-knowledge/benches/search_latency.rs` seeded atom `content` with a 10-word string; `validate_atom_content` requires `MIN_ATOM_CONTENT_WORDS = 20`, so the bench panicked at seed time | Widened the fixture content to 21 words, mirroring the fix already applied in `benches/knowledge_bench.rs`. Also found and fixed a second latent bug that blocked the bench from completing: the four `assert_eq!(resp["status"], "ok")` checks assumed an envelope shape `knowledge.search` never returns (the handler returns `{"results": [...], "total": N}` with no top-level `status` key) — replaced with `assert!(resp["results"].is_array())`. Verified: `cargo bench -p khive-pack-knowledge --bench search_latency` now runs to completion and prints p50/p95 latencies. |
| #32 | Three ADR section headings in crate design docs cite the wrong ADR number: `khive-pack-gtd/docs/design.md:59` cites ADR-030 (actually "Retrieval Stack Port") for the non-propagating `after_create` failure decision; `khive-merge/docs/design.md:24` and `:33` cite ADR-043 (actually "Embedding Model Migration") and ADR-048 (actually "Knowledge Section Profiles") for merge-conflict-taxonomy and edge-identity content | GTD doc: retargeted to **ADR-019** (GTD Pack), which documents the exact `after_create` non-fatal edge-creation behavior (`docs/adr/ADR-019-gtd-pack.md:418,536`). khive-merge doc: searched `docs/adr/README.md` and every ADR file for the `MergeConflict`/`ThreeWayMergeEngine`/edge-identity-preservation content described — no shipped ADR documents it (it is `khive-merge`-crate-internal design). Per the audit guidance, dropped the incorrect `ADR-NNN:` prefix on both headings and kept the descriptive text ("Three-Way Merge Conflict Taxonomy", "Edge Identity"). |
| #60 | KG pack `EDGE_RULES` had no `person→project` endpoint rows, even though `person→org` rows exist for the same "person is a member of X" semantic | Added `person part_of project` and `person instance_of project` to `KG_EDGE_RULES` in `crates/khive-pack-kg/src/pack.rs` (7→9 rules), updated the duplicate hint table in `crates/khive-pack-kg/src/handlers/common.rs` (`valid_relations_for_entity_pair`) so error-message hints stay consistent with the installed rules (full table/rule dedup tracked separately as #543), amended `docs/adr/ADR-002-edge-ontology.md`'s KG-pack-extensions table with the two new rows and a semantics note extending the accepted member-not-component stretch from `person→org`, and added two regression tests in `khive-pack-kg/tests/integration.rs` (`link_person_to_project_part_of_succeeds`, `link_person_to_project_instance_of_succeeds`) mirroring the existing `link_person_to_org_part_of_succeeds` test. |

## Test plan

- [x] `cargo test -p khive-pack-kg -p khive-pack-knowledge` — all suites green (135+5+3+173+11+60+1+6+64+80 tests passed, 1 ignored)
- [x] `cargo clippy -p khive-pack-kg -p khive-pack-knowledge --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-pack-kg` — clean
- [x] `cargo bench -p khive-pack-knowledge --bench search_latency` — runs to completion, prints latency percentiles

Does not close #26, #32, or #60 (left for the issue owner/reviewer to verify and close). Left as draft per review protocol — awaiting additional review before marking ready.