### PR TITLE
fix(brain): typed ConsumerKind vocabulary + shared tier-2 resolver (#542)

### DIFF
--- a/crates/khive-brain-core/src/lib.rs
+++ b/crates/khive-brain-core/src/lib.rs
@@ -13,7 +13,8 @@ pub use brain_signal::{entity_signal, is_recall_positive, BrainSignal};
 pub use brain_state::{validate_brain_state_snapshot, BrainState, BrainStateSnapshot};
 pub use posterior::{BetaPosterior, EntityPosteriors};
 pub use profile::{
-    BalancedRecallSnapshot, BalancedRecallState, ProfileBinding, ProfileLifecycle, ProfileRecord,
+    resolve_consumer_profile, BalancedRecallSnapshot, BalancedRecallState, ConsumerKind,
+    ProfileBinding, ProfileLifecycle, ProfileRecord,
 };
 pub use section_state::{
     derive_deterministic_weights, derive_weights, SectionPosteriorSnapshot, SectionPosteriorState,

--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -1,6 +1,8 @@
 //! Profile lifecycle, records, bindings, and the BalancedRecall state.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -19,6 +21,47 @@ pub enum ProfileLifecycle {
     Active,
     Inactive,
     Archived,
+}
+
+/// Closed vocabulary of brain profile consumers (ADR-058 amendment, #542).
+/// Adding a new consumer requires adding a variant here — never a bare string
+/// literal at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerKind {
+    Recall,
+    KnowledgeCompose,
+    Rerank,
+}
+
+impl ConsumerKind {
+    /// The exact wire-level `consumer_kind` string for this variant.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConsumerKind::Recall => "recall",
+            ConsumerKind::KnowledgeCompose => "knowledge_compose",
+            ConsumerKind::Rerank => "rerank",
+        }
+    }
+}
+
+impl fmt::Display for ConsumerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ConsumerKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "recall" => Ok(ConsumerKind::Recall),
+            "knowledge_compose" => Ok(ConsumerKind::KnowledgeCompose),
+            "rerank" => Ok(ConsumerKind::Rerank),
+            other => Err(format!("unknown ConsumerKind: {other:?}")),
+        }
+    }
 }
 
 /// Profile metadata stored in the registry.
@@ -62,6 +105,41 @@ pub struct ProfileBinding {
     pub profile_id: String,
     pub priority: i32,
     pub created_at: DateTime<Utc>,
+}
+
+/// Resolve the effective profile for a `(namespace, consumer_kind)` pair via
+/// the brain pack's tier-2 binding table. Returns `None` unless `brain.resolve`
+/// reports `matched_binding=true` — the system-default fallback profile it
+/// returns otherwise must not be mistaken for an explicit binding, or each
+/// pack's tier-3 (global tuning prior) would become unreachable.
+///
+/// Shared by the memory pack (`ConsumerKind::Recall`) and the knowledge pack
+/// (`ConsumerKind::KnowledgeCompose`) — ADR-058 amendment, #542.
+pub async fn resolve_consumer_profile(
+    registry: &khive_runtime::VerbRegistry,
+    namespace: &str,
+    consumer_kind: ConsumerKind,
+) -> Option<String> {
+    let resolve_params = serde_json::json!({
+        "namespace": namespace,
+        "consumer_kind": consumer_kind.as_str(),
+    });
+    match registry.dispatch("brain.resolve", resolve_params).await {
+        Ok(v) => {
+            let matched_binding = v
+                .get("matched_binding")
+                .and_then(|b| b.as_bool())
+                .unwrap_or(false);
+            if matched_binding {
+                v.get("resolved_profile_id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_owned)
+            } else {
+                None
+            }
+        }
+        Err(_) => None,
+    }
 }
 
 // ── BalancedRecallState ─────────────────────────────────────────────────────
@@ -229,6 +307,31 @@ pub struct BalancedRecallSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// ADR-058 amendment (#542): each variant's wire string is exact and stable.
+    #[test]
+    fn consumer_kind_as_str_matches_wire_vocabulary() {
+        assert_eq!(ConsumerKind::Recall.as_str(), "recall");
+        assert_eq!(ConsumerKind::KnowledgeCompose.as_str(), "knowledge_compose");
+        assert_eq!(ConsumerKind::Rerank.as_str(), "rerank");
+    }
+
+    /// ADR-058 amendment (#542): `as_str()` and `FromStr` round-trip for every variant.
+    #[test]
+    fn consumer_kind_from_str_round_trips() {
+        for kind in [
+            ConsumerKind::Recall,
+            ConsumerKind::KnowledgeCompose,
+            ConsumerKind::Rerank,
+        ] {
+            assert_eq!(kind.as_str().parse::<ConsumerKind>().unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn consumer_kind_from_str_rejects_unknown() {
+        assert!("bogus".parse::<ConsumerKind>().is_err());
+    }
 
     /// ADR-048 Phase-1 gate: profile save/load round-trip must produce identical
     /// posteriors (snapshot == restored state).

--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -85,7 +85,7 @@ impl ProfileRecord {
         Self {
             id: "balanced-recall-v1".into(),
             description: "Default recall profile: three-scalar Beta posteriors".into(),
-            consumer_kind: "recall".into(),
+            consumer_kind: ConsumerKind::Recall.as_str().into(),
             state_class: "Bayesian".into(),
             lifecycle: ProfileLifecycle::Active,
             created_at: Utc::now(),

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_brain_core::{FeedbackSignal, SectionType};
+use khive_brain_core::{resolve_consumer_profile, ConsumerKind, FeedbackSignal, SectionType};
 use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::EdgeRelation;
 
@@ -323,7 +323,7 @@ impl KnowledgePack {
     ///
     /// 3-tier profile resolution (ADR-035) — exclusive flow (each tier returns early):
     /// 1. Explicit brain profile in config (`self.brain_profile`) → route via `brain.feedback`
-    /// 2. Namespace-bound profile via `brain.resolve(consumer_kind="recall")` → route via `brain.feedback`
+    /// 2. Namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")` → route via `brain.feedback`
     /// 3. Global section_posteriors → update in-memory state directly (tier-3 only when neither 1 nor 2 resolves)
     pub(crate) async fn handle_feedback(
         &self,
@@ -392,12 +392,13 @@ impl KnowledgePack {
             }
         }
 
-        // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="recall").
-        // Use "recall" (not "knowledge.search") — the brain contract registers recall
-        // bindings under consumer_kind="recall" (brain pack design.md §34).
+        // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
+        // Use "knowledge_compose" (not "recall") — the knowledge pack's compose-ranking
+        // feedback has its own consumer_kind bucket (ADR-058 amendment, #542) so it no
+        // longer shares posteriors with the memory pack's recall bucket.
         if let Some(ref tid) = target_id_str {
             if let Some(profile_id) =
-                knowledge_resolve_namespace_profile(registry, &ns, "recall").await
+                resolve_consumer_profile(registry, &ns, ConsumerKind::KnowledgeCompose).await
             {
                 let brain_params = json!({
                     "namespace": ns,
@@ -438,7 +439,7 @@ impl KnowledgePack {
     /// used by `record_feedback`, completing read/write symmetry for section posteriors.
     ///
     /// Tier 1: explicit `brain_profile` config → `brain.profile` → extract `weight` per section.
-    /// Tier 2: namespace-bound profile via `brain.resolve(consumer_kind="recall")` → same.
+    /// Tier 2: namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")` → same.
     /// Tier 3: pack-local `section_posteriors` mutex → `deterministic_weights()`.
     /// Fallback: `SectionPosteriorState::default()`.
     pub(crate) async fn resolve_compose_type_weights(
@@ -455,8 +456,9 @@ impl KnowledgePack {
             }
         }
 
-        // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="recall").
-        if let Some(profile_id) = knowledge_resolve_namespace_profile(registry, &ns, "recall").await
+        // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
+        if let Some(profile_id) =
+            resolve_consumer_profile(registry, &ns, ConsumerKind::KnowledgeCompose).await
         {
             if let Some(weights) = load_profile_type_weights(registry, &profile_id).await {
                 return weights;
@@ -509,42 +511,6 @@ async fn load_profile_type_weights(
         None
     } else {
         Some(weights)
-    }
-}
-
-/// Try to resolve the profile bound to `namespace` for `consumer_kind` via
-/// `brain.resolve`. Returns `None` when the brain pack is absent, the verb
-/// errors, no binding matches, or the result is only a system-default fallback
-/// (`matched_binding = false`).
-///
-/// Per ADR-035, tier-2 fires only on a real binding match. A system-default
-/// fallback must fall through to tier-3 (pack-local global prior).
-/// Mirrors `resolve_namespace_profile` in the memory pack handler.
-async fn knowledge_resolve_namespace_profile(
-    registry: &VerbRegistry,
-    namespace: &str,
-    consumer_kind: &str,
-) -> Option<String> {
-    let resolve_params = json!({
-        "namespace": namespace,
-        "consumer_kind": consumer_kind,
-    });
-    match registry.dispatch("brain.resolve", resolve_params).await {
-        Ok(v) => {
-            // Only treat as a tier-2 hit when brain.resolve confirms an explicit binding.
-            let matched_binding = v
-                .get("matched_binding")
-                .and_then(|b| b.as_bool())
-                .unwrap_or(false);
-            if matched_binding {
-                v.get("resolved_profile_id")
-                    .and_then(|id| id.as_str())
-                    .map(str::to_owned)
-            } else {
-                None
-            }
-        }
-        Err(_) => None,
     }
 }
 
@@ -709,7 +675,7 @@ mod tests {
     ///
     /// Setup: register a brain profile with `seed_priors` that INVERT the default
     /// ordering (formalism high, operational_guidance low), bind it for
-    /// `namespace="local"` + `consumer_kind="recall"`, then call
+    /// `namespace="local"` + `consumer_kind="knowledge_compose"`, then call
     /// `resolve_compose_type_weights` with a registry that has `BrainPack` wired.
     ///
     /// With Tier 1 absent (`brain_profile=None`) and a real binding in Tier 2,
@@ -739,8 +705,8 @@ mod tests {
             .dispatch(
                 "brain.create_profile",
                 json!({
-                    "name": "recall-tuned-v1",
-                    "consumer_kind": "recall",
+                    "name": "compose-tuned-v1",
+                    "consumer_kind": "knowledge_compose",
                     "seed_priors": {
                         "section_posteriors": {
                             "formalism": {"alpha": 8.0, "beta": 1.0},
@@ -754,25 +720,25 @@ mod tests {
 
         // Activate so the profile leaves the Inactive state (matches proper usage).
         registry
-            .dispatch("brain.activate", json!({"profile_id": "recall-tuned-v1"}))
+            .dispatch("brain.activate", json!({"profile_id": "compose-tuned-v1"}))
             .await
-            .expect("activate recall-tuned-v1");
+            .expect("activate compose-tuned-v1");
 
-        // Bind for namespace="local", consumer_kind="recall".
-        // `knowledge_resolve_namespace_profile` dispatches:
-        //   brain.resolve(namespace="local", consumer_kind="recall")
+        // Bind for namespace="local", consumer_kind="knowledge_compose".
+        // `resolve_consumer_profile` dispatches:
+        //   brain.resolve(namespace="local", consumer_kind="knowledge_compose")
         // which must find this binding with matched_binding=true.
         registry
             .dispatch(
                 "brain.bind",
                 json!({
-                    "profile_id": "recall-tuned-v1",
+                    "profile_id": "compose-tuned-v1",
                     "namespace": "local",
-                    "consumer_kind": "recall"
+                    "consumer_kind": "knowledge_compose"
                 }),
             )
             .await
-            .expect("bind recall-tuned-v1 for namespace=local");
+            .expect("bind compose-tuned-v1 for namespace=local");
 
         // KnowledgePack with brain_profile=None → Tier 1 is skipped.
         let pack = KnowledgePack::new(rt.clone());

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -2,7 +2,7 @@
 //!
 //! Tier order (exclusive flow per ADR-035):
 //! 1. Explicit brain profile in pack config → route via `brain.feedback`, return early
-//! 2. Namespace-bound profile via `brain.resolve(consumer_kind="recall")`, matched_binding=true → return early
+//! 2. Namespace-bound profile via `brain.resolve(consumer_kind="knowledge_compose")`, matched_binding=true → return early
 //! 3. Global section_posteriors → update pack-local prior (only when tiers 1 and 2 do not resolve)
 
 use khive_pack_brain::BrainPack;
@@ -104,7 +104,7 @@ async fn feedback_tier1_explicit_wins_over_bound_profile() {
     registry
         .dispatch(
             "brain.create_profile",
-            json!({"namespace": ns.as_str(), "name": "alt-profile", "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "name": "alt-profile", "consumer_kind": "knowledge_compose"}),
         )
         .await
         .expect("create alt profile");
@@ -118,7 +118,7 @@ async fn feedback_tier1_explicit_wins_over_bound_profile() {
     registry
         .dispatch(
             "brain.bind",
-            json!({"namespace": ns.as_str(), "profile_id": "alt-profile", "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "profile_id": "alt-profile", "consumer_kind": "knowledge_compose"}),
         )
         .await
         .expect("bind alt profile");
@@ -180,25 +180,25 @@ async fn feedback_tier2_namespace_bound_profile_credited() {
 
     let atom_id = make_entity(&registry, ns.as_str()).await;
 
-    // Create a secondary profile and bind it explicitly for consumer_kind="recall".
+    // Create a secondary profile and bind it explicitly for consumer_kind="knowledge_compose".
     registry
         .dispatch(
             "brain.create_profile",
-            json!({"namespace": ns.as_str(), "name": "ns-bound-recall", "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "name": "ns-bound-compose", "consumer_kind": "knowledge_compose"}),
         )
         .await
         .expect("create ns-bound profile");
     registry
         .dispatch(
             "brain.activate",
-            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall"}),
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-compose"}),
         )
         .await
         .expect("activate ns-bound profile");
     registry
         .dispatch(
             "brain.bind",
-            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall", "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-compose", "consumer_kind": "knowledge_compose"}),
         )
         .await
         .expect("bind ns-bound profile");
@@ -207,12 +207,12 @@ async fn feedback_tier2_namespace_bound_profile_credited() {
     let resolve = registry
         .dispatch(
             "brain.resolve",
-            json!({"namespace": ns.as_str(), "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "consumer_kind": "knowledge_compose"}),
         )
         .await
         .expect("brain.resolve");
     assert_eq!(
-        resolve["resolved_profile_id"], "ns-bound-recall",
+        resolve["resolved_profile_id"], "ns-bound-compose",
         "brain.resolve must return the bound profile"
     );
     assert_eq!(
@@ -220,7 +220,7 @@ async fn feedback_tier2_namespace_bound_profile_credited() {
         "must be matched_binding=true for an explicit binding"
     );
 
-    // Send feedback — tier-2 must route to ns-bound-recall.
+    // Send feedback — tier-2 must route to ns-bound-compose.
     let r = registry
         .dispatch(
             "knowledge.feedback",
@@ -237,18 +237,18 @@ async fn feedback_tier2_namespace_bound_profile_credited() {
         "tier-2 feedback must route to brain pack: {r:?}"
     );
 
-    // ns-bound-recall must have total_events == 1.
+    // ns-bound-compose must have total_events == 1.
     let prof = registry
         .dispatch(
             "brain.profile",
-            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-recall"}),
+            json!({"namespace": ns.as_str(), "profile_id": "ns-bound-compose"}),
         )
         .await
         .expect("brain.profile");
     assert_eq!(
         prof["total_events"].as_u64().unwrap_or(0),
         1,
-        "ns-bound-recall must receive the feedback event"
+        "ns-bound-compose must receive the feedback event"
     );
 }
 
@@ -276,18 +276,26 @@ async fn feedback_tier3_global_fallback_no_explicit_binding() {
 
     let atom_id = make_entity(&registry, ns.as_str()).await;
 
-    // Confirm brain.resolve returns a system-default (matched_binding=false).
-    let resolve = registry
+    // Confirm brain.resolve reports no explicit binding for consumer_kind=
+    // "knowledge_compose". Unlike "recall" (which always has the seeded
+    // balanced-recall-v1 system default to fall back to), no default profile is
+    // registered for "knowledge_compose" yet, so brain.resolve legitimately
+    // errors here rather than returning matched_binding=false. Both outcomes mean
+    // "no tier-2 hit" to `khive_brain_core::resolve_consumer_profile` (ADR-058
+    // amendment, #542), which folds an Err the same as matched_binding=false —
+    // hence nothing to assert in the Err arm below.
+    if let Ok(resolve) = registry
         .dispatch(
             "brain.resolve",
-            json!({"namespace": ns.as_str(), "consumer_kind": "recall"}),
+            json!({"namespace": ns.as_str(), "consumer_kind": "knowledge_compose"}),
         )
         .await
-        .expect("brain.resolve");
-    assert_eq!(
-        resolve["matched_binding"], false,
-        "no explicit binding: matched_binding must be false (system default)"
-    );
+    {
+        assert_eq!(
+            resolve["matched_binding"], false,
+            "no explicit binding: matched_binding must be false (system default)"
+        );
+    }
 
     // Tier-3 must fire: section_posteriors updated, ok=true, no emitted key.
     let r = registry

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -46,10 +46,16 @@ impl MemoryPack {
         }
 
         // Tier 2: namespace-bound profile via brain.resolve.
-        // Use consumer_kind="recall" — the brain contract keys recall bindings/defaults
+        // consumer_kind=Recall — the brain contract keys recall bindings/defaults
         // under "recall" (brain.resolve(consumer_kind="recall") returns balanced-recall-v1).
         let ns = token.namespace().as_str().to_string();
-        if let Some(profile_id) = resolve_namespace_profile(registry, &ns, "recall").await {
+        if let Some(profile_id) = khive_brain_core::resolve_consumer_profile(
+            registry,
+            &ns,
+            khive_brain_core::ConsumerKind::Recall,
+        )
+        .await
+        {
             return route_to_brain(registry, token, &p.target_id, &p.signal, &profile_id).await;
         }
 
@@ -100,42 +106,6 @@ async fn route_to_brain(
         "served_by_profile_id": profile_id,
     });
     registry.dispatch("brain.feedback", brain_params).await
-}
-
-/// Try to resolve the profile bound to `namespace` for `consumer_kind` via
-/// `brain.resolve`. Returns `None` when the brain pack is absent, the verb
-/// errors, no binding matches, or the result is only a system-default fallback
-/// (`matched_binding = false`).
-///
-/// Per ADR-035, tier-2 fires only on a real binding match. A system-default
-/// fallback (e.g. `balanced-recall-v1` active with no explicit binding) must
-/// fall through to tier-3 (pack-local global prior).
-async fn resolve_namespace_profile(
-    registry: &VerbRegistry,
-    namespace: &str,
-    consumer_kind: &str,
-) -> Option<String> {
-    let resolve_params = json!({
-        "namespace": namespace,
-        "consumer_kind": consumer_kind,
-    });
-    match registry.dispatch("brain.resolve", resolve_params).await {
-        Ok(v) => {
-            // Only treat as a tier-2 hit when brain.resolve confirms an explicit binding.
-            let matched_binding = v
-                .get("matched_binding")
-                .and_then(|b| b.as_bool())
-                .unwrap_or(false);
-            if matched_binding {
-                v.get("resolved_profile_id")
-                    .and_then(|id| id.as_str())
-                    .map(str::to_owned)
-            } else {
-                None
-            }
-        }
-        Err(_) => None,
-    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -560,7 +530,7 @@ mod tests {
             .expect("activate ns-bound profile");
 
         // Bind ns-bound-recall to the "local" namespace for consumer_kind="recall".
-        // resolve_namespace_profile calls brain.resolve(namespace="local", consumer_kind="recall"),
+        // resolve_consumer_profile calls brain.resolve(namespace="local", consumer_kind="recall"),
         // which must match this binding when the consumer_kind fix is in place.
         registry
             .dispatch(
@@ -631,7 +601,7 @@ mod tests {
     /// namespace binding exists, feedback falls through to the pack-local global
     /// tuning prior — even when the brain pack is loaded and balanced-recall-v1 is active.
     ///
-    /// Before the matched_binding fix, resolve_namespace_profile treated the system-default
+    /// Before the matched_binding fix, resolve_consumer_profile treated the system-default
     /// fallback (balanced-recall-v1 active, no binding rows) as a tier-2 hit. This test
     /// verifies that the deactivation workaround is no longer needed: tier-3 fires in
     /// the normal case (brain loaded, no explicit binding).
@@ -661,7 +631,7 @@ mod tests {
 
         // Load brain pack but do NOT create any explicit bindings.
         // brain.resolve returns balanced-recall-v1 as system-default (matched_binding=false).
-        // With the fix, resolve_namespace_profile returns None for matched_binding=false,
+        // With the fix, resolve_consumer_profile returns None for matched_binding=false,
         // so tier-2 is skipped and tier-3 fires WITHOUT needing to deactivate the default profile.
         let brain = BrainPack::new(rt.clone());
         let mut builder = VerbRegistryBuilder::new();


### PR DESCRIPTION
## Summary

Implements the ADR-058 amendment (2026-07-03, merged in docs-only PR #551) — specifically
**Exact change list item 6** ("Consumer-kind vocabulary and resolver consolidation"), which is
the implementer checklist for gaps 1 and 2 of #542.

1. **Typed `consumer_kind` vocabulary.** `consumer_kind` was a bare, unvalidated `String` on
   `ProfileRecord`/`ProfileBinding` (`khive-brain-core/src/profile.rs:29,61`), hand-typed as a
   literal at every call site. Added a closed `ConsumerKind` enum (`Recall` / `KnowledgeCompose` /
   `Rerank`) with `as_str(&self) -> &'static str`, `FromStr`, and `Display`, matching the existing
   `SectionType` precedent in the same crate. The wire-level MCP `consumer_kind` param stays a
   plain JSON string — the enum is Rust-internal only.

2. **Duplicated resolver, wrong bucket.** `khive-pack-memory/src/handlers/feedback.rs` and
   `khive-pack-knowledge/src/handlers.rs` each hand-rolled an identical private tier-2 resolver
   (`resolve_namespace_profile` / `knowledge_resolve_namespace_profile`) that dispatches
   `brain.resolve` and gates on `matched_binding`. I audited both side by side before deleting
   either: **they are logically and structurally identical, byte-for-byte matching logic, no
   divergence found.** Consolidated into one shared
   `khive_brain_core::resolve_consumer_profile(registry, namespace, ConsumerKind) -> Option<String>`,
   ported verbatim from the confirmed-identical implementations. Both private fns deleted.

   Worse: the knowledge pack's two tier-2 call sites (`handle_feedback`,
   `resolve_compose_type_weights`) passed the literal `"recall"` instead of `"knowledge_compose"`
   — a real bug per ADR-048, not a naming choice. Knowledge-pack section-feedback tuning was
   silently updating the memory pack's recall posterior bucket instead of its own ADR-048 bucket.
   Both call sites now pass `ConsumerKind::KnowledgeCompose`. The inline comments that previously
   justified `"recall"` as deliberate were rewritten (they were factually wrong).

## Behavior change

Any deployment with an existing `consumer_kind="recall"` `brain.bind()` row that was intended to
tune knowledge-pack compose ranking will **no longer be picked up** by `knowledge.feedback`'s
tier-2 after this lands — it now resolves against `consumer_kind="knowledge_compose"`. A new
binding with `consumer_kind="knowledge_compose"` must be created to restore that intent. No stored
data is deleted, mutated, or migrated by this change — this is a resolution-key change only.
Memory-pack behavior (`consumer_kind="recall"`) is unchanged; see the regression test below.

Separately: `brain.resolve(consumer_kind="knowledge_compose")` currently returns `NotFound`
(errors) rather than `matched_binding=false` when no explicit binding exists, because — unlike
`"recall"`, which always has the seeded `balanced-recall-v1` system-default profile as a fallback
— there is no seeded system-default profile for `knowledge_compose` yet. Both
`resolve_consumer_profile` and both pack call sites already treat any `brain.resolve` error the
same as `matched_binding=false` (fall through to tier-3), so this is safe today and required no
code change. Seeding a `knowledge_compose` default profile, if wanted, is separate follow-up scope.

## Scope note — #542 is a 3-item issue, this PR covers 2

Issue #542 lists three gaps: (1) magic-string consumer kinds, (2) duplicated resolution ladder,
(3) dead `PackTunable`/`BrainProfileHint` config in `khive-pack-memory/src/config.rs` (tracked as
ADR-058 Q5, "Open: BrainProfileHint disposition"). This PR implements (1) and (2) — exactly ADR-058
amendment's Exact-change-list item 6. It does **not** touch `BrainProfileHint`/`config.rs`, which
remains an open, separate question per ADR-058 Q5. **This PR should not auto-close #542.**

## Test plan

- [x] `khive-brain-core::profile`: `consumer_kind_as_str_matches_wire_vocabulary`,
      `consumer_kind_from_str_round_trips`, `consumer_kind_from_str_rejects_unknown` (new).
- [x] `khive-pack-knowledge`: `resolve_compose_type_weights_reads_bound_profile_weights_at_tier2`
      (`handlers.rs`) and `feedback_tier2_namespace_bound_profile_credited`
      (`tests/feedback.rs`) updated to bind/resolve `consumer_kind="knowledge_compose"` — these
      now exercise the actual bug fix (fixture profile ids renamed `recall-tuned-v1` →
      `compose-tuned-v1`, `ns-bound-recall` → `ns-bound-compose` for accuracy).
      `feedback_tier3_global_fallback_no_explicit_binding` updated to tolerate the
      `brain.resolve` `NotFound` case described above.
- [x] `khive-pack-memory`: `feedback_tier2_namespace_bound_profile_credited` unchanged and still
      passing — confirms memory-pack recall behavior is unaffected by the refactor to the shared
      resolver.
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-brain-core -p khive-pack-memory -p khive-pack-knowledge` (all green;
      full `cargo test --workspace` intentionally not run — out of scope per task instructions)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`