### PR TITLE
docs(adr-058): fix §3 sample to use ConsumerKind::Recall.as_str()

### DIFF
--- a/docs/adr/ADR-058-brain-posterior-read-path.md
+++ b/docs/adr/ADR-058-brain-posterior-read-path.md
@@ -603,7 +603,7 @@ async fn resolve_brain_weights(
 
     let serve_params = serde_json::json!({
         "namespace": &ns,
-        "consumer_kind": "recall",
+        "consumer_kind": khive_brain_core::ConsumerKind::Recall.as_str(),
     });
 
     let result = registry


### PR DESCRIPTION
## Summary
- Companion to #552 (ADR-058 code implementation). PR #552 stays pure-code per project convention; this is the docs-only fix for the one gap TBV-verification found: ADR-058's own §3 illustrative sample still used the bare `"recall"` string literal the ADR's own MUST clause requires replacing everywhere.
- Fixes `docs/adr/ADR-058-brain-posterior-read-path.md`'s `resolve_brain_weights` sample to construct `consumer_kind` via `khive_brain_core::ConsumerKind::Recall.as_str()`, matching the real pattern #552 lands in `khive-pack-memory/src/handlers/feedback.rs`.

## Scope
Docs-only, one file, one line. No code changes — kept separate from #552 per the project's code/docs PR-split convention.

## Test plan
- [x] `deno fmt` docs check passes (ran via pre-commit hook on commit)
- [ ] CI docs-lint / doc-build green