### PR TITLE
fix(mcp,pack-session): resolve cross-PR test conflict + private doc links

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2203,7 +2203,7 @@ brain_profile = "project-profile"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg);
+        let result = build_registry_for_multi_backend(base_cfg, &khive_cfg, None);
         assert!(
             result.is_err(),
             "an undeclared configured pack backend must be a startup error, not a silent \
@@ -2260,7 +2260,7 @@ brain_profile = "project-profile"
 
         let base_cfg = base_runtime_config_for_multi_backend();
 
-        let result = build_server_multi_backend(base_cfg, &khive_cfg);
+        let result = build_server_multi_backend(base_cfg, &khive_cfg, None);
         assert!(
             result.is_err(),
             "an undeclared configured pack backend must be a startup error, not a silent \

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1531,6 +1531,7 @@ impl ServerHandler for KhiveMcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use khive_runtime::Namespace;
     use serial_test::serial;
 
     fn t(pack: &str, verb: &str, desc: &str) -> (String, String, String) {

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -12,7 +12,7 @@
 //! `INSERT OR IGNORE` keyed by the event UUID ensures idempotency.
 //!
 //! No single line, complete or partial, is ever buffered past
-//! `MirrorLimits::max_line_bytes` (see [`read_line_bounded`]): a complete
+//! `MirrorLimits::max_line_bytes` (see `read_line_bounded`): a complete
 //! line over that cap is skipped with a `tracing::warn!` naming the file and
 //! byte offset, and the offset advances past it so ingestion never wedges on
 //! one oversized line. The pass cap is gated on at least one complete line
@@ -25,7 +25,7 @@
 //! still-growing file's in-progress final line, or a genuinely truncated /
 //! corrupt tail — is its own bounded case, distinct from the complete
 //! (terminated) oversized-line skip above: `read_line_bounded` reports
-//! [`LineRead::OversizedUnterminated`] as soon as one bounded read window
+//! `LineRead::OversizedUnterminated` as soon as one bounded read window
 //! crosses the cap without finding `\n`, instead of scanning onward to EOF
 //! looking for one. The cursor is intentionally left at that line's start
 //! (like an ordinary `Partial`), so the next poll — or the next daemon
@@ -191,7 +191,7 @@ struct MirrorChunk {
     new_offset: u64,
 }
 
-/// Outcome of [`read_line_bounded`] for one line.
+/// Outcome of `read_line_bounded` for one line.
 #[derive(Debug)]
 enum LineRead {
     /// EOF with nothing read at all.
@@ -480,7 +480,7 @@ async fn mirror_file_with_limits(
 
 /// Default ceiling on the byte length of a ChatGPT export `conversations.json`
 /// file read in one [`mirror_chatgpt_export_file`] pass. Overridable via
-/// `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (see [`chatgpt_max_bytes`]).
+/// `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (see `chatgpt_max_bytes`).
 ///
 /// Unlike the JSONL line-tail sources, a ChatGPT export has no incremental
 /// "new bytes" boundary — it is always read and parsed whole (see the
@@ -518,7 +518,7 @@ fn chatgpt_max_bytes() -> u64 {
 /// error leaves the persisted cursor untouched, so a partially-downloaded
 /// export is retried whole on the next tick, never half-consumed.
 ///
-/// Before reading, the file is checked against [`chatgpt_max_bytes`]: an
+/// Before reading, the file is checked against `chatgpt_max_bytes`: an
 /// export over that ceiling is skipped (warn-logged) without ever calling
 /// `read_to_string`, so a very large export cannot materialize its full
 /// content (and, downstream, a full `Vec` of parsed events) in one pass.


### PR DESCRIPTION
## Summary

Main CI was red at `5f47b0f4` (merge of #549) with two independent breaks.

### Break 1 — semantic merge conflict in khive-mcp test code (#537 × #549)

PR #537 and PR #549 each touched the same test seams and were individually
green on bases that lacked the other's change, producing a conflict only
visible after both landed:

- `crates/khive-mcp/src/server.rs`: a test config construction referenced
  `Namespace` with no import in scope (only reachable via a private
  `coordinator::tests::Namespace` path) — E0433.
- `crates/khive-mcp/src/serve.rs`: two test call sites
  (`multi_backend_registry_rejects_undefined_pack_backend` and
  `multi_backend_server_rejects_undefined_pack_backend`) still called
  `build_registry_for_multi_backend` / `build_server_multi_backend` with 2
  args after #549 added a third `cli_db_override: Option<&str>` parameter
  to both functions (the coordinator dispatch helpers gaining namespace/CLI
  db-override resolution) — E0061.

Fixed by adding the missing `khive_runtime::Namespace` import and updating
both stale call sites to pass `None` for the new parameter, matching every
other call site in the file (verified via grep — all 13 other call sites
already pass 3 args).

### Break 2 — doc build (`-D warnings`) in khive-pack-session

Public documentation on the `mirror::ingest` module and on
`mirror_chatgpt_export_file` used intra-doc links (`` [`item`] ``) to
private items: `read_line_bounded`, `LineRead::OversizedUnterminated`, and
`chatgpt_max_bytes`. rustdoc's `private-intra-doc-links` lint fails the
build under `-D warnings`.

Fixed by converting the 5 offending links to plain code spans (backticks,
no link brackets) — no visibility changes to the referenced items.

Both fixes are test/doc-only; no production behavior changes.

## Test plan

Run from `crates/` with a scratch `CARGO_TARGET_DIR`:

- [x] `cargo test -p khive-mcp -p khive-pack-session` — 88 + 110 + 72 + 23 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean
- [x] `cargo fmt --all --check` — clean