### PR TITLE
fix(site): dedupe sidebar nav, drop purple accent, README docs+Discord links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -179,8 +179,9 @@ jobs:
           # Per-guide-page assembly: inject nav_order/title/description front matter,
           # rewrite in-repo relative links to the site's flat .html layout (links
           # outside docs/guide go to their GitHub blob URL; external links untouched),
-          # and drop a raw copy (no front matter, so Jekyll copies it verbatim as a
-          # static file) under $SRC/md/ for agent-fetchable raw markdown.
+          # and stage a raw copy in _raw_md/ (outside the Jekyll source so the theme
+          # never promotes it to a nav page); a post-build step copies these into
+          # _site/md/ for agent-fetchable raw markdown.
           for f in docs/guide/*.md; do
             base=$(basename "$f" .md)
             [ "$base" = "README" ] && continue

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,6 +81,8 @@ jobs:
               - "https://crates.io/crates/khive-mcp"
             "Discord":
               - "https://discord.gg/JDj9ENhUE8"
+            "llms.txt":
+              - "/khive/llms.txt"
           aux_links_new_tab: true
           EOF
 
@@ -248,6 +250,9 @@ jobs:
             echo "- [AGENTS.md](https://raw.githubusercontent.com/ohdearquant/khive/main/AGENTS.md): full verb reference for agents using khive"
             echo "- [llms-full.txt](${SITE_URL}/llms-full.txt): every doc page above, concatenated into one fetch"
           } > "$SRC/llms.txt"
+
+          # /llm.txt — singular alias; agents and humans guess both spellings.
+          cp "$SRC/llms.txt" "$SRC/llm.txt"
 
           # Raw markdown copy of the homepage too, matching the /md/<base>.md
           # convention for every other page — strip the front matter block.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,8 +48,13 @@ jobs:
         run: |
           set -euo pipefail
           SRC=_site_src
-          rm -rf "$SRC"
-          mkdir -p "$SRC/md"
+          rm -rf "$SRC" _raw_md
+          # Raw agent-fetchable markdown is staged OUTSIDE the Jekyll source and
+          # copied into the built site after the Jekyll step. If it lives inside
+          # the source, the github-pages gem's jekyll-optional-front-matter +
+          # jekyll-titles-from-headings plugins promote each raw file into a
+          # titled page, which duplicates every entry in the sidebar nav.
+          mkdir -p "$SRC" _raw_md
 
           cat > "$SRC/_config.yml" <<'EOF'
           title: khive
@@ -64,6 +69,7 @@ jobs:
             input: GFM
           search_enabled: true
           heading_anchors: true
+          color_scheme: khive
           nav_sort: case_insensitive
           back_to_top: true
           back_to_top_text: "Back to top"
@@ -73,7 +79,25 @@ jobs:
               - "https://github.com/ohdearquant/khive"
             "crates.io":
               - "https://crates.io/crates/khive-mcp"
+            "Discord":
+              - "https://discord.gg/JDj9ENhUE8"
           aux_links_new_tab: true
+          EOF
+
+          # Custom color scheme: neutral blue accents replacing the theme's
+          # default purple palette. The palette vars are declared !default in
+          # just-the-docs, so assignments here win; $link-color and
+          # $btn-primary-color are re-declared too because the light scheme
+          # derives them from the purple palette at its own load time.
+          mkdir -p "$SRC/_sass/color_schemes"
+          cat > "$SRC/_sass/color_schemes/khive.scss" <<'EOF'
+          $purple-000: #2b6cb0;
+          $purple-100: #0969da;
+          $purple-200: #0550ae;
+          $purple-300: #033d8b;
+          $link-color: #0969da;
+          $btn-primary-color: #0969da;
+          $sidebar-color: #f7f9fb;
           EOF
 
           # basename -> "nav_order|Title|one-line description used in llms.txt"
@@ -193,9 +217,10 @@ jobs:
               echo "Raw markdown for this page: [/md/${base}.md](${SITE_URL}/md/${base}.md)"
             } > "$SRC/$base.md"
 
-            # Raw copy for agents — no front matter, so Jekyll treats this as a
-            # static file and serves it byte-for-byte at /md/<base>.md.
-            cp "$f" "$SRC/md/$base.md"
+            # Raw copy for agents — staged outside the Jekyll source and copied
+            # into the built site post-build (see the step after Build with
+            # Jekyll), so the github-pages gem cannot promote it into a page.
+            cp "$f" "_raw_md/$base.md"
           done
 
           # llms.txt — the llms.txt convention: short summary + linked index,
@@ -226,7 +251,7 @@ jobs:
 
           # Raw markdown copy of the homepage too, matching the /md/<base>.md
           # convention for every other page — strip the front matter block.
-          awk 'BEGIN{n=0} /^---$/{n++; next} n>=2{print}' "$SRC/index.md" > "$SRC/md/index.md"
+          awk 'BEGIN{n=0} /^---$/{n++; next} n>=2{print}' "$SRC/index.md" > "_raw_md/index.md"
 
           # llms-full.txt — full concatenated markdown of every doc page.
           {
@@ -260,6 +285,17 @@ jobs:
         with:
           source: _site_src
           destination: _site
+
+      - name: Add raw markdown copies to built site
+        # Post-build so Jekyll never sees these files (they would otherwise be
+        # promoted into titled pages and duplicate the sidebar nav). The Jekyll
+        # container writes _site as root, hence sudo.
+        run: |
+          set -euo pipefail
+          sudo mkdir -p _site/md
+          sudo cp _raw_md/*.md _site/md/
+          test -f _site/md/getting-started.md
+          test -f _site/md/index.md
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ taxonomies, and a verb-consolidated MCP surface.
 [![CI](https://github.com/ohdearquant/khive/actions/workflows/ci.yml/badge.svg)](https://github.com/ohdearquant/khive/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Docs](https://img.shields.io/badge/docs-ohdearquant.github.io%2Fkhive-0969da)](https://ohdearquant.github.io/khive/)
+[![Discord](https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/JDj9ENhUE8)
+
+**[Documentation](https://ohdearquant.github.io/khive/)** &middot; **[Discord](https://discord.gg/JDj9ENhUE8)**
 
 Vector search finds similar text. A knowledge graph finds _structure_: lineages, dependencies,
 contradictions, gaps. khive gives your research agent a typed, queryable graph that grows as it
@@ -345,7 +349,8 @@ Runnable, copy-pasteable transcripts against a scratch database. See [`demos/`](
   recall
 
 Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agents: fetch
-[`/llms.txt`](https://ohdearquant.github.io/khive/llms.txt)).
+[`/llms.txt`](https://ohdearquant.github.io/khive/llms.txt)). Questions and discussion:
+[Discord](https://discord.gg/JDj9ENhUE8).
 
 ---
 


### PR DESCRIPTION
Fixes two issues flagged on the live site plus the README asks.

## Nav duplication (bug)
Every page appeared twice in the sidebar. Root cause: the raw agent-fetchable `/md/*.md` copies lived inside the Jekyll source; `actions/jekyll-build-pages` ships the github-pages gem with `jekyll-optional-front-matter` + `jekyll-titles-from-headings` enabled, which promoted each raw file into a titled page. Fix: stage raw copies in `_raw_md/` outside the source and copy them into `_site/md/` in a post-build step (with existence assertions). Raw URLs are unchanged (`/md/<name>.md`), still byte-identical.

## Color scheme
New `_sass/color_schemes/khive.scss` (activated via `color_scheme: khive`): overrides the theme's `$purple-*` palette plus derived `$link-color`/`$btn-primary-color` with blues (#0969da family). All theme vars are `!default`, so the scheme file wins.

## README + site links
- README: Docs + Discord badges under the existing badge row, a Documentation · Discord line, and the Discord invite next to the existing bottom docs pointer.
- Site: Discord added to `aux_links` (header, next to GitHub / crates.io).

## Verification
- YAML parses (`yaml.safe_load`); assembly script ran locally end-to-end: no `md/` inside `_site_src`, 8 raw files staged in `_raw_md/`, `khive.scss` + `color_scheme: khive` + Discord aux link present in generated config.
- Jekyll build itself still only runs in CI — watch the `pages` workflow after merge (same constraint as #579).