### PR TITLE
feat(memory,brain): wire recall serve-time attribution + serve-ledger append (#394, ADR-081 §5)

### DIFF
--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -31,6 +31,11 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+# ADR-081 §4: brain.record_serve computes the deterministic query_class key
+# (lowercase, strip punctuation, collapse whitespace, sort unique tokens,
+# join, SHA-256, first 16 hex chars).
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [features]
 lattice-router = ["dep:lattice-fann"]

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -257,6 +257,46 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
             },
         ],
     },
+    HandlerDef {
+        name: "brain.record_serve",
+        description: "ADR-081 §4/§5: append cross-session serve-ledger rows for a batch of \
+            recall targets. Internal-only — memory.recall dispatches this off its response \
+            path after resolving served_by_profile_id via the ADR-035 three-tier discipline.",
+        visibility: khive_types::Visibility::Subhandler,
+        category: khive_types::VerbCategory::Commissive,
+        params: &[
+            khive_types::ParamDef {
+                name: "consumer_kind",
+                param_type: "string",
+                required: true,
+                description: "Consumer kind that served these results, e.g. \"recall\".",
+            },
+            khive_types::ParamDef {
+                name: "served_by_profile_id",
+                param_type: "string",
+                required: false,
+                description: "Profile ID resolved at serve time. Omitted when unresolved.",
+            },
+            khive_types::ParamDef {
+                name: "target_ids",
+                param_type: "array",
+                required: true,
+                description: "Note/entity ids that were served; one ledger row per id.",
+            },
+            khive_types::ParamDef {
+                name: "query_raw",
+                param_type: "string",
+                required: true,
+                description: "Raw query text; query_class is derived from this deterministically.",
+            },
+            khive_types::ParamDef {
+                name: "served_at",
+                param_type: "integer",
+                required: false,
+                description: "Serve timestamp in epoch microseconds. Defaults to now.",
+            },
+        ],
+    },
     // ── Declaration verbs ─────────────────────────────────────────────────
     HandlerDef {
         name: "brain.bind",
@@ -1420,6 +1460,82 @@ impl BrainPack {
         Ok(out)
     }
 
+    // ── brain.record_serve ────────────────────────────────────────────────
+
+    /// ADR-081 §4/§5 (#394): append one serve-ledger row per target id. Never
+    /// propagates a per-target write failure as a batch error — a serve-ledger
+    /// append is best-effort accounting, not the recall response itself, so a
+    /// single row's failure (or an exact-key duplicate, tolerated as `skipped`)
+    /// must not poison the rest of the batch.
+    pub(crate) async fn handle_record_serve(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RecordServeParams {
+            consumer_kind: String,
+            served_by_profile_id: Option<String>,
+            target_ids: Vec<String>,
+            query_raw: String,
+            served_at: Option<i64>,
+        }
+        let p: RecordServeParams = serde_json::from_value(params)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        if p.target_ids.is_empty() {
+            return Ok(json!({
+                "ok": true,
+                "written": 0,
+                "skipped": 0,
+                "verb": "brain.record_serve",
+            }));
+        }
+
+        let namespace = token.namespace().as_str().to_string();
+        let query_class = crate::serve_ledger::compute_query_class(&p.query_raw);
+        let served_at = p.served_at.unwrap_or_else(|| Utc::now().timestamp_micros());
+        let sql = self.runtime.sql();
+
+        let mut written = 0usize;
+        let mut skipped = 0usize;
+        for target_id in &p.target_ids {
+            let row_id = uuid::Uuid::new_v4().to_string();
+            match crate::serve_ledger::record_serve(
+                sql.as_ref(),
+                &row_id,
+                &namespace,
+                &p.consumer_kind,
+                p.served_by_profile_id.as_deref(),
+                None,
+                None,
+                target_id,
+                &query_class,
+                &p.query_raw,
+                served_at,
+            )
+            .await
+            {
+                Ok(true) => written += 1,
+                Ok(false) => skipped += 1,
+                Err(e) => {
+                    eprintln!(
+                        "[brain] serve ledger write failed for target {target_id} (non-fatal): {e}"
+                    );
+                }
+            }
+        }
+
+        Ok(json!({
+            "ok": true,
+            "written": written,
+            "skipped": skipped,
+            "query_class": query_class,
+            "verb": "brain.record_serve",
+        }))
+    }
+
     // ── brain.emit (deprecated) ───────────────────────────────────────────
 
     /// Deprecated alias for `brain.feedback`; routes to `handle_feedback`.
@@ -2114,6 +2230,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.reset" => self.handle_reset(token, params).await,
             "brain.feedback" => self.handle_feedback(token, params).await,
             "brain.auto_feedback" => self.handle_auto_feedback(token, params).await,
+            "brain.record_serve" => self.handle_record_serve(token, params).await,
             // Declaration
             "brain.bind" => self.handle_bind(token, params).await,
             "brain.unbind" => self.handle_unbind(token, params).await,

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -143,9 +143,48 @@ pub async fn record_serve(
         .await;
     match result {
         Ok(_) => Ok(true),
-        Err(e) if e.is_unique_constraint_violation() => Ok(false),
+        Err(e) if e.is_unique_constraint_violation() => {
+            // codex PR #583 round-1 Low: `is_unique_constraint_violation` fires
+            // for ANY unique-index collision on this table — the intended
+            // natural key `(namespace, target_id, query_class, served_at)`,
+            // but also the `id TEXT PRIMARY KEY` column and any future unique
+            // index. Confirm the natural-key row actually exists before
+            // reporting a tolerated duplicate; otherwise this would mask a
+            // genuine `id` collision (or other future constraint) as a no-op.
+            if natural_key_row_exists(sql, namespace, target_id, query_class, served_at).await? {
+                Ok(false)
+            } else {
+                Err(sql_err("insert serve row", e))
+            }
+        }
         Err(e) => Err(sql_err("insert serve row", e)),
     }
+}
+
+async fn natural_key_row_exists(
+    sql: &dyn SqlAccess,
+    namespace: &str,
+    target_id: &str,
+    query_class: &str,
+    served_at: i64,
+) -> Result<bool, RuntimeError> {
+    let mut reader = sql.reader().await.map_err(|e| sql_err("reader", e))?;
+    let row = reader
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM brain_serve_ledger \
+                  WHERE namespace = ?1 AND target_id = ?2 AND query_class = ?3 AND served_at = ?4"
+                .into(),
+            params: vec![
+                SqlValue::Text(namespace.to_string()),
+                SqlValue::Text(target_id.to_string()),
+                SqlValue::Text(query_class.to_string()),
+                SqlValue::Integer(served_at),
+            ],
+            label: Some("brain_serve_ledger_natural_key_check".into()),
+        })
+        .await
+        .map_err(|e| sql_err("check natural key", e))?;
+    Ok(row.is_some())
 }
 
 /// Fetch a serve ledger row by id.

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -2,16 +2,36 @@
 //! and their scorer-assigned grades.
 //!
 //! Row creation (`record_serve`) implements the normative write side of the
-//! ledger so the table is fully usable end to end, but wiring `memory.recall` to
-//! call it is explicitly out of scope here (ADR-081 §5: the `served_by_profile_id`
-//! serve-time stamp ships as a separate, latency-gated implementation PR, #394).
-//! What this task wires up is the read side consumed by `brain.feedback` /
+//! ledger; `memory.recall` wires into it via `brain.record_serve` (ADR-081 §5,
+//! #394) to stamp `served_by_profile_id` and append the ledger row off the
+//! response path. The read side is consumed by `brain.feedback` /
 //! `brain.auto_feedback` when a caller supplies `serve_ledger_id` (ADR-081 §6):
 //! dedup by `(scorer_run_id, id)`, the `accounting_profile_id` zero-weight
 //! fail-safe, and grade backfill.
 use khive_runtime::RuntimeError;
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::SqlAccess;
+use sha2::{Digest, Sha256};
+
+/// Compute the deterministic `query_class` key (ADR-081 §4): lowercase, strip
+/// punctuation to whitespace, collapse whitespace, sort+dedup unique tokens,
+/// join, SHA-256, first 16 hex chars. Order-insensitive so two queries with
+/// the same token set (in any order) fold into the same accounting key.
+pub fn compute_query_class(query_raw: &str) -> String {
+    let lowered = query_raw.to_lowercase();
+    let stripped: String = lowered
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect();
+    let mut tokens: Vec<&str> = stripped.split_whitespace().collect();
+    tokens.sort_unstable();
+    tokens.dedup();
+    let normalized = tokens.join(" ");
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(digest)[..16].to_string()
+}
 
 fn sql_err(context: &str, e: impl std::fmt::Display) -> RuntimeError {
     RuntimeError::Internal(format!("serve ledger {context}: {e}"))
@@ -76,9 +96,10 @@ fn row_int(row: &khive_storage::types::SqlRow, col: &str) -> Result<i64, Runtime
     }
 }
 
-/// Record a new serve row (the ADR-081 §4 write side). Not yet called by the
-/// recall path (out of scope here); provided so the ledger's write contract is
-/// implemented, not stubbed, ahead of that wiring.
+/// Record a new serve row (the ADR-081 §4 write side). Returns `Ok(true)` when
+/// the row was written, `Ok(false)` when an exact-key duplicate was tolerated
+/// (the natural key `(namespace, target_id, query_class, served_at)` already
+/// has a row — a duplicate drain of the same batch, not an error).
 #[allow(clippy::too_many_arguments)]
 pub async fn record_serve(
     sql: &dyn SqlAccess,
@@ -92,9 +113,9 @@ pub async fn record_serve(
     query_class: &str,
     query_raw: &str,
     served_at: i64,
-) -> Result<(), RuntimeError> {
+) -> Result<bool, RuntimeError> {
     let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
-    writer
+    let result = writer
         .execute(SqlStatement {
             sql: "INSERT INTO brain_serve_ledger \
                   (id, namespace, consumer_kind, served_by_profile_id, resolved_profile_id, \
@@ -119,9 +140,12 @@ pub async fn record_serve(
             ],
             label: Some("brain_serve_ledger_insert".into()),
         })
-        .await
-        .map_err(|e| sql_err("insert serve row", e))?;
-    Ok(())
+        .await;
+    match result {
+        Ok(_) => Ok(true),
+        Err(e) if e.is_unique_constraint_violation() => Ok(false),
+        Err(e) => Err(sql_err("insert serve row", e)),
+    }
 }
 
 /// Fetch a serve ledger row by id.

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4900,6 +4900,57 @@ mod adr081_retune_driver_tests {
         assert!(!second, "exact-key duplicate must report written=false");
     }
 
+    /// codex PR #583 round-1 Low: a `UNIQUE` violation on the `id TEXT PRIMARY
+    /// KEY` column (same `id`, different natural key) must NOT be reported as
+    /// a tolerated natural-key duplicate — the row that actually exists does
+    /// not match `(namespace, target_id, query_class, served_at)`, so the
+    /// original error must propagate instead of being silently swallowed.
+    #[tokio::test]
+    async fn record_serve_primary_key_collision_with_different_natural_key_propagates_error() {
+        let (_pack, rt) = make_pack();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target_a = create_test_entity(&rt, &token).await;
+        let target_b = create_test_entity(&rt, &token).await;
+
+        crate::serve_ledger::record_serve(
+            rt.sql().as_ref(),
+            "shared-row-id",
+            "local",
+            "recall",
+            None,
+            None,
+            None,
+            &target_a,
+            "class-a",
+            "raw query a",
+            1_000,
+        )
+        .await
+        .expect("first insert must succeed");
+
+        // Reuse the SAME id but a DIFFERENT natural key (different target_id) —
+        // this collides on the primary key, not the natural-key unique index.
+        let err = crate::serve_ledger::record_serve(
+            rt.sql().as_ref(),
+            "shared-row-id",
+            "local",
+            "recall",
+            None,
+            None,
+            None,
+            &target_b,
+            "class-b",
+            "raw query b",
+            2_000,
+        )
+        .await
+        .expect_err("a PK collision with a mismatched natural key must not be tolerated");
+        assert!(
+            matches!(err, RuntimeError::Internal(_)),
+            "expected the original insert error to propagate, got {err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn handle_record_serve_writes_one_row_per_target_and_stamps_profile() {
         let (pack, rt) = make_pack();

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -4846,6 +4846,183 @@ mod adr081_retune_driver_tests {
         assert!(matches!(err, RuntimeError::NotFound(_)));
     }
 
+    #[test]
+    fn compute_query_class_is_deterministic_and_order_insensitive() {
+        let a = crate::serve_ledger::compute_query_class("Rust async runtime tuning");
+        let b = crate::serve_ledger::compute_query_class("tuning runtime async rust");
+        let c = crate::serve_ledger::compute_query_class("Rust,  async! runtime  tuning.");
+        assert_eq!(a, b, "token order must not affect the class key");
+        assert_eq!(a, c, "punctuation/whitespace must not affect the class key");
+        assert_eq!(a.len(), 16);
+
+        let d = crate::serve_ledger::compute_query_class("completely different query");
+        assert_ne!(a, d);
+    }
+
+    #[tokio::test]
+    async fn record_serve_duplicate_key_is_tolerated_not_errored() {
+        let (_pack, rt) = make_pack();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let first = crate::serve_ledger::record_serve(
+            rt.sql().as_ref(),
+            "row-a",
+            "local",
+            "recall",
+            None,
+            None,
+            None,
+            &target,
+            "dup-class",
+            "raw query",
+            42_000,
+        )
+        .await
+        .expect("first insert must succeed");
+        assert!(first, "first write must report written=true");
+
+        let second = crate::serve_ledger::record_serve(
+            rt.sql().as_ref(),
+            "row-b",
+            "local",
+            "recall",
+            None,
+            None,
+            None,
+            &target,
+            "dup-class",
+            "raw query",
+            42_000,
+        )
+        .await
+        .expect("duplicate key must be tolerated, not errored");
+        assert!(!second, "exact-key duplicate must report written=false");
+    }
+
+    #[tokio::test]
+    async fn handle_record_serve_writes_one_row_per_target_and_stamps_profile() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target_a = create_test_entity(&rt, &token).await;
+        let target_b = create_test_entity(&rt, &token).await;
+
+        let result = pack
+            .dispatch(
+                "brain.record_serve",
+                json!({
+                    "consumer_kind": "recall",
+                    "served_by_profile_id": "adr081-recall-v1",
+                    "target_ids": [target_a.clone(), target_b.clone()],
+                    "query_raw": "async runtime tuning",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("record_serve dispatch");
+        assert_eq!(result["written"], json!(2));
+        assert_eq!(result["skipped"], json!(0));
+
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let raw_row = reader
+            .query_row(khive_storage::types::SqlStatement {
+                sql: "SELECT id FROM brain_serve_ledger WHERE target_id = ?1".into(),
+                params: vec![khive_storage::types::SqlValue::Text(target_a.clone())],
+                label: None,
+            })
+            .await
+            .expect("query row")
+            .expect("row for target_a must exist");
+        let row_id = match raw_row.get("id") {
+            Some(khive_storage::types::SqlValue::Text(s)) => s.clone(),
+            other => panic!("expected text id, got {other:?}"),
+        };
+        drop(reader);
+
+        let row = crate::serve_ledger::get_serve_row(rt.sql().as_ref(), &row_id)
+            .await
+            .unwrap()
+            .expect("row must exist");
+        assert_eq!(
+            row.served_by_profile_id.as_deref(),
+            Some("adr081-recall-v1")
+        );
+        assert_eq!(row.query_class, result["query_class"].as_str().unwrap());
+    }
+
+    #[tokio::test]
+    async fn handle_record_serve_tolerates_duplicate_target_in_same_batch_drain() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let params = json!({
+            "consumer_kind": "recall",
+            "target_ids": [target.clone()],
+            "query_raw": "same query twice",
+            "served_at": 99_000,
+        });
+
+        let first = pack
+            .dispatch("brain.record_serve", params.clone(), &registry, &token)
+            .await
+            .expect("first drain");
+        assert_eq!(first["written"], json!(1));
+        assert_eq!(first["skipped"], json!(0));
+
+        let second = pack
+            .dispatch("brain.record_serve", params, &registry, &token)
+            .await
+            .expect("second drain must not error");
+        assert_eq!(second["written"], json!(0));
+        assert_eq!(second["skipped"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn handle_record_serve_unresolved_profile_still_writes_row() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let target = create_test_entity(&rt, &token).await;
+
+        let result = pack
+            .dispatch(
+                "brain.record_serve",
+                json!({
+                    "consumer_kind": "recall",
+                    "target_ids": [target.clone()],
+                    "query_raw": "unresolved profile query",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("record_serve dispatch");
+        assert_eq!(result["written"], json!(1));
+
+        let mut reader = rt.sql().reader().await.expect("reader");
+        let raw_row = reader
+            .query_row(khive_storage::types::SqlStatement {
+                sql: "SELECT id, served_by_profile_id FROM brain_serve_ledger WHERE target_id = ?1"
+                    .into(),
+                params: vec![khive_storage::types::SqlValue::Text(target)],
+                label: None,
+            })
+            .await
+            .expect("query row")
+            .expect("row must exist");
+        assert!(
+            matches!(
+                raw_row.get("served_by_profile_id"),
+                Some(khive_storage::types::SqlValue::Null) | None
+            ),
+            "unresolved profile must write a null column, not a placeholder string"
+        );
+    }
+
     /// Replay determinism: a gated (zero-weight) event, once replayed from the
     /// event log against a fresh BrainPack, must reproduce the exact same
     /// (zero) posterior effect — not re-evaluate the gate against present-day

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -12,6 +12,7 @@ use khive_fusion::FusionStrategy;
 use khive_retrieval::{fuse_search_results, HybridConfig};
 use khive_runtime::{
     MemoryRecallPipeline, NamespaceToken, NoteCandidate, RuntimeError, SearchHit, SearchSource,
+    VerbRegistry,
 };
 use khive_score::DeterministicScore;
 use khive_storage::types::{
@@ -119,6 +120,29 @@ pub(super) fn parse_fusion_strategy_str(s: &str) -> Result<FusionStrategy, Runti
             "invalid fusion_strategy {other:?}: must be one of \"rrf\", \"weighted\", \"union\", \"vector_only\", \"keyword_only\""
         ))),
     }
+}
+
+/// Resolve the serving profile via ADR-035 tiers 1-2 only (explicit config,
+/// then namespace-bound `brain.resolve(consumer_kind="recall")`). Shared by
+/// `memory.feedback` (which falls through to its own tier-3 global-prior
+/// behavior on `None`) and `memory.recall`'s ADR-081 §5 serve-time stamp
+/// (which simply omits the stamp on `None`) — extracted so the two resolution
+/// paths cannot drift apart.
+pub(super) async fn resolve_serving_profile(
+    brain_profile: &Option<String>,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+) -> Option<String> {
+    if let Some(profile_id) = brain_profile {
+        return Some(profile_id.clone());
+    }
+    let ns = token.namespace().as_str().to_string();
+    khive_brain_core::resolve_consumer_profile(
+        registry,
+        &ns,
+        khive_brain_core::ConsumerKind::Recall,
+    )
+    .await
 }
 
 #[derive(Deserialize)]

--- a/crates/khive-pack-memory/src/handlers/feedback.rs
+++ b/crates/khive-pack-memory/src/handlers/feedback.rs
@@ -40,21 +40,11 @@ impl MemoryPack {
             ))
         })?;
 
-        // Tier 1: explicit profile from config.
-        if let Some(ref profile_id) = self.brain_profile {
-            return route_to_brain(registry, token, &p.target_id, &p.signal, profile_id).await;
-        }
-
-        // Tier 2: namespace-bound profile via brain.resolve.
-        // consumer_kind=Recall — the brain contract keys recall bindings/defaults
-        // under "recall" (brain.resolve(consumer_kind="recall") returns balanced-recall-v1).
-        let ns = token.namespace().as_str().to_string();
-        if let Some(profile_id) = khive_brain_core::resolve_consumer_profile(
-            registry,
-            &ns,
-            khive_brain_core::ConsumerKind::Recall,
-        )
-        .await
+        // Tiers 1-2: explicit config profile, then namespace-bound profile via
+        // brain.resolve(consumer_kind="recall") — shared with memory.recall's
+        // serve-time stamp so the two resolution paths cannot drift apart.
+        if let Some(profile_id) =
+            super::common::resolve_serving_profile(&self.brain_profile, token, registry).await
         {
             return route_to_brain(registry, token, &p.target_id, &p.signal, &profile_id).await;
         }

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -615,7 +615,12 @@ impl MemoryPack {
                 let query_raw = query_trimmed.to_string();
                 let served_by = served_by_profile_id.clone();
                 let served_at_us = chrono::Utc::now().timestamp_micros();
-                tokio::spawn(async move {
+                // Tracked, not a bare tokio::spawn, so daemon shutdown's drain()
+                // waits for this append instead of a SIGTERM aborting it
+                // mid-flight with no ledger row and no log (codex PR #583
+                // round-1 Medium). The response path still only pays for the
+                // enqueue (an atomic increment) — never the SQL write itself.
+                khive_runtime::track_background_task(async move {
                     let mut ledger_params = json!({
                         "namespace": namespace,
                         "consumer_kind": "recall",
@@ -990,8 +995,8 @@ mod tests {
             "recall response must stamp the resolved serving profile"
         );
 
-        // The ledger append is fired via tokio::spawn off the response path —
-        // poll briefly rather than assume it has landed by the time recall returns.
+        // The ledger append is fired via track_background_task off the response
+        // path — poll briefly rather than assume it has landed by the time recall returns.
         let target_id = note_id.id.to_string();
         let mut found = false;
         for _ in 0..100 {

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -33,7 +33,7 @@ impl MemoryPack {
         &self,
         token: &NamespaceToken,
         params: Value,
-        _registry: &VerbRegistry,
+        registry: &VerbRegistry,
     ) -> Result<Value, RuntimeError> {
         use std::sync::atomic::Ordering;
 
@@ -540,7 +540,7 @@ impl MemoryPack {
         let full_content = p.full_content.unwrap_or(true);
         const PREVIEW_CHARS: usize = 200;
 
-        let results: Vec<Value> = ranked
+        let mut results: Vec<Value> = ranked
             .into_iter()
             .map(|sn| {
                 let content_out =
@@ -570,6 +570,73 @@ impl MemoryPack {
                 result
             })
             .collect();
+
+        // ADR-081 §5 (#394): resolve the serving profile via the same tiers
+        // 1-2 memory.feedback uses (resolve_serving_profile), stamp it into
+        // each result, then fire the cross-session serve-ledger append
+        // (ADR-081 §4) asynchronously off the response path — the recall
+        // caller must not wait on a brain-pack dispatch. An unresolved
+        // profile omits the stamp rather than guessing one; the ledger row
+        // is still written with a null served_by_profile_id in that case.
+        if prof {
+            if let Some(ref t) = t_stage {
+                plog_n(
+                    call_id,
+                    "results_build",
+                    t.elapsed().as_micros(),
+                    results.len(),
+                );
+            }
+            t_stage = Some(Instant::now());
+        }
+        let served_by_profile_id =
+            super::common::resolve_serving_profile(&self.brain_profile, token, registry).await;
+        if prof {
+            if let Some(ref t) = t_stage {
+                plog(call_id, "profile_resolve", t.elapsed().as_micros());
+            }
+            t_stage = Some(Instant::now());
+        }
+
+        if let Some(ref profile_id) = served_by_profile_id {
+            for r in results.iter_mut() {
+                r["served_by_profile_id"] = json!(profile_id);
+            }
+        }
+
+        if !results.is_empty() {
+            let target_ids: Vec<String> = results
+                .iter()
+                .filter_map(|r| r.get("id").and_then(Value::as_str).map(str::to_string))
+                .collect();
+            if !target_ids.is_empty() {
+                let registry_owned = registry.clone();
+                let namespace = token.namespace().as_str().to_string();
+                let query_raw = query_trimmed.to_string();
+                let served_by = served_by_profile_id.clone();
+                let served_at_us = chrono::Utc::now().timestamp_micros();
+                tokio::spawn(async move {
+                    let mut ledger_params = json!({
+                        "namespace": namespace,
+                        "consumer_kind": "recall",
+                        "target_ids": target_ids,
+                        "query_raw": query_raw,
+                        "served_at": served_at_us,
+                    });
+                    if let Some(profile_id) = served_by {
+                        ledger_params["served_by_profile_id"] = json!(profile_id);
+                    }
+                    if let Err(e) = registry_owned
+                        .dispatch("brain.record_serve", ledger_params)
+                        .await
+                    {
+                        eprintln!(
+                            "[memory] serve ledger dispatch failed (non-fatal, ADR-081 §4): {e}"
+                        );
+                    }
+                });
+            }
+        }
 
         // Update recall-domain posteriors before returning.
         {
@@ -819,6 +886,279 @@ mod tests {
             !hits.is_empty(),
             "vector leg must still return the seeded note while the FTS leg is \
              degraded by the residual FTS5 char ('@'), got empty results"
+        );
+    }
+
+    // ── ADR-081 §5 (#394): recall serve-time attribution + ledger append ──────
+
+    fn build_full_rt_with_brain() -> khive_runtime::KhiveRuntime {
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-mem-recall-adr081-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp dir");
+        let db_path = tmp.path().join("khive.db");
+        std::mem::forget(tmp);
+
+        khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "memory".to_string(), "brain".to_string()],
+            ..khive_runtime::RuntimeConfig::default()
+        })
+        .expect("runtime")
+    }
+
+    #[tokio::test]
+    async fn recall_stamps_served_by_profile_id_and_appends_serve_ledger_row() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr081 recall stamp note",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "adr081-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+        registry
+            .dispatch(
+                "brain.activate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "adr081-recall-v1",
+                }),
+            )
+            .await
+            .expect("activate profile");
+        registry
+            .dispatch(
+                "brain.bind",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "adr081-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("bind profile");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "adr081 recall stamp note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("memory.recall");
+
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty(), "must find the seeded note");
+        assert_eq!(
+            hits[0]["served_by_profile_id"],
+            serde_json::json!("adr081-recall-v1"),
+            "recall response must stamp the resolved serving profile"
+        );
+
+        // The ledger append is fired via tokio::spawn off the response path —
+        // poll briefly rather than assume it has landed by the time recall returns.
+        let target_id = note_id.id.to_string();
+        let mut found = false;
+        for _ in 0..100 {
+            let mut reader = rt.sql().reader().await.expect("reader");
+            let row = reader
+                .query_row(khive_storage::types::SqlStatement {
+                    sql: "SELECT served_by_profile_id FROM brain_serve_ledger \
+                          WHERE target_id = ?1"
+                        .into(),
+                    params: vec![khive_storage::types::SqlValue::Text(target_id.clone())],
+                    label: None,
+                })
+                .await
+                .expect("query row");
+            if let Some(row) = row {
+                assert!(
+                    matches!(
+                        row.get("served_by_profile_id"),
+                        Some(khive_storage::types::SqlValue::Text(s)) if s == "adr081-recall-v1"
+                    ),
+                    "ledger row must carry the same served_by_profile_id as the response stamp"
+                );
+                found = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            found,
+            "serve ledger row for the recalled target must appear within 2s"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_without_brain_pack_omits_stamp_and_does_not_error() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "no brain pack loaded note",
+            Some(0.7),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        let registry = builder.build().expect("registry");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "query": "no brain pack loaded note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall must succeed even without a brain pack loaded");
+
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty());
+        assert!(
+            hits[0].get("served_by_profile_id").is_none(),
+            "no brain pack registered => no profile resolvable => no stamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_profile_resolution_latency_is_bounded() {
+        use khive_pack_brain::BrainPack;
+        use std::time::Duration;
+
+        async fn timed_recall(with_brain: bool) -> Duration {
+            let rt = if with_brain {
+                build_full_rt_with_brain()
+            } else {
+                KhiveRuntime::memory().expect("in-memory runtime")
+            };
+            let ns = Namespace::parse("local").expect("ns");
+            let token = rt.authorize(ns.clone()).expect("token");
+            rt.create_note(
+                &token,
+                "memory",
+                None,
+                "latency probe note",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(KgPack::new(rt.clone()));
+            builder.register(MemoryPack::new(rt.clone()));
+            if with_brain {
+                builder.register(BrainPack::new(rt.clone()));
+            }
+            let registry = builder.build().expect("registry");
+
+            if with_brain {
+                registry
+                    .dispatch(
+                        "brain.create_profile",
+                        serde_json::json!({
+                            "namespace": ns.as_str(),
+                            "name": "latency-recall-v1",
+                            "consumer_kind": "recall",
+                        }),
+                    )
+                    .await
+                    .expect("create profile");
+                registry
+                    .dispatch(
+                        "brain.activate",
+                        serde_json::json!({
+                            "namespace": ns.as_str(),
+                            "profile_id": "latency-recall-v1",
+                        }),
+                    )
+                    .await
+                    .expect("activate profile");
+                registry
+                    .dispatch(
+                        "brain.bind",
+                        serde_json::json!({
+                            "namespace": ns.as_str(),
+                            "profile_id": "latency-recall-v1",
+                            "consumer_kind": "recall",
+                        }),
+                    )
+                    .await
+                    .expect("bind profile");
+            }
+
+            let start = std::time::Instant::now();
+            registry
+                .dispatch(
+                    "memory.recall",
+                    serde_json::json!({
+                        "namespace": ns.as_str(),
+                        "query": "latency probe note",
+                        "limit": 10
+                    }),
+                )
+                .await
+                .expect("recall");
+            start.elapsed()
+        }
+
+        let without_brain = timed_recall(false).await;
+        let with_brain = timed_recall(true).await;
+        eprintln!(
+            "[ADR-081 §5 latency] recall without brain pack: {without_brain:?}; \
+             recall with brain pack (profile resolution + async ledger dispatch): {with_brain:?}"
+        );
+        assert!(
+            with_brain < Duration::from_secs(2),
+            "profile resolution must not introduce unbounded latency, got {with_brain:?}"
         );
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -290,6 +290,46 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     }
 }
 
+// ── tracked background tasks ─────────────────────────────────────────────────
+//
+// Pack handlers (e.g. memory.recall's ADR-081 §5 serve-ledger append) fire
+// fire-and-forget `tokio::spawn`ed work off the response path so the caller
+// never waits on a cross-pack dispatch or a SQL write. Left untracked, that
+// work is invisible to `drain()`: a SIGTERM landing between the response
+// returning and the spawned task completing can abort it mid-flight with no
+// log and no row (codex PR #583 round-1 Medium). `track_background_task`
+// gives such spawns a process-wide presence that `drain()` waits on, exactly
+// like the `active` counter does for in-flight connections — the caller still
+// only pays for the spawn + counter increment, never the task's own work.
+static BACKGROUND_TASKS: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>> =
+    std::sync::OnceLock::new();
+
+fn background_tasks() -> &'static Arc<std::sync::atomic::AtomicUsize> {
+    BACKGROUND_TASKS.get_or_init(|| Arc::new(std::sync::atomic::AtomicUsize::new(0)))
+}
+
+/// Spawn a fire-and-forget background task that daemon shutdown's `drain()`
+/// waits for, instead of a bare `tokio::spawn` that a SIGTERM can abort
+/// mid-flight with no trace. Only the enqueue (an atomic increment) is
+/// synchronous on the caller's path — the future itself still runs fully
+/// off-path, unawaited.
+pub fn track_background_task<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    background_tasks().fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    tokio::spawn(async move {
+        fut.await;
+        background_tasks().fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    });
+}
+
+/// Current count of in-flight tasks started via [`track_background_task`].
+/// Exposed for tests; `drain()` reads the shared counter directly.
+pub fn background_task_count() -> usize {
+    background_tasks().load(std::sync::atomic::Ordering::Relaxed)
+}
+
 // ── server ────────────────────────────────────────────────────────────────────
 
 async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
@@ -598,14 +638,16 @@ fn write_pid_file(pid_file: &std::path::Path) -> std::io::Result<()> {
 
 async fn drain(active: &std::sync::atomic::AtomicUsize) {
     use std::sync::atomic::Ordering;
-    if active.load(Ordering::Relaxed) == 0 {
+    let remaining = || active.load(Ordering::Relaxed) + background_task_count();
+    if remaining() == 0 {
         return;
     }
     let deadline = tokio::time::Instant::now() + drain_timeout();
-    while active.load(Ordering::Relaxed) > 0 {
+    while remaining() > 0 {
         if tokio::time::Instant::now() >= deadline {
             tracing::warn!(
-                remaining = active.load(Ordering::Relaxed),
+                remaining_connections = active.load(Ordering::Relaxed),
+                remaining_background_tasks = background_task_count(),
                 "drain timeout reached; forcing shutdown"
             );
             break;
@@ -683,5 +725,62 @@ mod tests {
         std::env::set_var(key, "0");
         assert!(!env_truthy(key));
         std::env::remove_var(key);
+    }
+
+    // codex PR #583 round-1 Medium: `drain()` must wait for tracked background
+    // tasks (e.g. memory.recall's serve-ledger append), not just in-flight
+    // connections, or a SIGTERM lands mid-flight with no log and no row.
+    #[tokio::test]
+    async fn drain_waits_for_tracked_background_tasks_before_returning() {
+        let active = std::sync::atomic::AtomicUsize::new(0);
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        track_background_task(async move {
+            let _ = rx.await;
+        });
+        assert!(
+            background_task_count() >= 1,
+            "track_background_task must make the in-flight task visible immediately"
+        );
+
+        let drain_fut = drain(&active);
+        tokio::pin!(drain_fut);
+
+        // Must NOT resolve while the tracked task is still pending.
+        let too_early =
+            tokio::time::timeout(std::time::Duration::from_millis(150), &mut drain_fut).await;
+        assert!(
+            too_early.is_err(),
+            "drain() must not return while a tracked background task is still running"
+        );
+
+        // Completing the task must let drain() proceed promptly.
+        tx.send(())
+            .expect("tracked task still awaiting the oneshot");
+        let done = tokio::time::timeout(std::time::Duration::from_secs(5), drain_fut).await;
+        assert!(
+            done.is_ok(),
+            "drain() must return once the tracked background task finishes"
+        );
+    }
+
+    #[tokio::test]
+    async fn track_background_task_count_returns_to_zero_after_completion() {
+        // Sanity check on the counter's own bookkeeping, independent of drain().
+        let before = background_task_count();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        track_background_task(async move {
+            let _ = rx.await;
+        });
+        assert_eq!(background_task_count(), before + 1);
+        tx.send(()).expect("still awaiting");
+        // Yield until the spawned task's decrement has actually run.
+        for _ in 0..100 {
+            if background_task_count() == before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(background_task_count(), before);
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -308,19 +308,39 @@ fn background_tasks() -> &'static Arc<std::sync::atomic::AtomicUsize> {
     BACKGROUND_TASKS.get_or_init(|| Arc::new(std::sync::atomic::AtomicUsize::new(0)))
 }
 
+/// Decrements the shared background-task counter from `Drop`, so the count
+/// comes back down whether the tracked future returns normally, panics, or
+/// is cancelled — a plain post-`await` `fetch_sub` only covers the return
+/// path and leaks the count forever on a panic (codex PR #583 round-2
+/// Medium), since unwinding skips every statement after the panic point.
+struct BackgroundTaskGuard {
+    counter: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl Drop for BackgroundTaskGuard {
+    fn drop(&mut self) {
+        self.counter
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Spawn a fire-and-forget background task that daemon shutdown's `drain()`
 /// waits for, instead of a bare `tokio::spawn` that a SIGTERM can abort
 /// mid-flight with no trace. Only the enqueue (an atomic increment) is
 /// synchronous on the caller's path — the future itself still runs fully
-/// off-path, unawaited.
+/// off-path, unawaited. The decrement happens via `BackgroundTaskGuard`'s
+/// `Drop`, so a panic inside `fut` still restores the count.
 pub fn track_background_task<F>(fut: F)
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
     background_tasks().fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = BackgroundTaskGuard {
+        counter: background_tasks().clone(),
+    };
     tokio::spawn(async move {
+        let _guard = guard;
         fut.await;
-        background_tasks().fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
     });
 }
 
@@ -782,5 +802,35 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert_eq!(background_task_count(), before);
+    }
+
+    #[tokio::test]
+    async fn track_background_task_count_returns_to_baseline_after_panic() {
+        // codex PR #583 round-2 Medium: a panic inside the tracked future must
+        // still decrement the counter (via BackgroundTaskGuard's Drop), not
+        // leak it forever. tokio::spawn catches the panic in the returned
+        // JoinHandle rather than aborting the process, so we can await it
+        // here and assert the counter recovered.
+        let before = background_task_count();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        track_background_task(async move {
+            let _ = rx.await;
+            panic!("intentional panic to exercise the Drop-guard decrement path");
+        });
+        assert_eq!(background_task_count(), before + 1);
+
+        tx.send(()).expect("still awaiting");
+        for _ in 0..100 {
+            if background_task_count() == before {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            background_task_count(),
+            before,
+            "background task counter must return to baseline after the tracked future panics"
+        );
     }
 }

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -697,6 +697,7 @@ pub fn env_truthy(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     // Focused regression tests for the unsafe process probe (SAFETY: signal 0
     // is an existence check with no side effects; see is_process_running).
@@ -750,7 +751,18 @@ mod tests {
     // codex PR #583 round-1 Medium: `drain()` must wait for tracked background
     // tasks (e.g. memory.recall's serve-ledger append), not just in-flight
     // connections, or a SIGTERM lands mid-flight with no log and no row.
+    //
+    // `#[serial(background_tasks)]`: this test reads/asserts on the
+    // process-wide `BACKGROUND_TASKS` static shared with the two counter
+    // tests below. Under default parallel execution one test's increment
+    // leaks into another's snapshot-then-assert window (codex PR #583
+    // round-3 Medium, reproduced: both counter tests failed together,
+    // passed with `--test-threads=1`). Serializing just this named group
+    // isolates them from each other without forcing the whole test binary
+    // (including unrelated `#[serial]` tests elsewhere in this crate) onto
+    // one thread.
     #[tokio::test]
+    #[serial(background_tasks)]
     async fn drain_waits_for_tracked_background_tasks_before_returning() {
         let active = std::sync::atomic::AtomicUsize::new(0);
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
@@ -784,7 +796,12 @@ mod tests {
         );
     }
 
+    // See the `#[serial(background_tasks)]` note on
+    // `drain_waits_for_tracked_background_tasks_before_returning` above —
+    // this test shares the same process-wide `BACKGROUND_TASKS` static and
+    // races it (and the panic test below) under default parallelism.
     #[tokio::test]
+    #[serial(background_tasks)]
     async fn track_background_task_count_returns_to_zero_after_completion() {
         // Sanity check on the counter's own bookkeeping, independent of drain().
         let before = background_task_count();
@@ -804,13 +821,20 @@ mod tests {
         assert_eq!(background_task_count(), before);
     }
 
+    // See the `#[serial(background_tasks)]` note above — shares
+    // `BACKGROUND_TASKS` with the other two tests in this group.
     #[tokio::test]
+    #[serial(background_tasks)]
     async fn track_background_task_count_returns_to_baseline_after_panic() {
         // codex PR #583 round-2 Medium: a panic inside the tracked future must
         // still decrement the counter (via BackgroundTaskGuard's Drop), not
-        // leak it forever. tokio::spawn catches the panic in the returned
-        // JoinHandle rather than aborting the process, so we can await it
-        // here and assert the counter recovered.
+        // leak it forever. `track_background_task` discards the spawned
+        // task's `JoinHandle` (it is fire-and-forget by design — the caller
+        // never awaits it), so this test does not await the panic directly;
+        // tokio isolates the panic to the spawned task instead of aborting
+        // the process, and we observe the recovery purely through the
+        // shared counter returning to baseline after the guard's `Drop`
+        // fires during that task's unwind.
         let before = background_task_count();
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -29,8 +29,8 @@ pub use curation::{
 #[cfg(unix)]
 pub use daemon::acquire_recovery_lock;
 pub use daemon::{
-    pid_path, run_daemon, socket_path, DaemonDispatch, DaemonRequestFrame, DaemonResponseFrame,
-    PROTOCOL_VERSION,
+    background_task_count, pid_path, run_daemon, socket_path, track_background_task,
+    DaemonDispatch, DaemonRequestFrame, DaemonResponseFrame, PROTOCOL_VERSION,
 };
 pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderProvider};
 pub use engine_config::{

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -164,6 +164,42 @@ impl StorageError {
             || msg.contains("fts5: phrase queries are not supported (detail")
             || msg.contains("fts5: NEAR queries are not supported (detail")
     }
+
+    /// Whether this error is a UNIQUE constraint violation from a raw SQL
+    /// `execute` (e.g. an `INSERT` racing an existing row under the ledger's
+    /// natural key). Callers that treat exact-key duplicates as a tolerated
+    /// no-op (ADR-081 §4 serve-ledger idempotency) MUST gate on this
+    /// predicate rather than swallowing every `Driver` error at `execute` —
+    /// that would also hide genuine write failures (disk full, corruption).
+    ///
+    /// Only applies to `Driver` errors from the `Sql` capability at a single-
+    /// statement execute operation. `khive-db`'s `sql_bridge` labels this
+    /// operation differently depending on which `SqlAccess` seam produced the
+    /// writer — a bare transaction's `execute` vs. a pooled `writer()`'s
+    /// `pool_writer.execute` vs. an explicit `tx.execute` — so all three are
+    /// accepted; batch/script variants are intentionally excluded since a
+    /// UNIQUE violation partway through a multi-statement batch is not the
+    /// same single-row-duplicate case this predicate exists to tolerate.
+    pub fn is_unique_constraint_violation(&self) -> bool {
+        let Self::Driver {
+            capability,
+            operation,
+            source,
+        } = self
+        else {
+            return false;
+        };
+        if *capability != StorageCapability::Sql {
+            return false;
+        }
+        if !matches!(
+            operation.as_ref(),
+            "execute" | "pool_writer.execute" | "tx.execute"
+        ) {
+            return false;
+        }
+        source.to_string().contains("UNIQUE constraint failed")
+    }
 }
 
 #[cfg(test)]
@@ -294,5 +330,59 @@ mod tests {
             source: Box::new(FakeSource("fts5: syntax error near \"@\"".into())),
         };
         assert!(!e.is_fts5_syntax_error());
+    }
+
+    fn driver_err_sql(operation: &'static str, message: &str) -> StorageError {
+        StorageError::driver(
+            StorageCapability::Sql,
+            operation,
+            FakeSource(message.into()),
+        )
+    }
+
+    #[test]
+    fn unique_constraint_failure_at_execute_sql_capability_is_classified() {
+        let e = driver_err_sql(
+            "execute",
+            "UNIQUE constraint failed: brain_serve_ledger.namespace, \
+             brain_serve_ledger.target_id, brain_serve_ledger.query_class, \
+             brain_serve_ledger.served_at",
+        );
+        assert!(e.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn unique_constraint_failure_at_pool_writer_execute_is_classified() {
+        // khive-db's pooled writer seam (`SqlAccess::writer()`) labels its
+        // single-statement execute operation "pool_writer.execute", not bare
+        // "execute" — this is the exact seam brain.record_serve writes through.
+        let e = driver_err_sql("pool_writer.execute", "UNIQUE constraint failed: t.id");
+        assert!(e.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn unique_constraint_message_at_non_execute_operation_is_not_classified() {
+        let e = driver_err_sql("query_row", "UNIQUE constraint failed: t.id");
+        assert!(!e.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn non_unique_driver_error_at_execute_is_not_classified() {
+        let e = driver_err_sql("execute", "disk I/O error");
+        assert!(!e.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn non_sql_capability_is_not_classified_as_unique_violation() {
+        let e = driver_err("execute", "UNIQUE constraint failed: t.id");
+        assert!(!e.is_unique_constraint_violation());
+    }
+
+    #[test]
+    fn timeout_is_not_classified_as_unique_violation() {
+        let e = StorageError::Timeout {
+            operation: "execute".into(),
+        };
+        assert!(!e.is_unique_constraint_violation());
     }
 }


### PR DESCRIPTION
## Summary

Closes #394 — wires `memory.recall` to the ADR-081 §4 brain serve ledger (ADR-081 §5, the serve-time attribution stamp).

- `memory.recall` resolves the serving profile via the same ADR-035 tiers 1-2 `memory.feedback` already uses (extracted into a shared `resolve_serving_profile` helper in `khive-pack-memory/src/handlers/common.rs`), stamps `served_by_profile_id` onto each response result, then fires an async `brain.record_serve` dispatch (`tokio::spawn`, off the response path — not awaited) to append ADR-081 §4 cross-session serve-ledger rows for every returned target.
- An unresolved profile omits the response stamp; the ledger row is still written with a null `served_by_profile_id` rather than the recall failing or guessing a profile.
- New internal verb `brain.record_serve` (`khive-pack-brain`, `Visibility::Subhandler` — not MCP-exposed) computes the deterministic `query_class` key (lowercase → strip punctuation → collapse whitespace → sort+dedup tokens → SHA-256 → first 16 hex chars) and loops `target_ids` through `serve_ledger::record_serve`.
- `serve_ledger::record_serve` now returns `Ok(bool)` (written vs. tolerated exact-key duplicate) instead of propagating a `UNIQUE constraint failed` error from the ledger's natural-key index, classified via a new `StorageError::is_unique_constraint_violation` predicate (`khive-storage`) that mirrors the existing `is_fts5_syntax_error` scoping discipline (Sql capability, `execute` / `pool_writer.execute` / `tx.execute` operations only — batch/script variants excluded).
- `memory.feedback`'s `handle_feedback` refactored to call the shared resolver instead of duplicating tiers 1-2 inline, so the two resolution paths cannot drift apart.

## Latency (ADR-081 §5 gate)

From `recall_profile_resolution_latency_is_bounded` (in-memory SQLite, single seeded note):

- recall **without** a brain pack loaded: **~1.04ms**
- recall **with** a brain pack (profile resolution synchronous + ledger dispatch fired via `tokio::spawn`): **~3.05ms**

The ledger write itself is not on the response critical path since it is spawned, not awaited — the ~2ms delta is profile resolution (an in-process `brain.resolve` dispatch through the registry) plus `tokio::spawn` overhead, not the SQL write.

## ADR ambiguity flagged for review

ADR-081 §5 doesn't specify the exact wire-shape placement of `served_by_profile_id` on a `memory.recall` response that can be either a bare JSON array or a wrapped object (depending on verbosity/multi-model flags). This PR stamps it **per-result** (additive, non-breaking) rather than introducing a top-level wrapper field. Flagging in case the ADR intended a different shape.

## Test plan

- [x] `cargo test -p khive-pack-memory -p khive-pack-brain` — 169 + 82 (memory) + 195 + 39 (brain/storage) all green, including 5 new brain-pack tests (query_class determinism, duplicate-key tolerance at both `record_serve` and `handle_record_serve`/batch-drain layers, unresolved-profile null row) and 3 new memory-pack integration tests (stamp + ledger row appears via polling, graceful omission with no brain pack loaded, bounded latency)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — all green