### PR TITLE
feat(storage,db): open-transaction registry + WAL checkpoint instrumentation (ADR-091 Plank 0)

### DIFF
--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -23,7 +23,12 @@
 //! Threshold-crossing WARN semantics: both the `warn_pages` and `high_water_pages`
 //! warnings fire at most once per below→above crossing. Skipped ticks (writer
 //! busy) leave the crossing state unchanged so that a skip cannot spuriously
-//! re-arm the rate limit while WAL pressure is still elevated.
+//! re-arm the rate limit while WAL pressure is still elevated. The ADR-091
+//! Plank 0 open-transaction-registry WARNs (oldest-entry escalation and the
+//! high-water snapshot enumeration) ride the SAME crossing gates — they are
+//! not independently rate-limited, so they never repeat on consecutive ticks
+//! that remain above a threshold. Only the per-tick `debug!` trace of the
+//! oldest open entry fires unconditionally.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -161,12 +166,18 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
             CheckpointTick::Observed(n) => n,
         };
 
-        let in_warn_band = wal_pages >= config.warn_pages && wal_pages < config.high_water_pages;
+        let above_warn = wal_pages >= config.warn_pages;
         let above_high_water = wal_pages >= config.high_water_pages;
 
-        log_tx_registry_pressure(wal_pages, config.warn_pages, config.high_water_pages);
+        // Per-tick debug for the oldest open entry always fires (cheap, single
+        // `oldest()` lookup); the two `warn!`-level registry logs below are
+        // gated on the SAME crossing state as the WAL-threshold WARNs above,
+        // so sustained pressure logs once per crossing, not once per tick.
+        log_tx_registry_oldest_debug(wal_pages);
 
-        if crossing_warn(in_warn_band, &mut was_above_warn) {
+        let warn_crossed = crossing_warn(above_warn, &mut was_above_warn);
+        if warn_crossed {
+            log_tx_registry_oldest_warn(wal_pages);
             tracing::warn!(
                 wal_pages,
                 warn_threshold = config.warn_pages,
@@ -174,7 +185,9 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
             );
         }
 
-        if crossing_warn(above_high_water, &mut was_above_high_water) {
+        let high_water_crossed = crossing_warn(above_high_water, &mut was_above_high_water);
+        if high_water_crossed {
+            log_tx_registry_snapshot_warn(wal_pages);
             tracing::warn!(
                 wal_pages,
                 high_water = config.high_water_pages,
@@ -186,24 +199,15 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
 }
 
 /// ADR-091 Plank 0: log the oldest open transaction registry entry alongside
-/// the WAL frame count on every tick (`debug!` normally, escalating to
-/// `warn!` once `wal_pages` crosses `warn_pages`), and, once `wal_pages`
-/// reaches `high_water_pages`, enumerate every open registry entry at `warn!`
-/// — the "which caller is holding the pin" answer this ADR's static reading
-/// could not produce. Observe only: this never enforces or force-closes
-/// anything.
-fn log_tx_registry_pressure(wal_pages: u64, warn_pages: u64, high_water_pages: u64) {
-    let oldest = khive_storage::tx_registry::oldest();
-    if wal_pages >= warn_pages {
-        if let Some((age, label)) = &oldest {
-            tracing::warn!(
-                wal_pages,
-                oldest_tx_age_secs = age.as_secs_f64(),
-                oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
-                "WAL checkpoint tick: oldest open transaction registry entry"
-            );
-        }
-    } else if let Some((age, label)) = &oldest {
+/// the WAL frame count at `debug!`, on EVERY tick regardless of threshold
+/// state. This is the low-volume per-tick trace; the WARN-level escalations
+/// live in [`log_tx_registry_oldest_warn`] and
+/// [`log_tx_registry_snapshot_warn`], both of which are gated on threshold
+/// *crossing* by the caller (`run_checkpoint_task`) so they fire once per
+/// crossing rather than once per tick. Observe only: this never enforces or
+/// force-closes anything.
+fn log_tx_registry_oldest_debug(wal_pages: u64) {
+    if let Some((age, label)) = khive_storage::tx_registry::oldest() {
         tracing::debug!(
             wal_pages,
             oldest_tx_age_secs = age.as_secs_f64(),
@@ -211,19 +215,40 @@ fn log_tx_registry_pressure(wal_pages: u64, warn_pages: u64, high_water_pages: u
             "WAL checkpoint tick: oldest open transaction registry entry"
         );
     }
+}
 
-    if wal_pages >= high_water_pages {
-        // This is the load-bearing deliverable — enumerate every open registry
-        // entry so an operator can see which caller(s), if any, are pinning
-        // the WAL tail during sustained pressure.
-        for (age, label) in khive_storage::tx_registry::snapshot() {
-            tracing::warn!(
-                wal_pages,
-                tx_age_secs = age.as_secs_f64(),
-                tx_label = label.as_deref().unwrap_or("<unlabeled>"),
-                "WAL high-water: open transaction registry entry"
-            );
-        }
+/// ADR-091 Plank 0: escalate the oldest open registry entry to `warn!`.
+///
+/// Callers MUST gate this on a below→above `warn_pages` crossing (via
+/// `crossing_warn`) — it is not rate-limited internally, so calling it every
+/// tick would reproduce the log-spam bug this rewrite fixes.
+fn log_tx_registry_oldest_warn(wal_pages: u64) {
+    if let Some((age, label)) = khive_storage::tx_registry::oldest() {
+        tracing::warn!(
+            wal_pages,
+            oldest_tx_age_secs = age.as_secs_f64(),
+            oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+            "WAL checkpoint tick: oldest open transaction registry entry"
+        );
+    }
+}
+
+/// ADR-091 Plank 0: enumerate every open registry entry at `warn!` — the
+/// "which caller is holding the pin" answer this ADR's static reading could
+/// not produce.
+///
+/// Callers MUST gate this on a below→above `high_water_pages` crossing (via
+/// `crossing_warn`) — it is not rate-limited internally, so calling it every
+/// tick would repeat the full snapshot enumeration every tick under
+/// sustained pressure.
+fn log_tx_registry_snapshot_warn(wal_pages: u64) {
+    for (age, label) in khive_storage::tx_registry::snapshot() {
+        tracing::warn!(
+            wal_pages,
+            tx_age_secs = age.as_secs_f64(),
+            tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+            "WAL high-water: open transaction registry entry"
+        );
     }
 }
 
@@ -301,6 +326,7 @@ mod tests {
     struct CapturedEvent {
         message: Option<String>,
         oldest_tx_label: Option<String>,
+        tx_label: Option<String>,
     }
 
     #[derive(Default)]
@@ -311,6 +337,7 @@ mod tests {
             match field.name() {
                 "message" => self.0.message = Some(value.to_string()),
                 "oldest_tx_label" => self.0.oldest_tx_label = Some(value.to_string()),
+                "tx_label" => self.0.tx_label = Some(value.to_string()),
                 _ => {}
             }
         }
@@ -324,6 +351,7 @@ mod tests {
             match field.name() {
                 "message" => self.0.message = Some(cleaned),
                 "oldest_tx_label" => self.0.oldest_tx_label = Some(cleaned),
+                "tx_label" => self.0.tx_label = Some(cleaned),
                 _ => {}
             }
         }
@@ -355,11 +383,29 @@ mod tests {
         fn exit(&self, _: &tracing::span::Id) {}
     }
 
-    /// ADR-091 Plank 0: `log_tx_registry_pressure` emits a debug-level log
-    /// naming the oldest open registry entry's label when WAL pressure is
-    /// below `warn_pages`, and escalates to warn-level once at/above it.
+    /// ADR-091 Plank 0: `log_tx_registry_oldest_debug` emits a debug-level log
+    /// naming the oldest open registry entry's label, on every call.
+    ///
+    /// `#[serial(tx_registry)]`: the registry is a process-wide singleton
+    /// shared across every test in this binary — see `pool.rs`'s and
+    /// `sql_bridge.rs`'s registry tests, which share this same serial group
+    /// (round-1 fix: these three were previously unserialized and could
+    /// race, corrupting each other's `oldest()`/`snapshot()` reads).
+    ///
+    /// This test does NOT hardcode "checkpoint_tick_test" as the expected
+    /// label: production write paths elsewhere in this same test binary
+    /// (vectors/graph/text stores) also register short-lived registry
+    /// entries while their own tests run, and `serial(tx_registry)` only
+    /// serializes against the OTHER tests in that same group, not against
+    /// every write path in the crate. Instead it samples `oldest()` itself
+    /// immediately before invoking the function under test and asserts the
+    /// logged label matches whatever the registry considers oldest at that
+    /// instant — deterministic regardless of unrelated concurrent registry
+    /// churn, while still verifying `log_tx_registry_oldest_debug` correctly
+    /// surfaces the registry's own `oldest()` answer.
     #[test]
-    fn log_tx_registry_pressure_reports_oldest_open_entry() {
+    #[serial(tx_registry)]
+    fn log_tx_registry_oldest_debug_reports_oldest_open_entry() {
         let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = CaptureSubscriber {
             events: std::sync::Arc::clone(&buffer),
@@ -368,8 +414,12 @@ mod tests {
         let _handle =
             khive_storage::tx_registry::register(Some("checkpoint_tick_test".to_string()));
 
+        let expected_label = khive_storage::tx_registry::oldest()
+            .and_then(|(_, label)| label)
+            .unwrap_or_else(|| "<unlabeled>".to_string());
+
         tracing::subscriber::with_default(subscriber, || {
-            log_tx_registry_pressure(100, 2000, 6000);
+            log_tx_registry_oldest_debug(100);
         });
 
         let events = buffer.lock().unwrap();
@@ -377,9 +427,82 @@ mod tests {
             events.iter().any(|e| {
                 e.message.as_deref()
                     == Some("WAL checkpoint tick: oldest open transaction registry entry")
-                    && e.oldest_tx_label.as_deref() == Some("checkpoint_tick_test")
+                    && e.oldest_tx_label.as_deref() == Some(expected_label.as_str())
             }),
             "expected a log line naming the open registry entry's label, got: {events:?}"
+        );
+    }
+
+    /// ADR-091 Plank 0 (round-1 fix): the oldest-entry WARN and the
+    /// high-water snapshot-enumeration WARN are gated by `crossing_warn` at
+    /// the call site (mirroring the WAL-threshold WARNs), so driving two
+    /// consecutive above-threshold ticks through that same gate must produce
+    /// exactly one of each — never a repeat on the second tick.
+    #[test]
+    #[serial(tx_registry)]
+    fn registry_warns_fire_on_crossing_and_do_not_repeat() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+
+        let _handle =
+            khive_storage::tx_registry::register(Some("registry_warn_crossing_test".to_string()));
+
+        let mut was_above_warn = false;
+        let mut was_above_high_water = false;
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Tick 1: below→above crossing for both bands — both WARNs fire.
+            if crossing_warn(true, &mut was_above_warn) {
+                log_tx_registry_oldest_warn(6000);
+            }
+            if crossing_warn(true, &mut was_above_high_water) {
+                log_tx_registry_snapshot_warn(6000);
+            }
+
+            // Tick 2: still above both thresholds — neither must repeat.
+            if crossing_warn(true, &mut was_above_warn) {
+                log_tx_registry_oldest_warn(6000);
+            }
+            if crossing_warn(true, &mut was_above_high_water) {
+                log_tx_registry_snapshot_warn(6000);
+            }
+        });
+
+        let events = buffer.lock().unwrap();
+
+        // `tracing::subscriber::with_default` scopes capture to THIS thread for
+        // the duration of the closure, so `events` contains only the two
+        // `log_tx_registry_oldest_warn` calls made above — no concurrent test's
+        // log calls land in this buffer. This lets the crossing/no-repeat
+        // assertion match on message text alone: unlike the "names MY label"
+        // assertion in the sibling test above, WHICH label `oldest()` reports
+        // is irrelevant here (a concurrent write path elsewhere in the binary
+        // may transiently be the registry's genuine oldest entry) — only the
+        // fire-once-per-crossing COUNT is under test.
+        let oldest_warn_count = events
+            .iter()
+            .filter(|e| {
+                e.message.as_deref()
+                    == Some("WAL checkpoint tick: oldest open transaction registry entry")
+            })
+            .count();
+        assert_eq!(
+            oldest_warn_count, 1,
+            "oldest-entry WARN must fire exactly once across two above-threshold ticks, got: {events:?}"
+        );
+
+        let snapshot_warn_count = events
+            .iter()
+            .filter(|e| {
+                e.message.as_deref() == Some("WAL high-water: open transaction registry entry")
+                    && e.tx_label.as_deref() == Some("registry_warn_crossing_test")
+            })
+            .count();
+        assert_eq!(
+            snapshot_warn_count, 1,
+            "high-water snapshot WARN must fire exactly once across two above-threshold ticks, got: {events:?}"
         );
     }
 

--- a/crates/khive-db/src/checkpoint.rs
+++ b/crates/khive-db/src/checkpoint.rs
@@ -162,6 +162,10 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
         };
 
         let in_warn_band = wal_pages >= config.warn_pages && wal_pages < config.high_water_pages;
+        let above_high_water = wal_pages >= config.high_water_pages;
+
+        log_tx_registry_pressure(wal_pages, config.warn_pages, config.high_water_pages);
+
         if crossing_warn(in_warn_band, &mut was_above_warn) {
             tracing::warn!(
                 wal_pages,
@@ -170,13 +174,54 @@ pub async fn run_checkpoint_task(pool: Arc<ConnectionPool>, config: CheckpointCo
             );
         }
 
-        let above_high_water = wal_pages >= config.high_water_pages;
         if crossing_warn(above_high_water, &mut was_above_high_water) {
             tracing::warn!(
                 wal_pages,
                 high_water = config.high_water_pages,
                 "WAL high-water mark exceeded; sustained WAL pressure — \
                  a long-lived reader may be pinning an old snapshot that PASSIVE cannot reclaim"
+            );
+        }
+    }
+}
+
+/// ADR-091 Plank 0: log the oldest open transaction registry entry alongside
+/// the WAL frame count on every tick (`debug!` normally, escalating to
+/// `warn!` once `wal_pages` crosses `warn_pages`), and, once `wal_pages`
+/// reaches `high_water_pages`, enumerate every open registry entry at `warn!`
+/// — the "which caller is holding the pin" answer this ADR's static reading
+/// could not produce. Observe only: this never enforces or force-closes
+/// anything.
+fn log_tx_registry_pressure(wal_pages: u64, warn_pages: u64, high_water_pages: u64) {
+    let oldest = khive_storage::tx_registry::oldest();
+    if wal_pages >= warn_pages {
+        if let Some((age, label)) = &oldest {
+            tracing::warn!(
+                wal_pages,
+                oldest_tx_age_secs = age.as_secs_f64(),
+                oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+                "WAL checkpoint tick: oldest open transaction registry entry"
+            );
+        }
+    } else if let Some((age, label)) = &oldest {
+        tracing::debug!(
+            wal_pages,
+            oldest_tx_age_secs = age.as_secs_f64(),
+            oldest_tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+            "WAL checkpoint tick: oldest open transaction registry entry"
+        );
+    }
+
+    if wal_pages >= high_water_pages {
+        // This is the load-bearing deliverable — enumerate every open registry
+        // entry so an operator can see which caller(s), if any, are pinning
+        // the WAL tail during sustained pressure.
+        for (age, label) in khive_storage::tx_registry::snapshot() {
+            tracing::warn!(
+                wal_pages,
+                tx_age_secs = age.as_secs_f64(),
+                tx_label = label.as_deref().unwrap_or("<unlabeled>"),
+                "WAL high-water: open transaction registry entry"
             );
         }
     }
@@ -250,6 +295,93 @@ mod tests {
     use super::*;
     use crate::pool::PoolConfig;
     use serial_test::serial;
+    use tracing::field::{Field, Visit};
+
+    #[derive(Clone, Debug, Default)]
+    struct CapturedEvent {
+        message: Option<String>,
+        oldest_tx_label: Option<String>,
+    }
+
+    #[derive(Default)]
+    struct CapturedEventVisitor(CapturedEvent);
+
+    impl Visit for CapturedEventVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            match field.name() {
+                "message" => self.0.message = Some(value.to_string()),
+                "oldest_tx_label" => self.0.oldest_tx_label = Some(value.to_string()),
+                _ => {}
+            }
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let formatted = format!("{value:?}");
+            let cleaned = formatted
+                .trim_start_matches('"')
+                .trim_end_matches('"')
+                .to_string();
+            match field.name() {
+                "message" => self.0.message = Some(cleaned),
+                "oldest_tx_label" => self.0.oldest_tx_label = Some(cleaned),
+                _ => {}
+            }
+        }
+    }
+
+    /// Minimal `tracing::Subscriber` that captures events into a thread-local
+    /// vec, installed as the thread-local default for the duration of one
+    /// test closure via `tracing::subscriber::with_default`. Mirrors the
+    /// capture subscriber in `khive-runtime/src/pack.rs`'s gate-dispatch tests.
+    struct CaptureSubscriber {
+        events: std::sync::Arc<std::sync::Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl tracing::Subscriber for CaptureSubscriber {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut visitor = CapturedEventVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.0);
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    /// ADR-091 Plank 0: `log_tx_registry_pressure` emits a debug-level log
+    /// naming the oldest open registry entry's label when WAL pressure is
+    /// below `warn_pages`, and escalates to warn-level once at/above it.
+    #[test]
+    fn log_tx_registry_pressure_reports_oldest_open_entry() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            events: std::sync::Arc::clone(&buffer),
+        };
+
+        let _handle =
+            khive_storage::tx_registry::register(Some("checkpoint_tick_test".to_string()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_tx_registry_pressure(100, 2000, 6000);
+        });
+
+        let events = buffer.lock().unwrap();
+        assert!(
+            events.iter().any(|e| {
+                e.message.as_deref()
+                    == Some("WAL checkpoint tick: oldest open transaction registry entry")
+                    && e.oldest_tx_label.as_deref() == Some("checkpoint_tick_test")
+            }),
+            "expected a log line naming the open registry entry's label, got: {events:?}"
+        );
+    }
 
     fn file_pool(path: &std::path::Path) -> Arc<ConnectionPool> {
         let cfg = PoolConfig {

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -731,7 +731,16 @@ mod tests {
     /// ADR-091 Plank 0: `WriterGuard::transaction` registers an entry with the
     /// shared open-transaction registry for the duration of the closure, and
     /// deregisters it once the closure (and its commit/rollback) completes.
+    ///
+    /// `#[serial(tx_registry)]`: the open-transaction registry is a
+    /// process-wide singleton (`khive_storage::tx_registry`) shared across
+    /// every test in this binary. This test filters by its own unique label
+    /// so it is not vulnerable to another test's entry being reported as
+    /// "oldest", but it still shares the same `tx_registry` serial group as
+    /// `checkpoint.rs`'s and `sql_bridge.rs`'s registry tests for
+    /// defense-in-depth against cross-test interference.
     #[test]
+    #[serial(tx_registry)]
     fn writer_guard_transaction_registers_during_closure_only() {
         let cfg = PoolConfig {
             path: None,

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -179,6 +179,7 @@ impl<'pool> WriterGuard<'pool> {
         F: FnOnce(&Connection) -> Result<R, SqliteError>,
     {
         self.guard.execute_batch("BEGIN IMMEDIATE")?;
+        let _tx_handle = khive_storage::tx_registry::register(Some("writer_guard_tx".to_string()));
 
         match f(&self.guard) {
             Ok(result) => {
@@ -725,5 +726,38 @@ mod tests {
         let _writer2 = pool
             .writer()
             .expect("second writer checkout should succeed");
+    }
+
+    /// ADR-091 Plank 0: `WriterGuard::transaction` registers an entry with the
+    /// shared open-transaction registry for the duration of the closure, and
+    /// deregisters it once the closure (and its commit/rollback) completes.
+    #[test]
+    fn writer_guard_transaction_registers_during_closure_only() {
+        let cfg = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        let guard = pool.writer().unwrap();
+
+        let mut seen_during_closure = false;
+        let result: Result<(), SqliteError> = guard.transaction(|_conn| {
+            seen_during_closure = khive_storage::tx_registry::snapshot()
+                .iter()
+                .any(|(_, label)| label.as_deref() == Some("writer_guard_tx"));
+            Ok(())
+        });
+        result.expect("transaction should commit");
+
+        assert!(
+            seen_during_closure,
+            "expected a writer_guard_tx entry visible inside the closure"
+        );
+        assert!(
+            !khive_storage::tx_registry::snapshot()
+                .iter()
+                .any(|(_, label)| label.as_deref() == Some("writer_guard_tx")),
+            "expected the entry to be gone after the transaction completes"
+        );
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -356,10 +356,17 @@ impl khive_storage::SqlWriter for SqliteWriter {
             message: "connection already consumed".into(),
         })?;
         let (conn, result) = tokio::task::spawn_blocking(move || {
+            if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE") {
+                return (conn, Err(e));
+            }
+            // Registered only after BEGIN succeeds, so an unopened transaction is
+            // never counted. The handle is declared here — enclosing both the
+            // statement-execution closure below AND the ROLLBACK path — so it
+            // stays registered until the transaction is actually finished
+            // (COMMIT or ROLLBACK), not just until the inner closure returns.
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("execute_batch".to_string()));
             let result = (|| -> Result<u64, rusqlite::Error> {
-                conn.execute_batch("BEGIN IMMEDIATE")?;
-                let _tx_handle =
-                    khive_storage::tx_registry::register(Some("execute_batch".to_string()));
                 let mut total: u64 = 0;
                 for statement in &statements {
                     let mut stmt = conn.prepare(&statement.sql)?;
@@ -372,6 +379,7 @@ impl khive_storage::SqlWriter for SqliteWriter {
             if result.is_err() {
                 let _ = conn.execute_batch("ROLLBACK");
             }
+            // `_tx_handle` drops here, after ROLLBACK (or COMMIT) has already run.
             (conn, result)
         })
         .await
@@ -915,6 +923,7 @@ mod tests {
     use crate::pool::PoolConfig;
     use khive_storage::types::{SqlIsolation, SqlStatement, SqlTxOptions, SqlValue};
     use khive_storage::SqlAccess as _;
+    use serial_test::serial;
 
     /// Verify that a read-only transaction rejects INSERT statements via
     /// PRAGMA query_only.
@@ -965,7 +974,13 @@ mod tests {
 
     /// ADR-091 Plank 0: `begin_tx` registers with the shared open-transaction
     /// registry under its caller-supplied label, and `commit()` deregisters it.
+    ///
+    /// `#[serial(tx_registry)]`: the registry is a process-wide singleton
+    /// shared across every test in this binary; this test shares the
+    /// `tx_registry` serial group with `checkpoint.rs`'s and `pool.rs`'s
+    /// registry tests to avoid cross-test interference within one run.
     #[tokio::test]
+    #[serial(tx_registry)]
     async fn begin_tx_registers_and_commit_deregisters() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tx_registry.db");

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -358,6 +358,8 @@ impl khive_storage::SqlWriter for SqliteWriter {
         let (conn, result) = tokio::task::spawn_blocking(move || {
             let result = (|| -> Result<u64, rusqlite::Error> {
                 conn.execute_batch("BEGIN IMMEDIATE")?;
+                let _tx_handle =
+                    khive_storage::tx_registry::register(Some("execute_batch".to_string()));
                 let mut total: u64 = 0;
                 for statement in &statements {
                     let mut stmt = conn.prepare(&statement.sql)?;
@@ -404,6 +406,8 @@ struct SqliteTransaction {
     /// Must be reset to OFF before COMMIT/ROLLBACK so the connection can
     /// be returned cleanly (defensive; connection is dropped after use anyway).
     read_only: bool,
+    /// Open-transaction registry entry (ADR-091 Plank 0); deregisters on Drop.
+    _tx_handle: khive_storage::tx_registry::TxHandle,
 }
 
 #[async_trait]
@@ -736,6 +740,8 @@ impl khive_storage::SqlWriter for PoolBackedWriter {
             guard
                 .execute_batch("BEGIN IMMEDIATE")
                 .map_err(|e| map_rusqlite_err(e, "pool_writer.execute_batch"))?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("pool_writer.execute_batch".to_string()));
             let result = (|| -> Result<u64, StorageError> {
                 let mut total = 0u64;
                 for statement in &statements {
@@ -885,6 +891,7 @@ impl khive_storage::SqlAccess for SqlBridge {
         };
         conn.execute_batch(begin_stmt)
             .map_err(|e| map_rusqlite_err(e, "begin_tx"))?;
+        let tx_handle = khive_storage::tx_registry::register(options.label.clone());
 
         // Honor read_only: block all writes via PRAGMA query_only.
         // The connection is opened as read-write so COMMIT still works, but
@@ -897,6 +904,7 @@ impl khive_storage::SqlAccess for SqlBridge {
         Ok(Box::new(SqliteTransaction {
             conn: Some(conn),
             read_only: effective_read_only,
+            _tx_handle: tx_handle,
         }))
     }
 }
@@ -953,5 +961,46 @@ mod tests {
 
         // Rollback should succeed regardless.
         tx.rollback().await.unwrap();
+    }
+
+    /// ADR-091 Plank 0: `begin_tx` registers with the shared open-transaction
+    /// registry under its caller-supplied label, and `commit()` deregisters it.
+    #[tokio::test]
+    async fn begin_tx_registers_and_commit_deregisters() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tx_registry.db");
+        let config = PoolConfig {
+            path: Some(path.clone()),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        let tx = bridge
+            .begin_tx(SqlTxOptions {
+                read_only: false,
+                isolation: SqlIsolation::Default,
+                label: Some("begin_tx_registry_test".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let snapshot = khive_storage::tx_registry::snapshot();
+        assert!(
+            snapshot
+                .iter()
+                .any(|(_, label)| label.as_deref() == Some("begin_tx_registry_test")),
+            "expected the labeled tx to be visible in the registry while open"
+        );
+
+        tx.commit().await.unwrap();
+
+        let snapshot_after = khive_storage::tx_registry::snapshot();
+        assert!(
+            !snapshot_after
+                .iter()
+                .any(|(_, label)| label.as_deref() == Some("begin_tx_registry_test")),
+            "expected the labeled tx to be gone from the registry after commit"
+        );
     }
 }

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -323,6 +323,8 @@ impl EntityStore for SqlEntityStore {
 
         self.with_writer("upsert_entities", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("entity_upsert_batch".to_string()));
             let mut affected = 0u64;
             let mut failed = 0u64;
             let mut first_error = String::new();

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -705,6 +705,7 @@ impl EventStore for SqlEventStore {
     async fn append_event(&self, event: Event) -> Result<(), StorageError> {
         self.with_writer("append_event", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle = khive_storage::tx_registry::register(Some("event_append".to_string()));
             if let Err(e) = insert_event_with_observations(conn, &event) {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
@@ -720,6 +721,8 @@ impl EventStore for SqlEventStore {
 
         self.with_writer("append_events", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("event_append_batch".to_string()));
             let mut affected = 0u64;
 
             for event in &events {

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -350,6 +350,8 @@ impl GraphStore for SqlGraphStore {
 
         self.with_writer("upsert_edges", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("graph_upsert_edges".to_string()));
             let mut affected = 0u64;
 
             for edge in &edges {

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1025,6 +1025,14 @@ impl GraphStore for SqlGraphStore {
             // graph snapshot.  Without this, a writer committing between chunks could
             // let roots 1..400 see the pre-commit graph and 401..800 see the post-commit
             // graph.  One pool checkout, one snapshot for the full traverse.
+            //
+            // ADR-091 Plank 0: this is the most WAL-pin-relevant span in the store —
+            // it intentionally holds a read snapshot across chunked traversal work.
+            // Registered before the transaction is opened so the handle (declared
+            // first) drops after `tx`'s own Drop runs (locals drop in reverse
+            // declaration order within the same scope).
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("graph_traverse_read".to_string()));
             let tx = conn.unchecked_transaction()?;
 
             // Accumulate per-root state across all chunks: (nodes_with_path_weight, seen_set).

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -431,6 +431,8 @@ impl NoteStore for SqlNoteStore {
 
         self.with_writer("upsert_notes", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("note_upsert_batch".to_string()));
             let mut affected = 0u64;
             let mut failed = 0u64;
             let mut first_error = String::new();

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -247,6 +247,8 @@ impl SqliteSparseStore {
             );
 
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("sparse_insert_batch".to_string()));
             let mut affected = 0u64;
             let mut failed = 0u64;
             let mut first_error = String::new();

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -296,6 +296,8 @@ impl TextSearch for Fts5TextSearch {
 
         self.with_writer("fts_upsert", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("text_upsert_document".to_string()));
 
             let del_sql = format!(
                 "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
@@ -361,6 +363,8 @@ impl TextSearch for Fts5TextSearch {
             );
 
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("text_upsert_batch".to_string()));
             let mut affected = 0u64;
             let mut failed = 0u64;
             let mut first_error = String::new();
@@ -1109,6 +1113,8 @@ impl Fts5TextSearch {
             }
 
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("text_rename_namespace".to_string()));
 
             let del_sql = format!("DELETE FROM {} WHERE namespace = ?1", table);
             if let Err(e) = conn.execute(&del_sql, rusqlite::params![&old_ns]) {

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -294,6 +294,14 @@ impl VectorStore for SqliteVecStore {
             // vec0 does not support INSERT OR REPLACE — delete then insert.
             // Wrap in a transaction so a failed INSERT rolls back the DELETE,
             // leaving the previous vector intact (no-worse-than-stale guarantee).
+            //
+            // ADR-091 Plank 0: register the span before opening the transaction so
+            // the handle (declared first) drops AFTER `tx` (declared second) —
+            // locals drop in reverse declaration order, so `tx`'s own Drop (which
+            // rolls back if uncommitted) runs while the registry entry is still
+            // present.
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("vec_insert_tx".to_string()));
             let tx = conn.unchecked_transaction()?;
 
             let del_sql = format!(
@@ -495,6 +503,11 @@ impl VectorStore for SqliteVecStore {
 
             // DELETE then INSERT in one transaction so a failed INSERT rolls back
             // the DELETE, leaving the previous vector intact (no-worse-than-stale).
+            //
+            // ADR-091 Plank 0: registered before the transaction is opened — see
+            // the matching note in `insert()` above for the drop-order rationale.
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("vec_update_tx".to_string()));
             let tx = conn.unchecked_transaction()?;
 
             let del_sql = format!(
@@ -853,6 +866,12 @@ impl VectorStore for SqliteVecStore {
             // `with_writer` serialises all callers through the pool mutex — at most one
             // writer closure executes on this connection at a time, so no nested
             // transactions can exist when this line runs.
+            //
+            // ADR-091 Plank 0: registered before the transaction is opened — see the
+            // matching note in `insert()` for the drop-order rationale (the handle,
+            // declared first, drops after `tx`'s own Drop/rollback runs).
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("vec_orphan_sweep".to_string()));
             let tx = rusqlite::Transaction::new_unchecked(
                 conn,
                 rusqlite::TransactionBehavior::Immediate,

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -354,6 +354,8 @@ impl VectorStore for SqliteVecStore {
             );
 
             conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("vector_insert_batch".to_string()));
             let mut affected = 0u64;
             let mut failed = 0u64;
             let mut first_error = String::new();

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -167,6 +167,7 @@ pub async fn apply_fold_gate(
     exec_stmt(writer.as_mut(), "BEGIN IMMEDIATE", vec![], "begin")
         .await
         .map_err(|e| sql_err("begin", e))?;
+    let _tx_handle = khive_storage::tx_registry::register(Some("fold_gate_apply".to_string()));
 
     let result = apply_gate_within_tx(
         writer.as_mut(),
@@ -293,6 +294,8 @@ where
     exec_stmt(writer.as_mut(), "BEGIN IMMEDIATE", vec![], "begin")
         .await
         .map_err(|e| sql_err("begin", e))?;
+    let _tx_handle =
+        khive_storage::tx_registry::register(Some("fold_gate_apply_event".to_string()));
 
     let result = apply_gate_and_append_within_tx(
         writer.as_mut(),

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -375,6 +375,8 @@ pub async fn persist_brain_state_mutation<R>(
     let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
 
     exec_raw(writer.as_mut(), "BEGIN IMMEDIATE", "begin mutation tx").await?;
+    let _tx_handle =
+        khive_storage::tx_registry::register(Some("brain_persist_mutation".to_string()));
 
     let write_result: Result<(), RuntimeError> = async {
         append_brain_event_on_writer(

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -9,6 +9,7 @@ pub mod note;
 pub mod sparse;
 pub mod sql;
 pub mod text;
+pub mod tx_registry;
 pub mod types;
 pub mod vectors;
 

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -34,28 +34,43 @@ pub struct TxHandle {
 
 impl Drop for TxHandle {
     fn drop(&mut self) {
-        if let Ok(mut registry) = REGISTRY.lock() {
-            registry.remove(&self.id);
-        }
+        let mut registry = REGISTRY
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        registry.remove(&self.id);
     }
 }
 
 /// Register a new open transaction span with an optional diagnostic label.
+///
+/// This is observe-only telemetry: a poisoned lock (some other holder panicked
+/// mid-critical-section) must not make the registry silently stop tracking new
+/// spans, or a subsequent WAL-pressure diagnosis could read a false "no open
+/// transactions" signal. Recovers via `into_inner()` rather than the previous
+/// `if let Ok(..)` pattern, which dropped the write on poison.
 pub fn register(label: Option<String>) -> TxHandle {
     let id = TxId(NEXT_ID.fetch_add(1, Ordering::Relaxed));
     let meta = TxMeta {
         opened_at: Instant::now(),
         label,
     };
-    if let Ok(mut registry) = REGISTRY.lock() {
-        registry.insert(id, meta);
-    }
+    let mut registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry.insert(id, meta);
+    drop(registry);
     TxHandle { id }
 }
 
 /// Age and label of the oldest currently-open registry entry, if any.
+///
+/// Recovers a poisoned lock via `into_inner()` (see [`register`]) instead of
+/// returning `None`, which would otherwise read identically to "no open
+/// transactions" — indistinguishable from the genuinely-empty case.
 pub fn oldest() -> Option<(Duration, Option<String>)> {
-    let registry = REGISTRY.lock().ok()?;
+    let registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     registry
         .values()
         .min_by_key(|meta| meta.opened_at)
@@ -63,10 +78,14 @@ pub fn oldest() -> Option<(Duration, Option<String>)> {
 }
 
 /// Age and label of every currently-open registry entry.
+///
+/// Recovers a poisoned lock via `into_inner()` (see [`register`]) instead of
+/// returning an empty `Vec`, which would otherwise read identically to "no
+/// open transactions" during the one moment this diagnostic matters most.
 pub fn snapshot() -> Vec<(Duration, Option<String>)> {
-    let Ok(registry) = REGISTRY.lock() else {
-        return Vec::new();
-    };
+    let registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     registry
         .values()
         .map(|meta| (meta.opened_at.elapsed(), meta.label.clone()))

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -1,0 +1,150 @@
+//! Process-wide open-transaction registry (ADR-091 Plank 0).
+//!
+//! Every caller-controllable SQL transaction span (`SqliteTransaction::begin_tx`,
+//! `WriterGuard::transaction`, and the raw `BEGIN IMMEDIATE`/`COMMIT` batch-writer
+//! spans) registers here on open and deregisters via `TxHandle`'s `Drop`. This is
+//! observe-only: no enforcement reads the registry in this plank. It exists so the
+//! checkpoint task can name which caller, if any, is holding a WAL snapshot open.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// Identifier for one registered transaction span.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TxId(u64);
+
+#[derive(Clone, Debug)]
+struct TxMeta {
+    opened_at: Instant,
+    label: Option<String>,
+}
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static REGISTRY: LazyLock<Mutex<HashMap<TxId, TxMeta>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// RAII handle for a registered transaction span. Deregisters on `Drop` — this is
+/// the only deregistration path, so error and panic returns can never leak an
+/// entry in the registry.
+pub struct TxHandle {
+    id: TxId,
+}
+
+impl Drop for TxHandle {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = REGISTRY.lock() {
+            registry.remove(&self.id);
+        }
+    }
+}
+
+/// Register a new open transaction span with an optional diagnostic label.
+pub fn register(label: Option<String>) -> TxHandle {
+    let id = TxId(NEXT_ID.fetch_add(1, Ordering::Relaxed));
+    let meta = TxMeta {
+        opened_at: Instant::now(),
+        label,
+    };
+    if let Ok(mut registry) = REGISTRY.lock() {
+        registry.insert(id, meta);
+    }
+    TxHandle { id }
+}
+
+/// Age and label of the oldest currently-open registry entry, if any.
+pub fn oldest() -> Option<(Duration, Option<String>)> {
+    let registry = REGISTRY.lock().ok()?;
+    registry
+        .values()
+        .min_by_key(|meta| meta.opened_at)
+        .map(|meta| (meta.opened_at.elapsed(), meta.label.clone()))
+}
+
+/// Age and label of every currently-open registry entry.
+pub fn snapshot() -> Vec<(Duration, Option<String>)> {
+    let Ok(registry) = REGISTRY.lock() else {
+        return Vec::new();
+    };
+    registry
+        .values()
+        .map(|meta| (meta.opened_at.elapsed(), meta.label.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{self, AssertUnwindSafe};
+
+    // The registry is a process-wide singleton, shared across every test in this
+    // binary (cargo runs `#[test]`s in parallel threads of the same process). A
+    // module-local lock serializes these tests so one test's entries can't be
+    // observed as another's "oldest" or leak into another's snapshot assertion.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn register_reports_oldest_with_label() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let handle = register(Some("test_span".to_string()));
+        let (_, label) = oldest().expect("expected an open entry");
+        assert_eq!(label.as_deref(), Some("test_span"));
+        drop(handle);
+    }
+
+    #[test]
+    fn drop_deregisters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let handle = register(Some("drop_me".to_string()));
+        let id_present_before = snapshot()
+            .iter()
+            .any(|(_, label)| label.as_deref() == Some("drop_me"));
+        assert!(id_present_before);
+        drop(handle);
+        let id_present_after = snapshot()
+            .iter()
+            .any(|(_, label)| label.as_deref() == Some("drop_me"));
+        assert!(!id_present_after);
+    }
+
+    #[test]
+    fn oldest_is_genuinely_oldest() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let first = register(Some("first".to_string()));
+        std::thread::sleep(Duration::from_millis(5));
+        let second = register(Some("second".to_string()));
+        let (_, label) = oldest().expect("expected an open entry");
+        assert_eq!(label.as_deref(), Some("first"));
+        drop(first);
+        let (_, label) = oldest().expect("expected an open entry");
+        assert_eq!(label.as_deref(), Some("second"));
+        drop(second);
+    }
+
+    #[test]
+    fn snapshot_contains_all_open_entries() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let a = register(Some("snap_a".to_string()));
+        let b = register(Some("snap_b".to_string()));
+        let labels: Vec<Option<String>> = snapshot().into_iter().map(|(_, label)| label).collect();
+        assert!(labels.contains(&Some("snap_a".to_string())));
+        assert!(labels.contains(&Some("snap_b".to_string())));
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn panic_inside_scope_still_deregisters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            let _handle = register(Some("panics".to_string()));
+            panic!("boom");
+        }));
+        assert!(result.is_err());
+        let still_present = snapshot()
+            .iter()
+            .any(|(_, label)| label.as_deref() == Some("panics"));
+        assert!(!still_present);
+    }
+}


### PR DESCRIPTION
## Summary

Implements ADR-091 Plank 0: a process-wide open-transaction registry and observe-only checkpoint instrumentation, per the approved plan (sequencing 0 → 2 → 1). This is code-only — the ADR (#585) is already merged, no spec edits ride this PR.

**Zero behavior change to any transaction.** No enforcement, no caps, no rejection, no new config keys — that is Plank 1, gated on one cycle of production telemetry from this plank. This PR is pure observability: it lets the checkpoint task name which caller, if any, is holding a WAL snapshot open, the question ADR-091's static code reading could not answer.

### What registers where

- `crates/khive-storage/src/tx_registry.rs` (new): a process-wide `Mutex<HashMap<TxId, TxMeta>>` registry. `register(label) -> TxHandle`, `oldest()`, `snapshot()`. Exported from `khive-storage/src/lib.rs`.
- `crates/khive-db/src/sql_bridge.rs`:
  - `SqliteTransaction` gains a `_tx_handle: TxHandle` field; `begin_tx` (~:848) registers right after `BEGIN` succeeds, reusing the caller's `SqlTxOptions.label`.
  - `SqliteWriter::execute_batch` (~:360) and `PoolBackedWriter::execute_batch` (~:741) — label `"execute_batch"` / `"pool_writer.execute_batch"`.
- `crates/khive-db/src/pool.rs:181` `WriterGuard::transaction` — label `"writer_guard_tx"`. One instrumentation point covers every `guard.transaction(...)` caller: `khive-runtime/src/curation.rs`'s `merge_entity`/`merge_note_sql` and `khive-runtime/src/operations.rs:3623`'s edge update needed no per-site edits.
- Store batch-upsert methods (`khive-db/src/stores/`): `entity.rs` (`entity_upsert_batch`), `note.rs` (`note_upsert_batch`), `graph.rs` (`graph_upsert_edges`), `event.rs` (`event_append`, `event_append_batch`), `text.rs` (`text_upsert_document`, `text_upsert_batch`, `text_rename_namespace`), `vectors.rs` (`vector_insert_batch`), `sparse.rs` (`sparse_insert_batch`).
- `khive-vcs/src/sync.rs` needed no direct edit — its per-chunk writes route through `store.upsert_entities`/`text.upsert_documents`, already instrumented above.
- `khive-pack-brain`: `fold_gate.rs`'s `apply_fold_gate` (`fold_gate_apply`) and `apply_fold_gate_and_append_event` (`fold_gate_apply_event`); `persist.rs`'s `persist_brain_state_mutation` (`brain_persist_mutation`). `handlers.rs:1139` is a call site with no BEGIN of its own — no edit needed.
- `crates/khive-db/src/checkpoint.rs`: `run_checkpoint_task` now calls a new `log_tx_registry_pressure(wal_pages, warn_pages, high_water_pages)` helper every tick — `debug!` normally, escalating to `warn!` once `wal_pages` crosses `warn_pages`, naming the oldest open entry's age + label. Once `wal_pages` reaches `high_water_pages`, it enumerates every open registry entry via `snapshot()` at `warn!` — the load-bearing "which caller is pinning the WAL" answer.

### RAII rationale

`TxHandle` deregisters only via `Drop` — there is no manual `deregister()` call. Every registration site declares the handle as a local right after `BEGIN` succeeds, so it drops (and deregisters) on every return path out of that scope: normal commit, early-return error paths, and even a panic (`catch_unwind`-verified in the registry's own unit tests). This was an explicit call in the approved plan — manual deregister at 15+ call sites would leak on some path; RAII cannot.

The registry mutex is never held across a SQL call — `register`/`oldest`/`snapshot` are short, synchronous map operations only.

### Scope

- Observe-only (Plank 0). Enforcement reads (soft-cap WARN on per-statement age, cooperative stale-op guard, commit-past-cap rollback) are Plank 1, not built here.
- TRUNCATE escalation is Plank 2, not built here.
- No `KHIVE_TX_*` config keys added — those ship with Plank 1, tuned by this plank's telemetry.

### Gates run (from `crates/`, `CARGO_TARGET_DIR` set to a checkout-local dir)

- `cargo check --workspace` — pass
- `cargo test -p khive-storage -p khive-db -p khive-pack-brain -p khive-vcs` — 217 + 14 + 196 + 6 + 4 + 44 + 33 + 10 + 72 + 9 passed, 0 failed (workspace `--workspace` test intentionally NOT run per known lesson: the 4246-test suite times out gate agents)
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, 0 warnings
- `cargo fmt --all -- --check` — pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — pass

### Discrepancies / decisions beyond the plan

None found — the plan's anchors (file:line) needed re-grepping (as expected, called out in the plan itself) but the code shape at each site matched the plan's description exactly. No ADR-vs-code mismatch encountered.

## Test plan

- [x] `cargo test -p khive-storage -p khive-db -p khive-pack-brain -p khive-vcs` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo fmt --all -- --check` green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` green
- [ ] Additional review round on this draft PR