### PR TITLE
fix(db): batch_neighbors per-origin window ordering — weight DESC before limit (#589)

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -684,11 +684,18 @@ impl GraphStore for SqlGraphStore {
                     }
 
                     // Wrap combined inner with per-source ROW_NUMBER limit if needed.
+                    //
+                    // Deterministic weight-descending order, tie-broken by node_id
+                    // ascending, applied INSIDE the window's ORDER BY — otherwise a
+                    // per-origin cap can silently drop high-weight neighbors in favor
+                    // of arbitrary SQLite row order (mirrors neighbors(), ADR-089
+                    // context-verb review codex round-1 High-1; issue #589).
                     let full_sql = if let Some(lim) = query_clone.limit {
                         all_params.push(Box::new(lim as i64));
                         format!(
                             "SELECT origin_id, node_id, edge_id, relation, weight \
-                             FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY origin_id) AS rn \
+                             FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY origin_id \
+                                   ORDER BY weight DESC, node_id ASC) AS rn \
                                    FROM ({combined_inner})) WHERE rn <= ?{limit_param_idx}",
                         )
                     } else {

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1074,6 +1074,122 @@ async fn batch_neighbors_min_weight_filter_parity() {
     );
 }
 
+/// Regression guard (issue #589): a `limit` narrower than an origin's full
+/// neighbor set must keep that origin's highest-weight edges, not an
+/// arbitrary SQLite row-order subset. Before the fix, the `ROW_NUMBER()
+/// OVER (PARTITION BY origin_id)` window had no `ORDER BY`, so a low-weight
+/// neighbor could win over a high-weight one purely by insertion order —
+/// and because this is per-origin, one origin's row order could disagree
+/// with another's, so the test uses two origins with the low/mid/high
+/// insertion order reversed between them.
+#[tokio::test]
+async fn batch_neighbors_limit_keeps_highest_weight_per_origin_not_insertion_order() {
+    let store = setup_memory_store();
+
+    let centre_a = Uuid::new_v4();
+    let a_low = Uuid::new_v4();
+    let a_mid = Uuid::new_v4();
+    let a_high = Uuid::new_v4();
+
+    let centre_b = Uuid::new_v4();
+    let b_low = Uuid::new_v4();
+    let b_mid = Uuid::new_v4();
+    let b_high = Uuid::new_v4();
+
+    // centre_a: insert lowest-weight edge FIRST (insertion order disagrees
+    // with weight order).
+    store
+        .upsert_edge(make_edge(centre_a, a_low, EdgeRelation::Extends, 0.1))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre_a, a_mid, EdgeRelation::Extends, 0.5))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre_a, a_high, EdgeRelation::Extends, 0.9))
+        .await
+        .unwrap();
+
+    // centre_b: insert highest-weight edge FIRST — the reverse of centre_a —
+    // so a single global insertion-order artifact cannot accidentally pass
+    // both origins.
+    store
+        .upsert_edge(make_edge(centre_b, b_high, EdgeRelation::Extends, 0.9))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre_b, b_mid, EdgeRelation::Extends, 0.5))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre_b, b_low, EdgeRelation::Extends, 0.1))
+        .await
+        .unwrap();
+
+    let query = NeighborQuery {
+        direction: Direction::Out,
+        relations: None,
+        limit: Some(2),
+        min_weight: None,
+    };
+
+    let hits = store
+        .batch_neighbors(&[centre_a, centre_b], query)
+        .await
+        .unwrap();
+
+    let a_hits: Vec<&NeighborHit> = hits
+        .iter()
+        .filter(|(origin, _)| *origin == centre_a)
+        .map(|(_, h)| h)
+        .collect();
+    let b_hits: Vec<&NeighborHit> = hits
+        .iter()
+        .filter(|(origin, _)| *origin == centre_b)
+        .map(|(_, h)| h)
+        .collect();
+
+    assert_eq!(
+        a_hits.len(),
+        2,
+        "centre_a: per-origin limit=2 must return exactly 2 neighbors"
+    );
+    assert_eq!(
+        b_hits.len(),
+        2,
+        "centre_b: per-origin limit=2 must return exactly 2 neighbors"
+    );
+
+    let a_ids: HashSet<Uuid> = a_hits.iter().map(|h| h.node_id).collect();
+    assert!(
+        a_ids.contains(&a_high),
+        "centre_a: highest-weight neighbor must survive a narrowing limit"
+    );
+    assert!(
+        a_ids.contains(&a_mid),
+        "centre_a: second-highest-weight neighbor must survive a narrowing limit"
+    );
+    assert!(
+        !a_ids.contains(&a_low),
+        "centre_a: lowest-weight neighbor must be the one dropped by limit"
+    );
+
+    let b_ids: HashSet<Uuid> = b_hits.iter().map(|h| h.node_id).collect();
+    assert!(
+        b_ids.contains(&b_high),
+        "centre_b: highest-weight neighbor must survive a narrowing limit"
+    );
+    assert!(
+        b_ids.contains(&b_mid),
+        "centre_b: second-highest-weight neighbor must survive a narrowing limit"
+    );
+    assert!(
+        !b_ids.contains(&b_low),
+        "centre_b: lowest-weight neighbor must be the one dropped by limit"
+    );
+}
+
 // ---- get_edges direct SQLite tests ----
 
 /// get_edges must return all requested edges regardless of request order.


### PR DESCRIPTION
## Summary

`SqlGraphStore::batch_neighbors` (`crates/khive-db/src/stores/graph.rs`) caps
neighbors per origin with:

```sql
SELECT origin_id, node_id, edge_id, relation, weight
FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY origin_id) AS rn
      FROM (<combined_inner>)) WHERE rn <= ?<limit>
```

The `ROW_NUMBER() OVER (PARTITION BY origin_id)` window had **no `ORDER BY`**,
so within each origin the row numbering followed arbitrary SQLite row order.
When `limit` is narrower than an origin's full neighbor set, the retained
subset was an arbitrary slice — high-weight edges could be dropped in favor
of low-weight ones. Same class of defect as #588 (`neighbors()`, fixed with
`ORDER BY weight DESC, node_id ASC` before `LIMIT`).

## Fix

Added the same deterministic ordering inside the window itself:

```sql
ROW_NUMBER() OVER (PARTITION BY origin_id ORDER BY weight DESC, node_id ASC) AS rn
```

This mirrors `neighbors()`'s tie-break exactly (`crates/khive-db/src/stores/graph.rs:924-926`).

## Layer-trace evidence (mandatory per task spec — full path from storage to `traverse` verb output)

Per the #588 lesson (a storage-layer ORDER BY fix can be silently undone one
layer up by an unrelated sort/dedup), I traced every consumer of
`batch_neighbors` and every sort/dedup between it and the `traverse` verb
surface:

| Layer | File:line | What it does | Verdict |
|---|---|---|---|
| Storage | `khive-db/src/stores/graph.rs:687-699` (`batch_neighbors`) | `ROW_NUMBER() OVER (PARTITION BY origin_id ...)` + `LIMIT` | **Fixed this PR** — now orders `weight DESC, node_id ASC` inside the window |
| Runtime — BFS helper | `khive-runtime/src/graph_traversal.rs:80` (`bfs_traverse`) | Calls `batch_neighbors(&frontier, query)` with `limit: None` (line 75) | No truncation happens here — `None` limit means the ordering bug can't manifest via this call site regardless of storage fix |
| Runtime — bidirectional search | `khive-runtime/src/graph_traversal.rs:184,223` (`shortest_path`) | Calls `batch_neighbors` twice, both with `limit: None` | Same — no per-call truncation, no sort/dedup applied to the returned hits before use |
| Runtime — grep for all `batch_neighbors` callers | `grep -rln "batch_neighbors(" crates/` → `khive-storage/src/graph.rs` (trait decl), `khive-runtime/src/graph_traversal.rs`, `khive-db/src/stores/graph.rs` (impl + tests) | Exhaustive — these are the only three non-test call sites in the workspace | No other consumer exists |
| `traverse` verb handler | `khive-pack-kg/src/handlers/graph.rs:55` (`handle_traverse`) → `khive-runtime/src/operations.rs` `KhiveRuntime::traverse` | Calls `self.graph(&temp)?.traverse(request.clone())` — **a separate CTE-based SQL query in `graph.rs`, not `batch_neighbors`** | Out of scope for #589: the live `traverse` verb does not currently route through `batch_neighbors` at all. Its own per-root `limit` truncation (`graph.rs:1189-1202`) is BFS-depth-order (shallowest-first), by design (matches #285), not weight-order — a different, intentional contract, not this bug. |
| `context` verb (ADR-089) | `khive-pack-kg/src/handlers/context.rs:107-198` (`fetch_directed_neighbors`) | Routes through `neighbors_with_query` (single-anchor), never `batch_neighbors` | Not affected — matches the issue's own note that `context` and single-anchor `neighbors` are unaffected |
| Runtime — single-anchor path (`neighbors_with_query`, for comparison) | `khive-runtime/src/operations.rs:1690-1715` | `hits.sort_by_key((node_id, edge_id))` for dedup (destroys weight order), **then re-sorts** `weight DESC, node_id ASC` at line 1709 (the #588 round-2 review fix) | Confirmed already correct; not touched by this PR |

**Conclusion**: no second layer re-sorts or dedups `batch_neighbors` output in
a way that would undo this fix, because the only two live callers
(`bfs_traverse`, `shortest_path` in `graph_traversal.rs`) never pass a
per-call `limit`, and the `traverse`/`context` verb surfaces do not currently
route through `batch_neighbors` at all. The storage-layer fix in this PR is
sufficient and complete for the code as it stands today. If a future caller
adds a per-origin `limit` to a `batch_neighbors` call (e.g. a fanout-capped
BFS), the fixed window ordering guarantees it will keep the highest-weight
neighbors — that guarantee did not hold before this PR.

## Tests added

`crates/khive-db/src/stores/graph_tests.rs`:
`batch_neighbors_limit_keeps_highest_weight_per_origin_not_insertion_order`
— two origins (`centre_a`, `centre_b`) with insertion order reversed
relative to each other (low→mid→high vs. high→mid→low), `limit: Some(2)`
per origin. Asserts each origin's two highest-weight neighbors survive and
the lowest-weight one is dropped, per origin independently — so a single
global insertion-order artifact can't accidentally pass both origins.

Verified the test fails without the fix (reverted just the SQL change,
re-ran): `centre_a: highest-weight neighbor must survive a narrowing limit`
panics. Re-applied the fix, test passes.

## Gates (real exit codes)

- `cargo test -p khive-db -p khive-runtime -p khive-pack-kg` → exit 0 (all passed, including the new test and the full pre-existing `khive-db`/`khive-runtime`/`khive-pack-kg` suites)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo fmt --all -- --check` → exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` → exit 0

## Scope

Storage fix + regression test only. No cleanup, no drive-by edits.

Closes #589