### PR TITLE
docs(guide): tips & tricks + proof-graph case study (#595)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -2,14 +2,16 @@
 
 Documentation for using khive as a research knowledge graph runtime.
 
-| Guide                                          | What it covers                                  |
-| ---------------------------------------------- | ----------------------------------------------- |
-| [Getting Started](getting-started.md)          | Install, connect, first session                 |
-| [Knowledge Graph Modeling](knowledge-graph.md) | Entity kinds, edge relations, modeling patterns |
-| [Prompt Cookbook](prompt-cookbook.md)          | 20+ real-world verb patterns with examples      |
-| [Search and Retrieval](search.md)              | FTS, vector, hybrid fusion, reranking           |
-| [Memory and Recall](memory.md)                 | Episodic vs semantic, salience, decay           |
-| [GTD Task Management](tasks.md)                | Task lifecycle, priorities, dependencies        |
+| Guide                                               | What it covers                                  |
+| --------------------------------------------------- | ----------------------------------------------- |
+| [Getting Started](getting-started.md)               | Install, connect, first session                 |
+| [Knowledge Graph Modeling](knowledge-graph.md)      | Entity kinds, edge relations, modeling patterns |
+| [Prompt Cookbook](prompt-cookbook.md)               | 20+ real-world verb patterns with examples      |
+| [Search and Retrieval](search.md)                   | FTS, vector, hybrid fusion, reranking           |
+| [Memory and Recall](memory.md)                      | Episodic vs semantic, salience, decay           |
+| [GTD Task Management](tasks.md)                     | Task lifecycle, priorities, dependencies        |
+| [Tips and Tricks](tips-and-tricks.md)               | Query craft, DSL round-trips, param gotchas     |
+| [Proof-Graph Case Study](proof-graph-case-study.md) | Mathlib as a khive-at-scale case study          |
 
 ## How to read these guides
 

--- a/docs/guide/proof-graph-case-study.md
+++ b/docs/guide/proof-graph-case-study.md
@@ -1,0 +1,104 @@
+# Case Study: The Mathlib Proof Graph
+
+This page describes a khive-at-scale deployment: a knowledge graph of the
+[mathlib](https://leanprover-community.github.io/mathlib4_docs/) formal-math
+library, built to support automated redundancy detection across proofs. It
+focuses on the khive mechanics (ingestion, typed edges, traversal at scale),
+not the mathematical adjudication built on top.
+
+## Scale
+
+Mathlib v4.30.0 was ingested as a khive-native graph:
+
+| Metric               | Value     |
+| -------------------- | --------- |
+| Entities             | 320,810   |
+| `depends_on` edges   | 4,387,592 |
+| Avg edges per entity | ~13.7     |
+
+Every mathlib declaration (theorem, definition, structure, instance, axiom)
+became an entity; every dependency between declarations became a typed
+`depends_on` edge. This is the same edge relation khive uses elsewhere for
+build/runtime/data/artifact/tooling dependency modeling — proof dependency is
+one more instance of the same closed relation, not a schema extension.
+
+## Ingestion path
+
+At this scale, going through the MCP `request` surface one `create`/`link`
+call at a time is not the right tool: 4.7 million individual round trips
+would dominate wall time and add no value over a direct write. The ingestion
+instead writes straight to a khive-native SQLite database:
+
+1. **Bootstrap the canonical schema.** The same DDL khive's migrations apply
+   (`crates/khive-db/sql/`) is applied directly to a fresh database file, so
+   the resulting graph is a valid khive database — every verb (`get`,
+   `neighbors`, `traverse`, `query`) works against it exactly as it would
+   against a database built through the MCP surface.
+2. **Deterministic IDs.** Each declaration gets a UUIDv5 id derived from its
+   fully-qualified mathlib name, and every insert is `INSERT OR IGNORE`. This
+   makes the ingestion idempotent: re-running the ingestion script against an
+   updated mathlib snapshot (or after a crash) does not create duplicate
+   entities or duplicate edges, since re-deriving the same name always
+   produces the same id.
+3. **Skip vector tables for a graph-only workload.** This corpus is used for
+   structural traversal, not semantic search over declaration text, so the
+   ingestion does not populate `sqlite-vec` `vec0` virtual tables. This keeps
+   the ingestion path simpler and the resulting database smaller, at the cost
+   of not supporting `search`'s vector-similarity leg over this data — pure
+   graph reads (`get`, `neighbors`, `traverse`, `query`) do not depend on the
+   vector store at all.
+
+This direct-write path trades the MCP round-trip and its request-level
+validation for raw insert throughput, and only makes sense at this scale.
+For anything an agent produces interactively — reading a paper, forming a
+concept, linking two ideas — the normal `create`/`link` verbs over `request`
+are the right tool; see [Prompt Cookbook](prompt-cookbook.md).
+
+## Traversal at scale
+
+The resulting database is queried with the same verbs used against any
+khive graph. `neighbors` answers "what does this theorem depend on, or what
+depends on it" one hop at a time; `traverse` walks multi-hop dependency
+chains and lineage (see [Tips and Tricks](tips-and-tricks.md#traverse-vs-context)
+for when to reach for `traverse` versus a query-anchored `context` call).
+Multi-hop BFS over a graph this size behaves the same way it does over a
+small research graph: bounded by `max_depth` and `relations` filters, not by
+a separate large-graph code path. Nothing about the verb surface changes at
+4.4 million edges versus 4,000.
+
+## Structural signals built on the graph
+
+Two auditable signals were built on top of the ingested graph, both derived
+from graph structure rather than from a language model's judgment of a
+proof's content:
+
+- **Statement-template isomorphism.** Two theorem statements that are
+  structurally isomorphic up to variable renaming and metavariable
+  substitution are flagged as candidate restatements of the same result,
+  independent of naming or literal source-text similarity.
+- **Specialized-machinery scoring.** A proof's dependency footprint (traced
+  through `depends_on`) is scored for how much specialized machinery it pulls
+  in versus how directly it follows from more general, widely-depended-on
+  results, surfacing proofs that lean on narrow lemmas built for that one
+  result alone.
+
+Both signals are auditable: a mathematician can walk the same `depends_on`
+edges the signal used and check the claim directly, rather than trusting an
+opaque similarity score. That auditability, not the underlying math, is the
+khive-relevant point — it is a direct consequence of the graph being typed
+and the edges being traversable, not a property of any embedding.
+
+## Evidence
+
+- Live visualization: <https://swarm.unsorry.agentics.org.nz/math/proof-graph>
+  positions 4,770 credited proofs by mathlib territory and redundancy
+  classification, browsable interactively.
+- Public discussion of the redundancy-detection results:
+  <https://github.com/agenticsnz/unsorry/discussions/6645>
+
+## See also
+
+- [Knowledge Graph Modeling](knowledge-graph.md): entity kinds and edge
+  relations, including `depends_on`
+- [Search and Retrieval](search.md): `neighbors`, `traverse`, and `query`
+- [Tips and Tricks](tips-and-tricks.md): practical verb usage patterns

--- a/docs/guide/proof-graph-case-study.md
+++ b/docs/guide/proof-graph-case-study.md
@@ -19,7 +19,7 @@ Mathlib v4.30.0 was ingested as a khive-native graph:
 Every mathlib declaration (theorem, definition, structure, instance, axiom)
 became an entity; every dependency between declarations became a typed
 `depends_on` edge. This is the same edge relation khive uses elsewhere for
-build/runtime/data/artifact/tooling dependency modeling — proof dependency is
+build/runtime/data/artifact/tooling dependency modeling. Proof dependency is
 one more instance of the same closed relation, not a schema extension.
 
 ## Ingestion path
@@ -31,7 +31,7 @@ instead writes straight to a khive-native SQLite database:
 
 1. **Bootstrap the canonical schema.** The same DDL khive's migrations apply
    (`crates/khive-db/sql/`) is applied directly to a fresh database file, so
-   the resulting graph is a valid khive database — every verb (`get`,
+   the resulting graph is a valid khive database: every verb (`get`,
    `neighbors`, `traverse`, `query`) works against it exactly as it would
    against a database built through the MCP surface.
 2. **Deterministic IDs.** Each declaration gets a UUIDv5 id derived from its
@@ -44,14 +44,14 @@ instead writes straight to a khive-native SQLite database:
    structural traversal, not semantic search over declaration text, so the
    ingestion does not populate `sqlite-vec` `vec0` virtual tables. This keeps
    the ingestion path simpler and the resulting database smaller, at the cost
-   of not supporting `search`'s vector-similarity leg over this data — pure
+   of not supporting `search`'s vector-similarity leg over this data. Pure
    graph reads (`get`, `neighbors`, `traverse`, `query`) do not depend on the
    vector store at all.
 
 This direct-write path trades the MCP round-trip and its request-level
 validation for raw insert throughput, and only makes sense at this scale.
-For anything an agent produces interactively — reading a paper, forming a
-concept, linking two ideas — the normal `create`/`link` verbs over `request`
+For anything an agent produces interactively (reading a paper, forming a
+concept, linking two ideas), the normal `create`/`link` verbs over `request`
 are the right tool; see [Prompt Cookbook](prompt-cookbook.md).
 
 ## Traversal at scale
@@ -85,7 +85,7 @@ proof's content:
 Both signals are auditable: a mathematician can walk the same `depends_on`
 edges the signal used and check the claim directly, rather than trusting an
 opaque similarity score. That auditability, not the underlying math, is the
-khive-relevant point — it is a direct consequence of the graph being typed
+khive-relevant point: it is a direct consequence of the graph being typed
 and the edges being traversable, not a property of any embedding.
 
 ## Evidence

--- a/docs/guide/tips-and-tricks.md
+++ b/docs/guide/tips-and-tricks.md
@@ -30,7 +30,7 @@ coerced to any particular direction. This is covered by regression tests in
 only via an incoming edge is still surfaced when `direction` is omitted.
 
 Some older documentation and ADR prose (predating this fix) describes an
-`out`-only default as a live footgun — that description is stale as of this
+`out`-only default as a live footgun. That description is stale as of this
 writing. Pass `direction="both"` explicitly anyway when you want to be
 unambiguous about intent, or when you specifically want only one direction,
 pass `direction="out"` / `direction="in"`:
@@ -49,8 +49,8 @@ Both walk the graph, but they answer different question shapes:
 - `context(query=..., entity_ids=...)` resolves anchors from a natural
   language query (via `hybrid_search`), expands 1-2 hops, and assembles the
   result under a character budget in a single call. Use it when you do not
-  already have anchor UUIDs and want a budgeted neighborhood summary — for
-  example, injecting graph context into a model turn without a
+  already have anchor UUIDs and want a budgeted neighborhood summary, for
+  example injecting graph context into a model turn without a
   `search`-then-`neighbors` round trip.
 
 `context` composes the same runtime ops as `search` and `neighbors` (it adds
@@ -67,7 +67,7 @@ In a chain (`v1(...) | v2(...)`), `$prev` resolves to the result of the op
 directly before it, not to any earlier op in the chain. Each step in a chain
 overwrites the value `$prev` will resolve to on the next step. If op C needs
 a value produced by op A but not passed through by op B, that value is gone
-by the time C runs — restructure the chain, or split the calls and pass the
+by the time C runs. Restructure the chain, or split the calls and pass the
 value explicitly.
 
 ```
@@ -85,7 +85,7 @@ request(ops="[search(kind=\"entity\", query=\"LoRA\"), search(kind=\"note\", que
 ```
 
 Batches run with no ordering guarantee between ops, and a failed op does not
-abort the others — each result carries its own `ok`/`error`. The batch size
+abort the others: each result carries its own `ok`/`error`. The batch size
 ceiling is 100 ops; a larger array is rejected rather than silently
 truncated.
 
@@ -99,20 +99,27 @@ request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"GQA\", desc
 ```
 
 This only works when the value you need is produced by the op immediately
-before the one that consumes it — see the `$prev` scoping note above.
+before the one that consumes it. See the `$prev` scoping note above.
 
 ## Param gotchas
 
-A handful of verbs use a parameter name that is easy to guess wrong. These
-are enforced by `#[serde(deny_unknown_fields)]` on the underlying param
-structs, so a wrong name fails the call outright rather than silently being
-ignored:
+A handful of verbs use a parameter name that is easy to guess wrong, and the
+failure mode differs by pack. The KG pack's `search` and `comm.thread` param
+structs carry `#[serde(deny_unknown_fields)]` (`crates/khive-pack-kg/src/handlers/params.rs`,
+`crates/khive-pack-comm/src/params.rs`), so passing a wrong name fails the
+call outright with an unknown-field error. The knowledge pack's `search`,
+`suggest`, and `delete_atoms` param structs (`crates/khive-pack-knowledge/src/knowledge/schema.rs`)
+deserialize with plain `serde_json::from_value` (no `deny_unknown_fields`),
+so an extra unrecognized field is silently ignored; what actually fails the
+call is the _required_ field (`query`, `ids`) being missing because you sent
+the wrong name for it instead:
 
-| Verb                     | Correct param | Common wrong guess |
-| ------------------------ | ------------- | ------------------ |
-| `search`, `suggest`      | `query`       | `q`                |
-| `comm.thread`            | `id`          | `thread_id`        |
-| `knowledge.delete_atoms` | `ids`         | `slugs`            |
+| Verb                                    | Correct param | Common wrong guess | Failure mode                         |
+| --------------------------------------- | ------------- | ------------------ | ------------------------------------ |
+| `search` (KG)                           | `query`       | `q`                | rejected: unknown field              |
+| `comm.thread`                           | `id`          | `thread_id`        | rejected: unknown field              |
+| `knowledge.search`, `knowledge.suggest` | `query`       | `q`                | rejected: `query` missing (required) |
+| `knowledge.delete_atoms`                | `ids`         | `slugs`            | rejected: `ids` missing (required)   |
 
 String values in the function-call DSL must be double-quoted JSON string
 literals. The parser reads the raw value slice and feeds it to
@@ -120,10 +127,10 @@ literals. The parser reads the raw value slice and feeds it to
 JSON parsing and the op errors out, even as a standalone argument:
 
 ```
-# Wrong — bareword value, fails to parse
+# Wrong: bareword value, fails to parse
 request(ops="get(id=abc123)")
 
-# Right — double-quoted string literal
+# Right: double-quoted string literal
 request(ops="get(id=\"abc123\")")
 ```
 
@@ -134,7 +141,7 @@ are visible to `knowledge.search`'s FTS leg on the next call. The Vamana ANN
 vector index that provides the semantic leg is different: it is an
 in-memory, per-namespace structure that is loaded once and cached, and is
 only invalidated by an explicit `knowledge.index()` call (or a daemon
-restart) — not automatically after every `upsert_atoms`. A newly written atom
+restart), not automatically after every `upsert_atoms`. A newly written atom
 will not surface via the ANN path of `knowledge.search` until a reindex runs.
 Treat writes as helping the _next_ indexing pass, not as immediately
 recallable through the vector leg: batch writes, then call
@@ -144,12 +151,12 @@ recall over what you just wrote.
 ## Troubleshooting
 
 - `request(ops="verbs()")` and `help=true` on any verb are the live ground
-  truth for what is actually registered on the server you are talking to —
-  prefer them over any cached doc (including this one) when behavior looks
+  truth for what is actually registered on the server you are talking to.
+  Prefer them over any cached doc (including this one) when behavior looks
   off. `help=true` short-circuits before the pack's handler runs, so it never
   has side effects.
 - If an MCP client fails to connect to `kkernel mcp` with an opaque error,
-  see [Troubleshooting a connect failure](configuration.md#troubleshooting-a-connect-failure)
+  see [Troubleshooting a connect failure](../configuration.md#troubleshooting-a-connect-failure)
   in the configuration guide for the stderr probe that surfaces the real
   startup error.
 
@@ -157,7 +164,7 @@ recall over what you just wrote.
 
 - [Prompt Cookbook](prompt-cookbook.md): full verb syntax reference
 - [Search and Retrieval](search.md): scoring, reranking, and decompose
-- [Configuration](configuration.md): config resolution and connect-failure
+- [Configuration](../configuration.md): config resolution and connect-failure
   troubleshooting
 - [ADR-089](../adr/ADR-089-context-verb.md): `context` verb design
 - [Proof-Graph Case Study](proof-graph-case-study.md): khive at scale

--- a/docs/guide/tips-and-tricks.md
+++ b/docs/guide/tips-and-tricks.md
@@ -1,0 +1,163 @@
+# Tips and Tricks
+
+Practical usage knowledge for agents and operators working with the `request`
+MCP tool. This page collects gotchas that are easy to hit once but hard to
+find documented in one place.
+
+## Query craft
+
+### Long, keyword-rich queries beat short ones
+
+`search` and `knowledge.search` fuse full-text (FTS5 trigram) and vector
+similarity results with RRF. A short query (one or two words) gives both
+signals little to work with: FTS5 trigram matching has few n-grams to match
+against, and the embedding has little context to place in vector space. A
+longer query that names the language, framework, domain terms, and the shape
+of the question gives both retrieval legs more to latch onto and produces
+tighter fusion rankings. Prefer a query built from the same nouns you would
+use in the document itself over a terse keyword fragment. See
+[Search and Retrieval](search.md#score-interpretation) for how the fused
+scores are computed.
+
+### `neighbors` and `traverse` default to both directions
+
+As of the fix for issues #445/#480 (`crates/khive-pack-kg/src/handlers/common.rs`,
+`parse_direction`), omitting `direction` on `neighbors` or `traverse` resolves
+to `Direction::Both`, not outgoing-only. An unrecognized direction string
+(a typo like `"inbound"`) is now a rejected `InvalidInput`, not silently
+coerced to any particular direction. This is covered by regression tests in
+`crates/khive-pack-kg/tests/integration.rs` asserting that a node reachable
+only via an incoming edge is still surfaced when `direction` is omitted.
+
+Some older documentation and ADR prose (predating this fix) describes an
+`out`-only default as a live footgun — that description is stale as of this
+writing. Pass `direction="both"` explicitly anyway when you want to be
+unambiguous about intent, or when you specifically want only one direction,
+pass `direction="out"` / `direction="in"`:
+
+```
+request(ops="neighbors(node_id=\"<uuid>\", direction=\"in\", relations=[\"extends\"])")
+```
+
+### `traverse` vs `context`
+
+Both walk the graph, but they answer different question shapes:
+
+- `traverse(roots=[...], max_depth=N)` takes explicit root UUIDs and returns
+  paths reachable via BFS, filtered by relation. Use it when you already have
+  anchor entities and want lineage, dependency chains, or reachability.
+- `context(query=..., entity_ids=...)` resolves anchors from a natural
+  language query (via `hybrid_search`), expands 1-2 hops, and assembles the
+  result under a character budget in a single call. Use it when you do not
+  already have anchor UUIDs and want a budgeted neighborhood summary — for
+  example, injecting graph context into a model turn without a
+  `search`-then-`neighbors` round trip.
+
+`context` composes the same runtime ops as `search` and `neighbors` (it adds
+no new storage or index); see
+[ADR-089](../adr/ADR-089-context-verb.md) for the full parameter and
+ordering contract. `context`'s `direction` also defaults to `both`, matching
+`neighbors`' current default (see the direction note above).
+
+## DSL round-trip tricks
+
+### `$prev` chains only the immediately preceding op
+
+In a chain (`v1(...) | v2(...)`), `$prev` resolves to the result of the op
+directly before it, not to any earlier op in the chain. Each step in a chain
+overwrites the value `$prev` will resolve to on the next step. If op C needs
+a value produced by op A but not passed through by op B, that value is gone
+by the time C runs — restructure the chain, or split the calls and pass the
+value explicitly.
+
+```
+request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"NewConcept\") | link(source_id=$prev.id, target_id=\"<existing_id>\", relation=\"extends\")")
+```
+
+Path extraction supports `$prev` (the whole result), `$prev.field` (nested
+object field), `$prev.items[0].id` (array index into a field), and
+`$prev[2]` (top-level array index).
+
+### Parallel batches, max 100 ops
+
+```
+request(ops="[search(kind=\"entity\", query=\"LoRA\"), search(kind=\"note\", query=\"LoRA\"), stats()]")
+```
+
+Batches run with no ordering guarantee between ops, and a failed op does not
+abort the others — each result carries its own `ok`/`error`. The batch size
+ceiling is 100 ops; a larger array is rejected rather than silently
+truncated.
+
+### Create and link in one round trip
+
+Chaining a `create` into a `link` avoids the two-call round trip shown in
+the [Prompt Cookbook](prompt-cookbook.md#two-step-create-then-link):
+
+```
+request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"GQA\", description=\"Grouped-query attention\") | link(source_id=$prev.id, target_id=\"<existing_paper_id>\", relation=\"introduced_by\")")
+```
+
+This only works when the value you need is produced by the op immediately
+before the one that consumes it — see the `$prev` scoping note above.
+
+## Param gotchas
+
+A handful of verbs use a parameter name that is easy to guess wrong. These
+are enforced by `#[serde(deny_unknown_fields)]` on the underlying param
+structs, so a wrong name fails the call outright rather than silently being
+ignored:
+
+| Verb                     | Correct param | Common wrong guess |
+| ------------------------ | ------------- | ------------------ |
+| `search`, `suggest`      | `query`       | `q`                |
+| `comm.thread`            | `id`          | `thread_id`        |
+| `knowledge.delete_atoms` | `ids`         | `slugs`            |
+
+String values in the function-call DSL must be double-quoted JSON string
+literals. The parser reads the raw value slice and feeds it to
+`serde_json::from_str`, so a bareword value (an unquoted identifier) fails
+JSON parsing and the op errors out, even as a standalone argument:
+
+```
+# Wrong — bareword value, fails to parse
+request(ops="get(id=abc123)")
+
+# Right — double-quoted string literal
+request(ops="get(id=\"abc123\")")
+```
+
+## Indexing latency
+
+Writes to the knowledge corpus (`knowledge.upsert_atoms`) land in SQLite and
+are visible to `knowledge.search`'s FTS leg on the next call. The Vamana ANN
+vector index that provides the semantic leg is different: it is an
+in-memory, per-namespace structure that is loaded once and cached, and is
+only invalidated by an explicit `knowledge.index()` call (or a daemon
+restart) — not automatically after every `upsert_atoms`. A newly written atom
+will not surface via the ANN path of `knowledge.search` until a reindex runs.
+Treat writes as helping the _next_ indexing pass, not as immediately
+recallable through the vector leg: batch writes, then call
+`knowledge.index()` (or run `kkernel reindex`) before relying on semantic
+recall over what you just wrote.
+
+## Troubleshooting
+
+- `request(ops="verbs()")` and `help=true` on any verb are the live ground
+  truth for what is actually registered on the server you are talking to —
+  prefer them over any cached doc (including this one) when behavior looks
+  off. `help=true` short-circuits before the pack's handler runs, so it never
+  has side effects.
+- If an MCP client fails to connect to `kkernel mcp` with an opaque error,
+  see [Troubleshooting a connect failure](configuration.md#troubleshooting-a-connect-failure)
+  in the configuration guide for the stderr probe that surfaces the real
+  startup error.
+
+## See also
+
+- [Prompt Cookbook](prompt-cookbook.md): full verb syntax reference
+- [Search and Retrieval](search.md): scoring, reranking, and decompose
+- [Configuration](configuration.md): config resolution and connect-failure
+  troubleshooting
+- [ADR-089](../adr/ADR-089-context-verb.md): `context` verb design
+- [Proof-Graph Case Study](proof-graph-case-study.md): khive at scale


### PR DESCRIPTION
## Summary

- Adds `docs/guide/tips-and-tricks.md`: query craft, DSL round-trip patterns (`$prev` chaining scope, batch max, create+link), param gotchas (`query` not `q`, `comm.thread` `id` not `thread_id`, `knowledge.delete_atoms` `ids` not `slugs`, double-quoted string values), knowledge-corpus ANN indexing latency, and troubleshooting pointers (`verbs()`, `help=true`, the connect-failure stderr probe in `docs/configuration.md`).
- Adds `docs/guide/proof-graph-case-study.md`: mathlib v4.30.0 ingested as 320,810 entities / 4,387,592 `depends_on` edges, khive-native direct-write ingestion (schema bootstrap, UUIDv5 deterministic ids, `INSERT OR IGNORE` idempotency, vec0 skip for graph-only workload), traversal at scale, and the two auditable structural signals built on top. Cites the live visualization and public discussion per the issue.
- Links both new pages from `docs/guide/README.md`.

## Note on a stale premise in the issue

Issue #595 (and the current `docs/guide/search.md`, `docs/guide/prompt-cookbook.md`, and ADR-089's rationale prose) describe `neighbors` defaulting to outgoing-only as a live footgun. Per-source verification (`crates/khive-pack-kg/src/handlers/common.rs::parse_direction`, plus regression tests in `crates/khive-pack-kg/tests/integration.rs`) shows this was fixed to default `both` by #517 (issues #445/#480), merged 2026-07-03, one day before this issue was filed. The new tips page documents the corrected, current behavior and flags the older docs/ADR text as stale, rather than repeating the now-inaccurate claim. Fixing those three existing files is out of scope for this docs-only PR; filing as a fast follow-up.

## Test plan

- [x] `deno fmt --check docs/guide/tips-and-tricks.md docs/guide/proof-graph-case-study.md docs/guide/README.md` — clean
- [x] Pre-commit hooks (secrets guard, EOF, JSON/YAML checks) — passed
- [x] All internal links verified to resolve to existing files
- [x] Every behavioral claim traced to source (parser, handler params, ADR-089, vamana.rs, migrations) or explicitly softened where source didn't support the issue's phrasing

Closes #595.