### PR TITLE
fix(pages): register new guide pages in NAV_ORDER (unbreak pages build)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -112,7 +112,9 @@ jobs:
             [search]="5|Search and Retrieval|FTS5, vector search, hybrid fusion, and reranking."
             [tasks]="6|GTD Task Management|Task lifecycle, priorities, and dependency edges."
             [prompt-cookbook]="7|Prompt Cookbook|Ready-to-use verb patterns for common agent workflows."
-            [api-reference]="8|API Reference|Full verb catalog for all 8 production packs: params, DSL examples, response envelope."
+            [tips-and-tricks]="8|Tips and Tricks|Query craft, DSL round-trips, param gotchas, and troubleshooting for the request tool."
+            [proof-graph-case-study]="9|Proof Graph Case Study|Mathlib ingested as a 320K-entity, 4.4M-edge khive graph: ingestion path and traversal at scale."
+            [api-reference]="10|API Reference|Full verb catalog for all 8 production packs: params, DSL examples, response envelope."
           )
 
           cat > "$SRC/index.md" <<'EOF'


### PR DESCRIPTION
The pages workflow's ADR-090 §3 gate fails main since #607 merged: docs/guide/tips-and-tricks.md and docs/guide/proof-graph-case-study.md have no NAV_ORDER entries in .github/workflows/pages.yml, so the Jekyll assemble step exits 1 (runs 28719711843, 28719715505).

Fix: add both pages to NAV_ORDER (nav_order 8 and 9; API Reference moves 8 -> 10 to stay last). NAV_ORDER is the single source for the sidebar, /md/ copies, llms.txt, and llms-full.txt, so this also clears the ADR-090 §2 llms checks.