### PR TITLE
docs(guide): communication, sessions + provider ingest, specialized packs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -111,10 +111,13 @@ jobs:
             [memory]="4|Memory and Recall|Episodic vs semantic memory, salience, and decay-weighted recall."
             [search]="5|Search and Retrieval|FTS5, vector search, hybrid fusion, and reranking."
             [tasks]="6|GTD Task Management|Task lifecycle, priorities, and dependency edges."
-            [prompt-cookbook]="7|Prompt Cookbook|Ready-to-use verb patterns for common agent workflows."
-            [tips-and-tricks]="8|Tips and Tricks|Query craft, DSL round-trips, param gotchas, and troubleshooting for the request tool."
-            [proof-graph-case-study]="9|Proof Graph Case Study|Mathlib ingested as a 320K-entity, 4.4M-edge khive graph: ingestion path and traversal at scale."
-            [api-reference]="10|API Reference|Full verb catalog for all 8 production packs: params, DSL examples, response envelope."
+            [communication]="7|Communication and Email|Actor-addressed messaging, threading, and the optional email channel."
+            [sessions-and-ingest]="8|Agent Sessions and Data Ingest|Session record verbs and provider transcript mirror ingest."
+            [specialized-packs]="9|Specialized Packs|Niche packs beyond the production set, starting with the formal-math pack."
+            [prompt-cookbook]="10|Prompt Cookbook|Ready-to-use verb patterns for common agent workflows."
+            [tips-and-tricks]="11|Tips and Tricks|Query craft, DSL round-trips, param gotchas, and troubleshooting for the request tool."
+            [proof-graph-case-study]="12|Proof Graph Case Study|Mathlib ingested as a 320K-entity, 4.4M-edge khive graph: ingestion path and traversal at scale."
+            [api-reference]="13|API Reference|Full verb catalog for all 8 production packs: params, DSL examples, response envelope."
           )
 
           cat > "$SRC/index.md" <<'EOF'

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -1,0 +1,214 @@
+# Communication and Email
+
+This guide covers the comm pack: actor-addressed messaging inside khive, and
+the optional email channel that bridges that same messaging model to an
+external mailbox.
+
+## What messages are
+
+Messages are notes with `kind=message`, managed by the comm pack
+(`crates/khive-pack-comm/`). `comm.send` writes both an outbound copy (in the
+sender's namespace) and an inbound copy (addressed to the recipient), so a
+send always produces two notes and no cross-namespace write occurs even when
+`to` names a different actor.
+
+## Actor addressing
+
+Actors are labeled strings such as `lambda:leo` or `lambda:khive`. `comm.send`
+stores the caller's actor label as `from_actor` and the `to` argument as
+`to_actor` on both the outbound and inbound copies.
+
+```
+request(ops="comm.send(to=\"lambda:leo\", content=\"PR #610 merged\")")
+```
+
+`comm.inbox` filters by `to_actor` for the calling actor. Legacy messages
+written before actor addressing existed have no `to_actor` field and remain
+visible to every actor (an `EqOrMissing` match), so older history is not
+hidden by the newer filter.
+
+### Send
+
+| Param       | Type   | Required | Notes                                       |
+| ----------- | ------ | -------- | ------------------------------------------- |
+| `to`        | string | yes      | Actor label, e.g. `"lambda:leo"`.           |
+| `content`   | string | yes      | Message body. Must not be empty.            |
+| `subject`   | string | no       | Optional subject line.                      |
+| `thread_id` | uuid   | no       | Groups the message into an existing thread. |
+
+### Inbox
+
+| Param    | Type    | Required | Notes                                        |
+| -------- | ------- | -------- | -------------------------------------------- |
+| `limit`  | integer | no       | Default 20, max 200.                         |
+| `status` | string  | no       | `"unread"` (default) \| `"read"` \| `"all"`. |
+
+```
+request(ops="comm.inbox(limit=10)")
+request(ops="comm.inbox(status=\"all\")")
+```
+
+### Read
+
+Marks an inbound message read. Outbound messages cannot be marked read.
+
+```
+request(ops="comm.read(id=\"<message_id_or_prefix>\")")
+```
+
+`id` accepts either a full UUID or a short 8-character hex prefix.
+
+### Reply
+
+Replies thread against the original message. If the original had no subject,
+the reply carries no subject either; otherwise the reply subject is prefixed
+`Re:` (and not re-prefixed if it already starts with `Re:`).
+
+```
+request(ops="comm.reply(id=\"<message_id_or_prefix>\", content=\"Thanks, following up now\")")
+```
+
+### Thread
+
+Retrieves every message in a conversation thread, ordered chronologically,
+given the thread root's id.
+
+```
+request(ops="comm.thread(id=\"<root_message_id_or_prefix>\", limit=50)")
+```
+
+`limit` defaults to 100 and caps at 500.
+
+## The email channel
+
+The email channel (`crates/khive-channel-email/`) bridges `comm.send` /
+`comm.inbox` to a real mailbox over SMTP and IMAP. It is not part of the
+default build; see [Feature gating](#feature-gating) below.
+
+### Addressing an email recipient
+
+Send to an email address by prefixing `to` with `email:` and passing an
+explicit `subject`. Because the outbox loop reads `subject` off the stored
+note, a mail sent without `subject` goes out with `(no subject)` in the
+subject line.
+
+```
+request(ops="comm.send(to=\"email:prof.sheng@example.edu\", subject=\"Draft ready for review\", content=\"...\")")
+```
+
+### How outbound delivery works
+
+`comm.send` itself only writes the note; it does not talk to SMTP directly.
+A background outbox loop polls every 5 seconds for undelivered outbound
+notes:
+
+```
+list(namespace=<ingest_namespace>, kind="message", direction="outbound", delivered=false, limit=200)
+```
+
+For each note returned, the loop keeps only those where `to_actor` starts
+with `email:` and the note is not already delivered, then checks the
+recipient against the allowlist (`KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS`, or the
+channel's maintainer address if that variable is unset). Passing notes are
+sent over SMTP, using the note's `subject`, `content`, and any
+`thread_id`/`in_reply_to_message_id`/`references_chain` properties to set the
+RFC 822 `Message-ID`, `In-Reply-To`, and `References` headers so replies group
+correctly in native mail clients.
+
+### How inbound ingestion works
+
+A separate poll loop reads the IMAP mailbox every 5 seconds and, for each new
+message, calls the pack-internal `comm.ingest` subhandler (not callable
+directly over the MCP wire) with the parsed envelope: `from`, `to`, `content`,
+`subject`, `channel_kind`, `external_id` (an IMAP-derived dedup key of the
+form `imap:{host}:{uidvalidity}:{uid}`), `sent_at`, and the wire threading
+fields `wire_message_id` / `wire_references`. Duplicate `external_id` values
+are ignored, making re-delivery idempotent.
+
+### Configuration
+
+`EmailChannelConfig::from_env` reads configuration exclusively from
+environment variables; there is no file-based config for this channel. See
+[Configuration](../configuration.md) for the full khive-wide environment
+variable reference. The email-specific variables are:
+
+Required:
+
+- `KHIVE_EMAIL_SMTP_HOST`
+- `KHIVE_EMAIL_IMAP_HOST`
+- `KHIVE_EMAIL_USERNAME`
+- `KHIVE_EMAIL_MAINTAINER_ADDRESS` (comma-separated; the first entry is
+  primary and used for outbound-allowlist defaulting)
+- `KHIVE_EMAIL_AUTHSERV_ID` (the trust anchor for validating inbound
+  `Authentication-Results` headers; the reserved value
+  `!topmost-no-authserv-id` selects trust of the topmost header when the
+  receiving boundary emits no `authserv-id` at all, as with Exchange Online's
+  internal-hop stamp)
+
+Auth mode (choose one):
+
+- Basic: `KHIVE_EMAIL_PASSWORD`
+- OAuth (Exchange Online app-only client-credentials flow):
+  `KHIVE_EMAIL_OAUTH_CLIENT_ID`, `KHIVE_EMAIL_OAUTH_TENANT_ID`,
+  `KHIVE_EMAIL_OAUTH_CLIENT_SECRET` (all three required together; a partial
+  set is a config error, never a silent fallback to Basic)
+
+Optional, with defaults:
+
+- `KHIVE_EMAIL_SMTP_PORT` (default `587`)
+- `KHIVE_EMAIL_IMAP_PORT` (default `993`)
+- `KHIVE_EMAIL_MAILBOX` (default: same as `KHIVE_EMAIL_USERNAME`)
+- `KHIVE_EMAIL_QUARANTINE_STORE` (default `true`; when a message fails the
+  sender-authentication or allowlist gate, store it as an unattributed
+  quarantine record instead of dropping it)
+- `KHIVE_EMAIL_INGEST_NAMESPACE` (default `local`; target namespace for
+  ingested messages)
+- `KHIVE_EMAIL_DEFAULT_ACTOR` (default `lambda:leo`; inbound actor assigned to
+  fresh, uncorrelated email messages)
+- `KHIVE_EMAIL_SEND_ALLOWED_RECIPIENTS` (comma-separated outbound allowlist;
+  falls back to the maintainer address when unset)
+
+### Feature gating
+
+`channel-email` is an optional Cargo feature
+(`crates/khive-mcp/Cargo.toml`), not compiled into the plain
+`cargo build --workspace --release` invocation used by `make build` or by any
+release/CI workflow. It is enabled explicitly by `make local`
+(`cargo build --release --features channel-email`). A binary built without
+this feature has no email channel code at all: `to="email:..."` sends still
+write a note (the comm pack has no awareness of channels), but nothing polls
+IMAP or drains the outbox, so the message is never delivered.
+
+### Daemon-only channel loops
+
+The email poll loop and the outbox loop are spawned only by the persistent
+daemon process (`kkernel mcp --daemon`), never by a plain stdio `kkernel mcp`
+client. This is a deliberate role gate (issue #602): before it existed, every
+stdio client process spawned its own independent IMAP poll loop against the
+same mailbox, and nine concurrent pollers exhausted Exchange Online's
+per-mailbox connection slots, taking inbound email down for about 19 hours on
+2026-07-04.
+
+The gate logs one line at startup either way, so the decision is observable:
+
+```
+email channel loops: spawning (daemon role)
+email channel loops: skipped (client role; daemon owns channel loops)
+```
+
+If the ingest namespace fails authorization, the loops are not started at all
+(fail-closed) and this is logged separately:
+
+```
+email channel loops NOT started: ingest namespace authorization failed (fail-closed)
+```
+
+If no daemon is running, mail is simply not polled until one starts. That is
+the intended behavior, not a silent failure.
+
+## See also
+
+- [Agent Sessions and Data Ingest](sessions-and-ingest.md): a different
+  ingestion path, transcript mirroring rather than message channels.
+- [Configuration](../configuration.md): the full environment variable
+  reference.

--- a/docs/guide/knowledge-graph.md
+++ b/docs/guide/knowledge-graph.md
@@ -339,5 +339,7 @@ Overall target: 5+ edges per entity average. Check with `stats()`; if
 - [Prompt Cookbook](prompt-cookbook.md): concrete verb patterns for all the
   operations described here
 - [Search and Retrieval](search.md): how to find things in the graph
+- [Specialized Packs](specialized-packs.md): niche packs, such as the
+  formal-math pack, that extend the base edge ontology additively
 - [AGENTS.md](../../AGENTS.md): the full agent reference with GQL/SPARQL
   examples

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -210,3 +210,5 @@ request(ops="memory.remember(content=\"HANDOFF: Attention benchmark suite is rea
 - [Prompt Cookbook](prompt-cookbook.md): memory verb patterns
 - [GTD Task Management](tasks.md): task lifecycle (often paired with memory
   for context)
+- [Agent Sessions and Data Ingest](sessions-and-ingest.md): a separate,
+  session-scoped persistence model for transcripts and provider mirrors

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -151,11 +151,12 @@ at `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (default 256 MiB).
 
 ### Worked example
 
-Enable Codex mirroring only, then list the mirrored provider labels via
-`session.list` filtered by provider (the mirror writes `source` into the
-`sessions` table, not `properties.provider` on a note, so `session.list`
-filters khive-native `session.store` records, not mirrored rows; the two are
-queried separately today):
+Enable Codex mirroring only. Note that mirroring and the note-based session
+verbs are separate stores today: the mirror writes provider data (including
+`source`) into the private `sessions` table, while `session.list` queries
+khive-native `session.store` records and filters `properties.provider` on
+those notes. `session.list(provider="codex")` therefore does not return
+mirrored rows.
 
 ```bash
 KHIVE_MIRROR_ENABLED=false \

--- a/docs/guide/sessions-and-ingest.md
+++ b/docs/guide/sessions-and-ingest.md
@@ -1,0 +1,181 @@
+# Agent Sessions and Data Ingest
+
+This guide covers the session pack (`crates/khive-pack-session/`), which has
+two independent parts that are easy to conflate but serve different
+purposes:
+
+- **Session verbs** (`session.store`, `session.list`, `session.resume`,
+  `session.export`): explicit, caller-driven persistence of a session record
+  as a khive note.
+- **Provider mirror ingest**: an optional background service that tails
+  agent CLI transcript files and ChatGPT data exports into their own SQL
+  tables, entirely separate from the note substrate.
+
+Do not assume these two share storage. A session stored via `session.store`
+is a `kind=session` note, queryable like any other note. A conversation
+picked up by the mirror service lands in the `sessions` /
+`session_messages` tables and is not a note at all.
+
+## Session verbs
+
+`session.store` persists a session as a note with `kind="session"`. The pack
+declares `NOTE_KINDS = &["session"]` and requires the `kg` pack.
+
+### Store
+
+| Param                 | Type            | Required | Notes                                                      |
+| --------------------- | --------------- | -------- | ---------------------------------------------------------- |
+| `content`             | string          | yes      | Verbatim transcript or summary content. Must not be empty. |
+| `title`               | string          | no       | Stored as the note's `name`.                               |
+| `provider`            | string          | no       | Provider label, e.g. `codex`, `claude_code`, `openai`.     |
+| `provider_session_id` | string          | no       | Provider-native continuity anchor.                         |
+| `tags`                | array of string | no       | Stored in `properties.tags`.                               |
+
+```
+request(ops="session.store(content=\"...\", title=\"PR #610 review session\", provider=\"claude_code\")")
+```
+
+Any string field that is supplied must be non-empty after trimming; an empty
+`content`, or a present-but-blank `title`/`provider`/`provider_session_id`, or
+an empty tag entry, is rejected with a validation error naming the offending
+field.
+
+### List
+
+| Param      | Type    | Required | Notes                                        |
+| ---------- | ------- | -------- | -------------------------------------------- |
+| `limit`    | integer | no       | 1 to 200; default 20.                        |
+| `offset`   | integer | no       | Default 0.                                   |
+| `provider` | string  | no       | Exact match filter on `properties.provider`. |
+
+```
+request(ops="session.list(provider=\"codex\", limit=10)")
+```
+
+Results are ordered newest first and returned as summaries (no `content`
+field) with a `total` count when the underlying store can supply one.
+
+### Resume
+
+Fetches one session's full content, including `content`, by id.
+
+```
+request(ops="session.resume(id=\"<session_id_or_8+char_hex_prefix>\")")
+```
+
+`id` accepts a full UUID or an 8-or-more character hex prefix. A prefix that
+matches no record, an id that resolves to a note of any kind other than
+`session`, or a well-formed id with no matching record all produce distinct
+errors (a resolution error naming the mismatched kind, or a not-found error),
+so a caller can tell "wrong kind of record" apart from "does not exist" apart
+from "malformed id".
+
+### Export
+
+Serializes one stored session as `json` (the default) or `markdown`.
+
+```
+request(ops="session.export(id=\"<session_id>\", format=\"markdown\")")
+```
+
+`format` is validated before id resolution, so an invalid format is rejected
+even if the id itself would not resolve. The markdown form renders a heading
+from the title (or `Session {first 8 chars of id}` if untitled), a metadata
+list (`id`, `provider`, `provider_session_id`, `created_at`, `updated_at`,
+`tags`), and a `## Content` section containing the raw stored content
+verbatim.
+
+## Provider mirror ingest
+
+The mirror service (`crates/khive-pack-session/src/mirror/`) is a background
+task, distinct from the four verbs above, that discovers and tails local
+transcript files and writes their events into three dedicated tables
+(`sessions`, `session_messages`, `session_mirror_cursor`) created by the
+pack's schema plan. It never calls `session.store` and does not create
+`session` notes.
+
+### Supported providers
+
+Only three sources are implemented (`MirrorSource` in `mirror/ingest.rs`):
+
+- **Claude Code CLI transcripts** (`claude_code`): JSONL files under
+  `KHIVE_MIRROR_PROJECTS_DIR`.
+- **Codex CLI transcripts** (`codex`): JSONL files under
+  `KHIVE_MIRROR_CODEX_DIR`.
+- **ChatGPT data exports** (`chatgpt_export`): a `conversations.json` file
+  (the format ChatGPT's "export data" produces) under
+  `KHIVE_MIRROR_CHATGPT_DIR`.
+
+There is no ingest path for claude.ai (the web product) conversation history.
+If a future provider adds that, it belongs here as a fourth `MirrorSource`
+variant, not folded into the existing ChatGPT or Claude Code parsers.
+
+### Enabling it
+
+The mirror service only starts if at least one enable flag is true. This is
+checked once, in the session pack's `warm()` lifecycle hook, and `warm()` is
+only invoked by the persistent daemon's startup path
+(`crates/khive-runtime/src/daemon.rs`), not by a plain stdio client. So, like
+the email channel loops described in
+[Communication and Email](communication.md), running `kkernel mcp --daemon`
+is what actually starts background ingestion; a stdio session never spawns
+its own mirror poller.
+
+| Variable                       | Default                  |
+| ------------------------------ | ------------------------ |
+| `KHIVE_MIRROR_ENABLED`         | `false`                  |
+| `KHIVE_MIRROR_PROJECTS_DIR`    | `$HOME/.claude/projects` |
+| `KHIVE_MIRROR_CODEX_ENABLED`   | `false`                  |
+| `KHIVE_MIRROR_CODEX_DIR`       | `$HOME/.codex/sessions`  |
+| `KHIVE_MIRROR_CHATGPT_ENABLED` | `false`                  |
+| `KHIVE_MIRROR_CHATGPT_DIR`     | `$HOME/.chatgpt/exports` |
+| `KHIVE_MIRROR_POLL_SECS`       | `2`                      |
+| `KHIVE_MIRROR_BACKFILL`        | `true`                   |
+
+`KHIVE_MIRROR_POLL_SECS=0` is rejected (falls back to the default rather than
+busy-looping); a non-numeric value likewise falls back to the default, with a
+warning logged in both cases.
+
+### provider_session_id and idempotency
+
+Each mirrored file is tracked in `session_mirror_cursor` by file path and byte
+offset, so re-running the service resumes tailing from where it left off
+rather than re-reading from the start. Writes into `sessions` and
+`session_messages` are transactional and idempotent (`INSERT OR IGNORE` /
+`ON CONFLICT DO NOTHING` on stable keys), so a crash mid-write or a
+re-processed byte range does not duplicate rows. `provider_session_id`
+values are the mirror's continuity anchor across restarts. Reads are bounded
+in size (a byte/line/event cap per read) so a single oversized file cannot
+stall the tailer; the ChatGPT export path additionally caps the whole file
+at `KHIVE_MIRROR_CHATGPT_MAX_BYTES` (default 256 MiB).
+
+### Worked example
+
+Enable Codex mirroring only, then list the mirrored provider labels via
+`session.list` filtered by provider (the mirror writes `source` into the
+`sessions` table, not `properties.provider` on a note, so `session.list`
+filters khive-native `session.store` records, not mirrored rows; the two are
+queried separately today):
+
+```bash
+KHIVE_MIRROR_ENABLED=false \
+KHIVE_MIRROR_CODEX_ENABLED=true \
+KHIVE_MIRROR_CODEX_DIR="$HOME/.codex/sessions" \
+kkernel mcp --daemon
+```
+
+To store a manual session summary through the note-based verbs instead
+(unaffected by any mirror configuration):
+
+```
+request(ops="session.store(content=\"Reviewed PR #610, confirmed daemon-only gating\", title=\"PR 610 review\", provider=\"claude_code\")")
+request(ops="session.list(provider=\"claude_code\", limit=5)")
+```
+
+## See also
+
+- [Communication and Email](communication.md): the other daemon-only
+  background loop (email channel polling), and the same warm-hook /
+  daemon-role pattern.
+- [Specialized Packs](specialized-packs.md): packs beyond the eight loaded
+  by default.

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -1,0 +1,94 @@
+# Specialized Packs
+
+khive's default install loads eight production packs
+(`kg, gtd, memory, brain, comm, schedule, knowledge, session`, per
+`RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Beyond
+these, khive ships niche packs that extend the graph for a specific domain
+without adding verbs of their own. This guide covers the formal-math pack,
+the first of these, and how pack loading works in general.
+
+## Pack composition model
+
+Every pack implements the `Pack` trait (`crates/khive-types/`) and declares,
+additively, what it contributes: note kinds, entity kinds, verb handlers,
+and edge endpoint rules. A pack can declare zero verbs and still be useful,
+contributing purely to the edge ontology. Packs declare a `REQUIRES` list of
+other packs that must already be loaded; the runtime resolves this at
+startup. See [ADR-017](../adr/ADR-017-pack-standard.md) for the full
+standard, including how pack-declared edge endpoint rules combine with the
+base ADR-002 contract: rules are additive only, never tightening what the
+base contract already allows.
+
+### Loading a pack
+
+Packs are selected via the `--pack` CLI flag (repeatable) or the
+`KHIVE_PACKS` environment variable (comma- or whitespace-separated):
+
+```bash
+kkernel mcp --pack kg --pack gtd --pack formal
+# or
+KHIVE_PACKS="kg,gtd,formal" kkernel mcp
+```
+
+`formal` declares `REQUIRES = &["kg"]`, so `kg` must also be in the load set.
+
+## The formal pack
+
+`crates/khive-pack-formal/` is a pure ontology extension for formal
+mathematics, targeting Lean-style proof developments, built around six
+concept subtypes: `theorem`, `definition`, `structure`, `instance`, `axiom`,
+and `goal`. It is not part of the default pack set; opt in explicitly.
+
+### What it contributes
+
+`FormalPack` declares:
+
+- `NOTE_KINDS = &[]`, `ENTITY_KINDS = &[]`, `HANDLERS = &[]`: no new note
+  kinds, entity kinds, or verbs.
+- `EDGE_RULES = &FORMAL_EDGE_RULES`: 21 additive edge endpoint rules.
+
+Every rule is expressed via `EndpointKind::EntityOfType { kind: "concept",
+entity_type: <subtype> }`: all six subtypes are `concept` entities
+distinguished by their `entity_type` property, not by a new `EntityKind`
+variant. Because `dispatch()` unconditionally returns an error naming the
+verb, loading `formal` cannot be used to call any verb. Its only effect is
+widening which typed edges the graph accepts.
+
+### Endpoint rules by relation
+
+| Relation      | Rule count | Pairs                                                                                                                                                                                           |
+| ------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `depends_on`  | 14         | theorem to {theorem, definition, structure, axiom}; definition to {definition, structure, theorem, axiom}; instance to {structure, definition}; goal to {theorem, definition, structure, axiom} |
+| `instance_of` | 1          | instance to structure                                                                                                                                                                           |
+| `extends`     | 2          | structure to structure; definition to definition                                                                                                                                                |
+| `variant_of`  | 4          | theorem to theorem; definition to definition; goal to theorem; goal to definition                                                                                                               |
+
+`depends_on` models the prerequisite chain, so the source uses or builds on a
+target: a theorem may depend on other theorems, definitions, structures, or
+axioms it invokes, and a `goal` (an unproved target) may depend on the same
+four subtypes it will eventually need. `instance_of` models an instance
+implementing a structure. `extends` models structural or definitional
+inheritance. `variant_of` models a restatement, including a `goal` framed as
+a variant of an existing theorem or definition, which is useful as an
+anti-duplicate signal when the same result is proposed as a fresh goal.
+
+### Example
+
+```
+request(ops="create(kind=\"concept\", name=\"Cauchy-Schwarz\", properties={\"entity_type\": \"theorem\"})")
+request(ops="create(kind=\"concept\", name=\"Inner product space\", properties={\"entity_type\": \"structure\"})")
+request(ops="link(source_id=\"<theorem_id>\", target_id=\"<structure_id>\", relation=\"depends_on\")")
+```
+
+With only `kg` loaded (no `formal`), the same `link` call is rejected. The
+base ADR-002 contract does not admit a `concept`-to-`concept` `depends_on`
+edge between two arbitrary subtypes on its own; the `formal` pack's rules
+are what makes this specific `(theorem, depends_on, structure)` triple legal.
+
+## See also
+
+- [Knowledge Graph Modeling](knowledge-graph.md): the base entity kind and
+  edge relation taxonomy that specialized packs extend.
+- [Agent Sessions and Data Ingest](sessions-and-ingest.md): another optional
+  pack (`session`), included in the default set but with its own opt-in
+  background service.


### PR DESCRIPTION
## Summary

Adds three new `docs/guide/` pages, source-grounded against `crates/**` (never CLI --help, README summaries, or training data), plus the required `NAV_ORDER` entries in `.github/workflows/pages.yml` (ADR-090 §3).

- **communication.md**: comm pack verbs (`send`/`inbox`/`read`/`reply`/`thread`), actor addressing (ADR-057), and the optional email channel: `KHIVE_EMAIL_*` config surface, `to="email:..."` addressing with explicit `subject=`, outbox/inbound mechanics, the daemon-only channel-loop gate (issue #602, exact log lines), and confirmation that `channel-email` is an opt-in Cargo feature (not in `make build`/CI, only `make local`).
- **sessions-and-ingest.md**: session pack verbs (`session.store`/`list`/`resume`/`export`) and the separate provider mirror ingest service, clearly distinguished (notes vs. raw SQL tables). Documents only the providers that actually exist in source: Claude Code CLI transcripts, Codex CLI transcripts, and ChatGPT data exports. **Capability gap called out explicitly: there is no claude.ai (web product) ingest path in source.**
- **specialized-packs.md**: pack composition model (ADR-017) and the formal-math pack (`crates/khive-pack-formal/`): six concept subtypes, 21 additive edge endpoint rules by relation, with a worked example.

NAV_ORDER: `communication=7`, `sessions-and-ingest=8`, `specialized-packs=9`; renumbered `prompt-cookbook/tips-and-tricks/proof-graph-case-study/api-reference` to `10/11/12/13` (API Reference stays last, all numbers unique).

Cross-linked the new pages from each other and added natural "See also" links from `knowledge-graph.md` and `memory.md`.

Docs-only change: no Rust source touched.

## Source grounding (per page)

- **communication.md**: `crates/khive-pack-comm/src/vocab.rs`, `handlers.rs`, `params.rs`; `crates/khive-channel/src/lib.rs`; `crates/khive-channel-email/src/config.rs`; `crates/khive-mcp/src/serve.rs` (daemon-role gating, log lines, outbox/poll loop bodies); `crates/khive-mcp/Cargo.toml`; `Makefile`; `.github/workflows/*.yml`.
- **sessions-and-ingest.md**: `crates/khive-pack-session/src/vocab.rs`, `pack.rs`, `handlers/mod.rs`, `handlers/store.rs`, `handlers/list.rs`, `handlers/resume.rs`, `handlers/export.rs`, `mirror/mod.rs`, `mirror/parse.rs`, `mirror/ingest.rs`, `mirror/service.rs`; `crates/khive-runtime/src/daemon.rs` (confirms `warm()`/mirror service only starts under the daemon listener path).
- **specialized-packs.md**: `crates/khive-pack-formal/src/vocab.rs`, `pack.rs`, `lib.rs`; `crates/khive-mcp/src/args.rs` and `crates/khive-runtime/src/config.rs` (cross-checked to find the authoritative default pack list, since `args.rs`'s docstring is stale and omits `session`).

## Test plan

- [x] `deno fmt --check` passes (pre-commit hook green) on all new/edited files
- [x] Zero em dashes in every new/edited line (`grep -c "—"` = 0 across all touched files; confirmed against the actual diff, not just the file)
- [x] Relative links verified to resolve (`docs/adr/ADR-017-pack-standard.md`, `docs/configuration.md`, sibling `docs/guide/*.md` pages all exist)
- [x] NAV_ORDER numbers are unique and API Reference stays last
- [ ] CI (pages build, doc-link checks) — pending on this PR