### PR TITLE
fix(channel-email): per-credential IMAP single-flight + jittered exponential backoff (#605)

### DIFF
--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -28,6 +28,7 @@ mail-parser = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-channel-email/src/backoff.rs
+++ b/crates/khive-channel-email/src/backoff.rs
@@ -18,12 +18,17 @@ use rand::Rng;
 pub const DEFAULT_BASE: Duration = Duration::from_secs(5);
 
 /// Default cap: backoff never waits longer than this between attempts.
+/// This is a hard ceiling on `BackoffTick::delay` too -- jitter is clamped
+/// so the post-jitter sleep can never exceed `max` (see
+/// [`ImapBackoff::record_failure`]).
 pub const DEFAULT_MAX: Duration = Duration::from_secs(600);
 
 /// Outcome of recording one backoff-eligible failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackoffTick {
     /// The jittered delay the caller should sleep before the next attempt.
+    /// Always `<= max` (jitter is clamped, never allowed to push the sleep
+    /// past the configured cap).
     pub delay: Duration,
     /// The unjittered step this attempt landed on (used to detect escalation
     /// edges; stable across jitter so it never flaps the `should_warn` bit).
@@ -98,13 +103,20 @@ impl ImapBackoff {
     /// Advances the attempt counter, computes the next capped exponential
     /// step, and returns a [`BackoffTick`] carrying the jittered delay to
     /// sleep plus whether this is a new escalation edge worth a `warn!` log.
+    ///
+    /// The jittered `delay` is clamped to `max` (codex round-1 finding
+    /// 2026-07-04): jitter is additive noise on top of `step`, but `step`
+    /// itself can already equal `max` once escalation saturates, so an
+    /// unclamped `step + jitter` would let a "~10min cap" reach 750s at the
+    /// default 25% jitter window. Clamping here keeps `delay <= max` as a
+    /// hard invariant regardless of where jitter lands.
     pub fn record_failure(&mut self) -> BackoffTick {
         self.attempt = self.attempt.saturating_add(1);
         let step = self.step_for(self.attempt);
         let should_warn = self.last_step != Some(step);
         self.last_step = Some(step);
         BackoffTick {
-            delay: jitter(step),
+            delay: jitter(step).min(self.max),
             step,
             attempt: self.attempt,
             should_warn,
@@ -225,13 +237,39 @@ mod tests {
 
     #[test]
     fn caps_at_max_and_never_exceeds_it() {
-        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(600));
+        let max = Duration::from_secs(600);
+        let mut b = ImapBackoff::new(Duration::from_secs(5), max);
         for _ in 0..50 {
             let tick = b.record_failure();
-            assert!(tick.step <= Duration::from_secs(600));
-            // Jittered delay must never exceed step by more than the 25% window.
-            assert!(tick.delay >= tick.step);
-            assert!(tick.delay <= tick.step + tick.step / 4 + Duration::from_millis(1));
+            assert!(tick.step <= max);
+            assert!(tick.delay >= tick.step.min(max));
+            // Codex round-1 finding: the post-jitter delay must never exceed
+            // `max`, even once `step` itself has saturated at `max` (an
+            // unclamped 25% jitter window on a capped 600s step would reach
+            // 750s otherwise).
+            assert!(
+                tick.delay <= max,
+                "post-jitter delay {:?} exceeded the {max:?} cap",
+                tick.delay
+            );
+        }
+    }
+
+    #[test]
+    fn default_config_jittered_delay_never_exceeds_default_max() {
+        // Explicitly drive the DEFAULT_BASE/DEFAULT_MAX config to the cap and
+        // assert both the unjittered step and the jittered delay respect
+        // DEFAULT_MAX -- the exact scenario codex flagged (750s > 600s cap).
+        let mut b = ImapBackoff::default();
+        for _ in 0..20 {
+            let tick = b.record_failure();
+            assert!(tick.step <= DEFAULT_MAX);
+            assert!(
+                tick.delay <= DEFAULT_MAX,
+                "post-jitter delay {:?} exceeded DEFAULT_MAX {:?}",
+                tick.delay,
+                DEFAULT_MAX
+            );
         }
     }
 

--- a/crates/khive-channel-email/src/backoff.rs
+++ b/crates/khive-channel-email/src/backoff.rs
@@ -1,0 +1,373 @@
+//! Per-credential IMAP guardrail: single-flight connection cap + jittered
+//! exponential backoff on connect/auth failure (#605).
+//!
+//! The 2026-07-04 inbound-email outage (#602) was amplified by the poll
+//! loop's flat ~5s retry cadence with no per-credential concurrency cap:
+//! nine concurrent pollers on `leo@khive.ai` exhausted Exchange Online's
+//! per-mailbox connection slots, and the flat retry hammer kept the slots
+//! saturated for ~19h. `#602`/`#610` fixed the multi-process spawn that
+//! caused the concurrency; the types here make the channel degrade
+//! gracefully if polling pressure ever returns.
+
+use std::time::Duration;
+
+use khive_channel::ChannelError;
+use rand::Rng;
+
+/// Default base delay: the first backoff step after a single failure.
+pub const DEFAULT_BASE: Duration = Duration::from_secs(5);
+
+/// Default cap: backoff never waits longer than this between attempts.
+pub const DEFAULT_MAX: Duration = Duration::from_secs(600);
+
+/// Outcome of recording one backoff-eligible failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackoffTick {
+    /// The jittered delay the caller should sleep before the next attempt.
+    pub delay: Duration,
+    /// The unjittered step this attempt landed on (used to detect escalation
+    /// edges; stable across jitter so it never flaps the `should_warn` bit).
+    pub step: Duration,
+    /// 1-based count of consecutive failures since the last success.
+    pub attempt: u32,
+    /// `true` exactly when `step` differs from the step logged on the
+    /// previous failure -- i.e. an escalation edge, per ADR-091's
+    /// `crossing_warn` discipline (log on crossing, not on every tick).
+    /// Once the delay saturates at `max`, subsequent failures keep the same
+    /// step and this goes `false`, so sustained pressure logs once per
+    /// escalation, not once per retry.
+    pub should_warn: bool,
+}
+
+/// Per-credential exponential backoff state, jittered, capped, with reset on
+/// success.
+///
+/// One instance is owned per credential (in production, one per
+/// `ImapBackoff`-keyed channel poll target); state is never shared across
+/// credentials, so one mailbox's failures never throttle another's cadence.
+#[derive(Debug, Clone)]
+pub struct ImapBackoff {
+    base: Duration,
+    max: Duration,
+    attempt: u32,
+    last_step: Option<Duration>,
+}
+
+impl Default for ImapBackoff {
+    fn default() -> Self {
+        Self::new(DEFAULT_BASE, DEFAULT_MAX)
+    }
+}
+
+impl ImapBackoff {
+    /// Build a backoff with an explicit base delay and cap.
+    ///
+    /// `base` is the first step (attempt 1); each subsequent attempt doubles
+    /// the previous step, clamped to `max`.
+    pub fn new(base: Duration, max: Duration) -> Self {
+        Self {
+            base,
+            max,
+            attempt: 0,
+            last_step: None,
+        }
+    }
+
+    /// Current consecutive-failure count (0 when healthy or freshly reset).
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    /// The unjittered capped exponential step for a given 1-based attempt
+    /// count: `base * 2^(attempt-1)`, clamped to `max`. Attempt 0 yields
+    /// `Duration::ZERO` (no failure recorded yet).
+    fn step_for(&self, attempt: u32) -> Duration {
+        if attempt == 0 {
+            return Duration::ZERO;
+        }
+        let shift = attempt.saturating_sub(1).min(32);
+        let multiplier = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+        let base_ms = self.base.as_millis().min(u128::from(u64::MAX)) as u64;
+        let scaled_ms = base_ms.saturating_mul(multiplier);
+        let max_ms = self.max.as_millis().min(u128::from(u64::MAX)) as u64;
+        Duration::from_millis(scaled_ms.min(max_ms))
+    }
+
+    /// Record one backoff-eligible failure (see [`is_backoff_eligible`]).
+    ///
+    /// Advances the attempt counter, computes the next capped exponential
+    /// step, and returns a [`BackoffTick`] carrying the jittered delay to
+    /// sleep plus whether this is a new escalation edge worth a `warn!` log.
+    pub fn record_failure(&mut self) -> BackoffTick {
+        self.attempt = self.attempt.saturating_add(1);
+        let step = self.step_for(self.attempt);
+        let should_warn = self.last_step != Some(step);
+        self.last_step = Some(step);
+        BackoffTick {
+            delay: jitter(step),
+            step,
+            attempt: self.attempt,
+            should_warn,
+        }
+    }
+
+    /// Record a success: reset the attempt counter and escalation state so
+    /// the next failure (if any) starts back at `base`.
+    pub fn record_success(&mut self) {
+        self.attempt = 0;
+        self.last_step = None;
+    }
+}
+
+/// Add additive jitter to `step`, up to 25% of its value.
+///
+/// Additive (never subtractive) so the caller-visible delay is always at
+/// least the unjittered step -- callers relying on `step` as the escalation
+/// floor (e.g. the ~10min cap) are never surprised by a shorter sleep.
+fn jitter(step: Duration) -> Duration {
+    if step.is_zero() {
+        return step;
+    }
+    let ms = step.as_millis().min(u128::from(u64::MAX)) as u64;
+    let jitter_max = (ms / 4).max(1);
+    let jitter_ms = rand::thread_rng().gen_range(0..=jitter_max);
+    Duration::from_millis(ms + jitter_ms)
+}
+
+/// Classify whether a [`ChannelError`] from an IMAP poll represents
+/// connect/auth pressure that should back off, versus a failure that should
+/// keep the normal poll cadence.
+///
+/// Grounded in the actual errors `crates/khive-channel-email`'s IMAP
+/// connect/auth flow produces (see `connector/imap.rs::LiveImap::connect`
+/// and `fetch_since`):
+///
+/// - [`ChannelError::Auth`] -- TLS handshake, `LOGIN`, and `XOAUTH2`
+///   failures. This is exactly the credential/slot-exhaustion class from the
+///   2026-07-04 outage ("User is authenticated but not connected" surfaces
+///   here when Exchange rejects the handshake outright).
+/// - [`ChannelError::Transport`] -- TCP connect, greeting read, `SELECT`,
+///   `UID SEARCH`, and `UID FETCH` failures. Exchange's connection-slot
+///   exhaustion can also surface here (a post-login command failing because
+///   the mailbox has no free slot), so this class backs off too.
+///
+/// Not backoff-eligible:
+///
+/// - [`ChannelError::Config`] -- static misconfiguration; backing off would
+///   only delay an operator noticing and fixing it faster.
+/// - [`ChannelError::UnauthorizedSender`] -- a per-message attribution gate
+///   failure, not a connectivity failure; never produced by `poll`/`connect`.
+/// - [`ChannelError::InvalidEnvelope`] -- malformed data, not connectivity;
+///   never produced by `poll`/`connect`.
+pub fn is_backoff_eligible(err: &ChannelError) -> bool {
+    matches!(err, ChannelError::Auth(_) | ChannelError::Transport(_))
+}
+
+/// Per-credential single-flight guard: at most one concurrent IMAP
+/// connection attempt proceeds for a given credential. A second concurrent
+/// acquisition waits for the first to finish rather than opening a second
+/// connection.
+///
+/// Backed by a bounded semaphore of size 1 -- the ONLY way to widen the cap
+/// later is to raise the semaphore's permit count, never to bypass it.
+#[derive(Clone)]
+pub struct ImapSingleFlight {
+    sem: std::sync::Arc<tokio::sync::Semaphore>,
+}
+
+impl Default for ImapSingleFlight {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImapSingleFlight {
+    /// Build a new single-flight guard with exactly one permit.
+    pub fn new() -> Self {
+        Self {
+            sem: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        }
+    }
+
+    /// Acquire the single in-flight slot, waiting if another connection
+    /// attempt for this credential is already in progress. The returned
+    /// permit releases the slot when dropped.
+    pub async fn acquire(&self) -> tokio::sync::OwnedSemaphorePermit {
+        std::sync::Arc::clone(&self.sem)
+            .acquire_owned()
+            .await
+            .expect("ImapSingleFlight semaphore is never closed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- ImapBackoff: escalation, cap, reset ---
+
+    #[test]
+    fn escalates_5_10_20_40_80_160_320_capped_at_600() {
+        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(600));
+        let expected_steps = [5u64, 10, 20, 40, 80, 160, 320, 600, 600, 600];
+        for (i, &secs) in expected_steps.iter().enumerate() {
+            let tick = b.record_failure();
+            assert_eq!(
+                tick.step,
+                Duration::from_secs(secs),
+                "attempt {} (index {i}) expected step {secs}s, got {:?}",
+                tick.attempt,
+                tick.step
+            );
+            assert_eq!(tick.attempt, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn caps_at_max_and_never_exceeds_it() {
+        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(600));
+        for _ in 0..50 {
+            let tick = b.record_failure();
+            assert!(tick.step <= Duration::from_secs(600));
+            // Jittered delay must never exceed step by more than the 25% window.
+            assert!(tick.delay >= tick.step);
+            assert!(tick.delay <= tick.step + tick.step / 4 + Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn resets_to_base_on_success() {
+        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(600));
+        for _ in 0..5 {
+            b.record_failure();
+        }
+        assert!(b.attempt() > 0);
+        b.record_success();
+        assert_eq!(b.attempt(), 0);
+
+        let tick = b.record_failure();
+        assert_eq!(
+            tick.step,
+            Duration::from_secs(5),
+            "first failure after a success must restart at base, not resume escalation"
+        );
+        assert_eq!(tick.attempt, 1);
+    }
+
+    #[test]
+    fn should_warn_true_on_every_new_step_false_once_capped() {
+        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(20));
+        // step sequence: 5 (new), 10 (new), 20 (new, = cap), 20 (repeat, capped), 20 (repeat)
+        let expected_warn = [true, true, true, false, false];
+        for &want_warn in &expected_warn {
+            let tick = b.record_failure();
+            assert_eq!(
+                tick.should_warn, want_warn,
+                "attempt {}: step={:?}",
+                tick.attempt, tick.step
+            );
+        }
+    }
+
+    #[test]
+    fn should_warn_resets_after_success_then_new_failure() {
+        let mut b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(20));
+        assert!(b.record_failure().should_warn); // 5s, new
+        assert!(b.record_failure().should_warn); // 10s, new
+        assert!(b.record_failure().should_warn); // 20s, new (clamped to cap)
+        assert!(!b.record_failure().should_warn); // 20s, repeat at cap -> no re-log
+        b.record_success();
+        let tick = b.record_failure();
+        assert!(
+            tick.should_warn,
+            "escalation edge must re-arm after a success resets state"
+        );
+        assert_eq!(tick.step, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn attempt_zero_before_any_failure() {
+        let b = ImapBackoff::new(Duration::from_secs(5), Duration::from_secs(600));
+        assert_eq!(b.attempt(), 0);
+    }
+
+    #[test]
+    fn custom_base_and_max_respected() {
+        let mut b = ImapBackoff::new(Duration::from_millis(100), Duration::from_millis(300));
+        assert_eq!(b.record_failure().step, Duration::from_millis(100));
+        assert_eq!(b.record_failure().step, Duration::from_millis(200));
+        assert_eq!(b.record_failure().step, Duration::from_millis(300));
+        assert_eq!(b.record_failure().step, Duration::from_millis(300));
+    }
+
+    // --- is_backoff_eligible classification ---
+
+    #[test]
+    fn auth_and_transport_are_backoff_eligible() {
+        assert!(is_backoff_eligible(&ChannelError::Auth("x".into())));
+        assert!(is_backoff_eligible(&ChannelError::Transport("x".into())));
+    }
+
+    #[test]
+    fn config_unauthorized_invalid_envelope_are_not_backoff_eligible() {
+        assert!(!is_backoff_eligible(&ChannelError::Config("x".into())));
+        assert!(!is_backoff_eligible(&ChannelError::UnauthorizedSender(
+            "x".into()
+        )));
+        assert!(!is_backoff_eligible(&ChannelError::InvalidEnvelope(
+            "x".into()
+        )));
+    }
+
+    // --- ImapSingleFlight: single-flight enforcement ---
+
+    #[tokio::test]
+    async fn second_acquisition_waits_for_first_to_release() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let guard = ImapSingleFlight::new();
+        let order: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let guard1 = guard.clone();
+        let order1 = order.clone();
+        let first = tokio::spawn(async move {
+            let _permit = guard1.acquire().await;
+            order1.lock().await.push("first-acquired");
+            // Hold the slot long enough that a concurrent acquire is
+            // observably still pending while this task runs.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            order1.lock().await.push("first-released");
+        });
+
+        // Give the first task a head start so it holds the permit first.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let guard2 = guard.clone();
+        let order2 = order.clone();
+        let second = tokio::spawn(async move {
+            let _permit = guard2.acquire().await;
+            order2.lock().await.push("second-acquired");
+        });
+
+        first.await.unwrap();
+        second.await.unwrap();
+
+        let log = order.lock().await;
+        assert_eq!(
+            log.as_slice(),
+            ["first-acquired", "first-released", "second-acquired"],
+            "the second acquisition must not proceed until the first releases its permit"
+        );
+    }
+
+    #[tokio::test]
+    async fn only_one_permit_outstanding_at_a_time() {
+        let guard = ImapSingleFlight::new();
+        assert_eq!(guard.sem.available_permits(), 1);
+        let permit = guard.acquire().await;
+        assert_eq!(guard.sem.available_permits(), 0);
+        drop(permit);
+        assert_eq!(guard.sem.available_permits(), 1);
+    }
+}

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -16,6 +16,7 @@ use mail_parser::MessageParser;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::instrument;
 
+use crate::backoff::ImapSingleFlight;
 use crate::oauth::{TokenProvider, XOAuth2Authenticator};
 
 use super::RawEmail;
@@ -54,6 +55,10 @@ pub(crate) struct LiveImap {
     host: String,
     port: u16,
     auth: ImapAuthConfig,
+    /// Per-credential single-flight guard (#605): at most one concurrent
+    /// connection attempt for this `LiveImap` (i.e. this credential) proceeds;
+    /// a bounded semaphore is the only way to widen the cap later.
+    single_flight: ImapSingleFlight,
 }
 
 impl LiveImap {
@@ -71,6 +76,7 @@ impl LiveImap {
                 username: username.into(),
                 password: password.into(),
             },
+            single_flight: ImapSingleFlight::new(),
         }
     }
 
@@ -93,6 +99,7 @@ impl LiveImap {
                 mailbox: mailbox.into(),
                 token_provider,
             },
+            single_flight: ImapSingleFlight::new(),
         }
     }
 
@@ -190,6 +197,12 @@ impl ImapConnector for LiveImap {
         since: DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<RawEmail>, ChannelError> {
+        // Single-flight (#605): hold this credential's one permit for the
+        // full connect-through-logout lifecycle below, so a second concurrent
+        // call (e.g. a future caller widening the poll loop's concurrency)
+        // waits for this connection to finish instead of opening a second one
+        // against the same mailbox.
+        let _permit = self.single_flight.acquire().await;
         let mut session = self.connect().await?;
 
         // SELECT returns the Mailbox struct; uid_validity is the UIDVALIDITY value needed

--- a/crates/khive-channel-email/src/lib.rs
+++ b/crates/khive-channel-email/src/lib.rs
@@ -35,10 +35,12 @@
 //! | `KHIVE_EMAIL_INGEST_NAMESPACE` | `local` | Namespace used when persisting inbound and outbound messages |
 
 pub(crate) mod auth_results;
+pub mod backoff;
 pub mod channel;
 pub mod config;
 pub mod connector;
 pub(crate) mod oauth;
 
+pub use backoff::{is_backoff_eligible, BackoffTick, ImapBackoff, ImapSingleFlight};
 pub use channel::EmailChannel;
 pub use config::EmailChannelConfig;

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -267,6 +267,14 @@ fn preflight_ingest_namespace(ns_str: &str, registry: &khive_runtime::VerbRegist
 /// Background task that polls all registered channels every 5 seconds and
 /// ingests new inbound messages via `comm.ingest`.
 ///
+/// #605: the 5s cadence is the happy-path default only. A connect/auth
+/// failure (classified by `khive_channel_email::is_backoff_eligible`) starts
+/// a per-channel-kind jittered exponential backoff (`ImapBackoff`,
+/// 5s -> 10s -> ... capped at ~10min) instead of retrying flat every 5s; a
+/// success resets that channel's backoff to base, and the loop returns to
+/// the normal 5s cadence. This is process-side pressure relief on top of the
+/// per-credential single-flight guard inside `LiveImap` itself.
+///
 /// Only compiled when the `channel-email` feature is enabled.
 #[cfg(feature = "channel-email")]
 async fn channel_poll_loop(
@@ -276,12 +284,23 @@ async fn channel_poll_loop(
     default_inbound_actor: String,
 ) {
     use chrono::Utc;
+    use khive_channel_email::{is_backoff_eligible, ImapBackoff};
     use serde_json::json;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    const HAPPY_PATH_INTERVAL: Duration = Duration::from_secs(5);
 
     let mut last_poll = Utc::now();
+    // One backoff state per channel kind, i.e. per credential — a given
+    // channel kind (e.g. "email") maps to exactly one configured credential
+    // in this process, so failures on one credential never throttle another.
+    let mut backoffs: HashMap<String, ImapBackoff> = HashMap::new();
+    let mut next_interval = HAPPY_PATH_INTERVAL;
 
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(next_interval).await;
+        next_interval = HAPPY_PATH_INTERVAL;
 
         let since = last_poll;
         last_poll = Utc::now();
@@ -289,6 +308,9 @@ async fn channel_poll_loop(
         for (kind, channel) in channels.iter() {
             match channel.poll(since).await {
                 Ok(envelopes) => {
+                    if let Some(backoff) = backoffs.get_mut(kind) {
+                        backoff.record_success();
+                    }
                     for env in envelopes {
                         let params = json!({
                             "namespace": ingest_namespace,
@@ -315,6 +337,19 @@ async fn channel_poll_loop(
                 }
                 Err(e) => {
                     tracing::warn!(channel = kind, "channel poll failed: {e}");
+                    if is_backoff_eligible(&e) {
+                        let backoff = backoffs.entry(kind.to_string()).or_default();
+                        let tick = backoff.record_failure();
+                        if tick.should_warn {
+                            tracing::warn!(
+                                channel = kind,
+                                attempt = tick.attempt,
+                                delay_secs = tick.delay.as_secs_f64(),
+                                "IMAP poll backoff escalating after connect/auth failure"
+                            );
+                        }
+                        next_interval = next_interval.max(tick.delay);
+                    }
                 }
             }
         }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -273,7 +273,10 @@ fn preflight_ingest_namespace(ns_str: &str, registry: &khive_runtime::VerbRegist
 /// 5s -> 10s -> ... capped at ~10min) instead of retrying flat every 5s; a
 /// success resets that channel's backoff to base, and the loop returns to
 /// the normal 5s cadence. This is process-side pressure relief on top of the
-/// per-credential single-flight guard inside `LiveImap` itself.
+/// per-credential single-flight guard inside `LiveImap` itself. Eligible
+/// failures log via [`log_eligible_poll_failure`]: `warn!` only on an
+/// escalation edge, `debug!` while riding the same capped step — never one
+/// `warn!` per retry.
 ///
 /// Only compiled when the `channel-email` feature is enabled.
 #[cfg(feature = "channel-email")]
@@ -336,23 +339,53 @@ async fn channel_poll_loop(
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(channel = kind, "channel poll failed: {e}");
                     if is_backoff_eligible(&e) {
                         let backoff = backoffs.entry(kind.to_string()).or_default();
                         let tick = backoff.record_failure();
-                        if tick.should_warn {
-                            tracing::warn!(
-                                channel = kind,
-                                attempt = tick.attempt,
-                                delay_secs = tick.delay.as_secs_f64(),
-                                "IMAP poll backoff escalating after connect/auth failure"
-                            );
-                        }
+                        log_eligible_poll_failure(kind, &e, &tick);
                         next_interval = next_interval.max(tick.delay);
+                    } else {
+                        // Non-eligible failures (config/gate errors, never
+                        // produced by poll/connect in practice) are not
+                        // connectivity pressure, so they keep the pre-#605
+                        // warn-every-retry behavior at the normal cadence.
+                        tracing::warn!(channel = kind, "channel poll failed: {e}");
                     }
                 }
             }
         }
+    }
+}
+
+/// Log a backoff-eligible poll failure at the level ADR-091's `crossing_warn`
+/// discipline calls for: `warn!` only on an escalation edge
+/// (`tick.should_warn`, i.e. the computed step just changed), `debug!` on a
+/// repeat at the same step. Codex round-1 finding (2026-07-04): the poll loop
+/// previously emitted a generic `warn!` on every eligible retry in addition
+/// to the escalation-edge warn, so sustained pressure spammed warn-level logs
+/// once per retry instead of once per escalation. Extracted to a standalone
+/// function so the level decision is unit-testable without driving the full
+/// poll loop.
+#[cfg(feature = "channel-email")]
+fn log_eligible_poll_failure(
+    kind: &str,
+    err: &khive_channel::ChannelError,
+    tick: &khive_channel_email::BackoffTick,
+) {
+    if tick.should_warn {
+        tracing::warn!(
+            channel = kind,
+            attempt = tick.attempt,
+            delay_secs = tick.delay.as_secs_f64(),
+            "IMAP poll backoff escalating after connect/auth failure: {err}"
+        );
+    } else {
+        tracing::debug!(
+            channel = kind,
+            attempt = tick.attempt,
+            delay_secs = tick.delay.as_secs_f64(),
+            "channel poll failed, holding at current backoff step: {err}"
+        );
     }
 }
 
@@ -2921,6 +2954,186 @@ brain_profile = "project-profile"
             assert_eq!(
                 spawn_count, 0,
                 "spawn must not be called when namespace is invalid"
+            );
+        }
+    }
+
+    // --- log_eligible_poll_failure: edge-triggered warn (codex round-1 finding 2) ---
+
+    #[cfg(feature = "channel-email")]
+    mod eligible_poll_failure_log_tests {
+        use super::*;
+        use khive_channel::ChannelError;
+        use khive_channel_email::BackoffTick;
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+        use tracing::field::{Field, Visit};
+
+        #[derive(Clone, Debug, Default)]
+        struct CapturedEvent {
+            level: Option<tracing::Level>,
+            message: Option<String>,
+        }
+
+        #[derive(Default)]
+        struct CapturedEventVisitor(Option<String>);
+
+        impl Visit for CapturedEventVisitor {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.0 = Some(value.to_string());
+                }
+            }
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    let formatted = format!("{value:?}");
+                    self.0 = Some(
+                        formatted
+                            .trim_start_matches('"')
+                            .trim_end_matches('"')
+                            .to_string(),
+                    );
+                }
+            }
+        }
+
+        /// Minimal `tracing::Subscriber` capturing (level, message) pairs into
+        /// a thread-local vec, installed via `tracing::subscriber::with_default`.
+        /// Mirrors `khive-db/src/checkpoint.rs`'s `CaptureSubscriber` (same
+        /// ADR-091 `crossing_warn` test discipline: prove the log fires on
+        /// the escalation edge and stays silent on a same-step repeat).
+        struct CaptureSubscriber {
+            events: Arc<Mutex<Vec<CapturedEvent>>>,
+        }
+
+        impl tracing::Subscriber for CaptureSubscriber {
+            fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+                tracing::span::Id::from_u64(1)
+            }
+            fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+            fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+            fn event(&self, event: &tracing::Event<'_>) {
+                let mut visitor = CapturedEventVisitor::default();
+                event.record(&mut visitor);
+                self.events.lock().unwrap().push(CapturedEvent {
+                    level: Some(*event.metadata().level()),
+                    message: visitor.0,
+                });
+            }
+            fn enter(&self, _: &tracing::span::Id) {}
+            fn exit(&self, _: &tracing::span::Id) {}
+        }
+
+        fn tick(should_warn: bool, attempt: u32) -> BackoffTick {
+            BackoffTick {
+                delay: Duration::from_secs(10),
+                step: Duration::from_secs(10),
+                attempt,
+                should_warn,
+            }
+        }
+
+        #[test]
+        fn escalation_edge_logs_warn_not_debug() {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = CaptureSubscriber {
+                events: Arc::clone(&buffer),
+            };
+            let err = ChannelError::Transport("boom".into());
+
+            tracing::subscriber::with_default(subscriber, || {
+                log_eligible_poll_failure("email", &err, &tick(true, 1));
+            });
+
+            let events = buffer.lock().unwrap();
+            assert_eq!(
+                events.len(),
+                1,
+                "expected exactly one log event, got {events:?}"
+            );
+            assert_eq!(events[0].level, Some(tracing::Level::WARN));
+        }
+
+        #[test]
+        fn same_step_repeat_logs_debug_not_warn() {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = CaptureSubscriber {
+                events: Arc::clone(&buffer),
+            };
+            let err = ChannelError::Transport("boom".into());
+
+            tracing::subscriber::with_default(subscriber, || {
+                log_eligible_poll_failure("email", &err, &tick(false, 2));
+            });
+
+            let events = buffer.lock().unwrap();
+            assert_eq!(
+                events.len(),
+                1,
+                "expected exactly one log event, got {events:?}"
+            );
+            assert_eq!(events[0].level, Some(tracing::Level::DEBUG));
+        }
+
+        #[test]
+        fn sustained_capped_pressure_produces_exactly_one_warn() {
+            // Simulate one escalation edge followed by several repeats at the
+            // same (capped) step, as the poll loop would emit them across
+            // consecutive ticks -- exactly the "riding the cap" scenario
+            // codex round-1 flagged as spamming a WARN per retry.
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = CaptureSubscriber {
+                events: Arc::clone(&buffer),
+            };
+            let err = ChannelError::Auth("authenticated but not connected".into());
+
+            tracing::subscriber::with_default(subscriber, || {
+                log_eligible_poll_failure("email", &err, &tick(true, 8)); // escalation edge
+                for attempt in 9..=15 {
+                    log_eligible_poll_failure("email", &err, &tick(false, attempt));
+                    // repeats at cap
+                }
+            });
+
+            let events = buffer.lock().unwrap();
+            let warn_count = events
+                .iter()
+                .filter(|e| e.level == Some(tracing::Level::WARN))
+                .count();
+            let debug_count = events
+                .iter()
+                .filter(|e| e.level == Some(tracing::Level::DEBUG))
+                .count();
+            assert_eq!(
+                warn_count, 1,
+                "exactly one WARN expected across the whole sequence, got {warn_count} in {events:?}"
+            );
+            assert_eq!(
+                debug_count, 7,
+                "the 7 same-step repeats must log at debug, not warn"
+            );
+        }
+
+        #[test]
+        fn warn_message_contains_error_text() {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = CaptureSubscriber {
+                events: Arc::clone(&buffer),
+            };
+            let err = ChannelError::Auth("IMAP LOGIN failed: slot exhausted".into());
+
+            tracing::subscriber::with_default(subscriber, || {
+                log_eligible_poll_failure("email", &err, &tick(true, 1));
+            });
+
+            let events = buffer.lock().unwrap();
+            let message = events[0].message.as_deref().unwrap_or_default();
+            assert!(
+                message.contains("slot exhausted"),
+                "escalation warn must carry the underlying error text, got: {message}"
             );
         }
     }


### PR DESCRIPTION
## Summary

Closes #605. The 2026-07-04 inbound-email outage (#602) was amplified by
the IMAP poll loop's failure behavior: nine processes polling the same
mailbox retried auth on a flat ~5s cadence with no per-credential
concurrency cap, exhausting Exchange Online's connection slots
("User is authenticated but not connected") and keeping them saturated for
~19h. #602/#610 fixed the multi-process spawn itself; this PR makes the
channel degrade gracefully if polling pressure ever returns.

- **Per-credential single-flight** (`ImapSingleFlight`, `crates/khive-channel-email/src/backoff.rs`):
  a bounded `tokio::sync::Semaphore` of size 1, held for the full
  connect-through-logout lifecycle in `LiveImap::fetch_since`. One instance
  lives per `LiveImap` (== one per credential), so a second concurrent
  connection attempt against the same mailbox waits instead of opening a
  parallel connection. The semaphore is structurally the only way to widen
  the cap later.
- **Jittered exponential backoff** (`ImapBackoff`): 5s -> 10s -> 20s -> ...
  capped at 600s (~10min), +25% additive jitter, reset to base on the next
  success. Wired into `channel_poll_loop` (`crates/khive-mcp/src/serve.rs`)
  keyed per channel kind (== per credential today), replacing the flat 5s
  retry only on backoff-eligible failures — the happy-path 5s cadence is
  unchanged.
- **Error classification** (`is_backoff_eligible`): `ChannelError::Auth` and
  `ChannelError::Transport` back off (TLS/LOGIN/XOAUTH2 auth failures and
  TCP/SELECT/SEARCH/FETCH transport failures — both classes cover the
  Exchange connection-slot exhaustion from the outage). `Config`,
  `UnauthorizedSender`, and `InvalidEnvelope` do not back off (static
  misconfig / per-message gate failures, not connectivity pressure).
- **Edge-triggered warn logging**: `BackoffTick::should_warn` is true only
  when the computed step changes from the previously logged step (ADR-091
  `crossing_warn` discipline) — one `warn!` per escalation, not one per
  retry; silent once capped, re-arms after a success resets state.

## Error-classification table

| `ChannelError` variant | Backoff-eligible? | Where it's produced |
|---|---|---|
| `Auth` | yes | TLS handshake, IMAP `LOGIN`, XOAUTH2 authenticate (`LiveImap::connect`) |
| `Transport` | yes | TCP connect, greeting read, `SELECT INBOX`, `UID SEARCH`, `UID FETCH` (`LiveImap::connect` / `fetch_since`) |
| `Config` | no | static misconfiguration; backing off only delays an operator fix |
| `UnauthorizedSender` | no | per-message attribution gate, not connectivity |
| `InvalidEnvelope` | no | malformed data, not connectivity |

## Backoff parameters

base=5s, max=600s (~10min), jitter=additive up to 25% of the current step,
reset to base on the next successful poll.

## Test plan

- [x] `cargo test -p khive-channel-email` — 137 passed (0 failed), including
  new `backoff::tests` covering escalation (5/10/20/40/80/160/320/600s),
  cap saturation, reset-on-success, edge-triggered `should_warn`, error
  classification, and single-flight (second acquisition observably waits
  for the first to release; permit-count checks against the production
  `ImapSingleFlight` type directly).
- [x] `cargo test -p khive-mcp --features channel-email` — 110 passed (integration seam)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p khive-mcp --all-targets --features channel-email -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean