### PR TITLE
feat(comm): read-only comm.health() verb with daemon-persisted heartbeat rows

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -69,7 +69,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1.10", features = ["v4", "serde"] }
+uuid = { version = "1.10", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -301,6 +301,13 @@ impl Channel for EmailChannel {
         "email"
     }
 
+    /// khive #606: the mailbox address distinguishes multiple configured
+    /// email accounts (all `kind() == "email"`) so their channel health
+    /// rows never collapse into one.
+    fn slug(&self) -> String {
+        self.config.mailbox.clone()
+    }
+
     async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
         let from = strip_kind_prefix(&envelope.from, "email");
         let to = strip_kind_prefix(&envelope.to, "email");

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -179,6 +179,20 @@ pub trait Channel: Send + Sync + 'static {
     /// Short stable identifier for this transport (e.g. `"email"`, `"telegram"`).
     fn kind(&self) -> &'static str;
 
+    /// Stable per-credential identifier distinguishing multiple configured
+    /// accounts of the same `kind` (e.g. two mailboxes both polled via the
+    /// `"email"` channel). khive #606: channel health rows are keyed by
+    /// `(kind, slug)`, never `kind` alone, so two accounts of the same kind
+    /// never collapse into a single heartbeat row.
+    ///
+    /// The default implementation returns `kind()` — correct for any
+    /// transport that only ever has a single configured credential per
+    /// process. Adapters that can have distinct per-credential identity
+    /// (e.g. email's mailbox address) should override this.
+    fn slug(&self) -> String {
+        self.kind().to_string()
+    }
+
     /// Return `true` when this adapter has sufficient configuration to operate.
     ///
     /// The default implementation returns `true`; adapters with optional config

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -222,9 +222,15 @@ pub trait Channel: Send + Sync + 'static {
 ///
 /// The MCP server holds an `Arc<ChannelRegistry>` and polls all registered
 /// channels in a background loop, ingesting results via `comm.ingest`.
+///
+/// Keyed by the composite `(kind, slug)` identity (khive #606 round-1 codex
+/// review, High finding), NOT `kind` alone: two accounts of the same `kind`
+/// (e.g. two mailboxes, both `kind() == "email"`) must coexist as distinct
+/// registered adapters, or they collapse before the heartbeat writer ever
+/// gets a chance to persist separate `channel_health` rows for them.
 #[derive(Default)]
 pub struct ChannelRegistry {
-    channels: HashMap<String, Arc<dyn Channel>>,
+    channels: HashMap<(String, String), Arc<dyn Channel>>,
 }
 
 impl ChannelRegistry {
@@ -233,19 +239,46 @@ impl ChannelRegistry {
         Self::default()
     }
 
-    /// Register a channel adapter. Replaces any previous adapter with the same `kind`.
+    /// Register a channel adapter. Replaces any previous adapter with the
+    /// same `(kind, slug)` composite identity — the pre-#606 "same-kind
+    /// replaces" semantics still hold for the common single-credential-per-
+    /// kind case (where `slug()` falls back to `kind()`), but two adapters
+    /// of the same kind with distinct `slug()` values now coexist.
     pub fn register(&mut self, channel: Arc<dyn Channel>) {
-        self.channels.insert(channel.kind().to_string(), channel);
+        let key = (channel.kind().to_string(), channel.slug());
+        self.channels.insert(key, channel);
     }
 
-    /// Look up a channel by kind.
+    /// Look up a channel by kind only.
+    ///
+    /// When multiple adapters share `kind` (distinct `slug()` values), this
+    /// returns an unspecified one of them (`HashMap` iteration order is not
+    /// defined) — it exists for the common single-credential-per-kind case.
+    /// Callers that must resolve a specific credential among several sharing
+    /// a kind need [`ChannelRegistry::get_by_slug`]. No production call site
+    /// resolves outbound `send` through this registry today (the outbox loop
+    /// holds its own `Arc<EmailChannel>` directly), so no send-path
+    /// resolution currently depends on which adapter this returns when
+    /// several share a kind.
     pub fn get(&self, kind: &str) -> Option<Arc<dyn Channel>> {
-        self.channels.get(kind).cloned()
+        self.channels
+            .iter()
+            .find(|((k, _), _)| k == kind)
+            .map(|(_, v)| Arc::clone(v))
     }
 
-    /// Iterate over all registered channels.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &Arc<dyn Channel>)> {
-        self.channels.iter().map(|(k, v)| (k.as_str(), v))
+    /// Look up a channel by its exact `(kind, slug)` composite identity.
+    pub fn get_by_slug(&self, kind: &str, slug: &str) -> Option<Arc<dyn Channel>> {
+        self.channels
+            .get(&(kind.to_string(), slug.to_string()))
+            .cloned()
+    }
+
+    /// Iterate over all registered channels as `(kind, slug, channel)` triples.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &Arc<dyn Channel>)> {
+        self.channels
+            .iter()
+            .map(|((k, s), v)| (k.as_str(), s.as_str(), v))
     }
 
     /// Returns `true` if no channels are registered.
@@ -272,6 +305,10 @@ mod tests {
     struct MockChannel {
         sent: Arc<Mutex<Vec<ChannelEnvelope>>>,
         inbound: Vec<ChannelEnvelope>,
+        // `None` -> `slug()` falls back to the trait default (`kind()`).
+        // `Some(_)` -> distinct per-credential identity, for #606's
+        // same-kind-different-slug regressions.
+        slug: Option<String>,
     }
 
     impl MockChannel {
@@ -279,6 +316,15 @@ mod tests {
             Self {
                 sent: Arc::new(Mutex::new(Vec::new())),
                 inbound,
+                slug: None,
+            }
+        }
+
+        fn with_slug(inbound: Vec<ChannelEnvelope>, slug: impl Into<String>) -> Self {
+            Self {
+                sent: Arc::new(Mutex::new(Vec::new())),
+                inbound,
+                slug: Some(slug.into()),
             }
         }
     }
@@ -287,6 +333,10 @@ mod tests {
     impl Channel for MockChannel {
         fn kind(&self) -> &'static str {
             "mock"
+        }
+
+        fn slug(&self) -> String {
+            self.slug.clone().unwrap_or_else(|| self.kind().to_string())
         }
 
         async fn send(&self, envelope: ChannelEnvelope) -> Result<(), ChannelError> {
@@ -360,19 +410,49 @@ mod tests {
     }
 
     #[test]
-    fn registry_replaces_existing() {
+    fn registry_replaces_existing_same_composite_identity() {
+        // Two registrations with the SAME (kind, slug) — both default to
+        // slug() == kind() here — still replace in place, matching the
+        // pre-#606 single-credential-per-kind semantics.
         let mut reg = ChannelRegistry::new();
         reg.register(Arc::new(MockChannel::new(vec![])));
         reg.register(Arc::new(MockChannel::new(vec![])));
-        assert_eq!(reg.len(), 1, "same kind replaces");
+        assert_eq!(reg.len(), 1, "same (kind, slug) replaces");
+    }
+
+    #[test]
+    fn registry_does_not_collapse_same_kind_distinct_slug() {
+        // #606 round-1 codex review, High finding: two accounts sharing
+        // `kind()` but with distinct `slug()` values (e.g. two mailboxes)
+        // must coexist as two registered adapters, not collapse into one.
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockChannel::with_slug(vec![], "a@example.com")));
+        reg.register(Arc::new(MockChannel::with_slug(vec![], "b@example.com")));
+        assert_eq!(
+            reg.len(),
+            2,
+            "same kind + distinct slug must coexist, not collapse"
+        );
+        assert!(reg.get_by_slug("mock", "a@example.com").is_some());
+        assert!(reg.get_by_slug("mock", "b@example.com").is_some());
     }
 
     #[test]
     fn registry_iter_yields_all() {
         let mut reg = ChannelRegistry::new();
         reg.register(Arc::new(MockChannel::new(vec![])));
-        let kinds: Vec<&str> = reg.iter().map(|(k, _)| k).collect();
+        let kinds: Vec<&str> = reg.iter().map(|(k, _, _)| k).collect();
         assert_eq!(kinds, vec!["mock"]);
+    }
+
+    #[test]
+    fn registry_iter_yields_both_slugs_for_same_kind() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(Arc::new(MockChannel::with_slug(vec![], "a@example.com")));
+        reg.register(Arc::new(MockChannel::with_slug(vec![], "b@example.com")));
+        let mut slugs: Vec<&str> = reg.iter().map(|(_, s, _)| s).collect();
+        slugs.sort_unstable();
+        assert_eq!(slugs, vec!["a@example.com", "b@example.com"]);
     }
 
     #[test]

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -309,11 +309,20 @@ async fn channel_poll_loop(
         last_poll = Utc::now();
 
         for (kind, channel) in channels.iter() {
+            let slug = channel.slug();
             match channel.poll(since).await {
                 Ok(envelopes) => {
                     if let Some(backoff) = backoffs.get_mut(kind) {
                         backoff.record_success();
                     }
+                    record_channel_heartbeat(
+                        &registry,
+                        &ingest_namespace,
+                        kind,
+                        &slug,
+                        HeartbeatOutcome::Success,
+                    )
+                    .await;
                     for env in envelopes {
                         let params = json!({
                             "namespace": ingest_namespace,
@@ -339,6 +348,18 @@ async fn channel_poll_loop(
                     }
                 }
                 Err(e) => {
+                    let class = channel_error_class(&e);
+                    record_channel_heartbeat(
+                        &registry,
+                        &ingest_namespace,
+                        kind,
+                        &slug,
+                        HeartbeatOutcome::Failure {
+                            class,
+                            message: e.to_string(),
+                        },
+                    )
+                    .await;
                     if is_backoff_eligible(&e) {
                         let backoff = backoffs.entry(kind.to_string()).or_default();
                         let tick = backoff.record_failure();
@@ -354,6 +375,72 @@ async fn channel_poll_loop(
                 }
             }
         }
+    }
+}
+
+/// One poll attempt's outcome, as reported to `comm.heartbeat` (#606).
+#[cfg(feature = "channel-email")]
+enum HeartbeatOutcome {
+    Success,
+    Failure {
+        class: &'static str,
+        message: String,
+    },
+}
+
+/// Map a [`khive_channel::ChannelError`] to the `comm.heartbeat` `error_class`
+/// open string enum (#606 spec-gate amendment 4: `auth | transport | config`
+/// in v1, callers must tolerate unknown classes). `Auth`/`Transport` are the
+/// connectivity classes `is_backoff_eligible` already distinguishes;
+/// `Config`/`UnauthorizedSender`/`InvalidEnvelope` are static/attribution
+/// failures, never produced by `poll`/`connect` in practice (see
+/// `is_backoff_eligible`'s doc comment), so they all map to `"config"`.
+#[cfg(feature = "channel-email")]
+fn channel_error_class(err: &khive_channel::ChannelError) -> &'static str {
+    match err {
+        khive_channel::ChannelError::Auth(_) => "auth",
+        khive_channel::ChannelError::Transport(_) => "transport",
+        khive_channel::ChannelError::Config(_)
+        | khive_channel::ChannelError::UnauthorizedSender(_)
+        | khive_channel::ChannelError::InvalidEnvelope(_) => "config",
+    }
+}
+
+/// Persist one poll attempt's outcome via the `comm.heartbeat` subhandler
+/// (#606). Best-effort: a failed heartbeat write is logged and does not
+/// interrupt the poll loop — the heartbeat row is an observability surface,
+/// not a correctness dependency for message delivery.
+#[cfg(feature = "channel-email")]
+async fn record_channel_heartbeat(
+    registry: &khive_runtime::VerbRegistry,
+    namespace: &str,
+    channel_kind: &str,
+    channel_slug: &str,
+    outcome: HeartbeatOutcome,
+) {
+    use serde_json::json;
+
+    let params = match outcome {
+        HeartbeatOutcome::Success => json!({
+            "namespace": namespace,
+            "channel_kind": channel_kind,
+            "channel_slug": channel_slug,
+            "outcome": "success",
+        }),
+        HeartbeatOutcome::Failure { class, message } => json!({
+            "namespace": namespace,
+            "channel_kind": channel_kind,
+            "channel_slug": channel_slug,
+            "outcome": "failure",
+            "error_class": class,
+            "error_message": message,
+        }),
+    };
+    if let Err(e) = registry.dispatch("comm.heartbeat", params).await {
+        tracing::warn!(
+            channel = channel_kind,
+            "comm.heartbeat failed to persist poll outcome: {e}"
+        );
     }
 }
 
@@ -3306,6 +3393,100 @@ brain_profile = "project-profile"
             "enforce_strict_actor_mode must return Ok when comm pack is not loaded \
              (no party-line risk even without actor)"
         );
+    }
+
+    // --- channel_error_class / record_channel_heartbeat (khive #606) ---
+
+    #[cfg(feature = "channel-email")]
+    mod channel_heartbeat_tests {
+        use super::*;
+        use khive_channel::ChannelError;
+        use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+        #[test]
+        fn auth_maps_to_auth_class() {
+            assert_eq!(channel_error_class(&ChannelError::Auth("x".into())), "auth");
+        }
+
+        #[test]
+        fn transport_maps_to_transport_class() {
+            assert_eq!(
+                channel_error_class(&ChannelError::Transport("x".into())),
+                "transport"
+            );
+        }
+
+        #[test]
+        fn config_maps_to_config_class() {
+            assert_eq!(
+                channel_error_class(&ChannelError::Config("x".into())),
+                "config"
+            );
+        }
+
+        #[test]
+        fn unauthorized_sender_and_invalid_envelope_map_to_config_class() {
+            // Never produced by poll/connect in practice (see is_backoff_eligible's doc
+            // comment), but the mapping must still be total and defensible if it ever
+            // does surface from a future adapter.
+            assert_eq!(
+                channel_error_class(&ChannelError::UnauthorizedSender("x".into())),
+                "config"
+            );
+            assert_eq!(
+                channel_error_class(&ChannelError::InvalidEnvelope("x".into())),
+                "config"
+            );
+        }
+
+        /// `record_channel_heartbeat` must be best-effort: a heartbeat dispatch
+        /// failure (comm pack not loaded) must not panic the poll loop.
+        #[tokio::test]
+        async fn record_heartbeat_is_best_effort_when_comm_pack_absent() {
+            let registry = VerbRegistryBuilder::new()
+                .build()
+                .expect("empty registry builds");
+
+            // comm pack is not loaded, so "comm.heartbeat" is an unknown verb — this
+            // must return without panicking (the caller only logs a warning).
+            record_channel_heartbeat(
+                &registry,
+                "local",
+                "email",
+                "leo@khive.ai",
+                HeartbeatOutcome::Success,
+            )
+            .await;
+        }
+
+        /// End-to-end: a successful poll outcome persists via `comm.heartbeat` and
+        /// is readable via `comm.health` — the same wiring the live poll loop uses.
+        #[tokio::test]
+        async fn record_heartbeat_success_is_visible_via_comm_health() {
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            record_channel_heartbeat(
+                &registry,
+                "local",
+                "email",
+                "leo@khive.ai",
+                HeartbeatOutcome::Success,
+            )
+            .await;
+
+            let health = registry
+                .dispatch("comm.health", serde_json::json!({}))
+                .await
+                .expect("health succeeds");
+            let channels = health["channels"].as_array().expect("channels array");
+            assert_eq!(channels.len(), 1);
+            assert_eq!(channels[0]["channel_kind"].as_str(), Some("email"));
+            assert_eq!(channels[0]["channel_slug"].as_str(), Some("leo@khive.ai"));
+        }
     }
 
     // --- note_already_delivered: outbox defensive-guard regression (round-2 finding 1) ---

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -295,10 +295,12 @@ async fn channel_poll_loop(
     const HAPPY_PATH_INTERVAL: Duration = Duration::from_secs(5);
 
     let mut last_poll = Utc::now();
-    // One backoff state per channel kind, i.e. per credential — a given
-    // channel kind (e.g. "email") maps to exactly one configured credential
-    // in this process, so failures on one credential never throttle another.
-    let mut backoffs: HashMap<String, ImapBackoff> = HashMap::new();
+    // One backoff state per (kind, slug) — i.e. per credential (#606 round-1
+    // codex review, High finding). Keying by kind alone would throttle a
+    // second same-kind credential (e.g. a second mailbox) whenever the first
+    // one's connection fails, even though the two are independent
+    // credentials with independent connectivity.
+    let mut backoffs: HashMap<(String, String), ImapBackoff> = HashMap::new();
     let mut next_interval = HAPPY_PATH_INTERVAL;
 
     loop {
@@ -308,21 +310,15 @@ async fn channel_poll_loop(
         let since = last_poll;
         last_poll = Utc::now();
 
-        for (kind, channel) in channels.iter() {
-            let slug = channel.slug();
+        for (kind, slug, channel) in channels.iter() {
+            let backoff_key = (kind.to_string(), slug.to_string());
             match channel.poll(since).await {
                 Ok(envelopes) => {
-                    if let Some(backoff) = backoffs.get_mut(kind) {
+                    if let Some(backoff) = backoffs.get_mut(&backoff_key) {
                         backoff.record_success();
                     }
-                    record_channel_heartbeat(
-                        &registry,
-                        &ingest_namespace,
-                        kind,
-                        &slug,
-                        HeartbeatOutcome::Success,
-                    )
-                    .await;
+                    record_channel_heartbeat(&registry, kind, slug, HeartbeatOutcome::Success)
+                        .await;
                     for env in envelopes {
                         let params = json!({
                             "namespace": ingest_namespace,
@@ -351,9 +347,8 @@ async fn channel_poll_loop(
                     let class = channel_error_class(&e);
                     record_channel_heartbeat(
                         &registry,
-                        &ingest_namespace,
                         kind,
-                        &slug,
+                        slug,
                         HeartbeatOutcome::Failure {
                             class,
                             message: e.to_string(),
@@ -361,7 +356,7 @@ async fn channel_poll_loop(
                     )
                     .await;
                     if is_backoff_eligible(&e) {
-                        let backoff = backoffs.entry(kind.to_string()).or_default();
+                        let backoff = backoffs.entry(backoff_key).or_default();
                         let tick = backoff.record_failure();
                         log_eligible_poll_failure(kind, &e, &tick);
                         next_interval = next_interval.max(tick.delay);
@@ -410,16 +405,26 @@ fn channel_error_class(err: &khive_channel::ChannelError) -> &'static str {
 /// (#606). Best-effort: a failed heartbeat write is logged and does not
 /// interrupt the poll loop — the heartbeat row is an observability surface,
 /// not a correctness dependency for message delivery.
+///
+/// Takes NO `namespace` parameter (round-2, spec-gate Blocker fix, Leo
+/// 2026-07-04): heartbeat rows are an operational surface, not message data,
+/// so they are ALWAYS dispatched against
+/// `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE` — the same constant
+/// `handle_health` reads from — regardless of what
+/// `KHIVE_EMAIL_INGEST_NAMESPACE` this daemon is configured with for message
+/// ingestion. `handle_heartbeat` additionally hardcodes the persisted row's
+/// namespace to this same constant, so the guarantee holds even if a future
+/// caller changes what this dispatch call passes.
 #[cfg(feature = "channel-email")]
 async fn record_channel_heartbeat(
     registry: &khive_runtime::VerbRegistry,
-    namespace: &str,
     channel_kind: &str,
     channel_slug: &str,
     outcome: HeartbeatOutcome,
 ) {
     use serde_json::json;
 
+    let namespace = khive_pack_comm::CHANNEL_HEALTH_NAMESPACE;
     let params = match outcome {
         HeartbeatOutcome::Success => json!({
             "namespace": namespace,
@@ -3451,7 +3456,6 @@ brain_profile = "project-profile"
             // must return without panicking (the caller only logs a warning).
             record_channel_heartbeat(
                 &registry,
-                "local",
                 "email",
                 "leo@khive.ai",
                 HeartbeatOutcome::Success,
@@ -3471,7 +3475,6 @@ brain_profile = "project-profile"
 
             record_channel_heartbeat(
                 &registry,
-                "local",
                 "email",
                 "leo@khive.ai",
                 HeartbeatOutcome::Success,
@@ -3486,6 +3489,197 @@ brain_profile = "project-profile"
             assert_eq!(channels.len(), 1);
             assert_eq!(channels[0]["channel_kind"].as_str(), Some("email"));
             assert_eq!(channels[0]["channel_slug"].as_str(), Some("leo@khive.ai"));
+        }
+
+        /// #606 round-1 codex review, Blocker finding: a daemon polling under a
+        /// non-local `KHIVE_EMAIL_INGEST_NAMESPACE` must not cause a client-role
+        /// no-arg `comm.health()` to report empty state. `record_channel_heartbeat`
+        /// takes no `namespace` parameter — the write is unconditionally pinned to
+        /// `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE` — so this regression proves
+        /// the heartbeat row is visible via the default (local-scoped) `comm.health`
+        /// read even though this daemon's *messages* are configured to ingest into
+        /// a completely different namespace.
+        #[tokio::test]
+        async fn heartbeat_visible_via_health_regardless_of_configured_ingest_namespace() {
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            // Simulates `KHIVE_EMAIL_INGEST_NAMESPACE=lambda:mybot`: comm.ingest for
+            // an inbound message would target this namespace, but the heartbeat
+            // write must ignore it entirely.
+            let configured_ingest_namespace = "lambda:mybot";
+            let ingest_params = serde_json::json!({
+                "namespace": configured_ingest_namespace,
+                "from": "email:sender@example.com",
+                "to": "email:leo@khive.ai",
+                "content": "hello",
+                "channel_kind": "email",
+                "external_id": "test-msg-1",
+                "default_inbound_actor": "lambda:leo",
+            });
+            registry
+                .dispatch("comm.ingest", ingest_params)
+                .await
+                .expect("message ingest into the configured namespace succeeds");
+
+            record_channel_heartbeat(
+                &registry,
+                "email",
+                "leo@khive.ai",
+                HeartbeatOutcome::Success,
+            )
+            .await;
+
+            // A no-arg client-role comm.health() call must see the heartbeat row —
+            // it must NOT report role="client" with an empty channels array just
+            // because messages are configured to ingest into a non-local namespace.
+            let health = registry
+                .dispatch("comm.health", serde_json::json!({}))
+                .await
+                .expect("health succeeds");
+            assert_eq!(health["role"].as_str(), Some("daemon"));
+            let channels = health["channels"].as_array().expect("channels array");
+            assert_eq!(
+                channels.len(),
+                1,
+                "heartbeat row must be visible to a no-arg client comm.health() call \
+                 regardless of the configured message-ingest namespace"
+            );
+            assert_eq!(channels[0]["channel_kind"].as_str(), Some("email"));
+            assert_eq!(channels[0]["channel_slug"].as_str(), Some("leo@khive.ai"));
+        }
+    }
+
+    // --- ChannelRegistry composite-key production path (round-1 codex review, High finding) ---
+
+    #[cfg(feature = "channel-email")]
+    mod composite_key_registry_tests {
+        use super::*;
+        use async_trait::async_trait;
+        use chrono::{DateTime, Utc};
+        use khive_channel::{Channel, ChannelEnvelope, ChannelError, ChannelRegistry};
+        use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+        use std::sync::Arc;
+
+        /// Two independent inboxes that both report `kind() == "email"` but
+        /// distinct `slug()` mailbox addresses, exactly like two configured
+        /// `EmailChannel` credentials would.
+        struct TwoMailboxChannel {
+            slug: String,
+        }
+
+        #[async_trait]
+        impl Channel for TwoMailboxChannel {
+            fn kind(&self) -> &'static str {
+                "email"
+            }
+
+            fn slug(&self) -> String {
+                self.slug.clone()
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                Ok(vec![])
+            }
+        }
+
+        /// #606 round-1 codex review, High finding: this is the regression codex
+        /// specifically asked for — a PRODUCTION `ChannelRegistry` populated
+        /// through the real `register()` path (not a pack-level dispatch
+        /// bypassing registration) with two same-kind, different-slug adapters.
+        /// Both must be registered (not collapsed) and both must be pollable by
+        /// the production poll loop, producing two independent `comm.health()`
+        /// rows and two independent backoff states. This test FAILS against a
+        /// `kind`-only-keyed `ChannelRegistry` (both registrations collapse to
+        /// `len() == 1`) and PASSES against the `(kind, slug)`-composite-keyed
+        /// registry.
+        #[tokio::test]
+        async fn two_same_kind_channels_both_poll_and_both_persist_health_rows() {
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(TwoMailboxChannel {
+                slug: "mailbox-a@example.com".to_string(),
+            }));
+            ch_registry.register(Arc::new(TwoMailboxChannel {
+                slug: "mailbox-b@example.com".to_string(),
+            }));
+            assert_eq!(
+                ch_registry.len(),
+                2,
+                "two same-kind, different-slug adapters must both register, not collapse"
+            );
+
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            // Drive exactly what the production poll loop does per tick: iterate
+            // the registry and record a heartbeat for every (kind, slug, channel).
+            for (kind, slug, _channel) in ch_registry.iter() {
+                record_channel_heartbeat(&registry, kind, slug, HeartbeatOutcome::Success).await;
+            }
+
+            let health = registry
+                .dispatch("comm.health", serde_json::json!({}))
+                .await
+                .expect("health succeeds");
+            let channels = health["channels"].as_array().expect("channels array");
+            assert_eq!(
+                channels.len(),
+                2,
+                "both mailboxes must produce independent comm.health rows"
+            );
+            let slugs: std::collections::BTreeSet<&str> = channels
+                .iter()
+                .map(|c| c["channel_slug"].as_str().expect("channel_slug present"))
+                .collect();
+            assert_eq!(
+                slugs,
+                std::collections::BTreeSet::from([
+                    "mailbox-a@example.com",
+                    "mailbox-b@example.com"
+                ])
+            );
+        }
+
+        /// Backoff state independence: the production poll loop keys its
+        /// `HashMap<(String, String), ImapBackoff>` by the same composite
+        /// identity, so a failure on one mailbox must never throttle the other.
+        #[test]
+        fn backoff_state_is_independent_per_kind_slug_pair() {
+            use khive_channel_email::ImapBackoff;
+            use std::collections::HashMap;
+
+            let mut backoffs: HashMap<(String, String), ImapBackoff> = HashMap::new();
+            let key_a = ("email".to_string(), "mailbox-a@example.com".to_string());
+            let key_b = ("email".to_string(), "mailbox-b@example.com".to_string());
+
+            let tick_a = backoffs.entry(key_a.clone()).or_default().record_failure();
+            assert!(
+                !backoffs.contains_key(&key_b),
+                "mailbox-b must have no backoff state after only mailbox-a fails"
+            );
+            assert!(tick_a.delay.as_secs() >= 1, "mailbox-a backoff engaged");
+
+            // mailbox-b independently starts fresh and succeeds immediately.
+            let backoff_b = backoffs.entry(key_b).or_default();
+            backoff_b.record_success();
+            assert_eq!(
+                backoffs.get(&key_a).unwrap().attempt(),
+                1,
+                "mailbox-a's backoff attempt count must be unaffected by mailbox-b's success"
+            );
         }
     }
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -886,11 +886,26 @@ pub(crate) async fn handle_ingest(
 /// addition to kind is the point of #606's amendment 2: two accounts of the
 /// same kind (e.g. two mailboxes, both `kind() == "email"`) must not collapse
 /// into a single row.
+///
+/// The three components are hashed as a JSON array of strings, NOT joined
+/// with a `:` delimiter (round-1 codex review, Medium finding). Namespaces
+/// may themselves contain `:` (hierarchical namespace strings are explicitly
+/// allowed), so a delimiter-joined `format!("...:{a}:{b}:{c}")` is not an
+/// injective encoding: `(namespace="a:b", channel_kind="c", channel_slug="d")`
+/// and `(namespace="a", channel_kind="b:c", channel_slug="d")` both produced
+/// the identical string `"khive:channel_health:a:b:c:d"` under the old
+/// scheme. `serde_json::to_vec` of an array of strings is unambiguous —
+/// each element is quoted and internal quotes/backslashes are escaped — so
+/// distinct triples always serialize to distinct byte sequences.
 fn heartbeat_note_id(namespace: &str, channel_kind: &str, channel_slug: &str) -> Uuid {
-    Uuid::new_v5(
-        &Uuid::NAMESPACE_URL,
-        format!("khive:channel_health:{namespace}:{channel_kind}:{channel_slug}").as_bytes(),
-    )
+    let key = serde_json::to_vec(&(
+        "khive:channel_health",
+        namespace,
+        channel_kind,
+        channel_slug,
+    ))
+    .expect("a 4-tuple of &str always serializes to JSON");
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, &key)
 }
 
 /// `heartbeat` — persist one poll attempt's outcome into the channel's
@@ -948,7 +963,15 @@ pub(crate) async fn handle_heartbeat(
         ));
     }
 
-    let ns = token.namespace().as_str();
+    // #606 spec-gate Blocker fix (Leo 2026-07-04): heartbeat rows are an
+    // OPERATIONAL surface, not message data. Persist to
+    // `crate::CHANNEL_HEALTH_NAMESPACE` ALWAYS — never `token.namespace()` —
+    // so a poll loop configured with a non-local `KHIVE_EMAIL_INGEST_NAMESPACE`
+    // cannot cause heartbeat rows to land anywhere but where `handle_health`
+    // reads from. This is enforced here (not just at the serve.rs call site)
+    // so the guarantee holds even if a future caller passes a different
+    // `namespace` dispatch param.
+    let ns = crate::CHANNEL_HEALTH_NAMESPACE;
     let store = runtime.notes(token)?;
     let id = heartbeat_note_id(ns, &p.channel_kind, &p.channel_slug);
 
@@ -1049,19 +1072,25 @@ fn channel_health_to_json(note: &Note) -> Value {
 
 /// `health` — read-only per-channel health snapshot (khive #606).
 ///
-/// Reads the daemon-persisted `channel_health` rows for the caller's
-/// namespace. Cross-process read is the point of this verb (spec-gate
-/// amendment 1): a client-role process (stdio MCP without `--daemon`) has no
-/// in-memory poll-loop state of its own, so it must read what the daemon
-/// already wrote. `role` answers "who owns the loops", not "whose memory
-/// answered": any persisted row means some daemon owns the channel loops, so
-/// `role` is reported as `"daemon"` with `source: "daemon-heartbeat"`
-/// regardless of whether THIS process is that daemon. `role: "client"` with
-/// an empty `channels` array is correct only when no daemon heartbeat state
-/// exists at all (fresh install, or a daemon that has never completed a poll
-/// tick) — the comm pack has no visibility into which channels are
-/// configured (that lives in `khive-mcp`/`khive-channel-email`), so an empty
-/// result is the only fact-based response available at this layer.
+/// Reads the daemon-persisted `channel_health` rows from
+/// `crate::CHANNEL_HEALTH_NAMESPACE` UNCONDITIONALLY — never
+/// `token.namespace()` (spec-gate Blocker fix, Leo 2026-07-04). Heartbeat
+/// rows are an operational surface, not message data, so a client-role
+/// no-arg call must see them regardless of what namespace the caller's own
+/// messages happen to be ingested under (e.g. `KHIVE_EMAIL_INGEST_NAMESPACE`
+/// set to something other than `"local"`). Cross-process read is the point
+/// of this verb (spec-gate amendment 1): a client-role process (stdio MCP
+/// without `--daemon`) has no in-memory poll-loop state of its own, so it
+/// must read what the daemon already wrote. `role` answers "who owns the
+/// loops", not "whose memory answered": any persisted row means some daemon
+/// owns the channel loops, so `role` is reported as `"daemon"` with
+/// `source: "daemon-heartbeat"` regardless of whether THIS process is that
+/// daemon. `role: "client"` with an empty `channels` array is correct only
+/// when no daemon heartbeat state exists at all (fresh install, or a daemon
+/// that has never completed a poll tick) — the comm pack has no visibility
+/// into which channels are configured (that lives in
+/// `khive-mcp`/`khive-channel-email`), so an empty result is the only
+/// fact-based response available at this layer.
 ///
 /// Never returns a computed `healthy: bool` (spec-gate amendment: "report
 /// timestamps only") — staleness/alerting judgment belongs to the caller.
@@ -1088,7 +1117,7 @@ pub(crate) async fn handle_health(
     };
     let page = store
         .query_notes_filtered(
-            token.namespace().as_str(),
+            crate::CHANNEL_HEALTH_NAMESPACE,
             &filter,
             PageRequest {
                 limit: MAX_CHANNELS,
@@ -1096,6 +1125,14 @@ pub(crate) async fn handle_health(
             },
         )
         .await?;
+
+    if page.items.len() == MAX_CHANNELS as usize {
+        tracing::debug!(
+            max_channels = MAX_CHANNELS,
+            "comm.health: channel_health row count hit the page limit; \
+             results may be silently truncated"
+        );
+    }
 
     let channels: Vec<Value> = page.items.iter().map(channel_health_to_json).collect();
     let as_of = Utc::now().to_rfc3339();
@@ -1269,10 +1306,36 @@ fn build_references_header(parent_chain: Option<&str>, parent_message_id: &str) 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_references_header, message_id_match_candidates, parent_references_chain,
-        parent_wire_message_id, sanitize_reference_token, wrap_message_id,
+        build_references_header, heartbeat_note_id, message_id_match_candidates,
+        parent_references_chain, parent_wire_message_id, sanitize_reference_token, wrap_message_id,
     };
     use serde_json::json;
+
+    // #606 round-1 codex review, Medium finding: a delimiter-joined
+    // `format!("...:{a}:{b}:{c}")` id encoding is not injective once
+    // components may themselves contain `:` — these two distinct triples
+    // both produced `"khive:channel_health:a:b:c:d"` under the pre-fix
+    // scheme (`namespace:kind:slug` == `"a:b"` + `"c"` + `"d"` joins to the
+    // same string as `"a"` + `"b:c"` + `"d"`). The JSON-array encoding must
+    // keep them distinct.
+    #[test]
+    fn heartbeat_note_id_does_not_collide_on_delimiter_bearing_components() {
+        let a = heartbeat_note_id("a:b", "c", "d");
+        let b = heartbeat_note_id("a", "b:c", "d");
+        assert_ne!(
+            a, b,
+            "distinct (namespace, channel_kind, channel_slug) triples with \
+             colons inside a component must never hash to the same id"
+        );
+    }
+
+    #[test]
+    fn heartbeat_note_id_is_deterministic() {
+        assert_eq!(
+            heartbeat_note_id("local", "email", "leo@khive.ai"),
+            heartbeat_note_id("local", "email", "leo@khive.ai"),
+        );
+    }
 
     #[test]
     fn candidates_bare_input_adds_bracketed_form() {

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -16,7 +16,8 @@ use khive_storage::types::{PageRequest, SqlValue};
 
 use crate::message::{dual_write_message, note_to_message_json, resolve_id, short_id};
 use crate::params::{
-    deser, InboxParams, IngestParams, ReadParams, ReplyParams, SendParams, ThreadParams,
+    deser, HeartbeatParams, InboxParams, IngestParams, ReadParams, ReplyParams, SendParams,
+    ThreadParams,
 };
 
 /// Validate an actor label: non-empty, no control characters, ≤255 bytes (ADR-057 Q1 loose).
@@ -873,6 +874,243 @@ pub(crate) async fn handle_ingest(
         "thread_id": thread_id,
         "external_id": p.external_id,
         "deduplicated": false,
+    }))
+}
+
+/// Deterministic UUID identifying the `channel_health` row for one
+/// `(namespace, channel_kind, channel_slug)` triple (khive #606).
+///
+/// Deterministic (not `Uuid::new_v4`) so `handle_heartbeat` can compute the
+/// same id on every poll tick and `upsert_note`'s `INSERT OR REPLACE` updates
+/// the same row instead of accumulating a new one per tick. Keying by slug in
+/// addition to kind is the point of #606's amendment 2: two accounts of the
+/// same kind (e.g. two mailboxes, both `kind() == "email"`) must not collapse
+/// into a single row.
+fn heartbeat_note_id(namespace: &str, channel_kind: &str, channel_slug: &str) -> Uuid {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("khive:channel_health:{namespace}:{channel_kind}:{channel_slug}").as_bytes(),
+    )
+}
+
+/// `heartbeat` — persist one poll attempt's outcome into the channel's
+/// heartbeat row (khive #606). Subhandler — only the daemon's channel poll
+/// loop (`crates/khive-mcp/src/serve.rs::channel_poll_loop`) calls this.
+///
+/// Read-modify-write against the existing row (if any) so that:
+/// - `created_at` is preserved across updates (first-seen time), not reset
+///   every tick.
+/// - `last_error` is RETAINED across a subsequent success (spec-gate
+///   amendment 3): callers compare `last_error.at` against
+///   `last_success_at`/`last_failure_at` to tell a resolved issue from a live
+///   one, so a success must never clear it.
+/// - `consecutive_failures` resets to 0 on success and increments on failure,
+///   read from the prior row rather than any in-process counter, so it is
+///   correct even across a daemon restart.
+pub(crate) async fn handle_heartbeat(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    // Note: HeartbeatParams does not use deny_unknown_fields — mirrors
+    // IngestParams, since the poll loop passes `namespace` alongside these
+    // fields for VerbRegistry::dispatch to consume before the handler runs.
+    let p: HeartbeatParams = serde_json::from_value(params)
+        .map_err(|e| RuntimeError::InvalidInput(format!("heartbeat: bad params: {e}")))?;
+
+    if p.channel_kind.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "heartbeat: `channel_kind` must not be empty".into(),
+        ));
+    }
+    if p.channel_slug.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "heartbeat: `channel_slug` must not be empty".into(),
+        ));
+    }
+    let outcome = match p.outcome.as_str() {
+        s @ ("success" | "failure") => s,
+        other => {
+            return Err(RuntimeError::InvalidInput(format!(
+                "heartbeat: invalid `outcome` {other:?}; expected \"success\" or \"failure\""
+            )));
+        }
+    };
+    if outcome == "failure"
+        && p.error_class
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty()
+    {
+        return Err(RuntimeError::InvalidInput(
+            "heartbeat: `error_class` is required when outcome is \"failure\"".into(),
+        ));
+    }
+
+    let ns = token.namespace().as_str();
+    let store = runtime.notes(token)?;
+    let id = heartbeat_note_id(ns, &p.channel_kind, &p.channel_slug);
+
+    let existing = store
+        .get_note(id)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("heartbeat: get_note: {e}")))?;
+
+    let now = Utc::now();
+    let at = p.at.clone().unwrap_or_else(|| now.to_rfc3339());
+
+    let mut props = existing
+        .as_ref()
+        .and_then(|n| n.properties.clone())
+        .unwrap_or_else(|| json!({}));
+
+    props["channel_kind"] = json!(p.channel_kind);
+    props["channel_slug"] = json!(p.channel_slug);
+    props["last_poll_attempt_at"] = json!(at);
+
+    match outcome {
+        "success" => {
+            props["last_success_at"] = json!(at);
+            props["consecutive_failures"] = json!(0);
+            // last_error is intentionally left untouched — spec-gate amendment 3.
+        }
+        "failure" => {
+            props["last_failure_at"] = json!(at);
+            let prev_failures = props
+                .get("consecutive_failures")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            props["consecutive_failures"] = json!(prev_failures + 1);
+            props["last_error"] = json!({
+                "class": p.error_class.clone().unwrap_or_default(),
+                "message": p.error_message.clone().unwrap_or_default(),
+                "at": at,
+            });
+        }
+        _ => unreachable!("outcome already validated above"),
+    }
+
+    khive_runtime::secret_gate::check_json(&props)?;
+
+    let content = format!("channel heartbeat: {}:{}", p.channel_kind, p.channel_slug);
+    khive_runtime::secret_gate::check(&content)?;
+
+    let created_at = existing
+        .as_ref()
+        .map(|n| n.created_at)
+        .unwrap_or_else(|| now.timestamp_micros());
+
+    let note = Note {
+        id,
+        namespace: ns.to_string(),
+        kind: "channel_health".to_string(),
+        status: "active".to_string(),
+        name: Some(format!("{}:{}", p.channel_kind, p.channel_slug)),
+        content,
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(props),
+        created_at,
+        updated_at: now.timestamp_micros(),
+        deleted_at: None,
+    };
+
+    store
+        .upsert_note(note)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("heartbeat: upsert_note: {e}")))?;
+
+    Ok(json!({
+        "ok": true,
+        "channel_kind": p.channel_kind,
+        "channel_slug": p.channel_slug,
+        "outcome": outcome,
+    }))
+}
+
+/// Project a persisted `channel_health` note into the `comm.health()` channel
+/// entry shape. Missing fields (a row written before a given property existed)
+/// default to `null`/`0` rather than panicking — forward-compatible with rows
+/// written by an older heartbeat writer.
+fn channel_health_to_json(note: &Note) -> Value {
+    let props = note.properties.clone().unwrap_or_else(|| json!({}));
+    json!({
+        "channel_kind": props.get("channel_kind").cloned().unwrap_or(Value::Null),
+        "channel_slug": props.get("channel_slug").cloned().unwrap_or(Value::Null),
+        "last_success_at": props.get("last_success_at").cloned().unwrap_or(Value::Null),
+        "last_poll_attempt_at": props.get("last_poll_attempt_at").cloned().unwrap_or(Value::Null),
+        "last_failure_at": props.get("last_failure_at").cloned().unwrap_or(Value::Null),
+        "last_error": props.get("last_error").cloned().unwrap_or(Value::Null),
+        "consecutive_failures": props.get("consecutive_failures").cloned().unwrap_or(json!(0)),
+    })
+}
+
+/// `health` — read-only per-channel health snapshot (khive #606).
+///
+/// Reads the daemon-persisted `channel_health` rows for the caller's
+/// namespace. Cross-process read is the point of this verb (spec-gate
+/// amendment 1): a client-role process (stdio MCP without `--daemon`) has no
+/// in-memory poll-loop state of its own, so it must read what the daemon
+/// already wrote. `role` answers "who owns the loops", not "whose memory
+/// answered": any persisted row means some daemon owns the channel loops, so
+/// `role` is reported as `"daemon"` with `source: "daemon-heartbeat"`
+/// regardless of whether THIS process is that daemon. `role: "client"` with
+/// an empty `channels` array is correct only when no daemon heartbeat state
+/// exists at all (fresh install, or a daemon that has never completed a poll
+/// tick) — the comm pack has no visibility into which channels are
+/// configured (that lives in `khive-mcp`/`khive-channel-email`), so an empty
+/// result is the only fact-based response available at this layer.
+///
+/// Never returns a computed `healthy: bool` (spec-gate amendment: "report
+/// timestamps only") — staleness/alerting judgment belongs to the caller.
+pub(crate) async fn handle_health(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let has_args = match params.as_object() {
+        Some(obj) => !obj.is_empty(),
+        None => !params.is_null(),
+    };
+    if has_args {
+        return Err(RuntimeError::InvalidInput(
+            "health: takes no arguments".into(),
+        ));
+    }
+
+    let store = runtime.notes(token)?;
+    const MAX_CHANNELS: u32 = 200;
+    let filter = NoteFilter {
+        kind: Some("channel_health".to_string()),
+        ..Default::default()
+    };
+    let page = store
+        .query_notes_filtered(
+            token.namespace().as_str(),
+            &filter,
+            PageRequest {
+                limit: MAX_CHANNELS,
+                offset: 0,
+            },
+        )
+        .await?;
+
+    let channels: Vec<Value> = page.items.iter().map(channel_health_to_json).collect();
+    let as_of = Utc::now().to_rfc3339();
+
+    let (role, source) = if channels.is_empty() {
+        ("client", None::<&str>)
+    } else {
+        ("daemon", Some("daemon-heartbeat"))
+    };
+
+    Ok(json!({
+        "role": role,
+        "source": source,
+        "as_of": as_of,
+        "channels": channels,
     }))
 }
 

--- a/crates/khive-pack-comm/src/lib.rs
+++ b/crates/khive-pack-comm/src/lib.rs
@@ -7,3 +7,20 @@ pub(crate) mod params;
 pub(crate) mod vocab;
 
 pub use pack::CommPack;
+
+/// The namespace `comm.heartbeat` always writes to and `comm.health` always
+/// reads from (khive #606 spec-gate Blocker fix, Leo 2026-07-04).
+///
+/// Channel heartbeat rows are an OPERATIONAL surface, not message data: they
+/// must not follow `KHIVE_EMAIL_INGEST_NAMESPACE` (or any other caller-chosen
+/// namespace), or a client-role no-arg `comm.health()` call — which reads the
+/// default local-visible scope — would see `role: "client"` with an empty
+/// `channels` array even though a daemon has live heartbeat state, violating
+/// the binding amendment ("empty channels is correct only when no daemon
+/// state exists at all").
+///
+/// This is a single shared constant, not independent literals in the writer
+/// (`khive-mcp`'s channel poll loop) and the reader (`handle_health`) — two
+/// string literals that can drift apart is the same bug class one rename
+/// away.
+pub const CHANNEL_HEALTH_NAMESPACE: &str = "local";

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -20,7 +20,7 @@ pub struct CommPack {
 
 impl Pack for CommPack {
     const NAME: &'static str = "comm";
-    const NOTE_KINDS: &'static [&'static str] = &["message"];
+    const NOTE_KINDS: &'static [&'static str] = &["message", "channel_health"];
     const ENTITY_KINDS: &'static [&'static str] = &[];
     const HANDLERS: &'static [HandlerDef] = &COMM_HANDLERS;
     const REQUIRES: &'static [&'static str] = &["kg"];
@@ -91,6 +91,8 @@ impl PackRuntime for CommPack {
             "comm.reply" => handlers::handle_reply(self.runtime(), token, params).await,
             "comm.thread" => handlers::handle_thread(self.runtime(), token, params).await,
             "comm.ingest" => handlers::handle_ingest(self.runtime(), token, params).await,
+            "comm.heartbeat" => handlers::handle_heartbeat(self.runtime(), token, params).await,
+            "comm.health" => handlers::handle_health(self.runtime(), token, params).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "comm pack does not handle verb {verb:?}"
             ))),
@@ -195,7 +197,19 @@ mod help_tests {
 
     #[test]
     fn all_comm_handlers_have_non_empty_params() {
+        // comm.health is a legitimate no-args verb (khive #606 spec-gate: "read-only,
+        // NO args") -- same shape as kg's `stats()`. Every other comm verb takes at
+        // least one param, so the invariant still holds for the rest.
+        const NO_ARGS_VERBS: &[&str] = &["comm.health"];
         for handler in CommPack::HANDLERS {
+            if NO_ARGS_VERBS.contains(&handler.name) {
+                assert!(
+                    handler.params.is_empty(),
+                    "comm handler {:?} is declared no-args; params should be empty",
+                    handler.name
+                );
+                continue;
+            }
             assert!(
                 !handler.params.is_empty(),
                 "comm handler {:?} must have non-empty params",

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -111,6 +111,24 @@ pub(crate) struct IngestParams {
     pub metadata: Option<serde_json::Map<String, Value>>,
 }
 
+/// Parameters for `comm.heartbeat` — persists a per-channel-credential heartbeat row.
+///
+/// `deny_unknown_fields` is intentionally absent, matching `IngestParams`: the
+/// `namespace` routing key is consumed by `VerbRegistry::dispatch` before the
+/// handler sees `params`, not read from this struct.
+#[derive(Deserialize)]
+pub(crate) struct HeartbeatParams {
+    pub channel_kind: String,
+    pub channel_slug: String,
+    pub outcome: String,
+    #[serde(default)]
+    pub error_class: Option<String>,
+    #[serde(default)]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub at: Option<String>,
+}
+
 pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {
     serde_json::from_value(params)
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -34,7 +34,7 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
         WHERE deleted_at IS NULL",
 ];
 
-pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [
+pub(crate) static COMM_HANDLERS: [HandlerDef; 8] = [
     HandlerDef {
         name: "comm.send",
         description: "Send a message, optionally threaded.",
@@ -224,5 +224,67 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 6] = [
                 description: "Optional transport-layer metadata passthrough, merged additively into the stored note's properties (never overrides an already-set field). Generic and channel-agnostic; the email channel uses it for quarantine markers (quarantined, quarantine_reason, quarantine_claimed_from — ADR-056 Amendment 2026-07-02).",
             },
         ],
+    },
+    HandlerDef {
+        name: "comm.heartbeat",
+        description: "Persist a per-channel-credential heartbeat row after a poll attempt. \
+                       Subhandler — not callable on the MCP wire; only the daemon's channel \
+                       poll loop calls this (khive #606).",
+        visibility: Visibility::Subhandler,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "namespace",
+                param_type: "string",
+                required: true,
+                description: "Target namespace for the heartbeat row.",
+            },
+            ParamDef {
+                name: "channel_kind",
+                param_type: "string",
+                required: true,
+                description: "Channel kind identifier (e.g. `email`).",
+            },
+            ParamDef {
+                name: "channel_slug",
+                param_type: "string",
+                required: true,
+                description: "Stable per-credential identifier distinguishing accounts of the same kind (e.g. the mailbox address). Never `channel_kind` alone — two accounts of the same kind must not collapse into one row.",
+            },
+            ParamDef {
+                name: "outcome",
+                param_type: "string",
+                required: true,
+                description: "Poll outcome for this attempt: \"success\" or \"failure\".",
+            },
+            ParamDef {
+                name: "error_class",
+                param_type: "string",
+                required: false,
+                description: "Error class, required when outcome is \"failure\". Open string enum; v1 values: auth | transport | config. Callers must tolerate unknown classes.",
+            },
+            ParamDef {
+                name: "error_message",
+                param_type: "string",
+                required: false,
+                description: "Human-readable error detail when outcome is \"failure\". Must carry a message class, never raw secrets or wire headers.",
+            },
+            ParamDef {
+                name: "at",
+                param_type: "string",
+                required: false,
+                description: "RFC 3339 timestamp of this poll attempt. Defaults to now.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "comm.health",
+        description: "Read-only per-channel health snapshot (khive #606). Returns the \
+                       daemon-persisted heartbeat row for every known channel: timestamps \
+                       and consecutive-failure counts only — never a computed healthy bool. \
+                       Health judgment belongs to the caller.",
+        visibility: Visibility::Verb,
+        category: khive_types::VerbCategory::Assertive,
+        params: &[],
     },
 ];

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -229,7 +229,11 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 8] = [
         name: "comm.heartbeat",
         description: "Persist a per-channel-credential heartbeat row after a poll attempt. \
                        Subhandler — not callable on the MCP wire; only the daemon's channel \
-                       poll loop calls this (khive #606).",
+                       poll loop calls this (khive #606). The row is ALWAYS pinned to \
+                       `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE` (\"local\") regardless of \
+                       the caller's dispatch namespace — heartbeat rows are an operational \
+                       surface, not message data, so they never follow \
+                       `KHIVE_EMAIL_INGEST_NAMESPACE` or any other caller-chosen namespace.",
         visibility: Visibility::Subhandler,
         category: khive_types::VerbCategory::Declaration,
         params: &[
@@ -237,7 +241,13 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 8] = [
                 name: "namespace",
                 param_type: "string",
                 required: true,
-                description: "Target namespace for the heartbeat row.",
+                description: "Dispatch routing key (ADR-007 Rule 3 explicit escape) consumed \
+                              by `VerbRegistry::dispatch` to mint the call's `NamespaceToken`. \
+                              Callers should always pass \
+                              `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE`: the persisted row's \
+                              actual namespace is hardcoded to that constant inside the \
+                              handler regardless of this value, so a different value here \
+                              does not redirect where the row lands.",
             },
             ParamDef {
                 name: "channel_kind",
@@ -282,7 +292,11 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 8] = [
         description: "Read-only per-channel health snapshot (khive #606). Returns the \
                        daemon-persisted heartbeat row for every known channel: timestamps \
                        and consecutive-failure counts only — never a computed healthy bool. \
-                       Health judgment belongs to the caller.",
+                       Health judgment belongs to the caller. Reads \
+                       `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE` (\"local\") UNCONDITIONALLY \
+                       — regardless of the caller's dispatch/token namespace — so a client-role \
+                       no-arg call always sees daemon-persisted state when it exists, even if \
+                       the caller's own messages are ingested under a different namespace.",
         visibility: Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[],

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -40,11 +40,12 @@ fn comm_pack_declares_message_note_kind() {
 }
 
 #[test]
-fn comm_pack_declares_six_handlers() {
+fn comm_pack_declares_eight_handlers() {
     assert_eq!(
         CommPack::HANDLERS.len(),
-        6,
-        "comm pack must declare 6 handlers: send, inbox, read, reply, thread, ingest"
+        8,
+        "comm pack must declare 8 handlers: send, inbox, read, reply, thread, ingest, \
+         heartbeat, health"
     );
     let names: Vec<&str> = CommPack::HANDLERS.iter().map(|h| h.name).collect();
     assert!(names.contains(&"comm.send"));
@@ -58,6 +59,22 @@ fn comm_pack_declares_six_handlers() {
     assert!(
         names.contains(&"comm.ingest"),
         "comm.ingest verb must be registered"
+    );
+    assert!(
+        names.contains(&"comm.heartbeat"),
+        "comm.heartbeat verb must be registered (khive #606)"
+    );
+    assert!(
+        names.contains(&"comm.health"),
+        "comm.health verb must be registered (khive #606)"
+    );
+}
+
+#[test]
+fn comm_pack_declares_channel_health_note_kind() {
+    assert!(
+        CommPack::NOTE_KINDS.contains(&"channel_health"),
+        "khive #606: channel_health must be a pack-owned note kind"
     );
 }
 
@@ -5175,5 +5192,327 @@ async fn thread_includes_root_message_without_thread_id_property() {
     assert!(
         count >= 2,
         "thread must include root + child (at least 2); got count={count}"
+    );
+}
+
+// --- comm.heartbeat / comm.health (khive #606) ---
+
+/// Spec-gate amendment 1 (blocking): a fresh install with no persisted daemon
+/// heartbeat state must report `role: "client"` with an empty channel list —
+/// never fabricate channel entries the comm pack has no evidence for.
+#[tokio::test]
+async fn health_reports_client_role_when_no_heartbeat_state_exists() {
+    let (registry, _rt) = build_registry();
+
+    let result = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+
+    assert_eq!(result["role"].as_str(), Some("client"));
+    assert!(result["source"].is_null());
+    assert!(result["as_of"].as_str().is_some());
+    assert_eq!(
+        result["channels"]
+            .as_array()
+            .expect("channels is array")
+            .len(),
+        0
+    );
+}
+
+/// comm.health() takes no arguments — any caller-supplied args must be rejected
+/// rather than silently ignored (spec: "read-only, NO args").
+#[tokio::test]
+async fn health_rejects_stray_args() {
+    let (registry, _rt) = build_registry();
+
+    let err = registry
+        .dispatch("comm.health", serde_json::json!({ "limit": 10 }))
+        .await
+        .expect_err("health must reject unexpected args");
+    assert!(
+        err.to_string().contains("takes no arguments"),
+        "unexpected error message: {err}"
+    );
+}
+
+/// Core cross-process-read contract (spec-gate amendment 1): once the daemon
+/// persists a successful heartbeat, `comm.health()` returns it annotated
+/// `role: "daemon"`, `source: "daemon-heartbeat"` — this is true even though
+/// the *reading* call is a plain in-process dispatch here, mirroring a
+/// client-role stdio caller reading state it did not write itself.
+#[tokio::test]
+async fn heartbeat_success_is_visible_via_health() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("heartbeat succeeds");
+
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+
+    assert_eq!(health["role"].as_str(), Some("daemon"));
+    assert_eq!(health["source"].as_str(), Some("daemon-heartbeat"));
+    let channels = health["channels"].as_array().expect("channels is array");
+    assert_eq!(channels.len(), 1);
+    let ch = &channels[0];
+    assert_eq!(ch["channel_kind"].as_str(), Some("email"));
+    assert_eq!(ch["channel_slug"].as_str(), Some("leo@khive.ai"));
+    assert!(ch["last_success_at"].as_str().is_some());
+    assert!(ch["last_poll_attempt_at"].as_str().is_some());
+    assert!(ch["last_failure_at"].is_null());
+    assert!(ch["last_error"].is_null());
+    assert_eq!(ch["consecutive_failures"].as_u64(), Some(0));
+}
+
+/// Spec-gate amendment 3: `last_error` is RETAINED after a subsequent success
+/// (callers compare `last_error.at` vs `last_success_at`), and
+/// `consecutive_failures` resets to 0 on success.
+#[tokio::test]
+async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failures() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "failure",
+                "error_class": "auth",
+                "error_message": "XOAUTH2 handshake failed",
+            }),
+        )
+        .await
+        .expect("first failure heartbeat succeeds");
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "failure",
+                "error_class": "auth",
+                "error_message": "XOAUTH2 handshake failed",
+            }),
+        )
+        .await
+        .expect("second failure heartbeat succeeds");
+
+    let after_failures = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    let ch = &after_failures["channels"][0];
+    assert_eq!(ch["consecutive_failures"].as_u64(), Some(2));
+    assert_eq!(ch["last_error"]["class"].as_str(), Some("auth"));
+
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("success heartbeat succeeds");
+
+    let after_success = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    let ch = &after_success["channels"][0];
+    assert_eq!(
+        ch["consecutive_failures"].as_u64(),
+        Some(0),
+        "consecutive_failures must reset to 0 on success"
+    );
+    assert_eq!(
+        ch["last_error"]["class"].as_str(),
+        Some("auth"),
+        "last_error must be RETAINED after a subsequent success (spec-gate amendment 3)"
+    );
+    assert!(
+        ch["last_success_at"].as_str().is_some(),
+        "last_success_at must be set"
+    );
+}
+
+/// Spec-gate amendment 2: rows are keyed by channel slug + kind, never kind
+/// alone — two accounts of the same kind must not collapse into one row.
+#[tokio::test]
+async fn heartbeat_keys_by_slug_not_kind_alone() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "success",
+            }),
+        )
+        .await
+        .expect("first account heartbeat succeeds");
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "ops@khive.ai",
+                "outcome": "failure",
+                "error_class": "transport",
+                "error_message": "connect timeout",
+            }),
+        )
+        .await
+        .expect("second account heartbeat succeeds");
+
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    let channels = health["channels"].as_array().expect("channels is array");
+    assert_eq!(
+        channels.len(),
+        2,
+        "two accounts of the same channel_kind must produce two distinct rows; got {channels:?}"
+    );
+    let slugs: std::collections::HashSet<&str> = channels
+        .iter()
+        .map(|c| c["channel_slug"].as_str().unwrap())
+        .collect();
+    assert!(slugs.contains("leo@khive.ai"));
+    assert!(slugs.contains("ops@khive.ai"));
+}
+
+/// Repeated heartbeats for the same (kind, slug) update the same row (via
+/// `upsert_note`'s deterministic id) rather than accumulating duplicates.
+#[tokio::test]
+async fn heartbeat_repeated_calls_update_same_row() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    for _ in 0..3 {
+        registry
+            .dispatch(
+                "comm.heartbeat",
+                serde_json::json!({
+                    "namespace": "local",
+                    "channel_kind": "email",
+                    "channel_slug": "leo@khive.ai",
+                    "outcome": "success",
+                }),
+            )
+            .await
+            .expect("heartbeat succeeds");
+    }
+
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    assert_eq!(
+        health["channels"].as_array().expect("array").len(),
+        1,
+        "repeated heartbeats for the same channel must update one row, not accumulate"
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_requires_error_class_on_failure() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    let err = registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "failure",
+            }),
+        )
+        .await
+        .expect_err("failure outcome without error_class must be rejected");
+    assert!(
+        err.to_string().contains("error_class"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_rejects_invalid_outcome() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    let err = registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "maybe",
+            }),
+        )
+        .await
+        .expect_err("invalid outcome must be rejected");
+    assert!(
+        err.to_string().contains("outcome"),
+        "unexpected error message: {err}"
+    );
+}
+
+/// Spec: "report TIMESTAMPS only ... never a computed `healthy: bool`" —
+/// the channel entry shape must not carry any boolean health verdict.
+#[tokio::test]
+async fn health_channel_entry_never_carries_a_healthy_bool() {
+    let (registry, _rt) = build_registry_for_ns("local");
+
+    registry
+        .dispatch(
+            "comm.heartbeat",
+            serde_json::json!({
+                "namespace": "local",
+                "channel_kind": "email",
+                "channel_slug": "leo@khive.ai",
+                "outcome": "failure",
+                "error_class": "auth",
+                "error_message": "handshake failed",
+            }),
+        )
+        .await
+        .expect("heartbeat succeeds");
+
+    let health = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+    let ch = health["channels"][0]
+        .as_object()
+        .expect("channel entry is an object");
+    assert!(
+        !ch.contains_key("healthy"),
+        "channel entry must never carry a computed healthy bool: {ch:?}"
     );
 }


### PR DESCRIPTION
## Summary

Implements #606: a read-only `comm.health()` verb backed by daemon-persisted per-channel heartbeat rows, per the amended design-review contract ([comment](https://github.com/ohdearquant/khive/issues/606#issuecomment-4883980803)) which supersedes the original issue body where they differ.

Closes #606. Also closes the evidence lane tracked in #599 (this verb is the durable channel-health surface that lane was waiting on).

### Contract amendments implemented (per the design-review GO)

1. **Daemon persists heartbeat rows; `comm.health()` returns persisted state, annotated.** `role` is `"daemon"` whenever any persisted `channel_health` row exists (regardless of which process answers the read), else `"client"` with an empty `channels: []`. Every populated entry carries `source: "daemon-heartbeat"` implicitly via its presence in the daemon-authored row set; `as_of` is the query time.
2. **Keyed by `(channel_kind, channel_slug)`, never `kind` alone.** `Channel` trait gained a default `slug()` method (falls back to `kind()`); `EmailChannel` overrides it to the configured mailbox address, so two email accounts never collapse into one row.
3. **`last_error` retained after a subsequent success; `consecutive_failures: int` added.** A success does not clear `last_error` — it only resets `consecutive_failures` to 0. A failure replaces `last_error` and increments the counter.
4. **`error_class` is an open string enum** (v1: `auth` | `transport` | `config`, mapped 1:1 from `ChannelError` per #614's precedent — `Auth`→`auth`, `Transport`→`transport`, `Config`/`UnauthorizedSender`/`InvalidEnvelope`→`config`). Callers must tolerate unknown classes. The response reports timestamps and counts only — **never a computed `healthy: bool`**; health judgment is left to the caller.

### Where the heartbeat row lives — no schema migration

Heartbeat rows are ordinary `notes` of a new pack-owned kind, `"channel_health"` (added to `CommPack::NOTE_KINDS` — this is a Rust-level vocabulary extension, not a DB migration; note kinds are pack-owned per ADR-017/ADR-023, not the closed ADR-013 base set).

Each row's `id` is a deterministic `Uuid::new_v5` over `khive:channel_health:{namespace}:{channel_kind}:{channel_slug}`. Because `NoteStore::upsert_note` is `INSERT OR REPLACE` keyed by `id`, repeated heartbeat calls for the same channel credential idempotently update the same row in place. **No new table or column was needed** — this satisfies the dispatch's hard escalation gate (`crates/khive-db/sql/` untouched, no new `VersionedMigration`).

### New verbs

- `comm.heartbeat` (subhandler, not on the MCP wire) — called by `serve.rs`'s channel poll loop after every poll attempt (success and failure), best-effort (a dispatch failure logs a warning, never breaks the poll loop).
- `comm.health` (verb, zero args) — read-only per-channel snapshot.

### Judgment call flagged for review

The comm pack itself has no visibility into which channels are *configured*, only which have ever *reported* a heartbeat. So when no `channel_health` rows exist at all, the response is `role: "client"`, `channels: []` — there is no way at this architectural layer to enumerate "configured but never-polled" channels. This matches design-review amendment 1's "all-null only when no daemon state exists at all," but is worth a second look if a future consumer wants "configured channels with no data yet" surfaced explicitly.

## Test plan

- [x] `cargo test -p khive-pack-comm` — 105 passed (rc=0)
- [x] `cargo test -p khive-mcp --features channel-email` — 110 passed (rc=0)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (rc=0)
- [x] `cargo clippy -p khive-mcp --all-targets --features channel-email -- -D warnings` — clean (rc=0, covers the feature-gated serve.rs heartbeat code)
- [x] `cargo fmt --all -- --check` — clean (rc=0)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean (rc=0)
- New integration tests cover: client-role-with-no-state, stray-args rejection, success visible via health, last_error retention across success, slug-vs-kind keying, repeated-call idempotency, error_class-required-on-failure, invalid-outcome rejection, and the absence of any `healthy` bool in the response shape.