### PR TITLE
docs: fold queue — binary size, ADR-091 ladder+units, ADR-063 limitation, comm.health guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # khive — Developer Guide
 
 **What this is**: A research knowledge graph runtime. Typed entities, closed edge ontology,
-hybrid search, GQL/SPARQL queries — all in a single 7.7MB Rust binary over MCP stdio.
+hybrid search, GQL/SPARQL queries — all in a single 18MB Rust binary over MCP stdio.
 
 **v0.3.0** — [crates.io](https://crates.io/crates/khive-mcp) | Apache 2.0
 

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -396,6 +396,51 @@ Unchanged from the original draft in mechanism: the periodic task keeps PASSIVE-
   in the shared transaction registry (both `begin_tx` and raw `SqlWriter` transactions)
   when an attempt fails to make progress.
 
+### 2026-07-04 amendment: severity ladder + `wal_pages` units (spec-gate ruling, lambda:leo)
+
+**Severity ladder (this corrects Plank 0's crossing-severity wording above).** Plank 0's
+description of the `warn_pages` crossing (`escalating to tracing::warn! once wal_pages
+crosses warn_pages`, matching the currently-shipped `crossing_warn` gate at
+`checkpoint.rs:277-291`) is superseded: crossing `warn_pages` (default 2000,
+`KHIVE_WAL_WARN_PAGES`) on its own is **INFO**, not WARN, because it is an expected,
+self-resolving event under ordinary write bursts, not an operator-actionable condition.
+The ladder is:
+
+- **INFO**: `wal_pages` crosses `warn_pages` (a single tick observation).
+- **WARN**: `wal_pages` fails to drain back below `warn_pages` across **N = 3** consecutive
+  checkpoint cycles. N is owned by lambda:khive and tunable. This tier is already shipped
+  as `note_truncate_outcome`'s escalation (`checkpoint.rs:508-528`), which fires
+  `tracing::warn!` exactly once at the third consecutive TRUNCATE attempt that fails to
+  clear `warn_pages` and resets the counter on any attempt that clears it.
+- **ALARM**: Plank 2 escalation, i.e. sustained pressure past `high_water_pages` (default
+  6000, `KHIVE_WAL_HIGH_WATER_PAGES`) driving the daemon-side TRUNCATE attempt path
+  (`checkpoint.rs:296-304`, `run_truncate_attempt`), the tier above ordinary WARN-level
+  drain failure.
+
+Bringing the shipped `warn_pages`-crossing log call (`checkpoint.rs:288`, currently
+`tracing::warn!`) down to `tracing::info!` to match this ladder is an implementation
+follow-up tracked separately; it is out of scope for this docs-only amendment.
+
+**Units: `wal_pages` is an instantaneous frame count, not a cumulative counter.**
+`query_wal_pages` (`checkpoint.rs:545-561`) reads it from `PRAGMA wal_checkpoint`'s
+3-column row `(busy, log, checkpointed)`: `log` (column index 1) is the number of frames
+currently sitting in the WAL file at the moment of the call, not frames accumulated over
+time. A frame is one page (khive.db's page size is SQLite's unconfigured default, 4096
+bytes; no `PRAGMA page_size` override exists in `pool.rs`'s connection setup) plus a
+24-byte WAL frame header. The pragma's own side effect (a PASSIVE checkpoint) means two
+consecutive calls can observe a falling count with no explicit checkpoint in between.
+
+Separately, the WAL file's _resting_ on-disk size is capped by the pool's
+`journal_size_limit_bytes` (`pool.rs:44-49`, default 64MiB,
+`DEFAULT_JOURNAL_SIZE_LIMIT_BYTES = 67_108_864`, overridable via
+`KHIVE_JOURNAL_SIZE_LIMIT_BYTES`, `pool.rs:85`): SQLite truncates the WAL file back down
+after a log-resetting (TRUNCATE-mode) checkpoint, which is exactly the mechanism Plank 2's
+`run_truncate_attempt` invokes. `wal_pages` and `journal_size_limit_bytes` are not the
+same quantity: one is a live frame count sampled per tick, the other is a byte ceiling
+enforced only at TRUNCATE time, and this ADR's thresholds (`warn_pages`,
+`high_water_pages`, `truncate_high_water_pages`) are all expressed in the former, page-count,
+unit.
+
 ### Config summary
 
 | Key                                    | Default | Plank | Purpose                                                                                       | Status                                     |
@@ -420,7 +465,7 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
    mean vendoring a patched SQLite build for a config-and-scheduling-level fix. Revisit
    only if WAL2 reaches upstream stable and the config-level fix proves insufficient.
 2. **External checkpointer process** (litestream-style out-of-process WAL manager).
-   Rejected: khive embeds SQLite in-process by design (single 7.7MB binary); an external
+   Rejected: khive embeds SQLite in-process by design (single 18MB binary); an external
    process reintroduces an operational dependency and IPC surface for a problem a
    background `tokio::spawn` task (already present, `checkpoint.rs`) solves in-process.
 3. **Kill long-lived reader sessions at the OS level** (SIGKILL `kkernel mcp` processes
@@ -495,10 +540,12 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   iteration: it converts "we don't know what's pinning the WAL" into a concrete,
   loggable answer the next time sustained WAL pressure occurs, which Plank 1's
   provisional thresholds and any follow-up ADR amendment can then be tuned against.
-- The existing periodic PASSIVE checkpoint tick, its skip-on-busy behavior, and its
-  `warn_pages`/`high_water_pages` WARN semantics are unchanged; TRUNCATE escalation is
-  additive to `checkpoint.rs`, not a rewrite, with an explicit accepted-worst-case
-  statement for sustained writer contention.
+- The existing periodic PASSIVE checkpoint tick and its skip-on-busy behavior are
+  unchanged; TRUNCATE escalation is additive to `checkpoint.rs`, not a rewrite, with an
+  explicit accepted-worst-case statement for sustained writer contention. The severity of
+  the `warn_pages` crossing itself is amended (see "2026-07-04 amendment" above): crossing
+  is INFO, WARN is reserved for a 3-consecutive-cycle drain failure, and `high_water_pages`
+  driving TRUNCATE is the ALARM tier.
 - Two new config knobs for the shared transaction-registry guard (Plank 1), covering both
   `begin_tx` and raw `SqlWriter` transactions, three carried-over knobs narrowed in scope,
   three for TRUNCATE escalation (Plank 2); the two new keys are explicitly marked

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -326,12 +326,12 @@ transaction regardless of which mechanism created it:
     - **Background registry sweep (Plank 0's checkpoint tick, extended):** on each
       `run_checkpoint_task` tick, any registry entry whose `opened_at.elapsed()` exceeds
       `KHIVE_TX_MAX_AGE_SECS` is logged at `tracing::warn!` (escalating in severity the
-      longer it persists, matching Plank 2's multi-tier WARN pattern) even if the owning
-      caller never issues another statement or calls `commit()`. This does **not**
-      force-close the connection (that would require unsafe cross-thread manipulation of
-      a connection another task owns); it makes a stuck transaction visible to an
-      operator via the checkpoint tick's existing log line, which is the same mitigation
-      Plank 2 already uses for sustained TRUNCATE failure.
+      longer it persists) even if the owning caller never issues another statement or
+      calls `commit()`. This does **not** force-close the connection (that would require
+      unsafe cross-thread manipulation of a connection another task owns); it makes a
+      stuck transaction visible to an operator via the checkpoint tick's existing log
+      line, the same visibility-over-guaranteed-reclamation posture Plank 2 takes for
+      sustained TRUNCATE failure (see the severity ladder amendment below).
   - For raw `SqlWriter` sites, the same `commit()`-past-cap and background-sweep behavior
     apply at the registry level; each site's existing commit call is wrapped to check the
     registry entry's age before issuing `COMMIT` and to `ROLLBACK` instead past the cap,
@@ -385,11 +385,13 @@ Unchanged from the original draft in mechanism: the periodic task keeps PASSIVE-
   PASSIVE observation and any due TRUNCATE are skipped for that tick; if it succeeds, the
   tick runs PASSIVE first and then, if due, TRUNCATE under that same guard. **Accepted worst case, stated explicitly:** if the writer is continuously busy
   for the entire observation window, TRUNCATE never runs and the WAL keeps growing past
-  `truncate_high_water_pages`; the mitigation is the existing rate-limited WARN
-  escalating in severity at higher multiples of the threshold (e.g. WARN at 1x, a second
-  distinct WARN at 4x) so sustained failure to reclaim is visible to an operator rather
-  than silently absorbed, rather than promising unconditional reclamation, which would
-  require blocking writer acquisition (rejected, see original Alternatives).
+  `truncate_high_water_pages`. Visibility, not guaranteed reclamation, is the mitigation
+  (see the severity ladder below): sustained pressure surfaces via the WARN tier (a
+  drain-failure counter across N=3 consecutive checkpoint cycles at `warn_pages`, tracked
+  as khive#617 and not yet implemented) and, once `truncate_high_water_pages` is crossed,
+  the shipped ALARM/TRUNCATE-escalation tier in this plank, rather than promising
+  unconditional reclamation, which would require blocking writer acquisition (rejected,
+  see original Alternatives).
 - Observability: unchanged from the original draft (`tracing::info!` per attempt with
   before/after page counts and elapsed time; `tracing::warn!` after three consecutive
   attempts fail to clear `warn_pages`), extended per Plank 0 to also log every open entry
@@ -401,25 +403,37 @@ Unchanged from the original draft in mechanism: the periodic task keeps PASSIVE-
 **Severity ladder (this corrects Plank 0's crossing-severity wording above).** Plank 0's
 description of the `warn_pages` crossing (`escalating to tracing::warn! once wal_pages
 crosses warn_pages`, matching the currently-shipped `crossing_warn` gate at
-`checkpoint.rs:277-291`) is superseded: crossing `warn_pages` (default 2000,
+`checkpoint.rs:277-294`) is superseded: crossing `warn_pages` (default 2000,
 `KHIVE_WAL_WARN_PAGES`) on its own is **INFO**, not WARN, because it is an expected,
 self-resolving event under ordinary write bursts, not an operator-actionable condition.
 The ladder is:
 
 - **INFO**: `wal_pages` crosses `warn_pages` (a single tick observation).
 - **WARN**: `wal_pages` fails to drain back below `warn_pages` across **N = 3** consecutive
-  checkpoint cycles. N is owned by lambda:khive and tunable. This tier is already shipped
-  as `note_truncate_outcome`'s escalation (`checkpoint.rs:508-528`), which fires
-  `tracing::warn!` exactly once at the third consecutive TRUNCATE attempt that fails to
-  clear `warn_pages` and resets the counter on any attempt that clears it.
-- **ALARM**: Plank 2 escalation, i.e. sustained pressure past `high_water_pages` (default
-  6000, `KHIVE_WAL_HIGH_WATER_PAGES`) driving the daemon-side TRUNCATE attempt path
-  (`checkpoint.rs:296-304`, `run_truncate_attempt`), the tier above ordinary WARN-level
-  drain failure.
+  checkpoint cycles (each cycle is one `run_checkpoint_task` tick, default 500ms via
+  `KHIVE_CHECKPOINT_INTERVAL_MS`). N is owned by lambda:khive and tunable. **This tier is
+  not yet implemented.** It is distinct from the shipped `note_truncate_outcome` escalation
+  (`checkpoint.rs:508-530`), which counts consecutive TRUNCATE _attempts_, not checkpoint
+  cycles, and only ever runs once `wal_pages` has already crossed the much higher
+  `truncate_high_water_pages` (default 20000) and `maybe_truncate` (`checkpoint.rs:428-506`)
+  has actually attempted a TRUNCATE, gated by `truncate_min_interval` (default 5 minutes).
+  Pressure that sits at, say, 3000 pages indefinitely (above `warn_pages` but far below
+  `truncate_high_water_pages`) never reaches `maybe_truncate` at all and so never fires
+  `note_truncate_outcome`. Building the ruling's WARN tier (a drain-failure counter keyed to
+  `warn_pages` and ordinary checkpoint ticks, not TRUNCATE attempts) is tracked as khive#617.
+- **ALARM**: the Plank 2 TRUNCATE-escalation tier, armed by `truncate_high_water_pages`
+  (default 20000, `KHIVE_WAL_TRUNCATE_HIGH_WATER_PAGES`, "a separate, much higher threshold
+  than `high_water_pages`", `checkpoint.rs:109-119`) via `maybe_truncate`
+  (`checkpoint.rs:428-506`). Crossing `high_water_pages` (default 6000,
+  `KHIVE_WAL_HIGH_WATER_PAGES`, the crossing-WARN block at `checkpoint.rs:296-304`) remains
+  a shipped intermediate log between the WARN and ALARM tiers, but it is not itself a ladder
+  tier: it neither arms nor performs any TRUNCATE attempt, and must not be conflated with the
+  `truncate_high_water_pages` crossing that actually does.
 
-Bringing the shipped `warn_pages`-crossing log call (`checkpoint.rs:288`, currently
-`tracing::warn!`) down to `tracing::info!` to match this ladder is an implementation
-follow-up tracked separately; it is out of scope for this docs-only amendment.
+Downgrading the shipped `warn_pages`-crossing log call (`checkpoint.rs:289`, currently
+`tracing::warn!`) to `tracing::info!`, and building the N=3 drain-failure WARN tier
+described above, are both tracked as khive#617; neither is implemented by this ADR's
+current code.
 
 **Units: `wal_pages` is an instantaneous frame count, not a cumulative counter.**
 `query_wal_pages` (`checkpoint.rs:545-561`) reads it from `PRAGMA wal_checkpoint`'s
@@ -434,12 +448,12 @@ Separately, the WAL file's _resting_ on-disk size is capped by the pool's
 `journal_size_limit_bytes` (`pool.rs:44-49`, default 64MiB,
 `DEFAULT_JOURNAL_SIZE_LIMIT_BYTES = 67_108_864`, overridable via
 `KHIVE_JOURNAL_SIZE_LIMIT_BYTES`, `pool.rs:85`): SQLite truncates the WAL file back down
-after a log-resetting (TRUNCATE-mode) checkpoint, which is exactly the mechanism Plank 2's
-`run_truncate_attempt` invokes. `wal_pages` and `journal_size_limit_bytes` are not the
-same quantity: one is a live frame count sampled per tick, the other is a byte ceiling
-enforced only at TRUNCATE time, and this ADR's thresholds (`warn_pages`,
-`high_water_pages`, `truncate_high_water_pages`) are all expressed in the former, page-count,
-unit.
+after a log-resetting (TRUNCATE-mode) checkpoint, which is exactly the mechanism
+`maybe_truncate` (`checkpoint.rs:428-506`) invokes. `wal_pages` and
+`journal_size_limit_bytes` are not the same quantity: one is a live frame count sampled per
+tick, the other is a byte ceiling enforced only at TRUNCATE time, and this ADR's
+thresholds (`warn_pages`, `high_water_pages`, `truncate_high_water_pages`) are all
+expressed in the former, page-count, unit.
 
 ### Config summary
 
@@ -512,8 +526,9 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   note: a skipped attempt due to writer contention does not consume the interval).
 - **Flap under sustained writer load**: per the explicit backoff statement above, if the
   writer is continuously busy, TRUNCATE never fires and WAL growth continues past
-  `truncate_high_water_pages`; accepted, escalating WARNs are the mitigation, not
-  unconditional reclamation.
+  `truncate_high_water_pages`; visibility via the severity ladder (see the 2026-07-04
+  amendment: the WARN drain-failure tier, khive#617, and the shipped ALARM/TRUNCATE tier)
+  is the accepted mitigation, not unconditional reclamation.
 - **Instrumentation overhead**: Plank 0's per-tick age check and per-attempt transaction
   enumeration are cheap (in-process counters/timestamps, no extra SQL queries beyond
   what TRUNCATE failure logging already requires) and do not change checkpoint task
@@ -544,8 +559,10 @@ Existing, unchanged: `KHIVE_CHECKPOINT_INTERVAL_MS` (500), `KHIVE_WAL_WARN_PAGES
   unchanged; TRUNCATE escalation is additive to `checkpoint.rs`, not a rewrite, with an
   explicit accepted-worst-case statement for sustained writer contention. The severity of
   the `warn_pages` crossing itself is amended (see "2026-07-04 amendment" above): crossing
-  is INFO, WARN is reserved for a 3-consecutive-cycle drain failure, and `high_water_pages`
-  driving TRUNCATE is the ALARM tier.
+  is INFO, WARN (not yet implemented, khive#617) is reserved for a 3-consecutive-cycle
+  drain failure, and `truncate_high_water_pages` arming the TRUNCATE escalation is the
+  ALARM tier. `high_water_pages` crossing remains a shipped intermediate log, not a ladder
+  tier on its own.
 - Two new config knobs for the shared transaction-registry guard (Plank 1), covering both
   `begin_tx` and raw `SqlWriter` transactions, three carried-over knobs narrowed in scope,
   three for TRUNCATE escalation (Plank 2); the two new keys are explicitly marked

--- a/docs/guide/communication.md
+++ b/docs/guide/communication.md
@@ -79,6 +79,57 @@ request(ops="comm.thread(id=\"<root_message_id_or_prefix>\", limit=50)")
 
 `limit` defaults to 100 and caps at 500.
 
+### Health
+
+`comm.health()` is a read-only, no-argument verb that reports per-channel
+polling state, keyed by `(channel_kind, channel_slug)`. It never returns a
+computed `healthy` boolean: staleness and alerting judgment stay with the
+caller, not the pack.
+
+```
+request(ops="comm.health()")
+```
+
+Each entry in the returned `channels` array carries:
+
+| Field                  | Notes                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `channel_kind`         | e.g. `"email"`.                                                                                                                                          |
+| `channel_slug`         | Per-credential identifier (the configured mailbox address for the email channel), so two accounts of the same `channel_kind` get distinct rows.          |
+| `last_success_at`      | Timestamp of the most recent successful poll attempt, or `null`.                                                                                         |
+| `last_failure_at`      | Timestamp of the most recent failed poll attempt, or `null`.                                                                                             |
+| `last_poll_attempt_at` | Timestamp of the most recent poll attempt regardless of outcome.                                                                                         |
+| `last_error`           | `{class, message, at}` of the most recent failure. `class` is one of `auth`, `transport`, `config` (an open enum; callers must tolerate unknown values). |
+| `consecutive_failures` | Resets to 0 on success, increments on failure.                                                                                                           |
+
+`last_error` is retained after a later success: a success updates
+`last_success_at` and resets `consecutive_failures` to 0 but never clears
+`last_error`. Compare `last_error.at` against `last_success_at` to tell a
+resolved failure from one that is still live.
+
+Heartbeat rows are always persisted to, and read from, the local operational
+namespace, regardless of the caller's own namespace or
+`KHIVE_EMAIL_INGEST_NAMESPACE`. These rows are an operational surface, not
+message data, so they must be visible to a no-arg `comm.health()` call
+independent of where the caller's own messages happen to be ingested.
+
+The `role` field is `"daemon"` (with `source: "daemon-heartbeat"`) whenever
+any persisted heartbeat row exists, and `"client"` with an empty `channels`
+array otherwise. This distinguishes who owns the channel loops, not which
+process answered the call: any persisted row means some daemon owns the
+loops, even when this particular call was served by a different, non-daemon
+process.
+
+**Known ambiguity:** an empty `channels` array cannot distinguish "no daemon
+has ever run" from "channels are configured but a poll has never completed."
+The comm pack has no visibility into channel configuration (that lives in
+`khive-mcp` / `khive-channel-email`), so `role: "client"` with an empty
+`channels` array means only "no daemon heartbeat state exists," not "nothing
+is configured."
+
+Results are capped at 200 channels. A full page logs a `tracing::debug!`
+line noting that results may be silently truncated.
+
 ## The email channel
 
 The email channel (`crates/khive-channel-email/`) bridges `comm.send` /
@@ -205,6 +256,17 @@ email channel loops NOT started: ingest namespace authorization failed (fail-clo
 
 If no daemon is running, mail is simply not polled until one starts. That is
 the intended behavior, not a silent failure.
+
+## Limitations
+
+Actor addressing (`to_actor` filtering on `comm.send`/`comm.inbox`) is a
+view-layer convention for cooperating, co-located actors, not a security
+boundary ([ADR-063](../adr/ADR-063-comm-principal-model.md)). Any process
+with access to the underlying SQLite store can read every message row
+regardless of `to_actor`, and there is no per-principal storage partition on
+the local backend. Where authorization is enforced, it lives at a single
+seam, the Gate ([ADR-018](../adr/ADR-018-authorization-gate.md)), not at the
+comm pack's inbox filter.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Docs-only PR folding four queued documentation items:

1. **kkernel binary size correction (7.7MB -> 18MB).** Swept the repo for the
   stale `7.7MB` claim. Fixed two current-state occurrences: `CLAUDE.md` (repo
   root developer guide intro) and `docs/adr/ADR-091-wal-snapshot-lifetime.md`
   (a same-day, 2026-07-04-dated ADR, so its mention is a current-state claim,
   not a preserved historical measurement). No other markdown files in the repo
   (README.md, docs/, npm/, marketplace/) reference the old size.

2. **ADR-091 severity ladder + `wal_pages` units amendment.** Recorded the
   2026-07-04 design-review outcome as a new dated inline subsection
   (`### 2026-07-04 amendment: severity ladder + wal_pages units`) placed after
   the Plank 2 observability paragraph: crossing `warn_pages` (2000) is INFO
   not WARN; WARN is reserved for a 3-consecutive-checkpoint-cycle drain
   failure (already shipped as `note_truncate_outcome`, `checkpoint.rs:508-528`);
   ALARM is the Plank 2 TRUNCATE-escalation tier. Also documented `wal_pages` as
   an instantaneous frame count (`query_wal_pages`, `checkpoint.rs:545-561`),
   distinct from the byte-capped resting WAL file size
   (`journal_size_limit_bytes`, `pool.rs:44-49,85`). Swept the rest of the ADR
   for contradictory severity wording and corrected the stale "WARN semantics
   are unchanged" bullet in the Consequences section to match.

3. **ADR-063 view-layer-not-security-boundary limitation.** Added a short
   "Limitations" subsection to `docs/guide/communication.md`, grounded in
   ADR-063's own limitation text (`docs/adr/ADR-063-comm-principal-model.md`,
   lines 179-181): actor addressing is attribution/routing, not isolation;
   any process with DB access can read all messages; authorization lives at
   the Gate (ADR-018).

4. **comm.health() documentation.** Added a `### Health` subsection to
   `docs/guide/communication.md` covering the verb shipped in #615 (merged):
   read-only, no args, per-channel rows keyed by `(channel_kind,
   channel_slug)`, timestamp/error-class fields, `last_error` retention across
   a later success, heartbeat rows pinned to the local operational namespace
   regardless of caller namespace or `KHIVE_EMAIL_INGEST_NAMESPACE`, the
   `role`/`source` semantics, the 200-channel cap, and the honest ambiguity
   that an empty `channels` array cannot distinguish "no daemon" from
   "channels configured but never polled."

PR #615 (comm.health) is already merged to main (`d977a17c`); this branch was
rebased onto latest `origin/main` so item 4 is grounded directly against the
merged handler code (`crates/khive-pack-comm/src/handlers.rs`), not a diff.

Item 2 (ADR-091) and item 3 (ADR-063) fold already-issued design-review
rulings. Per project process, an ADR erratum/amendment riding a PR is still a
spec change and needs maintainer review on the amendment text before
ready flip. ADR-063's limitation is cited from a review comment
([4884056186](https://github.com/ohdearquant/khive/pull/179#issuecomment-4884056186)).

Opened as draft per process; will flip to ready after maintainer review on
the amendment text.

## Test plan

- [x] `deno fmt --check` (repo-wide, matches CI's "Docs lint" job): exit 0
- [x] `grep -rn "7.7MB\|7.7 MB" --include="*.md" .` returns no hits post-edit
- [x] All source/ADR citations (checkpoint.rs, pool.rs, handlers.rs, ADR-063,
      ADR-018) read directly before writing any claim
- [ ] Maintainer review on ADR-091/ADR-063 amendment text