### PR TITLE
feat(mcp): docs address + agent doc-reading guidance in initialize instructions

### DIFF
--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -1487,18 +1487,30 @@ fn render_result(
     render_format(value, batch_format, presentation)
 }
 
+/// Build the `initialize` instructions string from the verb catalog and the
+/// loaded builtin pack names. Extracted from [`ServerHandler::get_info`] so
+/// the docs-pointer section (#594) is unit-testable without standing up a
+/// full server.
+fn build_instructions(catalog: &str, builtins: &str) -> String {
+    format!(
+        "khive — request-only MCP surface. One tool, `request`, \
+         dispatches verbs through the loaded pack registry. Configure packs via \
+         KHIVE_PACKS or --pack (built-ins: {builtins}). Verbs registered on this \
+         server:\n{catalog}\nFor detailed usage of each verb, see the corresponding \
+         plugin's SKILL.md files.\n\
+         Docs: https://ohdearquant.github.io/khive/ (hosted) or docs/*.md in the repo \
+         checkout. Treat the live verb catalog above and help=true as authoritative over \
+         cached/training knowledge. Config/backend issues: docs/configuration.md. Usage \
+         patterns: docs/guide/tips-and-tricks.md."
+    )
+}
+
 #[tool_handler]
 impl ServerHandler for KhiveMcpServer {
     fn get_info(&self) -> ServerInfo {
         let catalog = self.verb_catalog();
         let builtins = builtin_pack_names().join(", ");
-        let instructions = format!(
-            "khive — request-only MCP surface. One tool, `request`, \
-             dispatches verbs through the loaded pack registry. Configure packs via \
-             KHIVE_PACKS or --pack (built-ins: {builtins}). Verbs registered on this \
-             server:\n{catalog}\nFor detailed usage of each verb, see the corresponding \
-             plugin's SKILL.md files."
-        );
+        let instructions = build_instructions(&catalog, &builtins);
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new(
                 env!("CARGO_PKG_NAME"),
@@ -1567,6 +1579,16 @@ mod tests {
         assert!(catalog.contains("[gtd] Create a task."));
         // The verb name must appear exactly once in the catalog header.
         assert_eq!(catalog.matches("  create — ").count(), 1);
+    }
+
+    #[test]
+    fn instructions_carry_docs_address_and_guidance_pointers() {
+        let instructions = build_instructions("  create — Create an entity or note.\n", "kg, gtd");
+        assert!(instructions.contains("https://ohdearquant.github.io/khive/"));
+        assert!(instructions.contains("docs/configuration.md"));
+        assert!(instructions.contains("docs/guide/tips-and-tricks.md"));
+        // help=true / live-catalog-over-training-knowledge guidance present.
+        assert!(instructions.contains("help=true"));
     }
 
     #[test]

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -115,7 +115,11 @@ def main():
         })
         init = recv(proc)
         assert init["result"]["serverInfo"]["name"] == "khive-mcp", f"unexpected: {init}"
-        print("  [ok] initialize")
+        instructions = init["result"].get("instructions") or ""
+        assert "https://ohdearquant.github.io/khive/" in instructions, (
+            f"initialize instructions missing docs address; got:\n{instructions}"
+        )
+        print("  [ok] initialize — instructions carry docs address")
 
         # Send initialized notification
         notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -197,18 +197,20 @@ def main():
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
         # unset) loads 8 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session), so verbs() returns exactly 73 user-facing
+        # knowledge, session), so verbs() returns exactly 74 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
-        # Visibility::Verb per ADR-083; brain.register_adapter (#354) and
-        # context (ADR-089, the 17th kg-substrate bare verb) are included in
-        # the count. Update this number when the pack set or verb surface
-        # changes; a silent drift here is the bug this assertion exists to catch.
-        assert verbs_result["total"] == 73, (
-            f"expected 73 user-facing verbs from the 8 default packs "
+        # Visibility::Verb per ADR-083; brain.register_adapter (#354), context
+        # (ADR-089, the 17th kg-substrate bare verb), and comm.health (#606,
+        # verified live 2026-07-04) are included in the count. Update this
+        # number when the pack set or verb surface changes; a silent drift
+        # here is the bug this assertion exists to catch.
+        assert verbs_result["total"] == 74, (
+            f"expected 74 user-facing verbs from the 8 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
-            f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089), "
+            f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
+            f"comm.health is #606), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]
@@ -222,7 +224,7 @@ def main():
         # pack= filter: handler_defs.rs:729 applies pack_name.eq_ignore_ascii_case(pk);
         # each returned entry carries its "pack" field (handler_defs.rs:736).
         # Assertions must be non-vacuous: a pack=kg filter that was ignored would
-        # return the full 67-verb list, so we verify the filter returns only kg verbs.
+        # return the full 74-verb list, so we verify the filter returns only kg verbs.
         kg_verbs = call_verb(proc, "verbs", {"pack": "kg"})
         assert len(kg_verbs["verbs"]) > 0, f"kg pack filter must return a nonempty list: {kg_verbs}"
         assert kg_verbs["total"] == len(kg_verbs["verbs"]), (


### PR DESCRIPTION
## Summary
- Extends the `initialize` instructions string (built in `crates/khive-mcp/src/server.rs`, `ServerHandler::get_info` via a new `build_instructions()` helper) with a few lines pointing agents at the hosted docs (https://ohdearquant.github.io/khive/) and `docs/*.md` in the repo checkout.
- Guidance: prefer the live verb catalog + `help=true` over cached/training knowledge; consult `docs/configuration.md` for backend/config issues; pointer (not inlined) to `docs/guide/tips-and-tricks.md`.
- Verb catalog itself is unchanged — this is a budget-conscious ~4-line, ~430-char addition, not prose.
- Also fixes the stale `verbs()` total tripwire in `tests/smoke_test.py` (73 -> 74): it rides this PR because this PR already modifies that file and its own acceptance criterion is the smoke test asserting on `instructions`, so the file must actually reach exit 0. The count drifted stale when `comm.health` (#606) merged to `main` ahead of this branch; verified the real total (74 = 57 non-kg + 17 kg-pack) live against a fresh release build before updating the assertion.

## Test plan
- [x] New Rust unit test `instructions_carry_docs_address_and_guidance_pointers` on `build_instructions()` (crates/khive-mcp/src/server.rs)
- [x] Extended `tests/smoke_test.py`'s `initialize` assertion to check the docs address appears in the real wire-level `instructions` field
- [x] `cargo test -p khive-mcp` — 110 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean
- [x] `uv run python3 tests/smoke_test.py` against a fresh release build — **full run now passes end-to-end, exit 0** (verb-count tripwire fixed to the verified live total of 74)

Closes #594
