### PR TITLE
refactor(kg): derive edge-relation error hints from installed pack EDGE_RULES

### DIFF
--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
 serde_json = { workspace = true }
 khive-pack-formal = { version = "0.3.0", path = "../khive-pack-formal" }
+khive-pack-gtd = { version = "0.3.0", path = "../khive-pack-gtd" }
 
 [[test]]
 name = "integration"

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -412,79 +412,43 @@ pub(crate) fn validate_weight(weight: Option<f64>) -> Result<f64, RuntimeError> 
     Ok(w)
 }
 
-pub(crate) fn valid_relations_for_entity_pair(src_kind: &str, tgt_kind: &str) -> Vec<&'static str> {
-    const RULES: &[(&str, &str, &str)] = &[
-        ("concept", "contains", "concept"),
-        ("project", "contains", "project"),
-        ("project", "contains", "artifact"),
-        ("org", "contains", "project"),
-        ("org", "contains", "service"),
-        ("concept", "part_of", "concept"),
-        ("project", "part_of", "project"),
-        ("project", "part_of", "org"),
-        ("*", "instance_of", "concept"),
-        ("service", "instance_of", "project"),
-        ("concept", "extends", "concept"),
-        ("concept", "variant_of", "concept"),
-        ("artifact", "variant_of", "artifact"),
-        ("concept", "introduced_by", "document"),
-        ("concept", "introduced_by", "person"),
-        ("artifact", "introduced_by", "document"),
-        ("artifact", "derived_from", "dataset"),
-        ("artifact", "derived_from", "document"),
-        ("artifact", "derived_from", "project"),
-        ("artifact", "derived_from", "artifact"),
-        ("document", "precedes", "document"),
-        ("dataset", "precedes", "dataset"),
-        ("artifact", "precedes", "artifact"),
-        ("service", "precedes", "service"),
-        ("project", "precedes", "project"),
-        ("project", "depends_on", "project"),
-        ("service", "depends_on", "project"),
-        ("service", "depends_on", "service"),
-        ("service", "depends_on", "artifact"),
-        ("service", "depends_on", "dataset"),
-        ("artifact", "depends_on", "project"),
-        ("artifact", "depends_on", "service"),
-        ("concept", "enables", "concept"),
-        ("service", "enables", "concept"),
-        ("dataset", "enables", "concept"),
-        ("project", "implements", "concept"),
-        ("service", "implements", "concept"),
-        ("concept", "competes_with", "concept"),
-        ("project", "competes_with", "project"),
-        ("service", "competes_with", "service"),
-        ("concept", "composed_with", "concept"),
-        ("project", "composed_with", "project"),
-        ("concept", "supersedes", "concept"),
-        ("document", "supersedes", "document"),
-        ("artifact", "supersedes", "artifact"),
-        ("service", "supersedes", "service"),
-        ("dataset", "supersedes", "dataset"),
-        // Epistemic (ADR-055)
-        ("concept", "supports", "concept"),
-        ("document", "supports", "concept"),
-        ("dataset", "supports", "concept"),
-        ("artifact", "supports", "concept"),
-        ("concept", "refutes", "concept"),
-        ("document", "refutes", "concept"),
-        ("dataset", "refutes", "concept"),
-        ("artifact", "refutes", "concept"),
-        ("person", "part_of", "org"),
-        ("person", "instance_of", "org"),
-        ("person", "part_of", "project"),
-        ("person", "instance_of", "project"),
-        ("org", "depends_on", "org"),
-        ("org", "enables", "org"),
-        ("org", "contains", "org"),
-        ("org", "part_of", "org"),
-        ("org", "precedes", "org"),
-    ];
-    let mut relations: Vec<&'static str> = RULES
+/// Relations valid for a `(src_kind, tgt_kind)` entity pair, derived from the
+/// SAME sources `validate_edge_relation_endpoints` consults when accepting or
+/// rejecting a link (issue #543): the base entity endpoint allowlist
+/// (`khive_runtime::operations::base_entity_endpoint_rules`) plus the
+/// runtime's live composed pack `EDGE_RULES` (`KhiveRuntime::pack_edge_rules`,
+/// the same call `pack_rule_allows` makes). There is no separate hand-authored
+/// table here — a hint can no longer diverge from what the validator itself
+/// accepts.
+///
+/// Only `EndpointKind::EntityOfKind` pack rules are considered: this function
+/// is only ever reached (via `enrich_allowlist_error`) after both endpoints
+/// have already been resolved as entities, so note-scoped pack rules (e.g.
+/// GTD's `task` -> `task` `depends_on`, declared as `NoteOfKind`) cannot match
+/// here regardless — that path produces a different validation error entirely
+/// ("must be an entity for relation ..."), not the base-allowlist error this
+/// function enriches.
+pub(crate) fn valid_relations_for_entity_pair(
+    runtime: &KhiveRuntime,
+    src_kind: &str,
+    tgt_kind: &str,
+) -> Vec<&'static str> {
+    let mut relations: Vec<&'static str> = khive_runtime::operations::base_entity_endpoint_rules()
         .iter()
         .filter(|(src, _rel, tgt)| (*src == "*" || *src == src_kind) && *tgt == tgt_kind)
-        .map(|(_src, rel, _tgt)| *rel)
+        .map(|(_src, rel, _tgt)| rel.as_str())
         .collect();
+
+    for rule in runtime.pack_edge_rules() {
+        let src_matches =
+            matches!(rule.source, khive_types::EndpointKind::EntityOfKind(k) if k == src_kind);
+        let tgt_matches =
+            matches!(rule.target, khive_types::EndpointKind::EntityOfKind(k) if k == tgt_kind);
+        if src_matches && tgt_matches {
+            relations.push(rule.relation.as_str());
+        }
+    }
+
     relations.sort_unstable();
     relations.dedup();
     relations
@@ -506,7 +470,7 @@ pub(crate) async fn enrich_allowlist_error(
         Ok(e) => e.kind,
         Err(_) => return original.to_string(),
     };
-    let valid = valid_relations_for_entity_pair(&src_kind, &tgt_kind);
+    let valid = valid_relations_for_entity_pair(runtime, &src_kind, &tgt_kind);
     let mut msg = if valid.is_empty() {
         format!(
             "Invalid relation {:?} for {src_kind}\u{2192}{tgt_kind}. \

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -412,26 +412,33 @@ pub(crate) fn validate_weight(weight: Option<f64>) -> Result<f64, RuntimeError> 
     Ok(w)
 }
 
-/// Relations valid for a `(src_kind, tgt_kind)` entity pair, derived from the
-/// SAME sources `validate_edge_relation_endpoints` consults when accepting or
-/// rejecting a link (issue #543): the base entity endpoint allowlist
+/// Relations valid for a `(src_kind, src_entity_type, tgt_kind,
+/// tgt_entity_type)` entity pair, derived from the SAME sources
+/// `validate_edge_relation_endpoints` consults when accepting or rejecting a
+/// link (issue #543): the base entity endpoint allowlist
 /// (`khive_runtime::operations::base_entity_endpoint_rules`) plus the
-/// runtime's live composed pack `EDGE_RULES` (`KhiveRuntime::pack_edge_rules`,
-/// the same call `pack_rule_allows` makes). There is no separate hand-authored
-/// table here — a hint can no longer diverge from what the validator itself
-/// accepts.
+/// runtime's live composed pack `EDGE_RULES`, matched through
+/// `khive_runtime::operations::accepted_pack_relations_for_entities` — the
+/// same `endpoint_matches` semantics `pack_rule_allows` applies internally
+/// (`EntityOfKind`, `EntityOfType`, `NoteOfKind`). There is no separate
+/// hand-authored table and no local re-filter of endpoint kinds here: a hint
+/// can no longer diverge from what the validator itself accepts, including
+/// pack rules scoped to a granular `entity_type` (e.g. `khive-pack-formal`'s
+/// typed `theorem -> definition` `depends_on` rule).
 ///
-/// Only `EndpointKind::EntityOfKind` pack rules are considered: this function
-/// is only ever reached (via `enrich_allowlist_error`) after both endpoints
-/// have already been resolved as entities, so note-scoped pack rules (e.g.
-/// GTD's `task` -> `task` `depends_on`, declared as `NoteOfKind`) cannot match
-/// here regardless — that path produces a different validation error entirely
-/// ("must be an entity for relation ..."), not the base-allowlist error this
-/// function enriches.
+/// Note-scoped pack rules (e.g. GTD's `task` -> `task` `depends_on`,
+/// declared as `NoteOfKind`) cannot match here regardless of the shared
+/// matcher, because this function is only ever reached (via
+/// `enrich_allowlist_error`) after both endpoints have already been resolved
+/// as entities — a note/note mismatch produces a different validation error
+/// entirely ("must be an entity for relation ..."), not the base-allowlist
+/// error this function enriches.
 pub(crate) fn valid_relations_for_entity_pair(
     runtime: &KhiveRuntime,
     src_kind: &str,
+    src_entity_type: Option<&str>,
     tgt_kind: &str,
+    tgt_entity_type: Option<&str>,
 ) -> Vec<&'static str> {
     let mut relations: Vec<&'static str> = khive_runtime::operations::base_entity_endpoint_rules()
         .iter()
@@ -439,14 +446,15 @@ pub(crate) fn valid_relations_for_entity_pair(
         .map(|(_src, rel, _tgt)| rel.as_str())
         .collect();
 
-    for rule in runtime.pack_edge_rules() {
-        let src_matches =
-            matches!(rule.source, khive_types::EndpointKind::EntityOfKind(k) if k == src_kind);
-        let tgt_matches =
-            matches!(rule.target, khive_types::EndpointKind::EntityOfKind(k) if k == tgt_kind);
-        if src_matches && tgt_matches {
-            relations.push(rule.relation.as_str());
-        }
+    let pack_rules = runtime.pack_edge_rules();
+    for rel in khive_runtime::operations::accepted_pack_relations_for_entities(
+        &pack_rules,
+        src_kind,
+        src_entity_type,
+        tgt_kind,
+        tgt_entity_type,
+    ) {
+        relations.push(rel.as_str());
     }
 
     relations.sort_unstable();
@@ -462,15 +470,21 @@ pub(crate) async fn enrich_allowlist_error(
     target_id: Uuid,
     relation: EdgeRelation,
 ) -> String {
-    let src_kind = match runtime.get_entity(token, source_id).await {
-        Ok(e) => e.kind,
+    let (src_kind, src_entity_type) = match runtime.get_entity(token, source_id).await {
+        Ok(e) => (e.kind, e.entity_type),
         Err(_) => return original.to_string(),
     };
-    let tgt_kind = match runtime.get_entity(token, target_id).await {
-        Ok(e) => e.kind,
+    let (tgt_kind, tgt_entity_type) = match runtime.get_entity(token, target_id).await {
+        Ok(e) => (e.kind, e.entity_type),
         Err(_) => return original.to_string(),
     };
-    let valid = valid_relations_for_entity_pair(runtime, &src_kind, &tgt_kind);
+    let valid = valid_relations_for_entity_pair(
+        runtime,
+        &src_kind,
+        src_entity_type.as_deref(),
+        &tgt_kind,
+        tgt_entity_type.as_deref(),
+    );
     let mut msg = if valid.is_empty() {
         format!(
             "Invalid relation {:?} for {src_kind}\u{2192}{tgt_kind}. \

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -524,7 +524,7 @@ fn valid_relations_concept_to_concept_includes_extends() {
     use khive_runtime::KhiveRuntime;
 
     let rt = KhiveRuntime::memory().expect("in-memory runtime");
-    let rels = valid_relations_for_entity_pair(&rt, "concept", "concept");
+    let rels = valid_relations_for_entity_pair(&rt, "concept", None, "concept", None);
     assert!(
         rels.contains(&"extends"),
         "#486: concept->concept must include extends; got: {rels:?}"
@@ -550,7 +550,7 @@ fn valid_relations_unsupported_pair_returns_empty() {
     use khive_runtime::KhiveRuntime;
 
     let rt = KhiveRuntime::memory().expect("in-memory runtime");
-    let rels = valid_relations_for_entity_pair(&rt, "person", "dataset");
+    let rels = valid_relations_for_entity_pair(&rt, "person", None, "dataset", None);
     assert!(
         rels.is_empty(),
         "#486: person->dataset has no base-contract relations; got: {rels:?}"
@@ -561,14 +561,21 @@ fn valid_relations_unsupported_pair_returns_empty() {
 // separate hand-authored table (the person->project gap, issue #60, was
 // exactly this divergence class) ----
 
-// Generative cross-check: for a given (source_kind, target_kind) pair, the hint
-// set returned by `valid_relations_for_entity_pair` must equal the set of
-// relations the REAL production validator (`KgPack::handle_link`, which
-// bottoms out in `KhiveRuntime::link` -> `validate_edge_relation_endpoints`)
+// Generative cross-check: for EVERY (source_kind, target_kind) entity pair in
+// the 9x9 closed entity-kind taxonomy, the hint set returned by
+// `valid_relations_for_entity_pair` must equal the set of relations the REAL
+// production validator (`KhiveRuntime::link` -> `validate_edge_relation_endpoints`)
 // actually accepts for that pair. This calls production code on both sides —
 // it never re-implements the rule check inline.
+//
+// Codex round-1 review of #621 flagged that a five-pair spot check missed an
+// `EntityOfType`-scoped divergence (see
+// `valid_relations_hint_covers_formal_pack_entity_of_type_rules` below); this
+// sweeps the full closed kind space so a future divergence at any pair fails
+// loudly rather than only at hand-picked pairs.
 #[tokio::test]
-async fn valid_relations_hint_matches_real_validator_acceptance() {
+async fn valid_relations_hint_matches_real_validator_acceptance_across_all_entity_kind_pairs() {
+    use crate::vocab::EntityKind as KgEntityKind;
     use crate::KgPack;
     use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
     use khive_storage::EdgeRelation;
@@ -616,31 +623,117 @@ async fn valid_relations_hint_matches_real_validator_acceptance() {
     let registry = builder.build().expect("kg registry builds");
     rt.install_edge_rules(registry.all_edge_rules());
 
-    for (src_kind, tgt_kind) in [
-        ("concept", "concept"),
-        ("project", "org"),
-        // issue #60 regression: person->project must be covered by the hint
-        // path exactly as the validator accepts it (KG_EDGE_RULES part_of +
-        // instance_of).
-        ("person", "project"),
-        ("person", "org"),
-        ("org", "org"),
-    ] {
-        let expected = accepted_relations_for(&rt, src_kind, tgt_kind).await;
-        let hinted = super::valid_relations_for_entity_pair(&rt, src_kind, tgt_kind);
-        assert_eq!(
-            hinted, expected,
-            "#543: hint set for {src_kind}->{tgt_kind} must equal the real \
-             validator's acceptance set; hinted={hinted:?} expected={expected:?}"
-        );
+    for src in KgEntityKind::ALL {
+        for tgt in KgEntityKind::ALL {
+            let (src_kind, tgt_kind) = (src.name(), tgt.name());
+            let expected = accepted_relations_for(&rt, src_kind, tgt_kind).await;
+            let hinted =
+                super::valid_relations_for_entity_pair(&rt, src_kind, None, tgt_kind, None);
+            assert_eq!(
+                hinted, expected,
+                "#543: hint set for {src_kind}->{tgt_kind} must equal the real \
+                 validator's acceptance set; hinted={hinted:?} expected={expected:?}"
+            );
+        }
     }
+}
+
+// Codex round-1 High finding on #621: `valid_relations_for_entity_pair` only
+// matched `EndpointKind::EntityOfKind` pack rules, silently omitting
+// `EndpointKind::EntityOfType` rules such as khive-pack-formal's typed
+// `concept/theorem -> concept/definition` `depends_on` rule
+// (`crates/khive-pack-formal/src/vocab.rs:29-38`) — exactly the #543
+// divergence class this PR fixes. This test proves the fix: with `kg,formal`
+// installed, the hint for the typed pair includes `depends_on`, and a
+// generative cross-check against the real validator confirms the hint set is
+// exactly the validator's acceptance set for that typed pair.
+#[tokio::test]
+async fn valid_relations_hint_covers_formal_pack_entity_of_type_rules() {
+    use crate::KgPack;
+    use khive_pack_formal::FormalPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_storage::EdgeRelation;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(FormalPack::new(rt.clone()));
+    let registry = builder.build().expect("kg+formal registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let hinted = super::valid_relations_for_entity_pair(
+        &rt,
+        "concept",
+        Some("theorem"),
+        "concept",
+        Some("definition"),
+    );
+    assert!(
+        hinted.contains(&"depends_on"),
+        "#621 round-2: hint for concept/theorem->concept/definition must \
+         include depends_on from khive-pack-formal's EntityOfType rule; \
+         got: {hinted:?}"
+    );
+
+    // Generative cross-check on the same typed pair: create real typed
+    // entities, call the real validator across all relations, and assert the
+    // hint equals the actual acceptance set — not just a presence check.
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let mut expected = Vec::new();
+    for relation in EdgeRelation::ALL {
+        if relation == EdgeRelation::Annotates {
+            continue;
+        }
+        let src = rt
+            .create_entity(
+                &token,
+                "concept",
+                Some("theorem"),
+                "src",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create typed source entity");
+        let tgt = rt
+            .create_entity(
+                &token,
+                "concept",
+                Some("definition"),
+                "tgt",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create typed target entity");
+        if rt
+            .link(&token, src.id, tgt.id, relation, 1.0, None)
+            .await
+            .is_ok()
+        {
+            expected.push(relation.as_str());
+        }
+    }
+    expected.sort_unstable();
+    expected.dedup();
+
+    assert_eq!(
+        hinted, expected,
+        "#621 round-2: hint set for typed concept/theorem->concept/definition \
+         must equal the real validator's acceptance set; hinted={hinted:?} \
+         expected={expected:?}"
+    );
 }
 
 // GTD's task->task depends_on rule is NoteOfKind-scoped, not an entity-pair
 // rule, so it structurally cannot appear in (and is correctly absent from)
 // this entity-pair hint path — a task/task mismatch produces a different
 // validation error ("must be an entity for relation ...") that never reaches
-// `enrich_allowlist_error` in the first place.
+// `enrich_allowlist_error` in the first place. This pure-function check
+// complements `gtd_task_mismatch_bypasses_enriched_hint_on_real_link_path`
+// below, which proves the same boundary on the real `handle_link` path.
 #[tokio::test]
 async fn valid_relations_hint_does_not_cover_gtd_note_scoped_rules() {
     use crate::KgPack;
@@ -656,15 +749,16 @@ async fn valid_relations_hint_does_not_cover_gtd_note_scoped_rules() {
 
     // No entity kind is named "task" (it's a note kind) so no (src_kind,
     // tgt_kind) entity pair can ever surface GTD's depends_on rule here.
-    let hinted = super::valid_relations_for_entity_pair(&rt, "project", "project");
+    let hinted = super::valid_relations_for_entity_pair(&rt, "project", None, "project", None);
     assert!(
         !hinted.is_empty(),
         "sanity: project->project must still have base-rule hints"
     );
     // The composed pack_edge_rules() DOES include GTD's rule at runtime, but
     // it is NoteOfKind("task") on both ends, so it can never satisfy the
-    // EntityOfKind match this hint function requires — confirmed by checking
-    // no entity-kind pair yields "depends_on" from a NoteOfKind source.
+    // entity-substrate match this hint function requires — confirmed by
+    // checking no entity-kind pair yields "depends_on" from a NoteOfKind
+    // source.
     assert!(
         rt.pack_edge_rules().iter().any(|r| matches!(
             (r.relation, r.source, r.target),
@@ -676,6 +770,74 @@ async fn valid_relations_hint_does_not_cover_gtd_note_scoped_rules() {
         )),
         "GTD's task->task depends_on rule must be present in the composed \
          runtime rule set (proves it's reachable, not just absent by omission)"
+    );
+}
+
+// Codex round-1 Medium finding on #621: proves the GTD boundary on the REAL
+// `KgPack::handle_link` path with real task notes, not just rule presence in
+// `pack_edge_rules()`. A task->task relation outside GTD's declared
+// `depends_on` must fail with the substrate-mismatch error ("must be an
+// entity for relation ...") and must NOT carry the enriched
+// "Valid relations:" hint -- proving `enrich_allowlist_error` is never
+// reached for a note/note mismatch. The GTD-declared relation
+// (`depends_on`) between the same two notes must still succeed.
+#[tokio::test]
+async fn gtd_task_mismatch_bypasses_enriched_hint_on_real_link_path() {
+    use crate::KgPack;
+    use khive_pack_gtd::GtdPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GtdPack::new(rt.clone()));
+    let registry = builder.build().expect("kg+gtd registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let token = rt.authorize(Namespace::local()).unwrap();
+    let src = rt
+        .create_note(&token, "task", None, "task A", None, None, vec![])
+        .await
+        .expect("create task note A");
+    let tgt = rt
+        .create_note(&token, "task", None, "task B", None, None, vec![])
+        .await
+        .expect("create task note B");
+
+    let pack = KgPack::new(rt.clone());
+
+    // "extends" is a valid relation string but not GTD's task->task rule
+    // (only depends_on is declared NoteOfKind for task->task).
+    let params = serde_json::json!({
+        "source_id": src.id.to_string(),
+        "target_id": tgt.id.to_string(),
+        "relation": "extends",
+    });
+    let result = pack.handle_link(&token, params).await;
+    assert!(result.is_err(), "task->task extends must be rejected");
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("must be an entity"),
+        "expected the substrate-mismatch error (only annotates crosses \
+         substrates), got: {err_msg}"
+    );
+    assert!(
+        !err_msg.contains("Valid relations:"),
+        "a note/note mismatch must NOT be enriched with the entity-pair hint \
+         -- enrich_allowlist_error is only reachable for entity/entity \
+         mismatches; got: {err_msg}"
+    );
+
+    // Sanity: the actual GTD-declared relation succeeds on the same two notes
+    // via the real link path.
+    let params_ok = serde_json::json!({
+        "source_id": src.id.to_string(),
+        "target_id": tgt.id.to_string(),
+        "relation": "depends_on",
+    });
+    assert!(
+        pack.handle_link(&token, params_ok).await.is_ok(),
+        "task->task depends_on must be accepted by the real link path"
     );
 }
 

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -521,7 +521,10 @@ fn normalize_entity_timestamps_array_converts_each_element() {
 #[test]
 fn valid_relations_concept_to_concept_includes_extends() {
     use super::valid_relations_for_entity_pair;
-    let rels = valid_relations_for_entity_pair("concept", "concept");
+    use khive_runtime::KhiveRuntime;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let rels = valid_relations_for_entity_pair(&rt, "concept", "concept");
     assert!(
         rels.contains(&"extends"),
         "#486: concept->concept must include extends; got: {rels:?}"
@@ -544,10 +547,135 @@ fn valid_relations_concept_to_concept_includes_extends() {
 #[test]
 fn valid_relations_unsupported_pair_returns_empty() {
     use super::valid_relations_for_entity_pair;
-    let rels = valid_relations_for_entity_pair("person", "dataset");
+    use khive_runtime::KhiveRuntime;
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let rels = valid_relations_for_entity_pair(&rt, "person", "dataset");
     assert!(
         rels.is_empty(),
         "#486: person->dataset has no base-contract relations; got: {rels:?}"
+    );
+}
+
+// ---- Issue #543: hints must equal the validator's own acceptance set, not a
+// separate hand-authored table (the person->project gap, issue #60, was
+// exactly this divergence class) ----
+
+// Generative cross-check: for a given (source_kind, target_kind) pair, the hint
+// set returned by `valid_relations_for_entity_pair` must equal the set of
+// relations the REAL production validator (`KgPack::handle_link`, which
+// bottoms out in `KhiveRuntime::link` -> `validate_edge_relation_endpoints`)
+// actually accepts for that pair. This calls production code on both sides —
+// it never re-implements the rule check inline.
+#[tokio::test]
+async fn valid_relations_hint_matches_real_validator_acceptance() {
+    use crate::KgPack;
+    use khive_runtime::{KhiveRuntime, Namespace, VerbRegistryBuilder};
+    use khive_storage::EdgeRelation;
+
+    async fn accepted_relations_for(
+        rt: &KhiveRuntime,
+        src_kind: &str,
+        tgt_kind: &str,
+    ) -> Vec<&'static str> {
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let mut accepted = Vec::new();
+        for relation in EdgeRelation::ALL {
+            // `annotates` requires a note source (never an entity), so it can
+            // never be accepted for an entity->entity pair regardless of
+            // kind; skip it (matches the hint function's own scope, which
+            // never emits "annotates"). supersedes/supports/refutes DO
+            // validate entity->entity pairs against the same base allowlist
+            // the hint function reads, so they stay in scope here.
+            if relation == EdgeRelation::Annotates {
+                continue;
+            }
+            let src = rt
+                .create_entity(&token, src_kind, None, "src", None, None, vec![])
+                .await
+                .expect("create source entity");
+            let tgt = rt
+                .create_entity(&token, tgt_kind, None, "tgt", None, None, vec![])
+                .await
+                .expect("create target entity");
+            let result = rt.link(&token, src.id, tgt.id, relation, 1.0, None).await;
+            if result.is_ok() {
+                accepted.push(relation.as_str());
+            }
+        }
+        accepted.sort_unstable();
+        accepted.dedup();
+        accepted
+    }
+
+    // kg pack alone: base allowlist + KG_EDGE_RULES (person->org, person->project,
+    // org->org additions from issue #60).
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("kg registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    for (src_kind, tgt_kind) in [
+        ("concept", "concept"),
+        ("project", "org"),
+        // issue #60 regression: person->project must be covered by the hint
+        // path exactly as the validator accepts it (KG_EDGE_RULES part_of +
+        // instance_of).
+        ("person", "project"),
+        ("person", "org"),
+        ("org", "org"),
+    ] {
+        let expected = accepted_relations_for(&rt, src_kind, tgt_kind).await;
+        let hinted = super::valid_relations_for_entity_pair(&rt, src_kind, tgt_kind);
+        assert_eq!(
+            hinted, expected,
+            "#543: hint set for {src_kind}->{tgt_kind} must equal the real \
+             validator's acceptance set; hinted={hinted:?} expected={expected:?}"
+        );
+    }
+}
+
+// GTD's task->task depends_on rule is NoteOfKind-scoped, not an entity-pair
+// rule, so it structurally cannot appear in (and is correctly absent from)
+// this entity-pair hint path — a task/task mismatch produces a different
+// validation error ("must be an entity for relation ...") that never reaches
+// `enrich_allowlist_error` in the first place.
+#[tokio::test]
+async fn valid_relations_hint_does_not_cover_gtd_note_scoped_rules() {
+    use crate::KgPack;
+    use khive_pack_gtd::GtdPack;
+    use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+
+    let rt = KhiveRuntime::memory().expect("in-memory runtime");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GtdPack::new(rt.clone()));
+    let registry = builder.build().expect("kg+gtd registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    // No entity kind is named "task" (it's a note kind) so no (src_kind,
+    // tgt_kind) entity pair can ever surface GTD's depends_on rule here.
+    let hinted = super::valid_relations_for_entity_pair(&rt, "project", "project");
+    assert!(
+        !hinted.is_empty(),
+        "sanity: project->project must still have base-rule hints"
+    );
+    // The composed pack_edge_rules() DOES include GTD's rule at runtime, but
+    // it is NoteOfKind("task") on both ends, so it can never satisfy the
+    // EntityOfKind match this hint function requires — confirmed by checking
+    // no entity-kind pair yields "depends_on" from a NoteOfKind source.
+    assert!(
+        rt.pack_edge_rules().iter().any(|r| matches!(
+            (r.relation, r.source, r.target),
+            (
+                khive_storage::EdgeRelation::DependsOn,
+                khive_types::EndpointKind::NoteOfKind("task"),
+                khive_types::EndpointKind::NoteOfKind("task"),
+            )
+        )),
+        "GTD's task->task depends_on rule must be present in the composed \
+         runtime rule set (proves it's reachable, not just absent by omission)"
     );
 }
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -275,6 +275,39 @@ fn endpoint_matches(
     }
 }
 
+/// Relations that a composed pack `EDGE_RULES` set accepts for a given
+/// `(entity_kind, entity_type)` endpoint pair, using the EXACT SAME
+/// `endpoint_matches` semantics `pack_rule_allows` applies internally
+/// (`EntityOfKind`, `EntityOfType`, `NoteOfKind`) — never a re-filtered copy.
+///
+/// Both endpoints are treated as entities (substrate `"entity"`), matching
+/// the only case pack-layer error-hint code needs (issue #543): a rejected
+/// `link` between two already-resolved entities. `entity_type` is the
+/// pack-owned granular subtype (e.g. `"theorem"`); pass `None` for
+/// untyped entities. Exposed so `khive-pack-kg`'s hint derivation cannot
+/// silently diverge from the validator by only matching `EntityOfKind` and
+/// missing pack rules declared via `EntityOfType` (e.g. `khive-pack-formal`'s
+/// typed `theorem -> definition` `depends_on` rules).
+pub fn accepted_pack_relations_for_entities(
+    rules: &[EdgeEndpointRule],
+    src_kind: &str,
+    src_entity_type: Option<&str>,
+    tgt_kind: &str,
+    tgt_entity_type: Option<&str>,
+) -> Vec<EdgeRelation> {
+    let mut relations: Vec<EdgeRelation> = rules
+        .iter()
+        .filter(|r| {
+            endpoint_matches(&r.source, "entity", src_kind, src_entity_type)
+                && endpoint_matches(&r.target, "entity", tgt_kind, tgt_entity_type)
+        })
+        .map(|r| r.relation)
+        .collect();
+    relations.sort_by_key(|r| r.as_str());
+    relations.dedup();
+    relations
+}
+
 /// `true` if any pack-declared edge endpoint rule allows the
 /// `(source, relation, target)` triple. Pack rules are additive only.
 fn pack_rule_allows(

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -622,7 +622,14 @@ impl KhiveRuntime {
     }
 
     /// Snapshot of currently-installed pack edge rules.
-    pub(crate) fn pack_edge_rules(&self) -> Vec<EdgeEndpointRule> {
+    ///
+    /// This is the SAME composed rule set `validate_edge_relation_endpoints`
+    /// consults via `pack_rule_allows` when accepting/rejecting an edge (issue
+    /// #543). Public so pack-layer error-hint code (e.g.
+    /// `khive-pack-kg`'s `valid_relations_for_entity_pair`) can derive hints
+    /// from the exact source the validator uses, rather than maintaining a
+    /// separate hand-authored table that can drift out of sync (issue #60).
+    pub fn pack_edge_rules(&self) -> Vec<EdgeEndpointRule> {
         self.edge_rules
             .read()
             .map(|g| g.clone())


### PR DESCRIPTION
## Summary

Closes #543.

`valid_relations_for_entity_pair` (`crates/khive-pack-kg/src/handlers/common.rs`)
maintained a separate, hand-authored static rule table used only to build the
"Valid relations: ..." hint on rejected `link` calls. The real validator,
`KhiveRuntime::validate_edge_relation_endpoints`
(`crates/khive-runtime/src/operations.rs`), checks two different live sources:

1. `operations::base_entity_endpoint_rules()` — the base ADR-002 entity
   allowlist (already `pub`, previously exposed for the ADR-076 certificate
   tests).
2. `KhiveRuntime::pack_edge_rules()` — the runtime's **composed** pack
   `EDGE_RULES` snapshot, populated at boot via
   `rt.install_edge_rules(registry.all_edge_rules())` across every loaded
   pack (kg, gtd, memory, ...). This is the exact call
   `pack_rule_allows(&self.pack_edge_rules(), ...)` makes inside the
   validator.

Two independently-maintained tables for the same contract is precisely the
divergence class that produced the person→project gap (issue #60) — the
static hint table had been hand-patched to include `person→org`/
`person→project`/`org→org` after the fact, but nothing enforced that it stay
in sync with `KG_EDGE_RULES` in `pack.rs`, let alone with any other pack's
`EDGE_RULES`.

## Derivation source (exact)

`valid_relations_for_entity_pair(runtime: &KhiveRuntime, src_kind, tgt_kind)`
now unions:

- `khive_runtime::operations::base_entity_endpoint_rules()` (base allowlist)
- `runtime.pack_edge_rules()` filtered to `EndpointKind::EntityOfKind` rules
  matching `(src_kind, tgt_kind)` (the same composed rule set the validator
  reads)

`KhiveRuntime::pack_edge_rules` was widened from `pub(crate)` to `pub` in
`crates/khive-runtime/src/runtime.rs` — the pack-layer hint code needed the
identical live source the validator consults, not a copy.

## Are pack-extended rules covered? (GTD task→task depends_on)

**No — not by omission, but structurally.** `pack_edge_rules()` at runtime
*does* include GTD's `depends_on` rule when the `gtd` pack is loaded (proven
by a new test, `valid_relations_hint_does_not_cover_gtd_note_scoped_rules`).
But GTD's rule is declared as `EndpointKind::NoteOfKind("task") ->
EndpointKind::NoteOfKind("task")`, and this hint path only ever fires for
**entity**→**entity** pairs:

- `enrich_allowlist_error` (the only caller) is only invoked from
  `KgPack::handle_link` when the error text contains "not in the base
  endpoint allowlist" — a message that is only produced by the branch of
  `validate_edge_relation_endpoints` reached after both endpoints are
  confirmed to be **entities**.
- A `task`→`task` (note→note) mismatch never reaches that branch at all — it
  fails earlier with a distinct error ("must be an entity for relation ...
  (only `annotates` crosses substrates)"), which is not enriched by
  `enrich_allowlist_error`.
- The hint function itself additionally filters pack rules to
  `EndpointKind::EntityOfKind` only, so even if a note-scoped rule were
  present in the composed set, it could never match an entity-kind pair.

So GTD's rule is real and live in the composed rule set the validator uses to
*accept* the edge — it just can never surface as a hint here, because this
specific error path only exists for entity-kind mismatches.

## Tests

- Deleted the static hint table entirely — no parallel table remains.
- Existing unit tests (`valid_relations_concept_to_concept_includes_extends`,
  `valid_relations_unsupported_pair_returns_empty`,
  `link_invalid_relation_error_suggests_valid_relations`) updated to pass a
  real `KhiveRuntime` instead of calling a pure static function.
- New generative regression test
  (`valid_relations_hint_matches_real_validator_acceptance`): for each of
  `concept→concept`, `project→org`, `person→project` (issue #60),
  `person→org`, `org→org`, creates real entities and calls the real
  `KhiveRuntime::link` validator across all 17 `EdgeRelation` variants
  (excluding `annotates`, which is note-source-only and can never accept an
  entity pair), then asserts the hint function's output set equals exactly
  the validator's real acceptance set. Never re-implements the rule logic
  inline.
- New test (`valid_relations_hint_does_not_cover_gtd_note_scoped_rules`)
  documents and proves the GTD-coverage boundary above.

## Gates (run from `crates/` in the checkout, `CARGO_TARGET_DIR=target-wt`)

- `cargo test -p khive-pack-kg` — **pass**, exit 0 (206 tests across lib +
  integration + certificate + apply_worker + projection_worker suites)
- `cargo clippy --workspace --all-targets -- -D warnings` — **pass**, exit 0
- `cargo fmt --all -- --check` — **pass**, exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — **pass**,
  exit 0

Also spot-checked `cargo test -p khive-runtime -p khive-pack-gtd` after the
`pack_edge_rules` visibility change (both pass, no regressions).

## LOC delta

```
crates/khive-pack-kg/Cargo.toml             |   1 +
crates/khive-pack-kg/src/handlers/common.rs | 106 ++++++++--------------
crates/khive-pack-kg/src/handlers/tests.rs  | 132 +++++++++++++++++++++++++++-
crates/khive-runtime/src/runtime.rs         |   9 +-
4 files changed, 174 insertions(+), 74 deletions(-)
```

## Scope

Hints only — no taxonomy changes, no new edge relations, no ADR needed. This
implements the existing endpoint contract as a single source of truth; it
does not change the contract. One incidental addition:
`khive-pack-gtd` was added as a dev-dependency of `khive-pack-kg` (mirroring
the existing `khive-pack-formal` dev-dependency) so the new GTD-coverage test
could construct a real `kg+gtd` registry.

## Test plan

- [x] `cargo test -p khive-pack-kg`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [ ] Review (per repo review process)