### PR TITLE
docs: editorial cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ the redundancy-drop even under `auto`/`table`, so agents still get their full ou
 3. `[runtime] default_output_format` in `khive.toml`
 4. Builtin `json`
 
-A fleet that wants the lean view everywhere sets `[runtime] default_output_format = "auto"` once;
+A deployment that wants the lean view everywhere sets `[runtime] default_output_format = "auto"` once;
 product/cloud surfaces leave the default `json`. Unknown values (e.g. `yaml`) warn and fall back to
 the next tier. `kkernel exec` honors all four tiers, including the TOML tier on its in-process path.
 

--- a/crates/khive-bm25/benches/bm25_bench.rs
+++ b/crates/khive-bm25/benches/bm25_bench.rs
@@ -39,7 +39,7 @@ const VOCAB: &[&str] = &[
     "forest",
     "mountain",
     "valley",
-    "ocean",
+    "operator",
     "desert",
     "plain",
     "cloud",

--- a/crates/khive-bm25/benches/bm25_bench.rs
+++ b/crates/khive-bm25/benches/bm25_bench.rs
@@ -39,7 +39,7 @@ const VOCAB: &[&str] = &[
     "forest",
     "mountain",
     "valley",
-    "operator",
+    "ocean",
     "desert",
     "plain",
     "cloud",

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -650,7 +650,7 @@ mod tests {
         );
     }
 
-    // ── entity_posterior_order strict coverage (PR #535 internal review round 1) ────────
+    // ── entity_posterior_order strict coverage regression guard (PR #535) ──────────────
 
     /// Build a fresh version-1 `BalancedRecallSnapshot` with `n` entity
     /// posteriors and a fully-covering order, for mutation in the tests below.

--- a/crates/khive-brain-core/src/brain_state.rs
+++ b/crates/khive-brain-core/src/brain_state.rs
@@ -650,7 +650,7 @@ mod tests {
         );
     }
 
-    // ── entity_posterior_order strict coverage (PR #535 codex round-1) ────────
+    // ── entity_posterior_order strict coverage (PR #535 internal review round 1) ────────
 
     /// Build a fresh version-1 `BalancedRecallSnapshot` with `n` entity
     /// posteriors and a fully-covering order, for mutation in the tests below.
@@ -765,7 +765,7 @@ mod tests {
 
     #[test]
     fn validate_brain_state_snapshot_with_capacity_rejects_version_zero_with_partial_order() {
-        // PR #535 codex round-2 finding 2: a version-0 snapshot with a
+        // PR #535 internal review round 2 finding 2: a version-0 snapshot with a
         // non-empty (here: partial) order is NOT the legacy empty-order
         // compatibility case. `serde(default)` lets `entity_posteriors_version`
         // silently resolve to 0 on an omitted field, so this must be rejected

--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -41,7 +41,7 @@ pub(crate) struct MethodResult {
 /// `parse_header` only ever produces `Some` from a non-empty first token, so
 /// `Some` is always non-empty -- this is a type-level invariant, not just a
 /// convention: an "empty configured id" can never be *represented* as a
-/// matchable authserv_id, let alone accidentally match one (Leo, SPEC-GATE,
+/// matchable authserv_id, let alone accidentally match one (example actor, design review,
 /// 2026-07-03: "guards decay; types don't").
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct AuthResults {
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn parse_header_reason_quoted_semicolon_does_not_forge_dmarc_pass() {
-        // codex #496 repro: a `;` inside a quoted reason= pvalue must never be
+        // review #496 repro: a `;` inside a quoted reason= pvalue must never be
         // treated as a top-level segment boundary, so this must NOT produce a
         // dmarc method result at all -- the real result here is spf=fail.
         let parsed = parse_header(
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn parse_header_dkim_non_numeric_version_suffix_is_ignored_not_trusted_as_v1() {
-        // codex round-2 evidence: a non-numeric "version" must never be silently
+        // internal review round 2 evidence: a non-numeric "version" must never be silently
         // treated as the supported version 1 -- the whole resinfo must be ignored.
         let parsed = parse_header("mx.example.com; dkim/evil=pass header.d=example.com").unwrap();
         assert!(
@@ -538,7 +538,7 @@ mod tests {
 
     /// The plain (non-ARC) `Authentication-Results` header value Exchange
     /// Online stamps on its internal hop, taken verbatim from the real fixture
-    /// `/Users/lion/projects/.khive/workspaces/20260703/email-restore/ocean_0110_raw_headers.txt`
+    /// `/Users/lion/projects/local workspace artifact`
     /// (unfolded), minus the leading `Authentication-Results: ` field name.
     const EXO_FIXTURE_HEADER_VALUE: &str = "spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100";
 
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn select_trusted_authserv_id_mode_empty_configured_id_never_matches_no_id_header() {
-        // Leo's exact point (SPEC-GATE 2026-07-03), independent of the
+        // the exact review point (design review 2026-07-03), independent of the
         // config-layer require_nonempty_env guard: construct
         // TrustAnchor::AuthservId(String::new()) directly, bypassing
         // from_env entirely, against a header that parses to

--- a/crates/khive-channel-email/src/auth_results.rs
+++ b/crates/khive-channel-email/src/auth_results.rs
@@ -537,9 +537,9 @@ mod tests {
     // --- EXO no-authserv-id trust anchor (ADR-056 Amendment 2026-07-03) ---
 
     /// The plain (non-ARC) `Authentication-Results` header value Exchange
-    /// Online stamps on its internal hop, taken verbatim from the real fixture
-    /// `/Users/lion/projects/local workspace artifact`
-    /// (unfolded), minus the leading `Authentication-Results: ` field name.
+    /// Online stamps on its internal hop, taken verbatim from a local test
+    /// mailbox fixture (unfolded), minus the leading `Authentication-Results: `
+    /// field name.
     const EXO_FIXTURE_HEADER_VALUE: &str = "spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100";
 
     #[test]

--- a/crates/khive-channel-email/src/backoff.rs
+++ b/crates/khive-channel-email/src/backoff.rs
@@ -104,8 +104,8 @@ impl ImapBackoff {
     /// step, and returns a [`BackoffTick`] carrying the jittered delay to
     /// sleep plus whether this is a new escalation edge worth a `warn!` log.
     ///
-    /// The jittered `delay` is clamped to `max` (internal review round 1 finding
-    /// 2026-07-04): jitter is additive noise on top of `step`, but `step`
+    /// The jittered `delay` is clamped to `max` (regression guard): jitter is additive
+    /// noise on top of `step`, but `step`
     /// itself can already equal `max` once escalation saturates, so an
     /// unclamped `step + jitter` would let a "~10min cap" reach 750s at the
     /// default 25% jitter window. Clamping here keeps `delay <= max` as a

--- a/crates/khive-channel-email/src/backoff.rs
+++ b/crates/khive-channel-email/src/backoff.rs
@@ -3,7 +3,7 @@
 //!
 //! The 2026-07-04 inbound-email outage (#602) was amplified by the poll
 //! loop's flat ~5s retry cadence with no per-credential concurrency cap:
-//! nine concurrent pollers on `leo@khive.ai` exhausted Exchange Online's
+//! nine concurrent pollers on `recipient@example.com` exhausted Exchange Online's
 //! per-mailbox connection slots, and the flat retry hammer kept the slots
 //! saturated for ~19h. `#602`/`#610` fixed the multi-process spawn that
 //! caused the concurrency; the types here make the channel degrade
@@ -104,7 +104,7 @@ impl ImapBackoff {
     /// step, and returns a [`BackoffTick`] carrying the jittered delay to
     /// sleep plus whether this is a new escalation edge worth a `warn!` log.
     ///
-    /// The jittered `delay` is clamped to `max` (codex round-1 finding
+    /// The jittered `delay` is clamped to `max` (internal review round 1 finding
     /// 2026-07-04): jitter is additive noise on top of `step`, but `step`
     /// itself can already equal `max` once escalation saturates, so an
     /// unclamped `step + jitter` would let a "~10min cap" reach 750s at the
@@ -243,7 +243,7 @@ mod tests {
             let tick = b.record_failure();
             assert!(tick.step <= max);
             assert!(tick.delay >= tick.step.min(max));
-            // Codex round-1 finding: the post-jitter delay must never exceed
+            // internal review round 1 finding: the post-jitter delay must never exceed
             // `max`, even once `step` itself has saturated at `max` (an
             // unclamped 25% jitter window on a capped 600s step would reach
             // 750s otherwise).
@@ -259,7 +259,7 @@ mod tests {
     fn default_config_jittered_delay_never_exceeds_default_max() {
         // Explicitly drive the DEFAULT_BASE/DEFAULT_MAX config to the cap and
         // assert both the unjittered step and the jittered delay respect
-        // DEFAULT_MAX -- the exact scenario codex flagged (750s > 600s cap).
+        // DEFAULT_MAX -- the exact cap regression scenario (750s > 600s cap).
         let mut b = ImapBackoff::default();
         for _ in 0..20 {
             let tick = b.record_failure();

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -943,7 +943,7 @@ mod tests {
 
     #[tokio::test]
     async fn quoted_reason_semicolon_forging_dmarc_pass_does_not_bypass_gate() {
-        // Regression for codex #496 Finding 1, driven through the REAL byte-parsing
+        // Regression for review #496 Finding 1, driven through the REAL byte-parsing
         // path (parse_raw_bytes), not a hand-built AuthResults: a quoted reason=
         // pvalue containing "; dmarc=pass; " must never be split into a separate
         // dmarc method -- the gate must see the genuine spf=fail result and
@@ -1013,7 +1013,7 @@ mod tests {
     #[tokio::test]
     async fn exo_no_authserv_id_fixture_end_to_end_is_attributed() {
         // Real Exchange Online header shape (verbatim values from the live
-        // fixture `ocean_0110_raw_headers.txt`): an ARC-Authentication-Results
+        // fixture `raw_headers.txt`): an ARC-Authentication-Results
         // header (must be ignored -- collecting/trusting ARC is the rejected
         // Shape B, out of scope) precedes the plain Authentication-Results
         // header EXO stamps on its own internal hop, which carries no
@@ -1021,20 +1021,20 @@ mod tests {
         // cleanly through the real byte-parsing path.
         let raw = b"ARC-Authentication-Results: i=2; mx.microsoft.com 1; spf=pass smtp.mailfrom=gmail.com; dmarc=pass header.from=gmail.com; dkim=pass header.d=gmail.com\r\n\
                     Authentication-Results: spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100\r\n\
-                    From: Ocean Li <quantocean.li@gmail.com>\r\n\
-                    To: Leo Li <leo@khive.ai>\r\n\
+                    From: Example Sender <sender@example.com>\r\n\
+                    To: Example Recipient <recipient@example.com>\r\n\
                     Subject: Khive email subject disappears into body\r\n\
                     \r\n\
                     body text";
         let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
 
-        let mut config = make_config("quantocean.li@gmail.com");
+        let mut config = make_config("sender@example.com");
         config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
         let ch = build_channel_from(config, vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
         assert_eq!(
-            envs[0].from, "email:quantocean.li@gmail.com",
+            envs[0].from, "email:sender@example.com",
             "the real EXO no-authserv-id header must attribute cleanly in TopmostNoAuthservId mode"
         );
     }
@@ -1048,13 +1048,13 @@ mod tests {
         // one, or an attacker's forged header floated to the top) --
         // quarantine rather than trust it.
         let raw = b"Authentication-Results: mx.microsoft.com; dmarc=pass header.from=gmail.com\r\n\
-                    From: Ocean Li <quantocean.li@gmail.com>\r\n\
-                    To: Leo Li <leo@khive.ai>\r\n\
+                    From: Example Sender <sender@example.com>\r\n\
+                    To: Example Recipient <recipient@example.com>\r\n\
                     Subject: forged topmost carries an id\r\n\
                     \r\n\
                     body";
         let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
-        let mut config = make_config("quantocean.li@gmail.com");
+        let mut config = make_config("sender@example.com");
         config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
         let ch = build_channel_from(config, vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -223,8 +223,8 @@ pub trait Channel: Send + Sync + 'static {
 /// The MCP server holds an `Arc<ChannelRegistry>` and polls all registered
 /// channels in a background loop, ingesting results via `comm.ingest`.
 ///
-/// Keyed by the composite `(kind, slug)` identity (khive #606 round-1 codex
-/// review, High finding), NOT `kind` alone: two accounts of the same `kind`
+/// Keyed by the composite `(kind, slug)` identity (khive #606), NOT `kind`
+/// alone: two accounts of the same `kind`
 /// (e.g. two mailboxes, both `kind() == "email"`) must coexist as distinct
 /// registered adapters, or they collapse before the heartbeat writer ever
 /// gets a chance to persist separate `channel_health` rows for them.
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn registry_does_not_collapse_same_kind_distinct_slug() {
-        // #606 round-1 codex review, High finding: two accounts sharing
+        // #606 round-1 internal review, High finding: two accounts sharing
         // `kind()` but with distinct `slug()` values (e.g. two mailboxes)
         // must coexist as two registered adapters, not collapse into one.
         let mut reg = ChannelRegistry::new();

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -691,7 +691,7 @@ impl GraphStore for SqlGraphStore {
                     // ascending, applied INSIDE the window's ORDER BY — otherwise a
                     // per-origin cap can silently drop high-weight neighbors in favor
                     // of arbitrary SQLite row order (mirrors neighbors(), ADR-089
-                    // context-verb review codex round-1 High-1; issue #589).
+                    // context-verb review internal review round 1 High-1; issue #589).
                     let full_sql = if let Some(lim) = query_clone.limit {
                         all_params.push(Box::new(lim as i64));
                         format!(
@@ -929,7 +929,7 @@ impl GraphStore for SqlGraphStore {
             // Deterministic weight-descending order, tie-broken by node_id ascending,
             // applied BEFORE `LIMIT` — otherwise a `limit`/`fanout` cap can silently
             // drop high-weight neighbors in favor of arbitrary SQLite row order
-            // (ADR-089 context-verb review, codex round 1, High-1).
+            // (ADR-089 context-verb review, internal review round 1, High-1).
             let full_sql = format!(
                 "SELECT node_id, edge_id, relation, weight FROM ({}){} \
                  ORDER BY weight DESC, node_id ASC{}",

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -148,7 +148,7 @@ async fn test_neighbors_outbound() {
     assert!(!neighbor_ids.contains(&d));
 }
 
-/// Regression guard (ADR-089 context-verb review, codex round 1, High-1): a
+/// Regression guard (ADR-089 context-verb review, internal review round 1, High-1): a
 /// `limit` narrower than the neighbor set must keep the highest-weight edges,
 /// not an arbitrary SQLite row-order subset. Before the fix, `neighbors()`
 /// applied `LIMIT` with no `ORDER BY`, so a low-weight neighbor could win over
@@ -1362,7 +1362,7 @@ async fn batch_neighbors_both_chunk_boundary() {
     );
 }
 
-// ---- per-root limit regression (codex-mandated) ----
+// ---- per-root limit regression ----
 
 /// Regression guard for the per-root `limit` regression introduced when N
 /// roots were batched into a single CTE with one global SQL LIMIT.

--- a/crates/khive-fold/src/selector.rs
+++ b/crates/khive-fold/src/selector.rs
@@ -223,7 +223,7 @@ impl<T: Clone> Selector<T> for GreedySelector {
         // it must be scaled by the same weight or rank comparisons would see
         // the unweighted value while `min_score` filtering sees the weighted
         // one, silently defeating `category_weights` for any candidate that
-        // set `rank_score` (khive/PR#535 codex round-2 finding 1).
+        // set `rank_score` (khive/PR#535 internal review round 2 finding 1).
         if !weights.category_weights.is_empty() {
             for item in &mut inputs {
                 if let Some(ref cat) = item.category {
@@ -812,7 +812,7 @@ mod tests {
         assert_eq!(out.selected[0].id, "a");
     }
 
-    // ── DeterministicScore rank-comparator tests (fold PR #535 codex round-1) ──
+    // ── DeterministicScore rank-comparator tests (fold PR #535 internal review round 1) ──
 
     #[test]
     fn rejects_non_finite_rank_score() {

--- a/crates/khive-gate-rego/docs/protocol.md
+++ b/crates/khive-gate-rego/docs/protocol.md
@@ -32,7 +32,7 @@ default decision := {"decision": "deny", "reason": "no rule matched"}
 
 decision := {"decision": "allow", "obligations": []} if {
     input.actor.kind == "user"
-    input.namespace  == "ocean"
+    input.namespace  == "team-a"
 }
 ```
 

--- a/crates/khive-gate-rego/tests/integration.rs
+++ b/crates/khive-gate-rego/tests/integration.rs
@@ -73,7 +73,7 @@ fn namespace_scoped_policy_emits_audit_obligation() {
     let gate = RegoGate::from_policy_str(&source).expect("compiles");
 
     let mut req = GateRequest::new(
-        ActorRef::new("user", "ocean"),
+        ActorRef::new("user", "operator"),
         Namespace::local(),
         "search",
         json!({}),

--- a/crates/khive-gate/src/tests.rs
+++ b/crates/khive-gate/src/tests.rs
@@ -147,7 +147,7 @@ fn obligation_custom_round_trips_bool() {
 
 fn sample_req_with_session() -> GateRequest {
     GateRequest::new(
-        ActorRef::new("user", "ocean"),
+        ActorRef::new("user", "operator"),
         Namespace::local(),
         "create",
         json!({"kind": "concept"}),
@@ -171,7 +171,7 @@ fn audit_event_roundtrips_through_serde_stable_shape() {
 
     // All required fields present with correct values.
     assert_eq!(json["actor"]["kind"], "user");
-    assert_eq!(json["actor"]["id"], "ocean");
+    assert_eq!(json["actor"]["id"], "operator");
     assert_eq!(json["namespace"], "local");
     assert_eq!(json["verb"], "create");
     assert_eq!(json["decision"], "allow");

--- a/crates/khive-gate/tests/integration.rs
+++ b/crates/khive-gate/tests/integration.rs
@@ -19,7 +19,7 @@ fn sample_request() -> GateRequest {
 
 fn sample_req_with_session() -> GateRequest {
     GateRequest::new(
-        ActorRef::new("user", "ocean"),
+        ActorRef::new("user", "operator"),
         Namespace::local(),
         "create",
         json!({"kind": "concept"}),
@@ -163,7 +163,7 @@ fn audit_event_roundtrips_through_serde_stable_shape() {
     let json = serde_json::to_value(&ev).unwrap();
 
     assert_eq!(json["actor"]["kind"], "user");
-    assert_eq!(json["actor"]["id"], "ocean");
+    assert_eq!(json["actor"]["id"], "operator");
     assert_eq!(json["namespace"], "local");
     assert_eq!(json["verb"], "create");
     assert_eq!(json["decision"], "allow");
@@ -350,11 +350,11 @@ fn rate_limit_try_rejects_zero_max() {
 
 #[test]
 fn valid_actor_ref_roundtrips() {
-    let a = ActorRef::new("user", "ocean");
+    let a = ActorRef::new("user", "operator");
     let json = serde_json::to_string(&a).unwrap();
     let back: ActorRef = serde_json::from_str(&json).unwrap();
     assert_eq!(back.kind, "user");
-    assert_eq!(back.id, "ocean");
+    assert_eq!(back.id, "operator");
 }
 
 #[test]

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1213,7 +1213,7 @@ mod tests {
     // The agent-facing `request` tool must stamp `from_wire=true` on its daemon
     // forward-frame. Without this, a daemon-backed MCP request would dispatch
     // with `from_wire=false` and silently reopen the agent subhandler bypass
-    // (codex #369 Medium). Pinned at the frame-builder seam so the daemon
+    // (review #369 Medium). Pinned at the frame-builder seam so the daemon
     // round-trip test above (which proves the daemon HONORS the bit) is paired
     // with proof that the tool SETS it.
     #[test]

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -296,7 +296,7 @@ async fn channel_poll_loop(
 
     let mut last_poll = Utc::now();
     // One backoff state per (kind, slug) — i.e. per credential (#606 round-1
-    // codex review, High finding). Keying by kind alone would throttle a
+    // internal review, High finding). Keying by kind alone would throttle a
     // second same-kind credential (e.g. a second mailbox) whenever the first
     // one's connection fails, even though the two are independent
     // credentials with independent connectivity.
@@ -384,7 +384,7 @@ enum HeartbeatOutcome {
 }
 
 /// Map a [`khive_channel::ChannelError`] to the `comm.heartbeat` `error_class`
-/// open string enum (#606 spec-gate amendment 4: `auth | transport | config`
+/// open string enum (#606 design review amendment 4: `auth | transport | config`
 /// in v1, callers must tolerate unknown classes). `Auth`/`Transport` are the
 /// connectivity classes `is_backoff_eligible` already distinguishes;
 /// `Config`/`UnauthorizedSender`/`InvalidEnvelope` are static/attribution
@@ -406,7 +406,7 @@ fn channel_error_class(err: &khive_channel::ChannelError) -> &'static str {
 /// interrupt the poll loop — the heartbeat row is an observability surface,
 /// not a correctness dependency for message delivery.
 ///
-/// Takes NO `namespace` parameter (round-2, spec-gate Blocker fix, Leo
+/// Takes NO `namespace` parameter (round-2, design review Blocker fix, example actor
 /// 2026-07-04): heartbeat rows are an operational surface, not message data,
 /// so they are ALWAYS dispatched against
 /// `khive_pack_comm::CHANNEL_HEALTH_NAMESPACE` — the same constant
@@ -452,7 +452,7 @@ async fn record_channel_heartbeat(
 /// Log a backoff-eligible poll failure at the level ADR-091's `crossing_warn`
 /// discipline calls for: `warn!` only on an escalation edge
 /// (`tick.should_warn`, i.e. the computed step just changed), `debug!` on a
-/// repeat at the same step. Codex round-1 finding (2026-07-04): the poll loop
+/// repeat at the same step. internal review round 1 finding (2026-07-04): the poll loop
 /// previously emitted a generic `warn!` on every eligible retry in addition
 /// to the escalation-edge warn, so sustained pressure spammed warn-level logs
 /// once per retry instead of once per escalation. Extracted to a standalone
@@ -1640,7 +1640,7 @@ brain_profile = "unrelated"
         );
     }
 
-    /// Regression for BLOCKER-1 (PR #52 codex review): project-toml brain_profile
+    /// Regression for BLOCKER-1 (PR #52 internal review): project-toml brain_profile
     /// MUST win over KHIVE_BRAIN_PROFILE env var.
     ///
     /// Merged ADR-035 §Precedence: CLI > project toml > global toml > env > default.
@@ -1994,7 +1994,7 @@ brain_profile = "project-profile"
         );
     }
 
-    /// Regression for ADR-073 codex r1: a pack assigned to a secondary backend must
+    /// Regression for ADR-073: a pack assigned to a secondary backend must
     /// have `core_backend` wired at boot so that `rt.core().backend_id()` returns "main".
     ///
     /// Before the fix, `build_server_multi_backend` called `KhiveRuntime::from_backend`
@@ -2196,7 +2196,7 @@ brain_profile = "project-profile"
         }
     }
 
-    /// Regression for B-BLOCKER-1 (HC-7 critic): the multi-backend boot path
+    /// Regression for B-BLOCKER-1 (design review critic): the multi-backend boot path
     /// MUST thread the configured actor identity (issue #75) into the registry,
     /// exactly as the single-backend path does. If `with_actor_id` is dropped,
     /// dispatch mints `ActorRef::anonymous()` and `comm.inbox` reverts to
@@ -3050,7 +3050,7 @@ brain_profile = "project-profile"
         }
     }
 
-    // --- log_eligible_poll_failure: edge-triggered warn (codex round-1 finding 2) ---
+    // --- log_eligible_poll_failure: edge-triggered warn (internal review round 1 finding 2) ---
 
     #[cfg(feature = "channel-email")]
     mod eligible_poll_failure_log_tests {
@@ -3175,7 +3175,7 @@ brain_profile = "project-profile"
             // Simulate one escalation edge followed by several repeats at the
             // same (capped) step, as the poll loop would emit them across
             // consecutive ticks -- exactly the "riding the cap" scenario
-            // codex round-1 flagged as spamming a WARN per retry.
+            // internal review round 1 flagged as spamming a WARN per retry.
             let buffer = Arc::new(Mutex::new(Vec::new()));
             let subscriber = CaptureSubscriber {
                 events: Arc::clone(&buffer),
@@ -3457,7 +3457,7 @@ brain_profile = "project-profile"
             record_channel_heartbeat(
                 &registry,
                 "email",
-                "leo@khive.ai",
+                "recipient@example.com",
                 HeartbeatOutcome::Success,
             )
             .await;
@@ -3476,7 +3476,7 @@ brain_profile = "project-profile"
             record_channel_heartbeat(
                 &registry,
                 "email",
-                "leo@khive.ai",
+                "recipient@example.com",
                 HeartbeatOutcome::Success,
             )
             .await;
@@ -3488,10 +3488,13 @@ brain_profile = "project-profile"
             let channels = health["channels"].as_array().expect("channels array");
             assert_eq!(channels.len(), 1);
             assert_eq!(channels[0]["channel_kind"].as_str(), Some("email"));
-            assert_eq!(channels[0]["channel_slug"].as_str(), Some("leo@khive.ai"));
+            assert_eq!(
+                channels[0]["channel_slug"].as_str(),
+                Some("recipient@example.com")
+            );
         }
 
-        /// #606 round-1 codex review, Blocker finding: a daemon polling under a
+        /// #606 round-1 internal review, Blocker finding: a daemon polling under a
         /// non-local `KHIVE_EMAIL_INGEST_NAMESPACE` must not cause a client-role
         /// no-arg `comm.health()` to report empty state. `record_channel_heartbeat`
         /// takes no `namespace` parameter — the write is unconditionally pinned to
@@ -3514,7 +3517,7 @@ brain_profile = "project-profile"
             let ingest_params = serde_json::json!({
                 "namespace": configured_ingest_namespace,
                 "from": "email:sender@example.com",
-                "to": "email:leo@khive.ai",
+                "to": "email:recipient@example.com",
                 "content": "hello",
                 "channel_kind": "email",
                 "external_id": "test-msg-1",
@@ -3528,7 +3531,7 @@ brain_profile = "project-profile"
             record_channel_heartbeat(
                 &registry,
                 "email",
-                "leo@khive.ai",
+                "recipient@example.com",
                 HeartbeatOutcome::Success,
             )
             .await;
@@ -3549,11 +3552,14 @@ brain_profile = "project-profile"
                  regardless of the configured message-ingest namespace"
             );
             assert_eq!(channels[0]["channel_kind"].as_str(), Some("email"));
-            assert_eq!(channels[0]["channel_slug"].as_str(), Some("leo@khive.ai"));
+            assert_eq!(
+                channels[0]["channel_slug"].as_str(),
+                Some("recipient@example.com")
+            );
         }
     }
 
-    // --- ChannelRegistry composite-key production path (round-1 codex review, High finding) ---
+    // --- ChannelRegistry composite-key production path (round-1 internal review, High finding) ---
 
     #[cfg(feature = "channel-email")]
     mod composite_key_registry_tests {
@@ -3593,8 +3599,7 @@ brain_profile = "project-profile"
             }
         }
 
-        /// #606 round-1 codex review, High finding: this is the regression codex
-        /// specifically asked for — a PRODUCTION `ChannelRegistry` populated
+        /// #606 regression guard: a PRODUCTION `ChannelRegistry` populated
         /// through the real `register()` path (not a pack-level dispatch
         /// bypassing registration) with two same-kind, different-slug adapters.
         /// Both must be registered (not collapsed) and both must be pollable by

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -2603,8 +2603,7 @@ async fn list_proposals_without_status_returns_all_rows() -> anyhow::Result<()> 
 //
 // These tests exercise the 4-tier resolution order without a live server, using
 // the same config-loading primitives that main.rs calls.  Each test covers one
-// isolated conflict tier to lock in the regression cases identified in codex
-// round-2 review finding [Medium] "Required Precedence Matrix Is Not Tested".
+// isolated conflict tier to lock in the precedence-matrix regression cases.
 
 /// Tier 4 (hard default): no CLI actor, no env, no config file → "local".
 #[test]

--- a/crates/khive-pack-brain/README.md
+++ b/crates/khive-pack-brain/README.md
@@ -35,7 +35,7 @@ verbs through the MCP `request` DSL, not called directly as a Rust API:
 
 ```text
 request(ops="brain.create_profile(name=\"my-profile-v1\", consumer_kind=\"recall\")")
-request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"lambda:khive\")")
+request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"agent:docs\")")
 request(ops="brain.feedback(target_id=\"<uuid>\", signal=\"useful\")")
 ```
 

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -184,7 +184,7 @@ pub async fn apply_fold_gate(
         Ok(outcome) => match exec_stmt(writer.as_mut(), "COMMIT", vec![], "commit").await {
             Ok(()) => Ok(outcome),
             Err(e) => {
-                // Finding 3 (codex round 1): a failed COMMIT must not skip the
+                // Finding 3 (internal review round 1): a failed COMMIT must not skip the
                 // rollback. The connection is dropped either way on a
                 // file-backed pool, but an explicit ROLLBACK avoids leaving a
                 // held write lock if the connection is pooled/reused
@@ -215,7 +215,7 @@ pub enum FeedbackGateMode {
     Nominal(f64),
     /// ADR-081 §4 fail-safe: the serve ledger row has no resolvable
     /// accounting profile. Always folds at zero weight and never writes
-    /// `brain_implicit_mass` — but (Finding 2, codex round 2) still
+    /// `brain_implicit_mass` — but (Finding 2, internal review round 2) still
     /// participates in the `(scorer_run_id, serve_ledger_id)` dedup claim,
     /// atomically with the event append, so two concurrent forced-zero
     /// submissions for the same pair cannot both append an audit event.
@@ -251,7 +251,7 @@ pub enum GateAndAppendOutcome {
     Applied(Box<GateAndAppendResult>),
 }
 
-/// ADR-081 §2/§6 (Finding 1 + Finding 2, codex round 2 review of PR #497):
+/// ADR-081 §2/§6 (Finding 1 + Finding 2 for PR #497):
 /// claim the `(scorer_run_id, serve_ledger_id)` dedup key (if supplied), run
 /// the bounded-mass fold gate (or skip it for `ForcedZero`), and append the
 /// resulting `brain.feedback` event — as ONE atomic, all-or-nothing unit on
@@ -472,7 +472,7 @@ async fn fold_within_tx(
     let mass_before = decayed_mass(old_mass, now_us - last_event_at);
     let (effective_weight, mass_after) = gate_decision(mass_before, weight, IMPLICIT_MASS_CAP);
 
-    // Finding 2 (codex round 1): never move `last_event_at` backwards. A
+    // Finding 2 (internal review round 1): never move `last_event_at` backwards. A
     // negative `delta_us` above (clock skew) already keeps `mass_before`
     // undecayed and the event clamps/folds conservatively, but persisting
     // `now_us` verbatim would still drag the accumulator's clock back to the
@@ -742,7 +742,7 @@ mod tests {
         (rt, dir)
     }
 
-    /// Proves the Finding-1 fix (codex round 1): concurrent duplicate scorer
+    /// Proves the Finding-1 fix (internal review round 1): concurrent duplicate scorer
     /// submissions — identical `(scorer_run_id, serve_ledger_id)` — fold
     /// exactly once, regardless of scheduling order.
     ///
@@ -868,7 +868,7 @@ mod tests {
         );
     }
 
-    /// Proves the Finding-2 fix (codex round 1): a negative-clock-skew event
+    /// Proves the Finding-2 fix (internal review round 1): a negative-clock-skew event
     /// must never drag the accumulator's `last_event_at` backwards, or a
     /// later, correctly-ordered event would decay mass that should still be
     /// at full weight and pass the clamp early.
@@ -1003,7 +1003,7 @@ mod tests {
         assert!((outcome2.mass_after - IMPLICIT_MASS_CAP).abs() < 1e-9);
     }
 
-    /// Proves the Finding-1 fix (codex round 2 review of PR #497): if the
+    /// Proves the Finding-1 fix for PR #497: if the
     /// feedback event append fails AFTER a successful dedup claim, the whole
     /// atomic unit — claim and (skipped-on-clamp-aside) mass write included
     /// — rolls back, so a retry sees no claim and proceeds normally.
@@ -1014,8 +1014,8 @@ mod tests {
     /// constraint violation on the INSERT, not a mock. `append_event_on_writer`'s
     /// INSERT has no `OR IGNORE`, so the conflict surfaces as an `Err` from
     /// `SqlWriter::execute`, propagating out of `apply_fold_gate_and_append_event`
-    /// before `COMMIT` — exercising exactly the rollback path codex flagged
-    /// as untested (before this fix, the claim+fold committed in their own
+    /// before `COMMIT` — exercising the previously untested rollback path
+    /// (before this fix, the claim+fold committed in their own
     /// transaction before the event append ran in a separate one, so this
     /// scenario could not roll back the claim at all).
     #[tokio::test]
@@ -1264,7 +1264,7 @@ mod tests {
         );
     }
 
-    /// Proves the Finding-2 fix (codex round 2 review of PR #497): the
+    /// Proves the Finding-2 fix for PR #497: the
     /// ADR-081 §4 forced-zero fail-safe (`FeedbackGateMode::ForcedZero`) now
     /// claims the dedup key atomically, on the SAME held transaction as the
     /// (skipped) mass fold and the event append — so N concurrent identical

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1029,7 +1029,7 @@ impl BrainPack {
         // PR-A1: by-ID ops are namespace-agnostic; authorization is the Gate's,
         // not a post-fetch namespace check). Rule 3b recall fans out actor-stamped
         // memories from other namespaces by design, so a primary-only check would
-        // reject the flywheel's own recalled targets. NotFound only for a
+        // reject the feedback loop's own recalled targets. NotFound only for a
         // genuinely absent UUID.
         use khive_runtime::Resolved;
         match self
@@ -1121,7 +1121,7 @@ impl BrainPack {
 
         // ADR-081 §2/§6: when both scorer fields are present, the dedup claim
         // is made atomically inside the SAME `BEGIN IMMEDIATE` transaction as
-        // the fold gate's mass check-and-write AND (Finding 1, codex round 2)
+        // the fold gate's mass check-and-write AND (Finding 1, internal review round 2)
         // the durable feedback event append (fold_gate.rs) — the `resolve`
         // check above is a non-atomic fast path only (it still handles the
         // common sequential case and the NotFound / forced-zero-weight
@@ -1165,7 +1165,7 @@ impl BrainPack {
             let nominal_weight = FeedbackEventKind::from_signal_str(signal)
                 .expect("is_gated_implicit implies from_signal_str is Some")
                 .update_weight();
-            // Finding 2 (codex round 2): the forced-zero fail-safe path now
+            // Finding 2 (internal review round 2): the forced-zero fail-safe path now
             // runs through the SAME atomic claim+append unit as the nominal
             // path below — only the mass fold write itself is skipped — so
             // it participates in the dedup claim instead of bypassing it.

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -1364,7 +1364,7 @@ mod braincore_aud_001_capacity {
         assert!(result.is_ok(), "in-capacity snapshot must load cleanly");
     }
 
-    /// PR #535 codex round-2 finding 2: a persisted snapshot with `{A, B}`
+    /// PR #535 internal review round 2 finding 2: a persisted snapshot with `{A, B}`
     /// entity_posteriors, `entity_posterior_order = [A]`, and an EXPLICIT
     /// `entity_posteriors_version = 0` must be rejected at the
     /// `load_latest_snapshot` boundary rather than silently normalized by

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -144,7 +144,7 @@ pub async fn record_serve(
     match result {
         Ok(_) => Ok(true),
         Err(e) if e.is_unique_constraint_violation() => {
-            // codex PR #583 round-1 Low: `is_unique_constraint_violation` fires
+            // internal review PR #583 round-1 Low: `is_unique_constraint_violation` fires
             // for ANY unique-index collision on this table — the intended
             // natural key `(namespace, target_id, query_class, served_at)`,
             // but also the `id TEXT PRIMARY KEY` column and any future unique

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -927,7 +927,7 @@ async fn test_357_feedback_no_double_count() {
 
 // #295: brain.reset must restore domain-informed priors, not Beta(1,1).
 //
-// Strengthened per codex P12 Medium: this test now exercises the full
+// Strengthened per internal review P12 Medium: this test now exercises the full
 // production path — handle_reset → reset_posteriors → sync helper — and
 // verifies that ALL three profile record fields (total_events,
 // exploration_epoch, state_snapshot) reflect the restored priors.
@@ -1150,7 +1150,7 @@ async fn brain_reset_accepts_empty_params() {
 // #355 (regression — real dispatch path): temporal posterior must update
 // when a recall hits via the on_dispatch hook carrying real hit/latency.
 //
-// This test exercises the production wiring added in the P12 codex fix:
+// This test exercises the production wiring added in the P12 fix:
 // the runtime now embeds duration_us + target_id in the hook event for
 // "recall" verbs.  Simulates that by constructing the hook event the way
 // the runtime now would, then verifies temporal.alpha() increments.
@@ -2867,7 +2867,7 @@ mod help_tests {
         );
     }
 
-    // ── Regression: schema-aware namespace strip (codex round-2 H1) ──────────
+    // ── Regression: schema-aware namespace strip (internal review round 2 H1) ──────────
     //
     // brain.bind / brain.resolve / brain.unbind / brain.bindings declare
     // `namespace` as a *business* parameter in their HandlerDef.params.  The
@@ -2893,7 +2893,7 @@ mod help_tests {
     }
 
     /// brain.bind via VerbRegistry must store the caller-supplied namespace,
-    /// not default to "*".  Regression for the blanket-strip bug (codex H1).
+    /// not default to "*".  Regression for the blanket-strip bug.
     #[tokio::test]
     async fn r2_h1_bind_via_registry_preserves_namespace() {
         use serde_json::json;
@@ -2942,7 +2942,7 @@ mod help_tests {
     }
 
     /// brain.resolve via VerbRegistry must use the caller-supplied namespace to
-    /// match the binding stored by brain.bind.  Regression for codex H1.
+    /// match the binding stored by brain.bind.  Regression for the binding match bug.
     #[tokio::test]
     async fn r2_h1_resolve_via_registry_uses_namespace() {
         use serde_json::json;
@@ -2982,7 +2982,7 @@ mod help_tests {
     }
 
     /// brain.unbind via VerbRegistry must use the caller-supplied namespace to
-    /// remove only the matching binding.  Regression for codex H1.
+    /// remove only the matching binding.  Regression for the binding removal bug.
     #[tokio::test]
     async fn r2_h1_unbind_via_registry_uses_namespace() {
         use serde_json::json;
@@ -4900,7 +4900,7 @@ mod adr081_retune_driver_tests {
         assert!(!second, "exact-key duplicate must report written=false");
     }
 
-    /// codex PR #583 round-1 Low: a `UNIQUE` violation on the `id TEXT PRIMARY
+    /// internal review PR #583 round-1 Low: a `UNIQUE` violation on the `id TEXT PRIMARY
     /// KEY` column (same `id`, different natural key) must NOT be reported as
     /// a tolerated natural-key duplicate — the row that actually exists does
     /// not match `(namespace, target_id, query_class, served_at)`, so the

--- a/crates/khive-pack-brain/tests/dispatch_hook.rs
+++ b/crates/khive-pack-brain/tests/dispatch_hook.rs
@@ -330,7 +330,7 @@ async fn cold_hook_signal_applies_on_top_of_persisted_snapshot() {
 /// owns authorization, not a post-fetch namespace comparison. Rule 3b recall
 /// fans out actor-stamped memories from other namespaces by design (a lambda's
 /// episodic memories carry its actor namespace), so a primary-only check
-/// rejected the flywheel's own recalled targets — exactly the fleet-wide
+/// rejected the feedback loop's own recalled targets — exactly shared
 /// feedback-discipline breakage this fixes.
 ///
 /// This reverses the earlier "Finding 3" primary-only behavior, which cited

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -888,7 +888,7 @@ pub(crate) async fn handle_ingest(
 /// into a single row.
 ///
 /// The three components are hashed as a JSON array of strings, NOT joined
-/// with a `:` delimiter (round-1 codex review, Medium finding). Namespaces
+/// with a `:` delimiter (round-1 internal review, Medium finding). Namespaces
 /// may themselves contain `:` (hierarchical namespace strings are explicitly
 /// allowed), so a delimiter-joined `format!("...:{a}:{b}:{c}")` is not an
 /// injective encoding: `(namespace="a:b", channel_kind="c", channel_slug="d")`
@@ -915,7 +915,7 @@ fn heartbeat_note_id(namespace: &str, channel_kind: &str, channel_slug: &str) ->
 /// Read-modify-write against the existing row (if any) so that:
 /// - `created_at` is preserved across updates (first-seen time), not reset
 ///   every tick.
-/// - `last_error` is RETAINED across a subsequent success (spec-gate
+/// - `last_error` is RETAINED across a subsequent success (design review
 ///   amendment 3): callers compare `last_error.at` against
 ///   `last_success_at`/`last_failure_at` to tell a resolved issue from a live
 ///   one, so a success must never clear it.
@@ -963,7 +963,7 @@ pub(crate) async fn handle_heartbeat(
         ));
     }
 
-    // #606 spec-gate Blocker fix (Leo 2026-07-04): heartbeat rows are an
+    // #606 design review Blocker fix (review fix): heartbeat rows are an
     // OPERATIONAL surface, not message data. Persist to
     // `crate::CHANNEL_HEALTH_NAMESPACE` ALWAYS — never `token.namespace()` —
     // so a poll loop configured with a non-local `KHIVE_EMAIL_INGEST_NAMESPACE`
@@ -996,7 +996,7 @@ pub(crate) async fn handle_heartbeat(
         "success" => {
             props["last_success_at"] = json!(at);
             props["consecutive_failures"] = json!(0);
-            // last_error is intentionally left untouched — spec-gate amendment 3.
+            // last_error is intentionally left untouched — design review amendment 3.
         }
         "failure" => {
             props["last_failure_at"] = json!(at);
@@ -1074,12 +1074,12 @@ fn channel_health_to_json(note: &Note) -> Value {
 ///
 /// Reads the daemon-persisted `channel_health` rows from
 /// `crate::CHANNEL_HEALTH_NAMESPACE` UNCONDITIONALLY — never
-/// `token.namespace()` (spec-gate Blocker fix, Leo 2026-07-04). Heartbeat
+/// `token.namespace()` (design review Blocker fix, example actor 2026-07-04). Heartbeat
 /// rows are an operational surface, not message data, so a client-role
 /// no-arg call must see them regardless of what namespace the caller's own
 /// messages happen to be ingested under (e.g. `KHIVE_EMAIL_INGEST_NAMESPACE`
 /// set to something other than `"local"`). Cross-process read is the point
-/// of this verb (spec-gate amendment 1): a client-role process (stdio MCP
+/// of this verb (design review amendment 1): a client-role process (stdio MCP
 /// without `--daemon`) has no in-memory poll-loop state of its own, so it
 /// must read what the daemon already wrote. `role` answers "who owns the
 /// loops", not "whose memory answered": any persisted row means some daemon
@@ -1092,7 +1092,7 @@ fn channel_health_to_json(note: &Note) -> Value {
 /// `khive-mcp`/`khive-channel-email`), so an empty result is the only
 /// fact-based response available at this layer.
 ///
-/// Never returns a computed `healthy: bool` (spec-gate amendment: "report
+/// Never returns a computed `healthy: bool` (design review amendment: "report
 /// timestamps only") — staleness/alerting judgment belongs to the caller.
 pub(crate) async fn handle_health(
     runtime: &KhiveRuntime,
@@ -1311,7 +1311,7 @@ mod tests {
     };
     use serde_json::json;
 
-    // #606 round-1 codex review, Medium finding: a delimiter-joined
+    // #606 round-1 internal review, Medium finding: a delimiter-joined
     // `format!("...:{a}:{b}:{c}")` id encoding is not injective once
     // components may themselves contain `:` — these two distinct triples
     // both produced `"khive:channel_health:a:b:c:d"` under the pre-fix
@@ -1332,8 +1332,8 @@ mod tests {
     #[test]
     fn heartbeat_note_id_is_deterministic() {
         assert_eq!(
-            heartbeat_note_id("local", "email", "leo@khive.ai"),
-            heartbeat_note_id("local", "email", "leo@khive.ai"),
+            heartbeat_note_id("local", "email", "recipient@example.com"),
+            heartbeat_note_id("local", "email", "recipient@example.com"),
         );
     }
 

--- a/crates/khive-pack-comm/src/lib.rs
+++ b/crates/khive-pack-comm/src/lib.rs
@@ -9,7 +9,7 @@ pub(crate) mod vocab;
 pub use pack::CommPack;
 
 /// The namespace `comm.heartbeat` always writes to and `comm.health` always
-/// reads from (khive #606 spec-gate Blocker fix, Leo 2026-07-04).
+/// reads from (khive #606 design review Blocker fix, example actor 2026-07-04).
 ///
 /// Channel heartbeat rows are an OPERATIONAL surface, not message data: they
 /// must not follow `KHIVE_EMAIL_INGEST_NAMESPACE` (or any other caller-chosen

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -197,7 +197,7 @@ mod help_tests {
 
     #[test]
     fn all_comm_handlers_have_non_empty_params() {
-        // comm.health is a legitimate no-args verb (khive #606 spec-gate: "read-only,
+        // comm.health is a legitimate no-args verb (khive #606 design review: "read-only,
         // NO args") -- same shape as kg's `stats()`. Every other comm verb takes at
         // least one param, so the invariant still holds for the rest.
         const NO_ARGS_VERBS: &[&str] = &["comm.health"];

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -2706,7 +2706,7 @@ async fn t5_recipient_inbox_sees_message() {
     );
 }
 
-// T5b — ADR-057: comm.reply always writes same-namespace (Fix 1, codex Critical #2).
+// T5b — ADR-057: comm.reply always writes same-namespace (Fix 1, internal review Critical #2).
 //
 // Reply on a configured-actor setup proves the fail-closed reply path: after the fix,
 // handle_reply ALWAYS passes caller_ns as both `from` and `to` to dual_write_message
@@ -3036,7 +3036,7 @@ async fn t8_sender_token_cannot_mutate_recipient_inbound_note() {
 // T9 — actor-addressed reply (ADR-057) with ADR-007 Rev 2 all-local model.
 //
 // ADR-007: all writes go to "local". ADR-057: actor labels distinguish routing.
-// Leo (registry_shared) sends to khive (both copies in "local"). Then replies to
+// example actor (registry_shared) sends to khive (both copies in "local"). Then replies to
 // the inbound copy, verifying reply inherits the canonical thread_id.
 #[tokio::test]
 async fn t9_reply_cross_ns_delivers_when_allowed() {
@@ -3046,7 +3046,7 @@ async fn t9_reply_cross_ns_delivers_when_allowed() {
     let (registry_shared, rt_shared) =
         build_crossns_registry(Arc::clone(&backend), "lambda:shared", vec![]);
 
-    // "Leo" (operating as lambda:shared) sends to "khive".
+    // "example actor" (operating as lambda:shared) sends to "khive".
     let send_result = registry_shared
         .dispatch(
             "comm.send",
@@ -4368,12 +4368,12 @@ async fn reply_sets_in_reply_to_for_inbound_originated_parent() {
 
     let parent_id = plant_message_note(
         &rt,
-        "hello from ocean",
+        "hello from sender",
         serde_json::json!({
             "direction": "inbound",
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
-            "from_actor": "email:ocean@example.com",
+            "from_actor": "email:sender@example.com",
             "to_actor": "lambda:khive",
             // IMAP dedup key -- must NOT be mistaken for a Message-ID.
             "external_id": "imap:host:1:42",
@@ -4410,7 +4410,7 @@ async fn reply_sets_in_reply_to_for_outbound_minted_parent() {
             "from": "local",
             "to": "local",
             "from_actor": "lambda:khive",
-            "to_actor": "email:ocean@example.com",
+            "to_actor": "email:sender@example.com",
             "external_id": "<outbound-msg-001@khive.ai>",
             "thread_id": uuid::Uuid::new_v4().as_hyphenated().to_string(),
             "sent_at": chrono::Utc::now().to_rfc3339(),
@@ -4469,7 +4469,7 @@ async fn ingest_persists_wire_message_id_distinct_from_external_id() {
         &registry,
         &rt,
         serde_json::json!({
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
             "content": "hello",
             "external_id": "imap:host:1:99",
@@ -4526,7 +4526,7 @@ async fn ingest_persists_wire_references_distinct_from_external_id() {
         &registry,
         &rt,
         serde_json::json!({
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
             "content": "hello",
             "external_id": "imap:host:1:101",
@@ -4576,7 +4576,7 @@ async fn ingest_omits_wire_references_when_absent() {
 
 // --- issue #403 finding 1: References must carry the full ancestor chain ---
 //
-// The codex round-1 review flagged that References was set from the single
+// The round-1 review flagged that References was set from the single
 // `in_reply_to` value, dropping any ancestors before the immediate parent.
 // These tests assert the exact serialized References/In-Reply-To values
 // (not just presence) for each required case.
@@ -4590,12 +4590,12 @@ async fn reply_extends_existing_references_chain_of_two_or_more() {
 
     let parent_id = plant_message_note(
         &rt,
-        "hello from ocean",
+        "hello from sender",
         serde_json::json!({
             "direction": "inbound",
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
-            "from_actor": "email:ocean@example.com",
+            "from_actor": "email:sender@example.com",
             "to_actor": "lambda:khive",
             "external_id": "imap:host:1:43",
             "wire_message_id": "parent123@example.com",
@@ -4630,12 +4630,12 @@ async fn reply_references_falls_back_to_parent_message_id_when_no_chain() {
 
     let parent_id = plant_message_note(
         &rt,
-        "hello from ocean",
+        "hello from sender",
         serde_json::json!({
             "direction": "inbound",
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
-            "from_actor": "email:ocean@example.com",
+            "from_actor": "email:sender@example.com",
             "to_actor": "lambda:khive",
             "external_id": "imap:host:1:44",
             "wire_message_id": "parent456@example.com",
@@ -4675,7 +4675,7 @@ async fn reply_extends_references_chain_for_outbound_parent() {
             "from": "local",
             "to": "local",
             "from_actor": "lambda:khive",
-            "to_actor": "email:ocean@example.com",
+            "to_actor": "email:sender@example.com",
             "external_id": "<outbound-msg-002@khive.ai>",
             // Realistic stored shape: an outbound row's own `references_chain` is
             // ancestors-only (exactly what `build_references_header` computes for
@@ -4714,12 +4714,12 @@ async fn reply_skips_malformed_token_in_parent_references_chain() {
 
     let parent_id = plant_message_note(
         &rt,
-        "hello from ocean",
+        "hello from sender",
         serde_json::json!({
             "direction": "inbound",
-            "from": "email:ocean@example.com",
+            "from": "email:sender@example.com",
             "to": "email:mailbox@example.com",
-            "from_actor": "email:ocean@example.com",
+            "from_actor": "email:sender@example.com",
             "to_actor": "lambda:khive",
             "external_id": "imap:host:1:45",
             "wire_message_id": "parent789@example.com",
@@ -4759,7 +4759,7 @@ async fn reply_dedups_tainted_parent_references_chain_containing_parent_id() {
             "from": "local",
             "to": "local",
             "from_actor": "lambda:khive",
-            "to_actor": "email:ocean@example.com",
+            "to_actor": "email:sender@example.com",
             "external_id": "<dup-msg@khive.ai>",
             "references_chain": "<root1@example.com> <dup-msg@khive.ai> <root2@example.com>",
             "thread_id": uuid::Uuid::new_v4().as_hyphenated().to_string(),
@@ -5197,7 +5197,7 @@ async fn thread_includes_root_message_without_thread_id_property() {
 
 // --- comm.heartbeat / comm.health (khive #606) ---
 
-/// Spec-gate amendment 1 (blocking): a fresh install with no persisted daemon
+/// design review amendment 1 (blocking): a fresh install with no persisted daemon
 /// heartbeat state must report `role: "client"` with an empty channel list —
 /// never fabricate channel entries the comm pack has no evidence for.
 #[tokio::test]
@@ -5237,7 +5237,7 @@ async fn health_rejects_stray_args() {
     );
 }
 
-/// Core cross-process-read contract (spec-gate amendment 1): once the daemon
+/// Core cross-process-read contract (design review amendment 1): once the daemon
 /// persists a successful heartbeat, `comm.health()` returns it annotated
 /// `role: "daemon"`, `source: "daemon-heartbeat"` — this is true even though
 /// the *reading* call is a plain in-process dispatch here, mirroring a
@@ -5252,7 +5252,7 @@ async fn heartbeat_success_is_visible_via_health() {
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "success",
             }),
         )
@@ -5270,7 +5270,7 @@ async fn heartbeat_success_is_visible_via_health() {
     assert_eq!(channels.len(), 1);
     let ch = &channels[0];
     assert_eq!(ch["channel_kind"].as_str(), Some("email"));
-    assert_eq!(ch["channel_slug"].as_str(), Some("leo@khive.ai"));
+    assert_eq!(ch["channel_slug"].as_str(), Some("recipient@example.com"));
     assert!(ch["last_success_at"].as_str().is_some());
     assert!(ch["last_poll_attempt_at"].as_str().is_some());
     assert!(ch["last_failure_at"].is_null());
@@ -5278,7 +5278,7 @@ async fn heartbeat_success_is_visible_via_health() {
     assert_eq!(ch["consecutive_failures"].as_u64(), Some(0));
 }
 
-/// Spec-gate amendment 3: `last_error` is RETAINED after a subsequent success
+/// design review amendment 3: `last_error` is RETAINED after a subsequent success
 /// (callers compare `last_error.at` vs `last_success_at`), and
 /// `consecutive_failures` resets to 0 on success.
 #[tokio::test]
@@ -5291,7 +5291,7 @@ async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failu
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "failure",
                 "error_class": "auth",
                 "error_message": "XOAUTH2 handshake failed",
@@ -5305,7 +5305,7 @@ async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failu
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "failure",
                 "error_class": "auth",
                 "error_message": "XOAUTH2 handshake failed",
@@ -5328,7 +5328,7 @@ async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failu
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "success",
             }),
         )
@@ -5348,7 +5348,7 @@ async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failu
     assert_eq!(
         ch["last_error"]["class"].as_str(),
         Some("auth"),
-        "last_error must be RETAINED after a subsequent success (spec-gate amendment 3)"
+        "last_error must be RETAINED after a subsequent success (design review amendment 3)"
     );
     assert!(
         ch["last_success_at"].as_str().is_some(),
@@ -5356,7 +5356,7 @@ async fn heartbeat_retains_last_error_after_success_but_resets_consecutive_failu
     );
 }
 
-/// Spec-gate amendment 2: rows are keyed by channel slug + kind, never kind
+/// design review amendment 2: rows are keyed by channel slug + kind, never kind
 /// alone — two accounts of the same kind must not collapse into one row.
 #[tokio::test]
 async fn heartbeat_keys_by_slug_not_kind_alone() {
@@ -5368,7 +5368,7 @@ async fn heartbeat_keys_by_slug_not_kind_alone() {
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "success",
             }),
         )
@@ -5403,7 +5403,7 @@ async fn heartbeat_keys_by_slug_not_kind_alone() {
         .iter()
         .map(|c| c["channel_slug"].as_str().unwrap())
         .collect();
-    assert!(slugs.contains("leo@khive.ai"));
+    assert!(slugs.contains("recipient@example.com"));
     assert!(slugs.contains("ops@khive.ai"));
 }
 
@@ -5420,7 +5420,7 @@ async fn heartbeat_repeated_calls_update_same_row() {
                 serde_json::json!({
                     "namespace": "local",
                     "channel_kind": "email",
-                    "channel_slug": "leo@khive.ai",
+                    "channel_slug": "recipient@example.com",
                     "outcome": "success",
                 }),
             )
@@ -5449,7 +5449,7 @@ async fn heartbeat_requires_error_class_on_failure() {
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "failure",
             }),
         )
@@ -5471,7 +5471,7 @@ async fn heartbeat_rejects_invalid_outcome() {
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "maybe",
             }),
         )
@@ -5495,7 +5495,7 @@ async fn health_channel_entry_never_carries_a_healthy_bool() {
             serde_json::json!({
                 "namespace": "local",
                 "channel_kind": "email",
-                "channel_slug": "leo@khive.ai",
+                "channel_slug": "recipient@example.com",
                 "outcome": "failure",
                 "error_class": "auth",
                 "error_message": "handshake failed",

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1033,13 +1033,13 @@ mod tests {
         );
     }
 
-    /// PR #389 codex round-1 High-1 regression: `search(kind="note", ...)` must
+    /// PR #389 internal review round 1 High-1 regression: `search(kind="note", ...)` must
     /// not hard-fail on a residual FTS5 metacharacter.
     ///
     /// `sanitize_fts5_query` (khive-db) strips known-unsafe characters like `$`,
     /// but by design stays minimal — it does not strip every character SQLite
-    /// FTS5's bareword parser rejects. `@` is one of 17 residual characters codex
-    /// round 1 found still crash the parser. Before this fix, `search_notes`
+    /// FTS5's bareword parser rejects. `@` is one residual character that still
+    /// crashes the parser. Before this fix, `search_notes`
     /// (khive-runtime/operations.rs) propagated that FTS error with `.await?`,
     /// so `search(kind="note")` aborted instead of degrading to vector-only
     /// results — unlike the entity branch and `memory.recall`, which already

--- a/crates/khive-pack-kg/src/handler_defs.rs
+++ b/crates/khive-pack-kg/src/handler_defs.rs
@@ -962,7 +962,7 @@ mod tests {
         );
     }
 
-    /// update.help must document `relation` for edges (codex High).
+    /// update.help must document `relation` for edges (internal review High).
     #[test]
     fn update_params_documents_relation_for_edges() {
         let h = find_handler("update");
@@ -977,7 +977,7 @@ mod tests {
         );
     }
 
-    /// update.help must document `weight` for edges (codex High).
+    /// update.help must document `weight` for edges (internal review High).
     #[test]
     fn update_params_documents_weight_for_edges() {
         let h = find_handler("update");

--- a/crates/khive-pack-kg/src/handlers/context.rs
+++ b/crates/khive-pack-kg/src/handlers/context.rs
@@ -272,7 +272,7 @@ impl KgPack {
         // or an edge UUID would otherwise resolve here and then silently vanish
         // from the response in Stage 4's lenient "missing entity" fallback. Fail
         // loudly instead: one batch existence check naming every offending id
-        // (codex round 1, High-2).
+        // (internal review round 1, High-2).
         if !explicit_ids.is_empty() {
             let mut dedup_explicit = explicit_ids.clone();
             dedup_explicit.sort_unstable();
@@ -323,8 +323,8 @@ impl KgPack {
             // collapse into `entity_ids` duplicates don't under-fill the query
             // leg: ADR-089 §1 promises search "fills up to `limit` additional
             // anchors" after explicit ids, which requires looking past the first
-            // `limit` hits when some of them overlap explicit anchors (codex
-            // round 1, Medium-1). Bounded by a documented cap so a pathological
+            // `limit` hits when some of them overlap explicit anchors. Bounded
+            // by a documented cap so a pathological
             // overlap can't turn into an unbounded search.
             const QUERY_FILL_WINDOW_MULTIPLIER: u32 = 4;
             let fetch_n = limit
@@ -481,7 +481,7 @@ impl KgPack {
         // ---- Stage 4: assembly with budget enforcement ----
         let t4 = if prof { Some(Instant::now()) } else { None };
         // Explicit `entity_ids` anchors are already verified to exist in Stage 1
-        // (codex round 1, High-2), so this only guards the residual race of an
+        // (internal review round 1, High-2), so this only guards the residual race of an
         // anchor deleted concurrently between resolution and this fetch, or a
         // neighbor entity that vanished the same way. Neighbors get the same
         // lenient "missing node reads as absent" convention `neighbors_with_query`

--- a/crates/khive-pack-kg/src/handlers/tests.rs
+++ b/crates/khive-pack-kg/src/handlers/tests.rs
@@ -568,7 +568,7 @@ fn valid_relations_unsupported_pair_returns_empty() {
 // actually accepts for that pair. This calls production code on both sides —
 // it never re-implements the rule check inline.
 //
-// Codex round-1 review of #621 flagged that a five-pair spot check missed an
+// #621 flagged that a five-pair spot check missed an
 // `EntityOfType`-scoped divergence (see
 // `valid_relations_hint_covers_formal_pack_entity_of_type_rules` below); this
 // sweeps the full closed kind space so a future divergence at any pair fails
@@ -638,7 +638,7 @@ async fn valid_relations_hint_matches_real_validator_acceptance_across_all_entit
     }
 }
 
-// Codex round-1 High finding on #621: `valid_relations_for_entity_pair` only
+// internal review round 1 High finding on #621: `valid_relations_for_entity_pair` only
 // matched `EndpointKind::EntityOfKind` pack rules, silently omitting
 // `EndpointKind::EntityOfType` rules such as khive-pack-formal's typed
 // `concept/theorem -> concept/definition` `depends_on` rule
@@ -773,7 +773,7 @@ async fn valid_relations_hint_does_not_cover_gtd_note_scoped_rules() {
     );
 }
 
-// Codex round-1 Medium finding on #621: proves the GTD boundary on the REAL
+// internal review round 1 Medium finding on #621: proves the GTD boundary on the REAL
 // `KgPack::handle_link` path with real task notes, not just rule presence in
 // `pack_edge_rules()`. A task->task relation outside GTD's declared
 // `depends_on` must fail with the substrate-mismatch error ("must be an

--- a/crates/khive-pack-kg/src/handlers/update.rs
+++ b/crates/khive-pack-kg/src/handlers/update.rs
@@ -105,7 +105,7 @@ impl KgPack {
         id_str: &str,
     ) -> Result<KindSpec, RuntimeError> {
         use khive_runtime::Resolved;
-        // PR-A1 (codex r2): by-ID substrate inference must NOT gate on caller namespace.
+        // PR-A1: by-ID substrate inference must NOT gate on caller namespace.
         // UUID v4 is globally unique — resolve without visible-set or primary-ns check.
         match self.runtime.resolve_by_id(token, id).await? {
             Some(Resolved::Entity(_)) => Ok(KindSpec::Entity { specific: None }),
@@ -127,7 +127,7 @@ impl KgPack {
         id_str: &str,
     ) -> Result<KindSpec, RuntimeError> {
         use khive_runtime::Resolved;
-        // PR-A1 (codex r2): hard-delete path must also locate foreign records.
+        // PR-A1: hard-delete path must also locate foreign records.
         match self
             .runtime
             .resolve_by_id_including_deleted(token, id)

--- a/crates/khive-pack-kg/src/projection_worker/tests.rs
+++ b/crates/khive-pack-kg/src/projection_worker/tests.rs
@@ -375,7 +375,7 @@ async fn on_proposal_withdrawn_cas_returns_false_on_second_call() {
     );
 }
 
-// H1 / Codex-R3 regression: two sequential `withdrawn_and_emit` calls on the same
+// H1 / internal-review R3 regression: two sequential `withdrawn_and_emit` calls on the same
 // open proposal must produce exactly ONE ProposalWithdrawn event in the events
 // table, and the second call must return cas_hit=false.
 #[tokio::test]
@@ -468,7 +468,7 @@ async fn withdrawn_and_emit_second_call_no_duplicate_event() {
     drop(rows); // silence unused-variable lint
 }
 
-// Codex round-4 regression: same-microsecond `updated_at` collision.
+// internal review round 4 regression: same-microsecond `updated_at` collision.
 #[tokio::test]
 async fn same_microsecond_timestamp_no_duplicate_event_changes_guard() {
     let (rt, tok) = setup();
@@ -610,7 +610,7 @@ async fn same_microsecond_timestamp_no_duplicate_event_changes_guard() {
         .unwrap_or(0);
     assert_eq!(
         count, 1,
-        "codex-R4: exactly ONE ProposalWithdrawn event must exist even with identical \
+        "R4: exactly ONE ProposalWithdrawn event must exist even with identical \
          `updated_at` timestamps; got {count}. \
          A value of 2 means the guard is checking timestamp equality (round-3 bug), \
          not connection-local changes()."

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -2862,7 +2862,7 @@ async fn bulk_link_verbose_controls_edges_key() {
     );
 }
 
-// ---- ADR-014 curation event payload regression tests (codex round-2) ----
+// ---- ADR-014 curation event payload regression tests (internal review round 2) ----
 
 /// Update an entity → list entity_updated events → assert payload has id, namespace,
 /// changed_fields per ADR-014.
@@ -3061,7 +3061,7 @@ async fn curation_delete_entity_hard_event_payload_has_adr014_fields() {
     );
 }
 
-// ---- ADR-022 provenance filter regression tests (codex round-2) ----
+// ---- ADR-022 provenance filter regression tests (internal review round 2) ----
 
 /// list(kind="event", observed=[uuid]) must pass the filter down to storage and
 /// return only events whose observed list contains that UUID.
@@ -3783,7 +3783,7 @@ async fn traverse_invalid_direction_is_rejected() {
     );
 }
 
-// ── verbs() dispatch-level tests (codex review Medium: H5 not covered) ────────
+// ── verbs() dispatch-level tests (internal review Medium: H5 not covered) ────────
 //
 // A fake pack with one public verb and one subhandler so we can verify that
 // `verbs()` excludes subhandlers and that category/pack filters work correctly.
@@ -4019,7 +4019,7 @@ async fn verbs_dispatch_pack_filter_fake_excludes_subhandler() {
     );
 }
 
-// M2 / codex H1 regression: three parallel singleton link() calls for the same
+// M2 / H1 regression: three parallel singleton link() calls for the same
 // (source, target, relation) triple must all return the same edge ID and the
 // database must contain exactly one edge row for that triple.
 //
@@ -4093,7 +4093,7 @@ async fn parallel_link_same_triple_returns_identical_ids() {
     );
 }
 
-// R4 / codex H1 round-4 regression: singleton link() must go through runtime.link()
+// R4 / H1 regression: singleton link() must go through runtime.link()
 // upsert even when the triple already exists, so caller-supplied weight and metadata
 // are persisted (ADR-009 §edge-upsert contract).
 //
@@ -4310,7 +4310,7 @@ async fn merge_rewire_symmetric_relation_canonicalization() {
     );
 }
 
-// ---- H1 codex round-3: update_edge canonicalizes symmetric relations ----
+// ---- H1 internal review round 3: update_edge canonicalizes symmetric relations ----
 
 /// H1-a: updating an edge from a non-symmetric relation to `competes_with`
 /// must store the row with `source_uuid < target_uuid` (canonical form).
@@ -8292,7 +8292,7 @@ async fn context_entity_ids_anchor_carries_full_entity_record() {
 
 #[tokio::test]
 async fn context_entity_ids_random_nonexistent_uuid_is_rejected() {
-    // codex round 1, High-2: a syntactically valid but nonexistent UUID must
+    // internal review round 1, High-2: a syntactically valid but nonexistent UUID must
     // error, not silently vanish from the response.
     let pack = pack();
     let random_id = uuid::Uuid::new_v4().to_string();
@@ -8840,7 +8840,7 @@ async fn context_query_and_entity_ids_combine_explicit_ids_first_then_search_fil
 
 #[tokio::test]
 async fn context_query_fill_reaches_limit_after_top_hit_duplicates_explicit_anchor() {
-    // codex round 1, Medium-1: if the query's top hit is also an explicit anchor,
+    // internal review round 1, Medium-1: if the query's top hit is also an explicit anchor,
     // the query leg must still fill up to `limit` DISTINCT non-explicit anchors
     // rather than silently returning fewer once the duplicate collapses.
     let pack = pack();
@@ -9044,7 +9044,7 @@ async fn context_fanout_caps_neighbors_per_node_per_hop() {
 
 #[tokio::test]
 async fn context_direction_outgoing_fanout_keeps_highest_weight_not_node_id_order() {
-    // Codex round 2, High: khive-runtime's neighbors_with_query re-sorts hits by
+    // internal review round 2, High: khive-runtime's neighbors_with_query re-sorts hits by
     // (node_id, edge_id) for dedup and, before this fix, never restored the
     // weight-descending order the storage layer established. That meant
     // context(direction="outgoing") returned neighbors in arbitrary node_id

--- a/crates/khive-pack-kg/tests/projection_worker.rs
+++ b/crates/khive-pack-kg/tests/projection_worker.rs
@@ -560,7 +560,7 @@ async fn same_microsecond_timestamp_no_duplicate_event_changes_guard() {
         .unwrap_or(0);
     assert_eq!(
         count, 1,
-        "codex-R4: exactly ONE ProposalWithdrawn event must exist; got {count}."
+        "R4: exactly ONE ProposalWithdrawn event must exist; got {count}."
     );
 }
 

--- a/crates/khive-pack-knowledge/tests/fixes.rs
+++ b/crates/khive-pack-knowledge/tests/fixes.rs
@@ -1172,7 +1172,7 @@ async fn f1_rrf_k_60_constant_produces_finite_scores() {
     );
 }
 
-// ── codex #527: status stays consistent with finalized through the UPDATE path ──
+// ── review #527: status stays consistent with finalized through the UPDATE path ──
 
 #[tokio::test]
 async fn upsert_finalizing_existing_atom_promotes_draft_to_reviewed() {
@@ -1931,7 +1931,7 @@ async fn search_default_rerank_decompose_guard_avoids_fts_no_such_column() {
 
 // ── embed_batch failure / count-mismatch counted as `failed` ─────────────────
 //
-// Regression for codex round-2 HIGH finding: embed_batch Err and count-mismatch
+// Regression for internal review round 2 HIGH finding: embed_batch Err and count-mismatch
 // were both mapped to `skipped` (exit 0); they must map to `failed` (exit non-0
 // without --best-effort).  The knowledge index handler cannot call embed_batch
 // without a non-empty default_embedder_name, so these tests use a fake provider
@@ -2156,7 +2156,7 @@ mod embed_failure_tests {
         );
     }
 
-    // ── Section embed failure regression (codex round-1 HIGH) ────────────────
+    // ── Section embed failure regression (internal review round 1 HIGH) ────────────────
     //
     // Mirrors the atom failure tests above but exercises the SECTION path via
     // `reindex_knowledge(sections:true, atoms:false)`. Blank-text sections are

--- a/crates/khive-pack-memory/benches/e2e_recall.rs
+++ b/crates/khive-pack-memory/benches/e2e_recall.rs
@@ -176,7 +176,7 @@ const QUERIES: &[&str] = &[
     "Rust cargo clippy workspace",
     "FTS text search trigram BM25",
     "memory decay salience temporal",
-    "ocean lambda leo session",
+    "operator actor peer session",
     "desktop app frontend wiring",
     "brain profile Bayesian posterior",
     "knowledge graph entity edge relation",

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -617,7 +617,7 @@ impl MemoryPack {
                 let served_at_us = chrono::Utc::now().timestamp_micros();
                 // Tracked, not a bare tokio::spawn, so daemon shutdown's drain()
                 // waits for this append instead of a SIGTERM aborting it
-                // mid-flight with no ledger row and no log (codex PR #583
+                // mid-flight with no ledger row and no log (internal review PR #583
                 // round-1 Medium). The response path still only pays for the
                 // enqueue (an atomic increment) — never the SQL write itself.
                 khive_runtime::track_background_task(async move {
@@ -721,7 +721,7 @@ mod tests {
     /// `$`, so this query no longer reaches the runtime-level fail-open `Err` arm
     /// added in PR #389 — it exercises the *sanitizer*, not the fail-open net.
     /// See `recall_with_residual_fts5_char_degrades_and_vector_leg_survives` below
-    /// for a test that forces the `Err` arm itself (PR #389 codex round-1 Medium).
+    /// for a test that forces the `Err` arm itself (PR #389 internal review round 1 Medium).
     #[tokio::test]
     async fn recall_with_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -827,7 +827,7 @@ mod tests {
         }
     }
 
-    /// PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped
+    /// PR #389 internal review round 1 Medium regression: unlike `$`, `@` is NOT stripped
     /// by `sanitize_fts5_query` (by design — the sanitizer stays minimal per
     /// #388 scope; the fail-open net is the systematic answer for residual
     /// punctuation). SQLite FTS5's bareword parser still rejects `@`
@@ -835,7 +835,7 @@ mod tests {
     /// `collect_recall_text_hits` (khive-pack-memory/handlers/common.rs) and must
     /// degrade to vector-only results rather than aborting the recall.
     ///
-    /// Ties Medium to the codex round-1 High-2 finding: with a real (non-null)
+    /// Ties Medium to the internal review round 1 High-2 finding: with a real (non-null)
     /// embedder registered, this proves the vector leg still returns the
     /// correct note while the FTS leg is degraded — i.e. degradation loses only
     /// the FTS signal, not the overall recall. (This test does NOT assert an

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -1937,7 +1937,7 @@ async fn recall_presentation_alias_is_rejected_by_deny_unknown_fields() {
     );
 }
 
-// ── Codex High fixes regressions (#444) ──────────────────────────────────────
+// ── internal review High fixes regressions (#444) ──────────────────────────────────────
 
 /// Trivial constant-vector embedding service for testing without real model weights.
 /// The `_model` parameter is ignored; returns a synthetic `dims × seed` vector.
@@ -1999,7 +1999,7 @@ impl EmbedderProvider for ConstVecProvider {
     }
 }
 
-/// Fix 1 regression (codex High #1, PR #444): a runtime with no lattice
+/// Fix 1 regression (internal review High #1, PR #444): a runtime with no lattice
 /// `embedding_model` in config but a custom registered embedder must fan out
 /// `remember` through that embedder and store a vector.
 ///
@@ -2062,7 +2062,7 @@ async fn test_custom_embedder_only_runtime_fanout_remember_recall() {
     );
 }
 
-/// Fix 2 regression (codex High #2, PR #444): Weighted fusion with N > 1
+/// Fix 2 regression (internal review High #2, PR #444): Weighted fusion with N > 1
 /// vector models must not zero-weight the text source.
 ///
 /// Previously `fuse_candidates` passed [vec_a, vec_b, text] as 3 sources to

--- a/crates/khive-pack-schedule/tests/create_validation.rs
+++ b/crates/khive-pack-schedule/tests/create_validation.rs
@@ -695,8 +695,7 @@ async fn schedule_schedule_accepts_create_with_kind() {
     assert_eq!(result["status"], "pending");
 }
 
-/// Round-2 regression (codex REJECT, "create replay validation still misses
-/// KG kind reconciliation failures"): `create(kind="concept",
+/// Round-2 regression: `create(kind="concept",
 /// entity_kind="person", name="x")` is accepted by `schedule.schedule` before
 /// this fix, yet the real `create` handler
 /// (`khive-pack-kg/src/handlers/create.rs` via

--- a/crates/khive-quant/src/lib.rs
+++ b/crates/khive-quant/src/lib.rs
@@ -900,7 +900,7 @@ mod tests {
 
     // ── GsSq8Codec tests ────────────────────────────────────────────────────
 
-    /// Codex counterexample (2026-06-12): ranges [0,1] and [0,1e6].
+    /// Regression counterexample (2026-06-12): ranges [0,1] and [0,1e6].
     ///
     /// Without global-scale, the per-dim fast path reversed near/far ordering by >6 OOM.
     /// With GsSq8Codec the global scale is dominated by the wide dim; the narrow dim

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -297,7 +297,7 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
 // never waits on a cross-pack dispatch or a SQL write. Left untracked, that
 // work is invisible to `drain()`: a SIGTERM landing between the response
 // returning and the spawned task completing can abort it mid-flight with no
-// log and no row (codex PR #583 round-1 Medium). `track_background_task`
+// log and no row (internal review PR #583 round-1 Medium). `track_background_task`
 // gives such spawns a process-wide presence that `drain()` waits on, exactly
 // like the `active` counter does for in-flight connections — the caller still
 // only pays for the spawn + counter increment, never the task's own work.
@@ -311,7 +311,7 @@ fn background_tasks() -> &'static Arc<std::sync::atomic::AtomicUsize> {
 /// Decrements the shared background-task counter from `Drop`, so the count
 /// comes back down whether the tracked future returns normally, panics, or
 /// is cancelled — a plain post-`await` `fetch_sub` only covers the return
-/// path and leaks the count forever on a panic (codex PR #583 round-2
+/// path and leaks the count forever on a panic (internal review PR #583 round-2
 /// Medium), since unwinding skips every statement after the panic point.
 struct BackgroundTaskGuard {
     counter: Arc<std::sync::atomic::AtomicUsize>,
@@ -748,14 +748,14 @@ mod tests {
         std::env::remove_var(key);
     }
 
-    // codex PR #583 round-1 Medium: `drain()` must wait for tracked background
+    // internal review PR #583 round-1 Medium: `drain()` must wait for tracked background
     // tasks (e.g. memory.recall's serve-ledger append), not just in-flight
     // connections, or a SIGTERM lands mid-flight with no log and no row.
     //
     // `#[serial(background_tasks)]`: this test reads/asserts on the
     // process-wide `BACKGROUND_TASKS` static shared with the two counter
     // tests below. Under default parallel execution one test's increment
-    // leaks into another's snapshot-then-assert window (codex PR #583
+    // leaks into another's snapshot-then-assert window (internal review PR #583
     // round-3 Medium, reproduced: both counter tests failed together,
     // passed with `--test-threads=1`). Serializing just this named group
     // isolates them from each other without forcing the whole test binary
@@ -826,7 +826,7 @@ mod tests {
     #[tokio::test]
     #[serial(background_tasks)]
     async fn track_background_task_count_returns_to_baseline_after_panic() {
-        // codex PR #583 round-2 Medium: a panic inside the tracked future must
+        // internal review PR #583 round-2 Medium: a panic inside the tracked future must
         // still decrement the counter (via BackgroundTaskGuard's Drop), not
         // leak it forever. `track_background_task` discards the spawned
         // task's `JoinHandle` (it is fire-and-forget by design — the caller

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -113,7 +113,7 @@ pub struct EngineConfig {
 /// ```toml
 /// [actor]
 /// id = "lambda:leo"                          # attribution identity (required)
-/// display_name = "Leo global orchestrator"   # human label (optional)
+/// display_name = "example actor"   # human label (optional)
 /// visible_namespaces = ["lambda:khive", "local"]  # widens default read scope (ADR-007 Rev 4 Rule 3b)
 /// ```
 ///
@@ -849,17 +849,14 @@ fusion_weight = 0.3
             r#"
 [actor]
 id = "lambda:khive"
-display_name = "Ocean's khive lambda"
+display_name = "example actor"
 "#,
         );
         let cfg = KhiveConfig::load(Some(&path))
             .expect("load should succeed")
             .expect("file should be found");
         assert_eq!(cfg.actor.id.as_deref(), Some("lambda:khive"));
-        assert_eq!(
-            cfg.actor.display_name.as_deref(),
-            Some("Ocean's khive lambda")
-        );
+        assert_eq!(cfg.actor.display_name.as_deref(), Some("example actor"));
         assert!(cfg.engines.is_empty());
     }
 

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -432,7 +432,7 @@ mod tests {
     // 10. #388 regression: hybrid_search_with_strategy must not hard-fail on a query
     // containing FTS5 metacharacters like `$`. After this test was first written,
     // sanitize_fts5_query (khive-db) already strips `$`, so this alone takes the `Ok`
-    // path and does not exercise the runtime-level fail-open `Err` arm (PR #389 codex
+    // path and does not exercise the runtime-level fail-open `Err` arm (PR #389 internal review
     // round-1 Medium finding) — kept as a sanitizer-path regression; see test 11 below
     // for the fail-open-branch regression.
     #[tokio::test]
@@ -462,7 +462,7 @@ mod tests {
         );
     }
 
-    // 11. PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped by
+    // 11. PR #389 internal review round 1 Medium regression: unlike `$`, `@` is NOT stripped by
     // sanitize_fts5_query (by design — the sanitizer stays minimal per #388 scope; the
     // fail-open net is the systematic answer for residual punctuation). SQLite FTS5's
     // bareword parser still rejects `@` unconditionally, so this query reaches the

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1738,7 +1738,7 @@ impl KhiveRuntime {
         // `dedup_by_key` adjacent-comparable and otherwise discards it. This
         // is the ADR-089 amended neighbor-ordering contract and must hold at
         // every call site of this op (context and neighbors verb alike),
-        // for every direction (ADR-089 context-verb review, codex round 2, High).
+        // for every direction (ADR-089 context-verb review, internal review round 2, High).
         hits.sort_by(|a, b| {
             b.weight
                 .partial_cmp(&a.weight)
@@ -2211,7 +2211,7 @@ impl KhiveRuntime {
             }
         }
 
-        // Codex round 2 Medium (PR #407): resolve embedding_model BEFORE any
+        // internal review round 2 Medium (PR #407): resolve embedding_model BEFORE any
         // note/FTS/vector write so unknown-model errors are atomic at the
         // runtime layer, not just at one pack handler. Direct Rust callers
         // (other packs, integration tests) get the same guarantee.
@@ -2251,7 +2251,7 @@ impl KhiveRuntime {
         } else {
             // Fan out to ALL registered models — includes both lattice models
             // from RuntimeConfig and any custom providers added via
-            // register_embedder() (codex High #1, PR #444).
+            // register_embedder() (internal review High #1, PR #444).
             // Gate on the registry, not config().embedding_model, so that
             // custom-only runtimes (no lattice model in config) also fan out.
             let names = self.registered_embedding_model_names();
@@ -2408,7 +2408,7 @@ impl KhiveRuntime {
                     Ok(Ok(vec)) => vectors.push(vec),
                 }
             }
-            // TODO(P2): parallelize vector inserts (codex review #444)
+            // TODO(P2): parallelize vector inserts (internal review #444)
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors.into_iter()) {
                 let insert_result = match self.vectors_for_model(token, model_name) {
@@ -2703,7 +2703,7 @@ impl KhiveRuntime {
         // soft-delete/kind filtering happen *after* this, and the final
         // `hits.truncate(limit)` is the only result-limiting cut. Truncating to
         // `candidates` here would drop a high-salience note ranked just outside
-        // the raw RRF cutoff before salience ever applied (codex #526).
+        // the raw RRF cutoff before salience ever applied (review #526).
         let fuse_k = text_hits.len() + vector_hits.len();
         let fused = crate::fusion::rrf_fuse_k(text_hits, vector_hits, RRF_K, fuse_k)?;
 
@@ -2957,7 +2957,7 @@ impl KhiveRuntime {
     /// By-ID contract (ADR-007): UUID v4 is globally unique — by-ID substrate
     /// inference must return the record regardless of caller namespace.  Used by
     /// the public `update` and `delete` verb handlers when no explicit `kind` is
-    /// supplied (PR-A1 / codex r2).
+    /// supplied (PR-A1).
     ///
     /// Does NOT consult the visible set or the primary-namespace check.  The
     /// token is still required to route to the correct backend pool but its
@@ -3168,7 +3168,7 @@ impl KhiveRuntime {
             self.text_for_notes(&record_tok)?
                 .delete_document(&record_ns, id)
                 .await?;
-            // Codex High 2 (PR #407): scoped delete — iterate over EVERY
+            // internal review High 2 (PR #407): scoped delete — iterate over EVERY
             // registered embedding model's vector store so non-default vectors
             // don't orphan when the note is deleted.
             for model_name in self.registered_embedding_model_names() {
@@ -3575,14 +3575,14 @@ impl KhiveRuntime {
         patch: crate::curation::EdgePatch,
     ) -> RuntimeResult<Edge> {
         // Fetch the edge by UUID — ID-only, no namespace check (PR-A1).
-        // get_edge already uses the record's stored namespace internally (codex r1 fix).
+        // get_edge already uses the record's stored namespace internally.
         let graph_for_fetch = self.graph(token)?;
         let mut edge = graph_for_fetch
             .get_edge(LinkId::from(edge_id))
             .await?
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
 
-        // PR-A1 (codex r2): after fetching, all mutations and validation must use the
+        // PR-A1: after fetching, all mutations and validation must use the
         // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
         // namespace so that endpoint validation, raw-SQL predicates, and graph routing
         // all address the correct backend partition.
@@ -4242,7 +4242,7 @@ mod tests {
         KhiveRuntime::memory().unwrap()
     }
 
-    // ── Fix-1 regression (codex High #1, PR #444) ────────────────────────────
+    // ── Fix-1 regression (internal review High #1, PR #444) ────────────────────────────
     // A runtime with no `config.embedding_model` but a custom registered
     // embedder must fan out create_note through that embedder and store a
     // vector so recall can find the note.
@@ -8483,7 +8483,7 @@ mod tests {
 
     // ---- PR #82 round-2 regression: edge-ID hard-delete path ----
     //
-    // Bug class (codex R2): delete_edge drove the primary-edge guard through get_edge()
+    // Bug class: delete_edge drove the primary-edge guard through get_edge()
     // (live-only) and the cascade through neighbors() (live-only). Two reachable holes:
     // (a) soft-deleted primary edge cannot be hard-purged via its own ID;
     // (b) an already-soft-deleted annotates edge targeting a base edge survives that
@@ -9006,7 +9006,7 @@ mod tests {
         // Create under "lambda:leo".
         let leo_tok = NamespaceToken::for_namespace(Namespace::parse("lambda:leo").unwrap());
         let entity = rt
-            .create_entity(&leo_tok, "concept", None, "Leo-Entity", None, None, vec![])
+            .create_entity(&leo_tok, "concept", None, "Peer-Entity", None, None, vec![])
             .await
             .unwrap();
         assert_eq!(entity.namespace, "lambda:leo");
@@ -9031,7 +9031,7 @@ mod tests {
                 &leo_tok,
                 "concept",
                 None,
-                "Leo-Entity-Update",
+                "Peer-Entity-Update",
                 None,
                 None,
                 vec![],
@@ -9042,7 +9042,7 @@ mod tests {
         // Update from "local" token — must not error with NotFound.
         let local_tok = NamespaceToken::local();
         let patch = crate::curation::EntityPatch {
-            name: Some("Leo-Entity-Updated".to_string()),
+            name: Some("Peer-Entity-Updated".to_string()),
             ..Default::default()
         };
         let result = rt.update_entity(&local_tok, entity.id, patch).await;
@@ -9051,7 +9051,7 @@ mod tests {
             "update_entity from local token must succeed on lambda:leo entity; got {:?}",
             result
         );
-        assert_eq!(result.unwrap().name, "Leo-Entity-Updated");
+        assert_eq!(result.unwrap().name, "Peer-Entity-Updated");
     }
 
     #[tokio::test]
@@ -9063,7 +9063,7 @@ mod tests {
                 &leo_tok,
                 "concept",
                 None,
-                "Leo-Entity-Delete",
+                "Peer-Entity-Delete",
                 None,
                 None,
                 vec![],
@@ -9331,7 +9331,7 @@ mod tests {
     #[test]
     fn endpoint_of_type_requires_base_kind_match() {
         // Regression: an entity with entity_type="theorem" but base kind != "concept"
-        // must NOT match a formal concept rule. This was the exact bypass codex named:
+        // must NOT match a formal concept rule. This was the exact bypass:
         // before the fix, EntityOfType("theorem") ignored the base kind entirely.
         let wrong_base_kind = "project"; // not "concept"
         let et = Some("theorem");

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -829,7 +829,7 @@ impl VerbRegistry {
             }
         }
         // Only list Verb-visibility handlers so internal subhandlers are not
-        // advertised in the unknown-verb error (ue-help-introspection C1 / codex High).
+        // advertised in the unknown-verb error (ue-help-introspection C1 / internal review High).
         let available: Vec<&str> = self
             .packs
             .iter()
@@ -1052,7 +1052,7 @@ impl VerbRegistry {
 
                     // For recall verbs: extract the first result's id as
                     // target_id so the brain temporal posterior can observe
-                    // real hit/miss and latency (fix for codex P12 Major).
+                    // real hit/miss and latency (fix for internal review P12 Major).
                     if verb == "memory.recall" {
                         let first_note_id = ok_val
                             .as_array()
@@ -1079,7 +1079,7 @@ impl VerbRegistry {
             }
         }
         // Only list Verb-visibility handlers so internal subhandlers are not
-        // advertised in the unknown-verb error (ue-help-introspection C1 / codex High).
+        // advertised in the unknown-verb error (ue-help-introspection C1 / internal review High).
         let available: Vec<&str> = self
             .packs
             .iter()
@@ -2169,7 +2169,7 @@ mod tests {
     }
 
     // Captures the namespace each call sees so we can assert what the gate
-    // actually receives — codex round-1 caught us hard-wiring `default_ns()`.
+    // actually receives — internal review round 1 caught us hard-wiring `default_ns()`.
     #[derive(Default, Debug)]
     struct NamespaceCapturingGate {
         seen: std::sync::Mutex<Vec<String>>,
@@ -3021,7 +3021,7 @@ mod tests {
 
     // ---- EventStore audit envelope round-trip ----
     //
-    // Codex review finding (Major #1): EventStore was persisting a summary
+    // internal review finding (Major #1): EventStore was persisting a summary
     // Event without the full AuditEvent fields (deny_reason, gate_impl,
     // obligations). This test verifies the complete envelope survives
     // append_event → query_events.
@@ -3158,7 +3158,7 @@ mod tests {
         }
     }
 
-    // ---- SQL-backed audit envelope round-trip (codex r2) ----
+    // ---- SQL-backed audit envelope round-trip ----
     //
     // The two tests above use MemoryEventStore (no serialization). This test
     // wires the production SqlEventStore via KhiveRuntime::memory() to verify
@@ -3255,7 +3255,7 @@ mod tests {
 
     // ---- SQL-backed audit envelope: non-empty obligations survive round-trip ----
     //
-    // Codex r3 identified a blind spot: the deny-path SQL test above only
+    // Blind spot: the deny-path SQL test above only
     // asserts obligations == [], which passes even if the SQL path drops the
     // field entirely (AuditEvent.obligations has #[serde(default)]).
     //
@@ -4313,11 +4313,11 @@ mod help_tests {
         );
     }
 
-    // ── codex High: unknown-verb error must not leak subhandler names ─────────
+    // ── internal review High: unknown-verb error must not leak subhandler names ─────────
 
     /// `describe_verb` on an unknown verb must list only Verb-visibility names
     /// in the "available" list — never subhandler names like `recall.embed`
-    /// (codex High — ue-help-introspection C1 / unknown-verb path).
+    /// (internal review High — ue-help-introspection C1 / unknown-verb path).
     #[tokio::test]
     async fn help_true_unknown_verb_available_list_excludes_subhandlers() {
         let reg = build_help_registry(Arc::new(AtomicUsize::new(0)));

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -1334,7 +1334,7 @@ mod tests {
     /// metacharacters like `$` (e.g. the DSL doc query `$prev.id`). After this test was
     /// first written, `sanitize_fts5_query` (khive-db) already strips `$`, so this alone
     /// takes the `Ok` path and does not exercise the runtime-level fail-open `Err` arm
-    /// (PR #389 codex round-1 Medium finding) — it stays as a sanitizer-path regression;
+    /// (PR #389 internal review round 1 Medium finding) — it stays as a sanitizer-path regression;
     /// see `hybrid_search_with_residual_fts5_char_degrades_to_vector_only` below for the
     /// fail-open-branch regression.
     #[tokio::test]
@@ -1364,7 +1364,7 @@ mod tests {
         );
     }
 
-    /// PR #389 codex round-1 Medium regression: unlike `$`, `@` is NOT stripped by
+    /// PR #389 internal review round 1 Medium regression: unlike `$`, `@` is NOT stripped by
     /// `sanitize_fts5_query` (by design — the sanitizer stays minimal per #388 scope;
     /// the fail-open net is the systematic answer for residual punctuation). SQLite
     /// FTS5's bareword parser still rejects `@` unconditionally, so this query reaches

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -675,7 +675,7 @@ impl KhiveRuntime {
     /// Includes both built-in lattice models and any custom embedders
     /// registered by packs via [`register_embedder`](Self::register_embedder).
     /// Useful for operations that must touch every model's storage (e.g.,
-    /// scoped vector deletion on note delete — codex High 2 (PR #407)).
+    /// scoped vector deletion on note delete — internal review High 2 (PR #407)).
     /// The default model is included.
     pub fn registered_embedding_model_names(&self) -> Vec<String> {
         self.embedder_registry

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -61,7 +61,7 @@
 //!   decomposes into two or more such runs and every run is letters-then-digits
 //!   or pure digits, at most 24 chars long, with a low case-transition density.
 //!   This covers content like `fable-ops/ADR-DRAFT-adr079.md` or
-//!   `.khive/workspaces/20260701/adr079/PACKET.md`, which is otherwise
+//!   `local workspace artifact`, which is otherwise
 //!   indistinguishable from a high-entropy secret once glued into one
 //!   whitespace token.  Random base64/base62 secrets do not decompose this
 //!   way: their case and digit placement is effectively uniform rather than
@@ -71,11 +71,11 @@
 //!   **This exemption applies ONLY outside an explicit credential trigger
 //!   context (round-4 decision).** Two narrower attempts to keep some form of
 //!   this exemption alive inside `near_trigger` context were tried and both
-//!   defeated: a trailing file-extension check (`.md`/`.rs`; codex round-2
+//!   defeated: a trailing file-extension check (`.md`/`.rs`; internal review round 2
 //!   Critical — appending an extension to any random credential re-enabled
 //!   the exemption), and a dual-signal check requiring both a run-shape count
 //!   and an average per-run letters-only Shannon entropy below a threshold
-//!   (codex round-3 Critical — an attacker who splits a credential into short
+//!   (internal review round 3 Critical — an attacker who splits a credential into short
 //!   runs, or pads it with extra short/digit-bearing runs, drives the
 //!   reported entropy for every run toward `log2(run_len)`, which ordinary
 //!   short English path segments already sit at or near; e.g. a 9-char
@@ -715,7 +715,7 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         // computation, since a legitimate path can exceed ENTROPY_THRESHOLD
         // on Shannon entropy alone.
         //
-        // Round-4 decision (codex round-3 Critical): this exemption applies
+        // Round-4 decision (internal review round 3 Critical): this exemption applies
         // ONLY outside an explicit credential trigger context. Two prior
         // attempts to narrow it for `near_trigger` instead of dropping it
         // — a trailing file-extension check (round 1→2 bypass) and a
@@ -2371,7 +2371,7 @@ mod tests {
 
     #[test]
     fn github_app_token_families_are_masked() {
-        // codex #368 round-2 [Critical]: ghu_ (user-to-server), ghs_
+        // review #368 round-2 [Critical]: ghu_ (user-to-server), ghs_
         // (server-to-server), and ghr_ (refresh) GitHub App tokens are real
         // credential families that previously bypassed the prefix detector and
         // leaked through the mirror. They are context-free — no trigger word
@@ -2401,7 +2401,7 @@ mod tests {
 
     #[test]
     fn mask_secrets_redacts_entropy_token_whose_trigger_is_left_of_earlier_secret() {
-        // codex #368 round-2 [Critical]: the entropy detector only fires near a
+        // review #368 round-2 [Critical]: the entropy detector only fires near a
         // trigger word. When the trigger (`api_key`) sits to the LEFT of an
         // earlier known-prefix secret (`ghp_…`), a masker that rescans only the
         // suffix after each redaction loses that context and leaks the later
@@ -2465,7 +2465,7 @@ mod tests {
     fn blocks_workspace_path_near_key_word_accepted_fp_round4() {
         // Was `allows_workspace_path_near_key_word` pre round-4. Full-token
         // entropy 4.7938 > 4.5 — now an accepted FP.
-        let content = "key: see .khive/workspaces/20260701/adr079-slices234/PACKET.md";
+        let content = "key: see internal/workspaces/20260701/adr079-slices234/PACKET.md";
         assert!(
             check(content).is_err(),
             "accepted FP post round-4: workspace path near 'key' is now blocked; \
@@ -2479,7 +2479,7 @@ mod tests {
         // Was `allows_short_run_path_near_auth_word` pre round-4. Full-token
         // entropy 4.5955 > 4.5 — now an accepted FP.
         let content =
-            "auth work saved at .khive/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
+            "auth work saved at internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
         assert!(
             check(content).is_err(),
             "accepted FP post round-4: path with a short 'R1' run near 'auth' is \
@@ -2490,7 +2490,8 @@ mod tests {
 
     #[test]
     fn allows_branch_and_review_filename_near_key_word() {
-        let content = "branch feat-session-codex-mirror pushed, see codex_review_pr335_round2.md for the key findings";
+        let content =
+            "branch feat-session-mirror pushed, see review_pr335_round2.md for the key findings";
         assert!(
             check(content).is_ok(),
             "branch name and review filename near 'key' must not be blocked; fired: {:?}",
@@ -2554,9 +2555,9 @@ mod tests {
     fn structured_identifier_true_for_repro_paths() {
         let paths = [
             "fable-ops/ADR-DRAFT-adr079-slices234.md",
-            ".khive/workspaces/20260701/adr079-slices234/PACKET.md",
-            ".khive/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
-            "codex_review_pr335_round2.md",
+            "internal/workspaces/20260701/adr079-slices234/PACKET.md",
+            "internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md",
+            "review_pr335_round2.md",
             "docs/adr/ADR-055-epistemic-edge-relations.md",
             "crates/khive-pack-session/src/mirror/ingest.rs",
             "check_entropy_heuristic_impl",
@@ -2595,7 +2596,7 @@ mod tests {
     }
 
     // ── Round-4 decision: drop the structured-identifier exemption entirely
-    //    in trigger context (codex round-3 Critical) ─────────────────────────
+    //    in trigger context (internal review round 3 Critical) ─────────────────────────
     //
     // Two narrower fixes were tried in trigger context and both defeated:
     //   round 1: required a trailing file-extension run       -> bypassed by
@@ -2617,8 +2618,8 @@ mod tests {
     // `accepted_false_positive_*` below).
 
     #[test]
-    fn blocks_codex_repro_secret_access_key_bypass() {
-        // The exact bypass string from the codex round-1 Critical finding.
+    fn blocks_separator_secret_access_key_bypass() {
+        // The exact bypass string from the round-1 Critical finding.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk";
         assert!(
             check(content).is_err(),
@@ -2663,7 +2664,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_codex_round2_extension_suffix_bypass_secret_access_key() {
+    fn blocks_extension_suffix_bypass_secret_access_key() {
         // The round-1 bypass string with `.md` appended — this is what
         // slipped through the round-1 extension-based exemption.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk.md";
@@ -2675,7 +2676,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_codex_round2_extension_suffix_bypass_token_assignment() {
+    fn blocks_extension_suffix_bypass_token_assignment() {
         let content = "token=zxkqwmvbpl/trfhysjgnc/dweiaoutkz-mnbvcxzlk.rs";
         assert!(
             check(content).is_err(),
@@ -2716,7 +2717,7 @@ mod tests {
 
     #[test]
     fn blocks_round3_padding_run_bypass_attempts() {
-        // Codex round-3 Critical repro: a low-entropy padding run (`aaaa`)
+        // internal review round 3 Critical repro: a low-entropy padding run (`aaaa`)
         // inserted before short/digit-shaped runs used to drag the round-2
         // AVERAGE per-run letters-only entropy below its threshold while
         // `has_low_entropy_run_signal` was satisfied by the trailing
@@ -2741,7 +2742,7 @@ mod tests {
     #[test]
     fn blocks_run_splitting_bypass_attempts() {
         // A further adversarial construction found while stress-testing the
-        // round-3 fix (not itself a codex finding, but proves the general
+        // round-3 fix, proving the general
         // unsoundness): splitting a credential into short (4-6 char) runs
         // drives EVERY run's own letters-only entropy toward log2(run_len),
         // which ordinary short English path words already sit at or near —
@@ -2770,7 +2771,7 @@ mod tests {
         // (4.5) — the exemption was never load-bearing for these regardless
         // of which version of it existed.
         let paths = [
-            "codex_review_pr335_round2.md",
+            "review_pr335_round2.md",
             "docs/adr/ADR-055-epistemic-edge-relations.md",
             "crates/khive-pack-session/src/mirror/ingest.rs",
             "check_entropy_heuristic_impl",
@@ -2808,7 +2809,7 @@ mod tests {
     #[test]
     fn accepted_false_positive_workspace_packet_path_near_trigger() {
         // Same tradeoff as above: full-token entropy 4.7938 > 4.5.
-        let content = "api_key handling in .khive/workspaces/20260701/adr079-slices234/PACKET.md";
+        let content = "api_key handling in internal/workspaces/20260701/adr079-slices234/PACKET.md";
         assert!(
             check(content).is_err(),
             "accepted FP: PACKET.md workspace path near 'api_key' is now blocked \
@@ -2821,7 +2822,7 @@ mod tests {
     fn accepted_false_positive_r1_repo_audit_path_near_trigger() {
         // Same tradeoff as above: full-token entropy 4.5955 > 4.5.
         let content =
-            "api_key handling in .khive/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
+            "api_key handling in internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
         assert!(
             check(content).is_err(),
             "accepted FP: R1-repo-audit path near 'api_key' is now blocked post \
@@ -3095,7 +3096,7 @@ mod tests {
 
     #[test]
     fn allows_benign_url_with_scheme_and_path_separators() {
-        // Adversarial self-check (codex round-8 guidance): any-suffix
+        // Adversarial self-check (internal review round 8 guidance): any-suffix
         // semantics must not newly block ordinary URLs, whose `://` and
         // `/` characters produce several suffix candidates but none of
         // them are UUID- or content-hash-shaped. Placed near a real

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -700,7 +700,7 @@ async fn synthetic_edge_observed_as_selected_returns_memory_note() {
 }
 
 // =============================================================================
-// update_edge conflict handling regression tests (codex round-3 H1)
+// update_edge conflict handling regression tests (internal review round 3 H1)
 // =============================================================================
 
 /// Regression for Bug 1: when update_edge absorbs a conflict (the requested edge

--- a/crates/khive-types/src/entity.rs
+++ b/crates/khive-types/src/entity.rs
@@ -304,7 +304,7 @@ mod tests {
             ),
             kind: EntityKind::Person,
             entity_type: Some("researcher".into()),
-            name: "Ocean".into(),
+            name: "Operator".into(),
             description: None,
             properties: props,
             tags: alloc::vec![],

--- a/crates/khive-types/src/event.rs
+++ b/crates/khive-types/src/event.rs
@@ -857,11 +857,11 @@ mod tests {
     fn proposal_payloads_are_typed() {
         let payload = EventPayload::ProposalReviewed(ProposalReviewedPayload {
             proposal_id: Id128::from_u128(42),
-            reviewer: "ocean".into(),
+            reviewer: "operator".into(),
             decision: ProposalDecision::Approve,
             comment: None,
         });
-        let event = EventBuilder::new("review", SubstrateKind::Entity, "ocean")
+        let event = EventBuilder::new("review", SubstrateKind::Entity, "operator")
             .kind(EventKind::ProposalReviewed)
             .payload(payload)
             .build(header());

--- a/crates/khive-vamana/src/index.rs
+++ b/crates/khive-vamana/src/index.rs
@@ -4052,13 +4052,13 @@ mod tests {
 
     /// RobustPrune alpha-predicate regression (ADR-052 §2 — R2 Finding 2).
     ///
-    /// Codex repro: when node AND multiple candidates all collapse to the same u8 code,
+    /// Regression reproduction: when node AND multiple candidates all collapse to the same u8 code,
     /// d2_node_candidate from the SQ8 pool is 0. The strict-≤ check then reads
     /// `alpha² * dist(selected, candidate) <= 0`, which is false for any non-zero
     /// inter-selected distance — so the candidate is NOT pruned even though exact f32
     /// WOULD prune it. This test verifies the fix: use exact f32 as the predicate RHS.
     ///
-    /// Fixture (exact codex repro): vectors=[0.0, 0.001, 0.0018, 1.0], DIM=1, node=0,
+    /// Fixture (exact reproduction): vectors=[0.0, 0.001, 0.0018, 1.0], DIM=1, node=0,
     /// candidates=[1,2], alpha=1.2.
     ///   - All of v0..v2 collapse to code 0 (gs=1/255, 0.001*255=0.255→0, 0.0018*255=0.459→0).
     ///   - f32 prune: selects v1, PRUNES v2 (alpha²*d(v1,v2)=0.000000922 ≤ d(v0,v2)=3.24e-6).

--- a/crates/khive-vamana/tests/lifecycle.rs
+++ b/crates/khive-vamana/tests/lifecycle.rs
@@ -1075,7 +1075,7 @@ fn oq2_consolidate_beats_no_consolidate_on_memory() {
     );
 }
 
-// ---- Regression tests (codex round-2 required) ----
+// ---- Regression tests (internal review round 2 required) ----
 
 /// T-R1: insert a distinctive vector, self-query k=1, assert the assigned ordinal is found.
 /// The previous suite only queried ORIGINAL vectors (lifecycle.rs:538). This closes that gap.
@@ -1103,7 +1103,7 @@ fn insert_then_self_query() {
     );
 }
 
-/// T-R2: exact codex repro (round-2 Critical).
+/// T-R2: exact regression reproduction.
 /// Graph: vectors [0.0, 0.1], dim=1, max_degree=1, search_list_size=1.
 /// After insert([-0.2]):
 ///   (a) self-query for [-0.2] must return the inserted ordinal.

--- a/crates/khive-vamana/tests/persistence.rs
+++ b/crates/khive-vamana/tests/persistence.rs
@@ -889,7 +889,7 @@ fn v2_parse_lifecycle_huge_fs_count_returns_invalid_format_not_panic() {
     assert_eq!(rebuilt.num_vectors(), n);
 }
 
-// ---- Fix 5 / codex R5: checked_add for offset + ts_bytes / offset + fs_bytes ----
+// ---- Fix 5 / R5: checked_add for offset + ts_bytes / offset + fs_bytes ----
 //
 // These two tests target the ADDITION overflow, not the multiplication.
 // ts_words = usize::MAX/8 passes checked_mul (ts_bytes = usize::MAX-7), but

--- a/crates/kkernel/src/engine.rs
+++ b/crates/kkernel/src/engine.rs
@@ -272,7 +272,7 @@ mod tests {
 
     // Engine tests must be hermetic: with `db: None` the command resolves to the
     // operator's real `~/.khive/khive.db` and runs migration writes against
-    // it. Always point tests at a throwaway temp DB (codex #531). Keep the
+    // it. Always point tests at a throwaway temp DB (review #531). Keep the
     // returned TempDir alive for the test's duration.
     fn temp_db() -> (TempDir, Option<std::path::PathBuf>) {
         let tmp = TempDir::new().expect("temp dir");

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -619,7 +619,7 @@ mod tests {
     use tempfile::TempDir;
 
     // A schema check must be read-only: it must not create a missing database,
-    // and it must not migrate (mutate) an existing one. Regression for the codex
+    // and it must not migrate (mutate) an existing one. Regression for the
     // finding that `db check` ran migrations via the read-only runtime path.
     #[tokio::test]
     async fn db_check_does_not_create_missing_file() {
@@ -778,7 +778,7 @@ mod tests {
         );
     }
 
-    /// Codex round 1 (#613) finding: the two sibling tests above never configure
+    /// internal review round 1 (#613) finding: the two sibling tests above never configure
     /// a non-default output format, so `output_format` parity was vacuous —
     /// both paths landing on the built-in `Json` default would pass even if one
     /// path silently dropped `apply_env_output_format(khive_cfg.runtime.default_output_format)`
@@ -799,7 +799,7 @@ mod tests {
         // original value (or leaves it removed) on drop — including on panic, so
         // a failing assertion or an unexpected constructor error never leaks the
         // cleared env var to later #[serial] tests. Mirrors `EmailEnvGuard` in
-        // `khive-mcp/src/serve.rs` (round 2 of the #603 codex review, PR #613:
+        // `khive-mcp/src/serve.rs` (round 2 of the #603 internal review, PR #613:
         // the prior manual save/clear/restore only ran on the success path).
         struct OutputFormatEnvGuard {
             prev: Option<String>,

--- a/crates/kkernel/src/pending_events.rs
+++ b/crates/kkernel/src/pending_events.rs
@@ -1403,8 +1403,8 @@ mod tests {
         );
     }
 
-    /// Round-2 regression (codex REJECT, "finalize must be bound to the
-    /// owning claim"): reproduces the exact stale-claimant-resumes
+    /// Round-2 regression: finalize must be bound to the owning claim. This
+    /// reproduces the exact stale-claimant-resumes
     /// interleaving. Drain A claims and (simulated) crashes/stalls past the
     /// stale timeout with its own `firing_at` token recorded. A reclaim pass
     /// then runs, and drain B re-claims the row, minting a fresh `firing_at`

--- a/docs/adr/ADR-001-entity-kind-taxonomy.md
+++ b/docs/adr/ADR-001-entity-kind-taxonomy.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-002-edge-ontology.md
+++ b/docs/adr/ADR-002-edge-ontology.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Amended by**: [ADR-076](ADR-076-relation-calculability-and-system-role.md) — `part_of` is a
 distinct relation, not the "inverse of `contains`"; the two coincide in some domains and diverge
 in others, and neither is derived from the other.

--- a/docs/adr/ADR-003-system-architecture.md
+++ b/docs/adr/ADR-003-system-architecture.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-004-substrate-observables.md
+++ b/docs/adr/ADR-004-substrate-observables.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-005-storage-capability-traits.md
+++ b/docs/adr/ADR-005-storage-capability-traits.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-22\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-006-deterministic-scoring.md
+++ b/docs/adr/ADR-006-deterministic-scoring.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted/Ratified (2026-06-19)
 **Date**: 2026-06-19
-**Authors**: lambda:khive, alpha:architect
+**Authors**: khive maintainers
 **Amends**: ADR-007-namespace.md (adds Rule 8 on top of Rev 6; all prior rules Rev 0–7 retained, Rule 8 is additive)
 **Supersedes (partial)**: None — additive amendment only
 **ADR chain**: ADR-018 (Gate trait, single dispatch site) | ADR-014 (curation, merge semantics)
@@ -45,7 +45,7 @@ skipped. Issue #75 has since shipped (commit `f1061d27`): `RuntimeConfig` now ca
 unconditional. Full detail in ADR-063 "Current State."
 
 A second, larger issue is cross-machine delivery. Lambda-to-lambda coordination across
-machines or sandboxes — the roadmap item Ocean identified — requires a transport that is
+machines or sandboxes — a roadmap item — requires a transport that is
 inherently multi-principal: each lambda authenticates independently, sends messages to peers
 by principal, and reads only its own inbox. This is a different trust model from the shared
 local substrate where all actors read the same pool. A remote message broker enforces
@@ -134,12 +134,12 @@ specified in ADR-063.
 
 ## Alternatives Considered
 
-| Alternative                                                            | Disposition                                                                                                                                                            |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Amend ADR-007 Rules 0-7 globally to allow per-pack namespace carry     | Rejected. This would re-open the Rev 3 debate and potentially undo the "all packs no-carry" ruling. Rule 8 is a carve-out for a specific backend type, not a reversal. |
-| Define the comm isolation contract in ADR-007 directly                 | Rejected. ADR-007 is a cross-cutting substrate contract. Per-pack backend contracts belong in their own ADRs (ADR-028 pattern).                                        |
-| Treat the remote broker as a pure platform crate with no ADR           | Rejected. A transport that enforces per-principal scope is an architectural decision; it requires an ADR per the project standard.                                     |
-| Apply Option A (local filter as security model) for both OSS and cloud | Rejected for cloud. See ADR-063 §Alternatives for the full argument; the short form is: a shared store filter is bypassable by any client with store access.           |
+| Alternative                                                            | Disposition                                                                                                                                                              |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Amend ADR-007 Rules 0-7 globally to allow per-pack namespace carry     | Rejected. This would re-open the Rev 3 debate and potentially undo the "all packs no-carry" decision. Rule 8 is a carve-out for a specific backend type, not a reversal. |
+| Define the comm isolation contract in ADR-007 directly                 | Rejected. ADR-007 is a cross-cutting substrate contract. Per-pack backend contracts belong in their own ADRs (ADR-028 pattern).                                          |
+| Treat the remote broker as a pure platform crate with no ADR           | Rejected. A transport that enforces per-principal scope is an architectural decision; it requires an ADR per the project standard.                                       |
+| Apply Option A (local filter as security model) for both OSS and cloud | Rejected for cloud. See ADR-063 §Alternatives for the full argument; the short form is: a shared store filter is bypassable by any client with store access.             |
 
 ---
 
@@ -184,7 +184,7 @@ specified in ADR-063.
 
 **Status**: Accepted/Ratified (2026-06-19)
 **Date**: 2026-06-19
-**Authors**: lambda:khive, alpha:architect
+**Authors**: khive maintainers
 **Amends**: ADR-007-namespace.md (replaces v1 base text, both 2026-05 amendments, Rev 2, Rev 3 read-scope clause; Rev 6 amends the Rev 4 Rule 0 write-default for episodic memory)
 **Supersedes (partial)**: ADR-050 §"Decision"; ADR-059 §"Decision" and §"Visibility tiers"
 **Superseded-by-none**: ADR-053 (ActorStore, SessionStore, actor threading) survives in full
@@ -250,8 +250,7 @@ AllowAllGate as the default gate. The 2026-05-27 Namespace-by-Layer amendment sp
 two routing groups. ADR-050 proposed removing the KG-pack token rebinding introduced by that
 split. ADR-059 drafted a three-tier visibility model.
 
-Ocean's ruling (CLAUDE.md "Authorization — the gate is a seam, by design" and "Namespace and
-authorization") resolves the divergence: namespace is attribution, not isolation. Storage is
+The accepted design resolves the divergence: namespace is attribution, not isolation. Storage is
 dumb. The Gate is the one enforcement seam.
 
 PR-A1 (commit 2607e263, merged 2026-06-16) shipped the by-ID half: all ensure_namespace /
@@ -276,7 +275,7 @@ Gate implementations plug into.
 khive's default deployment is a single shared brain: one SQLite file, one namespace
 ("local"), all lambdas and agents reading and writing together.
 
-Actor identity (lambda:khive, lambda:leo, agent:*, user:ocean) is attribution only: stamped on
+Actor identity (lambda:khive, lambda:leo, agent:*, user:operator) is attribution only: stamped on
 write records and gate-request context, available for logging, filtering, and operator policy
 input. It never silently becomes the storage namespace and never gates by-ID access.
 
@@ -288,8 +287,8 @@ ADR-053; until that lands, `[actor] id` is inert at the storage layer. This is t
 distinction Rule 0 turns on: a caller may target a named namespace per request, but the actor a
 deployment is configured as must not route storage on its own.
 
-Source: CLAUDE.md "The local system is a single shared brain: one namespace (`local`), and
-every lambda / agent / subagent reads and writes it."
+Source: project guidance: the local system is a single shared brain, with one namespace
+(`local`) and every lambda / agent / subagent reading and writing it.
 
 **Rev 6 amendment to Rule 0 (episodic memory writes stamp the actor id by default).** Rule 0
 continues to hold for every write path EXCEPT one: an episodic memory write
@@ -369,13 +368,13 @@ update_entity, update_note, update_edge, delete_edge.
 
 CHANGE FROM ADR-007 v1: The 2026-05-27 Namespace-by-Layer amendment routed memory, gtd, comm,
 brain, and schedule multi-record ops by actor namespace ("WHERE namespace = <actor_namespace>"),
-while routing KG and knowledge to "local". Gemini REFUTE Finding 2 correctly identified this
+while routing KG and knowledge to "local". internal review finding 2 correctly identified this
 as a contradiction of Rule 0: framing per-pack actor routing as "explicit pack policy"
-re-introduces the exact actor-as-namespace isolation coupling Ocean ordered removed. Finding 1
+re-introduces the exact actor-as-namespace isolation coupling the accepted design removed. Finding 1
 added that memory is live-audited as bulk "local" and that cross-lambda learning via
 memory.recall over one pool depends on the shared store.
 
-Ocean ruling (2026-06-17, Rev 3): ALL packs are NO-CARRY. There is no per-pack namespace
+Accepted Rev 3 decision (2026-06-17): ALL packs are NO-CARRY. There is no per-pack namespace
 carry, now or planned. This closes the two questions that Rev 2 left deferred to Rev 3:
 
 - Comm is NO-CARRY (reverses the Rev-2 "leans yes"). Messages are inherently actor-addressed,
@@ -421,8 +420,8 @@ partitions:
   carry is NO.
 - KG / knowledge: shared "local" store. Namespace carry was NO (confirmed in Rev 2; unchanged).
 
-This dissolves the Rule 0 vs Rule 3 contradiction present in the prior amendment (gemini
-Finding 2) and resolves the memory-pack scoping incoherence (gemini Finding 1). The Rev-2
+This dissolves the Rule 0 vs Rule 3 contradiction present in the prior amendment (internal review
+finding 2) and resolves the memory-pack scoping incoherence (internal review finding 1). The Rev-2
 deferred carry questions for comm and memory are now closed: both are NO-CARRY.
 
 Status: implemented. VerbRegistry::dispatch mints the storage token with primary = the explicit
@@ -515,10 +514,10 @@ per-edge namespace-join appears in any query, in any deployment. The graph is
 shared structure; no actor "owns" an edge via namespace.
 
 Edge namespace is NOT derived from the endpoints. The B1 storage-schema fact from the ADR-059
-gemini mirror (edge carries its own namespace column, not derived from endpoints) is retained
+internal review (edge carries its own namespace column, not derived from endpoints) is retained
 as a storage-schema description, not as an isolation mechanism.
 
-Source: ADR-059 §"Context" — gemini REFUTE correction 1 confirmed scheme B1 (edge carries its
+Source: ADR-059 §"Context" — internal review correction 1 confirmed scheme B1 (edge carries its
 own namespace column). That storage fact is accurate. What ADR-059's decision built on top of
 it (the three-column visibility filter) is withdrawn.
 
@@ -554,14 +553,14 @@ storage invariants all deployments preserve. "Namespace never becomes the storag
 is absolute. "Namespace may be a gate's policy key" is consistent with it: a policy input
 is not a storage boundary.
 
-Source: CLAUDE.md "The `Gate` is a replaceable trait. The runtime holds an `Arc<dyn Gate>` and
-consults it on every verb dispatch — one authorization boundary."
+Source: project guidance: the `Gate` is a replaceable trait, and the runtime consults it on
+every verb dispatch as the single authorization boundary.
 
 ### Rule 5 — Merge semantics: same-namespace guard survives as substrate check, not isolation
 
 CHANGE FROM ADR-007 v1: The v1 base text and Namespace-by-Layer amendment defended the
 merge_entity same-namespace guard on the grounds that it prevents merging a "local KG entity
-with an actor-scoped operational note." Gemini Finding 4 correctly refuted this: entities and
+with an actor-scoped operational note." Internal review finding 4 correctly refuted this: entities and
 notes are different substrates merged by different verbs (merge_entity vs merge_note), so the
 cross-substrate scenario is structurally impossible regardless of namespace values. In an
 all-"local" world the guard is circular ("local" == "local") and is dead code with respect to
@@ -573,7 +572,7 @@ anything in the current deployment. It is dead-but-harmless and may be cleaned u
 PR. It must not be defended as isolation.
 
 Source: curation.rs line 2908-2910 ("a merge-semantic constraint, not tenant isolation"),
-gemini Finding 4.
+internal review finding 4.
 
 ### Rule 6 — Namespace type: open string with validated factory
 
@@ -607,15 +606,15 @@ policy input. It does not route storage.
 
 ## Supersession Map
 
-| Document                                          | Status                      | Superseded clauses                                                                                                                                                                                                                            | Surviving clauses                                                                                                                                                                                        |
-| ------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ADR-007 v1 base text (this file, prior revision)  | Superseded (Rev 3 replaces) | NamespaceToken as by-ID guard; NamespaceView; Read-by-ID namespace check; Timing oracle mitigation; NamespaceGrants / AuthContext / PrincipalId                                                                                               | Namespace::parse structural validation; "No Default"; Namespace vs backend independent axes; Hierarchy helper naming utility                                                                             |
-| ADR-007 2026-05-25 amendment                      | Superseded (Rev 3 replaces) | Two-model framing (collapsed: the default is one model; operator-supplied Gate adds isolation)                                                                                                                                                | AllowAllGate as default gate; [actor] id as attribution config; 4-tier config search path; display_name advisory-only                                                                                    |
-| ADR-007 2026-05-27 amendment (Namespace-by-Layer) | Superseded (Rev 3 replaces) | KG-pack namespace override via token.with_namespace(); per-pack actor namespace routing for memory/gtd/comm — this ADR replaces routing with view-layer tag filters                                                                           | None; the routing intent is now stated correctly in Rule 3                                                                                                                                               |
-| ADR-007 Rev 2 (2026-06-16)                        | Superseded (Rev 3 replaces) | Status: Proposed; Rev-3-deferred comm carry question ("leans yes"); Rev-3-deferred memory carry question ("undecided")                                                                                                                        | All substantive rules 0-7 (retained and sharpened); gemini REFUTE findings; PR-A1 shipped status                                                                                                         |
-| ADR-050                                           | Partially superseded        | Decision: removal of KG-pack override (this ADR absorbs and confirms)                                                                                                                                                                         | Context: documents the override as a historical bug; Rationale "Why not token rebinding"                                                                                                                 |
-| ADR-053                                           | Survives in full            | No conflict                                                                                                                                                                                                                                   | All: ActorStore, SessionStore, DispatchRequest, actor threading. Attribution threading is orthogonal to namespace isolation.                                                                             |
-| ADR-059 (withdrawn)                               | Withdrawn before acceptance | Decision: visibility tiers (shared + private + proposal-only); three-column edge-visibility filter; subagents submit proposals; legacy "local" maps to private namespace. The three-column filter (Rule 3a) is rejected and remains rejected. | Gemini-mirror B1 storage-schema fact: edge carries its own namespace column, not derived from endpoints. Retained as a storage fact in Rule 3a; the isolation mechanism built on top of it is withdrawn. |
+| Document                                          | Status                      | Superseded clauses                                                                                                                                                                                                                            | Surviving clauses                                                                                                                                                                                          |
+| ------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-007 v1 base text (this file, prior revision)  | Superseded (Rev 3 replaces) | NamespaceToken as by-ID guard; NamespaceView; Read-by-ID namespace check; Timing oracle mitigation; NamespaceGrants / AuthContext / PrincipalId                                                                                               | Namespace::parse structural validation; "No Default"; Namespace vs backend independent axes; Hierarchy helper naming utility                                                                               |
+| ADR-007 2026-05-25 amendment                      | Superseded (Rev 3 replaces) | Two-model framing (collapsed: the default is one model; operator-supplied Gate adds isolation)                                                                                                                                                | AllowAllGate as default gate; [actor] id as attribution config; 4-tier config search path; display_name advisory-only                                                                                      |
+| ADR-007 2026-05-27 amendment (Namespace-by-Layer) | Superseded (Rev 3 replaces) | KG-pack namespace override via token.with_namespace(); per-pack actor namespace routing for memory/gtd/comm — this ADR replaces routing with view-layer tag filters                                                                           | None; the routing intent is now stated correctly in Rule 3                                                                                                                                                 |
+| ADR-007 Rev 2 (2026-06-16)                        | Superseded (Rev 3 replaces) | Status: Proposed; Rev-3-deferred comm carry question ("leans yes"); Rev-3-deferred memory carry question ("undecided")                                                                                                                        | All substantive rules 0-7 (retained and sharpened); internal review findings; PR-A1 shipped status                                                                                                         |
+| ADR-050                                           | Partially superseded        | Decision: removal of KG-pack override (this ADR absorbs and confirms)                                                                                                                                                                         | Context: documents the override as a historical bug; Rationale "Why not token rebinding"                                                                                                                   |
+| ADR-053                                           | Survives in full            | No conflict                                                                                                                                                                                                                                   | All: ActorStore, SessionStore, DispatchRequest, actor threading. Attribution threading is orthogonal to namespace isolation.                                                                               |
+| ADR-059 (withdrawn)                               | Withdrawn before acceptance | Decision: visibility tiers (shared + private + proposal-only); three-column edge-visibility filter; subagents submit proposals; legacy "local" maps to private namespace. The three-column filter (Rule 3a) is rejected and remains rejected. | Internal-review B1 storage-schema fact: edge carries its own namespace column, not derived from endpoints. Retained as a storage fact in Rule 3a; the isolation mechanism built on top of it is withdrawn. |
 
 Note on ADR-058: PR #143 proposes a new ADR-058 for the brain posterior read-path. That
 number is orthogonal to the namespace work. The supersession map above does not reference
@@ -626,14 +625,14 @@ collision.
 
 ## Alternatives Considered
 
-| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                                                                                                                                                   |
-| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                                                                                                                                                     |
-| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Rejected in full. Blanket form rejected in Rev 2; narrow comm-only carry and memory carry both closed as NO-CARRY by Ocean ruling 2026-06-17 (Rev 3). No per-pack carry exists or is planned. |
-| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Withdrawn before acceptance (ADR-007 Rev 2). Withdrawn status reaffirmed by Rev 3.                                                                                                            |
-| ADR-059 three-column edge visibility filter                  | Prevents edge-induced namespace leaks                          | Complexity; joins across three namespace columns on every edge query; incompatible with "edges are shared structure" | Rejected (Rule 3a). Edge namespace is attribution-only, stamped "local" by default. No per-edge namespace-join at any tier.                                                                   |
-| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                                                                                                                                                      |
-| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not                                                                                                                           |
+| Alternative                                                  | Pros                                                           | Cons                                                                                                                 | Disposition                                                                                                                                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep ADR-007 v1 NamespaceToken as by-ID guard                | Type-safe isolation proof                                      | Incompatible with dumb-storage contract; removed by PR-A1                                                            | Rejected, SHIPPED removal                                                                                                                                                                   |
+| Per-pack actor namespace routing (Namespace-by-Layer Rule 3) | Preserves operational separation for gtd/comm                  | Contradicts Rule 0; breaks cross-lambda memory.recall; live audit shows memory is already "local"                    | Rejected in full. Blanket form rejected in Rev 2; narrow comm-only carry and memory carry both closed as NO-CARRY by the 2026-06-17 Rev 3 decision. No per-pack carry exists or is planned. |
+| ADR-059 three-tier visibility model                          | Supports cooperative multi-lambda with fine-grained boundaries | Extra complexity; per-edge namespace-join query; "local" becomes ambiguous; conflicts with "one shared brain" ruling | Withdrawn before acceptance (ADR-007 Rev 2). Withdrawn status reaffirmed by Rev 3.                                                                                                          |
+| ADR-059 three-column edge visibility filter                  | Prevents edge-induced namespace leaks                          | Complexity; joins across three namespace columns on every edge query; incompatible with "edges are shared structure" | Rejected (Rule 3a). Edge namespace is attribution-only, stamped "local" by default. No per-edge namespace-join at any tier.                                                                 |
+| New ADR number (ADR-060) instead of amending ADR-007         | Clean slate                                                    | Leaves conflicting ADR-007 as active on main                                                                         | Rejected; amend in place                                                                                                                                                                    |
+| Namespace as pure write-stamp, no SQL filter anywhere        | Simplest storage                                               | Removes legitimate tag-based view filtering for gtd assignee, comm addressing                                        | Rejected; view-layer filtering is correct, namespace-routing is not                                                                                                                         |
 
 ---
 
@@ -727,12 +726,12 @@ Negative:
 
 ## References
 
-- CLAUDE.md "Authorization — the gate is a seam, by design" — Ocean's ratified design.
-- CLAUDE.md "Namespace and authorization" — coding standards.
+- Project guidance on authorization — ratified design.
+- Project guidance on namespace and authorization — coding standards.
 - v0 archive: khive-old/docs/_archive/adr_v0/ADR-007-namespace-as-open-string.md — original
   dumb-storage rules 1-4.
 - Commit 2607e263 — PR-A1 implementation, by-ID contract SHIPPED.
-- gemini_refute_adr007.md (resume 44078a77) — REFUTE findings 1-6, authoritative corrections.
+- Internal review artifact — findings 1-6 and authoritative corrections.
 - ADR-014 — curation operations, merge semantics.
 - ADR-018 — Gate trait, single dispatch site, AllowAllGate.
 - ADR-002 — edge cascade, no dangling refs.

--- a/docs/adr/ADR-007-namespace.md
+++ b/docs/adr/ADR-007-namespace.md
@@ -368,7 +368,7 @@ update_entity, update_note, update_edge, delete_edge.
 
 CHANGE FROM ADR-007 v1: The 2026-05-27 Namespace-by-Layer amendment routed memory, gtd, comm,
 brain, and schedule multi-record ops by actor namespace ("WHERE namespace = <actor_namespace>"),
-while routing KG and knowledge to "local". internal review finding 2 correctly identified this
+while routing KG and knowledge to "local". A review finding correctly identified this
 as a contradiction of Rule 0: framing per-pack actor routing as "explicit pack policy"
 re-introduces the exact actor-as-namespace isolation coupling the accepted design removed. Finding 1
 added that memory is live-audited as bulk "local" and that cross-lambda learning via

--- a/docs/adr/ADR-008-query-layer-separation.md
+++ b/docs/adr/ADR-008-query-layer-separation.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-009-backend-architecture.md
+++ b/docs/adr/ADR-009-backend-architecture.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-010-kg-versioning.md
+++ b/docs/adr/ADR-010-kg-versioning.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -191,12 +191,12 @@ remains in git history unless a force-push rewrite is performed.
 
 Data classes that may appear in NDJSON snapshots:
 
-| Data class        | Example                          | Sensitivity                                   |
-| ----------------- | -------------------------------- | --------------------------------------------- |
-| Entity names      | "Sinkhorn Distances", "Ocean Li" | Low–Medium (Person entities carry real names) |
-| Entity properties | JSON key-value metadata          | Variable (may contain internal notes)         |
-| Edge properties   | `dependency_kind`, `weight`      | Low                                           |
-| Edge topology     | Which entities are linked        | Medium (reveals research structure)           |
+| Data class        | Example                              | Sensitivity                                   |
+| ----------------- | ------------------------------------ | --------------------------------------------- |
+| Entity names      | "Sinkhorn Distances", "Ada Lovelace" | Low–Medium (Person entities carry real names) |
+| Entity properties | JSON key-value metadata              | Variable (may contain internal notes)         |
+| Edge properties   | `dependency_kind`, `weight`          | Low                                           |
+| Edge topology     | Which entities are linked            | Medium (reveals research structure)           |
 
 For multi-user deployments:
 

--- a/docs/adr/ADR-011-embedding-and-inference.md
+++ b/docs/adr/ADR-011-embedding-and-inference.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-012-retrieval-composition.md
+++ b/docs/adr/ADR-012-retrieval-composition.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 > Relationship to ADR-030: ADR-012 is the legacy-but-live high-level retrieval
 > composition record. It governs runtime and pack-level orchestration of storage

--- a/docs/adr/ADR-013-note-kind-taxonomy.md
+++ b/docs/adr/ADR-013-note-kind-taxonomy.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-015-schema-migrations.md
+++ b/docs/adr/ADR-015-schema-migrations.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-016-request-dsl.md
+++ b/docs/adr/ADR-016-request-dsl.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-017-pack-standard.md
+++ b/docs/adr/ADR-017-pack-standard.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 > **Amended ([ADR-055](ADR-055-epistemic-edge-relations.md))**: ADR-055 added 2
 > epistemic relations (`supports`, `refutes`), expanding the closed set from 15 to 17.

--- a/docs/adr/ADR-018-authorization-gate.md
+++ b/docs/adr/ADR-018-authorization-gate.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -156,7 +156,7 @@ decision := {
     "obligations": [{"kind": "audit", "tag": sprintf("verb.%s", [input.verb])}],
 } if {
     input.actor.kind == "user"
-    input.namespace == "ocean"
+    input.namespace == "operator"
 }
 
 decision := {"decision": "deny", "reason": "anonymous callers cannot write"} if {
@@ -263,7 +263,7 @@ The wire shape is stable:
 ```json
 {
   "timestamp": "2026-05-23T01:50:00Z",
-  "actor": { "kind": "user", "id": "ocean" },
+  "actor": { "kind": "user", "id": "operator" },
   "namespace": "research",
   "verb": "create",
   "decision": "allow",

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -78,7 +78,7 @@ The `properties` JSON column carries every GTD field:
 {
   "status": "next",
   "priority": "p1",
-  "assignee": "ocean",
+  "assignee": "operator",
   "due": "2026-06-01T10:00:00Z",
   "start": null,
   "end": null,
@@ -334,7 +334,7 @@ Every successful op returns a stable task envelope:
   "title":      "Implement retrieval",
   "status":     "next",
   "priority":   "p1",
-  "assignee":   "ocean",
+  "assignee": "operator",
   "due":        "2026-06-01T10:00:00Z",
   "namespace":  "local",
   "created_at": "2026-05-23T01:55:00Z",

--- a/docs/adr/ADR-020-git-native-kg-implementation.md
+++ b/docs/adr/ADR-020-git-native-kg-implementation.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-021-memory-pack.md
+++ b/docs/adr/ADR-021-memory-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Amended**: 2026-06-19, added §10 (`memory_type` to namespace routing) recording the
 [ADR-007](ADR-007-namespace.md) Rev 6 carve-out: episodic memory writes stamp the caller's actor
 id by default, semantic memory writes stamp the shared pool, and an explicit `namespace=`
@@ -46,10 +46,10 @@ stored under this kind, distinguished by a `memory_type` attribute on the note:
 | ------------- | ---------------------------- | ------------ | ----------------- |
 | `memory_type` | `"episodic"` \| `"semantic"` | `"episodic"` | `note.properties` |
 
-| memory_type | Shape                       | Examples                                                 |
-| ----------- | --------------------------- | -------------------------------------------------------- |
-| `episodic`  | Time-anchored, event-shaped | "On 2026-05-19 Ocean said prefer `uv run` over `python`" |
-| `semantic`  | Abstracted, fact-shaped     | "Ocean prefers `uv run` over `python`"                   |
+| memory_type | Shape                       | Examples                                                        |
+| ----------- | --------------------------- | --------------------------------------------------------------- |
+| `episodic`  | Time-anchored, event-shaped | "On 2026-05-19 a maintainer said prefer `uv run` over `python`" |
+| `semantic`  | Abstracted, fact-shaped     | "Maintainers prefer `uv run` over `python`"                     |
 
 The distinction is **advisory, not enforced**. Nothing structurally validates that
 episodic memories carry timestamps. Agents choose `memory_type` based on whether the
@@ -89,7 +89,7 @@ The `remember` verb accepts an optional `source_id` argument. When present, the 
 creates the memory note and links it to the source via `annotates` in the same invocation.
 When absent, no edge is created and the memory's provenance is unattributed.
 
-For the common case "Ocean said X" the source is a `person` entity. For "agent X
+For the common case "a maintainer said X" the source is a `person` entity. For "agent X
 produced this" the source is whichever entity represents the agent. For "this came from
 paper Y" the source is the `document` entity. All three resolve through the same
 `annotates` edge with no special-casing — provenance is queryable via

--- a/docs/adr/ADR-022-events-query-surface.md
+++ b/docs/adr/ADR-022-events-query-surface.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-023-declarative-pack-format.md
+++ b/docs/adr/ADR-023-declarative-pack-format.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted (supersedes the original ADR-023 "Declarative Pack Format")
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -486,7 +486,7 @@ Three reasons:
 
 | Alternative                                                   | Why rejected                                                                                                                                                                                             |
 | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| YAML pack manifests (original ADR-023 v0)                     | Bifurcates the pack ecosystem into code-packs and data-packs. Half-feature: real packs want vocabulary + verbs. Increases maintenance load. Per Ocean (2026-05-23): "declarative packs need to be Rust." |
+| YAML pack manifests (original ADR-023 v0)                     | Bifurcates the pack ecosystem into code-packs and data-packs. Half-feature: real packs want vocabulary + verbs. Increases maintenance load. The accepted decision keeps packs in Rust.                   |
 | Pack verb override (last-loaded-wins or explicit declaration) | Breaks agent predictability. Verb semantics become deployment-dependent. KindHook is the safe extension point.                                                                                           |
 | Pack middleware / wrap interception                           | Composes badly (order-dependent chains); auth and audit belong at the runtime gate (ADR-018), not the pack layer.                                                                                        |
 | Four-tier visibility (Public/Advanced/Debug/Internal)         | Conflates MCP exposure with documentation gating. Skills already handle docs; two tiers (on/off the MCP wire) are sufficient.                                                                            |
@@ -578,5 +578,5 @@ working crate. Reference impl: `crates/khive-pack-kg/`.
 ## Supersedes
 
 The v0 ADR-023 ("Declarative Pack Format") — YAML-manifest model is rescinded per
-Ocean (2026-05-23). Packs are Rust crates; vocabulary and verbs are declared together
+Accepted decision (2026-05-23). Packs are Rust crates; vocabulary and verbs are declared together
 in the pack trait.

--- a/docs/adr/ADR-024-fold-cognitive-primitives.md
+++ b/docs/adr/ADR-024-fold-cognitive-primitives.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-025-verb-speech-acts.md
+++ b/docs/adr/ADR-025-verb-speech-acts.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-026-rust-binary-packaging.md
+++ b/docs/adr/ADR-026-rust-binary-packaging.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-028-pack-scoped-backends.md
+++ b/docs/adr/ADR-028-pack-scoped-backends.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-029-substrate-coordinator.md
+++ b/docs/adr/ADR-029-substrate-coordinator.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-030-retrieval-stack-port.md
+++ b/docs/adr/ADR-030-retrieval-stack-port.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-031-multi-engine-retrieval.md
+++ b/docs/adr/ADR-031-multi-engine-retrieval.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Consolidates** (retired v0-series drafts predating the 2026-05-23 ADR renumbering; these
 numbers do not refer to current-index ADRs): ADR-078 (umbrella), ADR-081 (Embedder trait +
 EmbedderRegistry), ADR-082 (engine TOML schema), ADR-083 (runtime API — caller-computed

--- a/docs/adr/ADR-032-brain-profile-orchestration.md
+++ b/docs/adr/ADR-032-brain-profile-orchestration.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-006 (Deterministic Scoring)
@@ -996,7 +996,7 @@ A typical "train and serve per subagent per project" sequence:
      → live update loop begins
 4. brain.bind(profile_id=candidate,
               actor="implementer-α",
-              namespace="lambda:khive",
+              namespace="agent:docs",
               consumer_kind="recall")
      → next call by that actor in that namespace uses this profile
 5. (Optional) brain.unbind(...)

--- a/docs/adr/ADR-033-recall-pipeline.md
+++ b/docs/adr/ADR-033-recall-pipeline.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -30,7 +30,7 @@ composition ([ADR-024](ADR-024-fold-cognitive-primitives.md)). This means it can
 from precision-weighting (ADR-024 §Bayesian extensions), epistemic selector weight, or the
 `ComposePipeline` structure. The Hoare triple for recall is undocumented.
 
-Ocean's directive: expose a set of configurable handlers so recall behavior can be tuned and
+Design request: expose a set of configurable handlers so recall behavior can be tuned and
 calibrated empirically without recompilation.
 
 ## Decision

--- a/docs/adr/ADR-034-kg-validation-pipelines.md
+++ b/docs/adr/ADR-034-kg-validation-pipelines.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-035-cli-config-and-auto-embed.md
+++ b/docs/adr/ADR-035-cli-config-and-auto-embed.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -172,7 +172,7 @@ boosting reads. It is configured the same way namespace is — via `--brain-prof
 
 ```toml
 [runtime]
-namespace = "lambda:khive"
+namespace = "local"
 brain_profile = "project-recall-v1"
 ```
 

--- a/docs/adr/ADR-036-kg-import-export-adapters.md
+++ b/docs/adr/ADR-036-kg-import-export-adapters.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-037-remote-resolution-and-hash-verification.md
+++ b/docs/adr/ADR-037-remote-resolution-and-hash-verification.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-038-bulk-operations.md
+++ b/docs/adr/ADR-038-bulk-operations.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Consolidates**: ADR-069 and ADR-070 — draft proposals, never published as standalone ADRs
 **Depends on**: ADR-002 (Edge Ontology), ADR-014 (Curation Operations), ADR-016 (Request DSL), ADR-017 (Pack Standard), ADR-029 (SubstrateCoordinator)
 

--- a/docs/adr/ADR-039-note-merge.md
+++ b/docs/adr/ADR-039-note-merge.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-040-communication-and-schedule-packs.md
+++ b/docs/adr/ADR-040-communication-and-schedule-packs.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-05-23\
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 
@@ -76,7 +76,7 @@ The `properties` JSON column carries message-specific metadata:
 
 ```json
 {
-  "from": "agent:ocean",
+  "from": "agent:ops",
   "to": "agent:khive",
   "direction": "inbound",
   "subject": "retrieval port status",
@@ -372,7 +372,7 @@ auto-transitions a task to active at the scheduled time. No coupling at the pack
 the interaction is at the `action` payload level.
 
 **Schedule + Comm**: a scheduled message is a `scheduled_event` with
-`action="comm.send(to='agent:ocean', content='weekly status update')"`. At trigger time the
+`action="comm.send(to='agent:ops', content='weekly status update')"`. At trigger time the
 execution environment dispatches the `comm.send` verb. No coupling at the pack level.
 
 **Comm + KG**: messages attach to KG entities via `link(message_id, entity_id, annotates)`.

--- a/docs/adr/ADR-041-event-provenance-projection.md
+++ b/docs/adr/ADR-041-event-provenance-projection.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-004 (Substrate Observables — Event substrate)

--- a/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
+++ b/docs/adr/ADR-042-local-rerank-via-lattice-inference.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-011 (Embedding and Inference Architecture)

--- a/docs/adr/ADR-043-embedding-model-migration.md
+++ b/docs/adr/ADR-043-embedding-model-migration.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-011 (Embedding and Inference Architecture)

--- a/docs/adr/ADR-043-embedding-model-migration.md
+++ b/docs/adr/ADR-043-embedding-model-migration.md
@@ -28,7 +28,7 @@ subsystem, layered on top of what lattice already provides.
 
 ### What lattice already provides
 
-Per `/Users/lion/projects/khive/lattice/crates/{embed,transport}/`:
+Per the lattice repository's embed and transport crates:
 
 - **`lattice_embed::EmbeddingKey { model, revision, dims, metric, dtype, norm }`** with
   `canonical_bytes()`. Vectors under different keys are not exchangeable; lattice's

--- a/docs/adr/ADR-044-vector-store-extensions.md
+++ b/docs/adr/ADR-044-vector-store-extensions.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits (base `VectorStore`)

--- a/docs/adr/ADR-045-verb-response-presentation.md
+++ b/docs/adr/ADR-045-verb-response-presentation.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Extended by**: ADR-078 (Output Format and Shape-Aware Rendering), which introduces an orthogonal
 `format` axis (`json` / `auto` / `table`) and revises Agent-mode redundancy rules. ADR-078
 §7.1 partially supersedes the P-C1 implementation behavior that kept `full_id` present in all
@@ -28,7 +28,7 @@ Agents are token-budgeted; humans want pretty output for inspection; tooling
 different shapes of the same data. v1 forces handlers to pick one — and they
 picked the full shape, so agents pay the verbose cost on every call.
 
-Ocean's directive (2026-05-23):
+Design request (2026-05-23):
 
 > verb should include a handler for verbose output, aka if not verbose output,
 > we will normalize the data into agent friendly manner, like short datetime
@@ -326,7 +326,7 @@ it's metadata, not logic.
         "title": "Draft ADR-045",
         "status": "next",
         "priority": "p1",
-        "assignee": "lambda:khive",
+        "assignee": "agent:docs",
         "created_at": "2026-05-23T16:00:00.000000Z",
         "updated_at": "2026-05-23T16:18:15.234567Z",
         "completed_at": null,
@@ -334,7 +334,7 @@ it's metadata, not logic.
         "tags": [],
         "dependencies": [],
         "result": null,
-        "namespace": "lambda:khive"
+        "namespace": "agent:docs"
       },
       {/* ... */}
     ],
@@ -358,12 +358,12 @@ it's metadata, not logic.
         "title": "Draft ADR-045",
         "status": "next",
         "priority": "p1",
-        "assignee": "lambda:khive",
+        "assignee": "agent:docs",
         "created_at": "2026-05-23T16:00",
         "updated_at": "3m ago",
         "completed_at": null,
         "due_at": null,
-        "namespace": "lambda:khive"
+        "namespace": "agent:docs"
       },
       {/* ... */}
     ],
@@ -570,4 +570,4 @@ migrate to Agent-mode shapes or set `presentation=verbose` per call (or
   (this ADR's output-side counterpart)
 - ADR-017 (Pack Standard) — verb declaration, handler return shape
 - ADR-016 (Request DSL) — single-tool `request` envelope shape
-- Ocean directive 2026-05-23 — "verb should include a handler for verbose output…"
+- Design request 2026-05-23 — "verb should include a handler for verbose output…"

--- a/docs/adr/ADR-046-event-sourced-proposals.md
+++ b/docs/adr/ADR-046-event-sourced-proposals.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-23
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-014 (Curation Operations — apply step rides on existing curation primitives)
@@ -21,7 +21,7 @@ git operations from MCP — agents do not drive the KG through git. The agent
 workflow ("propose change → reviewer approves → change lands") was dropped
 without a replacement.
 
-Ocean (2026-05-23) selected option (c) **event-sourced proposals**: the
+The accepted decision selected option (c) **event-sourced proposals**: the
 proposal lifecycle is encoded purely as events on the existing log substrate
 (ADR-022). No new substrate. No new branch model. No git verbs over MCP. The
 brain already consumes events natively (ADR-032 §6); proposals slot into the
@@ -538,7 +538,7 @@ supersede, compound). Future arms add to the enum via additive semver bumps.
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Proposal-as-Note (option a)                                            | Forces changesets into note `body`; loses schema validation; muddies the note-kind taxonomy                                                                                   |
 | PendingEdit substrate (option b)                                       | New substrate, new store, new VCS dimension — heavyweight for a workflow object                                                                                               |
-| Git-native subset (option d)                                           | Re-imports the git assumption Ocean said he wasn't sure about                                                                                                                 |
+| Git-native subset (option d)                                           | Re-imports the git assumption the decision explicitly avoided                                                                                                                 |
 | Inline apply without a separate worker step or `ProposalApplied` event | Rejected: v1 may call `ProposalApplyWorker` synchronously from `review`, but apply remains a separate worker struct and emits `ProposalApplied` for audit/failure separation. |
 | Approve = side-effect of `update(id=<proposal>, status=approved)`      | Conflates review (a typed decision) with record mutation; loses the review-history audit trail                                                                                |
 | Per-proposer namespace for proposals                                   | Cross-cuts the namespace-isolation invariant; agents can't propose changes targeting namespaces they can read                                                                 |
@@ -731,7 +731,7 @@ Lookup wire shape:
   in future ADRs
 - ADR-041 (Event Provenance Projection) — projection-table pattern this ADR
   reuses
-- Ocean directive 2026-05-23: option (c) selected — "event sourced proposal
+- Design decision 2026-05-23: option (c) selected — "event sourced proposal
   sounds fine"
 
 ## Amendment (2026-06-14): proposal_id → id wire-key rename

--- a/docs/adr/ADR-047-knowledge-pack.md
+++ b/docs/adr/ADR-047-knowledge-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted (amended 2026-06-07, 2026-06-10, 2026-06-10b)
 **Date**: 2026-05-25
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Amendment (2026-06-10b): exclude_status precedence fix; auto-compose member filter; atom status taxonomy clarification
 

--- a/docs/adr/ADR-048-knowledge-section-profiles.md
+++ b/docs/adr/ADR-048-knowledge-section-profiles.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-27
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Current Implementation Status
 
@@ -294,8 +294,8 @@ The current MCP protocol does not carry per-request caller identity. Two candida
 A `UserPromptSubmit` hook could detect the lambda from cwd and write an actor file:
 
 ```bash
-# Hook detects: cwd=/Users/lion/projects/khive/khive → lambda:khive
-echo "lambda:khive" > /tmp/claude_hooks/actor_context
+# Hook detects: cwd=/workspace/project-a → lambda:project-a
+echo "lambda:project-a" > /tmp/claude_hooks/actor_context
 ```
 
 The MCP server would read this file on each `request` dispatch and use it as the actor
@@ -309,7 +309,7 @@ A future MCP protocol extension could carry caller context in the request envelo
 ```json
 {
   "tool": "request",
-  "args": { "ops": "...", "_context": { "actor": "lambda:khive", "session": "abc123" } }
+  "args": { "ops": "...", "_context": { "actor": "lambda:project-a", "session": "abc123" } }
 }
 ```
 
@@ -436,16 +436,16 @@ Fires at the start of every Claude Code turn. Responsibilities:
 # 1. Detect lambda from cwd
 CWD="$PWD"
 case "$CWD" in
-  */khive/khive*)  ACTOR="lambda:khive" ;;
-  */lionagi*)      ACTOR="lambda:lionagi" ;;
-  */lattice*)      ACTOR="lambda:lattice" ;;
+  */project-a*)  ACTOR="lambda:project-a" ;;
+  */project-b*)      ACTOR="lambda:project-b" ;;
+  */project-c*)      ACTOR="lambda:project-c" ;;
   *)               ACTOR="local" ;;
 esac
 
 # 2. Detect role from agent context (if spawned as subagent)
 AGENT_TYPE="${CLAUDE_AGENT_TYPE:-}" # Claude Code exposes this for subagents
 if [ -n "$AGENT_TYPE" ]; then
-  ACTOR="${ACTOR}:${AGENT_TYPE}"  # e.g. "lambda:khive:implementer"
+  ACTOR="${ACTOR}:${AGENT_TYPE}"  # e.g. "lambda:project-a:implementer"
 fi
 
 # 3. Write actor context for MCP server to read
@@ -644,8 +644,8 @@ three dimensions of specificity:
 
 ```
 # Dimension 1: Project-level (which codebase)
-brain.bind(actor="lambda:khive",   namespace="*", consumer_kind="knowledge_compose", profile_id="khive-knowledge-v1")
-brain.bind(actor="lambda:lionagi", namespace="*", consumer_kind="knowledge_compose", profile_id="lionagi-knowledge-v1")
+brain.bind(actor="lambda:project-a",   namespace="*", consumer_kind="knowledge_compose", profile_id="khive-knowledge-v1")
+brain.bind(actor="lambda:project-b", namespace="*", consumer_kind="knowledge_compose", profile_id="lionagi-knowledge-v1")
 
 # Dimension 2: Role-level (what kind of work)
 brain.bind(actor="implementer",    namespace="*", consumer_kind="knowledge_compose", profile_id="impl-knowledge-v1")
@@ -653,8 +653,8 @@ brain.bind(actor="theorist",       namespace="*", consumer_kind="knowledge_compo
 brain.bind(actor="researcher",     namespace="*", consumer_kind="knowledge_compose", profile_id="research-knowledge-v1")
 
 # Dimension 3: Compound (project + role, most specific)
-brain.bind(actor="lambda:khive:implementer", namespace="*", consumer_kind="knowledge_compose", profile_id="khive-impl-v1")
-brain.bind(actor="lambda:lionagi:theorist",  namespace="*", consumer_kind="knowledge_compose", profile_id="lionagi-theory-v1")
+brain.bind(actor="lambda:project-a:implementer", namespace="*", consumer_kind="knowledge_compose", profile_id="khive-impl-v1")
+brain.bind(actor="lambda:project-b:theorist",  namespace="*", consumer_kind="knowledge_compose", profile_id="lionagi-theory-v1")
 
 # Global fallback
 brain.bind(actor="*", namespace="*", consumer_kind="knowledge_compose", profile_id="balanced-knowledge-v1")
@@ -662,16 +662,16 @@ brain.bind(actor="*", namespace="*", consumer_kind="knowledge_compose", profile_
 
 Resolution is longest-match-wins (most specific actor > less specific > wildcard):
 
-| Session context              | Hook sets actor to         | Resolves to                                |
-| ---------------------------- | -------------------------- | ------------------------------------------ |
-| khive implementer subagent   | `lambda:khive:implementer` | `khive-impl-v1` (exact compound match)     |
-| khive session, no role       | `lambda:khive`             | `khive-knowledge-v1` (project match)       |
-| lionagi theorist subagent    | `lambda:lionagi:theorist`  | `lionagi-theory-v1` (exact compound match) |
-| unknown project, implementer | `local:implementer`        | `impl-knowledge-v1` (role match)           |
-| completely generic           | `local`                    | `balanced-knowledge-v1` (wildcard)         |
+| Session context                | Hook sets actor to             | Resolves to                                |
+| ------------------------------ | ------------------------------ | ------------------------------------------ |
+| project A implementer subagent | `lambda:project-a:implementer` | `khive-impl-v1` (exact compound match)     |
+| project A session, no role     | `lambda:project-a`             | `khive-knowledge-v1` (project match)       |
+| project B theorist subagent    | `lambda:project-b:theorist`    | `lionagi-theory-v1` (exact compound match) |
+| unknown project, implementer   | `local:implementer`            | `impl-knowledge-v1` (role match)           |
+| completely generic             | `local`                        | `balanced-knowledge-v1` (wildcard)         |
 
-Each profile learns independently. The khive implementer's posteriors reflect what
-khive implementation work needs. The lionagi theorist's posteriors reflect what
+Each profile learns independently. The project A implementer's posteriors reflect what
+khive implementation work needs. The project B theorist's posteriors reflect what
 formal verification work needs. They share the same corpus but get different views.
 
 ### 5. Profile lifecycle and cross-learning
@@ -1166,7 +1166,7 @@ the authoritative shipped tables are `brain_profile_snapshots` and `brain_event_
 
 ## Amendment: Research-Informed Design Corrections (2026-05-27)
 
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Source**: 10 targeted ChatGPT research consultations (Q1-Q10), digested into KG as 17
 entities + 72 edges + 9 notes.
 

--- a/docs/adr/ADR-049-khived-daemon.md
+++ b/docs/adr/ADR-049-khived-daemon.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-05-30
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-050-kg-token-namespace-contract.md
+++ b/docs/adr/ADR-050-kg-token-namespace-contract.md
@@ -98,7 +98,7 @@ The existing behavior continues to force all KG entity/edge writes into
 ### Add `with_shared_graph_namespace(false)` toggle
 
 A boolean field on `KgPack` would disable the override when set to false. Isolated-namespace
-deployments would call `.with_shared_graph_namespace(false)`. Explicitly rejected by Ocean:
+deployments would call `.with_shared_graph_namespace(false)`. Explicitly rejected:
 
 - Creates two contracts for the same pack; pack behavior becomes construction-time-dependent.
 - Leaks routing policy into pack instantiation.
@@ -138,7 +138,7 @@ This change is acceptable under ADR-007 by:
 - `In_pari_materia`: ADR-007's own namespace-resolution amendment (`ADR-007:389`) already
   states explicit namespace values are used unconditionally. The pack override was an
   internal contradiction with that text.
-- `Last_in_time`: Ocean's current intent (2026-06 decision) and ADR-028/029 make isolation a
+- `Last_in_time`: the current 2026-06 decision and ADR-028/029 make isolation a
   deployment routing and privilege concern, not a pack rewrite concern. The newer contract
   governs the conflict.
 - `Constitutional`: removing the override reduces pack coupling from 7 to 6 approximate
@@ -234,7 +234,7 @@ the caller token under ADR-050."
 - `In_pari_materia`: ADR-007 sections read together; explicit-namespace rule (`ADR-007:389`)
   and the Namespace-by-Layer Rule (`ADR-007:445–498`) were internally inconsistent; the
   explicit-namespace rule is the more principled text.
-- `Last_in_time`: Ocean's 2026-06 direction supersedes the 2026-05-27 Namespace-by-Layer Rule
+- `Last_in_time`: the 2026-06 direction supersedes the 2026-05-27 Namespace-by-Layer Rule
   for KG pack rebinding.
 - `Constitutional`: narrowing interpretation — removal reduces pack coupling below kappa 0.3
   threshold rather than widening it.

--- a/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
+++ b/docs/adr/ADR-051-section-embeddings-hybrid-compose.md
@@ -185,5 +185,5 @@ feature flag.
 
 - PR #17 — brain-core extraction (ADR-017 compliance)
 - PR #18 — hybrid section scoring in compose
-- PR #19 — progress bars, domain backfill, auto-compose, token budget, codex fixes
+- PR #19 — progress bars, domain backfill, auto-compose, token budget, review fixes
 - [ADR-021](ADR-021-memory-pack.md), [ADR-048](ADR-048-knowledge-section-profiles.md)

--- a/docs/adr/ADR-055-epistemic-edge-relations.md
+++ b/docs/adr/ADR-055-epistemic-edge-relations.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted\
 **Date**: 2026-06-14\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Amends**: [ADR-002](ADR-002-edge-ontology.md) — expands the closed edge set from 15 → 17
 relations and adds a 9th category (Epistemic / Evidential).
 
@@ -32,12 +32,12 @@ The existing relations approximate this badly and lose information:
 | `annotates`     | A note **comments on** a target. It is polarity-blind: it cannot distinguish "this finding supports the claim" from "this finding refutes it", and it does not connect two entities. |
 
 `annotates` is the closest, and it is what the research-pack design
-(`.khive/workspaces/.../research-pack-design/DESIGN.md`) currently leans on for findings. But
+(local research-pack design notes) currently leans on for findings. But
 `annotates` answers "is there commentary here?", not "is this evidence **for** or **against**,
 and how strongly?". The polarity and the strength are exactly the signal a confidence model
 needs, and `annotates` discards both.
 
-Ocean has decided to add the minimal pair of relations that carry this signal. This ADR
+The accepted decision to add the minimal pair of relations that carry this signal. This ADR
 formalizes that decision and specifies the contract.
 
 ## Decision
@@ -200,8 +200,8 @@ speculative growth — it is staged delivery with a named next consumer.
 
 ## Sub-decisions — review record
 
-The core decision — _add `supports`/`refutes` as the minimal epistemic pair_ — is Ocean's
-explicit call and is **not** open for relitigation. The following are **lambda:khive's design
+The core decision — _add `supports`/`refutes` as the minimal epistemic pair_ — is accepted
+and is **not** open for relitigation. The following are **maintainer design
 choices** in service of that decision. The adversarial review verdict and resolution are recorded
 for each.
 
@@ -311,4 +311,4 @@ the existing fallthrough). Endpoint validation in `khive-runtime` routes `suppor
 into the same-substrate branch alongside `supersedes`, and the base entity allowlist gains the
 four `* → concept` rows. No DSL parser, SQL compiler, or merge-layer change is required — those
 layers treat relations as opaque strings validated downstream. Full ordered breakdown:
-`.khive/workspaces/20260614/supports-refutes/IMPL_PLAN.md`.
+the local supports/refutes implementation plan.

--- a/docs/adr/ADR-055-epistemic-edge-relations.md
+++ b/docs/adr/ADR-055-epistemic-edge-relations.md
@@ -202,7 +202,7 @@ speculative growth — it is staged delivery with a named next consumer.
 
 The core decision — _add `supports`/`refutes` as the minimal epistemic pair_ — is accepted
 and is **not** open for relitigation. The following are **maintainer design
-choices** in service of that decision. The adversarial review verdict and resolution are recorded
+choices** in service of that decision. The review outcome and resolution are recorded
 for each.
 
 1. **Claim representation** (REFRAMED). A claim may be a `concept` entity (entity form) OR a

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -5,7 +5,7 @@
 [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening),
 [§Amendment 2026-07-03](#amendment-2026-07-03----exchange-online-no-authserv-id-boundary))\
 **Date**: 2026-06-14 (amended 2026-07-02, 2026-07-03)\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-017 (Pack Standard), ADR-018 (Authorization Gate), ADR-040 (Communication
 and Schedule Packs), ADR-053 (ActorStore / SessionStore -- extends ADR-018's actor model)\
 **Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter),
@@ -134,7 +134,7 @@ are amended.
 
 ### Finding
 
-The trusted receiving boundary for the production ingest mailbox (`leo@khive.ai`, Microsoft
+The trusted receiving boundary for the production ingest mailbox (Microsoft
 Exchange Online) emits **no `authserv-id`** on the plain `Authentication-Results` header it
 stamps. This is a known Microsoft deviation from RFC 8601 §2.2, which requires the header to begin
 with an `authserv-id` token. The observed header from a real delivered message begins directly
@@ -230,7 +230,7 @@ revision.
 
 ## Context
 
-The autonomous build loop blocks regularly on the maintainer. HC-7 merge approvals and ADR
+The autonomous build loop blocks regularly on the maintainer. Merge approvals and ADR
 decisions require a human judgment before work continues. The only current path to unblock is the
 maintainer opening a new session.
 

--- a/docs/adr/ADR-057-comm-actor-addressed-delivery.md
+++ b/docs/adr/ADR-057-comm-actor-addressed-delivery.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted\
 **Date**: 2026-06-15\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-007 (Namespace), ADR-017 (Pack Standard), ADR-040 (Communication and
 Schedule Packs)\
 **Related issues**: #57 (actor-addressed delivery -- primary), #13 (cross-namespace policy
@@ -358,12 +358,12 @@ blocking comm on it leaves agent-to-agent messaging broken without benefit.
 
 ## Open Questions
 
-The following questions could not be fully resolved from source and require Ocean's judgment
+The following questions could not be fully resolved from source and require maintainer judgment
 before implementation begins.
 
 **Q1. Actor label validation strictness.** This ADR proposes that `to` actor labels be
 validated for non-empty, no control characters, and max 255 bytes, but not via
-`Namespace::parse`. If Ocean prefers that actor labels be required to be valid namespace
+`Namespace::parse`. If maintainers prefer that actor labels be required to be valid namespace
 strings, the send handler can call `Namespace::parse(to)` and return an error for
 non-conforming values. The tradeoff: strict validation improves type safety but rejects labels
 that future transport adapters (ADR-056) may need to express (e.g., email addresses or channel
@@ -371,7 +371,7 @@ identifiers as actor labels in `comm.send`). Decision needed before implementati
 
 **Q2. Index creation placement.** The new `idx_comm_message_to_actor` index is proposed to be
 added via `COMM_SCHEMA_PLAN_STMTS` (run idempotently at pack startup via `CREATE INDEX IF NOT
-EXISTS`). Ocean should confirm this approach is acceptable, or specify that the index belongs
+EXISTS`). Maintainers should confirm this approach is acceptable, or specify that the index belongs
 in a numbered `VersionedMigration` (ADR-015) to keep startup behavior predictable.
 
 **Q3. Legacy message visibility.** Messages written before this ADR have no `to_actor` field.
@@ -379,4 +379,4 @@ Under the proposed fallback, these messages are visible only to callers whose ac
 `"local"`. Callers with a configured actor label (e.g., `lambda:leo`) will not see them.
 Whether existing party-line messages should be backfilled with `to_actor = "local"` (to
 remain visible in single-actor inboxes) or declared out-of-scope for actor-scoped inboxes is
-a product decision Ocean must settle before the migration story is finalized.
+a product decision maintainers must settle before the migration story is finalized.

--- a/docs/adr/ADR-058-brain-posterior-read-path.md
+++ b/docs/adr/ADR-058-brain-posterior-read-path.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-06-15 (updated 2026-06-23)\
-**Authors**: lambda:khive (architect draft); updated by alpha:architect\
+**Authors**: khive maintainers
 **Depends on**:
 
 - [ADR-021](ADR-021-memory-pack.md) (Memory Pack — recall scoring is a research surface, weights are starting values)
@@ -37,8 +37,8 @@ never consumes the resolved profile's posteriors.
 
 ### Verified current state (source-cited, double-confirmed)
 
-These findings were independently confirmed by an architect TBV pass and a gemini
-adversarial-mirror REFUTE-stance review. Both returned CONFIRMED on all findings below.
+These findings were independently confirmed by an architecture pass and an internal
+adversarial review. Both returned CONFIRMED on all findings below.
 
 Two posterior-consumption mechanisms are present in code; both are dead at ranking time.
 
@@ -139,7 +139,7 @@ Note: the knowledge pack also routes feedback through `brain.resolve(consumer_ki
 the write path (`crates/khive-pack-knowledge/src/handlers.rs:362-403`) but likewise does not read
 posteriors to rank `compose` output. The read path is dead for both consumers; this ADR scopes the
 memory-pack recall path, which is the canonical case. The knowledge pack's equivalent gap is
-flagged as an open question for Ocean (see Open Questions, Q4).
+flagged as an open question for maintainers (see Open Questions, Q4).
 
 ---
 
@@ -783,9 +783,9 @@ with no dispatch).
 path tier-2 discipline. System-default fallbacks (`matched_binding=false`) use pack defaults.
 See §Binding semantics above for rationale.
 
-### Q4 — Open (Ocean): knowledge pack read-path scope
+### Q4 — Open: knowledge pack read-path scope
 
-**The gemini mirror flagged this independently.** The `knowledge.compose` verb also lacks read-path
+**Internal review flagged this independently.** The `knowledge.compose` verb also lacks read-path
 wiring: it routes feedback through `brain.resolve(consumer_kind="recall")`
 (`crates/khive-pack-knowledge/src/handlers.rs:362-403`) — **note: as of the 2026-07-03 amendment
 above, this is a known gap, not a correct baseline; it should resolve against

--- a/docs/adr/ADR-059-namespace-write-tiers.md
+++ b/docs/adr/ADR-059-namespace-write-tiers.md
@@ -6,14 +6,13 @@ This ADR introduced a three-tier visibility model (shared / private / proposal-o
 associated per-namespace write enforcement. ADR-007 Rev 2 establishes that namespace is
 attribution-only and that all packs store in the single shared "local" namespace; actor
 identity is a view-layer tag filter, never a namespace partition. The write-tier model
-re-introduced the actor-as-namespace coupling that Ocean's "one shared brain" ruling ordered
-removed, making the core mechanism of this ADR incompatible with the ratified design.
+re-introduced the actor-as-namespace coupling that the "one shared brain" decision removed, making the core mechanism of this ADR incompatible with the ratified design.
 The subagent propose-only tier, which is operationally separable, may be proposed as a future
 ADR scoped to the propose/review verb lifecycle (ADR-046) rather than to namespace scoping.
 The ADR number 059 is burned — this file is preserved as a record of the withdrawn design.
 
 **Date**: 2026-06-15
-**Authors**: lambda:khive, Ocean
+**Authors**: khive maintainers
 **Withdrawn**: 2026-06-16 (superseded by ADR-007 Rev 2)
 **Depends on**:
 
@@ -31,7 +30,7 @@ The ADR number 059 is burned — this file is preserved as a record of the withd
 
 ## Context
 
-Three lambda orchestrators (lambda:leo, lambda:khive, lambda:lionagi) and an arbitrary number
+Three lambda orchestrators (lambda:beta, lambda:alpha, lambda:gamma) and an arbitrary number
 of ephemeral subagents share one SQLite knowledge graph via the khive MCP server. All sessions
 currently run as namespace `"local"` -- the fall-back when no `[actor] id` is configured. This
 is a deliberate stop-gap: a prior attempt to give each lambda a distinct namespace identifier
@@ -39,7 +38,7 @@ in `khive.toml` broke all cross-read access because `ensure_namespace` enforces 
 primary-namespace equality on write-guarded paths and the data corpus (approximately 12,380
 notes, 2,744 entities) lives entirely in `"local"`.
 
-Ocean's design intent (2026-06-15):
+Design intent (2026-06-15):
 
 - All lambdas may read and write to a **shared** cooperative KG namespace.
 - All lambdas may also maintain a **private** namespace for their own working state.
@@ -50,7 +49,7 @@ Ocean's design intent (2026-06-15):
   stored in the creator's namespace and the visibility filter must check all three namespace
   columns (edge, source endpoint, target endpoint) to avoid leaks.
 
-A gemini REFUTE-mirror review (2026-06-14) produced three binding corrections incorporated
+An internal review (2026-06-14) produced three binding corrections incorporated
 here:
 
 1. Edge namespace is stored on the edge (scheme B1), not derived from endpoint namespaces.
@@ -60,7 +59,7 @@ here:
 2. A link whose creator cannot reach both endpoints is rejected at link time. The error code
    is `NotFound`, not `Forbidden`. `Forbidden` is a UUID-existence oracle and violates the
    fail-closed rule.
-3. The legacy `"local"` namespace must map to a private `lambda:khive` namespace plus a fresh
+3. The legacy `"local"` namespace must map to a private `lambda:alpha` namespace plus a fresh
    empty shared namespace -- not become the shared namespace. Making `"local"` the shared
    namespace would expose operator working memory (tasks, episodic memories, session notes) to
    every cooperating agent, which is a privacy leak and pollutes a clean demo environment.
@@ -104,10 +103,10 @@ sponsoring lambda's token with a visibility set appropriate to its task.
 Two actor kinds are recognized for namespace write-tier enforcement. They map directly to the
 `ActorRef.kind` field already defined in `khive-gate/src/actor.rs`.
 
-| Kind     | `ActorRef.kind` value | Who                                          |
-| -------- | --------------------- | -------------------------------------------- |
-| Lambda   | `"lambda"`            | Standing orchestrators (leo, khive, lionagi) |
-| Subagent | `"subagent"`          | Ephemeral task-runners spawned by a lambda   |
+| Kind     | `ActorRef.kind` value | Who                                         |
+| -------- | --------------------- | ------------------------------------------- |
+| Lambda   | `"lambda"`            | Standing orchestrators (alpha, beta, gamma) |
+| Subagent | `"subagent"`          | Ephemeral task-runners spawned by a lambda  |
 
 The `"anonymous"` kind (the current default) is treated as a lambda for backward
 compatibility: unauthenticated local sessions retain full write access. A future ADR may
@@ -134,7 +133,7 @@ Two new fields are added to `ActorConfig` in `khive-runtime/src/engine_config.rs
 
 ```toml
 [actor]
-id           = "lambda:khive"        # primary write namespace (existing)
+id           = "lambda:alpha"        # primary write namespace (existing)
 kind         = "lambda"              # NEW: "lambda" | "subagent" | "anonymous"
 visible_namespaces  = ["shared"]     # existing: readable beyond primary
 writable_namespaces = ["shared"]     # NEW: namespaces this actor may write to
@@ -286,7 +285,7 @@ accept `namespaces: &[&str]` (or an equivalent `IN`-clause parameter). This is a
 breaking change to the trait contract and requires updates to all `GraphStore`
 implementations.
 
-This change is a cost callout (gemini mirror finding, 2026-06-14) and is tracked in a
+This change is a cost callout (internal review finding, 2026-06-14) and is tracked in a
 separate implementation ticket. The ADR specifies the required end state; the migration path
 is implementation-owned.
 
@@ -309,10 +308,10 @@ The relabel policy:
 
 | Record kind                                                                | Relabel target               | Rationale                                          |
 | -------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| `memory` notes (episodic / semantic)                                       | `lambda:khive` (private)     | Operator working memory; not for subagents to read |
-| `task` notes                                                               | `lambda:khive` (private)     | lambda:khive task queue                            |
-| `message` notes                                                            | `lambda:khive` (private)     | Comm pack messages are actor-addressed internally  |
-| `scheduled_event` notes                                                    | `lambda:khive` (private)     | Schedule pack intent is per-actor                  |
+| `memory` notes (episodic / semantic)                                       | `lambda:alpha` (private)     | Operator working memory; not for subagents to read |
+| `task` notes                                                               | `lambda:alpha` (private)     | lambda:alpha task queue                            |
+| `message` notes                                                            | `lambda:alpha` (private)     | Comm pack messages are actor-addressed internally  |
+| `scheduled_event` notes                                                    | `lambda:alpha` (private)     | Schedule pack intent is per-actor                  |
 | All other note kinds (observation, insight, question, decision, reference) | OPEN FORK F1                 | See Forks                                          |
 | All entities (concept, document, project, etc.)                            | OPEN FORK F1                 | See Forks                                          |
 | All edges                                                                  | Follow source entity relabel | Edge namespace = creator's namespace               |
@@ -323,7 +322,7 @@ populate it intentionally over time by creating records with their primary names
 
 The `"local"` identifier is not retired. Any existing config or process that passes
 `namespace="local"` will target a now-private-but-renamed namespace. Once all active sessions
-are reconfigured to use `lambda:khive` or `shared`, `"local"` becomes an orphan and can be
+are reconfigured to use `lambda:alpha` or `shared`, `"local"` becomes an orphan and can be
 aliased in config.
 
 **Data preservation invariant**: no record UUID changes. No edge is deleted. The migration is
@@ -340,20 +339,20 @@ the UPDATE statements.
 After this ADR, a typical `khive.toml` for each actor:
 
 ```toml
-# kkernel serving as lambda:khive
+# kkernel serving as lambda:alpha
 [actor]
-id                  = "lambda:khive"
+id                  = "lambda:alpha"
 kind                = "lambda"
 visible_namespaces  = ["shared"]
 writable_namespaces = ["shared"]
 ```
 
 ```toml
-# kkernel serving as lambda:leo
+# kkernel serving as lambda:beta
 [actor]
-id                  = "lambda:leo"
+id                  = "lambda:beta"
 kind                = "lambda"
-visible_namespaces  = ["shared", "lambda:khive"]   # can read khive's private ns
+visible_namespaces  = ["shared", "lambda:alpha"]   # can read alpha's private ns
 writable_namespaces = ["shared"]                   # writes to shared only
 ```
 
@@ -374,7 +373,7 @@ lambdas share `"local"`, and propose-only for subagents is enforced by a config 
 than namespace separation.
 
 Rejected because: (a) there is no write isolation between lambdas -- a misbehaving lambda
-can overwrite another's private notes; (b) Ocean's explicit requirement is per-lambda
+can overwrite another's private notes; (b) the design requirement is per-lambda
 private namespaces for working state; (c) without namespace separation, cross-namespace link
 semantics have no surface to operate on.
 
@@ -396,7 +395,7 @@ runtime and additive for a misconfigured one.
 
 All existing data becomes shared immediately. No migration required.
 
-Rejected by the gemini mirror (2026-06-14): lambda:khive's working memory (tasks, episodic
+Rejected by internal review (2026-06-14): lambda:alpha's working memory (tasks, episodic
 notes, session state) is not appropriate shared content. Dumping it into the shared namespace
 pollutes the cooperative KG and exposes operator context to every cooperating agent.
 
@@ -446,10 +445,10 @@ Isolation in multi-actor deployments uses per-actor database files
 
 ---
 
-## Open Questions (Forks for Ocean)
+## Open Questions
 
-See `.khive/workspaces/20260615/namespace-write-tiers/FORKS.md` for the full fork list with
-decision guidance. The questions that require Ocean's judgment before code lands are:
+See the local namespace-write-tiers fork list for the full set of options and decision
+guidance. The questions that require maintainer judgment before code lands are:
 
 - **F1**: Which existing `"local"` note kinds and entities map to shared vs private?
 - **F2**: How is the shared namespace identifier chosen and where is it declared?

--- a/docs/adr/ADR-063-comm-principal-model.md
+++ b/docs/adr/ADR-063-comm-principal-model.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-06-19
-**Authors**: lambda:khive, alpha:architect
+**Authors**: khive maintainers
 **Depends on**: ADR-007 Rev 7 (namespace carve-out for principal-scoped backends) |
 ADR-028 (Pack-Scoped Backends) | ADR-040 (Communication and Schedule Packs) |
 ADR-057 (Comm Actor-Addressed Delivery) | ADR-053 (ActorStore / SessionStore — pending)
@@ -51,7 +51,7 @@ the proxy collapses and per-actor filtering cannot activate.
 
 ### The remote backend requirement
 
-Ocean has identified cross-machine lambda-to-lambda communication as a roadmap item: lambdas
+Cross-machine lambda-to-lambda communication is a roadmap item: lambdas
 running in separate sandboxes or on separate machines need to exchange messages. This requires
 a transport with a fundamentally different trust model.
 
@@ -345,9 +345,9 @@ per-lambda namespace partitions). The correct fix for cross-machine is Step 3 (r
 Reopen the ADR-007 Rev 3 "all packs no-carry" ruling specifically for the comm pack, allowing
 comm to use the actor namespace as the storage namespace for message rows.
 
-Rejected. ADR-007 Rev 3 was a deliberate ruling by Ocean after a gemini REFUTE review that
+Rejected. ADR-007 Rev 3 was an accepted design decision after internal review that
 found per-pack actor routing to be a contradiction of Rule 0. Reopening it for one pack would
-require re-arguing the same ground and would leave the ruling unstable. The Rule 8 carve-out
+require re-arguing the same ground and would leave the decision unstable. The Rule 8 carve-out
 is the correct mechanism: it permits a different backend, not a different namespace routing
 rule for the shared substrate.
 
@@ -370,7 +370,7 @@ treated as a permanent state.
 The credential format (token type, rotation policy, revocation mechanism) for the remote
 broker is unspecified. This is intentional: the credential is part of the transport layer,
 which will be addressed in a dedicated transport ADR before Step 3 implementation begins.
-The question for Ocean's ruling is whether the credential should be a symmetric pre-shared
+The open question is whether the credential should be a symmetric pre-shared
 key per lambda pair, a public-key credential per lambda, or a centrally-issued token (e.g.,
 from a khive-cloud authority). Decision needed before any Step 3 implementation PR is opened.
 
@@ -392,7 +392,7 @@ the physical layout is not.
 
 ### OQ-3: Legacy message visibility under Step 2 — RESOLVED as shipped (commit `091231cd`, PR #213)
 
-This was originally posed as an open question for Ocean's ruling (same question as ADR-057
+This was originally posed as an open question for maintainer decision (same question as ADR-057
 Q3): whether legacy messages without a `to_actor` field should be backfilled with
 `to_actor="local"` or declared out-of-scope for actor-scoped inboxes. It was resolved by
 implementation rather than by a separate backfill decision. The shipped `EqOrMissing` filter
@@ -401,7 +401,7 @@ actor label matches the filter value, including the anonymous `"local"` caller. 
 migration was performed or is required: legacy messages remain visible under the
 `EqOrMissing` semantics as originally implemented in ADR-057, and PR #213's unconditional
 filter (see "Current State" above) extends the same semantics to the anonymous path. This
-question is closed; no further Ocean decision is pending on it.
+question is closed; no further decision is pending on it.
 
 ---
 

--- a/docs/adr/ADR-066-autonomous-merge-pipeline.md
+++ b/docs/adr/ADR-066-autonomous-merge-pipeline.md
@@ -118,7 +118,7 @@ each merge produces one revertable commit on `main`. Delete-branch-on-merge is e
 A lightweight workflow (`automerge.yml`) enables native auto-merge (`gh pr merge --auto
 --squash`) on every PR when it becomes ready for review (the `ready_for_review` event; draft
 PRs cannot carry auto-merge). This workflow uses a fine-grained token minted from a GitHub App
-(khive-leo[bot]) via a SHA-pinned token-minter action and runs on `pull_request_target` so it
+(a GitHub App bot) via a SHA-pinned token-minter action and runs on `pull_request_target` so it
 has no access to the PR head's code. Its sole action is `gh pr merge --auto --squash`.
 
 The bot proposer is an optional convenience layer, not a trust boundary. Its function is to

--- a/docs/adr/ADR-068-process-isolation-topology.md
+++ b/docs/adr/ADR-068-process-isolation-topology.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-06-23\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-007 (Namespace as Attribution), ADR-018 (Authorization Gate), ADR-049
 (khived daemon), ADR-057 (Comm Actor-Addressed Delivery)\
 **Amends (effective now)**: ADR-007 Rule 4 (TenantGate clause); ADR-018
@@ -431,20 +431,20 @@ launch, not per-request. Idle actors with no active process incur no RAM cost.
 The Postgres migration path activates when the following condition is met in production metrics:
 
 ```
-active_warm_processes * p95_rss_per_warm_vamana_index > fleet_ram_budget * 0.70
+active_warm_processes * p95_rss_per_warm_vamana_index > deployment_ram_budget * 0.70
 ```
 
 where:
 
 - `active_warm_processes`: count of actor processes with a loaded Vamana index, measured from
-  process-level RSS metrics in the fleet monitoring system.
+  process-level RSS metrics in the deployment monitoring system.
 - `p95_rss_per_warm_vamana_index`: the 95th-percentile per-process RSS increment attributable
   to a warm Vamana index, measured by comparing RSS of idle-process and index-loaded-process
   samples over a rolling 7-day window.
-- `fleet_ram_budget`: total available fleet RAM as reported by the infrastructure provider.
+- `deployment_ram_budget`: total available deployment RAM as reported by the infrastructure provider.
 - `0.70`: safety factor (30% headroom). Adjust only via an ADR amendment.
 
-Decision owner: lambda:khive. Review artifact: a filed ADR amendment with the measured metric
+Decision owner: maintainers. Review artifact: a filed ADR amendment with the measured metric
 values, a 7-day trend chart, and a proposed migration timeline. No Postgres migration may begin
 without that artifact.
 

--- a/docs/adr/ADR-069-subject-model.md
+++ b/docs/adr/ADR-069-subject-model.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-06-23\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy), ADR-002 (Edge Ontology), ADR-013 (Note Kind
 Taxonomy), ADR-017 (Pack Standard -- extends `EndpointKind` with `EntityOfType` variant)
 
@@ -581,11 +581,11 @@ carries no such guarantee.
   as subtype registration, `VerbRegistry::all_edge_rules()` aggregation
 - `crates/khive-runtime/src/operations.rs` lines 215-292: `base_entity_rule_allows` --
   implemented base endpoint contract; confirms `concept->concept DependsOn` absent
-- `.khive/workspaces/20260621/proof-gate/mathlib/phase2_select.py` lines 58-61: taxonomy
+- Local proof-gate `mathlib/phase2_select.py` lines 58-61: taxonomy
   derivation from module path; lines 24: `TOOLING_DISCIPLINES` drop
-- `.khive/workspaces/20260621/proof-gate/mathlib/build_taxonomy_layout.py` steps 2-6:
+- Local proof-gate `mathlib/build_taxonomy_layout.py` steps 2-6:
   Layout pipeline and silhouette annotation
-- `.khive/workspaces/20260621/proof-gate/mathlib/gen_edge_ops.py`: records the `enables`
+- Local proof-gate `mathlib/gen_edge_ops.py`: records the `enables`
   workaround and its reason ("depends_on is NOT c->c in base, only under draft ADR-065")
-- `.khive/workspaces/20260621/proof-gate/mathlib/PHASE2-SELECTION.md`: verified selection
+- Local proof-gate `mathlib/PHASE2-SELECTION.md`: verified selection
   counts (316,040 raw; 62,038 final selected; T=3 threshold)

--- a/docs/adr/ADR-071-backend-pluggable-runtime.md
+++ b/docs/adr/ADR-071-backend-pluggable-runtime.md
@@ -3,7 +3,7 @@
 **Status**: Accepted
 **Date**: 2026-06-25
 **Ratified**: 2026-06-28
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - [ADR-005](ADR-005-storage-capability-traits.md) — Storage Capability Traits

--- a/docs/adr/ADR-072-subject-ontologyspec-as-data.md
+++ b/docs/adr/ADR-072-subject-ontologyspec-as-data.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-06-26\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Extends**: ADR-069 (Subject Model -- component specification and D1)\
 **Depends on**: ADR-001 (Entity Kind Taxonomy), ADR-002 (Edge Ontology), ADR-017 (Pack
 Standard -- `EDGE_RULES`, `ENTITY_KINDS`, `all_edge_rules()`), ADR-055 (Epistemic Edge

--- a/docs/adr/ADR-073-pack-core-backend-accessor.md
+++ b/docs/adr/ADR-073-pack-core-backend-accessor.md
@@ -3,7 +3,7 @@
 **Status**: Accepted\
 **Date**: 2026-06-25\
 **PR**: #252\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: [ADR-017](ADR-017-pack-standard.md) (Pack Standard), [ADR-028](ADR-028-pack-scoped-backends.md) (Pack-Scoped Backends), [ADR-029](ADR-029-substrate-coordinator.md) (Substrate Coordinator)\
 **Extends**: ADR-028 §"Per-pack runtime instances"\
 **Sequencing note**: ADR-071 (Backend-Pluggable Runtime, proposed) introduces `BackendHandle` as the future seam. See §"Relationship to ADR-071" for the forward-compatibility constraint.

--- a/docs/adr/ADR-074-graph-aware-recall.md
+++ b/docs/adr/ADR-074-graph-aware-recall.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-06-25\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Measurement evidence**: lattice dogfood loop, delta #1 (2026-06-25)\
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-033](ADR-033-recall-pipeline.md) (Recall Pipeline), [ADR-042](ADR-042-local-rerank-via-lattice-inference.md) (Composable Rerank Pipeline), [ADR-002](ADR-002-edge-ontology.md) (Closed Edge Ontology)\
 **GitHub**: #139 (Personalized PageRank), #80 (retrieval coverage metric)
@@ -96,14 +96,14 @@ The lattice loop logs the boolean pair plus rank for each delta into the `khive-
 
 | Delta   | Discovery sweep      | Actionable prior                                              | recall-lift                                                  | rank-lift                            | Outcome                     |
 | ------- | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------ | --------------------------- |
-| delta-1 | `flash.rs` codex     | old, salience 0.72, flat rank #2 at raw 0.475                 | +1/2 (sibling cluster surfaced only via graph)               | +1 (graph promotes rank #2 to #1)    | graph fusion wins           |
+| delta-1 | `flash.rs` prior     | old, salience 0.72, flat rank #2 at raw 0.475                 | +1/2 (sibling cluster surfaced only via graph)               | +1 (graph promotes rank #2 to #1)    | graph fusion wins           |
 | delta-2 | `standard.rs` kernel | fresh session lessons, salience 0.85, decay 0.0, flat rank #1 | low, about +0.25 (entity leg adds marginal taxonomy framing) | about 0 (flat #1 already actionable) | flat plus salience suffices |
 
 The lift is conditional on the corpus. Graph proximity adds the most when the actionable prior is old, low-salience, or poorly ranked by raw cosine, which is exactly when flat retrieval under-ranks it. When the actionable priors are recent high-salience captures, the existing `salience` and `temporal` features already rank them first and graph proximity adds little. delta-2 is the control row that establishes this boundary, and it is logged precisely because flat recall won it.
 
 ### 4. Default-on gate
 
-Graph fusion becomes a default recall feature only after measured recall-parity evidence at scale. The delta-1 and delta-2 split above shows the default question is not binary: graph proximity earns default-on for corpora where stale, low-salience priors still carry actionable weight, and adds little where recent high-salience captures dominate. A scale measurement therefore reports the distribution of lift across corpus age and salience, not a single average. Until that threshold is established, the feature ships opt-in: `graph_proximity` is not present in the default `RecallConfig.reranker_weights` (which defaults to `HashMap::new()`). Callers who want graph-aware recall add the key explicitly or configure it in pack settings. The parity evidence and Ocean sign-off are both required to flip the default.
+Graph fusion becomes a default recall feature only after measured recall-parity evidence at scale. The delta-1 and delta-2 split above shows the default question is not binary: graph proximity earns default-on for corpora where stale, low-salience priors still carry actionable weight, and adds little where recent high-salience captures dominate. A scale measurement therefore reports the distribution of lift across corpus age and salience, not a single average. Until that threshold is established, the feature ships opt-in: `graph_proximity` is not present in the default `RecallConfig.reranker_weights` (which defaults to `HashMap::new()`). Callers who want graph-aware recall add the key explicitly or configure it in pack settings. The parity evidence and maintainer approval are both required to flip the default.
 
 ---
 
@@ -121,7 +121,7 @@ Graph fusion becomes a default recall feature only after measured recall-parity 
 
 ## Open Questions
 
-Acceptance is pending the lattice parity measurements and Ocean sign-off. These questions shape implementation details and are not resolved by this ADR.
+Acceptance is pending the lattice parity measurements and maintainer approval. These questions shape implementation details and are not resolved by this ADR.
 
 1. **Fusion weights.** What ratio of `graph_proximity` to `relevance` performs best across the dogfood corpus? The measurement protocol accumulates this signal; the shipped default config (if any) should come from measured evidence.
 2. **Hop budget.** Is a 2-hop expansion the right default? Wider expansion improves recall at the cost of proximity score dilution for distant nodes.

--- a/docs/adr/ADR-075-owl-rdf-interoperability.md
+++ b/docs/adr/ADR-075-owl-rdf-interoperability.md
@@ -2,7 +2,7 @@
 
 **Status**: Draft\
 **Date**: 2026-06-26\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-002 (Edge Ontology), ADR-008 (Query Layer Separation -- SPARQL subset),
 ADR-069 (Subject Model), ADR-072 (Subject OntologySpec as Runtime Data)
 

--- a/docs/adr/ADR-076-relation-calculability-and-system-role.md
+++ b/docs/adr/ADR-076-relation-calculability-and-system-role.md
@@ -2,7 +2,7 @@
 
 **Status**: proposed\
 **Date**: 2026-06-26\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Amends**: [ADR-002](ADR-002-edge-ontology.md) — corrects the `contains`/`part_of` "inverse"
 phrasing (the relations are distinct, not converses).\
 **Relates to**: [ADR-055](ADR-055-epistemic-edge-relations.md) (the `supports`/`refutes` case

--- a/docs/adr/ADR-078-output-format-shape-aware-rendering.md
+++ b/docs/adr/ADR-078-output-format-shape-aware-rendering.md
@@ -2,7 +2,7 @@
 
 **Status**: proposed
 **Date**: 2026-06-27
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**:
 
 - ADR-016 (Request DSL — wire envelope shape, `$prev` chain semantics)
@@ -120,7 +120,7 @@ would change what a parser sees. They are therefore scoped to `auto`/`table` (§
 has opted into a view. (3) A table renderer truncates long cells and collapses newlines — token-lean
 and legible for an agent _reading_ output, lossy for one _parsing_ it.
 
-A fleet that wants the aggressive savings everywhere sets `default_output_format = "auto"` in its
+A deployment that wants the aggressive savings everywhere sets `default_output_format = "auto"` in its
 `khive.toml` (or `KHIVE_OUTPUT_FORMAT=auto`), trading shape-stability for the −62%/−55% reduction.
 The product/cloud default stays `json` so that callers who parse responses are never surprised.
 
@@ -235,7 +235,7 @@ nested objects, must use `format=json` or pass an expand parameter.
 The following reductions are applied in `format=auto` and `format=table` only — they are a _view_
 transform, not a serialization. `format=json` (the default, on every surface) and
 `PresentationMode::Verbose` always emit the canonical shape without reduction, so the machine
-contract is shape-stable. A fleet that wants these reductions on every call opts in with
+contract is shape-stable. A deployment that wants these reductions on every call opts in with
 `default_output_format = "auto"`.
 
 **7.1. `full_id` suppression**
@@ -386,13 +386,13 @@ retained as an extension point for cases where the generic rules produce a poor 
 
 ## Alternatives Considered
 
-| Alternative                                                | Why rejected                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Single global YAML default                                 | Costs 11–17% more tokens than compact JSON for record arrays (§5). YAML beats neither the `json` default nor the `auto`/`table` views on token cost, so it was deferred rather than shipped as a variant.                                                                                                                                                                                                                     |
-| Field-compaction only, no format axis                      | ADR-045's Agent-mode compaction handles per-field trimming but leaves pretty-print whitespace and repeated key names intact. Those two factors remain the dominant cost on heavy verbs and require a separate format axis to address.                                                                                                                                                                                         |
-| Per-verb hardcoded renderers                               | Forces every pack author into a rendering concern, couples renderer tests to handler tests, and requires new verbs to declare renderers. Shape dispatch at the seam requires no per-pack work and is testable independently of pack logic. Per-verb renderers are retained as an extension point.                                                                                                                             |
-| Using `format=auto` (shape-aware table) as the MCP default | A table is a lossy view (cells truncate at ~120 chars, newlines collapse) and the redundancy-drop reshapes `properties`, so an `auto` default would silently change the parse contract for any agent or script reading MCP output. Compact `json` is lossless and shape-stable; `auto`/`table` are opt-in for callers reading rather than parsing, and a fleet can still adopt `auto` everywhere via `default_output_format`. |
-| Using `format=table` as the MCP default                    | Forcing markdown-table rendering before validating that all verb shapes are table-renderable risks rendering errors on complex or single-record shapes. `format=auto` with a compact-JSON fallback is the safer of the two view formats.                                                                                                                                                                                      |
+| Alternative                                                | Why rejected                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Single global YAML default                                 | Costs 11–17% more tokens than compact JSON for record arrays (§5). YAML beats neither the `json` default nor the `auto`/`table` views on token cost, so it was deferred rather than shipped as a variant.                                                                                                                                                                                                                          |
+| Field-compaction only, no format axis                      | ADR-045's Agent-mode compaction handles per-field trimming but leaves pretty-print whitespace and repeated key names intact. Those two factors remain the dominant cost on heavy verbs and require a separate format axis to address.                                                                                                                                                                                              |
+| Per-verb hardcoded renderers                               | Forces every pack author into a rendering concern, couples renderer tests to handler tests, and requires new verbs to declare renderers. Shape dispatch at the seam requires no per-pack work and is testable independently of pack logic. Per-verb renderers are retained as an extension point.                                                                                                                                  |
+| Using `format=auto` (shape-aware table) as the MCP default | A table is a lossy view (cells truncate at ~120 chars, newlines collapse) and the redundancy-drop reshapes `properties`, so an `auto` default would silently change the parse contract for any agent or script reading MCP output. Compact `json` is lossless and shape-stable; `auto`/`table` are opt-in for callers reading rather than parsing, and a deployment can still adopt `auto` everywhere via `default_output_format`. |
+| Using `format=table` as the MCP default                    | Forcing markdown-table rendering before validating that all verb shapes are table-renderable risks rendering errors on complex or single-record shapes. `format=auto` with a compact-JSON fallback is the safer of the two view formats.                                                                                                                                                                                           |
 
 ## Consequences
 
@@ -403,7 +403,7 @@ retained as an extension point for cases where the generic rules produce a poor 
   1,006) from removing pretty-print whitespace alone, with **zero shape change and zero caller
   migration**. The session-start triple `[gtd.next, gtd.tasks, comm.inbox]` falls from on the order
   of 4,000 tokens to roughly 3,000 on the default path.
-- **Opting into `auto`** (per-request, or fleet-wide via `default_output_format = "auto"`) adds the
+- **Opting into `auto`** (per-request, or deployment-wide via `default_output_format = "auto"`) adds the
   redundancy-drop and markdown-table view for approximately 55–62% off the pretty-print baseline:
   `gtd.tasks(10)` falls to 774 tokens (−62%) and `list(entity, 10)` to 932 (−55%), taking the
   session-start triple to roughly 2,000 tokens. For `gtd.tasks` the `properties` dedup is the
@@ -510,7 +510,7 @@ before shape detection. The pass is skipped entirely when `format=json` or
 - ADR-045 (Verb Response Presentation Modes) — `PresentationMode`; `include_full_id` override;
   §3.5 error envelope invariant; Chain `$prev` invariant; partially superseded on `full_id` default
   behavior by §7.1 of this ADR
-- Measurement workspace: `.khive/workspaces/20260627/output-verbosity/05-table-flavor-measurement.md`
+- Measurement artifact: local output-verbosity table-flavor measurement notes.
   (grounded cl100k_base integer token counts, agent path, 2026-06-27), with `SYNTHESIS.md` and
   `04-measurement.md` as supporting context
-- Ocean directive 2026-06-27 — output verbosity reduction, format axis as the design vehicle
+- Design request 2026-06-27 — output verbosity reduction, format axis as the design vehicle

--- a/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
+++ b/docs/adr/ADR-079-ann-persistence-warm-path-integration.md
@@ -2,7 +2,7 @@
 
 **Status**: proposed
 **Date**: 2026-06-28
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
+++ b/docs/adr/ADR-080-session-pack-oss-storage-mechanism.md
@@ -3,7 +3,7 @@
 **Status**: accepted
 **Date**: 2026-06-28
 **Amended**: 2026-07-02 — shipped-surface record (§3), session mirror (§6), scope revision (Context)
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 
 ## Context
 

--- a/docs/adr/ADR-081-recall-retune-driver.md
+++ b/docs/adr/ADR-081-recall-retune-driver.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-07-02\
-**Authors**: lambda:khive, lambda:leo (scorer design and evidence)\
+**Authors**: khive maintainers
 **Measurement evidence**: hook scorer v0 dry run over 19 serve ledgers, 7 sessions (2026-07-02)\
 **Depends on**: [ADR-021](ADR-021-memory-pack.md) (Memory Pack), [ADR-033](ADR-033-recall-pipeline.md) (Recall Pipeline), [ADR-032](ADR-032-brain-profile-orchestration.md) (Brain Profile Orchestration), [ADR-035](ADR-035-cli-config-and-auto-embed.md) (Feedback Profile Resolution Order), [ADR-055](ADR-055-epistemic-edge-relations.md) (Epistemic Relations)\
 **Amends**: the brain feedback weight table (`FeedbackEventKind::update_weight()`, khive-brain-core, issue #268) and the `brain.feedback` / `brain.auto_feedback` parameter surface (additive optional scorer-provenance fields, section 6)\

--- a/docs/adr/ADR-082-retrieval-quality-measurement-loop.md
+++ b/docs/adr/ADR-082-retrieval-quality-measurement-loop.md
@@ -2,7 +2,7 @@
 
 **Status**: proposed
 **Date**: 2026-07-02
-**Authors**: Ocean, lambda:khive
+**Authors**: khive maintainers
 **Depends on**: [ADR-015](ADR-015-schema-migrations.md) (Schema Migrations), [ADR-023](ADR-023-declarative-pack-format.md) (Pack Verb Surface, Visibility, and Composition — `Visibility::Subhandler`), [ADR-047](ADR-047-knowledge-pack.md) (Knowledge Pack)
 **GitHub**: #80
 **Note**: this number was previously used by a retired v0-series draft ("Engine
@@ -33,7 +33,7 @@ The real gap issue #80 surfaces is structural, not nominal: **no labeled query s
 evaluation run, and no persisted retrieval-quality signal exist anywhere in the system.**
 Retrieval quality has never been measured against ground truth. The one measurement that
 exists is qualitative and off-system: a 2026-06-10 12-probe study
-(`.khive/workspaces/20260610/knowledge-utilization/usage_patterns.md`, local and
+(local knowledge-utilization usage-pattern notes and
 gitignored) found a 50% useful-rate on real project questions, with reproducible gaps in
 specific domains (SQLite WAL internals, speculative decoding, Metal/MSL, admissions ML).
 That finding is not recorded anywhere the system itself can read, aggregate, or track
@@ -58,11 +58,11 @@ conventions here do not fit that use case).
 
 ### Scoping and rulings
 
-`.khive/workspaces/20260626/issue80-scoping/SCOPING.md` (alpha:architect, 2026-06-26)
-scoped this issue into four design forks and two Ocean-gated escalations: (1) verb
+local issue-80 scoping notes (2026-06-26)
+scoped this issue into four design forks and two maintainer-gated escalations: (1) verb
 contract and visibility for the eval runner, (2) labeled query-set location and data
 policy, (3) how `eval_coverage` gets computed and persisted, (4) feedback-grown set
-expansion. This ADR formalizes lambda:leo's 2026-07-02 rulings on the two escalations
+expansion. This ADR formalizes the 2026-07-02 decisions on the two escalations
 (D1, D2 below) and fixes the normative shape of slice-1. It does not reopen the forks;
 it records the decisions and specifies what ships.
 
@@ -369,7 +369,7 @@ produces the zero/null sentinel values described above.
 ## References
 
 - GitHub #80 — retrieval quality measurement loop
-- `.khive/workspaces/20260626/issue80-scoping/SCOPING.md` — design forks and escalations this ADR resolves
+- Local issue-80 scoping notes — design forks and escalations this ADR resolves
 - [ADR-015](ADR-015-schema-migrations.md) — schema migration mechanism; append-only `VersionedMigration` convention used by §"Schema"
 - [ADR-023](ADR-023-declarative-pack-format.md) — `Visibility::{Verb, Subhandler}`; kkernel `exec` CLI verb-DSL; the mechanism D2 relies on
 - [ADR-047](ADR-047-knowledge-pack.md) — Knowledge Pack; `knowledge.stats`, `knowledge.search`, and the 19-verb baseline this ADR extends

--- a/docs/adr/ADR-083-session-pack-t1-verbs.md
+++ b/docs/adr/ADR-083-session-pack-t1-verbs.md
@@ -2,7 +2,7 @@
 
 **Status**: accepted
 **Date**: 2026-07-02
-**Authors**: lambda:khive
+**Authors**: khive maintainers
 **GitHub**: #342
 **Amends**: [ADR-080](ADR-080-session-pack-oss-storage-mechanism.md) §3 (verb visibility, verb count,
 and parameter vocabulary) for the T1 continuity epic. Does not touch ADR-080 §6 (session mirror),
@@ -46,7 +46,7 @@ fixes a code citation (§4).
 ADR-080 §3 is accepted. Until this ADR is itself accepted, ADR-080 §3's shipped-surface record
 (three `Visibility::Subhandler` verbs, `agent_id`/`metadata`/`since` parameters, no dispatchable
 export) remains the authoritative description of what the `session` pack exposes. This ADR is the
-sign-off vehicle for changing that. If accepted, it supersedes ADR-080 §3 with the surface described
+decision vehicle for changing that. If accepted, it supersedes ADR-080 §3 with the surface described
 in §2 below, and leaves every other part of ADR-080 (§1, §2, §4, §5, §6) unchanged.
 
 No new schema is required for T1's own storage. The four verbs read and write the existing `notes`

--- a/docs/adr/ADR-084-verb-surface-consistency.md
+++ b/docs/adr/ADR-084-verb-surface-consistency.md
@@ -2,7 +2,7 @@
 
 **Status**: proposed
 **Date**: 2026-07-02
-**Authors**: lambda:khive
+**Authors**: khive maintainers
 **Amends**: [ADR-023](ADR-023-declarative-pack-format.md) §3 (kg verb table -- adds the
 `schema` verb, 16 → 17). The table edit itself rides with the PR that ships the verb, so
 ADR-023 keeps describing the live surface at every commit. `AGENTS.md` taxonomy sections
@@ -23,7 +23,7 @@ contract. The base endpoint allowlist lives in
 by each loaded pack's `EDGE_RULES` (ADR-017). No runtime surface exposes this merged
 contract. Agents learn it from documentation snapshots that provably rot:
 
-- **Measured casualty**: a fleet skill in production taught 11 relations and 4 entity
+- **Measured casualty**: a production skill taught 11 relations and 4 entity
   kinds against the real 17 and 9. Agents consuming that skill gave wrong answers to
   endpoint-legality questions until the drift was caught by hand.
 - **Endpoint-legality questions** ("can a `resource` be the source of an `annotates`
@@ -34,7 +34,7 @@ contract. Agents learn it from documentation snapshots that provably rot:
 ### Phantom capability gaps: the strongest evidence
 
 Three friction items on the motivating list turned out, under verification, to be
-capabilities that already ship. The fleet believed the surface could not do things it does:
+capabilities that already ship. Callers believed the surface could not do things it does:
 
 1. **Multi-line strings in the function-call DSL.** Believed impossible; escapes were
    specified in ADR-016 from the start ("String escapes follow JSON: `\\`, `\"`, `\n`,
@@ -64,7 +64,7 @@ Independent of drift, the verb surface has accumulated real inconsistencies as p
 added, each individually small, collectively a memorization tax:
 
 - **Param-name divergence**: `query` vs `q`, `at` (not `due`), `id` (not `thread_id`),
-  `ids` (not `slugs`) -- correct names are fleet folklore, not a stated convention.
+  `ids` (not `slugs`) -- correct names are operational folklore, not a stated convention.
 - **ID-resolution divergence**: most `id`-typed params accept a short unique prefix;
   `brain.feedback` requires a full UUID; `knowledge.get` accepts slug or full UUID but
   not a prefix.
@@ -119,7 +119,7 @@ parameter is a breaking change to a public surface; existing non-conforming para
 migrated only through an explicit deprecation path -- accept both names for a stated
 window, warn on the deprecated one, remove in a versioned release. No silent renames.
 Whether any existing param is worth that migration cost is decided case by case at
-sign-off, not by this contract.
+explicit approval, not by this contract.
 
 **Rule 5 -- substrate-symmetric field names.** Where a concept is identical across
 substrates, the parameter name is identical: `tags` means tags for entities and notes

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-07-03\
-**Authors**: Ocean, lambda:khive (advisor-drafted)\
+**Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy — `entity_type` subtype registration), ADR-002
 (Edge Ontology — closed 17 relations, base endpoint contract), ADR-013 (Note Kind Taxonomy —
 pack-declared note kinds), ADR-017 (Pack Standard — `EDGE_RULES`, `EntityOfType`,
@@ -15,7 +15,7 @@ introspection), issue #373 (verbs vs services — explicitly out of scope, see D
 
 khive's research graph compounds: an agent reads a paper once, records concepts and edges, and
 every later session queries the graph instead of re-reading the paper. Source code — the
-corpus this fleet works in daily — has no equivalent. Every session re-derives the same
+corpus maintainers work in daily — has no equivalent. Every session re-derives the same
 structural facts (what contains what, what depends on what, what implements which idea) by
 re-reading files. The recurring defect-audit pipeline (`.khive/scripts/audit_crate.py`)
 produces structured findings that live only as flat GitHub issues and local
@@ -258,7 +258,7 @@ Following `khive-pack-formal`'s shipped shape (`crates/khive-pack-formal/src/pac
 
 The pack roster names domains and capability surfaces that khive already owns; the closest
 analogue to "code" is `formal` — a domain vocabulary pack. Code passes the ADR-069 Subject
-test on all three ingredients, and the fleet's two concrete, recurring pains (comprehension
+test on all three ingredients, and the two concrete, recurring pains (comprehension
 re-work; audit findings invisible to queries) are both graph-vocabulary problems. An
 execution capability would collide head-on with the unresolved #373 interface taxonomy and
 carry a sandboxing risk class nothing in the one-line ask implies. Vocabulary now is useful
@@ -396,10 +396,10 @@ carry cross-language semantics.
   as gtd's `task` does today; until then `kind_status` lives in properties with
   hook-defaulted initial state.
 
-## Open Questions (for Ocean / lambda:leo)
+## Open Questions
 
 1. Is the audit-finding lane (D4) in scope for v1, or should this ADR ship code-ontology-only
-   (D1-D3, D5, D6) and defer `finding` to a follow-up amendment? Advisor recommendation:
+   (D1-D3, D5, D6) and defer `finding` to a follow-up amendment? Recommendation:
    include it — it rides shared CRUD at near-zero marginal mechanism cost and immediately
    makes the existing `audit_crate.py` harvest step's output graph-queryable.
 2. Default-pack-set promotion timing (D5's opt-in-at-v1 posture) — confirm gated on one
@@ -410,7 +410,7 @@ carry cross-language semantics.
 
 ## Implementation
 
-This ADR authorizes design, not code; implementation follows SPEC-GATE sign-off.
+This ADR authorizes design, not code; implementation follows design review approval.
 
 1. `crates/khive-pack-kg/src/entity_type_registry.rs` — add the four `EntityTypeDef`
    entries (D2 tokens + aliases) to `BUILTIN_DEFS` under a `// ── Code ──` section.
@@ -453,5 +453,4 @@ This ADR authorizes design, not code; implementation follows SPEC-GATE sign-off.
 - `crates/khive-pack-kg/src/entity_type_registry.rs` — token governance; the
   `struct`/`class` alias hazard (line 109)
 - `crates/khive-pack-formal/src/{vocab.rs,pack.rs}` — the reference implementation shape
-- `.khive/scripts/audit_crate.py` + `.khive/audits/**/findings.json` — the audit lane's
-  existing record shape mapped by D4
+- Existing audit harvest script and findings JSON — the audit lane's record shape mapped by D4

--- a/docs/adr/ADR-086-doc-file-pack.md
+++ b/docs/adr/ADR-086-doc-file-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-07-03\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy — `document` is a base kind; `entity_type`
 subtype registration), ADR-002 (Edge Ontology — `annotates`, `supersedes`), ADR-013 (Note
 Kind Taxonomy), ADR-017 (Pack Standard — `EntityTypeRegistry`, `KindHook`), ADR-021 (Memory
@@ -13,7 +13,7 @@ Pack — `EntityTypeRegistry` Modify precedent, `KindHook` validation precedent)
 
 ## Context
 
-Ocean's request: documents and files (specs, research notes, meeting artifacts, reports)
+Design request: documents and files (specs, research notes, meeting artifacts, reports)
 should be "on record and kept" — first-class, graph-queryable, versioned — rather than
 opaque files agents happen to read from disk. The `document` entity kind has existed since
 ADR-001 as one of the 8 base `EntityKind` variants, but nothing in the codebase specifies

--- a/docs/adr/ADR-087-workspace-mirror.md
+++ b/docs/adr/ADR-087-workspace-mirror.md
@@ -79,10 +79,10 @@ maps cleanly, e.g. `notes/handoffs/*` → `entity_type="handoff"`).
 4. **Scope: explicit include/exclude, not "everything under `.khive/`."** Config-driven
    glob lists (`KHIVE_MIRROR_WORKSPACE_INCLUDE` / `_EXCLUDE`, matching the session mirror's
    own env-var configuration convention), with a recommended default:
-   - **Include**: `.khive/notes/**`, `.khive/reports/**`, `.khive/reviews/**` (local,
+   - **Include**: `.khive/notes/**`, `.khive/reports/**`, `.khive/codex_reviews/**` (local,
      gitignored, but valuable review history worth having "on record" in the local graph —
      mirroring is orthogonal to what gets committed to the public repo), workspace
-     artifact and completion-report markdown from configured workspace roots.
+     `artifacts/`/completion-report markdown under `.khive/workspaces/*/`.
    - **Exclude**: `.khive/kg/*.ndjson` and `schema.yaml` (already graph-versioned via
      ADR-010's git-native snapshot mechanism — mirroring the graph's own export back into
      itself would be circular), `.khive/scripts/` (executable code, not document content —
@@ -141,7 +141,7 @@ config, defaulting to the high-value subpaths, avoids both.
 
 ## Consequences
 
-- `.khive/notes/`, `.khive/reports/`, and `.khive/reviews/` content becomes
+- `.khive/notes/`, `.khive/reports/`, and `.khive/codex_reviews/` content becomes
   queryable, linkable, and versioned the same way any agent-authored document would be.
 - The mirror inherits ADR-080 §6's operational risk profile (a misconfigured poll interval
   or an unbounded read) but also inherits its already-fixed defenses — no new defect class

--- a/docs/adr/ADR-087-workspace-mirror.md
+++ b/docs/adr/ADR-087-workspace-mirror.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-07-03\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-086 (Document/File Modeling — the `document`-entity shape this mirror
 populates), ADR-080 (Session Pack — OSS Storage Mechanism, §6 session mirror — the
 operational pattern this ADR reuses), ADR-002 (Edge Ontology — `supersedes`), ADR-017
@@ -12,8 +12,8 @@ is excluded from this mirror's scope), ADR-021 (Memory Pack)
 
 ## Context
 
-Ocean's request, verbatim intent: fold the `.khive/` filesystem convention (workspaces,
-notes, summaries, handoffs, reports, `codex_reviews/`) into khive itself, "on record and
+The design request: fold the `.khive/` filesystem convention (workspaces,
+notes, summaries, handoffs, reports, review artifacts) into khive itself, "on record and
 kept," explicitly drawing the analogy to `khive-pack-session`'s session mirror
 architecture. `.khive/` today is the root CLAUDE.md's documented Workspace Convention — a
 directory tree of markdown artifacts that exist only as files, invisible to
@@ -31,11 +31,11 @@ continue, exactly as the session mirror already does).
 **The critical divergence this ADR must state explicitly.** The session mirror's actual
 shipped implementation writes into pack-`khive-pack-session`-private auxiliary tables,
 entirely outside the graph substrate (entities/notes/edges) — appropriate for session
-transcripts, which are recall-only raw material, not meant to be graph nodes. Ocean's ask
+transcripts, which are recall-only raw material, not meant to be graph nodes. The requirement
 for `.khive/` is different in kind: the content must be "on record" in the sense of
 graph-queryable (`search`, `neighbors`, `traverse`), linkable, and versioned via
 `supersedes` — not merely recallable. Copying the session mirror's storage target verbatim
-would satisfy the operational-pattern analogy Ocean drew but miss the actual requirement.
+would satisfy the operational-pattern analogy but miss the actual requirement.
 This ADR reuses the OPERATIONAL PATTERN and deliberately changes the STORAGE TARGET.
 
 ## Decision
@@ -73,16 +73,16 @@ maps cleanly, e.g. `notes/handoffs/*` → `entity_type="handoff"`).
 3. **Retention follows ADR-086 exactly.** A file's content changing between polls produces
    a NEW `document` entity version + a `supersedes` edge to the prior version (matched by
    `properties.source_uri`, the stable identity key across versions) — never an
-   in-place content overwrite. This is Ocean's confirmed resolution: kept means
+   in-place content overwrite. This is the confirmed resolution: kept means
    version-history-via-supersedes, not a single mutable row.
 
 4. **Scope: explicit include/exclude, not "everything under `.khive/`."** Config-driven
    glob lists (`KHIVE_MIRROR_WORKSPACE_INCLUDE` / `_EXCLUDE`, matching the session mirror's
    own env-var configuration convention), with a recommended default:
-   - **Include**: `.khive/notes/**`, `.khive/reports/**`, `.khive/codex_reviews/**` (local,
+   - **Include**: `.khive/notes/**`, `.khive/reports/**`, `.khive/reviews/**` (local,
      gitignored, but valuable review history worth having "on record" in the local graph —
      mirroring is orthogonal to what gets committed to the public repo), workspace
-     `artifacts/`/completion-report markdown under `.khive/workspaces/*/`.
+     artifact and completion-report markdown from configured workspace roots.
    - **Exclude**: `.khive/kg/*.ndjson` and `schema.yaml` (already graph-versioned via
      ADR-010's git-native snapshot mechanism — mirroring the graph's own export back into
      itself would be circular), `.khive/scripts/` (executable code, not document content —
@@ -115,7 +115,7 @@ write target changes.
 
 Session transcripts are recall-only by design (ADR-080's own scope statement: the
 mirror stores raw material for `session.recall`, not curated graph content). `.khive/`
-notes, handoffs, and reports are exactly the kind of content Ocean's directive says
+notes, handoffs, and reports are exactly the kind of content the design request says
 should be linkable and traversable — decisions annotate documents, documents get
 superseded, agents `neighbors()` out from a report to the project it concerns. None of
 that is possible if the content sits in a pack-private table the graph substrate doesn't
@@ -124,7 +124,7 @@ see. The requirement, not just the analogy, decides the storage target.
 ## Alternatives Considered
 
 **A1: Copy the session mirror's auxiliary-table storage verbatim ("similar architecture"
-taken literally).** Rejected. Satisfies the literal analogy Ocean drew but not the
+taken literally).** Rejected. Satisfies the literal analogy but not the
 "on record, kept, queryable" requirement — the whole point of folding `.khive/` in.
 
 **A2: A new dedicated pack crate for the mirror.** Rejected. The mirror is a service that
@@ -141,7 +141,7 @@ config, defaulting to the high-value subpaths, avoids both.
 
 ## Consequences
 
-- `.khive/notes/`, `.khive/reports/`, and `.khive/codex_reviews/` content becomes
+- `.khive/notes/`, `.khive/reports/`, and `.khive/reviews/` content becomes
   queryable, linkable, and versioned the same way any agent-authored document would be.
 - The mirror inherits ADR-080 §6's operational risk profile (a misconfigured poll interval
   or an unbounded read) but also inherits its already-fixed defenses — no new defect class
@@ -154,7 +154,7 @@ config, defaulting to the high-value subpaths, avoids both.
 1. Exact default include/exclude glob list — proposed above as a starting point, but
    should be validated against real `.khive/` directory contents before the mirror ships,
    not fixed permanently in this ADR text.
-2. Should `codex_reviews/` mirroring be gated behind a separate opt-in flag, given it's
+2. Should review-artifact mirroring be gated behind a separate opt-in flag, given it is
    explicitly local-only/gitignored content, distinct in sensitivity from notes/reports?
    Recommend: mirror it (it's local-graph-only too, not re-exported anywhere), but keep it
    toggleable via the same include/exclude config.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed\
 **Date**: 2026-07-03\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy — `project` as the repo anchor), ADR-002
 (Edge Ontology — `annotates`), ADR-013 (Note Kind Taxonomy — pack-declared note kinds),
 ADR-017 (Pack Standard — `NOTE_KINDS`, `NoteKindSpec`, `KindHook`), ADR-085 (Code Pack —
@@ -13,7 +13,7 @@ reuses)
 
 ## Context
 
-Ocean's direct correction (relayed via lambda:leo, superseding an earlier
+A design review correction superseded an earlier
 properties-only framing this workstream had proposed): commits and issues should be
 first-class, pack-registered **note kinds** — not entity subtypes, not bare properties on
 another record — carrying canonical edge relations to code-pack `finding` notes and to
@@ -33,7 +33,7 @@ A7 correctly anticipated that commit/PR provenance would eventually need first-c
 representation once a real consumer needed commit-graph traversal — and correctly rejected
 entity-per-commit as bloat at the D6.1 granularity fence. It also **guessed a specific
 shape** for that eventual v2 amendment: `artifact` entity subtypes linked via
-`introduced_by`/`derived_from`. Ocean's actual resolution takes a different shape: note
+`introduced_by`/`derived_from`. The adopted resolution takes a different shape: note
 kinds, linked via `annotates`. This ADR is that v2 amendment, and it explains, not just
 asserts, why the note-kind shape is the better fit than the artifact-entity shape A7
 guessed at.
@@ -76,20 +76,19 @@ New pack crate `khive-pack-git`, `REQUIRES = ["kg"]`, following `khive-pack-form
 
 5. **Population: background git-ingester, same operational pattern as ADR-087.**
    Cursor-based (per-repo, per-kind: last-ingested commit SHA per branch; last-synced
-   issue `updated_at` per repo), reading local `.git` history and, for issues, whatever
-   GitHub API access the fleet already uses (`gh` / the GitHub App per the standing
-   `project_leo_github_app` context) — not a live poll of the GitHub API on a tight
+   issue `updated_at` per repo), reading local `.git` history and, for issues, available
+   GitHub API access (`gh`, an installed GitHub App, or direct REST) — not a live poll of the GitHub API on a tight
    interval, and not a new API client. Unconditional `secret_gate::mask_secrets` on commit
    messages and issue bodies before write (external, less-trusted content, same posture as
    ADR-087's file mirroring). No new agent-facing verbs — `create`/`update`/`get`/`search`
    already suffice for anything an agent needs to do with a `commit`/`issue` note once it
    exists.
 
-6. **Explicit non-goals**, matching Ocean's own framing and ADR-010's established
+6. **Explicit non-goals**, matching the design framing and ADR-010's established
    principle:
    - **Not a GitHub API mirror or replacement.** ADR-010: "khive does not build a GitHub
      replacement... add semantic enrichment instead." This pack structures git/GitHub
-     lifecycle events the fleet already cares about; it does not attempt to reproduce
+     lifecycle events khive tracks; it does not attempt to reproduce
      GitHub's UI, review threads, or CI state.
    - **Not first-class git entities.** Commits/issues are notes, per Decision §1 — deliberately
      lighter-weight than entities, matching their high-cardinality, event-like nature.
@@ -133,8 +132,8 @@ ADR-085 D4's `finding` properties contract already includes `refs` (`github_issu
 resolution-tracking need — "this finding was fixed by commit abc123" without requiring the
 commit to be a graph citizen. This ADR does not remove or change that. `finding.refs.commit`
 remains valid for the case where a single finding needs to point at a SHA and nothing more.
-The new `commit`/`issue` note kinds are for the different, additional case Ocean has now
-supplied a real consumer for: when the commit or issue itself needs identity, and needs to
+The new `commit`/`issue` note kinds are for the different, additional case now needed:
+when the commit or issue itself needs identity, and needs to
 be a target other records can `annotates` or be `annotates`-ed by. Both can point at the
 same SHA without conflict — a `finding.refs.commit` string and a `commit` note's `sha`
 property are simply two independent references to the same real-world commit; nothing
@@ -159,8 +158,8 @@ needs to walk lineage today (resolve via a follow-up `get`/`search` by SHA). If 
 consumer needs graph-native commit-history traversal, that is its own future amendment —
 the same "defer until needed" discipline A7 itself used.
 
-**A3: `finding.refs.*` alone, no new note kinds — reject Ocean's correction and keep
-ADR-085's v1 scope as final.** Rejected. This is precisely the resolution Ocean's direct
+**A3: `finding.refs.*` alone, no new note kinds — reject the updated design and keep
+ADR-085's v1 scope as final.** Rejected. This is precisely the resolution the design
 correction superseded; `refs` properties do not give a commit/issue independent identity,
 annotatability, or traversal, which is the explicit ask.
 
@@ -170,7 +169,7 @@ rejected — see Open Questions.
 
 ## Consequences
 
-- Commit/issue history relevant to the fleet's own work (fixes, tracked audit findings)
+- Commit/issue history relevant to maintainer work (fixes, tracked audit findings)
   becomes queryable and linkable, closing the exact gap A7 flagged as a future amendment
   trigger.
 - The audit pipeline's existing `finding.refs.*` properties are unaffected — no migration,
@@ -190,8 +189,8 @@ rejected — see Open Questions.
 2. **Per-repo cursor granularity** — commit ingestion cursors naturally key off branch tip
    SHAs; issue ingestion cursors key off `updated_at`. Exact schema for the shared cursor
    table is an implementation detail, not fixed here.
-3. **GitHub API access path for issues** — whether the ingester uses `gh` CLI, the
-   `khive-leo[bot]` GitHub App, or direct REST calls is an implementation choice deferred
+3. **GitHub API access path for issues** — whether the ingester uses `gh` CLI, an
+   installed GitHub App, or direct REST calls is an implementation choice deferred
    to whoever builds the ingester; this ADR only requires that it not become a live,
    tight-interval GitHub API poller (rate-limit and "GitHub replacement" concerns both
    argue for batch/cursor-based sync, matching ADR-087's own poll cadence discipline).

--- a/docs/adr/ADR-089-context-verb.md
+++ b/docs/adr/ADR-089-context-verb.md
@@ -24,7 +24,7 @@ The building blocks exist and are warm-path:
 
 No existing verb composes them. `traverse` takes explicit roots without semantic anchor
 selection; `knowledge.compose` ranks knowledge sections, not KG neighborhoods. The
-per-turn hook consumer (the fleet's prefetch integration) and khivedb end users both need
+per-turn hook consumer (the existing prefetch integration) and khivedb end users both need
 the composed form, so this is product surface, not an internal convenience.
 
 ## Decision

--- a/docs/adr/ADR-090-docs-site-standard.md
+++ b/docs/adr/ADR-090-docs-site-standard.md
@@ -10,7 +10,7 @@ khive publishes a public GitHub Pages docs site (`https://ohdearquant.github.io/
 built by `.github/workflows/pages.yml` from `docs/guide/*.md` via Jekyll's
 `remote_theme: just-the-docs`. The site serves two distinct audiences from one source: humans
 browsing the HTML site, and agents fetching machine-readable summaries (`llms.txt` and raw
-markdown). Ocean's bar for the site: match the OpenAI docs standard — easy to navigate, clean,
+markdown). The bar for the site: match the OpenAI docs standard — easy to navigate, clean,
 uncluttered — and keep agent-facing content hosted as md/txt, not HTML.
 
 Two problems surfaced on the live site and were fixed in PR #582 (following the site's initial
@@ -164,7 +164,7 @@ already requires for IA, color, and agent-surface changes.
    emerging, simple convention that agents already know to probe for; it needs no negotiation
    logic and no additional hosting. Rejected.
 3. **Keep the theme default purple accent.** Zero-effort, but it reads as unstyled theme
-   boilerplate rather than a site khive deliberately designed, and does not meet Ocean's
+   boilerplate rather than a site khive deliberately designed, and does not meet the
    "clean, uncluttered, considered" bar. Rejected.
 
 ## Consequences

--- a/docs/adr/ADR-091-wal-snapshot-lifetime.md
+++ b/docs/adr/ADR-091-wal-snapshot-lifetime.md
@@ -8,7 +8,7 @@
 ## Context
 
 Live incident, 2026-07-04 (#580): `~/.khive/khive.db` was 3.7GB; `khive.db-wal` had grown
-to 15.5GB (15,512,941,272 bytes); `-shm` was 30MB. The fleet was running roughly three
+to 15.5GB (15,512,941,272 bytes); `-shm` was 30MB. The deployment was running roughly three
 concurrent implementer agents plus a warm daemon. Writes started failing with
 `sqlite: invalid data: timed out after 5s waiting for sqlite writer connection` on
 `comm.send` and other write ops. `PRAGMA wal_checkpoint(PASSIVE)` returned `0|3768965|44`:
@@ -31,9 +31,9 @@ contended at diagnosis time; the writer was simply slow underneath a bloated WAL
 timeouts during separate bursts. Root cause is squarely "something pinned the checkpoint
 boundary," not writer contention.
 
-### Round-1 review correction (this section replaces the original draft's Plank 1 basis)
+### Internal review correction (this section replaces the original draft's Plank 1 basis)
 
-Codex round-1 review of this ADR rejected the original mechanism on two Blockers, both
+An internal review of this ADR rejected the original mechanism on two Blockers, both
 confirmed correct against the code:
 
 1. **An idle, returned autocommit connection does not pin a WAL snapshot.** The
@@ -223,7 +223,7 @@ Plank 1 bounds every mechanism proven to allow caller-controlled transaction dur
 mechanism, plus the in-memory/test pooled-reader path the original draft targeted,
 narrowed to the surface it actually covers. Plank 2 (TRUNCATE escalation) carries over
 from the original draft largely unchanged, with an explicit flap/backoff statement added
-per Leo's request.
+by design review.
 
 **Migrate-vs-instrument decision for (2b):** this ADR does **not** propose migrating the
 raw-`SqlWriter` call sites (`fold_gate.rs`, `persist.rs`, `sql_bridge.rs`'s own writer
@@ -300,7 +300,7 @@ transaction regardless of which mechanism created it:
   edge-triggered pattern as `crossing_warn`, `checkpoint.rs:224-228`) once it exceeds
   `KHIVE_TX_WARN_SECS` (default **30s**; provisional, see Plank 0), including the entry's
   `label` if supplied.
-- **Cooperative stale-operation guard, not a lifetime bound (reworded per codex round-2:
+- **Cooperative stale-operation guard, not a lifetime bound (reworded after internal review:
   the original "hard cap" language overclaimed).** Once a registry entry's
   `opened_at.elapsed()` exceeds `KHIVE_TX_MAX_AGE_SECS` (default **120s**; provisional, see
   Plank 0):
@@ -374,7 +374,7 @@ Unchanged from the original draft in mechanism: the periodic task keeps PASSIVE-
   specified: past the high-water mark, no more often than the min interval, attempt
   `PRAGMA wal_checkpoint(TRUNCATE)` via `try_writer_nowait` with a temporarily shortened
   busy timeout restored immediately after, win or lose.
-- **Explicit flap/backoff behavior (Leo's addition):** if `try_writer_nowait()` itself
+- **Explicit flap/backoff behavior:** if `try_writer_nowait()` itself
   fails (the writer mutex is held by a concurrent write) at the moment a TRUNCATE attempt
   is due, the attempt is skipped for that tick exactly like an ordinary PASSIVE skip; the
   task does not retry within the same tick or spin-wait. `last_truncate_attempt` is
@@ -398,7 +398,7 @@ Unchanged from the original draft in mechanism: the periodic task keeps PASSIVE-
   in the shared transaction registry (both `begin_tx` and raw `SqlWriter` transactions)
   when an attempt fails to make progress.
 
-### 2026-07-04 amendment: severity ladder + `wal_pages` units (spec-gate ruling, lambda:leo)
+### 2026-07-04 amendment: severity ladder + `wal_pages` units
 
 **Severity ladder (this corrects Plank 0's crossing-severity wording above).** Plank 0's
 description of the `warn_pages` crossing (`escalating to tracing::warn! once wal_pages
@@ -411,7 +411,7 @@ The ladder is:
 - **INFO**: `wal_pages` crosses `warn_pages` (a single tick observation).
 - **WARN**: `wal_pages` fails to drain back below `warn_pages` across **N = 3** consecutive
   checkpoint cycles (each cycle is one `run_checkpoint_task` tick, default 500ms via
-  `KHIVE_CHECKPOINT_INTERVAL_MS`). N is owned by lambda:khive and tunable. **This tier is
+  `KHIVE_CHECKPOINT_INTERVAL_MS`). N is owned by maintainers and tunable. **This tier is
   not yet implemented.** It is distinct from the shipped `note_truncate_outcome` escalation
   (`checkpoint.rs:508-530`), which counts consecutive TRUNCATE _attempts_, not checkpoint
   cycles, and only ever runs once `wal_pages` has already crossed the much higher

--- a/docs/adr/ADR-092-context-composer.md
+++ b/docs/adr/ADR-092-context-composer.md
@@ -18,7 +18,7 @@ No verb assembles across substrates. Today the per-turn prefetch hook does this 
 MCP round-trips (recall + search + per-anchor neighbors), caller-side budget math, and no place for
 the runtime to learn how much budget each substrate deserves per consumer.
 
-Three shapes were considered (Ocean ratified the third):
+Three shapes were considered, and the third was selected:
 
 - **A — pack-blind substrate retrieval + traversal** (one hybrid search across all kinds + annotates
   expansion). Rejected: discards each pack's ranker (memory decay/salience/posteriors, knowledge

--- a/docs/adr/ADR-094-lifecycle-telemetry-events.md
+++ b/docs/adr/ADR-094-lifecycle-telemetry-events.md
@@ -24,7 +24,7 @@ consecutive occurrences," and both currently have no ordered log to query.
 
 ### Three existing telemetry mechanisms, none built for this
 
-Recon (`.khive/workspaces/20260704/telemetry-recon/TELEMETRY_SURFACE.md`,
+Recon (local telemetry surface notes,
 `SINGLETON_AUDIT.md`, audited at `origin/main` `c8c16f49`, re-verified byte-identical in
 this worktree) found three mechanisms already in production:
 
@@ -375,7 +375,7 @@ id) DESC`; if fewer than 3 rows exist (e.g. shortly after daemon start), do not 
 taxonomy, the emission contract, and the drain-row addition that makes the query
 non-vacuous); #617 implements the actual query, the `tracing::warn!` downgrade/promotion
 described in the ADR-091 amendment, and any additional hysteresis #617's own design wants on
-top of this minimum.** N stays owned and tunable by lambda:khive per the amendment's text,
+top of this minimum.** N stays owned and tunable by maintainers per the amendment's text,
 unaffected by this ADR.
 
 ### 5. Retention/volume: edge-triggered for every variant except `ChannelPollStarted`
@@ -536,7 +536,7 @@ event, closing the singleton audit's top-ranked finding (`SINGLETON_AUDIT.md` §
 
   This drain-site choice (moving off `run_checkpoint_task` and onto `VerbRegistry::dispatch`)
   is a design delta from this ADR's prior revision and is called out here explicitly for
-  Leo's confirmation, on the strength of the one-directional-dependency rationale above.
+  maintainer confirmation, on the strength of the one-directional-dependency rationale above.
 
 (b) **`tx_registry.rs` (ADR-091 Plank 0)** stays out of scope for this ADR, per the audit's
 own framing (`SINGLETON_AUDIT.md` §4 item 2): it is a per-process, in-memory, observe-only

--- a/docs/adr/ADR-095-verb-surface-consolidation.md
+++ b/docs/adr/ADR-095-verb-surface-consolidation.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-07-04
-**Authors**: lambda:khive (advisor-hardened design)
+**Authors**: khive maintainers
 **Depends on**: ADR-016 (request DSL, single-tool contract), ADR-017 (pack standard),
 ADR-023 (pack verb surface, visibility, and composition), ADR-083 (session pack T1 verbs),
 ADR-084 (verb-surface
@@ -13,7 +13,7 @@ checks). Out of scope: brain and knowledge pack-private storage, closed taxonomi
 
 ## Context
 
-Ocean's directive (2026-07-03) asked for two things: (a) consolidate specialized-pack
+The design request asked for two things: (a) consolidate specialized-pack
 CRUD-shaped verbs (the example given was `session.resume`) into the kg pack's
 dispatch-by-kind pattern (`search(kind="session", ...)`), and (b) centralize EDGE_RULES
 validation so endpoint rules are "bundled and compiled together, instead of per verb
@@ -29,7 +29,7 @@ declared additions per ADR-017). The recon in VERB_SURFACE_INVENTORY.md (cited t
 plus #621) found no remaining duplicate rule site. So the EDGE_RULES half of the directive
 is done. Restating it would produce an ADR that ratifies work already merged.
 
-Second, the still-per-verb validation layer that Ocean's centralization intent actually
+Second, the still-per-verb validation layer that the centralization goal actually
 lands on is not edge endpoints. It is KindHook-shaped field validation: the status-enum
 checks in gtd, the memory_type enum in memory, the RFC-3339 datetime checks in schedule,
 each living inside its own pack handler with no composed-registry equivalent. That is the
@@ -77,7 +77,7 @@ resolve-depends_on-before-write orphan guard. Its status normalization helpers a
 with the hook (comment "Shared with hook.rs" at handlers.rs:372). So `gtd.assign`-the-verb
 and `create(kind="task")`+TaskHook are two write paths that produce the same kind of record
 from partly shared helpers. That is a genuine duplicate-path, and it is the one place in the
-current surface where Ocean's "compiled together instead of per-verb" instinct is correct at
+current surface where the "compiled together instead of per-verb" direction is correct at
 the code level, independent of any wire change.
 
 The gtd state machine must survive any change. `atomic_gtd_transition` (handlers.rs:444) is a
@@ -89,13 +89,13 @@ none should.
 
 ## Decision
 
-The honest answer to Ocean is: half of this is done, a quarter should not be done, and here
+The design answer is: half of this is done, a quarter should not be done, and here
 is the quarter worth doing.
 
 - The EDGE_RULES half (part b as literally stated) is shipped (#621). This ADR records that
   and does not reopen it.
 - The verb-retirement quarter (fold named pack verbs into dispatch-by-kind and remove them
-  from the surface) should not be done. It breaks a decision Ocean's fleet accepted 48 hours
+  from the surface) should not be done. It breaks a decision accepted 48 hours
   earlier (ADR-083), it degrades agent discoverability, and it buys a deduplication benefit
   that the existing KindHook seam already delivers without touching the wire.
 - The quarter worth doing is internal, not wire-facing: (1) make dispatch-by-kind plus
@@ -130,7 +130,7 @@ Argument against retirement (why it loses): three independent reasons.
    and that continuity requires "the verbs to be callable from the agent-facing MCP request
    surface." Folding `session.resume` back into `search(kind="session")` is the exact inverse
    of that decision, proposed 48 hours after it was accepted, and the packet names the session
-   pack as load-bearing for the commercial session-continuity pillar. Reopening a signed-off,
+   pack as load-bearing for the commercial session-continuity pillar. Reopening an accepted,
    commercially-tied decision within two days needs a stronger reason than surface tidiness,
    and there is none.
 
@@ -165,7 +165,7 @@ public entry point; its handler routes through the same create-plus-KindHook pat
 
 Argument for (a) hard removal: it is the only mechanism that actually shrinks the surface, so
 if surface size were the goal it would be the honest choice. It loses because F1 already
-rejected shrinking the surface: hard removal is a breaking wire change against the fleet, the
+rejected shrinking the surface: hard removal is a breaking wire change against existing callers, the
 marketplace plugin users, and ADR-083, for a goal this ADR does not adopt.
 
 Argument for (b) alias-and-deprecate (pack verbs become thin aliases over kg handlers, count
@@ -244,7 +244,7 @@ Decision: because nothing is retired, there is no wire-facing migration. The ver
 move). No deprecation window is needed because no breaking change is made.
 
 Argument for a deprecation window (the case for treating this as a migration): if we were
-retiring verbs, pre-1.0 status and a known consumer set (the fleet plus marketplace plugin
+retiring verbs, pre-1.0 status and a known consumer set (operators plus marketplace plugin
 users) would still argue for a clean break over a deprecation window, since the consumer set is
 small and reachable and a permanent alias surface is the F2-rejected outcome. But this decision
 retires nothing, so the question is moot for the wire.
@@ -287,7 +287,7 @@ Positive consequences:
   chance new packs add crud-dup verbs that later invite exactly this consolidation question.
 - ADR-083's session decision, the commercial continuity pillar, and the named discoverability
   surface are all preserved.
-- No breaking change ships to the fleet or plugin users.
+- No breaking change ships to operators or plugin users.
 
 Negative consequences and costs:
 

--- a/docs/design/kg-versioning-frontend.md
+++ b/docs/design/kg-versioning-frontend.md
@@ -2,7 +2,7 @@
 
 **Status**: draft\
 **Date**: 2026-05-19\
-**Authors**: Ocean, lambda:khive\
+**Authors**: khive maintainers
 **Target**: Next.js 15 + React 19 (PR #25 scaffold)
 
 ---

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -478,7 +478,7 @@ Create a GTD task (note with `kind=task`).
 | `tags`              | array\<string\> | no       | Tag list.                                                                                                                                                            |
 
 ```
-request(ops="gtd.assign(title=\"Ship API reference\", priority=\"p1\", assignee=\"lambda:khive\")")
+request(ops="gtd.assign(title=\"Ship API reference\", priority=\"p1\", assignee=\"agent:docs\")")
 ```
 
 ### `gtd.next` — Assertive
@@ -491,7 +491,7 @@ List actionable tasks (status `next` or `active`) by priority.
 | `assignee` | string  | no       | Filter to this assignee. |
 
 ```
-request(ops="gtd.next(assignee=\"lambda:khive\", limit=10)")
+request(ops="gtd.next(assignee=\"agent:docs\", limit=10)")
 ```
 
 ### `gtd.complete` — Declaration
@@ -521,7 +521,7 @@ List tasks filtered by status, assignee, priority.
 | `offset`   | integer | no       | Default 0.                                                                                         |
 
 ```
-request(ops="gtd.tasks(status=\"active\", assignee=\"lambda:khive\")")
+request(ops="gtd.tasks(status=\"active\", assignee=\"agent:docs\")")
 ```
 
 ### `gtd.transition` — Declaration
@@ -671,7 +671,7 @@ Show which profile would serve a caller context.
 | `namespace`     | string | no       | Default `*` (wildcard match).                                |
 
 ```
-request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"lambda:khive\")")
+request(ops="brain.resolve(consumer_kind=\"recall\", actor=\"agent:docs\")")
 ```
 
 ### `brain.activate` — Commissive
@@ -954,7 +954,7 @@ Schedule a future verb dispatch.
 | `repeat` | string | no       | Same recurrence grammar as `schedule.remind`.                       |
 
 ```
-request(ops="schedule.schedule(action=\"gtd.next(assignee=\\\"lambda:khive\\\")\", at=\"2026-07-05T09:00:00Z\")")
+request(ops="schedule.schedule(action=\"gtd.next(assignee=\\\"agent:docs\\\")\", at=\"2026-07-05T09:00:00Z\")")
 ```
 
 ### `schedule.agenda` — Assertive

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -201,7 +201,7 @@ request(ops="memory.recall(query=\"FlashAttention benchmark results\", limit=5)"
 When handing off work to another agent:
 
 ```
-request(ops="memory.remember(content=\"HANDOFF: Attention benchmark suite is ready at benchmarks/attention/. Next step: run on H100 cluster. Contact: lambda:platform for GPU allocation.\", salience=0.8, memory_type=\"episodic\")")
+request(ops="memory.remember(content=\"HANDOFF: Attention benchmark suite is ready at benchmarks/attention/. Next step: run on H100 cluster. Contact: agent:platform for GPU allocation.\", salience=0.8, memory_type=\"episodic\")")
 ```
 
 ## See also

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -76,7 +76,7 @@ via graph traversal.
 ### Task with assignee
 
 ```
-request(ops="gtd.assign(title=\"Write attention tests\", assignee=\"lambda:platform\")")
+request(ops="gtd.assign(title=\"Write attention tests\", assignee=\"agent:platform\")")
 ```
 
 ### Task with tags
@@ -108,7 +108,7 @@ Returns tasks with `status` in `[next, active]`, sorted by priority (p0 first).
 
 ```
 request(ops="gtd.tasks(status=\"active\")")
-request(ops="gtd.tasks(status=\"waiting\", assignee=\"lambda:khive\")")
+request(ops="gtd.tasks(status=\"waiting\", assignee=\"agent:docs\")")
 ```
 
 ### Transition a task
@@ -181,7 +181,7 @@ request(ops="gtd.transition(id=\"<task_id>\", status=\"next\", note=\"promoted a
 When picking up a new area of work, filter by assignee or tags:
 
 ```
-request(ops="gtd.tasks(assignee=\"lambda:khive\", status=\"next\")")
+request(ops="gtd.tasks(assignee=\"agent:docs\", status=\"next\")")
 ```
 
 ### Batch status update

--- a/marketplace/INSTALL.md
+++ b/marketplace/INSTALL.md
@@ -7,7 +7,7 @@ correctly to a running `kkernel mcp` server.
 
 | Plugin | Version | kkernel |
 | ------ | ------- | ------- |
-| khive  | 0.3.0  | ≥ 0.2.4 |
+| khive  | 0.3.0   | ≥ 0.2.4 |
 
 `khive` is a single umbrella plugin — one pattern skill per pack plus the kg stewardship agents,
 all over the one `kkernel mcp` server.

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -9,5 +9,14 @@
   "homepage": "https://github.com/ohdearquant/khive",
   "repository": "https://github.com/ohdearquant/khive",
   "license": "Apache-2.0",
-  "keywords": ["knowledge-graph", "gtd", "memory", "messaging", "scheduling", "agents", "mcp", "knowledge-management"]
+  "keywords": [
+    "knowledge-graph",
+    "gtd",
+    "memory",
+    "messaging",
+    "scheduling",
+    "agents",
+    "mcp",
+    "knowledge-management"
+  ]
 }

--- a/marketplace/khive/.claude-plugin/plugin.json
+++ b/marketplace/khive/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "khive for AI agents — knowledge graph, GTD, memory, inter-agent comm, scheduling, and domain knowledge over one MCP server. One pattern skill per pack, plus the kg stewardship agents.",
   "version": "0.3.0",
   "author": {
-    "name": "Ocean (HaiyangLi)",
+    "name": "khive maintainers",
     "url": "https://github.com/ohdearquant"
   },
   "homepage": "https://github.com/ohdearquant/khive",

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -18,32 +18,32 @@ server env (or pass `--actor`) before you start. See
 
 ## Pattern skills (one per pack)
 
-Each skill teaches the *reusable pattern* for its pack, not a how-to for every verb. Per-verb
+Each skill teaches the _reusable pattern_ for its pack, not a how-to for every verb. Per-verb
 parameter detail is always one call away at runtime: `request(ops="<verb>(help=true)")`.
 
-| Skill       | Pack      | The pattern it teaches                                                       |
-| ----------- | --------- | --------------------------------------------------------------------------- |
-| `kg`        | kg        | Search before you create; model as typed entities + edges; explore; propose |
+| Skill       | Pack      | The pattern it teaches                                                                     |
+| ----------- | --------- | ------------------------------------------------------------------------------------------ |
+| `kg`        | kg        | Search before you create; model as typed entities + edges; explore; propose                |
 | `gtd`       | gtd       | Capture with an assignee, process the inbox, advance the lifecycle, complete with evidence |
-| `memory`    | memory    | Store-before-recall with honest salience; recall before acting              |
-| `brain`     | brain     | Tune adaptive recall with profiles, feedback signals, and bindings          |
-| `comm`      | comm      | Be attributable, address by actor with a subject, triage, reply to thread   |
-| `schedule`  | schedule  | `remind` for prompts vs `schedule` for deferred verb dispatch; agenda; cancel |
-| `knowledge` | knowledge | Search (`rerank=true`) then suggest then compose; learn + cite to grow the corpus |
+| `memory`    | memory    | Store-before-recall with honest salience; recall before acting                             |
+| `brain`     | brain     | Tune adaptive recall with profiles, feedback signals, and bindings                         |
+| `comm`      | comm      | Be attributable, address by actor with a subject, triage, reply to thread                  |
+| `schedule`  | schedule  | `remind` for prompts vs `schedule` for deferred verb dispatch; agenda; cancel              |
+| `knowledge` | knowledge | Search (`rerank=true`) then suggest then compose; learn + cite to grow the corpus          |
 
 ## kg stewardship agents
 
 Bulk graph work — ingestion, gap analysis, hygiene — is owned by dedicated agents rather than
 hand-rolled. Four pair with a workflow skill (their operating contract); two run standalone.
 
-| Agent         | Paired skill | Role                                                              |
-| ------------- | ------------ | ---------------------------------------------------------------- |
+| Agent         | Paired skill | Role                                                                          |
+| ------------- | ------------ | ----------------------------------------------------------------------------- |
 | `digester`    | `digest`     | Turn source material (ADRs, papers, docs, code) into entities + edges + notes |
-| `gap-analyst` | `gap`        | Survey the graph's structural gaps; read-only frontier ranking   |
-| `expander`    | `expand`     | Grow the graph to close one strategic gap, with hard create caps |
-| `polisher`    | `polish`     | Fix orphans, under-linked nodes, duplicates, wrong-direction edges |
-| `librarian`   | —            | Swarm health monitor; watches the agent task queue, files taxonomy questions |
-| `researcher`  | —            | Context-aware investigation grounded in the persistent graph     |
+| `gap-analyst` | `gap`        | Survey the graph's structural gaps; read-only frontier ranking                |
+| `expander`    | `expand`     | Grow the graph to close one strategic gap, with hard create caps              |
+| `polisher`    | `polish`     | Fix orphans, under-linked nodes, duplicates, wrong-direction edges            |
+| `librarian`   | —            | Swarm health monitor; watches the agent task queue, files taxonomy questions  |
+| `researcher`  | —            | Context-aware investigation grounded in the persistent graph                  |
 
 Once installed, invoke them as `khive:digester`, `khive:polisher`, and so on.
 

--- a/marketplace/khive/agents/digester.md
+++ b/marketplace/khive/agents/digester.md
@@ -67,7 +67,7 @@ Before processing any source:
    concept), they are intentionally separate — do not merge.
 
    **Lesson (2026-06-09)**: 6 lionagi classes were double-ingested across two batch waves
-   ("source" 5/21 and "module" 5/27) and required manual merges by Leo.
+   ("source" 5/21 and "module" 5/27) and required manual merges by a maintainer.
 
 6. **Note salience honestly.** 0.85+ for cross-cutting insights, 0.5-0.75 for normal observations,
    <0.5 for context that doesn't matter long-term. Inflated salience poisons future recall.

--- a/marketplace/khive/agents/librarian.md
+++ b/marketplace/khive/agents/librarian.md
@@ -23,7 +23,7 @@ queue grows unboundedly.
 - When `gap-analyst` queues a taxonomy question (only librarian addresses those)
 
 The librarian is the only agent in the swarm that surfaces things to humans by default. The others
-self-handoff via GTD; the librarian's report is for Ocean.
+self-handoff via GTD; the librarian's report is for maintainers.
 
 ---
 
@@ -106,7 +106,7 @@ in the closed 17-relation set. Librarian's job:
 2. Determine whether the missing relation is genuine or whether the gap can be expressed with
    existing relations.
 3. If genuine, file an issue against `github.com/ohdearquant/khive` recommending an ADR amendment.
-   Surface to Ocean.
+   Surface to maintainers.
 4. If not genuine, write a `decision` note in the graph explaining how to express the relationship
    with existing tools, and add a `tags: ["library:precedent"]` so the next gap-analyst run finds
    it.
@@ -115,7 +115,7 @@ in the closed 17-relation set. Librarian's job:
 
 ## Handoff protocol (end of run)
 
-Librarian's primary "handoff" is **to Ocean** — a written summary, not a GTD task.
+Librarian's primary "handoff" is **to maintainers** — a written summary, not a GTD task.
 
 ```
 gtd.complete(id="<your-task-id>",

--- a/marketplace/khive/skills/comm/SKILL.md
+++ b/marketplace/khive/skills/comm/SKILL.md
@@ -6,7 +6,7 @@ description: Coordinate with other agents and lambdas over khive comm — be att
 
 khive comm is how agents and lambdas message each other. The surface is four verbs —
 `comm.send`, `comm.inbox`, `comm.reply`, `comm.thread` (plus `comm.read` to clear a message) —
-but the thing worth learning is the *coordination pattern*, not the verbs. Per-verb param
+but the thing worth learning is the _coordination pattern_, not the verbs. Per-verb param
 detail is one call away: `request(ops="comm.send(help=true)")`.
 
 ## The pattern
@@ -20,7 +20,7 @@ Two things break when you are `"local"`:
 
 - **Recipients can't tell who sent it** — every unattributed sender looks identical, and the
   reader has to guess from the content.
-- **Your inbox becomes a party line** — `comm.inbox` as `"local"` returns *every* local
+- **Your inbox becomes a party line** — `comm.inbox` as `"local"` returns _every_ local
   message, not just yours, because there is no actor to scope on.
 
 So set `KHIVE_ACTOR=lambda:<you>` in the MCP server env. The server logs a startup warning when

--- a/marketplace/khive/skills/digest/SKILL.md
+++ b/marketplace/khive/skills/digest/SKILL.md
@@ -52,7 +52,7 @@ create(kind="entity", entity_kind="<kind>", name="<short canonical name>",
 | `org`      | Labs, companies, institutions                                |
 | `artifact` | Generated files, model artifacts, build outputs              |
 | `service`  | Long-running services, APIs, deployed systems                |
-| `resource` | Knowledge atoms, domains, skills, tools                       |
+| `resource` | Knowledge atoms, domains, skills, tools                      |
 
 **Naming**: short canonical name people actually say. `LoRA` not
 `Low-Rank Adaptation of Large Language Models`. Full titles go in `properties`.

--- a/marketplace/khive/skills/gtd/SKILL.md
+++ b/marketplace/khive/skills/gtd/SKILL.md
@@ -13,7 +13,7 @@ Per-verb param detail is one call away: `request(ops="gtd.assign(help=true)")`.
 ### 1. Capture: always set assignee at creation
 
 ```
-request(ops="gtd.assign(title=\"write release notes\", priority=\"p1\", assignee=\"lambda:khive\")")
+request(ops="gtd.assign(title=\"write release notes\", priority=\"p1\", assignee=\"agent:docs\")")
 ```
 
 Multiple agents write into the same namespace. Without `assignee`, a task is invisible to
@@ -22,15 +22,15 @@ Default status is `inbox`, default priority is `p2`. Batch captures with the par
 
 ```
 request(ops="[
-  gtd.assign(title=\"reply to Mitchell\", priority=\"p1\", assignee=\"lambda:khive\"),
-  gtd.assign(title=\"file taxes\", priority=\"p0\", due=\"2026-04-15\", assignee=\"lambda:khive\")
+  gtd.assign(title=\"reply to maintainer\", priority=\"p1\", assignee=\"agent:docs\"),
+  gtd.assign(title=\"file quarterly report\", priority=\"p0\", due=\"2026-04-15\", assignee=\"agent:docs\")
 ]")
 ```
 
 ### 2. Process: clear the inbox before looking at next
 
 ```
-request(ops="gtd.tasks(status=\"inbox\", assignee=\"lambda:khive\", limit=25)")
+request(ops="gtd.tasks(status=\"inbox\", assignee=\"agent:docs\", limit=25)")
 ```
 
 For each inbox item, decide: `next` (committed, actionable), `active` (starting now),
@@ -53,7 +53,7 @@ still in `inbox` / `waiting` / `someday`, use `gtd.transition` (`status="cancell
 ### 3. Surface actionable work
 
 ```
-request(ops="gtd.next(assignee=\"lambda:khive\", limit=20)")
+request(ops="gtd.next(assignee=\"agent:docs\", limit=20)")
 ```
 
 `gtd.next` returns only `next` and `active` tasks, sorted by priority then recency. If it is
@@ -62,8 +62,8 @@ filtering:
 
 ```
 request(ops="[
-  gtd.tasks(status=\"active\", assignee=\"lambda:khive\"),
-  gtd.tasks(status=\"waiting\", assignee=\"lambda:khive\")
+  gtd.tasks(status=\"active\", assignee=\"agent:docs\"),
+  gtd.tasks(status=\"waiting\", assignee=\"agent:docs\")
 ]")
 ```
 

--- a/marketplace/khive/skills/kg/SKILL.md
+++ b/marketplace/khive/skills/kg/SKILL.md
@@ -7,7 +7,7 @@ description: Work the knowledge graph as typed entities and edges — search bef
 The kg pack is the shared, cross-project knowledge graph: typed entities (9 kinds), a closed set
 of edge relations (17), and notes. Sixteen verbs — `create`, `get`, `list`, `search`, `update`,
 `delete`, `merge`, `link`, `neighbors`, `traverse`, `query`, `stats`, `propose`, `review`,
-`withdraw`, `verbs` — but the thing worth learning is the *graph discipline*, not the verb list.
+`withdraw`, `verbs` — but the thing worth learning is the _graph discipline_, not the verb list.
 Per-verb param detail is one call away: `request(ops="create(help=true)")`.
 
 **Namespace (ADR-007).** kg ops always use the shared `local` namespace, even when the server
@@ -40,13 +40,13 @@ facts like year or language are **properties**, not edges.
 
 Then wire it in with `link` — direction matters:
 
-| Relation        | FROM → TO             | Reads as                              |
-| --------------- | --------------------- | ------------------------------------- |
-| `instance_of`   | specific → general    | GQA instance_of grouped-attention     |
-| `extends`       | child → parent        | QLoRA extends LoRA                    |
-| `introduced_by` | concept → paper       | LoRA introduced_by Hu-2021            |
-| `implements`    | code → concept        | lattice-inference implements GQA      |
-| `depends_on`    | consumer → dependency | quantization depends_on calibration   |
+| Relation        | FROM → TO             | Reads as                            |
+| --------------- | --------------------- | ----------------------------------- |
+| `instance_of`   | specific → general    | GQA instance_of grouped-attention   |
+| `extends`       | child → parent        | QLoRA extends LoRA                  |
+| `introduced_by` | concept → paper       | LoRA introduced_by Hu-2021          |
+| `implements`    | code → concept        | lattice-inference implements GQA    |
+| `depends_on`    | consumer → dependency | quantization depends_on calibration |
 
 Reach minimum density before you stop: concepts ≥ 4 edges, projects ≥ 3, documents ≥ 2. If the
 relation you want is not one of the 17, it is probably a property.

--- a/marketplace/khive/skills/memory/SKILL.md
+++ b/marketplace/khive/skills/memory/SKILL.md
@@ -6,7 +6,7 @@ description: Store and retrieve durable agent memory — remember decisions, pre
 
 khive memory is how context survives across sessions. The surface is three verbs —
 `memory.remember`, `memory.recall`, and `memory.feedback` — but the thing worth
-learning is the *salience discipline and store-before-recall cycle*, not the verbs.
+learning is the _salience discipline and store-before-recall cycle_, not the verbs.
 Per-verb param detail is one call away: `request(ops="memory.remember(help=true)")`.
 
 ## The pattern
@@ -30,12 +30,12 @@ When uncertain, use `episodic` — it preserves the context of when the memory w
 
 Salience controls ranking at recall time. Default it DOWN.
 
-| Salience | For |
-|----------|-----|
-| 0.9+ | Ocean directives, life-changing facts (rare) |
-| 0.65-0.85 | Stable design decisions, high-value patterns |
-| 0.5-0.7 | Session outcomes, useful observations |
-| 0.3-0.5 | Routine episodic notes (default range) |
+| Salience  | For                                               |
+| --------- | ------------------------------------------------- |
+| 0.9+      | Maintainer directives, life-changing facts (rare) |
+| 0.65-0.85 | Stable design decisions, high-value patterns      |
+| 0.5-0.7   | Session outcomes, useful observations             |
+| 0.3-0.5   | Routine episodic notes (default range)            |
 
 Most mid-session insights belong at 0.5, not 0.8. Inflated salience fills the top
 of every recall result with noise and defeats the ranking.


### PR DESCRIPTION
This draft PR updates design records, guides, marketplace content, and Rust comments to use neutral publication-ready wording while preserving the technical rationale, examples, and regression coverage.