### PR TITLE
fix(channel-email): restore DMARC-aligned sender domain in test fixtures

### DIFF
--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -1021,20 +1021,20 @@ mod tests {
         // cleanly through the real byte-parsing path.
         let raw = b"ARC-Authentication-Results: i=2; mx.microsoft.com 1; spf=pass smtp.mailfrom=gmail.com; dmarc=pass header.from=gmail.com; dkim=pass header.d=gmail.com\r\n\
                     Authentication-Results: spf=pass (sender IP is 2607:f8b0:4864:20::1129) smtp.mailfrom=gmail.com; dkim=pass (signature was verified) header.d=gmail.com;dmarc=pass action=none header.from=gmail.com;compauth=pass reason=100\r\n\
-                    From: Example Sender <sender@example.com>\r\n\
+                    From: Example Sender <sender@gmail.com>\r\n\
                     To: Example Recipient <recipient@example.com>\r\n\
                     Subject: Khive email subject disappears into body\r\n\
                     \r\n\
                     body text";
         let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
 
-        let mut config = make_config("sender@example.com");
+        let mut config = make_config("sender@gmail.com");
         config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
         let ch = build_channel_from(config, vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();
         assert_eq!(envs.len(), 1);
         assert_eq!(
-            envs[0].from, "email:sender@example.com",
+            envs[0].from, "email:sender@gmail.com",
             "the real EXO no-authserv-id header must attribute cleanly in TopmostNoAuthservId mode"
         );
     }
@@ -1048,13 +1048,13 @@ mod tests {
         // one, or an attacker's forged header floated to the top) --
         // quarantine rather than trust it.
         let raw = b"Authentication-Results: mx.microsoft.com; dmarc=pass header.from=gmail.com\r\n\
-                    From: Example Sender <sender@example.com>\r\n\
+                    From: Example Sender <sender@gmail.com>\r\n\
                     To: Example Recipient <recipient@example.com>\r\n\
                     Subject: forged topmost carries an id\r\n\
                     \r\n\
                     body";
         let email = parse_raw_bytes(1, raw, "imap.example.com", 1).unwrap();
-        let mut config = make_config("sender@example.com");
+        let mut config = make_config("sender@gmail.com");
         config.trust_anchor = TrustAnchor::TopmostNoAuthservId;
         let ch = build_channel_from(config, vec![email]);
         let envs = ch.poll(Utc::now()).await.unwrap();


### PR DESCRIPTION
Main went red after #633: the cleanup replaced test-fixture sender addresses with `sender@example.com`, but the `Authentication-Results` fixture data still authenticates `gmail.com`. DMARC alignment compares the From domain against the authenticated domain, so `exo_no_authserv_id_fixture_end_to_end_is_attributed` quarantined instead of attributing.

Fix: keep the placeholder mailbox name, put it on the domain the header data authenticates (`sender@gmail.com`, 5 occurrences in `channel.rs` tests). No production code touched.

Testing: `cargo test -p khive-channel-email --lib` — 138 passed, 0 failed, including the previously failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)