### PR TITLE
ci: add skip-aware ci-gate aggregate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,36 @@ jobs:
               sys.exit(1)
           print(f'OK: {current:.2f}% >= {baseline:.2f}% - {epsilon}% threshold')
           "
+
+  # Single aggregate context for branch protection. Requiring this one job
+  # (instead of raw matrix job names like "CI (macos-latest)") keeps the
+  # required set stable across matrix changes and stays skip-aware:
+  # dependency-review only runs on pull_request events, so its "skipped"
+  # result on push must not fail the gate. Anything other than
+  # success/skipped (failure, cancelled) fails the gate.
+  ci-gate:
+    name: CI gate
+    runs-on: ubuntu-latest
+    needs:
+      - ci
+      - supply-chain
+      - data-leak-guard
+      - secret-scan
+      - docs
+      - marketplace
+      - doc-build
+      - dependency-review
+      - coverage-ratchet
+    if: always()
+    steps:
+      - name: Check aggregated job results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key')
+          if [ -n "$bad" ]; then
+            echo "Gate failure — jobs not green: $bad"
+            exit 1
+          fi
+          echo "All gated jobs green (or legitimately skipped)."


### PR DESCRIPTION
Adds a single `ci-gate` job that aggregates every substantive CI job (`needs:` all of them, `if: always()`) and fails when any needed result is failure or cancelled, passing on success or skipped.

Rationale: branch protection should require one stable context instead of raw matrix job names. Requiring matrix legs directly makes the required set brittle (renaming a matrix leg silently drops protection) and can wedge docs-only PRs if a required job is conditionally skipped. `dependency-review` only runs on pull_request events, so the gate treats `skipped` as passing; `failure` and `cancelled` fail the gate.

After this merges, the ruleset's required status checks will be updated to require `CI gate`.