### PR TITLE
docs: fix stale neighbors/traverse outgoing-only default claims

### DIFF
--- a/docs/adr/ADR-089-context-verb.md
+++ b/docs/adr/ADR-089-context-verb.md
@@ -51,9 +51,11 @@ At least one of `query`, `entity_ids` is required; both may be supplied.
 | `fanout`     | int      | 10      | Max neighbors returned per expanded node per hop, clamped 1..=50                                 |
 | `namespace`  | string   | "local" | Standard multi-record namespace default (ADR-007)                                                |
 
-`direction` defaults to `both` for this verb. The `neighbors` verb's `outgoing` default
-is a known agent footgun in the context-assembly use case; a new verb is not bound by
-the old default and the divergence is documented in both verbs' help text.
+`direction` defaults to `both` for this verb. At the time of this decision the
+`neighbors` verb defaulted to `outgoing`, a known agent footgun in the
+context-assembly use case; a new verb is not bound by the old default. The
+`neighbors`/`traverse` default was later corrected to `both` as well (#517), so
+the two verbs no longer diverge.
 
 ### Semantics
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -331,8 +331,8 @@ Entity-anchored graph context in one call ([ADR-089](../adr/ADR-089-context-verb
 Resolves anchors from `query` and/or `entity_ids`, expands 1-2 hops via the same
 runtime op behind `neighbors`, and assembles a budgeted, deterministically-ordered
 response — replacing a caller-side `search | neighbors` chain with a single
-round-trip. `direction` defaults to `"both"` here, diverging deliberately from
-`neighbors`'s `"outgoing"` default. At least one of `query`/`entity_ids` is required.
+round-trip. `direction` defaults to `"both"`, matching `neighbors` and `traverse`
+(`outgoing`/`incoming` on request). At least one of `query`/`entity_ids` is required.
 One embedding inference when `query` is used; zero for a pure `entity_ids` call.
 
 | Param        | Type            | Required | Notes                                                                                 |

--- a/docs/guide/prompt-cookbook.md
+++ b/docs/guide/prompt-cookbook.md
@@ -113,8 +113,8 @@ the query and merges results.
 request(ops="neighbors(node_id=\"<uuid>\", direction=\"both\")")
 ```
 
-Use when: you want to see everything connected to a node. Always pass
-`direction="both"` unless you specifically need only outgoing or incoming edges.
+Use when: you want to see everything connected to a node. The default
+direction is `both`; pass `out` or `in` only when you need one side.
 
 ### Filtered neighbors
 

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -82,9 +82,9 @@ Use `list` when you want categorical browsing, not similarity ranking.
 request(ops="neighbors(node_id=\"<uuid>\", direction=\"both\")")
 ```
 
-Direction options: `out` (default), `in`, `both`. **Always pass
-`direction="both"` unless you specifically want only outgoing edges** — the
-default is outgoing-only, which misses inbound relationships.
+Direction options: `out`, `in`, `both` (default). Omitting `direction`
+returns edges in both directions; pass `out` or `in` when you specifically
+want only one side.
 
 Filter by relation:
 
@@ -101,7 +101,7 @@ request(ops="traverse(roots=[\"<uuid>\"], max_depth=3, relations=[\"extends\", \
 Returns paths — each path is a list of nodes from root to leaf. Use
 `include_roots=false` to exclude the starting nodes from results.
 
-Traverse is BFS-based. It respects `direction` (default: `out`) and
+Traverse is BFS-based. It respects `direction` (default: `both`) and
 `relations` filters.
 
 ## Pattern matching: `query`


### PR DESCRIPTION
Fixes the three doc locations that still described the pre-#517 outgoing-only default as current behavior: docs/guide/search.md, docs/guide/prompt-cookbook.md, and the rationale prose in ADR-089 (amended as a historical note per the issue's acceptance criteria, not rewritten).

Closes #608