### PR TITLE
docs(runtime): correct stale anonymous-inbox doc comment on actor_id

### DIFF
--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -263,7 +263,8 @@ pub struct RuntimeConfig {
     /// `khive.toml`. When `Some`, `authorize()` mints tokens carrying this actor
     /// label so that `comm.inbox` filters by `to_actor` instead of falling back to
     /// the party-line "local" behavior. When `None` (default), tokens carry
-    /// `ActorRef::anonymous()` and inbox shows all inbound messages.
+    /// `ActorRef::anonymous()` and inbox is scoped to party-line messages —
+    /// those addressed to `"local"` or carrying no `to_actor` stamp.
     pub actor_id: Option<String>,
 }
 


### PR DESCRIPTION
One-line doc-comment fix: `config.rs` still claimed the anonymous default means inbox shows all inbound messages. Anonymous callers are scoped to party-line messages (addressed to "local" or carrying no `to_actor` stamp) since the unconditional `to_actor` filter landed.

Closes #598