### PR TITLE
fix(runtime): correct env-var precedence wording in config warning

### DIFF
--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -401,7 +401,7 @@ pub(crate) fn register_configured_embedding_models(
 /// env-var-derived defaults from `RuntimeConfig::default()`.
 ///
 /// When both a config file and `KHIVE_EMBEDDING_MODEL` env var are present,
-/// the caller is responsible for emitting a warning that env vars are ignored.
+/// the caller is responsible for emitting a warning that env vars are overridden.
 /// This function purely converts `KhiveConfig` to `RuntimeConfig` fields.
 pub fn runtime_config_from_khive_config(
     khive_cfg: &crate::engine_config::KhiveConfig,


### PR DESCRIPTION
## Summary

- One-line doc-comment wording fix in `crates/khive-runtime/src/config.rs`
  (`runtime_config_from_khive_config`): the comment said the caller should warn
  that env vars are "ignored" when both a config file and
  `KHIVE_EMBEDDING_MODEL` are present. The shipped behavior (see
  `crates/khive-mcp/src/serve.rs:1299-1304`) is that the config file's
  `[[engines]]` takes precedence and env vars are overridden, not ignored.
  This brings the wording in `config.rs` in line with `serve.rs`.

## Test plan

- [x] `cargo check -p khive-runtime` (from `crates/`) — clean
- [x] `cargo fmt --all -- --check` (from `crates/`) — clean
- Comment-only change, no behavior change; no new tests needed

Closes #564