### PR TITLE
perf(context): single UNION ALL for direction=both expand (halve neighbor queries)

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -1053,10 +1053,16 @@ impl GraphStore for SqlGraphStore {
 
             // Same global weight-descending/node_id-ascending order as `neighbors`
             // (ADR-089 context-verb review, internal review round 1, High-1),
-            // applied across BOTH directions before `LIMIT` truncates.
+            // applied across BOTH directions before `LIMIT` truncates. A
+            // reciprocal pair (an Out edge and an In edge to/from the same
+            // neighbor at the same weight) ties on `(weight, node_id)`, so the
+            // order is extended with a direction rank (`out` before `in`) and
+            // finally `edge_id` to make the pre-`LIMIT` order fully
+            // deterministic (internal review round 2, High).
             let full_sql = format!(
                 "SELECT node_id, edge_id, relation, weight, dir FROM ({}){} \
-                 ORDER BY weight DESC, node_id ASC{}",
+                 ORDER BY weight DESC, node_id ASC, \
+                 CASE dir WHEN 'out' THEN 0 ELSE 1 END ASC, edge_id ASC{}",
                 sql, where_extra, limit_clause
             );
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -8,8 +8,9 @@ use uuid::Uuid;
 
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteSummary, DeleteMode, Edge, EdgeFilter, EdgeSortField, GraphPath, NeighborHit,
-    NeighborQuery, Page, PageRequest, PathNode, SortDirection, SortOrder, TraversalRequest,
+    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField,
+    GraphPath, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SortDirection, SortOrder,
+    TraversalRequest,
 };
 use khive_storage::GraphStore;
 use khive_storage::LinkId;
@@ -170,6 +171,85 @@ fn parse_uuid(s: &str) -> Result<Uuid, rusqlite::Error> {
     Uuid::parse_str(s).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
     })
+}
+
+/// Build the `relation IN (...)` / `weight >= ?` `WHERE`-extra clause and the
+/// `LIMIT` clause shared by `neighbors` and `neighbors_both_directions` —
+/// both filter and cap identically, differing only in which direction(s) the
+/// base `SELECT`s cover. `start_param_idx` is the next free `?N` placeholder
+/// (both callers bind `namespace` and `node_id` as `?1`/`?2` first).
+fn neighbor_extra_clause(
+    query: &NeighborQuery,
+    start_param_idx: usize,
+) -> (String, String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut conditions: Vec<String> = Vec::new();
+    let mut extra_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut param_idx = start_param_idx;
+
+    if let Some(ref rels) = query.relations {
+        if !rels.is_empty() {
+            let placeholders: Vec<String> = rels
+                .iter()
+                .map(|r| {
+                    extra_params.push(Box::new(r.to_string()));
+                    let p = format!("?{}", param_idx);
+                    param_idx += 1;
+                    p
+                })
+                .collect();
+            conditions.push(format!("relation IN ({})", placeholders.join(",")));
+        }
+    }
+
+    if let Some(min_w) = query.min_weight {
+        extra_params.push(Box::new(min_w));
+        conditions.push(format!("weight >= ?{}", param_idx));
+        param_idx += 1;
+    }
+
+    let where_extra = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", conditions.join(" AND "))
+    };
+
+    let limit_clause = if let Some(lim) = query.limit {
+        extra_params.push(Box::new(lim as i64));
+        format!(" LIMIT ?{}", param_idx)
+    } else {
+        String::new()
+    };
+
+    (where_extra, limit_clause, extra_params)
+}
+
+// Test-only counter of storage-level neighbor SELECT executions (`neighbors`
+// and `neighbors_both_directions` each issue exactly one `graph_edges`
+// query per call). Lets tests assert the query-count halving a
+// `Direction::Both` caller gets from `neighbors_both_directions` vs the old
+// pattern of two separate `neighbors` calls (ADR-089 context-verb
+// optimization). Gated out of release builds — no counter overhead on the
+// hot path in production.
+#[cfg(test)]
+static NEIGHBOR_SELECT_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+fn count_neighbor_select() {
+    NEIGHBOR_SELECT_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(not(test))]
+fn count_neighbor_select() {}
+
+#[cfg(test)]
+pub(crate) fn reset_neighbor_select_count() {
+    NEIGHBOR_SELECT_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+pub(crate) fn neighbor_select_count() -> usize {
+    NEIGHBOR_SELECT_COUNT.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 fn micros_to_datetime(micros: i64) -> DateTime<Utc> {
@@ -869,7 +949,7 @@ impl GraphStore for SqlGraphStore {
         node_id: Uuid,
         query: NeighborQuery,
     ) -> Result<Vec<NeighborHit>, StorageError> {
-        use khive_storage::types::Direction;
+        count_neighbor_select();
 
         let namespace = self.namespace.clone();
         let node_str = node_id.to_string();
@@ -888,43 +968,7 @@ impl GraphStore for SqlGraphStore {
                 Direction::Both => format!("{} UNION ALL {}", base_out, base_in),
             };
 
-            let mut conditions: Vec<String> = Vec::new();
-            let mut extra_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-            let mut param_idx = 3;
-
-            if let Some(ref rels) = query.relations {
-                if !rels.is_empty() {
-                    let placeholders: Vec<String> = rels
-                        .iter()
-                        .map(|r| {
-                            extra_params.push(Box::new(r.to_string()));
-                            let p = format!("?{}", param_idx);
-                            param_idx += 1;
-                            p
-                        })
-                        .collect();
-                    conditions.push(format!("relation IN ({})", placeholders.join(",")));
-                }
-            }
-
-            if let Some(min_w) = query.min_weight {
-                extra_params.push(Box::new(min_w));
-                conditions.push(format!("weight >= ?{}", param_idx));
-                param_idx += 1;
-            }
-
-            let where_extra = if conditions.is_empty() {
-                String::new()
-            } else {
-                format!(" WHERE {}", conditions.join(" AND "))
-            };
-
-            let limit_clause = if let Some(lim) = query.limit {
-                extra_params.push(Box::new(lim as i64));
-                format!(" LIMIT ?{}", param_idx)
-            } else {
-                String::new()
-            };
+            let (where_extra, limit_clause, extra_params) = neighbor_extra_clause(&query, 3);
 
             // Deterministic weight-descending order, tie-broken by node_id ascending,
             // applied BEFORE `LIMIT` — otherwise a `limit`/`fanout` cap can silently
@@ -972,6 +1016,95 @@ impl GraphStore for SqlGraphStore {
                     name: None,
                     kind: None,
                     entity_type: None,
+                });
+            }
+
+            Ok(hits)
+        })
+        .await
+    }
+
+    /// Single-query both-direction neighbor fetch (ADR-089 context-verb
+    /// optimization): projects a `'out'`/`'in'` literal from each `UNION ALL`
+    /// arm so the caller gets direction labels without a second direction-
+    /// scoped round trip. `query.direction` is ignored — always both.
+    async fn neighbors_both_directions(
+        &self,
+        node_id: Uuid,
+        query: NeighborQuery,
+    ) -> Result<Vec<DirectedNeighborHit>, StorageError> {
+        count_neighbor_select();
+
+        let namespace = self.namespace.clone();
+        let node_str = node_id.to_string();
+
+        self.with_reader("neighbors_both_directions", move |conn| {
+            let base_out = "SELECT target_id AS node_id, id AS edge_id, relation, weight, \
+                            'out' AS dir \
+                            FROM graph_edges \
+                            WHERE namespace = ?1 AND source_id = ?2 AND deleted_at IS NULL";
+            let base_in = "SELECT source_id AS node_id, id AS edge_id, relation, weight, \
+                           'in' AS dir \
+                           FROM graph_edges \
+                           WHERE namespace = ?1 AND target_id = ?2 AND deleted_at IS NULL";
+            let sql = format!("{} UNION ALL {}", base_out, base_in);
+
+            let (where_extra, limit_clause, extra_params) = neighbor_extra_clause(&query, 3);
+
+            // Same global weight-descending/node_id-ascending order as `neighbors`
+            // (ADR-089 context-verb review, internal review round 1, High-1),
+            // applied across BOTH directions before `LIMIT` truncates.
+            let full_sql = format!(
+                "SELECT node_id, edge_id, relation, weight, dir FROM ({}){} \
+                 ORDER BY weight DESC, node_id ASC{}",
+                sql, where_extra, limit_clause
+            );
+
+            let mut stmt = conn.prepare(&full_sql)?;
+
+            let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+            all_params.push(Box::new(namespace.clone()));
+            all_params.push(Box::new(node_str.clone()));
+            all_params.extend(extra_params);
+
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                all_params.iter().map(|p| p.as_ref()).collect();
+
+            let rows = stmt.query_map(param_refs.as_slice(), |row| {
+                let nid_str: String = row.get(0)?;
+                let eid_str: String = row.get(1)?;
+                let relation_str: String = row.get(2)?;
+                let weight: f64 = row.get(3)?;
+                let dir_str: String = row.get(4)?;
+                Ok((nid_str, eid_str, relation_str, weight, dir_str))
+            })?;
+
+            let mut hits = Vec::new();
+            for row in rows {
+                let (nid_str, eid_str, relation_str, weight, dir_str) = row?;
+                let relation = relation_str.parse::<EdgeRelation>().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        2,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?;
+                let direction = if dir_str == "out" {
+                    Direction::Out
+                } else {
+                    Direction::In
+                };
+                hits.push(DirectedNeighborHit {
+                    hit: NeighborHit {
+                        node_id: parse_uuid(&nid_str)?,
+                        edge_id: parse_uuid(&eid_str)?,
+                        relation,
+                        weight,
+                        name: None,
+                        kind: None,
+                        entity_type: None,
+                    },
+                    direction,
                 });
             }
 

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -207,6 +207,239 @@ async fn test_neighbors_limit_keeps_highest_weight_not_insertion_order() {
     assert!((hits[1].weight - 0.5).abs() < 1e-9);
 }
 
+/// Correctness parity (ADR-089 context-verb optimization): `neighbors_both_directions`
+/// must return exactly the union of a separate `Out` call and a separate `In`
+/// call — same node/edge/relation/weight set, same direction tag per hit, and
+/// the same global weight-descending/node_id-ascending order — while doing it
+/// in one storage query instead of two. Outgoing and incoming weights
+/// interleave (0.9, 0.6, 0.3 outgoing vs 0.8, 0.4 incoming) so the assertion
+/// proves global post-union ordering, not per-branch order.
+#[tokio::test]
+async fn test_neighbors_both_directions_matches_two_separate_calls_and_order() {
+    let store = setup_memory_store();
+
+    let centre = Uuid::new_v4();
+    let out_hi = Uuid::new_v4();
+    let out_mid = Uuid::new_v4();
+    let out_lo = Uuid::new_v4();
+    let in_hi = Uuid::new_v4();
+    let in_mid = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(centre, out_hi, EdgeRelation::Extends, 0.9))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(in_hi, centre, EdgeRelation::Extends, 0.8))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre, out_mid, EdgeRelation::Extends, 0.6))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(in_mid, centre, EdgeRelation::Extends, 0.4))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre, out_lo, EdgeRelation::Extends, 0.3))
+        .await
+        .unwrap();
+
+    let directed = store
+        .neighbors_both_directions(
+            centre,
+            NeighborQuery {
+                direction: Direction::Both,
+                relations: None,
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Global weight-descending order across BOTH directions, not per-branch:
+    // 0.9(out) > 0.8(in) > 0.6(out) > 0.4(in) > 0.3(out).
+    let got: Vec<(Uuid, f64, Direction)> = directed
+        .iter()
+        .map(|d| (d.hit.node_id, d.hit.weight, d.direction.clone()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (out_hi, 0.9, Direction::Out),
+            (in_hi, 0.8, Direction::In),
+            (out_mid, 0.6, Direction::Out),
+            (in_mid, 0.4, Direction::In),
+            (out_lo, 0.3, Direction::Out),
+        ],
+        "neighbors_both_directions must interleave by global weight DESC, tagging each hit's real direction"
+    );
+
+    // Parity: the same result set must be reconstructable from two separate
+    // direction-scoped `neighbors()` calls (the pre-optimization behavior).
+    let out_hits = store
+        .neighbors(
+            centre,
+            NeighborQuery {
+                direction: Direction::Out,
+                relations: None,
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+    let in_hits = store
+        .neighbors(
+            centre,
+            NeighborQuery {
+                direction: Direction::In,
+                relations: None,
+                limit: None,
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let directed_out: HashSet<(Uuid, Uuid)> = directed
+        .iter()
+        .filter(|d| d.direction == Direction::Out)
+        .map(|d| (d.hit.node_id, d.hit.edge_id))
+        .collect();
+    let directed_in: HashSet<(Uuid, Uuid)> = directed
+        .iter()
+        .filter(|d| d.direction == Direction::In)
+        .map(|d| (d.hit.node_id, d.hit.edge_id))
+        .collect();
+    let plain_out: HashSet<(Uuid, Uuid)> =
+        out_hits.iter().map(|h| (h.node_id, h.edge_id)).collect();
+    let plain_in: HashSet<(Uuid, Uuid)> = in_hits.iter().map(|h| (h.node_id, h.edge_id)).collect();
+    assert_eq!(
+        directed_out, plain_out,
+        "outgoing subset must match a separate Out call"
+    );
+    assert_eq!(
+        directed_in, plain_in,
+        "incoming subset must match a separate In call"
+    );
+}
+
+/// Tight `fanout`/`limit` parity: with a narrowing limit, `neighbors_both_directions`
+/// must keep the same top-K set (by global weight) that the pre-optimization
+/// two-call-then-merge-then-truncate approach kept.
+#[tokio::test]
+async fn test_neighbors_both_directions_limit_keeps_global_top_k() {
+    let store = setup_memory_store();
+
+    let centre = Uuid::new_v4();
+    let out_hi = Uuid::new_v4();
+    let in_hi = Uuid::new_v4();
+    let out_lo = Uuid::new_v4();
+    let in_lo = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(centre, out_hi, EdgeRelation::Extends, 0.95))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(in_hi, centre, EdgeRelation::Extends, 0.85))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(centre, out_lo, EdgeRelation::Extends, 0.2))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(in_lo, centre, EdgeRelation::Extends, 0.1))
+        .await
+        .unwrap();
+
+    let directed = store
+        .neighbors_both_directions(
+            centre,
+            NeighborQuery {
+                direction: Direction::Both,
+                relations: None,
+                limit: Some(2),
+                min_weight: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        directed.len(),
+        2,
+        "limit=2 must cap at 2 across both directions"
+    );
+    let ids: Vec<Uuid> = directed.iter().map(|d| d.hit.node_id).collect();
+    assert_eq!(
+        ids,
+        vec![out_hi, in_hi],
+        "the two globally-highest-weight neighbors must survive, in weight-descending order"
+    );
+    assert_eq!(directed[0].direction, Direction::Out);
+    assert_eq!(directed[1].direction, Direction::In);
+}
+
+/// Count-falsifiable A/B proof (ADR-089 context-verb optimization): a
+/// `direction="both"` neighbor fetch issues exactly ONE storage `neighbors`
+/// SELECT via `neighbors_both_directions`, versus TWO if a caller instead
+/// issued separate `Out` and `In` calls (the pre-fix `context` handler
+/// pattern this replaces — see `fetch_directed_neighbors` in
+/// `khive-pack-kg/src/handlers/context.rs`). For N expanded nodes across V
+/// visible namespaces this is the `2*N*V -> 1*N*V` reduction described in the
+/// verification verdict.
+#[tokio::test]
+async fn test_neighbors_both_directions_halves_storage_query_count() {
+    let store = setup_memory_store();
+    let centre = Uuid::new_v4();
+    let neighbor = Uuid::new_v4();
+    store
+        .upsert_edge(make_edge(centre, neighbor, EdgeRelation::Extends, 0.5))
+        .await
+        .unwrap();
+
+    let query = NeighborQuery {
+        direction: Direction::Both,
+        relations: None,
+        limit: None,
+        min_weight: None,
+    };
+
+    reset_neighbor_select_count();
+    store
+        .neighbors_both_directions(centre, query.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        neighbor_select_count(),
+        1,
+        "one neighbors_both_directions call must issue exactly 1 storage SELECT"
+    );
+
+    reset_neighbor_select_count();
+    let out_query = NeighborQuery {
+        direction: Direction::Out,
+        ..query.clone()
+    };
+    let in_query = NeighborQuery {
+        direction: Direction::In,
+        ..query
+    };
+    store.neighbors(centre, out_query).await.unwrap();
+    store.neighbors(centre, in_query).await.unwrap();
+    assert_eq!(
+        neighbor_select_count(),
+        2,
+        "the old pattern of two direction-scoped neighbors() calls issues 2 SELECTs — \
+         exactly the query count neighbors_both_directions halves"
+    );
+}
+
 #[tokio::test]
 async fn test_traverse_depth_2() {
     let store = setup_memory_store();

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::pool::PoolConfig;
 use khive_storage::types::{Direction, TraversalOptions};
+use serial_test::serial;
 use std::collections::HashSet;
 
 fn setup_memory_store() -> SqlGraphStore {
@@ -110,7 +111,11 @@ async fn test_count_edges() {
     assert_eq!(store.count_edges(EdgeFilter::default()).await.unwrap(), 5);
 }
 
+// `#[serial(neighbor_select_count)]`: shares the key with the tests that
+// assert on the process-wide `NEIGHBOR_SELECT_COUNT` so a concurrent
+// `neighbors()` call from this test can't corrupt their count.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn test_neighbors_outbound() {
     let store = setup_memory_store();
 
@@ -153,7 +158,9 @@ async fn test_neighbors_outbound() {
 /// not an arbitrary SQLite row-order subset. Before the fix, `neighbors()`
 /// applied `LIMIT` with no `ORDER BY`, so a low-weight neighbor could win over
 /// a high-weight one purely by insertion order.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn test_neighbors_limit_keeps_highest_weight_not_insertion_order() {
     let store = setup_memory_store();
 
@@ -214,7 +221,9 @@ async fn test_neighbors_limit_keeps_highest_weight_not_insertion_order() {
 /// in one storage query instead of two. Outgoing and incoming weights
 /// interleave (0.9, 0.6, 0.3 outgoing vs 0.8, 0.4 incoming) so the assertion
 /// proves global post-union ordering, not per-branch order.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn test_neighbors_both_directions_matches_two_separate_calls_and_order() {
     let store = setup_memory_store();
 
@@ -330,7 +339,9 @@ async fn test_neighbors_both_directions_matches_two_separate_calls_and_order() {
 /// Tight `fanout`/`limit` parity: with a narrowing limit, `neighbors_both_directions`
 /// must keep the same top-K set (by global weight) that the pre-optimization
 /// two-call-then-merge-then-truncate approach kept.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn test_neighbors_both_directions_limit_keeps_global_top_k() {
     let store = setup_memory_store();
 
@@ -393,7 +404,12 @@ async fn test_neighbors_both_directions_limit_keeps_global_top_k() {
 /// `khive-pack-kg/src/handlers/context.rs`). For N expanded nodes across V
 /// visible namespaces this is the `2*N*V -> 1*N*V` reduction described in the
 /// verification verdict.
+///
+/// `#[serial(neighbor_select_count)]`: `NEIGHBOR_SELECT_COUNT` is a process-wide
+/// counter — any other test issuing a neighbor SELECT while this one resets
+/// and checks it would corrupt the count under the default parallel test runner.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn test_neighbors_both_directions_halves_storage_query_count() {
     let store = setup_memory_store();
     let centre = Uuid::new_v4();
@@ -438,6 +454,60 @@ async fn test_neighbors_both_directions_halves_storage_query_count() {
         "the old pattern of two direction-scoped neighbors() calls issues 2 SELECTs — \
          exactly the query count neighbors_both_directions halves"
     );
+}
+
+/// Reciprocal equal-weight determinism (internal review round 2, High): a
+/// node with an Out edge to a neighbor and an In edge from the SAME neighbor
+/// at the SAME weight ties on `(weight, node_id)` — the pre-fix `ORDER BY`.
+/// Under a tight `limit`, the surviving row must be picked by a deterministic
+/// tie-break (the `out` row wins), not by whichever row SQLite happens to
+/// return first. Repeated to demonstrate the result is stable across calls.
+///
+/// `#[serial(neighbor_select_count)]`: shares the key with
+/// `test_neighbors_both_directions_halves_storage_query_count` so this test's
+/// repeated `neighbors_both_directions` calls can't corrupt that test's count
+/// of the process-wide `NEIGHBOR_SELECT_COUNT`.
+#[tokio::test]
+#[serial(neighbor_select_count)]
+async fn test_neighbors_both_directions_reciprocal_equal_weight_limit_is_deterministic() {
+    let store = setup_memory_store();
+
+    let centre = Uuid::new_v4();
+    let other = Uuid::new_v4();
+
+    store
+        .upsert_edge(make_edge(centre, other, EdgeRelation::Extends, 0.5))
+        .await
+        .unwrap();
+    store
+        .upsert_edge(make_edge(other, centre, EdgeRelation::Extends, 0.5))
+        .await
+        .unwrap();
+
+    let query = NeighborQuery {
+        direction: Direction::Both,
+        relations: None,
+        limit: Some(1),
+        min_weight: None,
+    };
+
+    for _ in 0..5 {
+        let directed = store
+            .neighbors_both_directions(centre, query.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            directed.len(),
+            1,
+            "limit=1 must return exactly one hit even with a reciprocal equal-weight pair"
+        );
+        assert_eq!(directed[0].hit.node_id, other);
+        assert_eq!(
+            directed[0].direction,
+            Direction::Out,
+            "the out-direction row must win the weight/node_id tie deterministically"
+        );
+    }
 }
 
 #[tokio::test]
@@ -1101,7 +1171,9 @@ fn single_neighbour_set(hits: &[NeighborHit]) -> HashSet<Uuid> {
 /// `limit` hits per source, not up to 2× (one per direction).
 /// Before the fix, Both ran Out and In separately and concatenated, so a node
 /// with ≥1 outgoing AND ≥1 incoming edge would yield 2 hits when limit=1.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_both_limit_matches_single_source_neighbors() {
     let store = setup_memory_store();
     // 2 outgoing, 2 incoming from centre
@@ -1147,7 +1219,9 @@ async fn batch_neighbors_both_limit_matches_single_source_neighbors() {
 }
 
 /// PARITY: set equality for Out direction, with and without limit.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_out_parity_with_neighbors() {
     let store = setup_memory_store();
     let (centre, out_nodes, _) = build_star(&store, 3, 2).await;
@@ -1177,7 +1251,9 @@ async fn batch_neighbors_out_parity_with_neighbors() {
 }
 
 /// PARITY: set equality for In direction.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_in_parity_with_neighbors() {
     let store = setup_memory_store();
     let (centre, _, in_nodes) = build_star(&store, 2, 3).await;
@@ -1204,7 +1280,9 @@ async fn batch_neighbors_in_parity_with_neighbors() {
 }
 
 /// PARITY: set equality for Both direction, no limit.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_both_parity_no_limit() {
     let store = setup_memory_store();
     let (centre, out_nodes, in_nodes) = build_star(&store, 2, 3).await;
@@ -1231,7 +1309,9 @@ async fn batch_neighbors_both_parity_no_limit() {
 }
 
 /// PARITY: relations filter applies correctly across directions.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_relations_filter_parity() {
     let store = setup_memory_store();
     let centre = Uuid::new_v4();
@@ -1270,7 +1350,9 @@ async fn batch_neighbors_relations_filter_parity() {
 }
 
 /// PARITY: min_weight filter applies correctly.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_min_weight_filter_parity() {
     let store = setup_memory_store();
     let centre = Uuid::new_v4();
@@ -1517,7 +1599,9 @@ async fn get_edges_chunk_boundary() {
 ///
 /// Correctness: for a random sample of sources, batch result must equal the
 /// per-source neighbors() result.
+// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
 #[tokio::test]
+#[serial(neighbor_select_count)]
 async fn batch_neighbors_both_chunk_boundary() {
     let store = setup_memory_store();
 

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -510,6 +510,120 @@ async fn test_neighbors_both_directions_reciprocal_equal_weight_limit_is_determi
     }
 }
 
+/// Forward-regression contract for `neighbors_both_directions`'s pre-`LIMIT`
+/// tie-break order: `weight DESC, node_id ASC, CASE dir WHEN 'out' THEN 0 ELSE
+/// 1 END ASC, edge_id ASC`. Four edges tie on `(weight, node_id)` — two Out
+/// and two In, all to/from the same neighbor — with edge_ids chosen so every
+/// Out edge_id sorts below every In edge_id, and inserted in an order that
+/// does not match the expected result order. That means neither the
+/// direction rank nor the `edge_id` tie-break can be satisfied by accidental
+/// insertion-order preservation: only the explicit `ORDER BY` can produce the
+/// sequence asserted below. A future change that reverses the direction rank
+/// (`in` before `out`) or flips `edge_id ASC` to `DESC` yields a different
+/// sequence than the one asserted here for either component, so this test
+/// fails the moment either tie-break regresses.
+///
+/// The two edges sharing a direction use different relations (`Extends` /
+/// `DependsOn`) purely to satisfy the storage layer's
+/// `(namespace, source_id, target_id, relation)` uniqueness constraint — a
+/// second edge with the same relation between the same ordered pair upserts
+/// onto the first rather than creating a second row. The relation choice is
+/// not part of the ordering contract under test.
+///
+/// `#[serial(neighbor_select_count)]`: see note on `test_neighbors_outbound`.
+#[tokio::test]
+#[serial(neighbor_select_count)]
+async fn test_neighbors_both_directions_direction_then_edge_id_is_a_forward_contract() {
+    let store = setup_memory_store();
+
+    let centre = Uuid::new_v4();
+    let other = Uuid::new_v4();
+
+    let out_lo: Uuid = "00000000-0000-0000-0000-000000000001".parse().unwrap();
+    let out_hi: Uuid = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+    let in_lo: Uuid = "00000000-0000-0000-0000-000000000003".parse().unwrap();
+    let in_hi: Uuid = "00000000-0000-0000-0000-000000000004".parse().unwrap();
+
+    // Inserted out of both the weight/direction tie-break order and the
+    // edge_id order, so nothing about the asserted sequence below can pass
+    // by coincidentally preserving insertion order.
+    for (id, source, target, relation) in [
+        (in_lo, other, centre, EdgeRelation::Extends),
+        (out_hi, centre, other, EdgeRelation::DependsOn),
+        (in_hi, other, centre, EdgeRelation::DependsOn),
+        (out_lo, centre, other, EdgeRelation::Extends),
+    ] {
+        let now = Utc::now();
+        store
+            .upsert_edge(Edge {
+                id: id.into(),
+                namespace: "default".to_string(),
+                source_id: source,
+                target_id: target,
+                relation,
+                weight: 0.5,
+                created_at: now,
+                updated_at: now,
+                deleted_at: None,
+                metadata: None,
+                target_backend: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let query = NeighborQuery {
+        direction: Direction::Both,
+        relations: None,
+        limit: None,
+        min_weight: None,
+    };
+
+    let unlimited = store
+        .neighbors_both_directions(centre, query)
+        .await
+        .unwrap();
+
+    let observed: Vec<(Direction, Uuid)> = unlimited
+        .iter()
+        .map(|h| (h.direction.clone(), h.hit.edge_id))
+        .collect();
+    assert_eq!(
+        observed,
+        vec![
+            (Direction::Out, out_lo),
+            (Direction::Out, out_hi),
+            (Direction::In, in_lo),
+            (Direction::In, in_hi),
+        ],
+        "tied (weight, node_id) rows must order Out-before-In, then edge_id ASC within each direction"
+    );
+
+    // The storage layer applies `LIMIT` to this pre-sorted order (the runtime
+    // caller only re-sorts after `LIMIT` has already truncated), so survivors
+    // under a narrowing limit must be a prefix of the sequence above, not an
+    // arbitrary 2-of-4 subset.
+    let limited_query = NeighborQuery {
+        direction: Direction::Both,
+        relations: None,
+        limit: Some(2),
+        min_weight: None,
+    };
+    let limited = store
+        .neighbors_both_directions(centre, limited_query)
+        .await
+        .unwrap();
+    let limited_observed: Vec<(Direction, Uuid)> = limited
+        .iter()
+        .map(|h| (h.direction.clone(), h.hit.edge_id))
+        .collect();
+    assert_eq!(
+        limited_observed,
+        vec![(Direction::Out, out_lo), (Direction::Out, out_hi)],
+        "limit=2 must keep exactly the first two rows of the deterministic order, both Out"
+    );
+}
+
 #[tokio::test]
 async fn test_traverse_depth_2() {
     let store = setup_memory_store();

--- a/crates/khive-pack-kg/src/handlers/context.rs
+++ b/crates/khive-pack-kg/src/handlers/context.rs
@@ -1,13 +1,14 @@
 //! `context` verb handler (ADR-089): entity-anchored graph context in one call.
 //!
 //! Composes `hybrid_search` (anchor selection from a query) and
-//! `neighbors_with_query` (bounded 1/2-hop expansion) — both runtime ops are
-//! reused unchanged. Two handler-local decisions fill gaps the runtime ops
-//! don't cover, documented at their call sites below:
-//!   1. `NeighborHit` carries no `direction` field (the storage-level query
-//!      does `source UNION ALL target` with no discriminator column), so
-//!      per-neighbor direction is reconstructed by issuing separate Out/In
-//!      calls when the effective direction is `Both`, then tagging results.
+//! `neighbors_with_query` / `neighbors_with_query_directed` (bounded 1/2-hop
+//! expansion) — both runtime ops are reused unchanged. Two handler-local
+//! decisions fill gaps the runtime ops don't cover, documented at their call
+//! sites below:
+//!   1. A plain `NeighborHit` carries no `direction` field, so an effective
+//!      direction of `Both` uses `neighbors_with_query_directed`, which fetches
+//!      both directions in a single storage query (`UNION ALL` with a
+//!      direction literal per arm) and returns each hit tagged `Out`/`In`.
 //!   2. Symmetric relations (`competes_with`, `composed_with`) force
 //!      `Direction::Both` inside `neighbors_with_query` regardless of the
 //!      direction requested (existing op behavior) — the handler mirrors
@@ -82,18 +83,9 @@ fn relations_all_symmetric(relations: Option<&[EdgeRelation]>) -> bool {
     }
 }
 
-fn cmp_weight_desc_id_asc(
-    a: &(Uuid, EdgeRelation, f64, &'static str),
-    b: &(Uuid, EdgeRelation, f64, &'static str),
-) -> std::cmp::Ordering {
-    b.2.partial_cmp(&a.2)
-        .unwrap_or(std::cmp::Ordering::Equal)
-        .then_with(|| a.0.cmp(&b.0))
-}
-
 /// Fetch up to `fanout` neighbors of `node_id`, each tagged with its actual
-/// direction relative to `node_id`. See module docs for why this composes
-/// two calls rather than trusting a `direction` field on `NeighborHit`.
+/// direction relative to `node_id`. See module docs for why this can't just
+/// trust a `direction` field on a plain `NeighborHit`.
 async fn fetch_directed_neighbors(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -161,42 +153,37 @@ async fn fetch_directed_neighbors(
                 .collect())
         }
         Direction::Both => {
-            let out_hits = runtime
-                .neighbors_with_query(
+            // Single UNION ALL query for both directions (ADR-089 context-verb
+            // optimization) instead of two separate direction-scoped calls —
+            // halves the storage neighbor SELECT count for this branch. The
+            // op already returns hits in global weight-descending,
+            // node_id-ascending order truncated to `fanout`, so no local
+            // re-sort/truncate is needed.
+            let hits = runtime
+                .neighbors_with_query_directed(
                     token,
                     node_id,
                     NeighborQuery {
-                        direction: Direction::Out,
-                        relations: relations_vec.clone(),
-                        limit: Some(fanout),
-                        min_weight: None,
-                    },
-                )
-                .await?;
-            let in_hits = runtime
-                .neighbors_with_query(
-                    token,
-                    node_id,
-                    NeighborQuery {
-                        direction: Direction::In,
+                        direction: Direction::Both,
                         relations: relations_vec,
                         limit: Some(fanout),
                         min_weight: None,
                     },
                 )
                 .await?;
-            let mut merged: Vec<(Uuid, EdgeRelation, f64, &'static str)> = out_hits
+            Ok(hits
                 .into_iter()
-                .map(|h| (h.node_id, h.relation, h.weight, "outgoing"))
-                .chain(
-                    in_hits
-                        .into_iter()
-                        .map(|h| (h.node_id, h.relation, h.weight, "incoming")),
-                )
-                .collect();
-            merged.sort_by(cmp_weight_desc_id_asc);
-            merged.truncate(fanout as usize);
-            Ok(merged)
+                .map(|(h, dir)| {
+                    // `neighbors_with_query_directed` only ever tags hits `Out`/`In`
+                    // (see `DirectedNeighborHit` doc comment) — `Both` never appears.
+                    let tag = if dir == Direction::Out {
+                        "outgoing"
+                    } else {
+                        "incoming"
+                    };
+                    (h.node_id, h.relation, h.weight, tag)
+                })
+                .collect())
         }
     }
 }
@@ -640,24 +627,6 @@ mod tests {
             EdgeRelation::CompetesWith,
             EdgeRelation::Extends
         ])));
-    }
-
-    #[test]
-    fn cmp_weight_desc_id_asc_orders_higher_weight_first() {
-        let hi = (Uuid::nil(), EdgeRelation::Extends, 0.9, "outgoing");
-        let lo = (Uuid::max(), EdgeRelation::Extends, 0.1, "outgoing");
-        assert_eq!(
-            cmp_weight_desc_id_asc(&hi, &lo),
-            std::cmp::Ordering::Less,
-            "higher weight must sort first"
-        );
-    }
-
-    #[test]
-    fn cmp_weight_desc_id_asc_ties_break_by_uuid_ascending() {
-        let a = (Uuid::nil(), EdgeRelation::Extends, 0.5, "outgoing");
-        let b = (Uuid::max(), EdgeRelation::Extends, 0.5, "outgoing");
-        assert_eq!(cmp_weight_desc_id_asc(&a, &b), std::cmp::Ordering::Less);
     }
 
     #[test]

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -9126,6 +9126,124 @@ async fn context_direction_outgoing_fanout_keeps_highest_weight_not_node_id_orde
 }
 
 #[tokio::test]
+async fn context_both_direction_mixed_weights_interleave_in_global_order() {
+    // ADR-089 context-verb optimization (single UNION ALL query for
+    // direction="both" expand, replacing two separate direction-scoped
+    // calls): outgoing and incoming edge weights interleave here so the
+    // assertion proves global post-union ordering (weight DESC, node_id ASC
+    // tiebreak) rather than "all outgoing, then all incoming" branch order.
+    let pack = pack();
+    let a = pack
+        .dispatch(
+            "create",
+            json!({"kind": "entity", "name": "CtxBothA", "entity_kind": "concept"}),
+        )
+        .await
+        .expect("create A");
+    let a_id = a["id"].as_str().unwrap().to_string();
+
+    let mut out_ids = Vec::new();
+    for (i, w) in [0.9, 0.5].into_iter().enumerate() {
+        let n = pack
+            .dispatch(
+                "create",
+                json!({"kind": "entity", "name": format!("CtxBothOut{i}"), "entity_kind": "concept"}),
+            )
+            .await
+            .expect("create outgoing neighbor");
+        let n_id = n["id"].as_str().unwrap().to_string();
+        pack.dispatch(
+            "link",
+            json!({"source_id": a_id, "target_id": n_id, "relation": "extends", "weight": w}),
+        )
+        .await
+        .expect("link A->neighbor");
+        out_ids.push((n_id, w));
+    }
+
+    let mut in_ids = Vec::new();
+    for (i, w) in [0.7, 0.2].into_iter().enumerate() {
+        let n = pack
+            .dispatch(
+                "create",
+                json!({"kind": "entity", "name": format!("CtxBothIn{i}"), "entity_kind": "concept"}),
+            )
+            .await
+            .expect("create incoming neighbor");
+        let n_id = n["id"].as_str().unwrap().to_string();
+        pack.dispatch(
+            "link",
+            json!({"source_id": n_id, "target_id": a_id, "relation": "extends", "weight": w}),
+        )
+        .await
+        .expect("link neighbor->A");
+        in_ids.push((n_id, w));
+    }
+
+    // Expected global order by weight DESC: 0.9(out), 0.7(in), 0.5(out), 0.2(in).
+    let expected_order = vec![
+        (out_ids[0].0.clone(), "outgoing"),
+        (in_ids[0].0.clone(), "incoming"),
+        (out_ids[1].0.clone(), "outgoing"),
+        (in_ids[1].0.clone(), "incoming"),
+    ];
+
+    let resp = pack
+        .dispatch(
+            "context",
+            json!({"entity_ids": [a_id], "hops": 1, "direction": "both", "fanout": 10}),
+        )
+        .await
+        .expect("context must succeed");
+    let neighbors = resp["anchors"][0]["neighbors"].as_array().unwrap();
+    assert_eq!(neighbors.len(), 4, "all four neighbors must be present");
+
+    let got: Vec<(String, String)> = neighbors
+        .iter()
+        .map(|n| {
+            (
+                n["id"].as_str().unwrap().to_string(),
+                n["direction"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let expected: Vec<(String, String)> = expected_order
+        .into_iter()
+        .map(|(id, dir)| (id, dir.to_string()))
+        .collect();
+    assert_eq!(
+        got, expected,
+        "direction=\"both\" must interleave outgoing/incoming by global weight DESC order, \
+         with each hit's real direction label preserved"
+    );
+
+    // Tight fanout must keep the top-K by GLOBAL weight, not per-direction top-K.
+    let resp_capped = pack
+        .dispatch(
+            "context",
+            json!({"entity_ids": [a_id], "hops": 1, "direction": "both", "fanout": 2}),
+        )
+        .await
+        .expect("context with fanout=2 must succeed");
+    let capped = resp_capped["anchors"][0]["neighbors"].as_array().unwrap();
+    assert_eq!(
+        capped.len(),
+        2,
+        "fanout=2 must cap at 2 across both directions"
+    );
+    assert_eq!(
+        capped[0]["id"], out_ids[0].0,
+        "highest-weight (outgoing) neighbor survives"
+    );
+    assert_eq!(
+        capped[1]["id"], in_ids[0].0,
+        "second-highest-weight (incoming) neighbor survives"
+    );
+    assert_eq!(capped[0]["direction"], "outgoing");
+    assert_eq!(capped[1]["direction"], "incoming");
+}
+
+#[tokio::test]
 async fn context_budget_truncation_sets_flag_and_dropped_counts() {
     let pack = pack();
     let a = pack

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -214,6 +214,20 @@ fn normalize_symmetric_direction(
     }
 }
 
+/// Stable tie-break rank for [`Direction`] — `Out` before `In` — used to make
+/// the both-direction sort/dedup key total over self-loop edges. A self-loop
+/// (`source_id == target_id == node_id`) produces two `UNION ALL` rows with
+/// the same `(node_id, edge_id)` but opposite directions; without direction in
+/// the key, sort-then-dedup collapses them to one and drops the direction
+/// parity a separate `Out` call plus a separate `In` call would preserve.
+fn direction_sort_rank(direction: &Direction) -> u8 {
+    match direction {
+        Direction::Out => 0,
+        Direction::In => 1,
+        Direction::Both => 2,
+    }
+}
+
 fn note_title(note: &Note) -> Option<String> {
     note.name
         .clone()
@@ -1788,8 +1802,24 @@ impl KhiveRuntime {
                 .await?;
             hits.append(&mut ns_hits);
         }
-        hits.sort_by_key(|h| (h.hit.node_id, h.hit.edge_id));
-        hits.dedup_by_key(|h| (h.hit.node_id, h.hit.edge_id));
+        // Direction is part of the key (not just node_id/edge_id) so a
+        // self-loop's Out row and In row — same node_id and edge_id, opposite
+        // direction — sort adjacent but distinct and both survive dedup
+        // (internal review round 2, High).
+        hits.sort_by_key(|h| {
+            (
+                h.hit.node_id,
+                h.hit.edge_id,
+                direction_sort_rank(&h.direction),
+            )
+        });
+        hits.dedup_by_key(|h| {
+            (
+                h.hit.node_id,
+                h.hit.edge_id,
+                direction_sort_rank(&h.direction),
+            )
+        });
 
         let mut plain_hits: Vec<NeighborHit> = hits.iter().map(|h| h.hit.clone()).collect();
         self.enrich_neighbor_hits(token, &mut plain_hits).await;
@@ -1805,8 +1835,8 @@ impl KhiveRuntime {
         }
         // Same global weight-descending/node_id-ascending restore as
         // `neighbors_with_query` (ADR-089 context-verb review, internal review
-        // round 2, High) — the (node_id, edge_id) sort above exists only to
-        // make `dedup_by_key` adjacent-comparable.
+        // round 2, High) — the (node_id, edge_id, direction) sort above exists
+        // only to make `dedup_by_key` adjacent-comparable.
         hits.sort_by(|a, b| {
             b.hit
                 .weight
@@ -5244,6 +5274,71 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].node_id, b.id);
         assert_eq!(filtered[0].relation, EdgeRelation::Extends);
+    }
+
+    /// Self-loop direction parity (internal review round 2, High):
+    /// `neighbors_with_query_directed`'s post-merge dedup must not collapse a
+    /// self-loop edge's Out row and In row into one — they share `(node_id,
+    /// edge_id)` but are opposite directions, matching what a separate `Out`
+    /// call plus a separate `In` call would return for the same edge. The
+    /// self-loop edge is inserted directly through the graph store (`link()`
+    /// rejects source_id == target_id) to exercise the merge/dedup path.
+    #[tokio::test]
+    async fn neighbors_with_query_directed_preserves_self_loop_direction_parity() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let centre = rt
+            .create_entity(&tok, "concept", None, "Centre", None, None, vec![])
+            .await
+            .unwrap();
+
+        let now = chrono::Utc::now();
+        rt.graph(&tok)
+            .unwrap()
+            .upsert_edge(Edge {
+                id: LinkId::from(Uuid::new_v4()),
+                namespace: "local".to_string(),
+                source_id: centre.id,
+                target_id: centre.id,
+                relation: EdgeRelation::Extends,
+                weight: 0.7,
+                created_at: now,
+                updated_at: now,
+                deleted_at: None,
+                metadata: None,
+                target_backend: None,
+            })
+            .await
+            .unwrap();
+
+        let directed = rt
+            .neighbors_with_query_directed(
+                &tok,
+                centre.id,
+                NeighborQuery {
+                    direction: Direction::Both,
+                    relations: None,
+                    limit: None,
+                    min_weight: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            directed.len(),
+            2,
+            "a self-loop edge must produce both an Out hit and an In hit, not one collapsed hit"
+        );
+        let directions: Vec<Direction> = directed.iter().map(|(_, d)| d.clone()).collect();
+        assert!(
+            directions.contains(&Direction::Out),
+            "self-loop must retain its Out-tagged hit"
+        );
+        assert!(
+            directions.contains(&Direction::In),
+            "self-loop must retain its In-tagged hit"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -17,9 +17,9 @@ use uuid::Uuid;
 use khive_score::DeterministicScore;
 use khive_storage::note::Note;
 use khive_storage::types::{
-    BatchWriteSummary, DeleteMode, Direction, EdgeSortField, GraphPath, LinkId, NeighborHit,
-    NeighborQuery, Page, PageRequest, SortOrder, SqlRow, SqlStatement, SqlValue, TextFilter,
-    TextQueryMode, TextSearchRequest, TraversalRequest,
+    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, EdgeSortField, GraphPath,
+    LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortOrder, SqlRow, SqlStatement,
+    SqlValue, TextFilter, TextQueryMode, TextSearchRequest, TraversalRequest,
 };
 use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
@@ -1758,6 +1758,63 @@ impl KhiveRuntime {
                 .then(a.node_id.cmp(&b.node_id))
         });
         Ok(hits)
+    }
+
+    /// Get both-direction neighbors, each tagged with the direction (`Out`/
+    /// `In`) it was found in, via a single storage query per visible
+    /// namespace instead of two separate direction-scoped `neighbors_with_query`
+    /// calls (ADR-089 context-verb optimization — halves the neighbor SELECT
+    /// count for `context(direction="both")` expansion). `query.direction` is
+    /// ignored — always both.
+    ///
+    /// Mirrors `neighbors_with_query`'s dedup/enrich/soft-delete-filter/order
+    /// pipeline exactly, carrying the per-hit direction tag through unchanged.
+    pub async fn neighbors_with_query_directed(
+        &self,
+        token: &NamespaceToken,
+        node_id: Uuid,
+        query: NeighborQuery,
+    ) -> RuntimeResult<Vec<(NeighborHit, Direction)>> {
+        if !self.substrate_exists_in_ns(token, node_id).await? {
+            return Ok(Vec::new());
+        }
+
+        let mut hits: Vec<DirectedNeighborHit> = Vec::new();
+        for ns in token.visible_namespaces() {
+            let temp = NamespaceToken::for_namespace(ns.clone());
+            let mut ns_hits = self
+                .graph(&temp)?
+                .neighbors_both_directions(node_id, query.clone())
+                .await?;
+            hits.append(&mut ns_hits);
+        }
+        hits.sort_by_key(|h| (h.hit.node_id, h.hit.edge_id));
+        hits.dedup_by_key(|h| (h.hit.node_id, h.hit.edge_id));
+
+        let mut plain_hits: Vec<NeighborHit> = hits.iter().map(|h| h.hit.clone()).collect();
+        self.enrich_neighbor_hits(token, &mut plain_hits).await;
+        for (dh, enriched) in hits.iter_mut().zip(plain_hits) {
+            dh.hit = enriched;
+        }
+
+        // Filter out soft-deleted entity nodes (Fix 2).
+        let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.hit.node_id).collect();
+        let deleted = self.deleted_entity_ids(candidate_ids).await;
+        if !deleted.is_empty() {
+            hits.retain(|h| !deleted.contains(&h.hit.node_id));
+        }
+        // Same global weight-descending/node_id-ascending restore as
+        // `neighbors_with_query` (ADR-089 context-verb review, internal review
+        // round 2, High) — the (node_id, edge_id) sort above exists only to
+        // make `dedup_by_key` adjacent-comparable.
+        hits.sort_by(|a, b| {
+            b.hit
+                .weight
+                .partial_cmp(&a.hit.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.hit.node_id.cmp(&b.hit.node_id))
+        });
+        Ok(hits.into_iter().map(|h| (h.hit, h.direction)).collect())
     }
 
     /// Traverse the graph from a set of root nodes.

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -4,8 +4,9 @@ use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::types::{
-    BatchWriteSummary, DeleteMode, Edge, EdgeFilter, EdgeSortField, GraphPath, LinkId, NeighborHit,
-    NeighborQuery, Page, PageRequest, SortOrder, StorageResult, TraversalRequest,
+    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField,
+    GraphPath, LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortOrder, StorageResult,
+    TraversalRequest,
 };
 
 /// Directed edge CRUD and graph traversal over the knowledge graph.
@@ -37,6 +38,40 @@ pub trait GraphStore: Send + Sync + 'static {
         node_id: Uuid,
         query: NeighborQuery,
     ) -> StorageResult<Vec<NeighborHit>>;
+    /// Return neighbors in BOTH directions in a single call, each tagged with
+    /// the direction (`Out`/`In`) it was found in. `query.direction` is
+    /// ignored — this always fetches both directions.
+    ///
+    /// Exists so a caller that needs both-direction neighbors labeled by
+    /// direction (e.g. the `context` verb) can do so with one storage query
+    /// instead of two separate direction-scoped `neighbors` calls. The
+    /// default implementation preserves the original two-call behavior for
+    /// backends that don't override it; `SqlGraphStore` overrides this with a
+    /// single `UNION ALL` query that projects a direction literal per arm.
+    async fn neighbors_both_directions(
+        &self,
+        node_id: Uuid,
+        query: NeighborQuery,
+    ) -> StorageResult<Vec<DirectedNeighborHit>> {
+        let mut out_query = query.clone();
+        out_query.direction = Direction::Out;
+        let mut in_query = query;
+        in_query.direction = Direction::In;
+        let mut result = Vec::new();
+        for hit in self.neighbors(node_id, out_query).await? {
+            result.push(DirectedNeighborHit {
+                hit,
+                direction: Direction::Out,
+            });
+        }
+        for hit in self.neighbors(node_id, in_query).await? {
+            result.push(DirectedNeighborHit {
+                hit,
+                direction: Direction::In,
+            });
+        }
+        Ok(result)
+    }
     /// Fetch multiple edges by their link IDs in a single round-trip.
     ///
     /// IDs that are not found (absent or soft-deleted) are silently skipped;

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -29,14 +29,14 @@ pub use types::StorageResult;
 pub use vectors::VectorStore;
 
 pub use types::{
-    BatchWriteSummary, DeleteMode, Direction, Edge, EdgeFilter, EdgeSortField, GraphPath,
-    IndexRebuildScope, LinkId, NeighborHit, NeighborQuery, OrphanSweepConfig, OrphanSweepResult,
-    Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SortDirection, SortOrder,
-    SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlIsolation, SqlRow,
-    SqlStatement, SqlTxOptions, SqlValue, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
-    TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
-    TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest, VectorIndexKind,
-    VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
+    BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField,
+    GraphPath, IndexRebuildScope, LinkId, NeighborHit, NeighborQuery, OrphanSweepConfig,
+    OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SortDirection,
+    SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlIsolation,
+    SqlRow, SqlStatement, SqlTxOptions, SqlValue, TextDocument, TextFilter, TextGatherMode,
+    TextIndexStats, TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest,
+    TextTermStats, TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest,
+    VectorIndexKind, VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
     VectorStoreCapabilities, VectorStoreInfo, MAX_SPARSE_SEARCH_TOP_K,
 };
 

--- a/crates/khive-storage/src/types/graph.rs
+++ b/crates/khive-storage/src/types/graph.rs
@@ -287,6 +287,18 @@ pub struct NeighborHit {
     pub entity_type: Option<String>,
 }
 
+/// A [`NeighborHit`] tagged with the direction it was found in, relative to
+/// the queried node. Returned by [`crate::GraphStore::neighbors_both_directions`],
+/// which fetches both directions in a single `UNION ALL` query instead of two
+/// separate direction-scoped calls — the tag lets a caller (e.g. the `context`
+/// verb) label each hit `outgoing`/`incoming` without paying for the second
+/// query. Only `Direction::Out` and `Direction::In` are ever populated here.
+#[derive(Clone, Debug)]
+pub struct DirectedNeighborHit {
+    pub hit: NeighborHit,
+    pub direction: Direction,
+}
+
 /// Raw deserialization target for [`TraversalOptions`].
 #[derive(Deserialize)]
 struct TraversalOptionsRaw {

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -13,8 +13,9 @@ use crate::error::StorageError;
 pub type StorageResult<T> = Result<T, StorageError>;
 
 pub use graph::{
-    Direction, Edge, EdgeFilter, EdgeSortField, GraphPath, LinkId, NeighborHit, NeighborQuery,
-    PathNode, SortDirection, SortOrder, TimeRange, TraversalOptions, TraversalRequest,
+    DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField, GraphPath, LinkId,
+    NeighborHit, NeighborQuery, PathNode, SortDirection, SortOrder, TimeRange, TraversalOptions,
+    TraversalRequest,
 };
 pub use pagination::{Page, PageRequest};
 pub use sparse::{


### PR DESCRIPTION
## Summary

The `context` verb's entity-anchored graph expansion (`crates/khive-pack-kg/src/handlers/context.rs`) issues a bounded 1/2-hop neighbor lookup for every anchor and hop-1 parent. When the effective direction is `both` (the default), the expansion previously issued **two** storage neighbor SELECTs per expanded node per visible namespace — one outgoing, one incoming — purely so each hit could be tagged `"outgoing"`/`"incoming"` in the response, since the plain neighbor-hit type carries no direction field.

The storage layer already has a single `UNION ALL` query that covers both directions in one SELECT (used by the `neighbors` and `traverse` verbs), so the second query was pure waste: `2 * expanded_nodes * visible_namespaces` SELECTs where `1 *` suffices.

## Change

- `GraphStore::neighbors_both_directions` (new trait method, default impl on the storage trait): returns both-direction neighbors tagged with the direction (`Out`/`In`) each hit was found in. The default implementation composes two `neighbors` calls (preserving behavior for any future backend that doesn't override it); the SQLite backend overrides it with a single `UNION ALL` query that projects an `'out'`/`'in'` literal from each arm, keeping the existing `ORDER BY weight DESC, node_id ASC` applied globally before `LIMIT`.
- `KhiveRuntime::neighbors_with_query_directed`: mirrors the existing `neighbors_with_query` dedup/enrich/soft-delete-filter/order pipeline, but over the newly tagged hits, preserving the direction through to the caller.
- `context`'s `fetch_directed_neighbors` now calls `neighbors_with_query_directed` once for the `Direction::Both` branch instead of issuing two direction-scoped calls and merging/truncating the results locally (the runtime op already returns the globally-ordered, truncated result).
- A shared `neighbor_extra_clause` helper factors out the relation/weight filter and `LIMIT` clause building that both the single-direction and both-direction SQL queries need, avoiding duplicating that logic.

Removed `context.rs`'s now-dead local `cmp_weight_desc_id_asc` merge/sort helper (and its two unit tests) — sorting/truncation is done by the runtime op now.

## Query count

For a `context(direction="both")` expand: **`2 * N * V` → `1 * N * V`** storage neighbor SELECTs, where `N` = expanded nodes (anchors + hop-1 parents when `hops=2`) and `V` = visible namespaces.

## Correctness tests added

- `khive-db/src/stores/graph_tests.rs`:
  - `test_neighbors_both_directions_matches_two_separate_calls_and_order` — interleaved outgoing/incoming weights prove **global** post-union ordering (not per-branch order), and the combined result set matches the union of two separate direction-scoped `neighbors()` calls.
  - `test_neighbors_both_directions_limit_keeps_global_top_k` — a narrowing `limit` keeps the global top-K across both directions.
  - `test_neighbors_both_directions_halves_storage_query_count` — count-falsifiable A/B proof: one `neighbors_both_directions` call issues exactly 1 storage SELECT (via a `#[cfg(test)]`-only counter), versus 2 for the old pattern of separate `Out`+`In` calls.
- `khive-pack-kg/tests/integration.rs`:
  - `context_both_direction_mixed_weights_interleave_in_global_order` — end-to-end through the `context` verb: interleaved outgoing/incoming weights, asserts global weight-descending order with correct `"outgoing"`/`"incoming"` labels, and that a tight `fanout` keeps the global (not per-direction) top-K.
  - Existing tests already covered direction-label preservation on the outgoing-only, both-default, and symmetric-relation (`"both"` tag) paths; all still pass unchanged.

## Gate output (scoped to affected crates, run from `crates/`)

```
$ cargo check -p khive-pack-kg -p khive-runtime -p khive-db -p khive-storage
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.10s

$ cargo clippy -p khive-pack-kg -p khive-runtime -p khive-db -p khive-storage --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.08s

$ cargo fmt --all -- --check
(clean, no diff)

$ cargo test -p khive-pack-kg -p khive-runtime -p khive-db
test result: ok. 227 passed; 0 failed
test result: ok. 14 passed; 0 failed
test result: ok. 147 passed; 0 failed
test result: ok. 5 passed; 0 failed
test result: ok. 3 passed; 0 failed
test result: ok. 209 passed; 0 failed
test result: ok. 11 passed; 0 failed
test result: ok. 583 passed; 0 failed; 5 ignored
test result: ok. 59 passed; 0 failed
```

All green.

## Test plan

- [x] `cargo check` on affected crates
- [x] `cargo clippy --all-targets -- -D warnings` on affected crates
- [x] `cargo fmt --all -- --check`
- [x] `cargo test` on affected crates (all suites pass, 0 failed)
- [x] New correctness tests for order parity, direction-label preservation, and the query-count halving

🤖 Generated with [Claude Code](https://claude.com/claude-code)