### PR TITLE
chore(ci): run rustdoc doc-build (-D warnings) in scripts/ci.sh

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -33,6 +33,12 @@ cargo clippy --manifest-path "$SCRIPT_DIR/../crates/khive-merge/Cargo.toml" --li
 echo "=== Clippy ==="
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+echo "=== Doc Build (-D warnings) ==="
+# Mirrors the "Doc build" CI job (.github/workflows/ci.yml): intra-doc link
+# breakage and other rustdoc lints are a distinct gate that check/clippy/test
+# do not cover.
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+
 echo "=== Tests ==="
 cargo test --workspace
 


### PR DESCRIPTION
## What

Add the rustdoc doc-build gate to `scripts/ci.sh` so `make ci` runs it locally.

## Why

The `Doc build (-D warnings)` GitHub Actions job runs
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`, but
`scripts/ci.sh` (the target of `make ci`) did not. That gap let a change pass
the full local gate (check + clippy + test + build) while still failing
doc-build on CI — for example a private intra-doc link from a public doc
comment, which only rustdoc's `-D rustdoc::private-intra-doc-links` flags.

## Change

One additive step after the Clippy step, invoking the exact command from
`.github/workflows/ci.yml`. Verified locally: `sh -n scripts/ci.sh` parses;
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` runs green on the
current workspace.