### PR TITLE
refactor(runtime): centralize db-path anchor resolution

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1358,14 +1358,7 @@ pub struct RuntimeConfigInputs<'a> {
 /// default/env model set while the MCP server serves recall from the
 /// config-file `[[engines]]` set.
 pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result<RuntimeConfig> {
-    let db_path = match inputs.db {
-        Some(":memory:") => None,
-        Some(path) => Some(PathBuf::from(path)),
-        None => {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-            Some(PathBuf::from(format!("{home}/.khive/khive.db")))
-        }
-    };
+    let db_path = khive_runtime::resolve_db_anchor(inputs.db);
 
     let packs = inputs
         .packs

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -333,6 +333,28 @@ impl Default for RuntimeConfig {
     }
 }
 
+/// Resolve the `--db`/`KHIVE_DB` value into the db path used to ANCHOR tier-3
+/// project-local `.khive/config.toml` discovery (`KhiveConfig::load_with_home_fallback`'s
+/// `db_path` parameter), mirroring the precedence `kkernel mcp` and the MCP server use to
+/// open the database itself: `:memory:` has no file to anchor on (`None`); an explicit path
+/// anchors on that path; an unset value anchors on the default `$HOME/.khive/khive.db`.
+///
+/// This is distinct from a plain override resolver that answers "does the caller want to
+/// override `RuntimeConfig::default().db_path`?" (2-arm, `None` meaning "keep the default").
+/// `resolve_db_anchor` always resolves to a concrete anchor value (3-arm) — it materializes
+/// the same default `RuntimeConfig::default()` would apply, rather than asking whether to
+/// override it.
+pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
+    match db {
+        Some(":memory:") => None,
+        Some(path) => Some(std::path::PathBuf::from(path)),
+        None => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+            Some(std::path::PathBuf::from(format!("{home}/.khive/khive.db")))
+        }
+    }
+}
+
 // ---- Embedding model helpers ----
 
 /// Sanitize an embedding model name into a valid SQL table suffix.
@@ -548,5 +570,30 @@ pub(crate) fn parse_embedding_model_alias(name: &str) -> Option<EmbeddingModel> 
     match normalized.as_str() {
         "paraphrase" => Some(EmbeddingModel::ParaphraseMultilingualMiniLmL12V2),
         _ => normalized.parse().ok(),
+    }
+}
+
+#[cfg(test)]
+mod resolve_db_anchor_tests {
+    use super::resolve_db_anchor;
+
+    #[test]
+    fn memory_sentinel_maps_to_none() {
+        assert_eq!(resolve_db_anchor(Some(":memory:")), None);
+    }
+
+    #[test]
+    fn explicit_path_maps_to_some() {
+        assert_eq!(
+            resolve_db_anchor(Some("/tmp/khive-anchor-test.db")),
+            Some(std::path::PathBuf::from("/tmp/khive-anchor-test.db"))
+        );
+    }
+
+    #[test]
+    fn absent_maps_to_home_default() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        let expected = std::path::PathBuf::from(format!("{home}/.khive/khive.db"));
+        assert_eq!(resolve_db_anchor(None), Some(expected));
     }
 }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -74,8 +74,8 @@ pub use presentation::{
 pub use registry::{ObjectiveRegistry, RegisteredObjective};
 pub use retrieval::{SearchHit, SearchSource};
 pub use runtime::{
-    parse_pack_list, runtime_config_from_khive_config, BackendId, EntityTypeValidatorFn,
-    KhiveRuntime, NamespaceToken, RuntimeConfig,
+    parse_pack_list, resolve_db_anchor, runtime_config_from_khive_config, BackendId,
+    EntityTypeValidatorFn, KhiveRuntime, NamespaceToken, RuntimeConfig,
 };
 pub use secret_gate::SecretMatch;
 pub use validation::{

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -29,7 +29,8 @@ pub type EntityTypeValidatorFn =
     Arc<dyn Fn(&str, Option<&str>) -> Result<Option<String>, RuntimeError> + Send + Sync>;
 
 pub use crate::config::{
-    parse_pack_list, runtime_config_from_khive_config, BackendId, NamespaceToken, RuntimeConfig,
+    parse_pack_list, resolve_db_anchor, runtime_config_from_khive_config, BackendId,
+    NamespaceToken, RuntimeConfig,
 };
 
 // ---- KhiveRuntime ----

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -242,14 +242,7 @@ async fn main() -> Result<()> {
             // uses. Anchoring only the explicit case and leaving the default case on
             // the process cwd would let this branch select a different topology than
             // the config the server actually resolves further down this path.
-            let db_path_hint: Option<std::path::PathBuf> = match a.db.as_deref() {
-                Some(":memory:") => None,
-                Some(p) => Some(std::path::PathBuf::from(p)),
-                None => {
-                    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-                    Some(std::path::PathBuf::from(format!("{home}/.khive/khive.db")))
-                }
-            };
+            let db_path_hint = khive_runtime::resolve_db_anchor(a.db.as_deref());
             let khive_cfg =
                 KhiveConfig::load_with_home_fallback(a.config.as_deref(), db_path_hint.as_deref())
                     .unwrap_or_default()


### PR DESCRIPTION
## Summary

- Extracts a duplicated 3-arm db-path precedence match (`:memory:` -> in-memory / explicit path -> that path / unset -> default `~/.khive/khive.db`) into one shared `khive_runtime::resolve_db_anchor(db: Option<&str>) -> Option<PathBuf>` function in `crates/khive-runtime/src/config.rs`.
- Replaces two hand-copied inline implementations of the same match expression with calls to the shared function:
  - `crates/khive-mcp/src/serve.rs` (`resolve_runtime_config`), which uses this value to anchor tier-3 project-local `.khive/config.toml` discovery to the resolved database's directory.
  - `crates/kkernel/src/main.rs` (the `mcp` subcommand entrypoint), which needs the same anchor for an early multi-backend classification check before server assembly.
- Behavior-preserving: verified both original call sites produced byte-identical logic across all three precedence arms (`:memory:`, explicit path, unset) before collapsing them into the shared function.

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo check -p khive-runtime -p khive-mcp` — pass
- [x] `cargo clippy -p khive-runtime -p khive-mcp --all-targets -- -D warnings` — pass, zero warnings
- [x] `cargo test -p khive-runtime -p khive-mcp` — all suites pass (khive-mcp: 110 unit + 59 integration; khive-runtime: 591 unit + 59 integration), including 3 new unit tests for `resolve_db_anchor` covering the `:memory:`, explicit-path, and default-home-path arms
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-runtime -p khive-mcp` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)