### PR TITLE
test(db): serialize pool-config defaults test to remove env-var race

### DIFF
--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -620,6 +620,7 @@ mod tests {
     use serial_test::serial;
 
     #[test]
+    #[serial]
     fn pool_config_default_values_match_constants() {
         // Ensure defaults are not accidentally changed.
         let cfg = PoolConfig::default();


### PR DESCRIPTION
## Summary

`crates/khive-db/src/pool.rs` had an intermittent test race that surfaced in the coverage CI job:

- `pool_config_default_values_match_constants` reads `PoolConfig::default()` and asserts its fields equal hardcoded default constants (e.g. `busy_timeout == Duration::from_secs(30)`). It was **not** marked `#[serial]`.
- Five sibling tests (`pool_config_env_override_busy_timeout`, `pool_config_env_override_checkout_timeout`, `pool_config_env_override_wal_autocheckpoint`, `pool_config_env_override_journal_size_limit`, `pool_config_env_invalid_falls_back_to_default`) are all `#[serial]` and mutate process-global env vars (`KHIVE_BUSY_TIMEOUT_SECS`, `KHIVE_CHECKOUT_TIMEOUT_SECS`, `KHIVE_WAL_AUTOCHECKPOINT_PAGES`, `KHIVE_JOURNAL_SIZE_LIMIT_BYTES`) around their own `PoolConfig::default()` reads.

`serial_test`'s `#[serial]` attribute only serializes tests within the same serial "set" — it does not implicitly include unmarked tests. Because the defaults test wasn't in that set, it could run concurrently with an env-mutating sibling and observe an overridden value mid-flight (e.g. `KHIVE_BUSY_TIMEOUT_SECS=60` set by another thread), producing a nondeterministic assertion failure against the hardcoded constant.

## Fix

One-attribute change: add `#[serial]` to `pool_config_default_values_match_constants`, matching the pattern already used by every other test in the module that touches these env vars or reads defaults sensitive to them. No production code changed.

## Test plan

- [x] `cargo test -p khive-db pool::tests -- --test-threads=8`, run 5x in a loop — all green each time (10/10 tests passing per run)
- [x] `cargo test -p khive-db` (full crate) — 200 + 10 contract tests passed, 0 failed
- [x] `cargo fmt -p khive-db -- --check` — exit 0
- [x] `cargo clippy -p khive-db --all-targets -- -D warnings` — exit 0