### PR TITLE
feat(runtime,mcp,kkernel): per-request identity over one warm daemon registry (ADR-096 Fork 1)

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -196,6 +196,7 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         format: Option<String>,
         format_per_op: Option<Vec<Option<String>>>,
         from_wire: bool,
+        identity: Option<khive_runtime::RequestIdentity>,
     ) -> Result<String, String> {
         let params = RequestParams {
             ops,
@@ -207,7 +208,11 @@ impl daemon::DaemonDispatch for crate::server::KhiveMcpServer {
         };
         // Honor the frame's origin: a wire-origin request enforces verb
         // visibility even when served by the daemon; an operator request does not.
-        self.dispatch_request_inner(params, from_wire)
+        // `identity` (ADR-096 Fork 1) is the caller's per-request identity
+        // context, built by `handle_conn` from the frame — threaded straight
+        // through so this call serves under the CALLER's namespace/actor
+        // rather than this server's own construction-baked identity.
+        self.dispatch_request_inner(params, from_wire, identity)
             .await
             .map_err(|e| e.message.to_string())
     }
@@ -614,6 +619,11 @@ async fn probe_daemon_identity(config_id: &str, namespace: &str, timeout_ms: u64
         presentation: None,
         presentation_per_op: None,
         namespace: namespace.to_string(),
+        // A probe never reaches the identity-context / dispatch arm (it
+        // short-circuits on `probe_only` right after the protocol/config_id
+        // checks), so no per-request identity is meaningful here.
+        actor_id: None,
+        visible_namespaces: Vec::new(),
         config_id: config_id.to_string(),
         protocol_version: PROTOCOL_VERSION,
         probe_only: true,
@@ -1032,6 +1042,24 @@ mod tests {
         crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+brain")
     }
 
+    /// Server whose pack set includes `comm`, whose `send` verb echoes the
+    /// dispatching actor directly in its JSON response (`"from": from_actor`,
+    /// where `from_actor = token.actor().id`). Used to verify per-request
+    /// actor stamping (ADR-096 Fork 1) without a readback/inbox round-trip.
+    fn make_comm_test_server(actor_id: Option<&str>) -> crate::server::KhiveMcpServer {
+        let config = RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::parse("test").unwrap(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "comm".to_string()],
+            actor_id: actor_id.map(str::to_string),
+            ..RuntimeConfig::default()
+        };
+        let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
+        crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+comm")
+    }
+
     fn clear_daemon_env() {
         std::env::remove_var("KHIVE_SOCKET");
         std::env::remove_var("KHIVE_PID");
@@ -1397,6 +1425,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: "test".to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1420,7 +1450,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn daemon_round_trip_dispatches_and_enforces_namespace() {
+    async fn daemon_round_trip_dispatches_and_enforces_config_id() {
         clear_daemon_env();
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("khived.sock");
@@ -1446,6 +1476,8 @@ mod tests {
             presentation: Some("verbose".to_string()),
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.clone(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1479,12 +1511,17 @@ mod tests {
         assert_eq!(resp.result.as_deref(), Some(reference_result.as_str()));
         assert!(reference_result.contains("\"entities\""));
 
-        // (b) different namespace → namespace_mismatch (config matches)
+        // (b) ADR-096 Fork 1: a different namespace, same config_id, is no
+        // longer rejected — the daemon accepts and serves the request under
+        // the frame's OWN namespace ("other") over the same shared warm
+        // registry, instead of setting `namespace_mismatch`.
         let other = DaemonRequestFrame {
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
             namespace: "other".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.clone(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1493,16 +1530,33 @@ mod tests {
             from_wire: false,
         };
         let resp_other = exchange(&sock, &other).await;
-        assert!(resp_other.namespace_mismatch);
-        assert!(!resp_other.ok);
+        assert!(
+            resp_other.ok,
+            "a differently-namespaced frame with a matching config_id must be \
+             served, not rejected; error={:?}",
+            resp_other.error
+        );
+        assert!(
+            !resp_other.namespace_mismatch,
+            "ADR-096 Fork 1 removed the namespace_mismatch reject"
+        );
+        assert!(!resp_other.config_mismatch);
+        assert_eq!(
+            resp_other.served_config_id.as_deref(),
+            Some(config_id.as_str())
+        );
 
         // (c) same namespace but different config (e.g. a `--pack kg` client
-        // hitting the broader daemon) → config_mismatch, no dispatch.
+        // hitting the broader daemon) → config_mismatch, no dispatch. The
+        // config_id reject stays hard under ADR-096 Fork 1 — only the
+        // namespace reject was softened.
         let mismatched_config = DaemonRequestFrame {
             ops: "stats()".to_string(),
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: "packs=[kg];db=:memory:;embed=none;extra=[];backend=main".to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1524,6 +1578,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.clone(),
             protocol_version: 0,
             probe_only: false,
@@ -1565,6 +1621,136 @@ mod tests {
         clear_daemon_env();
     }
 
+    // ── ADR-096 Fork 1: per-request identity over one warm registry ──────────
+    //
+    // Core capability test: two requests carrying DIFFERENT frame namespaces
+    // AND DIFFERENT frame actors, dispatched against ONE already-running warm
+    // daemon, must both be served over the shared backend — and each write
+    // must be stamped with its OWN frame's actor, never the other request's
+    // and never a daemon-baked default. `comm.send` is the vehicle: its JSON
+    // response echoes the dispatching actor directly (`"from": from_actor`),
+    // so this needs no readback/inbox round-trip.
+    #[tokio::test]
+    #[serial]
+    async fn daemon_serves_per_request_identity_over_one_warm_registry() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid = dir.path().join("khived.pid");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        // No baked actor_id on the daemon-side server: every actor must come
+        // from the per-request frame, never a construction-time default.
+        let reference = make_comm_test_server(None);
+        let config_id = reference.config_id().to_string();
+        let daemon_server = reference.clone();
+
+        let handle = tokio::spawn(async move {
+            let _ = run_daemon(daemon_server).await;
+        });
+        let _ready = connect_when_ready(&sock).await;
+        drop(_ready);
+
+        let alice_frame = DaemonRequestFrame {
+            ops: "comm.send(to=\"bob\", content=\"hello from alice\")".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "alpha".to_string(),
+            actor_id: Some("alice".to_string()),
+            visible_namespaces: Vec::new(),
+            config_id: config_id.clone(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+        };
+        let bob_frame = DaemonRequestFrame {
+            ops: "comm.send(to=\"alice\", content=\"hello from bob\")".to_string(),
+            presentation: None,
+            presentation_per_op: None,
+            namespace: "beta".to_string(),
+            actor_id: Some("bob".to_string()),
+            visible_namespaces: Vec::new(),
+            config_id: config_id.clone(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+        };
+
+        let resp_alice = exchange(&sock, &alice_frame).await;
+        assert!(
+            resp_alice.ok,
+            "alice's request must be served over the shared warm registry; error={:?}",
+            resp_alice.error
+        );
+        assert!(!resp_alice.namespace_mismatch);
+        assert!(!resp_alice.config_mismatch);
+        let body_alice: serde_json::Value =
+            serde_json::from_str(resp_alice.result.as_deref().expect("alice result body"))
+                .expect("decode alice result json");
+        assert_eq!(
+            body_alice["results"][0]["result"]["from"], "alice",
+            "write dispatched under alice's frame must stamp actor=alice, got: {body_alice}"
+        );
+
+        let resp_bob = exchange(&sock, &bob_frame).await;
+        assert!(
+            resp_bob.ok,
+            "bob's request must be served over the SAME shared warm registry; error={:?}",
+            resp_bob.error
+        );
+        assert!(!resp_bob.namespace_mismatch);
+        assert!(!resp_bob.config_mismatch);
+        let body_bob: serde_json::Value =
+            serde_json::from_str(resp_bob.result.as_deref().expect("bob result body"))
+                .expect("decode bob result json");
+        assert_eq!(
+            body_bob["results"][0]["result"]["from"], "bob",
+            "write dispatched under bob's frame must stamp actor=bob, NOT cross-\
+             contaminated with alice's actor; got: {body_bob}"
+        );
+
+        handle.abort();
+        let _ = handle.await;
+        clear_daemon_env();
+    }
+
+    // Back-compat: a caller with NO per-request identity context (pure local
+    // dispatch, never touching the daemon socket) must keep using the
+    // server's own construction-baked actor_id, unaffected by the identity-
+    // override machinery introduced for daemon-forwarded requests.
+    #[tokio::test]
+    #[serial]
+    async fn local_dispatch_without_identity_context_uses_baked_actor() {
+        clear_daemon_env();
+
+        let server = make_comm_test_server(Some("baked-actor"));
+        let result = server
+            .dispatch_request_local(RequestParams {
+                ops: "comm.send(to=\"someone\", content=\"hello\")".to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            })
+            .await
+            .expect("local dispatch of comm.send must succeed");
+
+        let body: serde_json::Value =
+            serde_json::from_str(&result).expect("decode local dispatch result json");
+        assert_eq!(
+            body["results"][0]["result"]["from"], "baked-actor",
+            "local dispatch (no daemon, no identity context) must use the server's \
+             own baked actor_id, got: {body}"
+        );
+    }
+
     // ── daemon-forward wire-origin gate (security regression) ────────────────
     //
     // The agent-facing MCP `request` tool sets `from_wire=true` on its daemon
@@ -1599,6 +1785,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "braintest".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.clone(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1757,6 +1945,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -1861,6 +2051,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -2105,6 +2297,7 @@ mod tests {
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
             _from_wire: bool,
+            _identity: Option<khive_runtime::RequestIdentity>,
         ) -> Result<String, String> {
             // Return a string whose serialized DaemonResponseFrame JSON length
             // exceeds MAX_FRAME_BYTES.  The frame JSON overhead is ~200 bytes so
@@ -2164,6 +2357,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -2271,6 +2466,7 @@ mod tests {
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
             _from_wire: bool,
+            _identity: Option<khive_runtime::RequestIdentity>,
         ) -> Result<String, String> {
             DAEMON_DISPATCH.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok("{\"ok\":true,\"counted\":true}".to_string())
@@ -2380,6 +2576,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -2531,6 +2729,7 @@ mod tests {
             _format: Option<String>,
             _format_per_op: Option<Vec<Option<String>>>,
             _from_wire: bool,
+            _identity: Option<khive_runtime::RequestIdentity>,
         ) -> Result<String, String> {
             Err("forced dispatch error: verb returned an error for testing".to_string())
         }
@@ -2578,6 +2777,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -2672,6 +2873,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,
@@ -2748,6 +2951,8 @@ mod tests {
             presentation: None,
             presentation_per_op: None,
             namespace: "test".to_string(),
+            actor_id: None,
+            visible_namespaces: Vec::new(),
             config_id: config_id.to_string(),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -431,17 +431,26 @@ impl KhiveMcpServer {
     /// Result semantics mirror the per-op envelope from the registry:
     /// `Ok(Value)` → success payload (caller wraps in `{ok:true, tool, result}`).
     /// `Err((tool, error_value))` → error payload (caller wraps in `{ok:false, tool, error}`).
+    ///
+    /// `identity` mirrors the override [`Self::dispatch_op`] applies to the
+    /// registry path (ADR-096 Fork 1): when present, its namespace is used
+    /// instead of `self.default_namespace` so a per-request identity can't
+    /// diverge between the coordinator intercept and the registry dispatch
+    /// it falls through to.
     async fn dispatch_via_coordinator(
         &self,
         tool: &str,
         args_value: &Value,
+        identity: Option<&khive_runtime::RequestIdentity>,
     ) -> Option<Result<Value, (String, Value)>> {
         let coord = self.coordinator.as_ref()?;
         if coord.is_single_backend() {
             return None;
         }
-        dispatch_via_coordinator_inner(coord.as_ref(), tool, args_value, &self.default_namespace)
-            .await
+        let default_namespace = identity
+            .map(|id| id.namespace.as_str())
+            .unwrap_or(self.default_namespace.as_str());
+        dispatch_via_coordinator_inner(coord.as_ref(), tool, args_value, default_namespace).await
     }
 
     /// Namespace this server's registry was built for.
@@ -452,6 +461,23 @@ impl KhiveMcpServer {
     /// Fingerprint of the runtime config this server's registry was built for.
     pub fn config_id(&self) -> &str {
         &self.config_id
+    }
+
+    /// This server's resolved actor identity label, if configured (ADR-057).
+    ///
+    /// Read when building the daemon request frame (ADR-096 Fork 1) to carry
+    /// this server's own identity on the wire, so a warm daemon with a
+    /// different baked identity serves the request under this caller's
+    /// actor instead of the daemon's.
+    pub fn actor_id(&self) -> Option<&str> {
+        self.registry.actor_id()
+    }
+
+    /// This server's resolved extra read-visibility namespaces (ADR-007
+    /// Rev 4 Rule 3b). See [`Self::actor_id`] for why this is exposed
+    /// (ADR-096 Fork 1).
+    pub fn visible_namespaces(&self) -> &[khive_runtime::Namespace] {
+        self.registry.visible_namespaces()
     }
 
     /// The connection pool to use for background WAL checkpointing, if any.
@@ -504,6 +530,7 @@ impl KhiveMcpServer {
         op: ParsedOp,
         prev_result: Option<&Value>,
         from_wire: bool,
+        identity: Option<&khive_runtime::RequestIdentity>,
     ) -> Result<Value, (String, Value)> {
         let ParsedOp { tool, args } = op;
 
@@ -616,12 +643,19 @@ impl KhiveMcpServer {
 
         // Multi-backend interception: route link/search through the coordinator (ADR-029 D3/D4).
         // Single-backend and non-link/search verbs fall through to the registry unchanged.
-        if let Some(coord_result) = self.dispatch_via_coordinator(&tool, &args_value).await {
+        if let Some(coord_result) = self
+            .dispatch_via_coordinator(&tool, &args_value, identity)
+            .await
+        {
             return coord_result
                 .map(|result| json!({ "ok": true, "tool": tool, "result": result }));
         }
 
-        match self.registry.dispatch(&tool, args_value).await {
+        match self
+            .registry
+            .dispatch_with_identity(&tool, args_value, identity.cloned())
+            .await
+        {
             Ok(result) => Ok(json!({ "ok": true, "tool": tool, "result": result })),
             Err(RuntimeError::Khive(k)) => {
                 let error_payload = serde_json::to_value(&k)
@@ -659,6 +693,7 @@ impl KhiveMcpServer {
         presentation: PresentationMode,
         presentation_per_op: Option<Vec<Option<PresentationMode>>>,
         from_wire: bool,
+        identity: Option<&khive_runtime::RequestIdentity>,
     ) -> Value {
         let now_unix = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -703,6 +738,10 @@ impl KhiveMcpServer {
                 // Clone coordinator and namespace for use in the per-op closures (ADR-029 D3/D4).
                 let coordinator: Option<Arc<dyn CoordinatorService>> = self.coordinator.clone();
                 let default_namespace = self.default_namespace.clone();
+                // ADR-096 Fork 1: a per-request identity overrides the default
+                // namespace for both the coordinator intercept and the registry
+                // dispatch below, so the two can't drift out of sync per op.
+                let identity_owned: Option<khive_runtime::RequestIdentity> = identity.cloned();
 
                 // Independent dispatch — run all concurrently, results in input order.
                 let futures = ops.into_iter().enumerate().map(|(i, op)| {
@@ -717,7 +756,11 @@ impl KhiveMcpServer {
 
                     let registry = self.registry.clone();
                     let coord = coordinator.clone();
-                    let ns_str = default_namespace.clone();
+                    let ns_str = identity_owned
+                        .as_ref()
+                        .map(|id| id.namespace.clone())
+                        .unwrap_or_else(|| default_namespace.clone());
+                    let op_identity = identity_owned.clone();
                     let op_mode = mode_for_op(i);
                     async move {
                         let tool = op.tool.clone();
@@ -808,7 +851,10 @@ impl KhiveMcpServer {
                             }
                         }
 
-                        match registry.dispatch(&tool, args_value).await {
+                        match registry
+                            .dispatch_with_identity(&tool, args_value, op_identity)
+                            .await
+                        {
                             Ok(result) => {
                                 let presented = present(result, effective_mode, now_unix);
                                 json!({ "ok": true, "tool": tool, "result": presented })
@@ -860,7 +906,10 @@ impl KhiveMcpServer {
                     } else {
                         op_mode
                     };
-                    match self.dispatch_op(op, prev_result.as_ref(), from_wire).await {
+                    match self
+                        .dispatch_op(op, prev_result.as_ref(), from_wire, identity)
+                        .await
+                    {
                         Ok(result_obj) => {
                             // Extract canonical result for $prev (pre-presentation).
                             prev_result = result_obj.get("result").cloned();
@@ -1233,6 +1282,16 @@ impl KhiveMcpServer {
             presentation: p.presentation.clone(),
             presentation_per_op: p.presentation_per_op.clone(),
             namespace: self.default_namespace.clone(),
+            // ADR-096 Fork 1: carry this server's OWN resolved actor/visibility
+            // identity on the frame so a warm daemon with a *different* baked
+            // identity serves the request under this caller's identity instead
+            // of rejecting it or silently stamping writes under its own actor.
+            actor_id: self.actor_id().map(str::to_string),
+            visible_namespaces: self
+                .visible_namespaces()
+                .iter()
+                .map(|ns| ns.as_str().to_string())
+                .collect(),
             config_id: self.config_id.clone(),
             protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
             probe_only: false,
@@ -1248,23 +1307,33 @@ impl KhiveMcpServer {
     /// allowed. `kkernel exec`, in-process callers, and tests use this. The
     /// agent-facing MCP wire surface goes through `dispatch_request_wire`
     /// (or sets `from_wire` on the daemon frame), which enforces verb visibility.
+    ///
+    /// Pure local dispatch: no [`khive_runtime::RequestIdentity`] override is
+    /// applied (ADR-096 Fork 1) — this server's own construction-baked
+    /// identity is used, unchanged from before per-request identity existed.
     pub async fn dispatch_request_local(&self, p: RequestParams) -> Result<String, McpError> {
-        self.dispatch_request_inner(p, false).await
+        self.dispatch_request_inner(p, false, None).await
     }
 
     /// Wire-surface dispatch: same as [`Self::dispatch_request_local`] but
     /// enforces verb visibility (`Visibility::Subhandler` verbs are rejected).
     /// Used by the stdio `request` tool's local-fallback path.
     pub(crate) async fn dispatch_request_wire(&self, p: RequestParams) -> Result<String, McpError> {
-        self.dispatch_request_inner(p, true).await
+        self.dispatch_request_inner(p, true, None).await
     }
 
     /// Shared body for both dispatch surfaces. `from_wire` decides whether the
     /// subhandler-visibility gate fires (see [`run_parsed`](Self::run_parsed)).
+    ///
+    /// `identity` is the per-request identity context threaded from a daemon
+    /// frame (ADR-096 Fork 1, see `crate::daemon`'s `DaemonDispatch` impl).
+    /// `None` for every local (non-daemon-served) call — this server's own
+    /// baked identity applies, exactly as before this parameter existed.
     pub(crate) async fn dispatch_request_inner(
         &self,
         p: RequestParams,
         from_wire: bool,
+        identity: Option<khive_runtime::RequestIdentity>,
     ) -> Result<String, McpError> {
         let save_to = p.save_to.clone();
         let parsed = parse_request(&p.ops).map_err(dsl_err_to_mcp)?;
@@ -1324,6 +1393,7 @@ impl KhiveMcpServer {
                 presentation,
                 presentation_per_op.clone(),
                 from_wire,
+                identity.as_ref(),
             )
             .await;
 

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -26,6 +26,8 @@ use tokio::net::{UnixListener, UnixStream};
 
 use khive_db::{run_checkpoint_task, CheckpointConfig, ConnectionPool};
 
+use crate::pack::RequestIdentity;
+
 /// Maximum frame size accepted in either direction.
 pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 
@@ -40,7 +42,12 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 /// Version history:
 ///   1 — initial versioned framing (added `protocol_version` + `version_mismatch`);
 ///       added `probe_only` request field + probe-ack sentinel shape in response
-pub const PROTOCOL_VERSION: u32 = 2;
+///   2 — gate subhandler verbs by wire origin (`from_wire` request field)
+///   3 — added per-request identity context to the request frame (`actor_id`,
+///       `visible_namespaces`, ADR-096 Fork 1); the daemon now serves a request
+///       under the frame's identity instead of rejecting on `namespace_mismatch`
+///       (the `config_id` equality reject stays hard)
+pub const PROTOCOL_VERSION: u32 = 3;
 
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
 
@@ -129,7 +136,29 @@ pub struct DaemonRequestFrame {
     pub ops: String,
     pub presentation: Option<String>,
     pub presentation_per_op: Option<Vec<Option<String>>>,
+    /// The client's resolved storage/gate default namespace for this request.
+    ///
+    /// Historically rejected outright when it differed from the daemon's own
+    /// construction-baked namespace (`namespace_mismatch`). As of protocol
+    /// version 3 (ADR-096 Fork 1) the daemon instead serves the request under
+    /// this namespace — the field is a per-request identity input, not a
+    /// same-process-identity assertion.
     pub namespace: String,
+    /// The client's resolved write-stamp / gate actor identity (ADR-057),
+    /// carried on the frame so the warm daemon stamps writes with the
+    /// *caller's* actor instead of the daemon's own baked `actor_id`
+    /// (ADR-096 Fork 1). `None` mints `ActorRef::anonymous()`, matching an
+    /// unconfigured actor. Pre-Fork-1 clients cannot send this field (an older
+    /// protocol version rejects at the version check before it would matter).
+    #[serde(default)]
+    pub actor_id: Option<String>,
+    /// The client's resolved extra read-visibility namespaces (ADR-007 Rev 4
+    /// Rule 3b), carried on the frame so the warm daemon widens read scope to
+    /// match the caller's own configuration rather than the daemon's baked
+    /// `visible_namespaces` (ADR-096 Fork 1). Empty means no extra visibility
+    /// beyond `namespace` itself.
+    #[serde(default)]
+    pub visible_namespaces: Vec<String>,
     /// Fingerprint of the client's resolved runtime config (packs, db target,
     /// embedders). The daemon rejects a request whose `config_id` differs from
     /// its own so a restricted client (e.g. `--pack kg`, `--db :memory:`) never
@@ -256,6 +285,15 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// [`DaemonRequestFrame::from_wire`]: when `true`, the implementor enforces
     /// verb visibility (rejects `Visibility::Subhandler` verbs); when `false`,
     /// the request is from a trusted operator surface and subhandlers pass.
+    ///
+    /// `identity` is the per-request identity context threaded from the frame
+    /// (ADR-096 Fork 1): `Some(..)` when serving a request forwarded over the
+    /// daemon socket (built from `frame.namespace` / `frame.actor_id` /
+    /// `frame.visible_namespaces` by the connection handler), `None` for any
+    /// other dispatch path. Implementors should mint the storage/gate token from
+    /// `identity` when present and fall back to their own construction-baked
+    /// identity when absent, so pure local (non-daemon) dispatch is unchanged.
+    #[allow(clippy::too_many_arguments)]
     async fn dispatch(
         &self,
         ops: String,
@@ -264,6 +302,7 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
         format: Option<String>,
         format_per_op: Option<Vec<Option<String>>>,
         from_wire: bool,
+        identity: Option<RequestIdentity>,
     ) -> Result<String, String>;
 
     /// Warm every pack's in-memory state (ANN indexes, etc.).
@@ -390,17 +429,15 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             version_mismatch: true,
             daemon_protocol_version: PROTOCOL_VERSION,
         }
-    } else if frame.namespace != dispatcher.namespace() {
-        DaemonResponseFrame {
-            ok: false,
-            result: None,
-            error: None,
-            namespace_mismatch: true,
-            config_mismatch: false,
-            served_config_id,
-            version_mismatch: false,
-            daemon_protocol_version: PROTOCOL_VERSION,
-        }
+    // ADR-096 Fork 1: there is no `frame.namespace != dispatcher.namespace()`
+    // reject here. The daemon accepts and serves the request under the
+    // frame's own identity (namespace / actor / visible_namespaces, built
+    // into a `RequestIdentity` below) over its one shared warm registry,
+    // rather than rejecting a differently-attributed same-uid connection to
+    // a cold local-dispatch fallback. `config_id` — which governs
+    // packs/db/embed coherence for the shared warm engine — remains a hard
+    // reject; it is not an identity field and softening it would let a
+    // restricted client dispatch through an incompatible broader daemon.
     } else if frame.config_id != dispatcher.config_id() {
         DaemonResponseFrame {
             ok: false,
@@ -427,6 +464,20 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             daemon_protocol_version: PROTOCOL_VERSION,
         }
     } else {
+        // Build the per-request identity context from the frame (ADR-096
+        // Fork 1) so the implementor mints the storage/gate token from the
+        // CALLER's identity, not the dispatcher's own construction-baked
+        // scalars. This is always `Some` here: every frame that reaches
+        // this arm carries a `namespace` (required on the wire) plus
+        // whatever `actor_id`/`visible_namespaces` the client resolved
+        // (defaulting to `None`/`vec![]` for a pre-Fork-1 field-absent
+        // payload, which is exactly the prior anonymous/no-extra-visibility
+        // behavior).
+        let identity = RequestIdentity {
+            namespace: frame.namespace.clone(),
+            actor_id: frame.actor_id.clone(),
+            visible_namespaces: frame.visible_namespaces.clone(),
+        };
         match dispatcher
             .dispatch(
                 frame.ops,
@@ -435,6 +486,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
                 frame.format,
                 frame.format_per_op,
                 frame.from_wire,
+                Some(identity),
             )
             .await
         {

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -64,8 +64,9 @@ pub use operations::{EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Res
 pub use pack::{
     resolve_explicit_namespace, DispatchHook, HandlerDef, KindHook, NoteKindSpec,
     NoteLifecycleSpec, PackByIdResolver, PackFactory, PackLoadError, PackRegistration,
-    PackRegistry, PackRuntime, PackSchemaCollisionError, PackSchemaPlan, ParamDef, SchemaPlan,
-    VerbCategory, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder, Visibility,
+    PackRegistry, PackRuntime, PackSchemaCollisionError, PackSchemaPlan, ParamDef, RequestIdentity,
+    SchemaPlan, VerbCategory, VerbPresentationPolicy, VerbRegistry, VerbRegistryBuilder,
+    Visibility,
 };
 pub use portability::{ImportSummary, KgArchive};
 pub use presentation::{

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -711,6 +711,38 @@ pub struct VerbRegistry {
     dispatch_hook: Option<Arc<dyn DispatchHook>>,
 }
 
+/// Per-request identity context that overrides a [`VerbRegistry`]'s
+/// construction-baked `default_namespace` / `actor_id` / `visible_namespaces`
+/// for exactly one [`VerbRegistry::dispatch_with_identity`] call (ADR-096
+/// Fork 1 — warm-daemon per-request identity).
+///
+/// A single warm registry is built once with a baked identity, but must be
+/// able to serve requests whose caller resolved a *different* attribution
+/// identity (e.g. a different project-local `[actor]`) without a cold
+/// fallback and without mis-stamping writes under the registry's own baked
+/// actor. Supplying `Some(RequestIdentity { .. })` threads the caller's
+/// identity through token minting for that one call; the registry's fields
+/// (and every other in-flight call) are untouched. `None` is exactly
+/// [`VerbRegistry::dispatch`] — the baked scalars apply, unchanged from
+/// before this type existed.
+#[derive(Debug, Clone, Default)]
+pub struct RequestIdentity {
+    /// Storage/gate default namespace for this request (used when the verb's
+    /// own params carry no explicit `namespace` field). Overrides
+    /// `VerbRegistry::default_namespace`.
+    pub namespace: String,
+    /// Write-stamp / gate actor label for this request (ADR-057). Overrides
+    /// `VerbRegistry::actor_id`. `None` mints `ActorRef::anonymous()`, same
+    /// as an unconfigured baked `actor_id`.
+    pub actor_id: Option<String>,
+    /// Extra read-visibility namespaces for this request (ADR-007 Rev 4 Rule
+    /// 3b). Overrides `VerbRegistry::visible_namespaces`. Entries that fail
+    /// `Namespace::parse` are skipped with a `tracing::warn!` rather than
+    /// failing the whole request — a single malformed visibility entry from a
+    /// caller-supplied frame must not block dispatch.
+    pub visible_namespaces: Vec<String>,
+}
+
 /// Error returned by [`VerbRegistry::apply_schema_plans_with_map`] when two
 /// packs on the same backend declare the same auxiliary table (ADR-028 §7).
 #[derive(Debug)]
@@ -777,6 +809,29 @@ fn extract_table_names(stmt: &str) -> Vec<String> {
 }
 
 impl VerbRegistry {
+    /// This registry's construction-baked default namespace.
+    ///
+    /// Used as the fallback when a request carries no [`RequestIdentity`]
+    /// override (ADR-096 Fork 1) and by transports that need to advertise
+    /// their own resolved identity when forwarding to a warm daemon.
+    pub fn default_namespace(&self) -> &str {
+        &self.default_namespace
+    }
+
+    /// This registry's construction-baked actor identity label, if configured
+    /// (ADR-057). `None` means dispatch mints `ActorRef::anonymous()` absent a
+    /// per-request [`RequestIdentity`] override (ADR-096 Fork 1).
+    pub fn actor_id(&self) -> Option<&str> {
+        self.actor_id.as_deref()
+    }
+
+    /// This registry's construction-baked extra read-visibility namespaces
+    /// (ADR-007 Rev 4 Rule 3b), used absent a per-request [`RequestIdentity`]
+    /// override (ADR-096 Fork 1).
+    pub fn visible_namespaces(&self) -> &[Namespace] {
+        &self.visible_namespaces
+    }
+
     /// Return the help schema envelope for a verb (issue #287).
     ///
     /// Walks registered packs for the first matching `HandlerDef` and returns a
@@ -875,7 +930,33 @@ impl VerbRegistry {
     /// Routes through the gate, then invokes the matching pack handler. When
     /// `params["help"] == true`, short-circuits to `describe_verb` with no side effects.
     /// Gate errors are fail-open. Full dispatch flow documented in `docs/protocol.md`.
+    ///
+    /// Equivalent to `self.dispatch_with_identity(verb, params, None)` — uses
+    /// this registry's construction-baked `default_namespace` / `actor_id` /
+    /// `visible_namespaces`.
     pub async fn dispatch(&self, verb: &str, params: Value) -> Result<Value, RuntimeError> {
+        self.dispatch_with_identity(verb, params, None).await
+    }
+
+    /// Dispatch a verb, optionally overriding this registry's baked identity
+    /// scalars for exactly this call (ADR-096 Fork 1).
+    ///
+    /// `identity = None` behaves exactly like [`Self::dispatch`]. `identity =
+    /// Some(id)` uses `id.namespace` / `id.actor_id` / `id.visible_namespaces`
+    /// in place of `self.default_namespace` / `self.actor_id` /
+    /// `self.visible_namespaces` for this call's namespace resolution, gate
+    /// request, and token minting — the registry's own fields are never
+    /// mutated, so concurrent calls with different (or no) identity are
+    /// independent. This is what lets one warm registry correctly serve
+    /// requests from many attribution identities over the same shared
+    /// backend (same db, same warm ANN indexes) instead of rejecting or
+    /// silently dispatching under its own baked identity.
+    pub async fn dispatch_with_identity(
+        &self,
+        verb: &str,
+        params: Value,
+        identity: Option<RequestIdentity>,
+    ) -> Result<Value, RuntimeError> {
         // help=true interception (issue #287) — short-circuit before gate/pack.
         if params.get("help").and_then(Value::as_bool) == Some(true) {
             return self.describe_verb(verb);
@@ -891,11 +972,21 @@ impl VerbRegistry {
         // the multi-backend coordinator intercept via `resolve_explicit_namespace`
         // so every MCP ingress path applies the same fail-closed rule.
         let explicit_namespace = params.get("namespace").is_some_and(Value::is_string);
-        let ns = resolve_explicit_namespace(&params, &self.default_namespace)?;
+        // ADR-096 Fork 1: a supplied per-request identity overrides the baked
+        // default_namespace/actor_id/visible_namespaces for this call only.
+        let default_namespace_str: &str = identity
+            .as_ref()
+            .map(|id| id.namespace.as_str())
+            .unwrap_or(self.default_namespace.as_str());
+        let ns = resolve_explicit_namespace(&params, default_namespace_str)?;
+        let actor_id_str: Option<&str> = match identity.as_ref() {
+            Some(id) => id.actor_id.as_deref(),
+            None => self.actor_id.as_deref(),
+        };
         // ADR-057: thread the configured actor identity into the gate request so
         // the gate can distinguish human vs agent callers at the dispatch seam.
         // Mirrors the actor resolution used by the token-minting path below.
-        let gate_actor = match self.actor_id.as_deref() {
+        let gate_actor = match actor_id_str {
             Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
             _ => ActorRef::anonymous(),
         };
@@ -987,16 +1078,18 @@ impl VerbRegistry {
         // When actor_id is configured (ADR-057), mint a token carrying that actor
         // label so that comm.inbox applies the to_actor filter for directed delivery.
         // Otherwise, use ActorRef::anonymous() and inbox falls back to party-line.
-        let configured_actor = match self.actor_id.as_deref() {
+        // ADR-096 Fork 1: `actor_id_str` already reflects the per-request identity
+        // override when supplied (resolved above, mirrored into the gate request).
+        let configured_actor = match actor_id_str {
             Some(id) if !id.trim().is_empty() => ActorRef::new("actor", id),
             _ => ActorRef::anonymous(),
         };
 
         // Rule 3b (Rev 4): on the default (no explicit `namespace=`) path, the read
-        // scope widens to `['local'] ∪ self.visible_namespaces`. `'local'` is always
-        // included (mint_with_visibility deduplicates). Writes remain pinned to
-        // `'local'`. Per-actor distinctions use view-layer tag filters
-        // (assignee, actor_id, from/to), not namespace partitions.
+        // scope widens to `['local'] ∪ visible_namespaces` (baked, or the per-request
+        // override — ADR-096 Fork 1). `'local'` is always included (mint_with_visibility
+        // deduplicates). Writes remain pinned to `'local'`. Per-actor distinctions use
+        // view-layer tag filters (assignee, actor_id, from/to), not namespace partitions.
         // `ns`/`explicit_namespace` were already validated above (RUNTIME-AUD-002 /
         // #433) — reuse them instead of re-reading `params["namespace"]` with
         // `as_str()`, which would silently drop malformed non-string values again.
@@ -1006,7 +1099,25 @@ impl VerbRegistry {
         } else {
             // Rule 3b: default path. Write namespace = local; read scope = ['local'] ∪ visible_namespaces.
             let primary = Namespace::local();
-            let mut extra_visible = self.visible_namespaces.clone();
+            let mut extra_visible: Vec<Namespace> = match identity.as_ref() {
+                Some(id) => id
+                    .visible_namespaces
+                    .iter()
+                    .filter_map(|s| match Namespace::parse(s) {
+                        Ok(parsed) => Some(parsed),
+                        Err(e) => {
+                            tracing::warn!(
+                                namespace = %s,
+                                error = %e,
+                                "dispatch_with_identity: skipping invalid visible_namespace \
+                                 entry from per-request identity"
+                            );
+                            None
+                        }
+                    })
+                    .collect(),
+                None => self.visible_namespaces.clone(),
+            };
             extra_visible.push(Namespace::local()); // 'local' always readable; mint dedups
             NamespaceToken::mint_with_visibility(primary, extra_visible, configured_actor)
         };

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -476,6 +476,12 @@ async fn run_exec_inline_with_forward(
             presentation: presentation.clone(),
             presentation_per_op: None,
             namespace: cfg.default_namespace.as_str().to_string(),
+            actor_id: cfg.actor_id.clone(),
+            visible_namespaces: cfg
+                .visible_namespaces
+                .iter()
+                .map(|ns| ns.as_str().to_string())
+                .collect(),
             config_id: compute_config_id(&cfg, None),
             protocol_version: PROTOCOL_VERSION,
             probe_only: false,


### PR DESCRIPTION
## Summary

Implements ADR-096 Fork 1: a warm daemon now serves requests carrying
different attribution identities (namespace, actor, visible namespaces)
over its *one* shared registry, instead of rejecting a differently-attributed
same-uid connection or silently dispatching it under the daemon's own baked
identity.

- `DaemonRequestFrame` gains `actor_id: Option<String>` and
  `visible_namespaces: Vec<String>` alongside the existing `namespace` field.
  `PROTOCOL_VERSION` bumps 2 → 3, so a pre-Fork-1 client hits the existing
  `version_mismatch` path (safe failure mode, no silent identity loss).
- `VerbRegistry::dispatch` is now a thin wrapper over
  `dispatch_with_identity(verb, params, identity: Option<RequestIdentity>)`.
  A supplied identity overrides the registry's construction-baked
  `default_namespace`/`actor_id`/`visible_namespaces` for exactly that one
  call (token minting only — the registry's own fields are never mutated).
  `identity = None` is byte-for-byte the old `dispatch` behavior.
- The daemon's hard `frame.namespace != dispatcher.namespace()` reject is
  removed. The connection handler instead builds a `RequestIdentity` from the
  frame and serves under it. **The `config_id` equality reject is unchanged
  and stays hard** — it governs packs/db/embedder coherence for the shared
  warm engine (backend compatibility), which is a materially different
  concern from caller attribution.
- `KhiveMcpServer` threads the identity through both per-op dispatch paths
  (parallel-batch closures and the chained-op loop) and the multi-backend
  coordinator intercept, so a per-request namespace can't drift between the
  coordinator route and the registry route for the same op.
- `kkernel exec`'s daemon-forward frame now carries the CLI's own resolved
  `actor_id`/`visible_namespaces` instead of leaving the new fields empty.
- **Implementation-sketch correction**: ADR-096's implementation sketch named
  `authorize_with_visibility(primary, extra_visible)` as the per-request entry
  point, but that helper takes no per-request actor and derives it from the
  construction-baked `self.config.actor_id`, so using it verbatim would
  reintroduce the actor misattribution this fork closes. Identity is threaded
  through the new `dispatch_with_identity` path instead. The ADR marks the
  sketch non-normative for sizing, so this is a sketch-level correction, not a
  contract change.

## Scope

Stays inside single-principal (0600 socket) serving. No connection-principal
capture, no `SO_PEERCRED`, no Gate binding of a connection to an allowed
namespace set — those are explicitly out of scope here and deferred to a
future gated design.

## Test plan

- [x] `daemon_serves_per_request_identity_over_one_warm_registry` (new): two
      requests to one already-running warm daemon, carrying different frame
      namespaces *and* different frame actors, both served over the shared
      backend; each write is stamped with its own frame's actor (verified via
      `comm.send`, whose JSON response echoes the dispatching actor directly).
- [x] `local_dispatch_without_identity_context_uses_baked_actor` (new):
      back-compat check — pure local dispatch (no daemon, no identity
      override) still uses the server's own construction-baked `actor_id`.
- [x] `daemon_round_trip_dispatches_and_enforces_config_id` (renamed from
      `..._enforces_namespace`): the differing-namespace case now asserts
      success instead of `namespace_mismatch`; the differing-`config_id` case
      is unchanged (still hard-rejected).
- [x] Existing protocol-version-mismatch test still asserts `version_mismatch`
      for a stale-version frame — this closes out #557's version-mismatch
      integration coverage as a side effect of this PR's test additions.
- [x] Fork 2 parity tests still green: `exec_config_id_matches_serve_config_id_for_project_toml_actor`,
      `config_id_byte_identical_across_different_actor_ids`, and the
      strict-actor-mode suite in `kkernel/src/exec.rs`.
- [x] `cargo test -p khive-mcp -p khive-runtime -p kkernel` — all green
      (khive-mcp: 116 + 110 integration; khive-runtime: 599 + 59 integration,
      5 ignored; kkernel: 174 + 5 + 2 verb-namespace-contract). 0 failures.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p khive-mcp -p khive-runtime -p kkernel --all-targets -- -D warnings` — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-mcp -p khive-runtime -p kkernel` — clean.

Docs (ADR-096 itself) already merged in #659; this PR is code-only.

Note on #567 (centralizing actor-identity resolution across call sites): out
of scope here by design — this PR does the minimal per-request threading
needed for Fork 1. It does make a future centralization easier (there's now
one `RequestIdentity` shape flowing through the dispatch seam), but does not
claim to close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
