### PR TITLE
feat(runtime): assert db-path resolution consistency at server construction

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -775,6 +775,14 @@ pub fn build_registry_for_multi_backend(
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
 ) -> anyhow::Result<MultiBackendRegistry> {
+    // Regression fence: `base_config.db_path` feeds `compute_config_id` below,
+    // so it must agree with the canonical anchor for this same `--db` input.
+    // This is the shared choke point both multi-backend boot paths funnel
+    // through — `build_server_multi_backend` in this file and `kkernel`'s
+    // `Command::Mcp` coordinator-attached branch — so the guard lives here
+    // once instead of at each caller.
+    khive_runtime::assert_db_anchor_consistent(base_config.db_path.as_deref(), cli_db_override)?;
+
     let backend_count = khive_cfg.backends.len();
     let force_memory = match cli_db_override {
         Some(":memory:") => {
@@ -1055,6 +1063,12 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
         brain_profile: args.brain_profile.clone(),
     })?;
 
+    // Regression fence: `config.db_path` must agree with what the canonical
+    // resolver derives from this same `--db` input, or `config_id` (computed
+    // from `config.db_path` below) would silently desynchronize this process
+    // from any daemon/peer anchored on the same database.
+    khive_runtime::assert_db_anchor_consistent(config.db_path.as_deref(), args.db.as_deref())?;
+
     // Load the KhiveConfig to check for multi-backend declarations (ADR-028).
     // When no [[backends]] are declared, fall through to the existing single-backend path
     // to preserve byte-for-byte backward compatibility.
@@ -1155,6 +1169,9 @@ pub fn build_server_multi_backend(
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
 ) -> anyhow::Result<KhiveMcpServer> {
+    // The db-anchor consistency guard runs inside `build_registry_for_multi_backend`
+    // (the shared choke point every multi-backend boot path funnels through),
+    // so it is not duplicated here.
     let multi = build_registry_for_multi_backend(base_config, khive_cfg, cli_db_override)?;
     Ok(build_server_from_multi_backend_registry(
         multi, khive_cfg, None,
@@ -2428,10 +2445,16 @@ id = "lambda:project-actor"
 
     /// Build a `RuntimeConfig` suitable for multi-backend tests: in-memory db,
     /// AllowAllGate, "local" namespace, no embedder, both kg and comm packs.
+    ///
+    /// `db_path` mirrors what `resolve_runtime_config` sets for a `--db`-unset
+    /// invocation (every call site below passes `cli_db_override: None` to
+    /// `build_server_multi_backend`/`build_registry_for_multi_backend`) — the
+    /// db-anchor consistency guard those functions run requires `db_path` to
+    /// agree with `resolve_db_anchor` for the same input.
     fn base_runtime_config_for_multi_backend() -> RuntimeConfig {
         use khive_runtime::{AllowAllGate, BackendId, Namespace};
         RuntimeConfig {
-            db_path: None,
+            db_path: khive_runtime::resolve_db_anchor(None),
             gate: std::sync::Arc::new(AllowAllGate),
             default_namespace: Namespace::parse("local").expect("ns"),
             embedding_model: None,
@@ -2787,7 +2810,14 @@ id = "lambda:project-actor"
             ..KhiveConfig::default()
         };
 
-        let base_cfg = base_runtime_config_for_multi_backend();
+        // `db_path` matches the concrete override passed below (the db-anchor
+        // consistency guard requires this pairing) — the ambiguity rejection
+        // this test exercises is a downstream check inside
+        // `build_registry_for_multi_backend`, distinct from anchor drift.
+        let base_cfg = RuntimeConfig {
+            db_path: khive_runtime::resolve_db_anchor(Some("/tmp/some-explicit-override.db")),
+            ..base_runtime_config_for_multi_backend()
+        };
 
         let result = build_registry_for_multi_backend(
             base_cfg,
@@ -3255,7 +3285,14 @@ id = "lambda:project-actor"
             ..KhiveConfig::default()
         };
 
-        let base_cfg = base_runtime_config_for_multi_backend();
+        // `db_path` matches the concrete override passed below (the db-anchor
+        // consistency guard requires this pairing) — the ambiguity rejection
+        // this test exercises is a downstream check inside
+        // `build_registry_for_multi_backend`, distinct from anchor drift.
+        let base_cfg = RuntimeConfig {
+            db_path: khive_runtime::resolve_db_anchor(Some("/tmp/some-explicit-override.db")),
+            ..base_runtime_config_for_multi_backend()
+        };
 
         let result = build_server_multi_backend(
             base_cfg,

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -364,6 +364,45 @@ pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
     }
 }
 
+/// Assert that a resolved `db_path` — the path a runtime is about to open, and
+/// the same value `compute_config_id` folds into a process's `config_id` — agrees
+/// with what [`resolve_db_anchor`] derives from the same explicit `--db` /
+/// `KHIVE_DB` input. Call this at each construction boundary right after the
+/// `db_path` that boundary is about to use has been resolved.
+///
+/// A construction path that recomputes `db_path` independently of
+/// `resolve_db_anchor` (instead of routing through it, directly or via
+/// `resolve_runtime_config`) would otherwise diverge only silently: its
+/// `config_id` would carry the wrong db path, so it would stop matching a
+/// daemon or peer process anchored on the same database, and would silently
+/// fall back to a disconnected, out-of-sync runtime instead of failing loud.
+/// This turns that divergence into a hard error at the point it is introduced.
+///
+/// When `resolve_db_anchor(args_db)` itself resolves to `None` (the
+/// `:memory:` sentinel), there is no canonical anchor path to compare
+/// against, so the guard is inert and returns `Ok(())` unconditionally.
+pub fn assert_db_anchor_consistent(
+    resolved_db_path: Option<&std::path::Path>,
+    args_db: Option<&str>,
+) -> anyhow::Result<()> {
+    let Some(anchor) = resolve_db_anchor(args_db) else {
+        return Ok(());
+    };
+    if resolved_db_path != Some(anchor.as_path()) {
+        anyhow::bail!(
+            "db-path resolution drift at server construction: resolved db_path {:?} \
+             does not match the canonical anchor {:?} computed by resolve_db_anchor \
+             from the same --db input; this construction path likely recomputed the \
+             db path independently instead of routing through the shared resolver, \
+             which would desynchronize config_id from other processes sharing the \
+             same database",
+            resolved_db_path,
+            anchor
+        );
+    }
+    Ok(())
+}
+
 /// Resolve the per-connection attribution actor from the project/cwd-anchored
 /// config tier, independently of the database-anchored config load that governs
 /// `config_id` (ADR-096 Fork 2).
@@ -652,6 +691,59 @@ mod resolve_db_anchor_tests {
         let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
         let expected = std::path::PathBuf::from(format!("{home}/.khive/khive.db"));
         assert_eq!(resolve_db_anchor(None), Some(expected));
+    }
+}
+
+#[cfg(test)]
+mod assert_db_anchor_consistent_tests {
+    use super::{assert_db_anchor_consistent, resolve_db_anchor};
+
+    #[test]
+    fn diverging_db_path_is_rejected_naming_both_paths() {
+        let args_db = "/tmp/khive-anchor-guard-real.db";
+        let anchor = resolve_db_anchor(Some(args_db)).expect("explicit path always anchors");
+        let wrong = std::path::PathBuf::from("/tmp/khive-anchor-guard-wrong.db");
+
+        let err = assert_db_anchor_consistent(Some(wrong.as_path()), Some(args_db))
+            .expect_err("a resolved db_path diverging from the anchor must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&wrong.display().to_string()),
+            "error must name the resolved (wrong) path: {msg}"
+        );
+        assert!(
+            msg.contains(&anchor.display().to_string()),
+            "error must name the canonical anchor path: {msg}"
+        );
+    }
+
+    #[test]
+    fn matching_explicit_db_path_passes() {
+        let args_db = "/tmp/khive-anchor-guard-consistent.db";
+        let anchor = resolve_db_anchor(Some(args_db)).expect("explicit path always anchors");
+        assert!(assert_db_anchor_consistent(Some(anchor.as_path()), Some(args_db)).is_ok());
+    }
+
+    #[test]
+    fn memory_sentinel_anchor_is_inert() {
+        // `resolve_db_anchor(":memory:")` yields `None` — there is no canonical
+        // path to assert against, so the guard passes regardless of what
+        // `resolved_db_path` happens to carry.
+        let bogus = std::path::PathBuf::from("/tmp/should-not-matter.db");
+        assert!(assert_db_anchor_consistent(Some(bogus.as_path()), Some(":memory:")).is_ok());
+        assert!(assert_db_anchor_consistent(None, Some(":memory:")).is_ok());
+    }
+
+    #[test]
+    fn normal_boot_with_db_unset_passes_silently() {
+        // Mirrors a normal boot: `--db` unset. `resolve_db_anchor(None)` always
+        // resolves to `Some(..)` (HOME-set or HOME-unset both produce a
+        // concrete anchor — see `absent_maps_to_home_default` above and the
+        // `resolve_db_anchor` doc comment on the HOME-unset arm), so a runtime
+        // whose resolved `db_path` equals that anchor passes silently.
+        let anchor = resolve_db_anchor(None);
+        assert!(assert_db_anchor_consistent(anchor.as_deref(), None).is_ok());
     }
 }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -75,8 +75,9 @@ pub use presentation::{
 pub use registry::{ObjectiveRegistry, RegisteredObjective};
 pub use retrieval::{SearchHit, SearchSource};
 pub use runtime::{
-    parse_pack_list, resolve_db_anchor, resolve_project_actor_id, runtime_config_from_khive_config,
-    BackendId, EntityTypeValidatorFn, KhiveRuntime, NamespaceToken, RuntimeConfig,
+    assert_db_anchor_consistent, parse_pack_list, resolve_db_anchor, resolve_project_actor_id,
+    runtime_config_from_khive_config, BackendId, EntityTypeValidatorFn, KhiveRuntime,
+    NamespaceToken, RuntimeConfig,
 };
 pub use secret_gate::SecretMatch;
 pub use validation::{

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -29,8 +29,8 @@ pub type EntityTypeValidatorFn =
     Arc<dyn Fn(&str, Option<&str>) -> Result<Option<String>, RuntimeError> + Send + Sync>;
 
 pub use crate::config::{
-    parse_pack_list, resolve_db_anchor, resolve_project_actor_id, runtime_config_from_khive_config,
-    BackendId, NamespaceToken, RuntimeConfig,
+    assert_db_anchor_consistent, parse_pack_list, resolve_db_anchor, resolve_project_actor_id,
+    runtime_config_from_khive_config, BackendId, NamespaceToken, RuntimeConfig,
 };
 
 // ---- KhiveRuntime ----

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -389,6 +389,11 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
         brain_profile: None,
     })?;
 
+    // Regression fence: `cfg.db_path` must agree with the canonical anchor for
+    // this same `--db`/`KHIVE_DB` input, or `compute_config_id` would silently
+    // desynchronize `kkernel exec` from the daemon it is trying to reach.
+    khive_runtime::assert_db_anchor_consistent(cfg.db_path.as_deref(), args.db.as_deref())?;
+
     match mode {
         ExecMode::Inline(ops) => {
             run_exec_inline(

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -692,7 +692,12 @@ mod tests {
     fn base_multi_backend_runtime_config() -> RuntimeConfig {
         use khive_runtime::Namespace;
         RuntimeConfig {
-            db_path: None,
+            // Matches what `resolve_runtime_config` would set for a `--db`-unset
+            // invocation (the `cli_db_override: None` every call site below
+            // passes) — `build_server_multi_backend`'s db-anchor consistency
+            // guard requires `db_path` to agree with `resolve_db_anchor` for
+            // the same input.
+            db_path: khive_runtime::resolve_db_anchor(None),
             default_namespace: Namespace::parse("local").expect("valid namespace"),
             embedding_model: None,
             additional_embedding_models: vec![],
@@ -871,5 +876,47 @@ mod tests {
 
         // `_env_guard` is dropped here (or on unwind, whichever comes first),
         // restoring KHIVE_OUTPUT_FORMAT regardless of assertion outcome.
+    }
+
+    /// The kkernel `Command::Mcp` coordinator-attached multi-backend boot path
+    /// (`build_multi_backend_server_with_coordinator`, the real `kkernel mcp
+    /// --daemon` production boundary) funnels through
+    /// `khive_mcp::serve::build_registry_for_multi_backend` exactly like the
+    /// plain `build_server_multi_backend` path does — that shared choke point
+    /// is where the db-anchor consistency guard lives, so a `db_path` that
+    /// diverges from the canonical anchor for the same `--db` input must be
+    /// rejected here too, naming both paths.
+    #[test]
+    fn coordinator_boundary_rejects_diverging_db_path() {
+        let args_db = "/tmp/khive-coordinator-guard-real.db";
+        let wrong_path = std::path::PathBuf::from("/tmp/khive-coordinator-guard-wrong.db");
+
+        let base_cfg = RuntimeConfig {
+            db_path: Some(wrong_path.clone()),
+            ..base_multi_backend_runtime_config()
+        };
+        let khive_cfg = KhiveConfig::default();
+
+        let result =
+            build_multi_backend_server_with_coordinator(base_cfg, &khive_cfg, Some(args_db));
+
+        let err = match result {
+            Ok(_) => panic!(
+                "a resolved db_path diverging from the canonical anchor must be rejected \
+                 at the coordinator-attached construction boundary"
+            ),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        let anchor =
+            khive_runtime::resolve_db_anchor(Some(args_db)).expect("explicit path always anchors");
+        assert!(
+            msg.contains(&wrong_path.display().to_string()),
+            "error must name the resolved (wrong) path: {msg}"
+        );
+        assert!(
+            msg.contains(&anchor.display().to_string()),
+            "error must name the canonical anchor path: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a construction-time consistency guard for db-path resolution: `assert_db_anchor_consistent(resolved_db_path, args_db)` in `khive-runtime`, next to the existing `resolve_db_anchor` resolver.

## Why

`resolve_db_anchor(Option<&str>) -> Option<PathBuf>` is the single canonical resolver for turning a `--db`/`KHIVE_DB` value into the db path used both to open the database and to anchor tier-3 project-local config discovery. `resolve_runtime_config` already routes through it directly, so today the invariant holds by construction — but nothing structurally *prevents* a future construction path (a new subcommand, a refactor that recomputes the path inline) from quietly diverging from it.

That divergence class is real and costly: a process's `config_id` folds in its resolved `db_path`, so if that path drifts from the canonical anchor, the process's `config_id` silently disagrees with a daemon or peer process anchored on the same database. The mismatch doesn't surface as an error — it causes a silent fallback to a disconnected, out-of-sync, in-process runtime.

This change turns that class of drift into a hard error at the point of construction instead of a downstream, hard-to-diagnose symptom.

## Invariant

At each construction boundary, the `db_path` a runtime is about to use must equal `resolve_db_anchor` applied to the same explicit `--db` input:

```
resolved_db_path == resolve_db_anchor(args_db)
```

When `resolve_db_anchor(args_db)` itself resolves to `None` (the `:memory:` sentinel), there is no canonical path to compare against, so the guard is inert and passes unconditionally — this is documented inline as the one legitimate case, not a bug.

## Call sites (construction boundaries only, not every runtime construction)

- `build_server` in `khive-mcp/src/serve.rs` (single-backend boot path), immediately after `resolve_runtime_config`
- `build_registry_for_multi_backend` in the same file — the shared choke point both multi-backend boot paths funnel through: the plain `build_server_multi_backend` path and the daemon-facing coordinator-attached boot path in `kkernel`'s binary both call it directly, so the guard lives here once rather than duplicated at each caller
- `kkernel exec`'s construction site in `kkernel/src/exec.rs`, immediately after `resolve_runtime_config`

Deliberately *not* installed at every `KhiveRuntime::new` call — several existing unit tests construct runtimes directly with paths that intentionally don't need to satisfy this invariant (e.g. synthetic in-memory test configs), and requiring it there would add no safety benefit while breaking legitimate test isolation.

## Tests

Unit tests in `khive-runtime/src/config.rs` (`assert_db_anchor_consistent_tests`):
- `diverging_db_path_is_rejected_naming_both_paths` — a deliberately-diverging resolved path is rejected, and the error message names both the resolved (wrong) path and the canonical anchor.
- `matching_explicit_db_path_passes` — an explicit `--db` value whose resolved path matches the anchor passes.
- `memory_sentinel_anchor_is_inert` — `:memory:` (anchor resolves to `None`) passes regardless of the resolved path.
- `normal_boot_with_db_unset_passes_silently` — `--db` unset resolves to the anchor and passes.

A regression test in `kkernel`'s binary test module, `coordinator_boundary_rejects_diverging_db_path`, drives a diverging `db_path` through the daemon-facing coordinator-attached boot path directly and asserts the error names both paths — proving that boundary is covered by the shared choke point, not just the plain multi-backend path.

All pre-existing tests in the touched crates continue to pass. Test fixtures that previously hardcoded `db_path` independent of the `--db` value they exercised now set it via `resolve_db_anchor` to correctly pair with the input each test actually passes — their original assertions are unchanged.

## Verification

- `cargo test -p khive-runtime --lib`: 603 passed, 0 failed
- `cargo test -p khive-mcp --lib`: 116 passed, 0 failed
- `cargo test -p kkernel --lib`: 174 passed, 0 failed
- `cargo test -p kkernel --bin kkernel`: 6 passed, 0 failed (includes the multi-backend boot-path wiring-parity tests and the new coordinator-boundary regression test)
- `cargo clippy -p khive-runtime -p khive-mcp -p kkernel --all-targets -- -D warnings`: clean
- `cargo fmt --all`: applied
