### PR TITLE
feat(khive-db): WriterTask single-writer core + bounded write queue (ADR-067 Component A, slice 1)

### DIFF
--- a/crates/khive-db/src/lib.rs
+++ b/crates/khive-db/src/lib.rs
@@ -19,6 +19,8 @@ pub mod pool;
 pub mod sql_bridge;
 /// Per-substrate store implementations (entity, note, graph, event, text, vectors, sparse).
 pub mod stores;
+/// Single-writer task and bounded write queue (ADR-067 Component A).
+pub mod writer_task;
 
 pub use backend::StorageBackend;
 pub use checkpoint::{checkpoint_once, run_checkpoint_task, CheckpointConfig, CheckpointTick};
@@ -29,3 +31,4 @@ pub use migrations::{
 };
 pub use pool::{ConnectionPool, PoolConfig, ReaderGuard, WriterGuard};
 pub use sql_bridge::SqlBridge;
+pub use writer_task::WriterTaskHandle;

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -16,6 +16,7 @@ const DEFAULT_READER_CAP: usize = 8;
 
 const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: u32 = 4000;
 const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES: i64 = 67_108_864; // 64 MiB
+const DEFAULT_WRITE_QUEUE_CAPACITY: usize = 256;
 
 /// Configuration for the connection pool.
 #[derive(Clone, Debug)]
@@ -55,6 +56,23 @@ pub struct PoolConfig {
     /// every connection that can execute SQL. Reader connections are already
     /// opened read-only regardless of this flag.
     pub read_only: bool,
+    /// Route migrated store write paths through the single-writer
+    /// `WriterTask` channel (ADR-067 Component A) instead of the legacy
+    /// per-call pool-mutex/standalone-connection path. Off by default.
+    ///
+    /// Slice 1 wires exactly one path (`SqlEntityStore::upsert_entities`)
+    /// behind this flag; enabling it does not yet claim ADR-067's
+    /// single-writer guarantee — other write paths still open their own
+    /// writers until later slices migrate them.
+    ///
+    /// Overridable via `KHIVE_WRITE_QUEUE` (`"1"` or `"true"`,
+    /// case-insensitive, enables it; anything else, or unset, leaves it off).
+    pub write_queue_enabled: bool,
+    /// Bounded channel capacity for the `WriterTask` write queue.
+    ///
+    /// Overridable via `KHIVE_WRITE_QUEUE_CAPACITY`. Default: 256 pending
+    /// operations (ADR-067 Component A recommended default).
+    pub write_queue_capacity: usize,
 }
 
 impl Default for PoolConfig {
@@ -87,6 +105,14 @@ impl Default for PoolConfig {
                 .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(DEFAULT_JOURNAL_SIZE_LIMIT_BYTES),
             read_only: false,
+            write_queue_enabled: std::env::var("KHIVE_WRITE_QUEUE")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
+            write_queue_capacity: std::env::var("KHIVE_WRITE_QUEUE_CAPACITY")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .filter(|&n| n > 0)
+                .unwrap_or(DEFAULT_WRITE_QUEUE_CAPACITY),
         }
     }
 }
@@ -670,6 +696,50 @@ mod tests {
         let cfg = PoolConfig::default();
         std::env::remove_var("KHIVE_CHECKOUT_TIMEOUT_SECS");
         assert_eq!(cfg.checkout_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_write_queue_defaults_off() {
+        let cfg = PoolConfig::default();
+        assert!(!cfg.write_queue_enabled);
+        assert_eq!(cfg.write_queue_capacity, DEFAULT_WRITE_QUEUE_CAPACITY);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_queue_enabled() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        assert!(cfg.write_queue_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_queue_enabled_accepts_true_case_insensitive() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "True");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        assert!(cfg.write_queue_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_override_write_queue_capacity() {
+        std::env::set_var("KHIVE_WRITE_QUEUE_CAPACITY", "64");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE_CAPACITY");
+        assert_eq!(cfg.write_queue_capacity, 64);
+    }
+
+    #[test]
+    #[serial]
+    fn pool_config_env_invalid_write_queue_capacity_falls_back_to_default() {
+        std::env::set_var("KHIVE_WRITE_QUEUE_CAPACITY", "0");
+        let cfg = PoolConfig::default();
+        std::env::remove_var("KHIVE_WRITE_QUEUE_CAPACITY");
+        assert_eq!(cfg.write_queue_capacity, DEFAULT_WRITE_QUEUE_CAPACITY);
     }
 
     #[test]

--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -4,11 +4,12 @@ use parking_lot::Mutex;
 use rusqlite::{Connection, OpenFlags};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::error::SqliteError;
+use crate::writer_task::WriterTaskHandle;
 
 const CACHE_SIZE_KIB: &str = "-65536";
 const MMAP_SIZE_BYTES: &str = "1073741824";
@@ -132,6 +133,18 @@ pub struct ConnectionPool {
     readers: ArrayQueue<Connection>,
     max_readers: usize,
     config: PoolConfig,
+    /// The pool-wide ADR-067 Component A writer task, spawned lazily and at
+    /// most once per pool (per DB file) via [`Self::writer_task_handle`] —
+    /// see that method's doc comment for why this lives here rather than on
+    /// each store.
+    writer_task: OnceLock<Option<WriterTaskHandle>>,
+    /// Test-only instrumentation: counts how many times the writer-task
+    /// init closure actually ran. Must never exceed 1 per pool no matter how
+    /// many stores are constructed over it — that is the invariant
+    /// `OnceLock::get_or_init` exists to guarantee, and what
+    /// `pool.rs`'s and `entity_tests.rs`'s one-writer-per-pool tests assert.
+    #[cfg(test)]
+    writer_task_spawn_count: std::sync::atomic::AtomicUsize,
 }
 
 enum ReaderLease<'pool> {
@@ -257,6 +270,9 @@ impl ConnectionPool {
             readers,
             max_readers,
             config,
+            writer_task: OnceLock::new(),
+            #[cfg(test)]
+            writer_task_spawn_count: std::sync::atomic::AtomicUsize::new(0),
         };
 
         for _ in 0..pool.max_readers {
@@ -383,6 +399,67 @@ impl ConnectionPool {
     /// Return the pool configuration.
     pub fn config(&self) -> &PoolConfig {
         &self.config
+    }
+
+    /// Return the pool-wide ADR-067 Component A writer task, spawning it
+    /// lazily on first access if `PoolConfig::write_queue_enabled` is set.
+    ///
+    /// Exactly one writer task exists per `ConnectionPool` (per DB file) no
+    /// matter how many stores or namespaces are constructed over it: the
+    /// `OnceLock` runs its init closure at most once, so concurrent callers
+    /// either race to run it once or block on the in-flight init and then
+    /// all receive a clone of the same resulting handle. This is what makes
+    /// the write queue an actual single-writer core rather than one writer
+    /// task per store — a per-store writer task would let concurrent
+    /// migrated stores over the same pool spawn independent writer
+    /// connections that contend with each other at `BEGIN IMMEDIATE`,
+    /// defeating the point of Component A.
+    ///
+    /// Returns `None` if the flag is off, or if the writer task failed to
+    /// spawn (for example, an in-memory pool has no standalone-connection
+    /// support) — callers fall back to the legacy pool-mutex write path in
+    /// either case. A spawn failure is logged once here (at first access),
+    /// not once per store.
+    ///
+    /// Must be called from within a Tokio runtime context on first access —
+    /// the initializing call may invoke `tokio::spawn` (via
+    /// `writer_task::spawn`). Every current caller (`SqlEntityStore::new`)
+    /// is reached only from async runtime paths (see the call-site audit in
+    /// ADR-067 slice 1's PR).
+    pub fn writer_task_handle(&self) -> Option<WriterTaskHandle> {
+        self.writer_task
+            .get_or_init(|| {
+                #[cfg(test)]
+                self.writer_task_spawn_count
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                if self.config.write_queue_enabled {
+                    match crate::writer_task::spawn(self, self.config.write_queue_capacity) {
+                        Ok(handle) => Some(handle),
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "KHIVE_WRITE_QUEUE=1 but the writer task failed to spawn; \
+                                 writes fall back to the pool-mutex path"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            })
+            .clone()
+    }
+
+    /// Test-only: how many times the writer-task init closure actually ran.
+    /// Must be at most 1 for the pool's whole lifetime, regardless of how
+    /// many times [`Self::writer_task_handle`] is called or how many stores
+    /// are constructed over this pool.
+    #[cfg(test)]
+    pub(crate) fn writer_task_spawn_count(&self) -> usize {
+        self.writer_task_spawn_count
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Compatibility method: returns the writer connection wrapped in `Arc<Mutex>`.

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -38,29 +38,19 @@ impl SqlEntityStore {
     ///
     /// When `KHIVE_WRITE_QUEUE=1` (`PoolConfig::write_queue_enabled`),
     /// `upsert_entities` — ADR-067 slice 1's single migrated write path —
-    /// routes through a dedicated `WriterTask` spawned here instead of the
-    /// legacy pool-mutex path (`with_writer`, unchanged and still used by
-    /// every other method on this store). If the task fails to spawn (for
+    /// routes through the pool-wide `WriterTask` (`ConnectionPool::writer_task_handle`)
+    /// instead of the legacy pool-mutex path (`with_writer`, unchanged and
+    /// still used by every other method on this store). The handle is a
+    /// clone of the ONE writer task owned by `pool` — constructing multiple
+    /// stores (or multiple namespaces) over the same pool never spawns more
+    /// than one writer task; see `ConnectionPool::writer_task_handle`'s doc
+    /// comment for why that matters. `None` (falling back to the legacy
+    /// path) if the flag is off, or if the writer task failed to spawn (for
     /// example, an in-memory pool, which has no standalone-connection
-    /// support), this falls back to the legacy path rather than failing
-    /// construction — the flag is a best-effort opt-in for slice 1, not a
-    /// hard requirement.
+    /// support) — the flag is a best-effort opt-in for slice 1, not a hard
+    /// requirement.
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
-        let writer_task = if pool.config().write_queue_enabled {
-            match crate::writer_task::spawn(&pool, pool.config().write_queue_capacity) {
-                Ok(handle) => Some(handle),
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "KHIVE_WRITE_QUEUE=1 but the writer task failed to spawn; \
-                         entity writes fall back to the pool-mutex path"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        let writer_task = pool.writer_task_handle();
 
         Self {
             pool,

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -13,6 +13,7 @@ use khive_storage::StorageCapability;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Entities, op, e)
@@ -29,14 +30,42 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 pub struct SqlEntityStore {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl SqlEntityStore {
     /// Create a new store.
+    ///
+    /// When `KHIVE_WRITE_QUEUE=1` (`PoolConfig::write_queue_enabled`),
+    /// `upsert_entities` — ADR-067 slice 1's single migrated write path —
+    /// routes through a dedicated `WriterTask` spawned here instead of the
+    /// legacy pool-mutex path (`with_writer`, unchanged and still used by
+    /// every other method on this store). If the task fails to spawn (for
+    /// example, an in-memory pool, which has no standalone-connection
+    /// support), this falls back to the legacy path rather than failing
+    /// construction — the flag is a best-effort opt-in for slice 1, not a
+    /// hard requirement.
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
+        let writer_task = if pool.config().write_queue_enabled {
+            match crate::writer_task::spawn(&pool, pool.config().write_queue_capacity) {
+                Ok(handle) => Some(handle),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "KHIVE_WRITE_QUEUE=1 but the writer task failed to spawn; \
+                         entity writes fall back to the pool-mutex path"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         Self {
             pool,
             is_file_backed,
+            writer_task,
         }
     }
 
@@ -168,6 +197,73 @@ fn read_entity(row: &rusqlite::Row<'_>) -> Result<Entity, rusqlite::Error> {
         deleted_at,
         merged_into,
         merge_event_id,
+    })
+}
+
+/// DML-only batch upsert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `upsert_entities` paths (ADR-067 slice 1).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction. Per-row failures are captured into
+/// `BatchWriteSummary::failed`/`first_error` rather than aborting the loop,
+/// matching the existing partial-success contract: this function's own
+/// `Result` is `Ok` unless a caller bug is present, since no branch here
+/// returns `Err`.
+fn batch_upsert_entities(
+    conn: &rusqlite::Connection,
+    entities: &[Entity],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let mut affected = 0u64;
+    let mut failed = 0u64;
+    let mut first_error = String::new();
+
+    for entity in entities {
+        let id_str = entity.id.to_string();
+        let properties_str = entity
+            .properties
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        let tags_str = serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
+
+        let merged_into_str = entity.merged_into.map(|u| u.to_string());
+        let merge_event_id_str = entity.merge_event_id.map(|u| u.to_string());
+        match conn.execute(
+            "INSERT OR REPLACE INTO entities \
+             (id, namespace, kind, entity_type, name, description, properties, tags, \
+              created_at, updated_at, deleted_at, merged_into, merge_event_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            rusqlite::params![
+                id_str,
+                &entity.namespace,
+                entity.kind,
+                entity.entity_type,
+                entity.name,
+                entity.description,
+                properties_str,
+                tags_str,
+                entity.created_at,
+                entity.updated_at,
+                entity.deleted_at,
+                merged_into_str,
+                merge_event_id_str,
+            ],
+        ) {
+            Ok(_) => affected += 1,
+            Err(e) => {
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed,
+        first_error,
     })
 }
 
@@ -321,66 +417,36 @@ impl EntityStore for SqlEntityStore {
     ) -> Result<BatchWriteSummary, StorageError> {
         let attempted = entities.len() as u64;
 
+        // ADR-067 slice 1: when the write queue is enabled, route through
+        // the WriterTask channel. The closure is DML-only — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction and `WriteRequest::execute_and_reply` owns
+        // the commit/rollback decision (a bare BEGIN IMMEDIATE inside this
+        // closure would violate SQLite's nested-transaction rule).
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    batch_upsert_entities(conn, &entities, attempted)
+                        .map_err(|e| map_err(e, "upsert_entities"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
+        // via the pool-mutex writer.
         self.with_writer("upsert_entities", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("entity_upsert_batch".to_string()));
-            let mut affected = 0u64;
-            let mut failed = 0u64;
-            let mut first_error = String::new();
 
-            for entity in &entities {
-                let id_str = entity.id.to_string();
-                let properties_str = entity
-                    .properties
-                    .as_ref()
-                    .map(|v| serde_json::to_string(v).unwrap_or_default());
-                let tags_str =
-                    serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
-
-                let merged_into_str = entity.merged_into.map(|u| u.to_string());
-                let merge_event_id_str = entity.merge_event_id.map(|u| u.to_string());
-                match conn.execute(
-                    "INSERT OR REPLACE INTO entities \
-                     (id, namespace, kind, entity_type, name, description, properties, tags, \
-                      created_at, updated_at, deleted_at, merged_into, merge_event_id) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                    rusqlite::params![
-                        id_str,
-                        &entity.namespace,
-                        entity.kind,
-                        entity.entity_type,
-                        entity.name,
-                        entity.description,
-                        properties_str,
-                        tags_str,
-                        entity.created_at,
-                        entity.updated_at,
-                        entity.deleted_at,
-                        merged_into_str,
-                        merge_event_id_str,
-                    ],
-                ) {
-                    Ok(_) => affected += 1,
-                    Err(e) => {
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                    }
-                }
-            }
+            let summary = batch_upsert_entities(conn, &entities, attempted)?;
 
             if let Err(e) = conn.execute_batch("COMMIT") {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
             }
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed,
-                first_error,
-            })
+            Ok(summary)
         })
         .await
     }

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -580,3 +580,49 @@ async fn upsert_entities_legacy_path_unchanged_when_flag_is_off() {
     assert_eq!(summary.affected, 2);
     assert_eq!(summary.failed, 0);
 }
+
+/// ADR-067 Component A's whole point is ONE writer owning the write
+/// connection for a DB file — a per-store writer task would let concurrent
+/// stores over the same pool spawn independent writer connections that
+/// contend with each other at `BEGIN IMMEDIATE`, so the migrated path would
+/// race itself instead of eliminating write contention. Constructing
+/// several `SqlEntityStore`s over the SAME pool with the flag on must spawn
+/// the writer task exactly once; every store resolves to a clone of the one
+/// pool-owned handle (`ConnectionPool::writer_task_handle`).
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial]
+async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_shared_writer.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+    }
+
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    // Three independent stores over the same pool, each resolving the
+    // write-queue flag on construction and asking the pool for its writer
+    // task — none of them must trigger a second spawn.
+    let _store1 = SqlEntityStore::new(Arc::clone(&pool), true);
+    let _store2 = SqlEntityStore::new(Arc::clone(&pool), true);
+    let _store3 = SqlEntityStore::new(Arc::clone(&pool), true);
+
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "N stores constructed over one pool must spawn the writer task \
+         exactly once — one writer task per pool (per DB file), not one \
+         per store"
+    );
+}

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::pool::PoolConfig;
+use serial_test::serial;
 
 fn setup_pool() -> Arc<ConnectionPool> {
     let config = PoolConfig {
@@ -499,4 +500,83 @@ async fn page_offset_over_i64max_rejected() {
         matches!(result, Err(StorageError::InvalidInput { .. })),
         "expected InvalidInput, got {result:?}"
     );
+}
+
+// =============================================================================
+// ADR-067 slice 1: WriterTask-routed `upsert_entities` (KHIVE_WRITE_QUEUE=1)
+// =============================================================================
+
+/// Flag-ON mechanism: with `KHIVE_WRITE_QUEUE=1`, `upsert_entities` routes
+/// through the WriterTask channel instead of the pool-mutex path, and the
+/// `BatchWriteSummary` fields (attempted/affected/failed/first_error) survive
+/// the trip through the type-erased channel intact, and both rows are
+/// actually committed and independently readable back through the store.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial]
+async fn upsert_entities_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_entities.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+    }
+
+    let store = SqlEntityStore::new(Arc::clone(&pool), true);
+
+    // Confined to the smallest possible window around construction, which is
+    // the only place this flag is read.
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let e1 = make_entity("default", "concept", "LoRA");
+    let e2 = make_entity("default", "concept", "QLoRA");
+    let id1 = e1.id;
+    let id2 = e2.id;
+
+    let summary = store.upsert_entities(vec![e1, e2]).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
+    assert!(summary.first_error.is_empty());
+
+    let fetched1 = store.get_entity(id1).await.unwrap();
+    assert!(
+        fetched1.is_some(),
+        "entity 1 must be committed and readable"
+    );
+    assert_eq!(fetched1.unwrap().name, "LoRA");
+
+    let fetched2 = store.get_entity(id2).await.unwrap();
+    assert!(
+        fetched2.is_some(),
+        "entity 2 must be committed and readable"
+    );
+    assert_eq!(fetched2.unwrap().name, "QLoRA");
+}
+
+/// Flag-OFF regression (explicit): with the flag at its default (off), the
+/// store never spawns a writer task, and `upsert_entities` still returns a
+/// correct `BatchWriteSummary` via the legacy pool-mutex path — the same
+/// shape `test_batch_upsert` above already covers, restated here to
+/// document the flag-off/flag-on pairing for ADR-067 slice 1.
+#[tokio::test]
+async fn upsert_entities_legacy_path_unchanged_when_flag_is_off() {
+    let store = setup_memory_store();
+
+    let e1 = make_entity("default", "concept", "LoRA");
+    let e2 = make_entity("default", "concept", "QLoRA");
+
+    let summary = store.upsert_entities(vec![e1, e2]).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
 }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -72,11 +72,27 @@ pub trait AnyWriteRequest: sealed::Sealed + Send {
     /// (possibly commit-failure-adjusted) result to the request's oneshot
     /// reply channel.
     ///
-    /// `conn` must already be inside a `BEGIN IMMEDIATE` transaction opened
-    /// by the caller (`run_writer_task`) — this method issues only
-    /// `COMMIT` / `ROLLBACK`, never `BEGIN`, so `run_writer_task` remains
-    /// the sole issuer of `BEGIN IMMEDIATE` (ADR-067 Component A).
+    /// `conn` must already be inside a successfully-opened `BEGIN IMMEDIATE`
+    /// transaction opened by the caller (`run_writer_task`) — this method
+    /// issues only `COMMIT` / `ROLLBACK`, never `BEGIN`, so `run_writer_task`
+    /// remains the sole issuer of `BEGIN IMMEDIATE` (ADR-067 Component A).
+    /// Callers must use [`Self::reply_error`] instead when the enclosing
+    /// `BEGIN IMMEDIATE` itself failed — this method must not be invoked in
+    /// that case.
     fn execute_and_reply(self: Box<Self>, conn: &Connection);
+
+    /// Replies with `err` without running this request's operation or
+    /// touching `conn`.
+    ///
+    /// Used when the enclosing `BEGIN IMMEDIATE` failed (for example,
+    /// `SQLITE_BUSY` from lock contention with an unmigrated writer path
+    /// still holding the pool's writer mutex — reachable while only
+    /// `entity.rs` is routed through this channel). Running the operation
+    /// anyway would execute its DML against `conn` in autocommit mode,
+    /// landing partial writes for a request the caller is told failed.
+    /// Skipping the operation entirely keeps "the caller got an error" and
+    /// "no rows landed" true together.
+    fn reply_error(self: Box<Self>, err: StorageError);
 }
 
 impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
@@ -101,6 +117,12 @@ impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
         // The receiver may already be gone (caller dropped its future) —
         // that is not this task's problem to report; it just moves on.
         let _ = self.reply.send(final_result);
+    }
+
+    fn reply_error(self: Box<Self>, err: StorageError) {
+        // Same "receiver may already be gone" reasoning as above — send and
+        // move on regardless of outcome.
+        let _ = self.reply.send(Err(err));
     }
 }
 
@@ -195,6 +217,16 @@ pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle,
 /// Drain loop: the sole caller of `BEGIN IMMEDIATE` for write traffic routed
 /// through the channel (ADR-067 Component A).
 ///
+/// A `BEGIN IMMEDIATE` failure (for example, `SQLITE_BUSY` from lock
+/// contention with an unmigrated writer path still holding the pool's writer
+/// mutex — reachable while only `entity.rs` is routed through this channel
+/// in this slice) replies the request's error via
+/// [`AnyWriteRequest::reply_error`] without ever invoking the request's
+/// operation closure via [`AnyWriteRequest::execute_and_reply`]. Slice 1 has
+/// no watchdog/retry story for a failed `BEGIN` (Component D is a later
+/// slice); the connection simply tries `BEGIN IMMEDIATE` fresh on the next
+/// request.
+///
 /// Exits when every [`WriterTaskHandle`] clone is dropped and the channel
 /// closes (`rx.recv()` returns `None`), or if the blocking closure panics.
 /// Either way, this task's `rx` is dropped when the function returns, which
@@ -209,22 +241,24 @@ async fn run_writer_task(
         let outcome = tokio::task::spawn_blocking(move || {
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("writer_task_tx".to_string()));
-            if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE") {
-                // Slice 1 has no watchdog/retry story for a failed BEGIN
-                // (Component D is a later slice). Proceeding without an
-                // explicit transaction still yields a correct reply: the
-                // op's own statements run in autocommit mode, and
-                // `execute_and_reply`'s subsequent `COMMIT` attempt fails
-                // with "no transaction is active", which it maps to
-                // `StorageError::Pool` and returns to the caller — a
-                // request never silently hangs or panics on this path.
-                tracing::warn!(
-                    error = %e,
-                    "writer task: BEGIN IMMEDIATE failed; request proceeds \
-                     without an explicit transaction"
-                );
+            match conn.execute_batch("BEGIN IMMEDIATE") {
+                Ok(()) => request.execute_and_reply(&conn),
+                Err(e) => {
+                    // Do NOT run the request's operation: `conn` never
+                    // entered a transaction, so executing the op's DML here
+                    // would run in autocommit mode and land partial writes
+                    // for a request the caller is about to be told failed.
+                    tracing::warn!(
+                        error = %e,
+                        "writer task: BEGIN IMMEDIATE failed; replying an \
+                         error without running the request's operation"
+                    );
+                    request.reply_error(StorageError::Pool {
+                        operation: "writer_task_begin".into(),
+                        message: e.to_string(),
+                    });
+                }
             }
-            request.execute_and_reply(&conn);
             conn
         })
         .await;
@@ -246,6 +280,8 @@ async fn run_writer_task(
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::time::Duration;
 
     fn file_pool(path: &std::path::Path) -> ConnectionPool {
@@ -254,6 +290,78 @@ mod tests {
             ..PoolConfig::default()
         };
         ConnectionPool::new(cfg).expect("pool open")
+    }
+
+    #[tokio::test]
+    async fn begin_immediate_failure_replies_error_without_running_op() {
+        // Real lock contention, not a simulation: hold the database-level
+        // write lock from the pool's own writer connection (the unmigrated
+        // path this fix is guarding against) so the writer task's dedicated
+        // connection genuinely fails `BEGIN IMMEDIATE` with `SQLITE_BUSY`
+        // after a short `busy_timeout`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_begin_failure.db");
+        let cfg = PoolConfig {
+            path: Some(path.clone()),
+            busy_timeout: Duration::from_millis(150),
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                .unwrap();
+        }
+
+        let handle = spawn(&pool, 8).expect("writer task should spawn on a file-backed pool");
+
+        let lock_holder = pool.try_writer().unwrap();
+        lock_holder.conn().execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let op_ran = Arc::new(AtomicBool::new(false));
+        let op_ran_clone = Arc::clone(&op_ran);
+        let result = handle
+            .send(move |conn| {
+                op_ran_clone.store(true, Ordering::SeqCst);
+                conn.execute("INSERT INTO t (id, v) VALUES (99, 'should-not-land')", [])
+                    .map_err(|e| StorageError::Pool {
+                        operation: "test_insert".into(),
+                        message: e.to_string(),
+                    })
+            })
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(StorageError::Pool { operation, .. }) if operation == "writer_task_begin"
+            ),
+            "expected a writer_task_begin Pool error on BEGIN IMMEDIATE \
+             failure, got {result:?}"
+        );
+        assert!(
+            !op_ran.load(Ordering::SeqCst),
+            "the request's operation closure must never run when BEGIN \
+             IMMEDIATE fails — running it would land a partial write in \
+             autocommit mode for a request the caller is told failed"
+        );
+
+        // Release the contended lock, then verify no row landed from the
+        // failed request.
+        lock_holder.conn().execute_batch("ROLLBACK").unwrap();
+        drop(lock_holder);
+
+        let reader = pool.reader().expect("reader");
+        let count: i64 = reader
+            .conn()
+            .query_row("SELECT COUNT(*) FROM t WHERE id = 99", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            count, 0,
+            "no row must have landed from the request whose BEGIN IMMEDIATE failed"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -1,0 +1,397 @@
+//! Single-writer task and bounded write queue (ADR-067 Component A).
+//!
+//! `WriterTask` (via `spawn` and the drain loop `run_writer_task`) owns a
+//! dedicated standalone writer `rusqlite::Connection` and is the only code
+//! path that issues `BEGIN IMMEDIATE` for write traffic routed through the
+//! channel it drains. Callers reach it exclusively through a
+//! [`WriterTaskHandle`], sending a typed closure and awaiting a typed
+//! oneshot reply so each store method's natural return type (e.g.
+//! `BatchWriteSummary`, with its `attempted`/`affected`/`failed`/
+//! `first_error` fields) survives the trip through the type-erased channel
+//! unmodified — a flat `Result<u64, StorageError>` reply would conflate
+//! `affected`/`failed` into one count and drop `first_error` (ADR-067
+//! Component A, lines 176-224).
+//!
+//! Slice 1 scope: this module builds the mechanism and wires exactly one
+//! write path (`SqlEntityStore::upsert_entities`, gated behind
+//! `KHIVE_WRITE_QUEUE=1` / `PoolConfig::write_queue_enabled`) through it. It
+//! commits one request per `BEGIN IMMEDIATE` — Component B's batched-commit
+//! window and three-level SAVEPOINT hierarchy, Component C's checkpoint
+//! coordination signal, and Component D's transaction watchdog are later
+//! slices. With only one store migrated, other write paths still open their
+//! own writer connections, so this slice does not yet reduce contention or
+//! claim the ADR's single-writer guarantee — it proves the mechanism works
+//! and that the flag-off path is unchanged.
+
+use rusqlite::Connection;
+use tokio::sync::{mpsc, oneshot};
+
+use khive_storage::error::StorageError;
+
+use crate::error::SqliteError;
+use crate::pool::ConnectionPool;
+
+/// Closure signature for a write operation executed against the writer
+/// task's dedicated connection.
+///
+/// `conn` is already inside a `BEGIN IMMEDIATE` transaction opened by
+/// `run_writer_task` when this runs. The closure must issue DML (and, in
+/// later slices, named `SAVEPOINT`s) only — never a bare `BEGIN` / `COMMIT`
+/// / `ROLLBACK` — a nested bare `BEGIN IMMEDIATE` would violate SQLite's
+/// nested-transaction rule and return `SQLITE_ERROR: cannot start a
+/// transaction within a transaction` (ADR-067 lines 271-276).
+type WriteOp<R> = Box<dyn FnOnce(&Connection) -> Result<R, StorageError> + Send>;
+
+/// One write request awaiting execution by the writer task.
+///
+/// Carries a typed closure and a typed oneshot reply so that the concrete
+/// return type `R` (e.g. `BatchWriteSummary`) is preserved end to end,
+/// while [`AnyWriteRequest`] lets the drain loop hold heterogeneous
+/// requests in one homogeneous channel.
+pub struct WriteRequest<R: Send + 'static> {
+    op: WriteOp<R>,
+    reply: oneshot::Sender<Result<R, StorageError>>,
+}
+
+mod sealed {
+    /// Restricts [`super::AnyWriteRequest`] to implementations defined in
+    /// this module — only [`super::WriteRequest<R>`] implements it.
+    pub trait Sealed {}
+}
+
+impl<R: Send + 'static> sealed::Sealed for WriteRequest<R> {}
+
+/// Type-erased write request the writer task's drain loop can hold in a
+/// homogeneous channel (`mpsc::Sender<Box<dyn AnyWriteRequest + Send>>`),
+/// while each concrete [`WriteRequest<R>`] still carries its own typed
+/// reply. Sealed: only this module may implement it (ADR-067 lines
+/// 210-212).
+pub trait AnyWriteRequest: sealed::Sealed + Send {
+    /// Runs this request's operation against `conn`, commits or rolls back
+    /// the enclosing transaction based on the outcome, and sends the
+    /// (possibly commit-failure-adjusted) result to the request's oneshot
+    /// reply channel.
+    ///
+    /// `conn` must already be inside a `BEGIN IMMEDIATE` transaction opened
+    /// by the caller (`run_writer_task`) — this method issues only
+    /// `COMMIT` / `ROLLBACK`, never `BEGIN`, so `run_writer_task` remains
+    /// the sole issuer of `BEGIN IMMEDIATE` (ADR-067 Component A).
+    fn execute_and_reply(self: Box<Self>, conn: &Connection);
+}
+
+impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
+    fn execute_and_reply(self: Box<Self>, conn: &Connection) {
+        let outcome = (self.op)(conn);
+        let final_result = match outcome {
+            Ok(value) => match conn.execute_batch("COMMIT") {
+                Ok(()) => Ok(value),
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(StorageError::Pool {
+                        operation: "writer_task_commit".into(),
+                        message: e.to_string(),
+                    })
+                }
+            },
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        };
+        // The receiver may already be gone (caller dropped its future) —
+        // that is not this task's problem to report; it just moves on.
+        let _ = self.reply.send(final_result);
+    }
+}
+
+/// Sender half of the write queue. Cheaply cloneable (wraps an
+/// `mpsc::Sender`) — every migrated store that shares one writer task holds
+/// a clone of this handle.
+#[derive(Clone)]
+pub struct WriterTaskHandle {
+    tx: mpsc::Sender<Box<dyn AnyWriteRequest + Send>>,
+}
+
+impl WriterTaskHandle {
+    /// Send a write operation to the writer task and await its typed reply.
+    ///
+    /// Backpressure: this suspends on the channel's `send().await` when the
+    /// bounded queue is full (ADR-067 "Channel capacity and queue-full
+    /// policy") — there is no `try_send` escape hatch. Callers that need a
+    /// deadline should use [`Self::send_with_timeout`] instead.
+    pub async fn send<R, F>(&self, op: F) -> Result<R, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
+    {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = WriteRequest {
+            op: Box::new(op),
+            reply: reply_tx,
+        };
+
+        self.tx
+            .send(Box::new(request))
+            .await
+            .map_err(|_| StorageError::Internal("writer task channel closed".to_string()))?;
+
+        reply_rx.await.map_err(|_| {
+            StorageError::Internal("writer task dropped before replying".to_string())
+        })?
+    }
+
+    /// Like [`Self::send`], but bounds the wait on a full channel with
+    /// `timeout`.
+    ///
+    /// ADR-067's queue-full policy has no immediate-error `try_send` path —
+    /// only a caller-side deadline wrapping the blocking `send().await`. A
+    /// full channel that does not free capacity within `timeout` returns
+    /// `StorageError::WriteQueueFull` instead of resolving.
+    pub async fn send_with_timeout<R, F>(
+        &self,
+        op: F,
+        timeout: std::time::Duration,
+    ) -> Result<R, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
+    {
+        match tokio::time::timeout(timeout, self.send(op)).await {
+            Ok(result) => result,
+            Err(_elapsed) => Err(StorageError::WriteQueueFull {
+                timeout_ms: timeout.as_millis() as u64,
+            }),
+        }
+    }
+}
+
+/// Spawn the write-owner task (ADR-067 Component A) on the current Tokio
+/// runtime.
+///
+/// Opens a dedicated standalone writer connection
+/// ([`ConnectionPool::open_standalone_writer`]) that the task owns
+/// exclusively for its lifetime — independent of the pool's Mutex-guarded
+/// `writer()` connection, which unmigrated paths continue to use in this
+/// slice. Returns the cloneable [`WriterTaskHandle`] sender half; the task
+/// keeps running in the background until every clone of the handle is
+/// dropped and the channel closes, at which point the drain loop exits.
+///
+/// `capacity` bounds the channel (ADR-067 recommends 256;
+/// `PoolConfig::write_queue_capacity` resolves the default from
+/// `KHIVE_WRITE_QUEUE_CAPACITY`). Slice 1 commits one request per `BEGIN
+/// IMMEDIATE` — Component B's batched-commit window is a later slice.
+///
+/// Must be called from within a Tokio runtime context (this calls
+/// `tokio::spawn`). Returns an error if the pool cannot open a standalone
+/// writer connection — for example, an in-memory pool, which has no
+/// standalone-connection support (`ConnectionPool::open_standalone_writer`).
+pub fn spawn(pool: &ConnectionPool, capacity: usize) -> Result<WriterTaskHandle, SqliteError> {
+    let conn = pool.open_standalone_writer()?;
+    let (tx, rx) = mpsc::channel(capacity.max(1));
+    tokio::spawn(run_writer_task(conn, rx));
+    Ok(WriterTaskHandle { tx })
+}
+
+/// Drain loop: the sole caller of `BEGIN IMMEDIATE` for write traffic routed
+/// through the channel (ADR-067 Component A).
+///
+/// Exits when every [`WriterTaskHandle`] clone is dropped and the channel
+/// closes (`rx.recv()` returns `None`), or if the blocking closure panics.
+/// Either way, this task's `rx` is dropped when the function returns, which
+/// is what turns subsequent `WriterTaskHandle::send` calls into
+/// `StorageError::Internal` (ADR-067 failure-mode table: "Receiver drop
+/// (writer task stopped)" / "Writer task panic").
+async fn run_writer_task(
+    mut conn: Connection,
+    mut rx: mpsc::Receiver<Box<dyn AnyWriteRequest + Send>>,
+) {
+    while let Some(request) = rx.recv().await {
+        let outcome = tokio::task::spawn_blocking(move || {
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("writer_task_tx".to_string()));
+            if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE") {
+                // Slice 1 has no watchdog/retry story for a failed BEGIN
+                // (Component D is a later slice). Proceeding without an
+                // explicit transaction still yields a correct reply: the
+                // op's own statements run in autocommit mode, and
+                // `execute_and_reply`'s subsequent `COMMIT` attempt fails
+                // with "no transaction is active", which it maps to
+                // `StorageError::Pool` and returns to the caller — a
+                // request never silently hangs or panics on this path.
+                tracing::warn!(
+                    error = %e,
+                    "writer task: BEGIN IMMEDIATE failed; request proceeds \
+                     without an explicit transaction"
+                );
+            }
+            request.execute_and_reply(&conn);
+            conn
+        })
+        .await;
+
+        match outcome {
+            Ok(returned_conn) => conn = returned_conn,
+            Err(join_err) => {
+                tracing::error!(
+                    error = %join_err,
+                    "writer task blocking closure panicked; writer task is exiting"
+                );
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::PoolConfig;
+    use std::time::Duration;
+
+    fn file_pool(path: &std::path::Path) -> ConnectionPool {
+        let cfg = PoolConfig {
+            path: Some(path.to_path_buf()),
+            ..PoolConfig::default()
+        };
+        ConnectionPool::new(cfg).expect("pool open")
+    }
+
+    #[tokio::test]
+    async fn writer_task_executes_op_and_commits() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_commit.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                .unwrap();
+        }
+
+        let handle = spawn(&pool, 8).expect("writer task should spawn on a file-backed pool");
+
+        let affected = handle
+            .send(|conn| {
+                conn.execute("INSERT INTO t (id, v) VALUES (1, 'hello')", [])
+                    .map_err(|e| StorageError::Pool {
+                        operation: "test_insert".into(),
+                        message: e.to_string(),
+                    })
+            })
+            .await
+            .expect("op should succeed");
+        assert_eq!(affected, 1);
+
+        // Verify the write actually committed to the shared file — read it
+        // back via a fresh pooled reader connection, not the writer task's
+        // own connection.
+        let reader = pool.reader().expect("reader");
+        let v: String = reader
+            .conn()
+            .query_row("SELECT v FROM t WHERE id = 1", [], |row| row.get(0))
+            .expect("row must be committed and visible to a reader");
+        assert_eq!(v, "hello");
+    }
+
+    #[test]
+    fn spawn_fails_on_in_memory_pool() {
+        // In-memory pools have no standalone-connection support
+        // (`ConnectionPool::open_standalone_writer`) — `spawn` must surface
+        // that as an error rather than panicking. Deliberately a plain
+        // `#[test]` (no Tokio runtime): `spawn` fails before it ever reaches
+        // `tokio::spawn`, so no runtime is required for this path.
+        let cfg = PoolConfig {
+            path: None,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).unwrap();
+        let result = spawn(&pool, 8);
+        assert!(
+            result.is_err(),
+            "in-memory pools must reject spawn, not panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_channel_applies_backpressure_not_immediate_error() {
+        // Build the channel directly (bypassing `spawn`/`run_writer_task`)
+        // so nothing ever drains it — deterministic control over "the
+        // channel is full" instead of racing a real writer task's
+        // processing speed.
+        let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
+        let handle = WriterTaskHandle { tx };
+
+        // First send fills the sole channel slot. Its reply never arrives
+        // since nothing drains `_rx`, so run it in the background.
+        let first = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                let _ = handle.send(|_conn| Ok::<(), StorageError>(())).await;
+            }
+        });
+
+        // Give the first send a moment to occupy the channel slot.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Second send must block (backpressure), not fail immediately: a
+        // short timeout should elapse rather than resolve.
+        let second = tokio::time::timeout(
+            Duration::from_millis(100),
+            handle.send(|_conn| Ok::<(), StorageError>(())),
+        )
+        .await;
+
+        assert!(
+            second.is_err(),
+            "a full channel must apply backpressure (send suspends) rather \
+             than erroring immediately — no try_send escape hatch per ADR-067"
+        );
+
+        first.abort();
+    }
+
+    #[tokio::test]
+    async fn send_with_timeout_maps_full_channel_to_write_queue_full() {
+        let (tx, _rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(1);
+        let handle = WriterTaskHandle { tx };
+
+        let first = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                let _ = handle.send(|_conn| Ok::<(), StorageError>(())).await;
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let result = handle
+            .send_with_timeout(
+                |_conn| Ok::<(), StorageError>(()),
+                Duration::from_millis(50),
+            )
+            .await;
+
+        match result {
+            Err(StorageError::WriteQueueFull { timeout_ms }) => assert_eq!(timeout_ms, 50),
+            other => panic!("expected WriteQueueFull, got {other:?}"),
+        }
+
+        first.abort();
+    }
+
+    #[tokio::test]
+    async fn dropped_receiver_maps_send_to_internal_error() {
+        // Simulates the writer task having stopped/panicked: its `rx` is
+        // gone, so `tx.send()` must fail rather than hang.
+        let (tx, rx) = mpsc::channel::<Box<dyn AnyWriteRequest + Send>>(4);
+        drop(rx);
+
+        let handle = WriterTaskHandle { tx };
+        let result = handle.send(|_conn| Ok::<(), StorageError>(())).await;
+
+        match result {
+            Err(StorageError::Internal(_)) => {}
+            other => panic!("expected Internal error on a closed channel, got {other:?}"),
+        }
+    }
+}

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -135,13 +135,21 @@ pub struct WriterTaskHandle {
 }
 
 impl WriterTaskHandle {
-    /// Send a write operation to the writer task and await its typed reply.
+    /// Enqueue a write operation and return the oneshot receiver its reply
+    /// will arrive on, once the request has actually been accepted onto the
+    /// channel.
     ///
-    /// Backpressure: this suspends on the channel's `send().await` when the
-    /// bounded queue is full (ADR-067 "Channel capacity and queue-full
-    /// policy") — there is no `try_send` escape hatch. Callers that need a
-    /// deadline should use [`Self::send_with_timeout`] instead.
-    pub async fn send<R, F>(&self, op: F) -> Result<R, StorageError>
+    /// Shared by [`Self::send`] and [`Self::send_with_timeout`] so that a
+    /// caller-supplied deadline (see `send_with_timeout`) can bound ONLY
+    /// this enqueue step — never the reply-wait that follows it. Once this
+    /// returns `Ok`, the request has been accepted by the writer task and
+    /// will run to completion; the returned receiver must be awaited without
+    /// a timeout; abandoning it here would silently drop the request's
+    /// eventual result, not cancel the request itself.
+    async fn enqueue<R, F>(
+        &self,
+        op: F,
+    ) -> Result<oneshot::Receiver<Result<R, StorageError>>, StorageError>
     where
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
@@ -157,18 +165,40 @@ impl WriterTaskHandle {
             .await
             .map_err(|_| StorageError::Internal("writer task channel closed".to_string()))?;
 
+        Ok(reply_rx)
+    }
+
+    /// Send a write operation to the writer task and await its typed reply.
+    ///
+    /// Backpressure: this suspends on the channel's `send().await` when the
+    /// bounded queue is full (ADR-067 "Channel capacity and queue-full
+    /// policy") — there is no `try_send` escape hatch. Callers that need a
+    /// deadline on that wait should use [`Self::send_with_timeout`] instead.
+    pub async fn send<R, F>(&self, op: F) -> Result<R, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
+    {
+        let reply_rx = self.enqueue(op).await?;
         reply_rx.await.map_err(|_| {
             StorageError::Internal("writer task dropped before replying".to_string())
         })?
     }
 
-    /// Like [`Self::send`], but bounds the wait on a full channel with
-    /// `timeout`.
+    /// Like [`Self::send`], but bounds the wait for the bounded channel to
+    /// free capacity with `timeout`.
     ///
-    /// ADR-067's queue-full policy has no immediate-error `try_send` path —
-    /// only a caller-side deadline wrapping the blocking `send().await`. A
-    /// full channel that does not free capacity within `timeout` returns
-    /// `StorageError::WriteQueueFull` instead of resolving.
+    /// The timeout applies ONLY to enqueueing the request (the channel
+    /// `send().await` that can suspend on a full queue) — never to waiting
+    /// for the writer task's reply once the request has been accepted.
+    /// `StorageError::WriteQueueFull` means exactly "the bounded channel was
+    /// full and this request was never accepted"; it must never be returned
+    /// for a request that was accepted and is still executing (or already
+    /// committed) by the time `timeout` elapses — that would misreport a
+    /// slow op or a lock wait as a queue-capacity failure, and could tell a
+    /// caller a write failed when it actually landed. ADR-067's queue-full
+    /// policy has no immediate-error `try_send` path — only this caller-side
+    /// deadline on the enqueue step.
     pub async fn send_with_timeout<R, F>(
         &self,
         op: F,
@@ -178,12 +208,19 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
-        match tokio::time::timeout(timeout, self.send(op)).await {
-            Ok(result) => result,
-            Err(_elapsed) => Err(StorageError::WriteQueueFull {
-                timeout_ms: timeout.as_millis() as u64,
-            }),
-        }
+        let reply_rx = match tokio::time::timeout(timeout, self.enqueue(op)).await {
+            Ok(Ok(reply_rx)) => reply_rx,
+            Ok(Err(e)) => return Err(e),
+            Err(_elapsed) => {
+                return Err(StorageError::WriteQueueFull {
+                    timeout_ms: timeout.as_millis() as u64,
+                })
+            }
+        };
+
+        reply_rx.await.map_err(|_| {
+            StorageError::Internal("writer task dropped before replying".to_string())
+        })?
     }
 }
 
@@ -485,6 +522,59 @@ mod tests {
         }
 
         first.abort();
+    }
+
+    #[tokio::test]
+    async fn send_with_timeout_returns_op_result_when_op_outlives_the_timeout() {
+        // `send_with_timeout`'s timeout must bound ONLY the enqueue step —
+        // never the reply-wait. An accepted request (channel not full) must
+        // run to completion and report its REAL result even when that takes
+        // longer than `timeout`; before this fix, wrapping the whole
+        // send-plus-reply-wait in one timeout would misreport this as
+        // `WriteQueueFull` despite the write actually landing.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_slow_op.db");
+        let pool = file_pool(&path);
+        {
+            let writer = pool.try_writer().unwrap();
+            writer
+                .conn()
+                .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                .unwrap();
+        }
+
+        let handle = spawn(&pool, 8).expect("writer task should spawn on a file-backed pool");
+
+        let result = handle
+            .send_with_timeout(
+                |conn| {
+                    // Deliberately slower than the timeout below: proves the
+                    // reply-wait itself is never bounded by `timeout`.
+                    std::thread::sleep(Duration::from_millis(150));
+                    conn.execute("INSERT INTO t (id, v) VALUES (1, 'slow')", [])
+                        .map_err(|e| StorageError::Pool {
+                            operation: "test_insert".into(),
+                            message: e.to_string(),
+                        })
+                },
+                Duration::from_millis(20),
+            )
+            .await;
+
+        let affected = result.expect(
+            "an accepted request must return its real result even when the \
+             op takes longer than the enqueue timeout, not WriteQueueFull",
+        );
+        assert_eq!(affected, 1);
+
+        // The slow op's write must have actually committed, not just been
+        // reported as successful.
+        let reader = pool.reader().expect("reader");
+        let v: String = reader
+            .conn()
+            .query_row("SELECT v FROM t WHERE id = 1", [], |row| row.get(0))
+            .expect("the slow op's write must have committed");
+        assert_eq!(v, "slow");
     }
 
     #[tokio::test]

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -79,6 +79,21 @@ pub enum StorageError {
         #[source]
         source: Box<dyn StdError + Send + Sync>,
     },
+
+    /// The bounded write-queue channel (ADR-067 Component A) did not free
+    /// capacity within the caller-supplied deadline. Returned only when a
+    /// caller wraps `WriterTaskHandle::send`'s `channel.send().await` in a
+    /// `tokio::time::timeout` — there is no immediate-error `try_send` path;
+    /// an un-timed-out send simply keeps applying backpressure.
+    #[error("write queue full: timed out after {timeout_ms}ms waiting for writer task capacity")]
+    WriteQueueFull { timeout_ms: u64 },
+
+    /// An internal write-queue plumbing failure not attributable to a
+    /// specific storage capability: the writer task's channel closed (the
+    /// task panicked or was dropped) or its oneshot reply was dropped before
+    /// sending a result.
+    #[error("internal storage error: {0}")]
+    Internal(String),
 }
 
 impl StorageError {
@@ -106,7 +121,11 @@ impl StorageError {
             | Self::Serialization { capability, .. }
             | Self::IndexMaintenance { capability, .. }
             | Self::Driver { capability, .. } => Some(*capability),
-            Self::Pool { .. } | Self::Timeout { .. } | Self::Transaction { .. } => None,
+            Self::Pool { .. }
+            | Self::Timeout { .. }
+            | Self::Transaction { .. }
+            | Self::WriteQueueFull { .. }
+            | Self::Internal(..) => None,
         }
     }
 
@@ -114,7 +133,10 @@ impl StorageError {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Self::Pool { .. } | Self::Timeout { .. } | Self::Transaction { .. }
+            Self::Pool { .. }
+                | Self::Timeout { .. }
+                | Self::Transaction { .. }
+                | Self::WriteQueueFull { .. }
         )
     }
 


### PR DESCRIPTION
## Summary

Slice 1 of ADR-067 (Write-Owner Daemon), Component A only.

- Adds `writer_task.rs`: a dedicated writer task owning a standalone
  connection, reached through a bounded `mpsc` channel of type-erased
  write requests (`WriteRequest<R>` / sealed `AnyWriteRequest`) with
  typed `oneshot` replies. Each request's natural return type (e.g.
  `BatchWriteSummary`) survives the channel unmodified — no collapsing
  to a flat count.
- Wires exactly one write path, `SqlEntityStore::upsert_entities`,
  through the new mechanism, gated behind an off-by-default
  `KHIVE_WRITE_QUEUE` flag (`PoolConfig::write_queue_enabled` /
  `write_queue_capacity`, both env-overridable via `KHIVE_WRITE_QUEUE`
  and `KHIVE_WRITE_QUEUE_CAPACITY`).
- With the flag off, the path is byte-for-byte unchanged: the
  batch-upsert loop was extracted into a shared helper so both the
  legacy and WriterTask-routed paths call the same code, but the
  legacy path's own `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` sequence
  and return value are untouched.
- Adds two `StorageError` variants: `WriteQueueFull` (returned by
  `WriterTaskHandle::send_with_timeout` when the bounded channel does
  not free capacity in time) and `Internal` (the writer task's channel
  closed, or its oneshot reply was dropped before sending).
- The writer task is owned once per `ConnectionPool` (per DB file),
  spawned lazily via `OnceLock` on first access and shared by every
  store constructed over that pool — see "One writer task per pool"
  below.

## Out of scope for this slice

Later ADR-067 slices: Component B (batched commits, three-level
`SAVEPOINT` hierarchy), Component C (checkpoint coordination signal),
Component D (transaction watchdog, `StorageError::WatchdogTimeout`),
and migrating the other write paths onto the writer task. With only
one store migrated, this slice does not yet reduce write contention
or claim the ADR's single-writer guarantee — it proves the mechanism
works and that the flag-off path is a true no-op.

## Correctness: a failed BEGIN IMMEDIATE never runs the operation

`run_writer_task`'s drain loop branches on the `BEGIN IMMEDIATE`
result. On success it runs the request via `execute_and_reply`
(unchanged). On failure — for example `SQLITE_BUSY` from lock
contention with an unmigrated writer path still holding the pool's
writer mutex, reachable while only `entity.rs` is migrated — it calls
a new `reply_error` method on the sealed `AnyWriteRequest` trait
instead, which sends the error straight to the request's oneshot reply
without ever invoking the request's operation closure. No DML from
that request executes, so nothing can land in autocommit mode ahead of
a reported failure.

```rust
match conn.execute_batch("BEGIN IMMEDIATE") {
    Ok(()) => request.execute_and_reply(&conn),
    Err(e) => {
        request.reply_error(StorageError::Pool {
            operation: "writer_task_begin".into(),
            message: e.to_string(),
        });
    }
}
```

Test `writer_task::tests::begin_immediate_failure_replies_error_without_running_op`
forces a genuine `BEGIN IMMEDIATE` failure rather than simulating one:
it opens a file-backed pool with a short `busy_timeout` (150ms), holds
the database-level write lock from the pool's own writer connection
(`BEGIN IMMEDIATE` with no commit — the unmigrated path this guards
against), then sends a request through the writer task. It asserts
both:
- the caller receives `Err(StorageError::Pool { operation: "writer_task_begin", .. })`, and
- the op closure never ran (an `AtomicBool` flip inside the closure stays `false`), and separately, after releasing the lock, that the row it would have inserted does not exist in the table.

Ran 5x back to back with no flakiness (~0.2s each).

## Correctness: send_with_timeout's timeout bounds only the enqueue step

`send_with_timeout` previously wrapped the entire send-plus-reply-wait
in one `tokio::time::timeout`. If the timeout elapsed after the
request was already enqueued but before the writer replied, the caller
received `WriteQueueFull` even though the accepted request could still
execute and commit — a write-landed-but-reported-failed interleaving,
and a misclassification of a slow op or lock wait as a queue-capacity
failure.

Fixed by splitting the enqueue step (the channel `send`) from the
reply-wait (the oneshot receiver) into a private `enqueue` helper
shared by `send` and `send_with_timeout`:

```rust
async fn enqueue<R, F>(&self, op: F)
    -> Result<oneshot::Receiver<Result<R, StorageError>>, StorageError> { ... }

pub async fn send<R, F>(&self, op: F) -> Result<R, StorageError> {
    let reply_rx = self.enqueue(op).await?;
    reply_rx.await.map_err(|_| StorageError::Internal(..))?
}

pub async fn send_with_timeout<R, F>(&self, op: F, timeout: Duration) -> Result<R, StorageError> {
    let reply_rx = match tokio::time::timeout(timeout, self.enqueue(op)).await {
        Ok(Ok(reply_rx)) => reply_rx,
        Ok(Err(e)) => return Err(e),
        Err(_elapsed) => return Err(StorageError::WriteQueueFull { timeout_ms: .. }),
    };
    reply_rx.await.map_err(|_| StorageError::Internal(..))?
}
```

Only `send_with_timeout`'s timeout wraps the enqueue call; the
reply-wait that follows a successful enqueue is never subject to a
timeout. `WriteQueueFull` now means exactly "the bounded channel was
full and this request was never accepted."

Test `writer_task::tests::send_with_timeout_returns_op_result_when_op_outlives_the_timeout`
sends an op that sleeps 150ms through `send_with_timeout` with a 20ms
timeout, over a channel that is not full. It asserts the call returns
the op's real `Ok` result (not `WriteQueueFull`), and that the write
actually committed — proving an accepted request is never abandoned or
misreported regardless of how long it takes to run. The existing
`send_with_timeout_maps_full_channel_to_write_queue_full` (full
channel → `WriteQueueFull`) remains green.

## Correctness: one writer task per pool, not one per store

`SqlEntityStore::new` previously spawned its own writer task on every
construction, and `entities_for_namespace` constructs a fresh
`SqlEntityStore` on every call — so concurrent runtime calls with the
flag on could each spawn an independent writer task and standalone
connection. Migrated writes then went through separate queues and
contended with each other at `BEGIN IMMEDIATE`, defeating the
single-writer core even for the one migrated path in this slice.

Fixed by moving the writer task to a `OnceLock` owned by
`ConnectionPool`:

```rust
pub fn writer_task_handle(&self) -> Option<WriterTaskHandle> {
    self.writer_task
        .get_or_init(|| {
            if self.config.write_queue_enabled {
                crate::writer_task::spawn(self, self.config.write_queue_capacity).ok()
            } else {
                None
            }
        })
        .clone()
}
```

`SqlEntityStore::new` now does `let writer_task = pool.writer_task_handle();`
instead of spawning its own — every store constructed over the same
pool clones the one handle the pool owns. The writer task's lifetime
now matches the pool's (the DB file's), not the store's, which is what
Component A requires: exactly one writer per pool.

`writer_task_handle`'s initializing call may invoke `tokio::spawn`,
so it must run inside a Tokio runtime context on first access. That
holds today: the only production call site of `SqlEntityStore::new` is
`StorageBackend::entities_for_namespace`
(`khive-db/src/backend.rs:163`), whose only caller is `Runtime::entities`
(`khive-runtime/src/runtime.rs:288-292`). Every call site of
`Runtime::entities` is inside an `async fn` that immediately `.await`s
a method on the returned store in the same function:
- `khive-runtime/src/operations.rs` (many call sites, e.g. lines 596, 3069, 3501, 3527)
- `khive-runtime/src/curation.rs` (lines 217, 327)
- `khive-runtime/src/portability.rs` (lines 96, 211)
- `khive-runtime/src/retrieval.rs` (line 464)
- `khive-runtime/src/fusion.rs` (line 206)
- `khive-vcs/src/sync.rs` (`run_sync` / `run_sync_remote`, both `pub async fn`)
- `khive-pack-kg/src/handlers/{list,common,search,context}.rs` (all `async fn` verb handlers)
- `kkernel/src/coordinator/dispatch.rs`, `kkernel/src/reindex.rs` (`async fn`)

The sole production binary entrypoint driving all of the above is
`kkernel/src/main.rs` (`#[tokio::main] async fn main()`); `khive-mcp`
is a library-only crate (no `main.rs` / `[[bin]]`) consumed by
`kkernel`, so there is exactly one Tokio runtime root in production.
Test call sites (`entity_tests.rs`, `writer_task.rs`) are all
`#[tokio::test]`, with one deliberate exception:
`writer_task::tests::spawn_fails_on_in_memory_pool` is a plain
`#[test]` because `spawn()`'s `pool.open_standalone_writer()?` call
returns `Err` via `?` for in-memory pools before the function ever
reaches its `tokio::spawn(...)` line.

Test `stores::entity::tests::multiple_stores_over_one_pool_share_a_single_writer_task`
constructs three `SqlEntityStore`s over the same pool with the flag on
and asserts a test-only spawn counter on the pool (incremented inside
the `OnceLock` init closure) equals exactly `1`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p khive-db -p khive-storage` (317 tests, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-db -p khive-storage`
