### PR TITLE
feat(khive-db): route all write paths through WriterTask (ADR-067 Component A single-writer guarantee)

### DIFF
--- a/crates/khive-db/src/pool.rs
+++ b/crates/khive-db/src/pool.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use crate::error::SqliteError;
 use crate::writer_task::WriterTaskHandle;
+use khive_storage::error::StorageError;
 
 const CACHE_SIZE_KIB: &str = "-65536";
 const MMAP_SIZE_BYTES: &str = "1073741824";
@@ -415,41 +416,57 @@ impl ConnectionPool {
     /// connections that contend with each other at `BEGIN IMMEDIATE`,
     /// defeating the point of Component A.
     ///
-    /// Returns `None` if the flag is off, or if the writer task failed to
-    /// spawn (for example, an in-memory pool has no standalone-connection
-    /// support) — callers fall back to the legacy pool-mutex write path in
-    /// either case. A spawn failure is logged once here (at first access),
-    /// not once per store.
+    /// Returns `Ok(None)` if the flag is off, or if the writer task failed to
+    /// spawn for a reason other than a missing runtime (for example, an
+    /// in-memory pool has no standalone-connection support) — callers fall
+    /// back to the legacy pool-mutex write path in either case. A spawn
+    /// failure is logged once here (at first access), not once per store.
     ///
-    /// Must be called from within a Tokio runtime context on first access —
-    /// the initializing call may invoke `tokio::spawn` (via
-    /// `writer_task::spawn`). Every current caller (`SqlEntityStore::new`)
-    /// is reached only from async runtime paths (see the call-site audit in
-    /// ADR-067 slice 1's PR).
-    pub fn writer_task_handle(&self) -> Option<WriterTaskHandle> {
-        self.writer_task
+    /// Returns `Err(StorageError::WriterTaskNoRuntime)` instead of panicking
+    /// when `write_queue_enabled` is set but this is the first access and no
+    /// Tokio runtime is available on the calling thread (checked via
+    /// [`tokio::runtime::Handle::try_current`]) — spawning the writer task
+    /// requires `tokio::spawn`, which panics outside a runtime. Callers that
+    /// already treat a missing writer task as best-effort (construction-time
+    /// degrade to the legacy path, matching slice 1's documented policy) can
+    /// collapse this into `None` with `.ok().flatten()`; callers that need to
+    /// fail loud on a genuine misconfiguration (write queue requested but no
+    /// runtime to run it on) can propagate the `Err` directly.
+    pub fn writer_task_handle(&self) -> Result<Option<WriterTaskHandle>, StorageError> {
+        if !self.config.write_queue_enabled {
+            return Ok(None);
+        }
+        // Fast path: already resolved (spawned, degraded, or off) by an
+        // earlier call — no need to re-check the runtime.
+        if let Some(existing) = self.writer_task.get() {
+            return Ok(existing.clone());
+        }
+        // Not yet initialized and the flag is on: spawning requires
+        // `tokio::spawn`, which panics outside a runtime context. Check
+        // first and fail loud with a typed error instead.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(StorageError::WriterTaskNoRuntime);
+        }
+        Ok(self
+            .writer_task
             .get_or_init(|| {
                 #[cfg(test)]
                 self.writer_task_spawn_count
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-                if self.config.write_queue_enabled {
-                    match crate::writer_task::spawn(self, self.config.write_queue_capacity) {
-                        Ok(handle) => Some(handle),
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "KHIVE_WRITE_QUEUE=1 but the writer task failed to spawn; \
-                                 writes fall back to the pool-mutex path"
-                            );
-                            None
-                        }
+                match crate::writer_task::spawn(self, self.config.write_queue_capacity) {
+                    Ok(handle) => Some(handle),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "KHIVE_WRITE_QUEUE=1 but the writer task failed to spawn; \
+                             writes fall back to the pool-mutex path"
+                        );
+                        None
                     }
-                } else {
-                    None
                 }
             })
-            .clone()
+            .clone())
     }
 
     /// Test-only: how many times the writer-task init closure actually ran.
@@ -915,6 +932,41 @@ mod tests {
                 .iter()
                 .any(|(_, label)| label.as_deref() == Some("writer_guard_tx")),
             "expected the entry to be gone after the transaction completes"
+        );
+    }
+
+    /// ADR-067 Component A runtime-handle guard: `write_queue_enabled` is set
+    /// but the calling thread has no Tokio runtime context, so spawning the
+    /// writer task (which requires `tokio::spawn`) is impossible.
+    /// `writer_task_handle` must return a clean typed error instead of
+    /// panicking.
+    ///
+    /// Deliberately a plain `#[test]` (no Tokio runtime) — mirrors
+    /// `writer_task::spawn_fails_on_in_memory_pool`'s shape: the failure must
+    /// be observable without ever entering an async context, since entering
+    /// one here would defeat the point of the test.
+    #[test]
+    fn writer_task_handle_fails_loud_without_tokio_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer_task_no_runtime.db");
+        let cfg = PoolConfig {
+            path: Some(path),
+            write_queue_enabled: true,
+            ..PoolConfig::default()
+        };
+        let pool = ConnectionPool::new(cfg).expect("file-backed pool should open");
+
+        let result = pool.writer_task_handle();
+
+        assert!(
+            matches!(result, Err(StorageError::WriterTaskNoRuntime)),
+            "expected Err(StorageError::WriterTaskNoRuntime) outside a Tokio \
+             runtime, got {result:?}"
+        );
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            0,
+            "the guard must reject before ever attempting tokio::spawn"
         );
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -260,6 +260,12 @@ impl khive_storage::SqlReader for SqliteReader {
 
 struct SqliteWriter {
     conn: Option<rusqlite::Connection>,
+    /// ADR-067 Component A: when the write queue is enabled, `execute_batch`
+    /// routes the whole caller-supplied statement list through the
+    /// single-writer task instead of opening its own `BEGIN IMMEDIATE` on
+    /// `conn`. `None` when the flag is off or no writer task is available
+    /// (best-effort — degrades to the standalone-connection path below).
+    writer_task: Option<crate::writer_task::WriterTaskHandle>,
 }
 
 #[async_trait]
@@ -351,6 +357,34 @@ impl khive_storage::SqlWriter for SqliteWriter {
         &mut self,
         statements: Vec<SqlStatement>,
     ) -> khive_storage::types::StorageResult<u64> {
+        // ADR-067 Component A: this call is self-contained (the full statement
+        // list is supplied up front and the whole thing commits or rolls back
+        // as one unit) — unlike `writer()`'s live incrementally-driven handle,
+        // it maps cleanly onto a single `WriteRequest`. Route it through the
+        // writer task when available; `self.conn` is left untouched so a
+        // subsequent `execute`/`execute_script` call on this same handle still
+        // works over the standalone connection (that dispatch is unmigrated —
+        // see `SqlBridge::writer()`).
+        if let Some(writer_task) = self.writer_task.clone() {
+            return writer_task
+                .send(move |conn| {
+                    let mut total: u64 = 0;
+                    for statement in &statements {
+                        let mut stmt = conn
+                            .prepare(&statement.sql)
+                            .map_err(|e| map_rusqlite_err(e, "execute_batch"))?;
+                        bind_params(&mut stmt, &statement.params)
+                            .map_err(|e| map_rusqlite_err(e, "execute_batch"))?;
+                        total += stmt
+                            .raw_execute()
+                            .map_err(|e| map_rusqlite_err(e, "execute_batch"))?
+                            as u64;
+                    }
+                    Ok(total)
+                })
+                .await;
+        }
+
         let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
             operation: "execute_batch".into(),
             message: "connection already consumed".into(),
@@ -851,7 +885,14 @@ impl khive_storage::SqlAccess for SqlBridge {
                 });
             }
             let conn = open_standalone_writer(&self.pool)?;
-            Ok(Box::new(SqliteWriter { conn: Some(conn) }))
+            // Best-effort: a lookup failure (no runtime context) degrades to the
+            // standalone-connection path in `execute_batch` rather than failing
+            // handle construction (mirrors every other migrated store).
+            let writer_task = self.pool.writer_task_handle().ok().flatten();
+            Ok(Box::new(SqliteWriter {
+                conn: Some(conn),
+                writer_task,
+            }))
         } else {
             Ok(Box::new(PoolBackedWriter {
                 pool: Arc::clone(&self.pool),
@@ -1016,6 +1057,157 @@ mod tests {
                 .iter()
                 .any(|(_, label)| label.as_deref() == Some("begin_tx_registry_test")),
             "expected the labeled tx to be gone from the registry after commit"
+        );
+    }
+
+    /// ADR-067 Component A entry 10: with `KHIVE_WRITE_QUEUE=1`,
+    /// `SqliteWriter::execute_batch` (reached via `SqlBridge::writer()`)
+    /// routes the whole statement list through the WriterTask channel
+    /// instead of opening its own `BEGIN IMMEDIATE` on the standalone
+    /// connection, and the row is actually committed and readable back.
+    ///
+    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+    /// shared with `pool.rs`'s own env-override tests in this same test binary.
+    #[tokio::test]
+    #[serial]
+    async fn execute_batch_routes_through_writer_task_when_flag_enabled() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("write_queue_execute_batch.db");
+        let config = PoolConfig {
+            path: Some(path.clone()),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS write_queue_batch_test \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                )
+                .unwrap();
+        }
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let mut writer = bridge.writer().await.unwrap();
+        let affected = writer
+            .execute_batch(vec![
+                SqlStatement {
+                    sql: "INSERT INTO write_queue_batch_test (id, val) VALUES (?1, ?2)".into(),
+                    params: vec![SqlValue::Integer(1), SqlValue::Text("a".into())],
+                    label: None,
+                },
+                SqlStatement {
+                    sql: "INSERT INTO write_queue_batch_test (id, val) VALUES (?1, ?2)".into(),
+                    params: vec![SqlValue::Integer(2), SqlValue::Text("b".into())],
+                    label: None,
+                },
+            ])
+            .await
+            .unwrap();
+        assert_eq!(affected, 2);
+
+        let mut reader = bridge.reader().await.unwrap();
+        let count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM write_queue_batch_test".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(count, Some(SqlValue::Integer(2))),
+            "expected 2 rows, got {count:?}"
+        );
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            1,
+            "the flag-ON path must actually spawn and use the writer task"
+        );
+    }
+
+    /// ADR-067 Component A entry 10, atomicity: a batch whose second
+    /// statement fails (duplicate primary key) must roll back the WHOLE
+    /// request — including the first statement's otherwise-successful
+    /// INSERT — because the WriterTask commits or rolls back one
+    /// `WriteRequest` as a single unit (ADR-067 Component A). Zero rows must
+    /// land, not one.
+    ///
+    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+    #[tokio::test]
+    #[serial]
+    async fn execute_batch_rolls_back_atomically_on_mid_sequence_failure() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("write_queue_execute_batch_rollback.db");
+        let config = PoolConfig {
+            path: Some(path.clone()),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS write_queue_rollback_test \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                )
+                .unwrap();
+        }
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let mut writer = bridge.writer().await.unwrap();
+        let result = writer
+            .execute_batch(vec![
+                // Statement 1: succeeds on its own.
+                SqlStatement {
+                    sql: "INSERT INTO write_queue_rollback_test (id, val) VALUES (?1, ?2)".into(),
+                    params: vec![SqlValue::Integer(1), SqlValue::Text("first".into())],
+                    label: None,
+                },
+                // Statement 2: duplicate primary key — fails mid-sequence.
+                SqlStatement {
+                    sql: "INSERT INTO write_queue_rollback_test (id, val) VALUES (?1, ?2)".into(),
+                    params: vec![SqlValue::Integer(1), SqlValue::Text("duplicate".into())],
+                    label: None,
+                },
+                // Statement 3: never reached.
+                SqlStatement {
+                    sql: "INSERT INTO write_queue_rollback_test (id, val) VALUES (?1, ?2)".into(),
+                    params: vec![SqlValue::Integer(2), SqlValue::Text("third".into())],
+                    label: None,
+                },
+            ])
+            .await;
+        assert!(
+            result.is_err(),
+            "a batch with a mid-sequence PK conflict must return an error"
+        );
+
+        let mut reader = bridge.reader().await.unwrap();
+        let count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM write_queue_rollback_test".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(count, Some(SqlValue::Integer(0))),
+            "the whole request must roll back — including statement 1's \
+             otherwise-successful INSERT — not just the failing statement; \
+             got {count:?}"
         );
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1426,18 +1426,13 @@ mod tests {
     /// routes the whole statement list through the WriterTask channel
     /// instead of opening its own `BEGIN IMMEDIATE` on the standalone
     /// connection, and the row is actually committed and readable back.
-    ///
-    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-    /// shared with `pool.rs`'s own env-override tests in this same test binary.
     #[tokio::test]
-    #[serial]
     async fn execute_batch_routes_through_writer_task_when_flag_enabled() {
-        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("write_queue_execute_batch.db");
         let config = PoolConfig {
             path: Some(path.clone()),
+            write_queue_enabled: true,
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());
@@ -1453,7 +1448,6 @@ mod tests {
         }
 
         let bridge = SqlBridge::new(Arc::clone(&pool), true);
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
 
         let mut writer = bridge.writer().await.unwrap();
         let affected = writer
@@ -1499,17 +1493,13 @@ mod tests {
     /// INSERT — because the WriterTask commits or rolls back one
     /// `WriteRequest` as a single unit (ADR-067 Component A). Zero rows must
     /// land, not one.
-    ///
-    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
     #[tokio::test]
-    #[serial]
     async fn execute_batch_rolls_back_atomically_on_mid_sequence_failure() {
-        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("write_queue_execute_batch_rollback.db");
         let config = PoolConfig {
             path: Some(path.clone()),
+            write_queue_enabled: true,
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(config).unwrap());
@@ -1525,7 +1515,6 @@ mod tests {
         }
 
         let bridge = SqlBridge::new(Arc::clone(&pool), true);
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
 
         let mut writer = bridge.writer().await.unwrap();
         let result = writer

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -476,6 +476,43 @@ impl khive_storage::SqlWriter for SqliteWriter {
         self.conn = Some(conn);
         result.map_err(|e| map_rusqlite_err(e, "execute_script"))
     }
+
+    async fn execute_script_top_level(
+        &mut self,
+        script: String,
+    ) -> khive_storage::types::StorageResult<()> {
+        // ADR-067 Component A (Fork C slice 2 round 2, BLOCKER A): unlike
+        // `execute_script`, this must NOT run inside the writer task's
+        // per-request `BEGIN IMMEDIATE` — statements such as VACUUM are
+        // rejected by SQLite inside any open transaction. Route through
+        // `WriterTaskHandle::send_top_level`, which still serializes this
+        // call through the single writer owner but skips the transaction
+        // wrap entirely.
+        if let Some(writer_task) = self.writer_task.clone() {
+            return writer_task
+                .send_top_level(move |conn| {
+                    conn.execute_batch(&script)
+                        .map_err(|e| map_rusqlite_err(e, "execute_script_top_level"))
+                })
+                .await;
+        }
+
+        // Flag off / no writer task: identical to `execute_script`'s own
+        // flag-off path — a bare `execute_batch` on the standalone
+        // connection, already transaction-free.
+        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
+            operation: "execute_script_top_level".into(),
+            message: "connection already consumed".into(),
+        })?;
+        let (conn, result) = tokio::task::spawn_blocking(move || {
+            let res = conn.execute_batch(&script);
+            (conn, res)
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Sql, "execute_script_top_level", e))?;
+        self.conn = Some(conn);
+        result.map_err(|e| map_rusqlite_err(e, "execute_script_top_level"))
+    }
 }
 
 // =============================================================================
@@ -1009,11 +1046,25 @@ impl khive_storage::SqlWriter for InlineWriter {
 ///
 /// Only sound for futures that never actually suspend — every caller in
 /// this module drives an [`InlineWriter`], whose methods are pure
-/// synchronous rusqlite calls with no real `.await` point. Panics loudly
-/// (rather than silently hanging or busy-looping) if that invariant is ever
-/// violated, since that would mean a future genuinely needs a real
-/// executor.
-fn block_on_sync<F: std::future::Future>(fut: F) -> F::Output {
+/// synchronous rusqlite calls with no real `.await` point.
+///
+/// ADR-067 Component A, Fork C slice 2 round 2 (HIGH finding): this used to
+/// `unreachable!()`-panic on `Poll::Pending`, and a panicking closure
+/// running inside the writer task's `spawn_blocking` (see
+/// `SqlBridge::atomic_unit`'s flag-on branch) would surface as a
+/// `JoinError` in `run_writer_task`, which is treated as fatal — the writer
+/// task exits and every subsequent `WriterTaskHandle::send` on this pool
+/// fails for the rest of the process. A future `atomic_unit` caller whose
+/// closure ever gains a real suspend point (this file's own contract
+/// already forbids it, but the invariant is enforced by convention, not the
+/// type system) would take down the writer task for the whole daemon.
+/// Returning `Err` instead lets `Pending` flow through the SAME error path
+/// as any other `atomic_unit` op failure: `WriteRequest::execute_and_reply`
+/// treats it as an ordinary `Err`, issues `ROLLBACK` on the writer task's
+/// held transaction, replies the error to the caller, and the writer task's
+/// `spawn_blocking` closure returns normally (not via panic) — so the task
+/// keeps draining subsequent requests instead of dying with the whole pool.
+fn block_on_sync<F: std::future::Future>(fut: F) -> Result<F::Output, StorageError> {
     use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
     fn no_op(_: *const ()) {}
@@ -1030,11 +1081,17 @@ fn block_on_sync<F: std::future::Future>(fut: F) -> F::Output {
 
     let mut fut = std::pin::pin!(fut);
     match fut.as_mut().poll(&mut cx) {
-        Poll::Ready(v) => v,
-        Poll::Pending => unreachable!(
-            "block_on_sync: future was Pending on first poll — InlineWriter's \
-             methods must be purely synchronous with no real await points"
-        ),
+        Poll::Ready(v) => Ok(v),
+        Poll::Pending => {
+            tracing::error!(
+                "block_on_sync: atomic_unit future suspended on its first poll — \
+                 the closure passed to SqlAccess::atomic_unit must be non-blocking \
+                 (synchronous InlineWriter calls only, no real .await point)"
+            );
+            Err(StorageError::Internal(
+                "atomic_unit future suspended — closure must be non-blocking".to_string(),
+            ))
+        }
     }
 }
 
@@ -1225,7 +1282,19 @@ impl khive_storage::SqlAccess for SqlBridge {
                         let mut inline = InlineWriter {
                             conn: conn as *const rusqlite::Connection,
                         };
-                        block_on_sync(op(&mut inline))
+                        // Flatten: `block_on_sync` now returns `Result<F::Output,
+                        // StorageError>` (outer = "did the future actually
+                        // resolve on first poll", inner = the op's own
+                        // `StorageResult`) instead of panicking on `Pending`
+                        // (HIGH finding, ADR-067 Fork C slice 2 round 2). Either
+                        // error flows through this closure's ordinary `Err`
+                        // return, which `WriteRequest::execute_and_reply`
+                        // already turns into a normal ROLLBACK + error reply —
+                        // no panic, so the writer task survives.
+                        match block_on_sync(op(&mut inline)) {
+                            Ok(inner) => inner,
+                            Err(e) => Err(e),
+                        }
                     })
                     .await;
             }
@@ -1500,6 +1569,111 @@ mod tests {
             "the whole request must roll back — including statement 1's \
              otherwise-successful INSERT — not just the failing statement; \
              got {count:?}"
+        );
+    }
+
+    /// ADR-067 Component A, Fork C slice 2 round 2 (HIGH finding): before
+    /// this fix, `block_on_sync` (this file) `unreachable!()`-panicked if
+    /// an `atomic_unit` closure's future was `Pending` on its first poll.
+    /// That panic ran inside the writer task's own `spawn_blocking` frame
+    /// (see `atomic_unit`'s flag-on branch), and `run_writer_task` treats
+    /// any `spawn_blocking` `JoinError` as fatal — the whole writer task
+    /// exits, taking down every subsequent write for this pool. Proves the
+    /// fix: an `atomic_unit` op built to suspend on first poll (via
+    /// `std::future::pending`, never actually resolving) now returns a
+    /// clean `Err` from `atomic_unit` — no panic — AND the writer task
+    /// survives to serve a completely unrelated, well-behaved `atomic_unit`
+    /// call immediately afterward.
+    ///
+    /// Not `#[serial]` / no env var: builds the pool directly with
+    /// `write_queue_enabled: true` in the `PoolConfig` literal, same
+    /// technique as this round's other new routing tests.
+    #[tokio::test]
+    async fn atomic_unit_pending_future_errors_without_killing_writer_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("atomic_unit_pending_future.db");
+        let config = PoolConfig {
+            path: Some(path.clone()),
+            write_queue_enabled: true,
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config).unwrap());
+        {
+            let guard = pool.writer().unwrap();
+            guard
+                .conn()
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS atomic_unit_pending_test \
+                     (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+                )
+                .unwrap();
+        }
+        assert!(
+            pool.writer_task_handle().unwrap().is_some(),
+            "writer task must be spawned with the flag on for a file-backed pool"
+        );
+
+        let bridge = SqlBridge::new(Arc::clone(&pool), true);
+
+        // A closure whose future never resolves on first poll — the exact
+        // misuse `block_on_sync` must reject instead of panicking on.
+        let pending_op: AtomicUnitOp = Box::new(|_writer| {
+            Box::pin(std::future::pending::<
+                khive_storage::types::StorageResult<Box<dyn std::any::Any + Send>>,
+            >())
+        });
+
+        let pending_result = bridge.atomic_unit(pending_op).await;
+        assert!(
+            pending_result.is_err(),
+            "a Pending-on-first-poll atomic_unit closure must return Err, \
+             not panic; got {pending_result:?}"
+        );
+
+        // If the panic had instead killed the writer task, every subsequent
+        // write on this pool (including a completely unrelated, correctly
+        // non-blocking atomic_unit call) would now fail with a channel-closed
+        // error. Prove the task is still alive and serving requests.
+        let ok_op: AtomicUnitOp = Box::new(|writer| {
+            Box::pin(async move {
+                writer
+                    .execute(SqlStatement {
+                        sql: "INSERT INTO atomic_unit_pending_test (id, val) VALUES (?1, ?2)"
+                            .into(),
+                        params: vec![SqlValue::Integer(1), SqlValue::Text("survived".into())],
+                        label: None,
+                    })
+                    .await
+                    .map_err(|e| {
+                        khive_storage::StorageError::driver(
+                            StorageCapability::Sql,
+                            "atomic_unit_pending_future_test_insert",
+                            e,
+                        )
+                    })?;
+                Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+            })
+        });
+        let ok_result = bridge.atomic_unit(ok_op).await;
+        assert!(
+            ok_result.is_ok(),
+            "writer task must survive a Pending misuse and keep serving \
+             subsequent well-behaved atomic_unit requests; got {ok_result:?}"
+        );
+
+        let mut reader = bridge.reader().await.unwrap();
+        let count = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT COUNT(*) FROM atomic_unit_pending_test".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(count, Some(SqlValue::Integer(1))),
+            "the well-behaved atomic_unit call after the Pending misuse must \
+             have actually committed its write; got {count:?}"
         );
     }
 }

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -4,13 +4,14 @@
 //! - **File-backed**: Opens standalone connections per reader/writer/tx call (high concurrency).
 //! - **Memory**: Uses pool-backed approach (acquire pool connection per-query inside `spawn_blocking`).
 
+use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use khive_storage::error::StorageError;
 use khive_storage::types::{SqlColumn, SqlIsolation, SqlRow, SqlStatement, SqlTxOptions, SqlValue};
-use khive_storage::StorageCapability;
+use khive_storage::{AtomicUnitOp, StorageCapability};
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
@@ -334,6 +335,27 @@ impl khive_storage::SqlWriter for SqliteWriter {
         &mut self,
         statement: SqlStatement,
     ) -> khive_storage::types::StorageResult<u64> {
+        // ADR-067 Component A (Fork C slice 2): a single statement is
+        // self-contained, just like `execute_batch`'s full statement list —
+        // route it through the writer task when available. `self.conn` is
+        // left untouched so a subsequent `execute`/`execute_script` call on
+        // this same handle still works over the standalone connection.
+        if let Some(writer_task) = self.writer_task.clone() {
+            return writer_task
+                .send(move |conn| {
+                    let mut stmt = conn
+                        .prepare(&statement.sql)
+                        .map_err(|e| map_rusqlite_err(e, "execute"))?;
+                    bind_params(&mut stmt, &statement.params)
+                        .map_err(|e| map_rusqlite_err(e, "execute"))?;
+                    let affected = stmt
+                        .raw_execute()
+                        .map_err(|e| map_rusqlite_err(e, "execute"))?;
+                    Ok(affected as u64)
+                })
+                .await;
+        }
+
         let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
             operation: "execute".into(),
             message: "connection already consumed".into(),
@@ -423,6 +445,24 @@ impl khive_storage::SqlWriter for SqliteWriter {
     }
 
     async fn execute_script(&mut self, script: String) -> khive_storage::types::StorageResult<()> {
+        // ADR-067 Component A (Fork C slice 2): the script text is
+        // self-contained (supplied up front, runs as one unit), just like
+        // `execute_batch` — route it through the writer task when
+        // available. `self.conn` is left untouched so a subsequent
+        // `execute`/`execute_script` call on this same handle still works
+        // over the standalone connection. Callers must supply a DML-only
+        // script (no bare `BEGIN`/`COMMIT`/`ROLLBACK`) on the flag-on path,
+        // since it runs inside the writer task's own transaction — same
+        // contract as `execute_batch`'s statement list.
+        if let Some(writer_task) = self.writer_task.clone() {
+            return writer_task
+                .send(move |conn| {
+                    conn.execute_batch(&script)
+                        .map_err(|e| map_rusqlite_err(e, "execute_script"))
+                })
+                .await;
+        }
+
         let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
             operation: "execute_script".into(),
             message: "connection already consumed".into(),
@@ -836,6 +876,209 @@ impl khive_storage::SqlWriter for PoolBackedWriter {
 }
 
 // =============================================================================
+// atomic_unit (ADR-067 Component A, Fork C slice 2)
+// =============================================================================
+
+/// A purely-synchronous `SqlReader`/`SqlWriter` over a borrowed connection,
+/// used ONLY to drive an [`AtomicUnitOp`] on the flag-on path, where the
+/// closure body runs inside the writer task's `spawn_blocking` (synchronous
+/// `FnOnce(&rusqlite::Connection) -> ...`) rather than a real async context.
+///
+/// Every method here does plain, non-suspending rusqlite work — there is no
+/// real `.await` point anywhere in this impl — so [`block_on_sync`] driving
+/// the resulting future to completion with a single poll is sound, not a
+/// hack: the future can never actually be `Pending`.
+///
+/// `SqlReader`/`SqlWriter` both carry a `'static` supertrait bound (they are
+/// used as `Box<dyn ...>` elsewhere in this module), so this type cannot
+/// hold a real `&'c Connection` borrow — it would tie `InlineWriter` to a
+/// non-`'static` lifetime and, independently, `&Connection` is not `Send`
+/// (`Connection` is `!Sync`), which the `#[async_trait]`-generated futures
+/// require. A raw pointer sidesteps both: `*const Connection` is `Send` and
+/// `'static` on its face, and the safety burden (the pointee outliving
+/// every dereference) is upheld by construction — see `atomic_unit`, the
+/// only call site: it builds an `InlineWriter` from `conn: &Connection`,
+/// drives `op` to completion via `block_on_sync` synchronously, and drops
+/// the `InlineWriter` before that borrow ends, all within one stack frame.
+struct InlineWriter {
+    conn: *const rusqlite::Connection,
+}
+
+// SAFETY: `InlineWriter` is never actually shared across a real thread
+// boundary — it is constructed, driven to completion synchronously via
+// `block_on_sync`, and dropped within a single call frame inside the
+// writer task's `spawn_blocking` closure (see `atomic_unit`). The `Send`
+// bound `async_trait` imposes on the futures below is a static
+// over-approximation for this restricted, single-threaded usage pattern.
+unsafe impl Send for InlineWriter {}
+
+impl InlineWriter {
+    /// SAFETY: valid for the lifetime of the enclosing synchronous scope in
+    /// `atomic_unit` (see the struct doc comment above) — the pointee is
+    /// never dereferenced after that scope ends.
+    fn conn(&self) -> &rusqlite::Connection {
+        unsafe { &*self.conn }
+    }
+}
+
+#[async_trait]
+impl khive_storage::SqlReader for InlineWriter {
+    async fn query_row(
+        &mut self,
+        statement: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Option<SqlRow>> {
+        let rows = execute_query(self.conn(), &statement)
+            .map_err(|e| map_rusqlite_err(e, "inline.query_row"))?;
+        Ok(rows.into_iter().next())
+    }
+
+    async fn query_all(
+        &mut self,
+        statement: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Vec<SqlRow>> {
+        execute_query(self.conn(), &statement).map_err(|e| map_rusqlite_err(e, "inline.query_all"))
+    }
+
+    async fn query_scalar(
+        &mut self,
+        statement: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Option<SqlValue>> {
+        let row = khive_storage::SqlReader::query_row(self, statement).await?;
+        Ok(row.and_then(|r| r.columns.into_iter().next().map(|c| c.value)))
+    }
+
+    async fn explain(
+        &mut self,
+        statement: SqlStatement,
+    ) -> khive_storage::types::StorageResult<Vec<SqlRow>> {
+        let explain_stmt = SqlStatement {
+            sql: format!("EXPLAIN QUERY PLAN {}", statement.sql),
+            params: statement.params,
+            label: statement.label,
+        };
+        khive_storage::SqlReader::query_all(self, explain_stmt).await
+    }
+}
+
+#[async_trait]
+impl khive_storage::SqlWriter for InlineWriter {
+    async fn execute(
+        &mut self,
+        statement: SqlStatement,
+    ) -> khive_storage::types::StorageResult<u64> {
+        let mut stmt = self
+            .conn()
+            .prepare(&statement.sql)
+            .map_err(|e| map_rusqlite_err(e, "inline.execute"))?;
+        bind_params(&mut stmt, &statement.params)
+            .map_err(|e| map_rusqlite_err(e, "inline.execute"))?;
+        let affected = stmt
+            .raw_execute()
+            .map_err(|e| map_rusqlite_err(e, "inline.execute"))?;
+        Ok(affected as u64)
+    }
+
+    async fn execute_batch(
+        &mut self,
+        statements: Vec<SqlStatement>,
+    ) -> khive_storage::types::StorageResult<u64> {
+        let mut total: u64 = 0;
+        for statement in &statements {
+            let mut stmt = self
+                .conn()
+                .prepare(&statement.sql)
+                .map_err(|e| map_rusqlite_err(e, "inline.execute_batch"))?;
+            bind_params(&mut stmt, &statement.params)
+                .map_err(|e| map_rusqlite_err(e, "inline.execute_batch"))?;
+            total += stmt
+                .raw_execute()
+                .map_err(|e| map_rusqlite_err(e, "inline.execute_batch"))?
+                as u64;
+        }
+        Ok(total)
+    }
+
+    async fn execute_script(&mut self, script: String) -> khive_storage::types::StorageResult<()> {
+        self.conn()
+            .execute_batch(&script)
+            .map_err(|e| map_rusqlite_err(e, "inline.execute_script"))
+    }
+}
+
+/// Poll `fut` exactly once with a no-op waker and return its output.
+///
+/// Only sound for futures that never actually suspend — every caller in
+/// this module drives an [`InlineWriter`], whose methods are pure
+/// synchronous rusqlite calls with no real `.await` point. Panics loudly
+/// (rather than silently hanging or busy-looping) if that invariant is ever
+/// violated, since that would mean a future genuinely needs a real
+/// executor.
+fn block_on_sync<F: std::future::Future>(fut: F) -> F::Output {
+    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    fn no_op(_: *const ()) {}
+    fn clone_waker(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_waker, no_op, no_op, no_op);
+
+    // SAFETY: every `RawWakerVTable` function is a no-op that never
+    // dereferences the data pointer, so a null data pointer is sound.
+    let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
+    let waker = unsafe { Waker::from_raw(raw_waker) };
+    let mut cx = Context::from_waker(&waker);
+
+    let mut fut = std::pin::pin!(fut);
+    match fut.as_mut().poll(&mut cx) {
+        Poll::Ready(v) => v,
+        Poll::Pending => unreachable!(
+            "block_on_sync: future was Pending on first poll — InlineWriter's \
+             methods must be purely synchronous with no real await points"
+        ),
+    }
+}
+
+/// Run `op` under a manual `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on `writer`
+/// — the pre-ADR-067 shape, used by [`SqlBridge::atomic_unit`] whenever no
+/// writer task applies (flag off, no runtime, or an in-memory pool),
+/// preserving that path byte-for-byte.
+async fn run_manual_atomic_unit(
+    writer: &mut dyn khive_storage::SqlWriter,
+    op: AtomicUnitOp,
+) -> khive_storage::types::StorageResult<Box<dyn Any + Send>> {
+    fn tx_stmt(sql: &str, label: &str) -> SqlStatement {
+        SqlStatement {
+            sql: sql.to_string(),
+            params: vec![],
+            label: Some(label.to_string()),
+        }
+    }
+    khive_storage::SqlWriter::execute(writer, tx_stmt("BEGIN IMMEDIATE", "begin")).await?;
+    let _tx_handle = khive_storage::tx_registry::register(Some("atomic_unit".to_string()));
+
+    let result = op(writer).await;
+
+    match result {
+        Ok(value) => {
+            match khive_storage::SqlWriter::execute(writer, tx_stmt("COMMIT", "commit")).await {
+                Ok(_) => Ok(value),
+                Err(e) => {
+                    let _ =
+                        khive_storage::SqlWriter::execute(writer, tx_stmt("ROLLBACK", "rollback"))
+                            .await;
+                    Err(e)
+                }
+            }
+        }
+        Err(e) => {
+            let _ =
+                khive_storage::SqlWriter::execute(writer, tx_stmt("ROLLBACK", "rollback")).await;
+            Err(e)
+        }
+    }
+}
+
+// =============================================================================
 // SqlBridge: the SqlAccess implementor
 // =============================================================================
 
@@ -955,6 +1198,55 @@ impl khive_storage::SqlAccess for SqlBridge {
             read_only: effective_read_only,
             _tx_handle: tx_handle,
         }))
+    }
+
+    async fn atomic_unit(
+        &self,
+        op: AtomicUnitOp,
+    ) -> khive_storage::types::StorageResult<Box<dyn Any + Send>> {
+        if self.is_file_backed {
+            if self.pool.config().read_only {
+                return Err(StorageError::Pool {
+                    operation: "atomic_unit".into(),
+                    message: "backend is read-only".into(),
+                });
+            }
+            // Best-effort, same guard `writer()` uses: `Ok(None)` on flag-off;
+            // `Err(WriterTaskNoRuntime)` propagates loud rather than silently
+            // falling back to a competing connection from a sync caller.
+            if let Some(writer_task) = self.pool.writer_task_handle()? {
+                // Flag-on: ONE queued WriteRequest. `run_writer_task` already
+                // has an open `BEGIN IMMEDIATE` on its dedicated connection
+                // before this closure runs and issues `COMMIT`/`ROLLBACK`
+                // after it returns — `op` must not (and, via `InlineWriter`,
+                // does not) issue its own transaction control.
+                return writer_task
+                    .send(move |conn| {
+                        let mut inline = InlineWriter {
+                            conn: conn as *const rusqlite::Connection,
+                        };
+                        block_on_sync(op(&mut inline))
+                    })
+                    .await;
+            }
+            // Flag-off (or no writer task available): manual
+            // BEGIN IMMEDIATE/COMMIT/ROLLBACK on a standalone writer —
+            // byte-for-byte the pre-ADR-067 shape.
+            let conn = open_standalone_writer(&self.pool)?;
+            let mut writer = SqliteWriter {
+                conn: Some(conn),
+                writer_task: None,
+            };
+            run_manual_atomic_unit(&mut writer, op).await
+        } else {
+            // In-memory pools are exempt (not accept-loop reachable, per the
+            // rework spec's "Out of scope") — preserve the existing
+            // pool-backed manual-transaction behavior.
+            let mut writer = PoolBackedWriter {
+                pool: Arc::clone(&self.pool),
+            };
+            run_manual_atomic_unit(&mut writer, op).await
+        }
     }
 }
 

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -50,7 +50,12 @@ impl SqlEntityStore {
     /// support) — the flag is a best-effort opt-in for slice 1, not a hard
     /// requirement.
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
-        let writer_task = pool.writer_task_handle();
+        // Best-effort opt-in (slice 1 policy, unchanged): a missing writer
+        // task — whether the flag is off, spawn degraded (e.g. in-memory
+        // pool), or no Tokio runtime was available at this first access
+        // (ADR-067 Component A runtime-handle guard) — degrades to the
+        // legacy pool-mutex path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
 
         Self {
             pool,

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -36,19 +36,20 @@ pub struct SqlEntityStore {
 impl SqlEntityStore {
     /// Create a new store.
     ///
-    /// When `KHIVE_WRITE_QUEUE=1` (`PoolConfig::write_queue_enabled`),
-    /// `upsert_entities` — ADR-067 slice 1's single migrated write path —
-    /// routes through the pool-wide `WriterTask` (`ConnectionPool::writer_task_handle`)
-    /// instead of the legacy pool-mutex path (`with_writer`, unchanged and
-    /// still used by every other method on this store). The handle is a
-    /// clone of the ONE writer task owned by `pool` — constructing multiple
-    /// stores (or multiple namespaces) over the same pool never spawns more
-    /// than one writer task; see `ConnectionPool::writer_task_handle`'s doc
-    /// comment for why that matters. `None` (falling back to the legacy
-    /// path) if the flag is off, or if the writer task failed to spawn (for
+    /// When `KHIVE_WRITE_QUEUE=1` (`PoolConfig::write_queue_enabled`), every
+    /// write path on this store — the batch `upsert_entities` (its own
+    /// explicit flag check) AND every single-row write routed through the
+    /// shared `with_writer` helper (`upsert_entity`, `delete_entity`) —
+    /// routes through the pool-wide `WriterTask`
+    /// (`ConnectionPool::writer_task_handle`) instead of the legacy
+    /// pool-mutex path. The handle is a clone of the ONE writer task owned
+    /// by `pool` — constructing multiple stores (or multiple namespaces)
+    /// over the same pool never spawns more than one writer task; see
+    /// `ConnectionPool::writer_task_handle`'s doc comment for why that
+    /// matters. `None` (falling back to the legacy path for every write)
+    /// if the flag is off, or if the writer task failed to spawn (for
     /// example, an in-memory pool, which has no standalone-connection
-    /// support) — the flag is a best-effort opt-in for slice 1, not a hard
-    /// requirement.
+    /// support) — the flag is a best-effort opt-in, not a hard requirement.
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
         // Best-effort opt-in (slice 1 policy, unchanged): a missing writer
         // task — whether the flag is off, spawn degraded (e.g. in-memory
@@ -89,11 +90,33 @@ impl SqlEntityStore {
         Ok(conn)
     }
 
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy pool-mutex path.
+    ///
+    /// ADR-067 Component A (Fork C slice 2): this is the ONE routing point
+    /// for every `with_writer` caller in this store — `upsert_entity`,
+    /// `delete_entity` (soft/hard) all reach the WriterTask through this
+    /// helper rather than each duplicating the flag check. `f` must be
+    /// DML-only (a single statement, no bare `BEGIN IMMEDIATE`): on the
+    /// flag-on path it runs inside the WriterTask's own transaction, and a
+    /// nested `BEGIN IMMEDIATE` would violate SQLite's nested-transaction
+    /// rule. `upsert_entities` (the batch method) does its OWN flag check
+    /// and returns early on `Some`, so its fallback call into this helper
+    /// only ever executes on the flag-off path (`self.writer_task` is
+    /// `None` by construction whenever that call is reached) — no
+    /// double-routing.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::pool::PoolConfig;
 use serial_test::serial;
+use std::time::Duration;
+use tokio::sync::oneshot;
 
 fn setup_pool() -> Arc<ConnectionPool> {
     let config = PoolConfig {
@@ -795,4 +797,130 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
         "concurrent writes across every migrated path plus both design-fork \
          paths must not trigger a second writer task spawn"
     );
+}
+
+// =============================================================================
+// Fork C slice 2: single-row `upsert_entity` (via `with_writer`) routes
+// through the WriterTask when the flag is on
+// =============================================================================
+
+/// Proves `upsert_entity` (the SINGLE-row path, going through the
+/// `with_writer` helper directly rather than the already-migrated
+/// `upsert_entities` batch path) is actually enqueued on the pool's shared
+/// `WriterTaskHandle` channel when `KHIVE_WRITE_QUEUE=1` — not inferred from
+/// wall-clock contention (real SQLite file-level locking would serialize a
+/// competing writer connection against an in-flight transaction regardless
+/// of which Rust-level path issued it, which makes elapsed-time alone a
+/// vacuous signal here), but read directly off `WriterTaskHandle::queue_depth`,
+/// the live gauge over the exact `mpsc` channel `with_writer`'s writer-task
+/// branch must call `send` on.
+///
+/// Technique: submit an occupier request directly on the SAME
+/// `WriterTaskHandle` the store resolved at construction. The occupier signals
+/// a oneshot once it is actually running inside the writer task's single
+/// drain slot, then parks on a second oneshot (`blocking_recv`, valid here
+/// because this closure runs inside the writer task's `spawn_blocking`) until
+/// the test releases it — deterministically holding that one drain slot open
+/// for as long as the test needs, no sleep/timing race. While the slot is
+/// held, call `store.upsert_entity` on a separate task and poll
+/// `queue_depth()`: a version that genuinely routes this call through
+/// `writer_task.send(..)` must show `queue_depth() >= 1` (the request sitting
+/// in the channel behind the still-running occupier) before the occupier is
+/// released; a version that left `upsert_entity`/`with_writer` on the legacy
+/// `pool.try_writer()` path never touches this channel at all, so
+/// `queue_depth()` would stay `0` for the full poll window — this is what
+/// makes the test non-vacuous (verified: reverting `with_writer` to always
+/// take the legacy branch makes this assertion fail, see khive-db PR history
+/// for Fork C slice 2).
+#[tokio::test]
+#[serial]
+async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_entity_single.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+    }
+
+    let store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
+
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let writer_task = pool
+        .writer_task_handle()
+        .unwrap()
+        .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+    let (started_tx, started_rx) = oneshot::channel::<()>();
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    let occupier = {
+        let writer_task = writer_task.clone();
+        tokio::spawn(async move {
+            writer_task
+                .send(move |_conn| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.blocking_recv();
+                    Ok::<(), StorageError>(())
+                })
+                .await
+        })
+    };
+
+    started_rx
+        .await
+        .expect("occupier must signal it has started running inside the writer task");
+    assert_eq!(
+        writer_task.queue_depth(),
+        0,
+        "channel must start empty once the occupier has been dequeued and is running"
+    );
+
+    let entity = make_entity("default", "concept", "RoPE");
+    let entity_id = entity.id;
+
+    let store_task = {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move { store.upsert_entity(entity).await })
+    };
+
+    let mut saw_enqueued = false;
+    for _ in 0..100 {
+        if writer_task.queue_depth() >= 1 {
+            saw_enqueued = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(
+        saw_enqueued,
+        "upsert_entity's write request never appeared in the writer task's \
+         channel while the occupier held the single drain slot — with_writer \
+         is not routing this single-row write through the shared writer task"
+    );
+
+    release_tx
+        .send(())
+        .expect("occupier must still be waiting on the release signal");
+    occupier
+        .await
+        .expect("occupier task must not panic")
+        .expect("occupier write must succeed");
+    store_task
+        .await
+        .expect("store task must not panic")
+        .expect("upsert_entity must succeed once unblocked");
+
+    let fetched = store.get_entity(entity_id).await.unwrap();
+    assert!(
+        fetched.is_some(),
+        "entity must be committed and readable after queuing behind the occupier"
+    );
+    assert_eq!(fetched.unwrap().name, "RoPE");
 }

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::pool::PoolConfig;
-use serial_test::serial;
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -514,17 +513,18 @@ async fn page_offset_over_i64max_rejected() {
 /// the trip through the type-erased channel intact, and both rows are
 /// actually committed and independently readable back through the store.
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
+/// crate's other tests are NOT `#[serial]` against it, so a window where it
+/// is set here could leak into a concurrently-scheduled test's own pool
+/// construction (ADR-067 Fork C slice 2 round 2, LOW finding).
 #[tokio::test]
-#[serial]
 async fn upsert_entities_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_entities.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -534,10 +534,6 @@ async fn upsert_entities_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = SqlEntityStore::new(Arc::clone(&pool), true);
-
-    // Confined to the smallest possible window around construction, which is
-    // the only place this flag is read.
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let e1 = make_entity("default", "concept", "LoRA");
     let e2 = make_entity("default", "concept", "QLoRA");
@@ -592,17 +588,17 @@ async fn upsert_entities_legacy_path_unchanged_when_flag_is_off() {
 /// the writer task exactly once; every store resolves to a clone of the one
 /// pool-owned handle (`ConnectionPool::writer_task_handle`).
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — see the sibling
+/// `upsert_entities_routes_through_writer_task_when_flag_enabled` test's doc
+/// comment for the race this avoids.
 #[tokio::test]
-#[serial]
 async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_shared_writer.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -610,8 +606,6 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
         let writer = pool.writer().unwrap();
         writer.conn().execute_batch(ENTITIES_DDL).unwrap();
     }
-
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     // Three independent stores over the same pool, each resolving the
     // write-queue flag on construction and asking the pool for its writer
@@ -640,9 +634,11 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
 /// design-fork paths coexist over a single DB file without contending at
 /// `BEGIN IMMEDIATE` or racing the writer task's own spawn-once guarantee.
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — see the sibling
+/// `upsert_entities_routes_through_writer_task_when_flag_enabled` test's doc
+/// comment for the race this avoids.
 #[tokio::test]
-#[serial]
 async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     use crate::stores::graph::SqlGraphStore;
     use crate::stores::note::SqlNoteStore;
@@ -651,12 +647,11 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     use khive_storage::{GraphStore as _, NoteStore as _, SqlAccess as _};
     use khive_types::EdgeRelation;
 
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_all_paths_shared_writer.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -666,8 +661,6 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
         crate::stores::note::ensure_notes_schema(writer.conn()).unwrap();
         crate::stores::graph::ensure_graph_schema(writer.conn()).unwrap();
     }
-
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let entity_store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
     let note_store = Arc::new(SqlNoteStore::new(Arc::clone(&pool), true));
@@ -832,15 +825,18 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
 /// makes the test non-vacuous (verified: reverting `with_writer` to always
 /// take the legacy branch makes this assertion fail, see khive-db PR history
 /// for Fork C slice 2).
+///
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — see
+/// `upsert_entities_routes_through_writer_task_when_flag_enabled`'s doc
+/// comment for the race this avoids.
 #[tokio::test]
-#[serial]
 async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_entity_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -850,8 +846,6 @@ async fn upsert_entity_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
-
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let writer_task = pool
         .writer_task_handle()

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -626,3 +626,173 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
          per store"
     );
 }
+
+/// Full-slice single-writer guarantee (ADR-067 Component A, Fork C slice 2):
+/// with every MIGRATE-listed write path routed through the writer task, drive
+/// CONCURRENT writes across entity, note, and graph stores (entries 2/3/6 —
+/// er, 1/2/3) plus `SqlBridge`'s unmigrated `writer()` (entry 8, still routes
+/// its self-contained `execute_batch` through the task per entry 10) and
+/// `begin_tx()` (entry 9, a genuine design fork — stays on its own standalone
+/// connection) over ONE pool. Asserts exactly one writer task is ever spawned
+/// and every write actually lands, proving the migrated paths and the two
+/// design-fork paths coexist over a single DB file without contending at
+/// `BEGIN IMMEDIATE` or racing the writer task's own spawn-once guarantee.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+#[tokio::test]
+#[serial]
+async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
+    use crate::stores::graph::SqlGraphStore;
+    use crate::stores::note::SqlNoteStore;
+    use khive_storage::note::Note;
+    use khive_storage::types::{Edge, SqlStatement, SqlTxOptions, SqlValue};
+    use khive_storage::{GraphStore as _, NoteStore as _, SqlAccess as _};
+    use khive_types::EdgeRelation;
+
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_all_paths_shared_writer.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(ENTITIES_DDL).unwrap();
+        crate::stores::note::ensure_notes_schema(writer.conn()).unwrap();
+        crate::stores::graph::ensure_graph_schema(writer.conn()).unwrap();
+    }
+
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let entity_store = Arc::new(SqlEntityStore::new(Arc::clone(&pool), true));
+    let note_store = Arc::new(SqlNoteStore::new(Arc::clone(&pool), true));
+    let graph_store = Arc::new(SqlGraphStore::new_scoped(
+        Arc::clone(&pool),
+        true,
+        "default",
+    ));
+    let bridge = crate::sql_bridge::SqlBridge::new(Arc::clone(&pool), true);
+
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "entity + note + graph stores plus SqlBridge over one pool must still \
+         share exactly one writer task"
+    );
+
+    let entity = make_entity("default", "concept", "WriterTaskConcurrency");
+    let entity_id = entity.id;
+
+    let note = Note::new("default", "observation", "concurrent writer task note");
+    let note_id = note.id;
+
+    let edge_src = Uuid::new_v4();
+    let edge_tgt = Uuid::new_v4();
+    let now = chrono::Utc::now();
+    let edge = Edge {
+        id: Uuid::new_v4().into(),
+        namespace: "default".to_string(),
+        source_id: edge_src,
+        target_id: edge_tgt,
+        relation: EdgeRelation::Extends,
+        weight: 0.9,
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+        metadata: None,
+        target_backend: None,
+    };
+    let edge_id = edge.id;
+
+    // Entry 10 (SqliteWriter::execute_batch, migrated): a raw INSERT issued
+    // through SqlBridge's file-backed writer() handle.
+    let batch_row_id = Uuid::new_v4();
+    let batch_src = Uuid::new_v4();
+    let batch_tgt = Uuid::new_v4();
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let insert_stmt = SqlStatement {
+        sql: "INSERT INTO graph_edges (namespace, id, source_id, target_id, relation, \
+              weight, created_at, updated_at, deleted_at, metadata, target_backend) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL)"
+            .to_string(),
+        params: vec![
+            SqlValue::Text("default".to_string()),
+            SqlValue::Text(batch_row_id.to_string()),
+            SqlValue::Text(batch_src.to_string()),
+            SqlValue::Text(batch_tgt.to_string()),
+            SqlValue::Text("extends".to_string()),
+            SqlValue::Float(0.5),
+            SqlValue::Integer(now_micros),
+            SqlValue::Integer(now_micros),
+        ],
+        label: Some("test_execute_batch".to_string()),
+    };
+
+    // Entry 9 (SqlBridge::begin_tx, design fork, unmigrated): its own
+    // standalone connection, running concurrently with the writer task.
+    let tx_row_id = Uuid::new_v4();
+    let tx_src = Uuid::new_v4();
+    let tx_tgt = Uuid::new_v4();
+    let tx_insert_stmt = SqlStatement {
+        sql: "INSERT INTO graph_edges (namespace, id, source_id, target_id, relation, \
+              weight, created_at, updated_at, deleted_at, metadata, target_backend) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL)"
+            .to_string(),
+        params: vec![
+            SqlValue::Text("default".to_string()),
+            SqlValue::Text(tx_row_id.to_string()),
+            SqlValue::Text(tx_src.to_string()),
+            SqlValue::Text(tx_tgt.to_string()),
+            SqlValue::Text("extends".to_string()),
+            SqlValue::Float(0.7),
+            SqlValue::Integer(now_micros),
+            SqlValue::Integer(now_micros),
+        ],
+        label: Some("test_begin_tx".to_string()),
+    };
+
+    let entity_fut = {
+        let entity_store = Arc::clone(&entity_store);
+        async move { entity_store.upsert_entity(entity).await }
+    };
+    let note_fut = {
+        let note_store = Arc::clone(&note_store);
+        async move { note_store.upsert_note(note).await }
+    };
+    let edge_fut = {
+        let graph_store = Arc::clone(&graph_store);
+        async move { graph_store.upsert_edge(edge).await }
+    };
+    let batch_fut = async {
+        let mut writer = bridge.writer().await.unwrap();
+        writer.execute_batch(vec![insert_stmt]).await
+    };
+    let tx_fut = async {
+        let mut tx = bridge.begin_tx(SqlTxOptions::default()).await.unwrap();
+        tx.execute(tx_insert_stmt).await?;
+        tx.commit().await
+    };
+
+    let (entity_res, note_res, edge_res, batch_res, tx_res) =
+        tokio::join!(entity_fut, note_fut, edge_fut, batch_fut, tx_fut);
+
+    entity_res.unwrap();
+    note_res.unwrap();
+    edge_res.unwrap();
+    batch_res.unwrap();
+    tx_res.unwrap();
+
+    assert!(entity_store.get_entity(entity_id).await.unwrap().is_some());
+    assert!(note_store.get_note(note_id).await.unwrap().is_some());
+    assert!(graph_store.get_edge(edge_id).await.unwrap().is_some());
+
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "concurrent writes across every migrated path plus both design-fork \
+         paths must not trigger a second writer task spawn"
+    );
+}

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -22,6 +22,7 @@ use khive_types::{EventKind, EventOutcome, SubstrateKind};
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Events, op, e)
@@ -36,6 +37,7 @@ pub struct SqlEventStore {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
     namespace: String,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl SqlEventStore {
@@ -45,10 +47,15 @@ impl SqlEventStore {
         is_file_backed: bool,
         namespace: impl Into<String>,
     ) -> Self {
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task degrades to the legacy pool-mutex /
+        // standalone-connection path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
         Self {
             pool,
             is_file_backed,
             namespace: namespace.into(),
+            writer_task,
         }
     }
 
@@ -280,6 +287,31 @@ fn insert_event_with_observations(
     }
 
     Ok(())
+}
+
+/// DML-only batch append loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `append_events` paths (ADR-067 Component A).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction. All-or-nothing: the first failed insert returns
+/// `Err` immediately (matching the pre-existing `append_events` contract) —
+/// the caller's transaction wrapper issues the ROLLBACK.
+fn batch_append_events_dml(
+    conn: &rusqlite::Connection,
+    events: &[Event],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let mut affected = 0u64;
+    for event in events {
+        insert_event_with_observations(conn, event)?;
+        affected += 1;
+    }
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed: 0,
+        first_error: String::new(),
+    })
 }
 
 /// Insert `event` (and any derived `event_observations` rows) through the
@@ -703,6 +735,21 @@ fn schema_absent(name: &'static str) -> rusqlite::Error {
 #[async_trait]
 impl EventStore for SqlEventStore {
     async fn append_event(&self, event: Event) -> Result<(), StorageError> {
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction.
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    insert_event_with_observations(conn, &event)
+                        .map_err(|e| map_err(e, "append_event"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
         self.with_writer("append_event", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle = khive_storage::tx_registry::register(Some("event_append".to_string()));
@@ -719,27 +766,37 @@ impl EventStore for SqlEventStore {
     async fn append_events(&self, events: Vec<Event>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = events.len() as u64;
 
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure preserving the
+        // all-or-nothing semantics (first failed insert aborts the whole
+        // batch) — the WriterTask's run loop owns the enclosing transaction
+        // and issues the ROLLBACK on `Err`.
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    batch_append_events_dml(conn, &events, attempted)
+                        .map_err(|e| map_err(e, "append_events"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
         self.with_writer("append_events", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("event_append_batch".to_string()));
-            let mut affected = 0u64;
 
-            for event in &events {
-                if let Err(e) = insert_event_with_observations(conn, event) {
+            let summary = match batch_append_events_dml(conn, &events, attempted) {
+                Ok(summary) => summary,
+                Err(e) => {
                     let _ = conn.execute_batch("ROLLBACK");
                     return Err(e);
                 }
-                affected += 1;
-            }
+            };
 
             conn.execute_batch("COMMIT")?;
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed: 0,
-                first_error: String::new(),
-            })
+            Ok(summary)
         })
         .await
     }

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -71,11 +71,28 @@ impl SqlEventStore {
             .map_err(|e| map_sqlite_err(e, "open_event_reader"))
     }
 
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy standalone-connection / pool-mutex path (ADR-067
+    /// Component A, Fork C slice 2).
+    ///
+    /// `append_event`/`append_events` do their own flag check and return
+    /// early on `Some`, so their fallback calls into this helper only ever
+    /// execute on the flag-off path (`self.writer_task` is `None` by
+    /// construction whenever those calls are reached) — no double-routing.
+    /// `f` must be DML-only on the flag-on path (no bare `BEGIN IMMEDIATE`)
+    /// since it runs inside the WriterTask's own transaction.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
         if self.is_file_backed {
             let conn = self.open_standalone_writer()?;
             tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -577,3 +577,48 @@ async fn page_offset_over_i64max_rejected() {
         "expected InvalidInput, got {result:?}"
     );
 }
+
+/// ADR-067 Component A entry 5: with `KHIVE_WRITE_QUEUE=1`, `append_events`
+/// routes through the WriterTask channel instead of the pool-mutex path, and
+/// both events are actually committed and independently readable back.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial_test::serial]
+async fn append_events_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_events.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(EVENTS_DDL).unwrap();
+    }
+
+    let store = SqlEventStore::new_scoped(Arc::clone(&pool), true, "default");
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let e1 = make_event("default");
+    let e2 = make_event("default");
+    let id1 = e1.id;
+    let id2 = e2.id;
+
+    let summary = store.append_events(vec![e1, e2]).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
+
+    assert!(store.get_event(id1).await.unwrap().is_some());
+    assert!(store.get_event(id2).await.unwrap().is_some());
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "the flag-ON path must actually spawn and use the writer task"
+    );
+}

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -581,18 +581,13 @@ async fn page_offset_over_i64max_rejected() {
 /// ADR-067 Component A entry 5: with `KHIVE_WRITE_QUEUE=1`, `append_events`
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both events are actually committed and independently readable back.
-///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
 #[tokio::test]
-#[serial_test::serial]
 async fn append_events_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_events.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -602,7 +597,6 @@ async fn append_events_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = SqlEventStore::new_scoped(Arc::clone(&pool), true, "default");
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let e1 = make_event("default");
     let e2 = make_event("default");

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -19,6 +19,7 @@ use khive_types::EdgeRelation;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 /// Map a rusqlite error to `StorageError` with `Graph` capability.
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
@@ -37,6 +38,7 @@ pub struct SqlGraphStore {
     /// WHERE filter on `query_edges`/`neighbors`/`traverse`, never as an
     /// enforcement gate on by-ID operations).
     namespace: String,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl SqlGraphStore {
@@ -52,10 +54,16 @@ impl SqlGraphStore {
         is_file_backed: bool,
         namespace: impl Into<String>,
     ) -> Self {
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task degrades to the legacy pool-mutex /
+        // standalone-connection path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
+
         Self {
             pool,
             is_file_backed,
             namespace: namespace.into(),
+            writer_task,
         }
     }
 
@@ -369,6 +377,80 @@ fn canonical_edge_endpoints(
     }
 }
 
+/// DML-only batch upsert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `upsert_edges` paths (ADR-067 Component A).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction. All-or-nothing: the first row failure returns
+/// `Err` immediately (matching the pre-existing `upsert_edges` contract,
+/// unlike `upsert_entities`/`upsert_notes`'s partial-success accounting) —
+/// the caller's transaction wrapper (either the legacy `with_writer` closure
+/// or `WriteRequest::execute_and_reply`) issues the ROLLBACK.
+fn batch_upsert_edges(
+    conn: &rusqlite::Connection,
+    edges: &[Edge],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let mut affected = 0u64;
+
+    for edge in edges {
+        let id_str = Uuid::from(edge.id).to_string();
+        let (canon_src, canon_tgt) =
+            canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+        let src_str = canon_src.to_string();
+        let tgt_str = canon_tgt.to_string();
+        let relation_str = edge.relation.to_string();
+        let metadata_str = edge
+            .metadata
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+        conn.execute(
+            "INSERT INTO graph_edges \
+             (namespace, id, source_id, target_id, relation, weight, \
+              created_at, updated_at, deleted_at, metadata, target_backend) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
+             ON CONFLICT(namespace, id) DO UPDATE SET \
+                 source_id = excluded.source_id, \
+                 target_id = excluded.target_id, \
+                 relation = excluded.relation, \
+                 weight = excluded.weight, \
+                 updated_at = excluded.updated_at, \
+                 deleted_at = NULL, \
+                 metadata = excluded.metadata, \
+                 target_backend = excluded.target_backend \
+             ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
+                 weight = excluded.weight, \
+                 updated_at = excluded.updated_at, \
+                 deleted_at = NULL, \
+                 metadata = excluded.metadata, \
+                 target_backend = excluded.target_backend",
+            rusqlite::params![
+                edge.namespace.as_str(),
+                id_str,
+                src_str,
+                tgt_str,
+                relation_str,
+                edge.weight,
+                edge.created_at.timestamp_micros(),
+                edge.updated_at.timestamp_micros(),
+                edge.deleted_at.map(|t| t.timestamp_micros()),
+                metadata_str,
+                edge.target_backend.as_deref(),
+            ],
+        )?;
+        affected += 1;
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed: 0,
+        first_error: String::new(),
+    })
+}
+
 #[async_trait]
 impl GraphStore for SqlGraphStore {
     async fn upsert_edge(&self, edge: Edge) -> Result<(), StorageError> {
@@ -428,75 +510,41 @@ impl GraphStore for SqlGraphStore {
     async fn upsert_edges(&self, edges: Vec<Edge>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = edges.len() as u64;
 
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction (a bare BEGIN IMMEDIATE here would violate
+        // SQLite's nested-transaction rule).
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    batch_upsert_edges(conn, &edges, attempted)
+                        .map_err(|e| map_err(e, "upsert_edges"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
+        // via the pool-mutex/standalone writer.
         self.with_writer("upsert_edges", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("graph_upsert_edges".to_string()));
-            let mut affected = 0u64;
 
-            for edge in &edges {
-                let id_str = Uuid::from(edge.id).to_string();
-                let (canon_src, canon_tgt) =
-                    canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
-                let src_str = canon_src.to_string();
-                let tgt_str = canon_tgt.to_string();
-                let relation_str = edge.relation.to_string();
-                let metadata_str = edge
-                    .metadata
-                    .as_ref()
-                    .map(serde_json::to_string)
-                    .transpose()
-                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-                if let Err(e) = conn.execute(
-                    "INSERT INTO graph_edges \
-                     (namespace, id, source_id, target_id, relation, weight, \
-                      created_at, updated_at, deleted_at, metadata, target_backend) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
-                     ON CONFLICT(namespace, id) DO UPDATE SET \
-                         source_id = excluded.source_id, \
-                         target_id = excluded.target_id, \
-                         relation = excluded.relation, \
-                         weight = excluded.weight, \
-                         updated_at = excluded.updated_at, \
-                         deleted_at = NULL, \
-                         metadata = excluded.metadata, \
-                         target_backend = excluded.target_backend \
-                     ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
-                         weight = excluded.weight, \
-                         updated_at = excluded.updated_at, \
-                         deleted_at = NULL, \
-                         metadata = excluded.metadata, \
-                         target_backend = excluded.target_backend",
-                    rusqlite::params![
-                        edge.namespace.as_str(),
-                        id_str,
-                        src_str,
-                        tgt_str,
-                        relation_str,
-                        edge.weight,
-                        edge.created_at.timestamp_micros(),
-                        edge.updated_at.timestamp_micros(),
-                        edge.deleted_at.map(|t| t.timestamp_micros()),
-                        metadata_str,
-                        edge.target_backend.as_deref(),
-                    ],
-                ) {
+            let summary = match batch_upsert_edges(conn, &edges, attempted) {
+                Ok(summary) => summary,
+                Err(e) => {
                     let _ = conn.execute_batch("ROLLBACK");
                     return Err(e);
                 }
-                affected += 1;
-            }
+            };
 
             if let Err(e) = conn.execute_batch("COMMIT") {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
             }
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed: 0,
-                first_error: String::new(),
-            })
+            Ok(summary)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -79,11 +79,31 @@ impl SqlGraphStore {
             .map_err(|e| map_sqlite_err(e, "open_graph_reader"))
     }
 
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy standalone-connection / pool-mutex path (ADR-067
+    /// Component A, Fork C slice 2).
+    ///
+    /// This is the ONE routing point for every `with_writer` caller in this
+    /// store (`upsert_edge`, `delete_edge`, `purge_incident_edges`). `f`
+    /// must be DML-only — on the flag-on path it runs inside the
+    /// WriterTask's own transaction, so a bare `BEGIN IMMEDIATE` would
+    /// violate SQLite's nested-transaction rule. `upsert_edges` (the batch
+    /// method) does its own flag check and returns early on `Some`, so its
+    /// fallback call into this helper only ever executes on the flag-off
+    /// path (`self.writer_task` is `None` by construction whenever that
+    /// call is reached) — no double-routing.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
         if self.is_file_backed {
             let conn = self.open_standalone_writer()?;
             tokio::task::spawn_blocking(move || f(&conn).map_err(|e| map_err(e, op)))

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2388,3 +2388,48 @@ async fn traverse_max_depth_over_i64max_rejected() {
         "expected InvalidInput, got {result:?}"
     );
 }
+
+/// ADR-067 Component A entry 3: with `KHIVE_WRITE_QUEUE=1`, `upsert_edges`
+/// routes through the WriterTask channel instead of the pool-mutex path, and
+/// both edges are actually committed and independently readable back.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial]
+async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_graph.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+    }
+
+    let store = SqlGraphStore::new_scoped(Arc::clone(&pool), true, "default");
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let e1 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.6);
+    let e2 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.7);
+    let id1 = e1.id;
+    let id2 = e2.id;
+
+    let summary = store.upsert_edges(vec![e1, e2]).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
+
+    assert!(store.get_edge(id1).await.unwrap().is_some());
+    assert!(store.get_edge(id2).await.unwrap().is_some());
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "the flag-ON path must actually spawn and use the writer task"
+    );
+}

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2393,17 +2393,18 @@ async fn traverse_max_depth_over_i64max_rejected() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both edges are actually committed and independently readable back.
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
+/// crate's other tests are NOT `#[serial]` against it, so a window where it
+/// is set here could leak into a concurrently-scheduled test's own pool
+/// construction (ADR-067 Fork C slice 2 round 2, LOW finding).
 #[tokio::test]
-#[serial]
 async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_graph.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -2413,7 +2414,6 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = SqlGraphStore::new_scoped(Arc::clone(&pool), true, "default");
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let e1 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.6);
     let e2 = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.7);
@@ -2452,16 +2452,17 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
 /// slot open (parked on a oneshot via `blocking_recv`, not a sleep/timing
 /// race).
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — see
+/// `upsert_edges_routes_through_writer_task_when_flag_enabled`'s doc comment
+/// for the race this avoids.
 #[tokio::test]
-#[serial]
 async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_graph_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -2475,7 +2476,6 @@ async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
         true,
         "default",
     ));
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let writer_task = pool
         .writer_task_handle()

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2433,3 +2433,117 @@ async fn upsert_edges_routes_through_writer_task_when_flag_enabled() {
         "the flag-ON path must actually spawn and use the writer task"
     );
 }
+
+/// Fork C slice 2: proves the SINGLE-row `upsert_edge` (via `with_writer`,
+/// distinct from the already-migrated batch `upsert_edges` above) is
+/// actually enqueued on the pool's shared `WriterTaskHandle` channel when
+/// `KHIVE_WRITE_QUEUE=1`.
+///
+/// `graph.rs`'s own flag-off/no-writer-task fallback (`open_standalone_writer`)
+/// differs from entity.rs/note.rs's (`pool.try_writer()`), so a wall-clock
+/// occupier-timing test is even less trustworthy here — a real file-backed
+/// fallback connection opened per call would ALSO contend with the occupier
+/// for SQLite's own write lock and could look "queued" by pure accident of
+/// file-level locking, independent of whether `with_writer` used the shared
+/// channel at all. This test sidesteps that confound entirely by reading
+/// `WriterTaskHandle::queue_depth` directly — the live gauge over the exact
+/// `mpsc` channel `with_writer`'s writer-task branch must call `send` on —
+/// while an occupier deterministically holds the writer task's one drain
+/// slot open (parked on a oneshot via `blocking_recv`, not a sleep/timing
+/// race).
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+#[tokio::test]
+#[serial]
+async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_graph_single.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+    }
+
+    let store = Arc::new(SqlGraphStore::new_scoped(
+        Arc::clone(&pool),
+        true,
+        "default",
+    ));
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let writer_task = pool
+        .writer_task_handle()
+        .unwrap()
+        .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let occupier = {
+        let writer_task = writer_task.clone();
+        tokio::spawn(async move {
+            writer_task
+                .send(move |_conn| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.blocking_recv();
+                    Ok::<(), StorageError>(())
+                })
+                .await
+        })
+    };
+
+    started_rx
+        .await
+        .expect("occupier must signal it has started running inside the writer task");
+    assert_eq!(
+        writer_task.queue_depth(),
+        0,
+        "channel must start empty once the occupier has been dequeued and is running"
+    );
+
+    let edge = make_edge(Uuid::new_v4(), Uuid::new_v4(), EdgeRelation::Extends, 0.42);
+    let edge_id = edge.id;
+
+    let store_task = {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move { store.upsert_edge(edge).await })
+    };
+
+    let mut saw_enqueued = false;
+    for _ in 0..100 {
+        if writer_task.queue_depth() >= 1 {
+            saw_enqueued = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        saw_enqueued,
+        "upsert_edge's write request never appeared in the writer task's \
+         channel while the occupier held the single drain slot — with_writer \
+         is not routing this single-row write through the shared writer task"
+    );
+
+    release_tx
+        .send(())
+        .expect("occupier must still be waiting on the release signal");
+    occupier
+        .await
+        .expect("occupier task must not panic")
+        .expect("occupier write must succeed");
+    store_task
+        .await
+        .expect("store task must not panic")
+        .expect("upsert_edge must succeed once unblocked");
+
+    let fetched = store.get_edge(edge_id).await.unwrap();
+    assert!(
+        fetched.is_some(),
+        "edge must be committed and readable after queuing behind the occupier"
+    );
+}

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -74,12 +74,30 @@ impl SqlNoteStore {
         Ok(conn)
     }
 
-    /// Write via pool writer (serializes writes through the mutex).
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
+    ///
+    /// This is the ONE routing point for every `with_writer` caller in this
+    /// store (`upsert_note`, `try_insert_note`, `delete_note`). `f` must be
+    /// DML-only — on the flag-on path it runs inside the WriterTask's own
+    /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
+    /// nested-transaction rule. `upsert_notes` (the batch method) does its
+    /// own flag check and returns early on `Some`, so its fallback call
+    /// into this helper only ever executes on the flag-off path
+    /// (`self.writer_task` is `None` by construction whenever that call is
+    /// reached) — no double-routing.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -13,6 +13,7 @@ use khive_storage::StorageCapability;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Notes, op, e)
@@ -29,14 +30,22 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 pub struct SqlNoteStore {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl SqlNoteStore {
     /// Create a new store.
     pub fn new(pool: Arc<ConnectionPool>, is_file_backed: bool) -> Self {
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task — flag off, spawn degraded, or no
+        // Tokio runtime available at this first access — degrades to the
+        // legacy pool-mutex path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
+
         Self {
             pool,
             is_file_backed,
+            writer_task,
         }
     }
 
@@ -155,6 +164,70 @@ fn read_note(row: &rusqlite::Row<'_>) -> Result<Note, rusqlite::Error> {
 fn parse_uuid(s: &str) -> Result<Uuid, rusqlite::Error> {
     Uuid::parse_str(s).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })
+}
+
+/// DML-only batch upsert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `upsert_notes` paths (ADR-067 Component A).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction. Per-row failures are captured into
+/// `BatchWriteSummary::failed`/`first_error` rather than aborting the loop,
+/// matching the existing partial-success contract.
+fn batch_upsert_notes(
+    conn: &rusqlite::Connection,
+    notes: &[Note],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let mut affected = 0u64;
+    let mut failed = 0u64;
+    let mut first_error = String::new();
+
+    for note in notes {
+        let id_str = note.id.to_string();
+        let kind_str = note.kind.to_string();
+        let status_str = note.status.clone();
+        let properties_str = note
+            .properties
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+        match conn.execute(
+            "INSERT OR REPLACE INTO notes \
+             (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+              properties, created_at, updated_at, deleted_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            rusqlite::params![
+                id_str,
+                &note.namespace,
+                kind_str,
+                status_str,
+                &note.name,
+                note.content,
+                note.salience,
+                note.decay_factor,
+                note.expires_at,
+                properties_str,
+                note.created_at,
+                note.updated_at,
+                note.deleted_at,
+            ],
+        ) {
+            Ok(_) => affected += 1,
+            Err(e) => {
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed,
+        first_error,
     })
 }
 
@@ -429,64 +502,35 @@ impl NoteStore for SqlNoteStore {
     async fn upsert_notes(&self, notes: Vec<Note>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = notes.len() as u64;
 
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction (a bare BEGIN IMMEDIATE here would violate
+        // SQLite's nested-transaction rule).
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    batch_upsert_notes(conn, &notes, attempted)
+                        .map_err(|e| map_err(e, "upsert_notes"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
+        // via the pool-mutex writer.
         self.with_writer("upsert_notes", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("note_upsert_batch".to_string()));
-            let mut affected = 0u64;
-            let mut failed = 0u64;
-            let mut first_error = String::new();
 
-            for note in &notes {
-                let id_str = note.id.to_string();
-                let kind_str = note.kind.to_string();
-                let status_str = note.status.clone();
-                let properties_str = note
-                    .properties
-                    .as_ref()
-                    .map(|v| serde_json::to_string(v).unwrap_or_default());
-
-                match conn.execute(
-                    "INSERT OR REPLACE INTO notes \
-                     (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
-                      properties, created_at, updated_at, deleted_at) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                    rusqlite::params![
-                        id_str,
-                        &note.namespace,
-                        kind_str,
-                        status_str,
-                        &note.name,
-                        note.content,
-                        note.salience,
-                        note.decay_factor,
-                        note.expires_at,
-                        properties_str,
-                        note.created_at,
-                        note.updated_at,
-                        note.deleted_at,
-                    ],
-                ) {
-                    Ok(_) => affected += 1,
-                    Err(e) => {
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                    }
-                }
-            }
+            let summary = batch_upsert_notes(conn, &notes, attempted)?;
 
             if let Err(e) = conn.execute_batch("COMMIT") {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
             }
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed,
-                first_error,
-            })
+            Ok(summary)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -461,3 +461,112 @@ async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
         "the flag-ON path must actually spawn and use the writer task"
     );
 }
+
+/// Fork C slice 2: proves the SINGLE-row `upsert_note` (via `with_writer`,
+/// distinct from the already-migrated batch `upsert_notes` above) is actually
+/// enqueued on the pool's shared `WriterTaskHandle` channel when
+/// `KHIVE_WRITE_QUEUE=1`.
+///
+/// Deliberately NOT a wall-clock/occupier-timing test: real SQLite
+/// file-level locking would serialize a second writer connection against an
+/// occupier's open transaction regardless of which Rust-level path issued
+/// it, making elapsed time alone vacuous here (confirmed empirically while
+/// designing khive-db's entity.rs sibling test in this same PR). Instead
+/// this reads `WriterTaskHandle::queue_depth` directly — the live gauge over
+/// the exact `mpsc` channel `with_writer`'s writer-task branch must call
+/// `send` on — while an occupier deterministically holds the writer task's
+/// one drain slot open (parked on a oneshot via `blocking_recv`, valid
+/// because it runs inside the writer task's own `spawn_blocking`, not a
+/// sleep/timing race).
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+#[tokio::test]
+#[serial_test::serial]
+async fn upsert_note_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_note_single.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(NOTES_DDL).unwrap();
+    }
+
+    let store = Arc::new(SqlNoteStore::new(Arc::clone(&pool), true));
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let writer_task = pool
+        .writer_task_handle()
+        .unwrap()
+        .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let occupier = {
+        let writer_task = writer_task.clone();
+        tokio::spawn(async move {
+            writer_task
+                .send(move |_conn| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.blocking_recv();
+                    Ok::<(), StorageError>(())
+                })
+                .await
+        })
+    };
+
+    started_rx
+        .await
+        .expect("occupier must signal it has started running inside the writer task");
+    assert_eq!(
+        writer_task.queue_depth(),
+        0,
+        "channel must start empty once the occupier has been dequeued and is running"
+    );
+
+    let note = make_note("default", "observation", "single-row write-queue routing");
+    let note_id = note.id;
+
+    let store_task = {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move { store.upsert_note(note).await })
+    };
+
+    let mut saw_enqueued = false;
+    for _ in 0..100 {
+        if writer_task.queue_depth() >= 1 {
+            saw_enqueued = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        saw_enqueued,
+        "upsert_note's write request never appeared in the writer task's \
+         channel while the occupier held the single drain slot — with_writer \
+         is not routing this single-row write through the shared writer task"
+    );
+
+    release_tx
+        .send(())
+        .expect("occupier must still be waiting on the release signal");
+    occupier
+        .await
+        .expect("occupier task must not panic")
+        .expect("occupier write must succeed");
+    store_task
+        .await
+        .expect("store task must not panic")
+        .expect("upsert_note must succeed once unblocked");
+
+    let fetched = store.get_note(note_id).await.unwrap();
+    assert!(
+        fetched.is_some(),
+        "note must be committed and readable after queuing behind the occupier"
+    );
+}

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -421,17 +421,18 @@ async fn page_offset_over_i64max_rejected() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both rows are actually committed and independently readable back.
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
+/// crate's other tests are NOT `#[serial]` against it, so a window where it
+/// is set here could leak into a concurrently-scheduled test's own pool
+/// construction (ADR-067 Fork C slice 2 round 2, LOW finding).
 #[tokio::test]
-#[serial_test::serial]
 async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_notes.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -441,7 +442,6 @@ async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = SqlNoteStore::new(Arc::clone(&pool), true);
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let n1 = make_note("default", "observation", "first");
     let n2 = make_note("default", "observation", "second");
@@ -479,16 +479,17 @@ async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
 /// because it runs inside the writer task's own `spawn_blocking`, not a
 /// sleep/timing race).
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — see
+/// `upsert_notes_routes_through_writer_task_when_flag_enabled`'s doc comment
+/// for the race this avoids.
 #[tokio::test]
-#[serial_test::serial]
 async fn upsert_note_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_note_single.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -498,7 +499,6 @@ async fn upsert_note_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = Arc::new(SqlNoteStore::new(Arc::clone(&pool), true));
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let writer_task = pool
         .writer_task_handle()

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -416,3 +416,48 @@ async fn page_offset_over_i64max_rejected() {
         "query_notes_filtered: expected InvalidInput, got {filtered_result:?}"
     );
 }
+
+/// ADR-067 Component A entry 2: with `KHIVE_WRITE_QUEUE=1`, `upsert_notes`
+/// routes through the WriterTask channel instead of the pool-mutex path, and
+/// both rows are actually committed and independently readable back.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial_test::serial]
+async fn upsert_notes_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_notes.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(NOTES_DDL).unwrap();
+    }
+
+    let store = SqlNoteStore::new(Arc::clone(&pool), true);
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let n1 = make_note("default", "observation", "first");
+    let n2 = make_note("default", "observation", "second");
+    let id1 = n1.id;
+    let id2 = n2.id;
+
+    let summary = store.upsert_notes(vec![n1, n2]).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
+
+    assert!(store.get_note(id1).await.unwrap().is_some());
+    assert!(store.get_note(id2).await.unwrap().is_some());
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "the flag-ON path must actually spawn and use the writer task"
+    );
+}

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -950,21 +950,23 @@ mod tests {
     /// channel instead of the pool-mutex path, and both rows are actually
     /// committed and independently searchable back.
     ///
-    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-    /// shared with `pool.rs`'s own env-override tests in this same test binary.
+    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`),
+    /// not the `KHIVE_WRITE_QUEUE` env var — that env var is process-global
+    /// and this crate's other tests are NOT `#[serial]` against it, so a
+    /// window where it is set here could leak into a
+    /// concurrently-scheduled test's own pool construction (ADR-067 Fork C
+    /// slice 2 round 2, LOW finding).
     #[tokio::test]
-    #[serial_test::serial]
     async fn insert_batch_routes_through_writer_task_when_flag_enabled() {
         use chrono::Utc;
         use khive_types::SubstrateKind;
-
-        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
 
         let model_key = "write_queue_flag_test";
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("write_queue_sparse.db");
         let pool_cfg = PoolConfig {
             path: Some(path.clone()),
+            write_queue_enabled: true,
             ..PoolConfig::default()
         };
         let pool = Arc::new(ConnectionPool::new(pool_cfg).expect("pool"));
@@ -980,7 +982,6 @@ mod tests {
             "ns:test".to_string(),
         )
         .expect("store");
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
 
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -224,11 +224,30 @@ impl SqliteSparseStore {
         })
     }
 
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
+    ///
+    /// This is the ONE routing point for every `with_writer` caller in this
+    /// store (`upsert_sparse_vector`, `delete_sparse_subject`). `f` must be
+    /// DML-only — on the flag-on path it runs inside the WriterTask's own
+    /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
+    /// nested-transaction rule. `insert_sparse_batch` (the batch method)
+    /// does its own flag check and returns early on `Some`, so its
+    /// fallback call into this helper only ever executes on the flag-off
+    /// path (`self.writer_task` is `None` by construction whenever that
+    /// call is reached) — no double-routing.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
     {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;

--- a/crates/khive-db/src/stores/sparse.rs
+++ b/crates/khive-db/src/stores/sparse.rs
@@ -17,6 +17,7 @@ use khive_types::SubstrateKind;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Sparse, op, e)
@@ -82,6 +83,93 @@ fn f32_slice_as_bytes(data: &[f32]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, std::mem::size_of_val(data)) }
 }
 
+/// DML-only batch insert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `insert_sparse_batch` paths (ADR-067
+/// Component A).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction. Per-row failures (validation or SQL) are captured
+/// into `BatchWriteSummary::failed`/`first_error` rather than aborting the
+/// loop, matching the existing partial-success contract.
+fn batch_insert_sparse_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    records: &[SparseRecord],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let sql = format!(
+        "INSERT INTO {table} \
+         (subject_id, namespace, kind, field, indices_json, values_blob, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         ON CONFLICT(subject_id, namespace, field) DO UPDATE SET \
+         indices_json = excluded.indices_json, \
+         values_blob = excluded.values_blob, \
+         updated_at = excluded.updated_at"
+    );
+
+    let mut affected = 0u64;
+    let mut failed = 0u64;
+    let mut first_error = String::new();
+
+    for record in records {
+        // Validate inline — skip invalid records rather than aborting the batch.
+        if record.vector.indices.len() != record.vector.values.len()
+            || record.vector.indices.is_empty()
+            || record.vector.values.iter().any(|v| !v.is_finite())
+            || record.vector.indices.windows(2).any(|w| w[0] >= w[1])
+        {
+            if first_error.is_empty() {
+                first_error = format!("invalid sparse vector for subject {}", record.subject_id);
+            }
+            failed += 1;
+            continue;
+        }
+
+        let indices_json = match serde_json::to_string(&record.vector.indices) {
+            Ok(j) => j,
+            Err(e) => {
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+                continue;
+            }
+        };
+        let values_blob = f32_slice_as_bytes(&record.vector.values);
+        let now = record.updated_at.timestamp();
+        let id_str = record.subject_id.to_string();
+        let kind_str = record.kind.to_string();
+
+        match conn.execute(
+            &sql,
+            rusqlite::params![
+                &id_str,
+                &record.namespace,
+                &kind_str,
+                &record.field,
+                &indices_json,
+                values_blob,
+                now
+            ],
+        ) {
+            Ok(_) => affected += 1,
+            Err(e) => {
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed,
+        first_error,
+    })
+}
+
 /// Create the sparse table and its index for the given model_key.
 pub(crate) fn ensure_sparse_schema(
     conn: &rusqlite::Connection,
@@ -111,6 +199,7 @@ pub struct SqliteSparseStore {
     is_file_backed: bool,
     table_name: String,
     namespace: String,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl SqliteSparseStore {
@@ -122,11 +211,16 @@ impl SqliteSparseStore {
         namespace: String,
     ) -> Result<Self, SqliteError> {
         let table_name = format!("sparse_{}", model_key);
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task degrades to the legacy pool-mutex
+        // path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
         Ok(Self {
             pool,
             is_file_backed,
             table_name,
             namespace,
+            writer_task,
         })
     }
 
@@ -235,83 +329,31 @@ impl SqliteSparseStore {
         let table = self.table_name.clone();
         let attempted = records.len() as u64;
 
-        self.with_writer("sparse_insert_batch", move |conn| {
-            let sql = format!(
-                "INSERT INTO {table} \
-                 (subject_id, namespace, kind, field, indices_json, values_blob, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
-                 ON CONFLICT(subject_id, namespace, field) DO UPDATE SET \
-                 indices_json = excluded.indices_json, \
-                 values_blob = excluded.values_blob, \
-                 updated_at = excluded.updated_at"
-            );
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction.
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            return writer_task
+                .send(move |conn| {
+                    batch_insert_sparse_dml(conn, &table2, &records, attempted)
+                        .map_err(|e| map_err(e, "sparse_insert_batch"))
+                })
+                .await;
+        }
 
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
+        self.with_writer("sparse_insert_batch", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("sparse_insert_batch".to_string()));
-            let mut affected = 0u64;
-            let mut failed = 0u64;
-            let mut first_error = String::new();
 
-            for record in &records {
-                // Validate inline — skip invalid records rather than aborting the batch.
-                if record.vector.indices.len() != record.vector.values.len()
-                    || record.vector.indices.is_empty()
-                    || record.vector.values.iter().any(|v| !v.is_finite())
-                    || record.vector.indices.windows(2).any(|w| w[0] >= w[1])
-                {
-                    if first_error.is_empty() {
-                        first_error =
-                            format!("invalid sparse vector for subject {}", record.subject_id);
-                    }
-                    failed += 1;
-                    continue;
-                }
-
-                let indices_json = match serde_json::to_string(&record.vector.indices) {
-                    Ok(j) => j,
-                    Err(e) => {
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                        continue;
-                    }
-                };
-                let values_blob = f32_slice_as_bytes(&record.vector.values);
-                let now = record.updated_at.timestamp();
-                let id_str = record.subject_id.to_string();
-                let kind_str = record.kind.to_string();
-
-                match conn.execute(
-                    &sql,
-                    rusqlite::params![
-                        &id_str,
-                        &record.namespace,
-                        &kind_str,
-                        &record.field,
-                        &indices_json,
-                        values_blob,
-                        now
-                    ],
-                ) {
-                    Ok(_) => affected += 1,
-                    Err(e) => {
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                    }
-                }
-            }
+            let summary = batch_insert_sparse_dml(conn, &table, &records, attempted)?;
 
             conn.execute_batch("COMMIT")?;
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed,
-                first_error,
-            })
+            Ok(summary)
         })
         .await
     }
@@ -882,5 +924,75 @@ mod tests {
         assert_eq!(summary.affected, 2);
         assert_eq!(summary.failed, 0);
         assert_eq!(store.count().await.unwrap(), 2);
+    }
+
+    /// ADR-067 Component A entry 6: with `KHIVE_WRITE_QUEUE=1`, `insert_batch`
+    /// (delegating to `insert_sparse_batch`) routes through the WriterTask
+    /// channel instead of the pool-mutex path, and both rows are actually
+    /// committed and independently searchable back.
+    ///
+    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+    /// shared with `pool.rs`'s own env-override tests in this same test binary.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn insert_batch_routes_through_writer_task_when_flag_enabled() {
+        use chrono::Utc;
+        use khive_types::SubstrateKind;
+
+        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+        let model_key = "write_queue_flag_test";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("write_queue_sparse.db");
+        let pool_cfg = PoolConfig {
+            path: Some(path.clone()),
+            ..PoolConfig::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let writer = pool.writer().expect("writer");
+            ensure_sparse_schema(writer.conn(), model_key).expect("schema");
+        }
+
+        let store = SqliteSparseStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            "ns:test".to_string(),
+        )
+        .expect("store");
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let records = vec![
+            SparseRecord {
+                subject_id: id1,
+                kind: SubstrateKind::Entity,
+                namespace: "ns:test".into(),
+                field: "body".into(),
+                vector: sv(vec![0, 3], vec![0.5, 0.8]),
+                updated_at: Utc::now(),
+            },
+            SparseRecord {
+                subject_id: id2,
+                kind: SubstrateKind::Entity,
+                namespace: "ns:test".into(),
+                field: "body".into(),
+                vector: sv(vec![1], vec![1.0]),
+                updated_at: Utc::now(),
+            },
+        ];
+
+        let summary = store.insert_batch(records).await.unwrap();
+        assert_eq!(summary.attempted, 2);
+        assert_eq!(summary.affected, 2);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(store.count().await.unwrap(), 2);
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            1,
+            "the flag-ON path must actually spawn and use the writer task"
+        );
     }
 }

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -19,6 +19,7 @@ use khive_types::SubstrateKind;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::writer_task::WriterTaskHandle;
 
 /// Ensure the FTS5 virtual table for `table_key` exists.
 ///
@@ -62,6 +63,7 @@ pub struct Fts5TextSearch {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
     table_name: String,
+    writer_task: Option<WriterTaskHandle>,
 }
 
 impl Fts5TextSearch {
@@ -70,10 +72,15 @@ impl Fts5TextSearch {
     /// The FTS5 virtual table must already exist (created by `StorageBackend::text()`).
     pub(crate) fn new(pool: Arc<ConnectionPool>, is_file_backed: bool, table_key: String) -> Self {
         let table_name = format!("fts_{}", table_key);
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task degrades to the legacy pool-mutex /
+        // standalone-connection path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
         Self {
             pool,
             is_file_backed,
             table_name,
+            writer_task,
         }
     }
 
@@ -288,51 +295,158 @@ fn build_filter_clause(
     }
 }
 
+/// DML-only single-document upsert shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `upsert_document` paths (ADR-067 Component A).
+///
+/// Issues no `BEGIN` / `COMMIT` / `ROLLBACK` itself — the caller owns the
+/// enclosing transaction.
+fn upsert_document_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    document: &TextDocument,
+) -> Result<(), rusqlite::Error> {
+    let namespace = &document.namespace;
+
+    let del_sql = format!(
+        "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
+        table
+    );
+    conn.execute(
+        &del_sql,
+        rusqlite::params![namespace, document.subject_id.to_string()],
+    )?;
+
+    let ins_sql = format!(
+        "INSERT INTO {} \
+         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        table
+    );
+    let tags_json = tags_to_json(&document.tags);
+    let metadata_json: Option<String> = document.metadata.as_ref().map(|v| v.to_string());
+
+    conn.execute(
+        &ins_sql,
+        rusqlite::params![
+            document.subject_id.to_string(),
+            document.kind.to_string(),
+            document.title.as_deref().unwrap_or(""),
+            document.body,
+            tags_json,
+            namespace,
+            metadata_json,
+            dt_to_micros(&document.updated_at),
+        ],
+    )?;
+    Ok(())
+}
+
+/// DML-only batch upsert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `upsert_documents` paths (ADR-067 Component A).
+///
+/// Issues no OUTER `BEGIN` / `COMMIT` / `ROLLBACK` — the caller owns the
+/// enclosing transaction. The per-row named `SAVEPOINT fts_upsert_doc` is
+/// preserved unchanged: it is what gives this loop its partial-success
+/// semantics (one bad document does not abort the whole batch) independent
+/// of which outer transaction wraps the loop.
+fn batch_upsert_documents_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    documents: &[TextDocument],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let del_sql = format!(
+        "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
+        table
+    );
+    let ins_sql = format!(
+        "INSERT INTO {} \
+         (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        table
+    );
+
+    let mut affected = 0u64;
+    let mut failed = 0u64;
+    let mut first_error = String::new();
+
+    for doc in documents {
+        conn.execute_batch("SAVEPOINT fts_upsert_doc")?;
+        let id_str = doc.subject_id.to_string();
+        let namespace = &doc.namespace;
+        let result = (|| {
+            conn.execute(&del_sql, rusqlite::params![namespace, &id_str])?;
+
+            let tags_json = tags_to_json(&doc.tags);
+            let metadata_json: Option<String> = doc.metadata.as_ref().map(|v| v.to_string());
+
+            conn.execute(
+                &ins_sql,
+                rusqlite::params![
+                    &id_str,
+                    &doc.kind.to_string(),
+                    doc.title.as_deref().unwrap_or(""),
+                    &doc.body,
+                    &tags_json,
+                    namespace,
+                    &metadata_json,
+                    dt_to_micros(&doc.updated_at),
+                ],
+            )?;
+            Ok::<(), rusqlite::Error>(())
+        })();
+
+        match result {
+            Ok(()) => {
+                conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc")?;
+                affected += 1;
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT fts_upsert_doc");
+                let _ = conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc");
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed,
+        first_error,
+    })
+}
+
 #[async_trait]
 impl TextSearch for Fts5TextSearch {
     async fn upsert_document(&self, document: TextDocument) -> Result<(), StorageError> {
         let table = self.table_name.clone();
-        let namespace = document.namespace.clone();
 
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure — no BEGIN
+        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
+        // owns the transaction.
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            return writer_task
+                .send(move |conn| {
+                    upsert_document_dml(conn, &table2, &document)
+                        .map_err(|e| map_err(e, "fts_upsert"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK.
         self.with_writer("fts_upsert", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("text_upsert_document".to_string()));
 
-            let del_sql = format!(
-                "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
-                table
-            );
-            if let Err(e) = conn.execute(
-                &del_sql,
-                rusqlite::params![&namespace, document.subject_id.to_string()],
-            ) {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-
-            let ins_sql = format!(
-                "INSERT INTO {} \
-                 (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                table
-            );
-            let tags_json = tags_to_json(&document.tags);
-            let metadata_json: Option<String> = document.metadata.as_ref().map(|v| v.to_string());
-
-            if let Err(e) = conn.execute(
-                &ins_sql,
-                rusqlite::params![
-                    document.subject_id.to_string(),
-                    document.kind.to_string(),
-                    document.title.as_deref().unwrap_or(""),
-                    document.body,
-                    tags_json,
-                    &namespace,
-                    metadata_json,
-                    dt_to_micros(&document.updated_at),
-                ],
-            ) {
+            if let Err(e) = upsert_document_dml(conn, &table, &document) {
                 let _ = conn.execute_batch("ROLLBACK");
                 return Err(e);
             }
@@ -350,76 +464,33 @@ impl TextSearch for Fts5TextSearch {
         let table = self.table_name.clone();
         let attempted = documents.len() as u64;
 
-        self.with_writer("fts_upsert_batch", move |conn| {
-            let del_sql = format!(
-                "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
-                table
-            );
-            let ins_sql = format!(
-                "INSERT INTO {} \
-                 (subject_id, kind, title, body, tags, namespace, metadata, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                table
-            );
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure (the per-row
+        // `SAVEPOINT fts_upsert_doc` is preserved unchanged — only the OUTER
+        // BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's run loop
+        // owns the enclosing transaction).
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            return writer_task
+                .send(move |conn| {
+                    batch_upsert_documents_dml(conn, &table2, &documents, attempted)
+                        .map_err(|e| map_err(e, "fts_upsert_batch"))
+                })
+                .await;
+        }
 
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
+        self.with_writer("fts_upsert_batch", move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("text_upsert_batch".to_string()));
-            let mut affected = 0u64;
-            let mut failed = 0u64;
-            let mut first_error = String::new();
 
-            for doc in &documents {
-                conn.execute_batch("SAVEPOINT fts_upsert_doc")?;
-                let id_str = doc.subject_id.to_string();
-                let namespace = &doc.namespace;
-                let result = (|| {
-                    conn.execute(&del_sql, rusqlite::params![namespace, &id_str])?;
-
-                    let tags_json = tags_to_json(&doc.tags);
-                    let metadata_json: Option<String> =
-                        doc.metadata.as_ref().map(|v| v.to_string());
-
-                    conn.execute(
-                        &ins_sql,
-                        rusqlite::params![
-                            &id_str,
-                            &doc.kind.to_string(),
-                            doc.title.as_deref().unwrap_or(""),
-                            &doc.body,
-                            &tags_json,
-                            namespace,
-                            &metadata_json,
-                            dt_to_micros(&doc.updated_at),
-                        ],
-                    )?;
-                    Ok::<(), rusqlite::Error>(())
-                })();
-
-                match result {
-                    Ok(()) => {
-                        conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc")?;
-                        affected += 1;
-                    }
-                    Err(e) => {
-                        let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT fts_upsert_doc");
-                        let _ = conn.execute_batch("RELEASE SAVEPOINT fts_upsert_doc");
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                    }
-                }
-            }
+            let summary = batch_upsert_documents_dml(conn, &table, &documents, attempted)?;
 
             conn.execute_batch("COMMIT")?;
 
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed,
-                first_error,
-            })
+            Ok(summary)
         })
         .await
     }

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -96,7 +96,51 @@ impl Fts5TextSearch {
             .map_err(|e| map_sqlite_err(e, "open_fts_reader"))
     }
 
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy standalone-connection / pool-mutex path (ADR-067
+    /// Component A, Fork C slice 2).
+    ///
+    /// This is the routing point for `with_writer` callers whose closure is
+    /// DML-only (`delete_document`/`fts_delete`, `rebuild`/`fts_rebuild`):
+    /// on the flag-on path the closure runs inside the WriterTask's own
+    /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
+    /// nested-transaction rule. `upsert_document`/`upsert_documents` (the
+    /// single-doc and batch write methods) do their own flag check and
+    /// return early on `Some`, so their fallback calls into this helper
+    /// only ever execute on the flag-off path (`self.writer_task` is
+    /// `None` by construction whenever those calls are reached) — no
+    /// double-routing.
+    ///
+    /// `rename_namespace` (`#[allow(dead_code)]`, no production caller —
+    /// see ADR-067's `BEGIN IMMEDIATE` site inventory, EXEMPT) manages its
+    /// own manual transaction and calls [`Self::with_writer_unmanaged`]
+    /// instead of this helper — routing its closure through the WriterTask
+    /// would nest a bare `BEGIN IMMEDIATE` inside the WriterTask's own
+    /// transaction.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
+        self.with_writer_unmanaged(op, f).await
+    }
+
+    /// Legacy standalone-connection / pool-mutex write path, bypassing the
+    /// WriterTask channel unconditionally regardless of
+    /// `KHIVE_WRITE_QUEUE`.
+    ///
+    /// Reserved for closures that manage their own transaction (a bare
+    /// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`) — those cannot be sent through
+    /// the WriterTask channel, which already wraps every request in its own
+    /// transaction. `rename_namespace` is the only caller.
+    async fn with_writer_unmanaged<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
@@ -1148,7 +1192,7 @@ impl Fts5TextSearch {
         let old_ns = old_namespace.to_string();
         let new_ns = new_namespace.to_string();
 
-        self.with_writer("fts_rename_namespace", move |conn| {
+        self.with_writer_unmanaged("fts_rename_namespace", move |conn| {
             let sel_sql = format!(
                 "SELECT subject_id, kind, title, body, tags, metadata, updated_at \
                  FROM {} WHERE namespace = ?1",

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1362,3 +1362,59 @@ async fn upsert_documents_first_error_populated_on_item_failure() {
          but got an empty string; the error is being silently swallowed"
     );
 }
+
+/// ADR-067 Component A entry 4: with `KHIVE_WRITE_QUEUE=1`, `upsert_documents`
+/// routes through the WriterTask channel instead of the pool-mutex path, and
+/// both documents are actually committed and independently readable back.
+///
+/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+/// shared with `pool.rs`'s own env-override tests in this same test binary.
+#[tokio::test]
+#[serial_test::serial]
+async fn upsert_documents_routes_through_writer_task_when_flag_enabled() {
+    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+    let table_key = "write_queue_flag_test";
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("write_queue_text.db");
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        ensure_fts5_schema(writer.conn(), table_key).unwrap();
+    }
+
+    let store = Fts5TextSearch::new(Arc::clone(&pool), true, table_key.to_string());
+    std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+    let subject1 = Uuid::new_v4();
+    let subject2 = Uuid::new_v4();
+    let docs = vec![
+        make_document(subject1, "Doc A", "body a"),
+        make_document(subject2, "Doc B", "body b"),
+    ];
+
+    let summary = store.upsert_documents(docs).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+    assert_eq!(summary.failed, 0);
+
+    assert!(store
+        .get_document("test_ns", subject1)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_document("test_ns", subject2)
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(
+        pool.writer_task_spawn_count(),
+        1,
+        "the flag-ON path must actually spawn and use the writer task"
+    );
+}

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -1367,18 +1367,19 @@ async fn upsert_documents_first_error_populated_on_item_failure() {
 /// routes through the WriterTask channel instead of the pool-mutex path, and
 /// both documents are actually committed and independently readable back.
 ///
-/// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-/// shared with `pool.rs`'s own env-override tests in this same test binary.
+/// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
+/// the `KHIVE_WRITE_QUEUE` env var — that env var is process-global and this
+/// crate's other tests are NOT `#[serial]` against it, so a window where it
+/// is set here could leak into a concurrently-scheduled test's own pool
+/// construction (ADR-067 Fork C slice 2 round 2, LOW finding).
 #[tokio::test]
-#[serial_test::serial]
 async fn upsert_documents_routes_through_writer_task_when_flag_enabled() {
-    std::env::set_var("KHIVE_WRITE_QUEUE", "1");
-
     let table_key = "write_queue_flag_test";
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("write_queue_text.db");
     let pool_cfg = PoolConfig {
         path: Some(path.clone()),
+        write_queue_enabled: true,
         ..PoolConfig::default()
     };
     let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
@@ -1388,7 +1389,6 @@ async fn upsert_documents_routes_through_writer_task_when_flag_enabled() {
     }
 
     let store = Fts5TextSearch::new(Arc::clone(&pool), true, table_key.to_string());
-    std::env::remove_var("KHIVE_WRITE_QUEUE");
 
     let subject1 = Uuid::new_v4();
     let subject2 = Uuid::new_v4();

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -236,8 +236,49 @@ impl SqliteVecStore {
         Ok(conn)
     }
 
-    /// Write via pool writer to serialize through the mutex.
+    /// Route a single-row write through the pool-wide `WriterTask` when
+    /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
+    /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
+    ///
+    /// This is the routing point for `with_writer` callers whose closure is
+    /// DML-only (`delete`/`vec_delete`, `delete_subjects`/
+    /// `vec_delete_subjects`): on the flag-on path the closure runs inside
+    /// the WriterTask's own transaction, so a bare `BEGIN IMMEDIATE` (or an
+    /// inner `conn.unchecked_transaction()`) would violate SQLite's
+    /// nested-transaction rule. `insert`/`update` (which need their own
+    /// delete-then-insert atomicity) and `insert_batch` (the batch method)
+    /// each do their own flag check and return early on `Some`, routing a
+    /// SAVEPOINT-wrapped DML-only closure directly through the WriterTask
+    /// instead — their fallback calls into this helper only ever execute on
+    /// the flag-off path (`self.writer_task` is `None` by construction
+    /// whenever those calls are reached) — no double-routing.
+    ///
+    /// `orphan_sweep` (`Transaction::new_unchecked`, its own manual
+    /// transaction) calls [`Self::with_writer_unmanaged`] instead of this
+    /// helper — routing it through the WriterTask would nest a transaction
+    /// inside the WriterTask's own transaction.
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
+        self.with_writer_unmanaged(op, f).await
+    }
+
+    /// Legacy pool-mutex write path, bypassing the WriterTask channel
+    /// unconditionally regardless of `KHIVE_WRITE_QUEUE`.
+    ///
+    /// Reserved for closures that manage their own transaction — those
+    /// cannot be sent through the WriterTask channel, which already wraps
+    /// every request in its own transaction. `orphan_sweep` is the only
+    /// caller.
+    async fn with_writer_unmanaged<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
         R: Send + 'static,
@@ -389,6 +430,91 @@ fn batch_insert_vectors_dml(
     })
 }
 
+/// Shared DELETE-then-INSERT DML for single-record `insert`/`update`, run
+/// inside a named `SAVEPOINT` (nestable inside the WriterTask's own
+/// transaction) instead of `conn.unchecked_transaction()` (which would
+/// attempt a nested `BEGIN` and fail once this runs inside the WriterTask's
+/// already-open transaction). A failed INSERT rolls back only this
+/// SAVEPOINT, leaving the previous vector intact (no-worse-than-stale
+/// guarantee) — the single-record analog of `batch_insert_vectors_dml`'s
+/// per-record `SAVEPOINT vec_batch_record`.
+#[allow(clippy::too_many_arguments)]
+fn vec_upsert_atomic_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    dims: usize,
+    subject_id: Uuid,
+    kind_str: &str,
+    namespace: &str,
+    field: &str,
+    embedding_model: &str,
+    embedding: &[f32],
+    savepoint_name: &'static str,
+    _failpoint_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<(), rusqlite::Error> {
+    if embedding.len() != dims {
+        return Err(rusqlite::Error::InvalidParameterCount(
+            embedding.len(),
+            dims,
+        ));
+    }
+
+    conn.execute_batch(&format!("SAVEPOINT {savepoint_name}"))?;
+    let result = (|| {
+        let del_sql = format!(
+            "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
+            table
+        );
+        conn.execute(
+            &del_sql,
+            rusqlite::params![subject_id.to_string(), namespace],
+        )?;
+
+        // Failpoint: fires only in cfg(test) when the guard is active.
+        // DELETE has already run; if ROLLBACK TO SAVEPOINT is missing, the
+        // deleted row is lost permanently.
+        #[cfg(test)]
+        if let Some(ref fp) = _failpoint_flag {
+            if failpoint::take(fp) {
+                return Err(rusqlite::Error::InvalidParameterName(
+                    "__test_failpoint_after_delete__".into(),
+                ));
+            }
+        }
+
+        let ins_sql = format!(
+            "INSERT INTO {} (subject_id, namespace, kind, field, embedding_model, embedding) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            table
+        );
+        let blob = f32_slice_as_bytes(embedding);
+        conn.execute(
+            &ins_sql,
+            rusqlite::params![
+                subject_id.to_string(),
+                namespace,
+                kind_str,
+                field,
+                embedding_model,
+                blob
+            ],
+        )?;
+        Ok::<(), rusqlite::Error>(())
+    })();
+
+    match result {
+        Ok(()) => {
+            conn.execute_batch(&format!("RELEASE SAVEPOINT {savepoint_name}"))?;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = conn.execute_batch(&format!("ROLLBACK TO SAVEPOINT {savepoint_name}"));
+            let _ = conn.execute_batch(&format!("RELEASE SAVEPOINT {savepoint_name}"));
+            Err(e)
+        }
+    }
+}
+
 #[async_trait]
 impl VectorStore for SqliteVecStore {
     async fn insert(
@@ -421,6 +547,46 @@ impl VectorStore for SqliteVecStore {
             }
         }
 
+        // Capture the failpoint Arc (if any) from the thread-local on the
+        // calling thread before handing the closure to spawn_blocking.
+        let failpoint_flag = current_failpoint();
+
+        // ADR-067 Component A (Fork C slice 2): when the write queue is
+        // enabled, route through the pool-wide WriterTask. DML-only
+        // closure — atomicity is provided by `vec_upsert_atomic_dml`'s
+        // named SAVEPOINT rather than `conn.unchecked_transaction()`,
+        // which would attempt a nested `BEGIN` and fail under the
+        // WriterTask's already-open transaction.
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            let namespace2 = namespace.clone();
+            let field2 = field.clone();
+            let kind_str2 = kind_str.clone();
+            let embedding_model2 = embedding_model.clone();
+            let embedding2 = embedding.clone();
+            return writer_task
+                .send(move |conn| {
+                    vec_upsert_atomic_dml(
+                        conn,
+                        &table2,
+                        dims,
+                        subject_id,
+                        &kind_str2,
+                        &namespace2,
+                        &field2,
+                        &embedding_model2,
+                        &embedding2,
+                        "vec_insert_atomic",
+                        failpoint_flag,
+                    )
+                    .map_err(|e| map_err(e, "vec_insert"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from
+        // pre-ADR-067 behavior — the closure owns its own transaction via
+        // `conn.unchecked_transaction()`.
         self.with_writer("vec_insert", move |conn| {
             if embedding.len() != dims {
                 return Err(rusqlite::Error::InvalidParameterCount(
@@ -572,6 +738,43 @@ impl VectorStore for SqliteVecStore {
         #[cfg(test)]
         let _failpoint_flag = failpoint::CURRENT.with(|c| c.borrow().clone());
 
+        // ADR-067 Component A (Fork C slice 2): when the write queue is
+        // enabled, route through the pool-wide WriterTask. DML-only
+        // closure — atomicity is provided by `vec_upsert_atomic_dml`'s
+        // named SAVEPOINT rather than `conn.unchecked_transaction()`,
+        // which would attempt a nested `BEGIN` and fail under the
+        // WriterTask's already-open transaction.
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            let namespace2 = namespace.clone();
+            let field2 = field.clone();
+            let kind_str2 = kind_str.clone();
+            let embedding_model2 = embedding_model.clone();
+            let embedding2 = embedding.clone();
+            let failpoint_flag2 = current_failpoint();
+            return writer_task
+                .send(move |conn| {
+                    vec_upsert_atomic_dml(
+                        conn,
+                        &table2,
+                        dims,
+                        subject_id,
+                        &kind_str2,
+                        &namespace2,
+                        &field2,
+                        &embedding_model2,
+                        &embedding2,
+                        "vec_update_atomic",
+                        failpoint_flag2,
+                    )
+                    .map_err(|e| map_err(e, "vec_update"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from
+        // pre-ADR-067 behavior — the closure owns its own transaction via
+        // `conn.unchecked_transaction()`.
         self.with_writer("vec_update", move |conn| {
             if embedding.len() != dims {
                 return Err(rusqlite::Error::InvalidParameterCount(
@@ -932,7 +1135,7 @@ impl VectorStore for SqliteVecStore {
         let max_delete = config.max_delete as i64;
         let dry_run = config.dry_run;
 
-        self.with_writer("orphan_sweep", move |conn| {
+        self.with_writer_unmanaged("orphan_sweep", move |conn| {
             // `Transaction::new_unchecked` issues `BEGIN IMMEDIATE` and RAII-manages
             // rollback via its Drop impl: it checks `conn.is_autocommit()` and issues
             // ROLLBACK when the connection still has an open transaction — covering both

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -3211,17 +3211,6 @@ mod write_queue_tests {
     use super::*;
     use crate::pool::{ConnectionPool, PoolConfig};
 
-    fn make_file_backed_pool(path: std::path::PathBuf) -> Arc<ConnectionPool> {
-        crate::extension::ensure_extensions_loaded();
-        Arc::new(
-            ConnectionPool::new(PoolConfig {
-                path: Some(path),
-                ..PoolConfig::default()
-            })
-            .expect("file-backed pool"),
-        )
-    }
-
     fn create_vec_table(pool: &Arc<ConnectionPool>, model_key: &str, dims: usize) {
         let ddl = format!(
             "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
@@ -3240,18 +3229,30 @@ mod write_queue_tests {
             .expect("create vec table");
     }
 
-    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
-    /// shared with `pool.rs`'s own env-override tests in this same test binary.
+    /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`),
+    /// not the `KHIVE_WRITE_QUEUE` env var — that env var is process-global
+    /// and this crate's other tests are NOT `#[serial]` against it, so a
+    /// window where it is set here could leak into a
+    /// concurrently-scheduled test's own pool construction (ADR-067 Fork C
+    /// slice 2 round 2, LOW finding). Builds the pool inline (rather than
+    /// via `make_file_backed_pool`, which hardcodes `PoolConfig::default()`)
+    /// so `write_queue_enabled` can be set directly in the literal.
     #[tokio::test]
-    #[serial_test::serial]
     async fn insert_batch_routes_through_writer_task_when_flag_enabled() {
-        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+        crate::extension::ensure_extensions_loaded();
 
         let model_key = "write_queue_flag_test";
         let dims = 4usize;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("write_queue_vectors.db");
-        let pool = make_file_backed_pool(path);
+        let pool = Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                write_queue_enabled: true,
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        );
         create_vec_table(&pool, model_key, dims);
 
         let store = SqliteVecStore::new(
@@ -3263,7 +3264,6 @@ mod write_queue_tests {
             "ns:test".to_string(),
         )
         .expect("SqliteVecStore::new");
-        std::env::remove_var("KHIVE_WRITE_QUEUE");
 
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -111,6 +111,22 @@ fn f32_slice_as_bytes(data: &[f32]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, std::mem::size_of_val(data)) }
 }
 
+/// Snapshot the current thread's failpoint flag (test builds only; always
+/// `None` in a release build). Exists so `insert_batch` can capture the
+/// thread-local's value once, unconditionally, before choosing between the
+/// flag-on (WriterTask) and flag-off (legacy pool-mutex) write paths —
+/// both eventually move the captured `Option` into a `spawn_blocking`
+/// closure on a different thread than the one that read the thread-local.
+#[cfg(test)]
+fn current_failpoint() -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+    failpoint::CURRENT.with(|c| c.borrow().clone())
+}
+
+#[cfg(not(test))]
+fn current_failpoint() -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+    None
+}
+
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Vectors, op, e)
 }
@@ -162,6 +178,7 @@ pub struct SqliteVecStore {
     dimensions: usize,
     table_name: String,
     namespace: String,
+    writer_task: Option<crate::writer_task::WriterTaskHandle>,
 }
 
 impl SqliteVecStore {
@@ -178,6 +195,10 @@ impl SqliteVecStore {
     ) -> Result<Self, SqliteError> {
         validate_model_key(&model_key)?;
         let table_name = format!("vec_{}", model_key);
+        // Best-effort opt-in (ADR-067 Component A, mirrors entity.rs slice 1
+        // policy): a missing writer task degrades to the legacy pool-mutex
+        // path rather than failing construction.
+        let writer_task = pool.writer_task_handle().ok().flatten();
         Ok(Self {
             pool,
             is_file_backed,
@@ -186,6 +207,7 @@ impl SqliteVecStore {
             dimensions,
             table_name,
             namespace,
+            writer_task,
         })
     }
 
@@ -249,6 +271,122 @@ impl SqliteVecStore {
             .map_err(|e| StorageError::driver(StorageCapability::Vectors, op, e))?
         }
     }
+}
+
+/// DML-only batch insert loop shared by both the legacy (flag-off) and
+/// WriterTask-routed (flag-on) `insert_batch` paths (ADR-067 Component A).
+///
+/// Issues no OUTER `BEGIN` / `COMMIT` / `ROLLBACK` — the caller owns the
+/// enclosing transaction. The per-record named `SAVEPOINT vec_batch_record`
+/// is preserved unchanged: it gives a failed INSERT a no-worse-than-stale
+/// rollback (only that record's DELETE is undone) independent of which
+/// outer transaction wraps the loop.
+#[allow(clippy::too_many_arguments)]
+fn batch_insert_vectors_dml(
+    conn: &rusqlite::Connection,
+    table: &str,
+    dims: usize,
+    store_embedding_model: &str,
+    records: &[VectorRecord],
+    attempted: u64,
+    _failpoint_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    let del_sql = format!(
+        "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
+        table
+    );
+    let ins_sql = format!(
+        "INSERT INTO {} (subject_id, namespace, kind, field, embedding_model, embedding) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        table
+    );
+
+    let mut affected = 0u64;
+    let mut failed = 0u64;
+    let mut first_error = String::new();
+
+    for record in records {
+        if record.vectors.len() != 1 {
+            if first_error.is_empty() {
+                first_error = format!("expected 1 vector per record, got {}", record.vectors.len());
+            }
+            failed += 1;
+            continue;
+        }
+        let embedding = &record.vectors[0];
+        if embedding.len() != dims {
+            if first_error.is_empty() {
+                first_error = format!(
+                    "wrong vector dimension: expected {dims}, got {}",
+                    embedding.len()
+                );
+            }
+            failed += 1;
+            continue;
+        }
+        if non_finite_index(embedding).is_some() {
+            if first_error.is_empty() {
+                first_error = "embedding contains non-finite values (NaN or Inf)".to_string();
+            }
+            failed += 1;
+            continue;
+        }
+        let blob = f32_slice_as_bytes(embedding);
+        let id_str = record.subject_id.to_string();
+        let kind_str = record.kind.to_string();
+
+        // Wrap each record's DELETE+INSERT in a savepoint so a failed INSERT
+        // rolls back only that record's DELETE, leaving the prior vector intact
+        // (no-worse-than-stale guarantee, same as single-record `insert`).
+        conn.execute_batch("SAVEPOINT vec_batch_record")?;
+        let result = (|| {
+            conn.execute(&del_sql, rusqlite::params![&id_str, &record.namespace])?;
+            // Failpoint: fires only in cfg(test) when the guard is active.
+            // DELETE has already run; if ROLLBACK TO SAVEPOINT is missing,
+            // the deleted row is lost permanently.
+            #[cfg(test)]
+            if let Some(ref fp) = _failpoint_flag {
+                if failpoint::take(fp) {
+                    return Err(rusqlite::Error::InvalidParameterName(
+                        "__test_failpoint_after_delete__".into(),
+                    ));
+                }
+            }
+            conn.execute(
+                &ins_sql,
+                rusqlite::params![
+                    &id_str,
+                    &record.namespace,
+                    &kind_str,
+                    &record.field,
+                    &store_embedding_model,
+                    blob
+                ],
+            )?;
+            Ok::<(), rusqlite::Error>(())
+        })();
+        match result {
+            Ok(()) => {
+                conn.execute_batch("RELEASE SAVEPOINT vec_batch_record")?;
+                affected += 1;
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT vec_batch_record");
+                let _ = conn.execute_batch("RELEASE SAVEPOINT vec_batch_record");
+                if first_error.is_empty() {
+                    first_error = e.to_string();
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed,
+        first_error,
+    })
 }
 
 #[async_trait]
@@ -346,114 +484,55 @@ impl VectorStore for SqliteVecStore {
         let store_embedding_model = self.embedding_model.clone();
 
         // Capture the failpoint Arc (if any) from the thread-local on the
-        // calling thread before handing the closure to spawn_blocking.
-        #[cfg(test)]
-        let _failpoint_flag = failpoint::CURRENT.with(|c| c.borrow().clone());
+        // calling thread before handing the closure to spawn_blocking — both
+        // the WriterTask path and the legacy path eventually run the closure
+        // on a different thread than the one that reads the thread-local.
+        let failpoint_flag = current_failpoint();
 
+        // ADR-067 Component A: when the write queue is enabled, route
+        // through the pool-wide WriterTask. DML-only closure (the per-record
+        // `SAVEPOINT vec_batch_record` is preserved unchanged — only the
+        // OUTER BEGIN IMMEDIATE/COMMIT is removed, since the WriterTask's
+        // run loop owns the enclosing transaction).
+        if let Some(writer_task) = &self.writer_task {
+            let table2 = table.clone();
+            let store_embedding_model2 = store_embedding_model.clone();
+            return writer_task
+                .send(move |conn| {
+                    batch_insert_vectors_dml(
+                        conn,
+                        &table2,
+                        dims,
+                        &store_embedding_model2,
+                        &records,
+                        attempted,
+                        failpoint_flag,
+                    )
+                    .map_err(|e| map_err(e, "vec_insert_batch"))
+                })
+                .await;
+        }
+
+        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
+        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT.
         self.with_writer("vec_insert_batch", move |conn| {
-            let del_sql = format!(
-                "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
-                table
-            );
-            let ins_sql = format!(
-                "INSERT INTO {} (subject_id, namespace, kind, field, embedding_model, embedding) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                table
-            );
-
             conn.execute_batch("BEGIN IMMEDIATE")?;
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("vector_insert_batch".to_string()));
-            let mut affected = 0u64;
-            let mut failed = 0u64;
-            let mut first_error = String::new();
 
-            for record in &records {
-                if record.vectors.len() != 1 {
-                    if first_error.is_empty() {
-                        first_error =
-                            format!("expected 1 vector per record, got {}", record.vectors.len());
-                    }
-                    failed += 1;
-                    continue;
-                }
-                let embedding = &record.vectors[0];
-                if embedding.len() != dims {
-                    if first_error.is_empty() {
-                        first_error = format!(
-                            "wrong vector dimension: expected {dims}, got {}",
-                            embedding.len()
-                        );
-                    }
-                    failed += 1;
-                    continue;
-                }
-                if non_finite_index(embedding).is_some() {
-                    if first_error.is_empty() {
-                        first_error =
-                            "embedding contains non-finite values (NaN or Inf)".to_string();
-                    }
-                    failed += 1;
-                    continue;
-                }
-                let blob = f32_slice_as_bytes(embedding);
-                let id_str = record.subject_id.to_string();
-                let kind_str = record.kind.to_string();
-
-                // Wrap each record's DELETE+INSERT in a savepoint so a failed INSERT
-                // rolls back only that record's DELETE, leaving the prior vector intact
-                // (no-worse-than-stale guarantee, same as single-record `insert`).
-                conn.execute_batch("SAVEPOINT vec_batch_record")?;
-                let result = (|| {
-                    conn.execute(&del_sql, rusqlite::params![&id_str, &record.namespace])?;
-                    // Failpoint: fires only in cfg(test) when the guard is active.
-                    // DELETE has already run; if ROLLBACK TO SAVEPOINT is missing,
-                    // the deleted row is lost permanently.
-                    #[cfg(test)]
-                    if let Some(ref fp) = _failpoint_flag {
-                        if failpoint::take(fp) {
-                            return Err(rusqlite::Error::InvalidParameterName(
-                                "__test_failpoint_after_delete__".into(),
-                            ));
-                        }
-                    }
-                    conn.execute(
-                        &ins_sql,
-                        rusqlite::params![
-                            &id_str,
-                            &record.namespace,
-                            &kind_str,
-                            &record.field,
-                            &store_embedding_model,
-                            blob
-                        ],
-                    )?;
-                    Ok::<(), rusqlite::Error>(())
-                })();
-                match result {
-                    Ok(()) => {
-                        conn.execute_batch("RELEASE SAVEPOINT vec_batch_record")?;
-                        affected += 1;
-                    }
-                    Err(e) => {
-                        let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT vec_batch_record");
-                        let _ = conn.execute_batch("RELEASE SAVEPOINT vec_batch_record");
-                        if first_error.is_empty() {
-                            first_error = e.to_string();
-                        }
-                        failed += 1;
-                    }
-                }
-            }
+            let summary = batch_insert_vectors_dml(
+                conn,
+                &table,
+                dims,
+                &store_embedding_model,
+                &records,
+                attempted,
+                failpoint_flag,
+            )?;
 
             conn.execute_batch("COMMIT")?;
 
-            Ok(BatchWriteSummary {
-                attempted,
-                affected,
-                failed,
-                first_error,
-            })
+            Ok(summary)
         })
         .await
     }
@@ -2904,6 +2983,123 @@ mod orphan_sweep_tests {
         assert!(
             present.contains(&id),
             "vector inserted after failed sweep must be present"
+        );
+    }
+}
+
+/// ADR-067 Component A entry 7: `insert_batch` is the sole `BEGIN
+/// IMMEDIATE`-issuing site in this store (per the ADR's own write-path
+/// inventory — `insert`/`update`/`orphan_sweep` use
+/// `conn.unchecked_transaction()`, a different mechanism, and are out of
+/// scope for this slice). Needs the real `vec0` extension loaded, so it
+/// lives behind the same `feature = "vectors"` gate as its sibling
+/// `atomic_replace_tests`/`orphan_sweep_tests` modules — `cargo test
+/// --workspace` (no `--all-features`) does not compile or run it, matching
+/// the existing convention in this file.
+#[cfg(all(test, feature = "vectors"))]
+mod write_queue_tests {
+    use std::sync::Arc;
+
+    use khive_storage::types::VectorRecord;
+    use khive_storage::VectorStore;
+    use khive_types::SubstrateKind;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::pool::{ConnectionPool, PoolConfig};
+
+    fn make_file_backed_pool(path: std::path::PathBuf) -> Arc<ConnectionPool> {
+        crate::extension::ensure_extensions_loaded();
+        Arc::new(
+            ConnectionPool::new(PoolConfig {
+                path: Some(path),
+                ..PoolConfig::default()
+            })
+            .expect("file-backed pool"),
+        )
+    }
+
+    fn create_vec_table(pool: &Arc<ConnectionPool>, model_key: &str, dims: usize) {
+        let ddl = format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS vec_{} USING vec0(\
+             subject_id TEXT PRIMARY KEY, \
+             namespace TEXT NOT NULL, \
+             kind TEXT NOT NULL, \
+             field TEXT NOT NULL, \
+             embedding_model TEXT NOT NULL, \
+             embedding float[{}] distance_metric=cosine)",
+            model_key, dims
+        );
+        pool.writer()
+            .expect("writer")
+            .conn()
+            .execute_batch(&ddl)
+            .expect("create vec table");
+    }
+
+    /// `#[serial]`: mutates the process-global `KHIVE_WRITE_QUEUE` env var,
+    /// shared with `pool.rs`'s own env-override tests in this same test binary.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn insert_batch_routes_through_writer_task_when_flag_enabled() {
+        std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+
+        let model_key = "write_queue_flag_test";
+        let dims = 4usize;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("write_queue_vectors.db");
+        let pool = make_file_backed_pool(path);
+        create_vec_table(&pool, model_key, dims);
+
+        let store = SqliteVecStore::new(
+            Arc::clone(&pool),
+            true,
+            model_key.to_string(),
+            model_key.to_string(),
+            dims,
+            "ns:test".to_string(),
+        )
+        .expect("SqliteVecStore::new");
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let records = vec![
+            VectorRecord {
+                subject_id: id1,
+                kind: SubstrateKind::Entity,
+                namespace: "ns:test".to_string(),
+                field: "body".to_string(),
+                embedding_model: None,
+                vectors: vec![vec![0.1, 0.2, 0.3, 0.4]],
+                updated_at: chrono::Utc::now(),
+            },
+            VectorRecord {
+                subject_id: id2,
+                kind: SubstrateKind::Entity,
+                namespace: "ns:test".to_string(),
+                field: "body".to_string(),
+                embedding_model: None,
+                vectors: vec![vec![0.5, 0.6, 0.7, 0.8]],
+                updated_at: chrono::Utc::now(),
+            },
+        ];
+
+        let summary = store.insert_batch(records).await.unwrap();
+        assert_eq!(summary.attempted, 2);
+        assert_eq!(summary.affected, 2);
+        assert_eq!(summary.failed, 0);
+
+        let present = store
+            .batch_exists(&[id1, id2], "ns:test")
+            .await
+            .expect("batch_exists");
+        assert!(present.contains(&id1));
+        assert!(present.contains(&id2));
+        assert_eq!(
+            pool.writer_task_spawn_count(),
+            1,
+            "the flag-ON path must actually spawn and use the writer task"
         );
     }
 }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -129,7 +129,7 @@ impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
 /// Sender half of the write queue. Cheaply cloneable (wraps an
 /// `mpsc::Sender`) — every migrated store that shares one writer task holds
 /// a clone of this handle.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WriterTaskHandle {
     tx: mpsc::Sender<Box<dyn AnyWriteRequest + Send>>,
 }

--- a/crates/khive-db/src/writer_task.rs
+++ b/crates/khive-db/src/writer_task.rs
@@ -48,9 +48,18 @@ type WriteOp<R> = Box<dyn FnOnce(&Connection) -> Result<R, StorageError> + Send>
 /// return type `R` (e.g. `BatchWriteSummary`) is preserved end to end,
 /// while [`AnyWriteRequest`] lets the drain loop hold heterogeneous
 /// requests in one homogeneous channel.
+///
+/// `top_level` (ADR-067 Component A, Fork C slice 2 round 2): when `true`,
+/// the drain loop runs this request's operation WITHOUT wrapping it in a
+/// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` — still serialized through the
+/// single writer owner (only one request drains at a time regardless of
+/// this flag), but with the transaction wrap skipped entirely. Exists for
+/// statements SQLite forbids inside any open transaction (e.g. `VACUUM`);
+/// see [`WriterTaskHandle::send_top_level`].
 pub struct WriteRequest<R: Send + 'static> {
     op: WriteOp<R>,
     reply: oneshot::Sender<Result<R, StorageError>>,
+    top_level: bool,
 }
 
 mod sealed {
@@ -81,6 +90,17 @@ pub trait AnyWriteRequest: sealed::Sealed + Send {
     /// that case.
     fn execute_and_reply(self: Box<Self>, conn: &Connection);
 
+    /// Runs this request's operation directly against `conn` — no
+    /// transaction wrap, no `COMMIT`/`ROLLBACK` — and sends the result to
+    /// the request's oneshot reply channel.
+    ///
+    /// Used only for [`Self::is_top_level`] requests: the drain loop calls
+    /// this INSTEAD of `execute_and_reply` for such requests, skipping
+    /// `BEGIN IMMEDIATE` entirely so a statement that must run outside any
+    /// transaction (e.g. `VACUUM`) can still be serialized through the
+    /// single writer owner.
+    fn execute_and_reply_top_level(self: Box<Self>, conn: &Connection);
+
     /// Replies with `err` without running this request's operation or
     /// touching `conn`.
     ///
@@ -93,6 +113,11 @@ pub trait AnyWriteRequest: sealed::Sealed + Send {
     /// Skipping the operation entirely keeps "the caller got an error" and
     /// "no rows landed" true together.
     fn reply_error(self: Box<Self>, err: StorageError);
+
+    /// `true` if the drain loop must run this request via
+    /// [`Self::execute_and_reply_top_level`] (no transaction wrap) instead
+    /// of [`Self::execute_and_reply`] (wrapped in `BEGIN IMMEDIATE`).
+    fn is_top_level(&self) -> bool;
 }
 
 impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
@@ -119,10 +144,21 @@ impl<R: Send + 'static> AnyWriteRequest for WriteRequest<R> {
         let _ = self.reply.send(final_result);
     }
 
+    fn execute_and_reply_top_level(self: Box<Self>, conn: &Connection) {
+        let outcome = (self.op)(conn);
+        // No COMMIT/ROLLBACK here: this request explicitly did not open a
+        // transaction, so there is nothing for this method to close.
+        let _ = self.reply.send(outcome);
+    }
+
     fn reply_error(self: Box<Self>, err: StorageError) {
         // Same "receiver may already be gone" reasoning as above — send and
         // move on regardless of outcome.
         let _ = self.reply.send(Err(err));
+    }
+
+    fn is_top_level(&self) -> bool {
+        self.top_level
     }
 }
 
@@ -154,10 +190,26 @@ impl WriterTaskHandle {
         R: Send + 'static,
         F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
     {
+        self.enqueue_inner(op, false).await
+    }
+
+    /// Shared enqueue path for both transaction-wrapped ([`Self::enqueue`])
+    /// and top-level ([`Self::send_top_level`]) requests — `top_level`
+    /// controls which [`AnyWriteRequest`] method the drain loop invokes.
+    async fn enqueue_inner<R, F>(
+        &self,
+        op: F,
+        top_level: bool,
+    ) -> Result<oneshot::Receiver<Result<R, StorageError>>, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
+    {
         let (reply_tx, reply_rx) = oneshot::channel();
         let request = WriteRequest {
             op: Box::new(op),
             reply: reply_tx,
+            top_level,
         };
 
         self.tx
@@ -218,6 +270,28 @@ impl WriterTaskHandle {
             }
         };
 
+        reply_rx.await.map_err(|_| {
+            StorageError::Internal("writer task dropped before replying".to_string())
+        })?
+    }
+
+    /// Send a write operation that MUST run outside any open transaction
+    /// (e.g. `VACUUM`, which SQLite forbids inside `BEGIN`/`COMMIT`) and
+    /// await its typed reply.
+    ///
+    /// Still serialized through the same single writer owner as
+    /// [`Self::send`] — the request goes through the identical bounded
+    /// channel and drain loop, one request at a time — but the drain loop
+    /// skips the per-request `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` wrap
+    /// entirely for this request (ADR-067 Component A, Fork C slice 2
+    /// round 2, BLOCKER A). The single-writer guarantee is preserved; only
+    /// the transaction wrap is skipped.
+    pub async fn send_top_level<R, F>(&self, op: F) -> Result<R, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&Connection) -> Result<R, StorageError> + Send + 'static,
+    {
+        let reply_rx = self.enqueue_inner(op, true).await?;
         reply_rx.await.map_err(|_| {
             StorageError::Internal("writer task dropped before replying".to_string())
         })?
@@ -294,6 +368,17 @@ async fn run_writer_task(
 ) {
     while let Some(request) = rx.recv().await {
         let outcome = tokio::task::spawn_blocking(move || {
+            if request.is_top_level() {
+                // ADR-067 Component A, Fork C slice 2 round 2 (BLOCKER A):
+                // no BEGIN IMMEDIATE for this request — some statements
+                // (e.g. VACUUM) are rejected by SQLite inside any open
+                // transaction. Still runs on this task's dedicated
+                // connection and still serialized one-request-at-a-time by
+                // this same drain loop, so the single-writer guarantee
+                // holds; only the transaction wrap is skipped.
+                request.execute_and_reply_top_level(&conn);
+                return conn;
+            }
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("writer_task_tx".to_string()));
             match conn.execute_batch("BEGIN IMMEDIATE") {

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -50,6 +50,7 @@ khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
 khive-pack-memory = { version = "0.3.0", path = "../khive-pack-memory" }
 criterion = { workspace = true }
 tempfile = { workspace = true }
+serial_test = { workspace = true }
 
 [[bench]]
 name = "brain_pack_bench"

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -162,47 +162,48 @@ pub async fn apply_fold_gate(
     now_us: i64,
     dedup_key: Option<(&str, &str)>,
 ) -> Result<GateOutcome, RuntimeError> {
-    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+    // ADR-067 Component A (Fork C slice 2): the whole claim+check+fold unit
+    // is handed to `atomic_unit` as ONE closure instead of this function
+    // opening its own `writer()` handle and issuing `BEGIN IMMEDIATE`/
+    // `COMMIT`/`ROLLBACK` by hand. On the flag-on path `atomic_unit` runs
+    // this closure inside the writer task's single request transaction —
+    // no separate connection competes for SQLite's write lock. On the
+    // flag-off (or in-memory) path `atomic_unit` wraps it in the same
+    // manual BEGIN IMMEDIATE/COMMIT/ROLLBACK sequence this function used to
+    // issue directly, so that path is unchanged.
+    let namespace = namespace.to_string();
+    let profile_id = profile_id.to_string();
+    let target_id = target_id.to_string();
+    let dedup_key = dedup_key.map(|(a, b)| (a.to_string(), b.to_string()));
 
-    exec_stmt(writer.as_mut(), "BEGIN IMMEDIATE", vec![], "begin")
-        .await
-        .map_err(|e| sql_err("begin", e))?;
-    let _tx_handle = khive_storage::tx_registry::register(Some("fold_gate_apply".to_string()));
+    let op: khive_storage::AtomicUnitOp = Box::new(move |writer| {
+        Box::pin(async move {
+            let dedup_ref = dedup_key.as_ref().map(|(a, b)| (a.as_str(), b.as_str()));
+            apply_gate_within_tx(
+                writer,
+                &namespace,
+                &profile_id,
+                &target_id,
+                weight,
+                now_us,
+                dedup_ref,
+            )
+            .await
+            .map(|outcome| Box::new(outcome) as Box<dyn std::any::Any + Send>)
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "fold_gate_apply",
+                    e,
+                )
+            })
+        })
+    });
 
-    let result = apply_gate_within_tx(
-        writer.as_mut(),
-        namespace,
-        profile_id,
-        target_id,
-        weight,
-        now_us,
-        dedup_key,
-    )
-    .await;
-
-    match result {
-        Ok(outcome) => match exec_stmt(writer.as_mut(), "COMMIT", vec![], "commit").await {
-            Ok(()) => Ok(outcome),
-            Err(e) => {
-                // Finding 3 (internal review round 1): a failed COMMIT must not skip the
-                // rollback. The connection is dropped either way on a
-                // file-backed pool, but an explicit ROLLBACK avoids leaving a
-                // held write lock if the connection is pooled/reused
-                // (in-memory backend) — matching the error-path behavior
-                // below, so every early return rolls back, not just the
-                // fold-body error path.
-                let _ = exec_stmt(writer.as_mut(), "ROLLBACK", vec![], "rollback").await;
-                Err(sql_err("commit", e))
-            }
-        },
-        Err(e) => {
-            // Best-effort: the connection is dropped either way, but an explicit
-            // ROLLBACK avoids leaving a held write lock if the connection is
-            // pooled/reused (in-memory backend).
-            let _ = exec_stmt(writer.as_mut(), "ROLLBACK", vec![], "rollback").await;
-            Err(e)
-        }
-    }
+    let boxed = sql.atomic_unit(op).await?;
+    Ok(*boxed
+        .downcast::<GateOutcome>()
+        .expect("atomic_unit op for apply_fold_gate must return GateOutcome"))
 }
 
 /// Which gating applies to the implicit event participating in the ADR-081
@@ -287,44 +288,46 @@ pub async fn apply_fold_gate_and_append_event<F>(
     build_event: F,
 ) -> Result<GateAndAppendOutcome, RuntimeError>
 where
-    F: FnOnce(Option<&FoldGateOutcome>, bool) -> Event,
+    F: FnOnce(Option<&FoldGateOutcome>, bool) -> Event + Send + 'static,
 {
-    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+    // ADR-067 Component A (Fork C slice 2): see `apply_fold_gate`'s doc
+    // comment — same conversion, from a manually-owned `writer()` handle
+    // with hand-issued `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` to ONE
+    // `atomic_unit` closure.
+    let namespace = namespace.to_string();
+    let profile_id = profile_id.to_string();
+    let target_id = target_id.to_string();
+    let dedup_key = dedup_key.map(|(a, b)| (a.to_string(), b.to_string()));
 
-    exec_stmt(writer.as_mut(), "BEGIN IMMEDIATE", vec![], "begin")
-        .await
-        .map_err(|e| sql_err("begin", e))?;
-    let _tx_handle =
-        khive_storage::tx_registry::register(Some("fold_gate_apply_event".to_string()));
+    let op: khive_storage::AtomicUnitOp = Box::new(move |writer| {
+        Box::pin(async move {
+            let dedup_ref = dedup_key.as_ref().map(|(a, b)| (a.as_str(), b.as_str()));
+            apply_gate_and_append_within_tx(
+                writer,
+                &namespace,
+                &profile_id,
+                &target_id,
+                gate_mode,
+                now_us,
+                dedup_ref,
+                build_event,
+            )
+            .await
+            .map(|outcome| Box::new(outcome) as Box<dyn std::any::Any + Send>)
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "fold_gate_apply_event",
+                    e,
+                )
+            })
+        })
+    });
 
-    let result = apply_gate_and_append_within_tx(
-        writer.as_mut(),
-        namespace,
-        profile_id,
-        target_id,
-        gate_mode,
-        now_us,
-        dedup_key,
-        build_event,
-    )
-    .await;
-
-    match result {
-        Ok(outcome) => match exec_stmt(writer.as_mut(), "COMMIT", vec![], "commit").await {
-            Ok(()) => Ok(outcome),
-            Err(e) => {
-                // Same rationale as `apply_fold_gate`: an explicit ROLLBACK
-                // on a failed COMMIT avoids leaving a held write lock on a
-                // pooled/reused connection (in-memory backend).
-                let _ = exec_stmt(writer.as_mut(), "ROLLBACK", vec![], "rollback").await;
-                Err(sql_err("commit", e))
-            }
-        },
-        Err(e) => {
-            let _ = exec_stmt(writer.as_mut(), "ROLLBACK", vec![], "rollback").await;
-            Err(e)
-        }
-    }
+    let boxed = sql.atomic_unit(op).await?;
+    Ok(*boxed.downcast::<GateAndAppendOutcome>().expect(
+        "atomic_unit op for apply_fold_gate_and_append_event must return GateAndAppendOutcome",
+    ))
 }
 
 /// Run the dedup claim (if any), the fold-or-skip, and the event append on
@@ -514,6 +517,12 @@ async fn fold_within_tx(
     })
 }
 
+// ADR-067 Component A (Fork C slice 2): `apply_fold_gate`/
+// `apply_fold_gate_and_append_event` no longer issue their own manual
+// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` via this helper (that now lives in
+// `SqlBridge::atomic_unit`'s `run_manual_atomic_unit`) — this remains only
+// as a small test-seeding utility.
+#[cfg(test)]
 async fn exec_stmt(
     writer: &mut dyn SqlWriter,
     sql: &str,
@@ -740,6 +749,129 @@ mod tests {
         })
         .expect("file-backed runtime");
         (rt, dir)
+    }
+
+    /// Fork C slice 2: proves `apply_fold_gate` — via the new
+    /// `SqlAccess::atomic_unit` seam this fix introduced — is actually
+    /// enqueued on the pool's shared `WriterTaskHandle` channel when the
+    /// write queue is enabled, rather than falling back to
+    /// `run_manual_atomic_unit`'s own standalone-connection path.
+    ///
+    /// Deliberately NOT a wall-clock/occupier-timing test: `atomic_unit`'s
+    /// own flag-off/no-writer-task fallback opens a real standalone
+    /// connection to the same db file and issues its own `BEGIN IMMEDIATE`,
+    /// which would ALSO serialize behind an occupier's held transaction via
+    /// SQLite's real file-level locking — indistinguishable by elapsed time
+    /// alone from the correctly-routed case (confirmed empirically while
+    /// designing this fix's khive-db sibling tests for entity/note/graph).
+    /// Instead this reads `WriterTaskHandle::queue_depth` directly while an
+    /// occupier deterministically holds the writer task's one drain slot
+    /// open (parked on a oneshot via `blocking_recv`, not a sleep/timing
+    /// race).
+    ///
+    /// Deliberately NOT built via `file_backed_runtime` + the
+    /// `KHIVE_WRITE_QUEUE` env var: that env var is process-global, and this
+    /// crate's other tests are NOT `#[serial]` against it, so a window where
+    /// it is set here can leak into a concurrently-scheduled test's own
+    /// `KhiveRuntime::new` and unexpectedly flip its pool's write-queue flag
+    /// (observed directly: `fold_gate_rolls_back_claim_and_mass_when_event_append_fails`'s
+    /// manual seed transaction hit "cannot start a transaction within a
+    /// transaction" under `cargo test`'s default parallelism before this test
+    /// was rewritten to avoid the env var). Constructing the pool directly
+    /// with `write_queue_enabled: true` in the config literal, and driving
+    /// `apply_fold_gate` over a bare `SqlBridge` instead of a full
+    /// `KhiveRuntime`, sidesteps global mutable state entirely — no
+    /// `#[serial]` needed, and no risk to any other test in this binary.
+    #[tokio::test]
+    async fn fold_gate_apply_routes_through_writer_task_when_flag_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("fold-gate-write-queue-routing.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+        let sql: std::sync::Arc<dyn SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), khive_storage::StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let apply_task = tokio::spawn(async move {
+            apply_fold_gate(
+                sql.as_ref(),
+                "local",
+                "write-queue-routing-profile",
+                "write-queue-routing-target",
+                0.3,
+                1_700_000_000_000_000,
+                None,
+            )
+            .await
+        });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "apply_fold_gate's atomic_unit request never appeared in the writer \
+             task's channel while the occupier held the single drain slot — \
+             atomic_unit is not routing this call through the shared writer task"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+
+        let outcome = apply_task
+            .await
+            .expect("apply_task must not panic")
+            .expect("apply_fold_gate must succeed once unblocked");
+        assert!(
+            matches!(outcome, GateOutcome::Folded(_)),
+            "expected a fresh (non-deduped) fold to succeed"
+        );
     }
 
     /// Proves the Finding-1 fix (internal review round 1): concurrent duplicate scorer
@@ -1070,7 +1202,7 @@ mod tests {
             FeedbackGateMode::Nominal(weight),
             now_us,
             Some((scorer_run_id, serve_ledger_id)),
-            |_fold_outcome, _forced_zero| Event {
+            move |_fold_outcome, _forced_zero| Event {
                 id: colliding_id,
                 ..Event::new(
                     namespace.to_string(),
@@ -1158,7 +1290,7 @@ mod tests {
             FeedbackGateMode::Nominal(weight),
             now_us,
             Some((scorer_run_id, serve_ledger_id)),
-            |_fold_outcome, _forced_zero| {
+            move |_fold_outcome, _forced_zero| {
                 Event::new(
                     namespace.to_string(),
                     "brain.feedback",

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1176,6 +1176,15 @@ impl BrainPack {
             };
 
             let namespace = token.namespace().as_str().to_string();
+            // `apply_fold_gate_and_append_event`'s `build_event` closure is
+            // now required to be `'static` (ADR-067 Component A, Fork C
+            // slice 2 — it is boxed into an `AtomicUnitOp` and may run
+            // inside the writer task's `spawn_blocking`), so it must own
+            // its captures rather than borrow `namespace`/`base_data` — a
+            // separate `namespace_for_event` clone avoids conflicting with
+            // the `&namespace` borrow passed as this call's own argument.
+            let namespace_for_event = namespace.clone();
+            let base_data_for_event = base_data.clone();
             let outcome = crate::fold_gate::apply_fold_gate_and_append_event(
                 sql.as_ref(),
                 &namespace,
@@ -1184,8 +1193,8 @@ impl BrainPack {
                 gate_mode,
                 now_us,
                 dedup_key,
-                |fold_outcome, forced_zero| {
-                    let mut data = base_data.clone();
+                move |fold_outcome, forced_zero| {
+                    let mut data = base_data_for_event;
                     let (effective_weight, mass_before, mass_after) = match fold_outcome {
                         Some(o) => (o.effective_weight, o.mass_before, o.mass_after),
                         None => (0.0, 0.0, 0.0),
@@ -1198,7 +1207,7 @@ impl BrainPack {
                     });
                     let duration_us = feedback_start.elapsed().as_micros().max(1) as i64;
                     Event::new(
-                        namespace.clone(),
+                        namespace_for_event,
                         "brain.feedback",
                         khive_types::EventKind::FeedbackExplicit,
                         khive_types::SubstrateKind::Event,

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -837,7 +837,7 @@ impl BrainPack {
         let event_payload = json!({ "profile_id": profile_id, "lifecycle": lifecycle.clone() });
 
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
@@ -910,7 +910,7 @@ impl BrainPack {
         // applied to a proposed state copy and only takes effect after the
         // brain event-log append + snapshot upsert commit.
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
@@ -1284,7 +1284,7 @@ impl BrainPack {
         // `self.state` is left completely untouched (no phantom in-memory
         // posterior update that vanishes on restart).
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
@@ -1618,7 +1618,7 @@ impl BrainPack {
         // change is applied to a proposed state copy and only takes effect
         // after the brain event-log append + snapshot upsert commit.
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
@@ -1712,7 +1712,7 @@ impl BrainPack {
         // removal is applied to a proposed state copy and only takes effect
         // after the brain event-log append + snapshot upsert commit.
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,
@@ -1861,7 +1861,7 @@ impl BrainPack {
         // upsert commit — so a persistence failure never leaves a phantom
         // profile that vanishes on restart.
         crate::persist::persist_brain_state_mutation(
-            &self.runtime,
+            self.runtime.sql().as_ref(),
             token,
             &self.persistence,
             &self.state,

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -317,42 +317,45 @@ pub struct BrainMutationEvent {
     pub payload: Value,
 }
 
-async fn exec_raw(writer: &mut dyn SqlWriter, sql: &str, label: &str) -> Result<(), RuntimeError> {
-    writer
-        .execute(SqlStatement {
-            sql: sql.to_string(),
-            params: Vec::new(),
-            label: Some(label.to_string()),
-        })
-        .await
-        .map_err(|e| sql_err(label, e))?;
-    Ok(())
-}
-
 /// Apply a `BrainState` mutation with durability as part of the success
 /// contract (issues #457/#458).
 ///
 /// `mutate` runs against a *proposed* copy of the state (never the live
 /// `state` mutex) built via a snapshot round-trip. Its result and the
 /// resulting snapshot are then persisted — brain event-log append AND
-/// snapshot upsert — inside ONE `BEGIN IMMEDIATE` transaction held on a
-/// single `SqlWriter` connection. Only after that transaction commits does
-/// the proposed state replace the live state and the tracker get marked
-/// clean.
+/// snapshot upsert — as ONE atomic unit via `SqlAccess::atomic_unit`
+/// (ADR-067 Component A, Fork C slice 2 round 2). Only after that unit
+/// commits does the proposed state replace the live state and the tracker
+/// get marked clean.
 ///
 /// This deliberately does NOT use `SqlAccess::begin_tx` — per `fold_gate.rs`'s
 /// module doc, that API requires a file-backed database and errors for
 /// in-memory pools (used throughout this crate's test suite and by
-/// `KhiveRuntime::memory()`). Issuing `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` as
-/// ordinary statements on a plain `SqlWriter` handle gives the same
-/// all-or-nothing guarantee on both backends.
+/// `KhiveRuntime::memory()`). It also, as of this round, does NOT issue a
+/// manual `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` sequence on a plain
+/// `SqlWriter` handle: under `KHIVE_WRITE_QUEUE=1` that sequence would nest
+/// inside the WriterTask's own per-request `BEGIN IMMEDIATE`, which SQLite
+/// rejects ("cannot start a transaction within a transaction" — the same
+/// class of bug `fold_gate.rs`'s `atomic_unit` conversion fixed). Handing the
+/// whole append+upsert unit to `atomic_unit` instead means the WriterTask's
+/// own transaction wrapping provides the atomicity on the flag-on path, and
+/// `run_manual_atomic_unit` (khive-db) preserves the old manual-transaction
+/// shape byte-for-byte on the flag-off/in-memory path.
 ///
-/// If `mutate` fails, or the transaction fails to begin, append, upsert, or
-/// commit, this returns `Err` and the live state is left completely
-/// untouched — there is no in-memory mutation to roll back because it was
-/// never applied to the shared state in the first place.
+/// If `mutate` fails, or the atomic unit fails to append, upsert, or commit,
+/// this returns `Err` and the live state is left completely untouched —
+/// there is no in-memory mutation to roll back because it was never applied
+/// to the shared state in the first place.
+///
+/// Takes `sql: &dyn SqlAccess` rather than `&KhiveRuntime` — the only thing
+/// this function ever needed from the runtime was its `SqlAccess` handle
+/// (`KhiveRuntime::sql()`). Narrowing the parameter lets tests exercise this
+/// function against a bare `SqlBridge`/`ConnectionPool` (write-queue-enabled
+/// via a `PoolConfig` literal, mirroring `fold_gate.rs`'s routing test)
+/// without needing a full file-backed `KhiveRuntime` and its associated
+/// `KHIVE_WRITE_QUEUE` env-var race across this crate's test binary.
 pub async fn persist_brain_state_mutation<R>(
-    runtime: &KhiveRuntime,
+    sql: &dyn SqlAccess,
     token: &NamespaceToken,
     tracker: &Mutex<PersistenceTracker>,
     state: &Mutex<BrainState>,
@@ -371,40 +374,42 @@ pub async fn persist_brain_state_mutation<R>(
     let result = mutate(&mut proposed)?;
     let snapshot = proposed.to_snapshot();
 
-    let sql = runtime.sql();
-    let mut writer = sql.writer().await.map_err(|e| sql_err("writer", e))?;
+    let namespace_for_op = namespace.clone();
+    let profile_id = event.profile_id;
+    let event_kind = event.event_kind;
+    let payload = event.payload;
+    let op: khive_storage::AtomicUnitOp = Box::new(move |writer| {
+        Box::pin(async move {
+            append_brain_event_on_writer(
+                writer,
+                &namespace_for_op,
+                &profile_id,
+                &event_kind,
+                &payload,
+                now_us,
+            )
+            .await
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "brain_persist_append_event",
+                    e,
+                )
+            })?;
+            upsert_snapshot_on_writer(writer, &namespace_for_op, &snapshot, now_us)
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "brain_persist_upsert_snapshot",
+                        e,
+                    )
+                })?;
+            Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+        })
+    });
 
-    exec_raw(writer.as_mut(), "BEGIN IMMEDIATE", "begin mutation tx").await?;
-    let _tx_handle =
-        khive_storage::tx_registry::register(Some("brain_persist_mutation".to_string()));
-
-    let write_result: Result<(), RuntimeError> = async {
-        append_brain_event_on_writer(
-            writer.as_mut(),
-            &namespace,
-            &event.profile_id,
-            &event.event_kind,
-            &event.payload,
-            now_us,
-        )
-        .await?;
-        upsert_snapshot_on_writer(writer.as_mut(), &namespace, &snapshot, now_us).await?;
-        Ok(())
-    }
-    .await;
-
-    match write_result {
-        Ok(()) => {
-            if let Err(e) = exec_raw(writer.as_mut(), "COMMIT", "commit mutation tx").await {
-                let _ = exec_raw(writer.as_mut(), "ROLLBACK", "rollback mutation tx").await;
-                return Err(e);
-            }
-        }
-        Err(e) => {
-            let _ = exec_raw(writer.as_mut(), "ROLLBACK", "rollback mutation tx").await;
-            return Err(e);
-        }
-    }
+    sql.atomic_unit(op).await?;
 
     {
         let mut live = state.lock().unwrap();
@@ -1482,5 +1487,145 @@ mod braincore_aud_001_capacity {
             err.contains("snapshot invariant violation"),
             "error must name the load-boundary invariant violation, got: {err}"
         );
+    }
+}
+
+// ── ADR-067 Fork C slice 2 round 2 (BLOCKER B): persist_brain_state_mutation
+// write-queue routing ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod persist_write_queue_routing {
+    use super::*;
+    use khive_brain_core::BrainState;
+    use khive_runtime::{KhiveRuntime, Namespace};
+
+    /// Fork C slice 2 round 2 (BLOCKER B): proves `persist_brain_state_mutation`
+    /// — after its conversion from a manual `BEGIN IMMEDIATE`/`COMMIT` sequence
+    /// to the `SqlAccess::atomic_unit` seam — is actually enqueued on the
+    /// pool's shared `WriterTaskHandle` channel when the write queue is
+    /// enabled, mirroring `fold_gate.rs`'s
+    /// `fold_gate_apply_routes_through_writer_task_when_flag_enabled` test
+    /// (same `queue_depth` + occupier-parked-on-oneshot technique; a
+    /// wall-clock/timing-based test would be indistinguishable from the
+    /// flag-off fallback, which serializes via real SQLite file locking
+    /// regardless of Rust-level routing — see that test's doc comment for the
+    /// full rationale).
+    ///
+    /// Deliberately does NOT construct a full file-backed `KhiveRuntime` (with
+    /// or without the `KHIVE_WRITE_QUEUE` env var) for the `sql` handle this
+    /// function now takes directly: `persist_brain_state_mutation`'s `sql`
+    /// parameter is a bare `&dyn SqlAccess`, so this test builds a
+    /// `ConnectionPool`/`SqlBridge` straight from a `PoolConfig` literal with
+    /// `write_queue_enabled: true` (no env var, no `#[serial]`, no risk to any
+    /// other test in this binary — the exact env-var race documented on the
+    /// fold_gate test). A `NamespaceToken` is still required by this
+    /// function's signature; `NamespaceToken`'s constructors are
+    /// crate-private to `khive-runtime`, so one is minted via
+    /// `KhiveRuntime::memory().authorize(..)` — an in-memory runtime never
+    /// spawns a writer task (`open_standalone_writer` requires a real file
+    /// path) and is completely inert with respect to `KHIVE_WRITE_QUEUE`,
+    /// so minting the token this way cannot introduce the race either.
+    #[tokio::test]
+    async fn persist_brain_state_mutation_routes_through_writer_task_when_flag_enabled() {
+        // Token minted from an in-memory runtime: never touches the write
+        // queue / env var, used only for its `NamespaceToken`.
+        let token_rt = KhiveRuntime::memory().expect("memory runtime for token minting");
+        let token = token_rt
+            .authorize(Namespace::local())
+            .expect("authorize local namespace");
+
+        // The actual storage this test exercises: a bare, file-backed,
+        // write-queue-enabled pool/bridge — no KhiveRuntime, no env var.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("persist-write-queue-routing.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+        let sql: std::sync::Arc<dyn SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), khive_storage::StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let tracker: Mutex<PersistenceTracker> = Mutex::new(PersistenceTracker::new());
+        let state: Mutex<BrainState> = Mutex::new(BrainState::new(16));
+
+        let persist_task = tokio::spawn(async move {
+            persist_brain_state_mutation(
+                sql.as_ref(),
+                &token,
+                &tracker,
+                &state,
+                BrainMutationEvent {
+                    profile_id: "write-queue-routing-profile".to_string(),
+                    event_kind: "brain.test_mutation".to_string(),
+                    payload: serde_json::json!({"probe": true}),
+                },
+                16,
+                |_state: &mut BrainState| -> Result<(), RuntimeError> { Ok(()) },
+            )
+            .await
+        });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "persist_brain_state_mutation's atomic_unit request never appeared in the \
+             writer task's channel while the occupier held the single drain slot — \
+             atomic_unit is not routing this call through the shared writer task"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+
+        persist_task
+            .await
+            .expect("persist_task must not panic")
+            .expect("persist_brain_state_mutation must succeed once unblocked");
     }
 }

--- a/crates/khive-pack-brain/src/serve_ledger.rs
+++ b/crates/khive-pack-brain/src/serve_ledger.rs
@@ -291,3 +291,129 @@ pub async fn resolve(
         accounting_profile_id: row.accounting_profile_id,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fork C slice 2: proves `record_serve`'s single-row INSERT — issued via
+    /// `sql.writer().execute(..)` — is actually enqueued on the pool's shared
+    /// `WriterTaskHandle` channel when the write queue is enabled. This is
+    /// the BLOCKER 2 Part A fix (`SqliteWriter::execute` routes through the
+    /// writer task like `execute_batch` already did): `record_serve` itself
+    /// needed zero code changes, but this test proves the fix actually
+    /// reaches this call site rather than asserting it by inspection alone.
+    ///
+    /// Deliberately NOT a wall-clock/occupier-timing test — see the sibling
+    /// `fold_gate::tests::fold_gate_apply_routes_through_writer_task_when_flag_enabled`
+    /// doc comment for why real SQLite file-level locking makes elapsed time
+    /// alone vacuous here. Instead this reads `WriterTaskHandle::queue_depth`
+    /// directly while an occupier deterministically holds the writer task's
+    /// one drain slot open (parked on a oneshot via `blocking_recv`, not a
+    /// sleep/timing race).
+    ///
+    /// Deliberately NOT built via a full `KhiveRuntime` + the
+    /// `KHIVE_WRITE_QUEUE` env var: that env var is process-global and this
+    /// crate's other tests are not `#[serial]` against it, so a window where
+    /// it is set here could leak into a concurrently-scheduled test's own
+    /// `KhiveRuntime::new` and unexpectedly flip its pool's write-queue flag
+    /// (see `fold_gate::tests::fold_gate_apply_routes_through_writer_task_when_flag_enabled`'s
+    /// doc comment for the concrete failure this caused before both tests
+    /// were rewritten to avoid the env var). Constructing the pool directly
+    /// with `write_queue_enabled: true` in the config literal, and driving
+    /// `record_serve` over a bare `SqlBridge` instead of a full
+    /// `KhiveRuntime`, sidesteps global mutable state entirely.
+    #[tokio::test]
+    async fn record_serve_routes_through_writer_task_when_flag_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("serve-ledger-write-queue-routing.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+        let sql: std::sync::Arc<dyn SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), khive_storage::StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let record_task = tokio::spawn(async move {
+            record_serve(
+                sql.as_ref(),
+                "write-queue-routing-row",
+                "local",
+                "recall",
+                Some("profile-a"),
+                None,
+                None,
+                "write-queue-routing-target",
+                "write-queue-routing-class",
+                "write queue routing test query",
+                1_700_000_000_000_000,
+            )
+            .await
+        });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "record_serve's write request never appeared in the writer task's \
+             channel while the occupier held the single drain slot — \
+             SqliteWriter::execute is not routing this single-row write \
+             through the shared writer task"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+
+        let inserted = record_task
+            .await
+            .expect("record_task must not panic")
+            .expect("record_serve must succeed once unblocked");
+        assert!(inserted, "record_serve must report a fresh row insert");
+    }
+}

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -148,13 +148,83 @@ impl MemoryPack {
             RuntimeError::InvalidInput(format!("memory.vacuum: invalid params: {e}"))
         })?;
 
-        // VACUUM must run outside an open transaction. A plain writer connection
-        // via execute_script (which calls execute_batch internally) satisfies
-        // SQLite's requirement that VACUUM is issued at the top level.
+        // VACUUM must run outside an open transaction. Under
+        // `KHIVE_WRITE_QUEUE=1`, a plain `execute_script` call would run
+        // inside the WriterTask's per-request `BEGIN IMMEDIATE` — SQLite
+        // rejects VACUUM there (ADR-067 Component A, Fork C slice 2 round 2,
+        // BLOCKER A). `execute_script_top_level` is still serialized through
+        // the single writer owner but skips that transaction wrap, so
+        // VACUUM runs genuinely top-level on both the flag-on and flag-off
+        // paths.
         let sql = self.runtime.sql();
         let mut writer = sql.writer().await?;
-        writer.execute_script("VACUUM;".to_string()).await?;
+        writer
+            .execute_script_top_level("VACUUM;".to_string())
+            .await?;
 
         Ok(json!({ "ok": true }))
+    }
+}
+
+// ── ADR-067 Fork C slice 2 round 2 (BLOCKER A): memory.vacuum under the write
+// queue ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod vacuum_write_queue_tests {
+    /// Fork C slice 2 round 2 (BLOCKER A): before this fix, `handle_vacuum`
+    /// sent `"VACUUM;"` via plain `execute_script`, which — once
+    /// `execute_script`'s flag-on path was migrated to route through the
+    /// writer task (Fork C slice 2 round 1) — ran inside that task's
+    /// per-request `BEGIN IMMEDIATE`. SQLite rejects `VACUUM` inside any
+    /// open transaction ("cannot VACUUM from within a transaction"), so
+    /// `memory.vacuum` broke under `KHIVE_WRITE_QUEUE=1`. This proves the
+    /// fix: routing the SAME statement through
+    /// `SqlWriter::execute_script_top_level` (what `handle_vacuum` now
+    /// calls) succeeds with the write queue enabled.
+    ///
+    /// Deliberately does NOT build a full `KhiveRuntime` (env-var or
+    /// otherwise) to reach `handle_vacuum` through the `memory.vacuum` verb
+    /// dispatch: `MemoryPack::new` requires an owned `KhiveRuntime`, and
+    /// `KhiveRuntime`/`RuntimeConfig` have no config-injection path for
+    /// `PoolConfig::write_queue_enabled` other than the process-global
+    /// `KHIVE_WRITE_QUEUE` env var — which this crate's other tests are NOT
+    /// `#[serial]` against (the exact race documented on
+    /// `khive-pack-brain`'s `fold_gate.rs` / `persist.rs` sibling routing
+    /// tests for this same round). Exercising the identical
+    /// `sql.writer().await?.execute_script_top_level("VACUUM;")` call
+    /// `handle_vacuum` makes, over a bare write-queue-enabled
+    /// `ConnectionPool`/`SqlBridge` built from a `PoolConfig` literal,
+    /// proves the same fix with no env var and no risk to any other test in
+    /// this binary.
+    #[tokio::test]
+    async fn vacuum_top_level_succeeds_with_write_queue_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("memory-vacuum-write-queue.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+        assert!(
+            pool.writer_task_handle().unwrap().is_some(),
+            "writer task must be spawned with the flag on for a file-backed pool"
+        );
+
+        let sql: std::sync::Arc<dyn khive_storage::SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let mut writer = sql.writer().await.expect("writer handle");
+        let result = writer.execute_script_top_level("VACUUM;".to_string()).await;
+
+        assert!(
+            result.is_ok(),
+            "VACUUM via execute_script_top_level must succeed under \
+             KHIVE_WRITE_QUEUE (no BEGIN IMMEDIATE wrap); got {result:?}"
+        );
     }
 }

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -335,17 +335,41 @@ impl KhiveRuntime {
         }
 
         let pool = self.backend().pool_arc();
+        // ADR-067 Component A: when the write queue is enabled, route this
+        // multi-statement merge through the single-writer task instead of the
+        // pool's writer mutex. Best-effort lookup mirrors every other migrated
+        // store: a lookup failure (no runtime context) degrades to the legacy
+        // mutex path rather than failing the merge outright.
+        let writer_task = pool.writer_task_handle().ok().flatten();
 
-        let (summary, updated_entity) = tokio::task::spawn_blocking(move || {
-            let guard = pool.writer()?;
-            guard.transaction(|conn| {
-                merge_entity_sql(
-                    conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
-                )
+        let (summary, updated_entity) = if let Some(writer_task) = writer_task {
+            writer_task
+                .send(move |conn| {
+                    merge_entity_sql(
+                        conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
+                    )
+                    .map_err(|e| {
+                        khive_storage::StorageError::driver(
+                            khive_storage::StorageCapability::Entities,
+                            "merge_entity",
+                            e,
+                        )
+                    })
+                })
+                .await
+                .map_err(RuntimeError::Storage)?
+        } else {
+            tokio::task::spawn_blocking(move || {
+                let guard = pool.writer()?;
+                guard.transaction(|conn| {
+                    merge_entity_sql(
+                        conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
+                    )
+                })
             })
-        })
-        .await
-        .map_err(|e| RuntimeError::Internal(e.to_string()))??;
+            .await
+            .map_err(|e| RuntimeError::Internal(e.to_string()))??
+        };
 
         // If vectors are configured, reindex into_entity (requires async embedding).
         // FTS and vec-deletes for all registered models were already committed inside
@@ -657,24 +681,53 @@ impl KhiveRuntime {
         }
 
         let pool = self.backend().pool_arc();
-        let (summary, updated_note) = tokio::task::spawn_blocking(move || {
-            let guard = pool.writer()?;
-            guard.transaction(|conn| {
-                merge_note_sql(
-                    conn,
-                    ns,
-                    fts_table,
-                    vec_tables,
-                    into_id,
-                    from_id,
-                    strategy,
-                    content_strategy,
-                    dry_run,
-                )
+        // ADR-067 Component A: same writer-task routing as merge_entity above.
+        let writer_task = pool.writer_task_handle().ok().flatten();
+
+        let (summary, updated_note) = if let Some(writer_task) = writer_task {
+            writer_task
+                .send(move |conn| {
+                    merge_note_sql(
+                        conn,
+                        ns,
+                        fts_table,
+                        vec_tables,
+                        into_id,
+                        from_id,
+                        strategy,
+                        content_strategy,
+                        dry_run,
+                    )
+                    .map_err(|e| {
+                        khive_storage::StorageError::driver(
+                            khive_storage::StorageCapability::Notes,
+                            "merge_note",
+                            e,
+                        )
+                    })
+                })
+                .await
+                .map_err(RuntimeError::Storage)?
+        } else {
+            tokio::task::spawn_blocking(move || {
+                let guard = pool.writer()?;
+                guard.transaction(|conn| {
+                    merge_note_sql(
+                        conn,
+                        ns,
+                        fts_table,
+                        vec_tables,
+                        into_id,
+                        from_id,
+                        strategy,
+                        content_strategy,
+                        dry_run,
+                    )
+                })
             })
-        })
-        .await
-        .map_err(|e| RuntimeError::Internal(e.to_string()))??;
+            .await
+            .map_err(|e| RuntimeError::Internal(e.to_string()))??
+        };
 
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_note(token, &updated_note).await?;

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -479,7 +479,7 @@ fn build_metrics_snapshot<D: DaemonDispatch>(dispatcher: &D) -> MetricsSnapshot 
 
     let (write_queue_depth, write_queue_capacity) = dispatcher
         .pool_for_checkpoint()
-        .and_then(|pool| pool.writer_task_handle())
+        .and_then(|pool| pool.writer_task_handle().ok().flatten())
         .map(|handle| (Some(handle.queue_depth()), Some(handle.capacity())))
         .unwrap_or((None, None));
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -3678,6 +3678,107 @@ impl KhiveRuntime {
         Ok(results)
     }
 
+    /// DML-only body of the symmetric-relation conflict-resolution path in
+    /// [`Self::update_edge`] (ADR-067 Component A). Runs the conflict-check SELECT,
+    /// then either the DELETE+UPDATE (case b, a canonical row already exists) or the
+    /// in-place UPDATE (case a, no conflict). Callers own the surrounding transaction
+    /// boundary — this function issues DML only, no `BEGIN`/`COMMIT`/`ROLLBACK`.
+    ///
+    /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
+    /// requested edge was deleted, the existing canonical row refreshed), or
+    /// `Ok(None)` when the requested edge was updated in place.
+    #[allow(clippy::too_many_arguments)]
+    fn update_edge_symmetric_dml(
+        conn: &rusqlite::Connection,
+        ns: &str,
+        edge_id_str: &str,
+        canon_src_str: &str,
+        canon_tgt_str: &str,
+        relation_str: &str,
+        weight: f64,
+        metadata: Option<String>,
+        target_backend: Option<String>,
+    ) -> Result<Option<String>, SqliteError> {
+        let now_ts = chrono::Utc::now().timestamp();
+
+        // Check for a conflicting canonical row (same namespace + natural key,
+        // different id). This catches conflicts whether or not endpoints were
+        // flipped — Bug 2 fix.
+        let conflict_id: Option<String> = conn
+            .query_row(
+                "SELECT id FROM graph_edges \
+                 WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
+                 AND relation = ?4 AND id != ?5",
+                rusqlite::params![
+                    &ns,
+                    &canon_src_str,
+                    &canon_tgt_str,
+                    &relation_str,
+                    &edge_id_str
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(SqliteError::Rusqlite)?;
+
+        if let Some(existing_id) = conflict_id {
+            // Case (b): canonical row already exists — delete the non-canonical
+            // edge and refresh the existing canonical row. Return the surviving
+            // id so the caller can re-fetch it (Bug 1 fix: do not return the
+            // deleted edge's id).
+            conn.execute(
+                "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+                rusqlite::params![&ns, &edge_id_str],
+            )
+            .map_err(SqliteError::Rusqlite)?;
+            let affected = conn
+                .execute(
+                    "UPDATE graph_edges SET \
+                     weight = ?1, updated_at = ?2, deleted_at = NULL, \
+                     target_backend = ?3, metadata = ?4 \
+                     WHERE namespace = ?5 AND id = ?6",
+                    rusqlite::params![weight, now_ts, target_backend, metadata, &ns, &existing_id],
+                )
+                .map_err(SqliteError::Rusqlite)?;
+            if affected == 0 {
+                return Err(SqliteError::InvalidData(format!(
+                    "update_edge: surviving canonical row {existing_id} vanished during update"
+                )));
+            }
+            Ok(Some(existing_id))
+        } else {
+            // Case (a): no conflict — update source_id/target_id in-place,
+            // preserving the original edge UUID.
+            let affected = conn
+                .execute(
+                    "UPDATE graph_edges SET \
+                     source_id = ?1, target_id = ?2, relation = ?3, \
+                     weight = ?4, updated_at = ?5, metadata = ?6 \
+                     WHERE namespace = ?7 AND id = ?8",
+                    rusqlite::params![
+                        &canon_src_str,
+                        &canon_tgt_str,
+                        &relation_str,
+                        weight,
+                        now_ts,
+                        metadata,
+                        &ns,
+                        &edge_id_str,
+                    ],
+                )
+                .map_err(SqliteError::Rusqlite)?;
+            if affected == 0 {
+                // The edge row was not found under the record's namespace.
+                // This must never happen because ns = record_ns (fetched above).
+                return Err(SqliteError::InvalidData(format!(
+                    "update_edge: zero rows affected updating edge {edge_id_str} \
+                     in namespace {ns} — row vanished between fetch and update"
+                )));
+            }
+            Ok(None)
+        }
+    }
+
     /// Patch-style edge update. Only `Some(_)` fields are applied.
     ///
     /// When `relation` is `Some(new_rel)`, validates that the edge's existing endpoints
@@ -3769,103 +3870,61 @@ impl KhiveRuntime {
             let target_backend = edge.target_backend.clone();
 
             let pool = self.backend().pool_arc();
+            // ADR-067 Component A: route through the single-writer task when the
+            // write queue is enabled; best-effort lookup degrades to the legacy
+            // pool-mutex path (mirrors merge_entity/merge_note above).
+            let writer_task = pool.writer_task_handle().ok().flatten();
 
-            // spawn_blocking returns Some(surviving_id) when a canonical conflict was
-            // absorbed (the requested edge was deleted, existing canonical row refreshed),
-            // or None when the requested edge was updated in-place.
-            let surviving_id: Option<String> = tokio::task::spawn_blocking(move || {
-                let guard = pool.writer()?;
-                guard.transaction(|conn| {
-                    let now_ts = chrono::Utc::now().timestamp();
-
-                    // Check for a conflicting canonical row (same namespace + natural key,
-                    // different id). This catches conflicts whether or not endpoints were
-                    // flipped — Bug 2 fix.
-                    let conflict_id: Option<String> = conn
-                        .query_row(
-                            "SELECT id FROM graph_edges \
-                             WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
-                             AND relation = ?4 AND id != ?5",
-                            rusqlite::params![
-                                &ns,
-                                &canon_src_str,
-                                &canon_tgt_str,
-                                &relation_str,
-                                &edge_id_str,
-                            ],
-                            |row| row.get(0),
+            // Some(surviving_id) when a canonical conflict was absorbed (the requested
+            // edge was deleted, existing canonical row refreshed), or None when the
+            // requested edge was updated in-place.
+            let surviving_id: Option<String> = if let Some(writer_task) = writer_task {
+                writer_task
+                    .send(move |conn| {
+                        Self::update_edge_symmetric_dml(
+                            conn,
+                            &ns,
+                            &edge_id_str,
+                            &canon_src_str,
+                            &canon_tgt_str,
+                            &relation_str,
+                            weight,
+                            metadata,
+                            target_backend,
                         )
-                        .optional()
-                        .map_err(SqliteError::Rusqlite)?;
-
-                    if let Some(existing_id) = conflict_id {
-                        // Case (b): canonical row already exists — delete the non-canonical
-                        // edge and refresh the existing canonical row. Return the surviving
-                        // id so the caller can re-fetch it (Bug 1 fix: do not return the
-                        // deleted edge's id).
-                        conn.execute(
-                            "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
-                            rusqlite::params![&ns, &edge_id_str],
+                        .map_err(|e| {
+                            khive_storage::StorageError::driver(
+                                khive_storage::StorageCapability::Graph,
+                                "update_edge",
+                                e,
+                            )
+                        })
+                    })
+                    .await
+                    .map_err(RuntimeError::Storage)?
+            } else {
+                tokio::task::spawn_blocking(move || {
+                    let guard = pool.writer()?;
+                    guard.transaction(|conn| {
+                        Self::update_edge_symmetric_dml(
+                            conn,
+                            &ns,
+                            &edge_id_str,
+                            &canon_src_str,
+                            &canon_tgt_str,
+                            &relation_str,
+                            weight,
+                            metadata,
+                            target_backend,
                         )
-                        .map_err(SqliteError::Rusqlite)?;
-                        let affected = conn
-                            .execute(
-                                "UPDATE graph_edges SET \
-                                 weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                                 target_backend = ?3, metadata = ?4 \
-                                 WHERE namespace = ?5 AND id = ?6",
-                                rusqlite::params![
-                                    weight,
-                                    now_ts,
-                                    target_backend,
-                                    metadata,
-                                    &ns,
-                                    &existing_id,
-                                ],
-                            )
-                            .map_err(SqliteError::Rusqlite)?;
-                        if affected == 0 {
-                            return Err(SqliteError::InvalidData(format!(
-                                "update_edge: surviving canonical row {existing_id} vanished during update"
-                            )));
-                        }
-                        Ok(Some(existing_id))
-                    } else {
-                        // Case (a): no conflict — update source_id/target_id in-place,
-                        // preserving the original edge UUID.
-                        let affected = conn
-                            .execute(
-                                "UPDATE graph_edges SET \
-                                 source_id = ?1, target_id = ?2, relation = ?3, \
-                                 weight = ?4, updated_at = ?5, metadata = ?6 \
-                                 WHERE namespace = ?7 AND id = ?8",
-                                rusqlite::params![
-                                    &canon_src_str,
-                                    &canon_tgt_str,
-                                    &relation_str,
-                                    weight,
-                                    now_ts,
-                                    metadata,
-                                    &ns,
-                                    &edge_id_str,
-                                ],
-                            )
-                            .map_err(SqliteError::Rusqlite)?;
-                        if affected == 0 {
-                            // The edge row was not found under the record's namespace.
-                            // This must never happen because ns = record_ns (fetched above).
-                            return Err(SqliteError::InvalidData(format!(
-                                "update_edge: zero rows affected updating edge {edge_id_str} \
-                                 in namespace {ns} — row vanished between fetch and update"
-                            )));
-                        }
-                        Ok(None)
-                    }
+                    })
                 })
-            })
-            .await
-            .map_err(|e| RuntimeError::Internal(format!("update_edge: spawn_blocking join: {e}")))?
-            .map_err(RuntimeError::Sqlite)?;
+                .await
+                .map_err(|e| {
+                    RuntimeError::Internal(format!("update_edge: spawn_blocking join: {e}"))
+                })?
+                .map_err(RuntimeError::Sqlite)?
+            };
 
             if let Some(sid) = surviving_id {
                 // A conflict was absorbed: re-fetch the surviving canonical row so the

--- a/crates/khive-storage/src/error.rs
+++ b/crates/khive-storage/src/error.rs
@@ -94,6 +94,20 @@ pub enum StorageError {
     /// sending a result.
     #[error("internal storage error: {0}")]
     Internal(String),
+
+    /// `KHIVE_WRITE_QUEUE=1` is set but the calling thread has no Tokio
+    /// runtime context, so the writer task (which spawns via `tokio::spawn`)
+    /// cannot be started (ADR-067 Component A).
+    ///
+    /// Returned instead of panicking: a caller that constructs a store from
+    /// a plain, non-async context with the flag on gets a clean, typed
+    /// failure at first write rather than a `tokio::spawn`-outside-runtime
+    /// panic. Flag-off callers never see this variant — `writer_task_handle`
+    /// only attempts to spawn when `PoolConfig::write_queue_enabled` is set.
+    #[error(
+        "KHIVE_WRITE_QUEUE=1 but no Tokio runtime context is available to spawn the writer task"
+    )]
+    WriterTaskNoRuntime,
 }
 
 impl StorageError {
@@ -125,7 +139,8 @@ impl StorageError {
             | Self::Timeout { .. }
             | Self::Transaction { .. }
             | Self::WriteQueueFull { .. }
-            | Self::Internal(..) => None,
+            | Self::Internal(..)
+            | Self::WriterTaskNoRuntime => None,
         }
     }
 

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -23,7 +23,7 @@ pub use event::{
 pub use graph::GraphStore;
 pub use note::{FilterOp, Note, NoteFilter, NoteStore, SortDir};
 pub use sparse::SparseStore;
-pub use sql::{SqlAccess, SqlReader, SqlTransaction, SqlWriter};
+pub use sql::{AtomicUnitOp, BoxFuture, SqlAccess, SqlReader, SqlTransaction, SqlWriter};
 pub use text::TextSearch;
 pub use types::StorageResult;
 pub use vectors::VectorStore;

--- a/crates/khive-storage/src/sql.rs
+++ b/crates/khive-storage/src/sql.rs
@@ -50,6 +50,23 @@ pub trait SqlWriter: SqlReader + Send + 'static {
     async fn execute_batch(&mut self, statements: Vec<SqlStatement>) -> StorageResult<u64>;
     /// Execute a raw SQL script (no parameters; used for migrations).
     async fn execute_script(&mut self, script: String) -> StorageResult<()>;
+
+    /// Execute a raw SQL script that MUST run outside any open transaction
+    /// (ADR-067 Component A, Fork C slice 2 round 2, BLOCKER A) — e.g.
+    /// `VACUUM`, which SQLite rejects if issued inside `BEGIN`/`COMMIT`.
+    ///
+    /// Default implementation delegates to [`Self::execute_script`]: every
+    /// writer implementation in this codebase except khive-db's
+    /// write-queue-routed `SqliteWriter` already runs `execute_script`
+    /// transaction-free (a plain connection call, or already inside a
+    /// caller-managed transaction where a top-level statement would be
+    /// invalid regardless of which method is called). `SqliteWriter`
+    /// overrides this to route around its writer task's per-request `BEGIN
+    /// IMMEDIATE` specifically for this call, while still serializing
+    /// through the single writer owner.
+    async fn execute_script_top_level(&mut self, script: String) -> StorageResult<()> {
+        self.execute_script(script).await
+    }
 }
 
 /// A SQL transaction (extends `SqlWriter`).

--- a/crates/khive-storage/src/sql.rs
+++ b/crates/khive-storage/src/sql.rs
@@ -1,8 +1,32 @@
 //! SQL access capability traits.
 
+use std::any::Any;
+use std::future::Future;
+use std::pin::Pin;
+
 use async_trait::async_trait;
 
 use crate::types::{SqlRow, SqlStatement, SqlTxOptions, SqlValue, StorageResult};
+
+/// A boxed future, borrowing from the `&mut dyn SqlWriter` an
+/// [`AtomicUnitOp`] is called with (see [`SqlAccess::atomic_unit`]).
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A caller-supplied unit of work to run as ONE atomic operation via
+/// [`SqlAccess::atomic_unit`] (ADR-067 Component A, Fork C slice 2).
+///
+/// `op` receives a live `&mut dyn SqlWriter` already inside an open write
+/// transaction — it must issue DML only (no bare `BEGIN`/`COMMIT`/
+/// `ROLLBACK`; the caller-visible transaction boundary is owned entirely by
+/// `atomic_unit`, exactly like the existing `execute_batch` contract) — and
+/// returns its result type-erased via `Box<dyn Any + Send>` so this trait
+/// method stays object-safe (no method-level generics on a trait used as
+/// `dyn SqlAccess`). Callers downcast the returned box back to their own
+/// concrete outcome type.
+pub type AtomicUnitOp = Box<
+    dyn for<'w> FnOnce(&'w mut dyn SqlWriter) -> BoxFuture<'w, StorageResult<Box<dyn Any + Send>>>
+        + Send,
+>;
 
 /// Read-capable SQL connection.
 #[async_trait]
@@ -46,4 +70,18 @@ pub trait SqlAccess: Send + Sync + 'static {
     async fn writer(&self) -> StorageResult<Box<dyn SqlWriter>>;
     /// Begin a transaction with the given isolation options.
     async fn begin_tx(&self, options: SqlTxOptions) -> StorageResult<Box<dyn SqlTransaction>>;
+
+    /// Run `op` as ONE atomic unit of work (ADR-067 Component A, Fork C
+    /// slice 2).
+    ///
+    /// Where a single-writer task is active (file-backed pool,
+    /// `KHIVE_WRITE_QUEUE=1`), `op` runs inside that task's one write
+    /// transaction for this request — no separate connection is opened, so
+    /// this call cannot compete with the writer task for SQLite's write
+    /// lock. Where no writer task applies (flag off, no runtime, or an
+    /// in-memory pool), `op` runs under a manual
+    /// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on a writer handle exactly like
+    /// calling [`Self::writer`] and driving the statements by hand — the
+    /// pre-ADR-067 behavior, preserved byte-for-byte on this path.
+    async fn atomic_unit(&self, op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>>;
 }

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -26,3 +26,4 @@ tempfile = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
 khive-vcs-adapters = { version = "0.3.0", path = "../khive-vcs-adapters" }
+khive-db = { version = "0.3.0", path = "../khive-db" }

--- a/crates/khive-vcs/src/sync.rs
+++ b/crates/khive-vcs/src/sync.rs
@@ -925,8 +925,13 @@ fn read_edges(path: &Path) -> Result<Vec<NdjsonEdge>> {
 
 async fn checkpoint_wal(runtime: &KhiveRuntime) -> Result<()> {
     let mut writer = runtime.backend().sql().writer().await?;
+    // Top-level statement — a checkpoint cannot complete while a transaction
+    // is open on the same connection. `execute_script` wraps its statement in
+    // the WriterTask's per-request BEGIN IMMEDIATE under KHIVE_WRITE_QUEUE=1,
+    // which would make this call silently no-op the checkpoint (the subsequent
+    // rename above would then lose data — see the comment at the call site).
     writer
-        .execute_script("PRAGMA wal_checkpoint(TRUNCATE);".to_string())
+        .execute_script_top_level("PRAGMA wal_checkpoint(TRUNCATE);".to_string())
         .await?;
     Ok(())
 }
@@ -2538,6 +2543,102 @@ mod tests {
         assert!(
             !err_str.contains("secret-repo") && !err_chain.contains("secret-repo"),
             "scp repo path must not appear in public error: {err_str} | {err_chain}"
+        );
+    }
+}
+
+// ── ADR-067 Fork C slice 2 round 3 (BLOCKER, sibling of memory.vacuum's round-2
+// BLOCKER A): `checkpoint_wal` under the write queue ───────────────────────────
+//
+// `checkpoint_wal` used to send `"PRAGMA wal_checkpoint(TRUNCATE);"` via plain
+// `execute_script`, which — once `execute_script` started routing through the
+// WriterTask (ADR-067 Component A) under `KHIVE_WRITE_QUEUE=1` — landed inside
+// the WriterTask's own per-request `BEGIN IMMEDIATE`. A checkpoint cannot
+// complete while a transaction is open on the same connection, so the
+// checkpoint would silently no-op and the subsequent `rename(tmp, target)`
+// (see the comment at the `checkpoint_wal` call site above) would drop any
+// writes still sitting in the `-wal` file. This proves the fixed
+// `execute_script_top_level` path (no BEGIN/COMMIT/ROLLBACK wrap) succeeds
+// with the write queue enabled.
+//
+// `KhiveRuntime` has no config-injection point for `PoolConfig` (production
+// construction hardcodes `PoolConfig::default()`), so — mirroring the
+// `memory.vacuum` regression test in khive-pack-memory's `prune.rs` — this
+// drives the underlying mechanism directly at the `SqlBridge` level: the same
+// `execute_script_top_level("PRAGMA wal_checkpoint(TRUNCATE);")` call that
+// `checkpoint_wal` makes, over a `PoolConfig { write_queue_enabled: true, .. }`
+// literal (no env var mutation, no cross-test race).
+#[cfg(test)]
+mod checkpoint_wal_write_queue_tests {
+    #[tokio::test]
+    async fn wal_checkpoint_truncate_succeeds_with_write_queue_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("vcs-checkpoint-write-queue.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+        assert!(
+            pool.writer_task_handle().unwrap().is_some(),
+            "writer task must be spawned with the flag on for a file-backed pool"
+        );
+
+        let sql: std::sync::Arc<dyn khive_storage::SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let mut writer = sql.writer().await.expect("writer handle");
+        let result = writer
+            .execute_script_top_level("PRAGMA wal_checkpoint(TRUNCATE);".to_string())
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "PRAGMA wal_checkpoint(TRUNCATE) via execute_script_top_level must succeed under \
+             KHIVE_WRITE_QUEUE (no BEGIN IMMEDIATE wrap); got {result:?}"
+        );
+    }
+
+    /// Revert-and-confirm-fails companion: the OLD (broken) call shape —
+    /// plain `execute_script`, which wraps the pragma in the WriterTask's
+    /// `BEGIN IMMEDIATE` — must fail under the write queue. This proves the
+    /// test above is actually exercising the regression, not passing
+    /// vacuously.
+    #[tokio::test]
+    async fn wal_checkpoint_truncate_via_plain_execute_script_fails_with_write_queue_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("vcs-checkpoint-write-queue-regression.db");
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = std::sync::Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let mut writer = pool.writer().expect("writer");
+            khive_db::run_migrations(writer.conn_mut()).expect("migrations");
+        }
+
+        let sql: std::sync::Arc<dyn khive_storage::SqlAccess> =
+            std::sync::Arc::new(khive_db::SqlBridge::new(std::sync::Arc::clone(&pool), true));
+
+        let mut writer = sql.writer().await.expect("writer handle");
+        let result = writer
+            .execute_script("PRAGMA wal_checkpoint(TRUNCATE);".to_string())
+            .await;
+
+        assert!(
+            result.is_err(),
+            "PRAGMA wal_checkpoint(TRUNCATE) via plain execute_script must FAIL under \
+             KHIVE_WRITE_QUEUE (it wraps in BEGIN IMMEDIATE, and SQLite rejects a WAL \
+             checkpoint inside an open transaction); got {result:?} — if this now passes, \
+             the WriterTask no longer wraps execute_script in a transaction and this whole \
+             regression class needs re-auditing"
         );
     }
 }


### PR DESCRIPTION
## Summary

Extends the WriterTask mechanism (previously wired to `SqlEntityStore` only) to every remaining MIGRATE-listed write path in ADR-067's write-path inventory (Component A):

- The shared `with_writer` helper in all seven stores (`SqlEntityStore`, `SqlNoteStore`, `SqlGraphStore`, `Fts5TextSearch`, `SqlEventStore`, `SqliteSparseStore`, `SqliteVecStore`) — single-row and batch write paths both route through the writer task when the flag is on
- `SqlBridge`'s `SqliteWriter::execute`, `execute_batch`, and `execute_script` — single statements and self-contained scripts route through the queue
- A new `SqlAccess::atomic_unit` seam for multi-statement units that need transactional atomicity: on the flag-on path the writer task's own per-request transaction provides it (one queued request); on the flag-off path the prior manual-transaction shape is preserved. The brain pack's fold-gate apply and durable state-mutation persist paths are converted onto it, replacing their manual `BEGIN IMMEDIATE`/`COMMIT` sequences (which would nest inside the writer task's transaction under the flag)
- A top-level maintenance path (`SqlWriter::execute_script_top_level` → `WriterTaskHandle::send_top_level`) for statements SQLite forbids inside any open transaction: the request goes through the same bounded channel and is serialized by the same drain loop (single-writer guarantee intact), but the per-request transaction wrap is skipped. `memory.vacuum`'s `VACUUM` now uses this path
- `KhiveRuntime::merge_entity` / `merge_note` and `update_edge` (symmetric-relation conflict resolution)

Each site preserves its existing byte-for-byte behavior when the write queue is disabled (the default) and routes through the pool's single writer task when `KHIVE_WRITE_QUEUE=1` is set.

## Scope: what the single-writer guarantee covers after this change

With the flag enabled, exactly one connection issues `BEGIN IMMEDIATE` for all write traffic routed through the paths above. Two known write paths remain outside the queue, deliberately:

- `SqlBridge::begin_tx()` (caller-driven multi-call transactions) is deferred to #195 per the ADR's transaction-handle exemption. It has live production callers in the session-mirror ingest path, so **enabling `KHIVE_WRITE_QUEUE=1` while concurrent session-mirror ingest is active still admits a competing writer until #195 lands.** #195's acceptance must include a session-ingest concurrency test.
- The vector store's `orphan_sweep` maintenance path stays on its unmanaged writer (documented in-code).

Robustness fixes in the same change:

- `ConnectionPool::writer_task_handle` returns `Result<Option<WriterTaskHandle>, StorageError>` and fails loud with `StorageError::WriterTaskNoRuntime` when the flag is on but no Tokio runtime is available, instead of panicking
- An `atomic_unit` closure that suspends on first poll now returns a typed error through the normal rollback-and-reply path instead of panicking inside the writer task (which would have killed the task and every subsequent write on the pool); a regression test proves the task survives and keeps serving

Batched commits across multiple requests, checkpoint coordination, and the transaction watchdog are separate ADR-067 components and out of scope.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-db -p khive-pack-brain -p khive-pack-memory --all-targets -- -D warnings` (also re-checked with `--features vectors`)
- [x] `cargo test -p khive-db -p khive-storage -p khive-runtime -p khive-pack-brain -p khive-pack-memory` (all green, 0 failures)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-db -p khive-storage -p khive-runtime`
- [x] Per-store flag-on routing tests observe `WriterTaskHandle::queue_depth()` with a deterministic occupier parked on the writer task (non-vacuous: a pool-path implementation cannot increment the channel gauge); each was confirmed to fail with the fix reverted
- [x] New test proves `VACUUM` succeeds over a write-queue-enabled pool via the top-level path
- [x] New test proves the brain persist path enqueues on the shared writer-task channel when the flag is on
- [x] New test proves a suspending `atomic_unit` closure errors cleanly and the writer task survives to serve the next request
- [x] Multi-statement batch mid-sequence failure rolls back to zero rows; runtime-handle guard errors instead of panicking outside a Tokio runtime
- [x] Flag-on routing tests construct `PoolConfig { write_queue_enabled: true }` literals directly (no process-global env mutation)
