### PR TITLE
docs(adr): ADR-099 cross-op atomicity for bulk apply + ADR-067 Amendment 1

### DIFF
--- a/docs/adr/ADR-067-write-owner-daemon.md
+++ b/docs/adr/ADR-067-write-owner-daemon.md
@@ -693,3 +693,49 @@ The following are explicitly excluded from this ADR:
 - `crates/kkernel/src/exec.rs` — `apply_ops_file` and daemon fast-path bypass (`exec.rs:214`, `408`)
 - PR #221 — Slice 1: `CheckpointConfig` and `run_checkpoint_task` (in-flight, ADR-independent; must land before Slice 2)
 - Issue #195: cross-op atomicity for `--ops-file` bulk apply
+
+## Amendment 1 (2026-07-06)
+
+Component A landed in full (PR #670). This amendment corrects the migration inventory
+against the merged implementation and records two seams the implementation added beyond
+the original text.
+
+### Seams shipped beyond the original text
+
+1. **`SqlAccess::atomic_unit`** — a transaction-enlisted closure seam. With the write
+   queue enabled, the closure runs on the writer task's own transaction for the request;
+   with it disabled, a manual `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` path byte-identical to
+   the prior behavior. Multi-statement write units (brain persist, fold-gate) were
+   converted onto it.
+2. **`SqlWriter::execute_script_top_level`** — a top-level maintenance seam for statements
+   SQLite forbids inside any transaction (`VACUUM`, `PRAGMA wal_checkpoint(TRUNCATE)`).
+   Requests serialize through the same writer channel and drain loop, but the transaction
+   wrap is skipped. Callers: `memory.vacuum` and the VCS sync WAL checkpoint. Both carry
+   revert-companion tests proving the plain routed path fails under the queue.
+
+Additionally, `block_on_sync` returns a typed error (rather than panicking) on a pending
+future, and the writer task survives such an error; covered by a regression test.
+
+### Corrected inventory (final state at merge)
+
+Anchors are given by function name; line numbers in the original inventory tables have
+drifted and should not be relied on.
+
+| Path                                                                                             | State at merge                                                                                                                                                                                                   | Disposition                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All store write paths (entity, note, graph, text, event, sparse, vectors CRUD) via `with_writer` | Routed through the writer task                                                                                                                                                                                   | DONE                                                                                                                                                                        |
+| `SqlBridge::writer` / `execute` / `execute_script` / `execute_batch`                             | Routed                                                                                                                                                                                                           | DONE                                                                                                                                                                        |
+| Brain persist + fold-gate multi-statement units                                                  | Converted to `atomic_unit`                                                                                                                                                                                       | DONE                                                                                                                                                                        |
+| `memory.vacuum`, VCS `checkpoint_wal`                                                            | `execute_script_top_level`                                                                                                                                                                                       | DONE                                                                                                                                                                        |
+| Entry 9 — `begin_tx()`                                                                           | Standalone connection; **sole live production caller** is session-mirror ingest (`write_events_and_cursor` in `khive-pack-session/src/mirror/ingest.rs`); all other references are tests or explanatory comments | DEFERRED to the follow-up ADR (issue #195 companion), which converts the caller to `atomic_unit` and retires the method if no non-test caller remains                       |
+| Vector-store `orphan_sweep` (`with_writer_unmanaged`)                                            | Opens its own `BEGIN IMMEDIATE` on a pool writer connection outside the writer task; serialized against other pool-mutex callers but **not** against the writer task under the queue                             | MIGRATE — convert to `atomic_unit` (mechanical; the accepted seam covers it). Until converted, this is a known residual competing-writer path alongside `begin_tx`'s caller |
+| Periodic checkpoint task (`try_writer_nowait` + direct `execute_batch`)                          | Deliberate bypass of the channel; nowait acquisition, never holds a transaction across the checkpoint                                                                                                            | EXEMPT (by design)                                                                                                                                                          |
+| Startup migrations + pack DDL (direct pool at boot)                                              | Run before concurrent traffic exists                                                                                                                                                                             | EXEMPT (by design)                                                                                                                                                          |
+
+### Clarification to the "Issue #195 — decision" section
+
+The original text says the follow-up work "depends on Component A's `WriterTask` being the
+stable owner of write connections." Precisely: the bulk-apply path runs against an
+in-process runtime (it does not traverse the daemon), so the dependency is on the
+**`atomic_unit` seam** — whose queue-on and queue-off arms are both shipped — rather than
+on the daemon-resident task being in the loop for that path.

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -1,0 +1,412 @@
+# ADR-099: Cross-Op Atomicity for Bulk Apply — Atomic Units over the Single-Writer Seam
+
+**Status**: Accepted (2026-07-06)
+**Date**: 2026-07-06
+**Issue**: #195 (true cross-op atomicity for `exec --ops-file` bulk apply)
+**Depends on**: ADR-067 (Write-Owner Daemon — single-writer task and the `atomic_unit` seam), ADR-005 (storage capability traits), ADR-016 (request DSL), ADR-091 (bounded read-transaction lifetime; Plank 0 open-transaction registry)
+**Amends**: none (a companion ADR-067 amendment records the now-final write-path inventory; see D6)
+
+---
+
+## Context
+
+### What bulk apply does today
+
+The `exec --ops-file` command reads a newline-delimited file of `{"tool": ..., "args": ...}`
+operations, groups them into chunks of 100, and dispatches each chunk as a **parallel batch**
+through the same in-process dispatch path the `request` tool uses (`apply_ops_file` →
+`dispatch_request_local` in `crates/kkernel/src/exec.rs`). The daemon fast-path is deliberately
+bypassed for bulk apply, so the ops run against an in-process runtime.
+
+Each op inside a chunk dispatches through its own verb handler, and each handler acquires a
+write path and commits independently. Two consequences follow:
+
+1. **No rollback across ops.** A failure in op 47 of a 100-op chunk leaves ops 1..46 committed.
+   There is no rollback across ops within a chunk, and none across chunks.
+2. **Chunk boundaries are a transport artifact.** The chunk size of 100 exists to bound frame
+   size, not to define a meaningful unit of work. All-or-nothing "per chunk" would make the
+   atomic boundary depend on an arbitrary transport constant.
+
+This is acceptable for idempotent mass updates (the original bulk-apply value: one process
+instead of N spawns, parse-first safety, dry-run preview). It is **not** acceptable for
+cleansing operations that require all-or-nothing semantics, which is the stated end goal of
+issue #195.
+
+### What the single-writer work already gives us
+
+ADR-067 introduced a single write-owner task and, as part of that work, shipped a
+transaction-enlisted execution seam on the `SqlAccess` trait
+(`crates/khive-storage/src/sql.rs`):
+
+```rust
+async fn atomic_unit(&self, op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>>;
+```
+
+`atomic_unit` runs a caller-supplied closure **inside one open write transaction**. Where the
+single-writer task is active, the closure runs on that task's transaction for the request, so it
+cannot compete with the writer for the SQLite write lock. Where no writer task applies (flag off,
+no async runtime, or an in-memory pool), the closure runs under a manual
+`BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on a writer handle — byte-identical to the pre-ADR-067
+behavior. The closure must issue DML only; the transaction boundary is owned entirely by
+`atomic_unit`. This seam is already in production use by the fold-gate write path.
+
+This ADR builds the cross-op atomicity of issue #195 **on that existing seam**, rather than
+introducing a new transaction primitive or threading a transaction handle through every verb
+handler signature.
+
+### The remaining standalone-writer hole
+
+The `SqlAccess` trait also exposes `begin_tx(options)`, which returns a live
+`Box<dyn SqlTransaction>` (a handle supporting incremental `execute`, then `commit`/`rollback`).
+Unlike `atomic_unit`, `begin_tx` opens a **standalone connection** and issues its own
+`BEGIN IMMEDIATE` outside the single-writer task. It is the one remaining write path that can
+compete with the writer for the WAL write lock.
+
+An exhaustive audit of the current tree finds exactly **one live production caller** of
+`begin_tx`: the session-mirror ingest path (`write_events_and_cursor` in
+`crates/khive-pack-session/src/mirror/ingest.rs`), which opens a transaction, loops over parsed
+session events inserting session/message rows and advancing a file cursor, and commits once. Its
+no-partial-state contract (the cursor advances only if the row writes commit) is covered by a
+regression test in the same file. All other references to `begin_tx` are tests, or comments in
+the brain pack explaining why that code uses `atomic_unit` instead.
+
+Closing this hole is in scope here because the same mechanism that gives bulk apply its atomic
+unit also gives session-mirror ingest a home that does not open a competing connection.
+
+---
+
+## Decision
+
+Add cross-op atomicity as an **opt-in restricted atomic unit** built on the existing
+`atomic_unit` seam, and retire the last standalone-writer caller onto the same seam.
+
+Concretely:
+
+- **D1**: Bulk apply gains an `--atomic` flag. Under `--atomic`, the whole file is executed as
+  one atomic unit: all ops commit, or none do. The default (no flag) is unchanged per-op
+  behavior.
+- **D2**: The atomic unit executes through the **real verb handlers**, enlisted in one shared
+  `atomic_unit` transaction via an ambient write context — not by threading a transaction handle
+  through every handler signature, and not by compiling ops to raw SQL that bypasses handler
+  logic.
+- **D3**: Under `--atomic`, only **write-shaped verbs** are admissible; read/query/recall verbs
+  are rejected at parse time. This bounds the work held inside the open transaction to fast DML
+  and preserves the single-writer latency guarantees ADR-067 established.
+- **D4**: The failure envelope is **additive**. Non-atomic batches are byte-identical to today.
+  An atomic unit that aborts reports the failing op index and marks every op rolled back.
+- **D5**: `begin_tx`'s single live caller (session-mirror ingest) is converted to `atomic_unit`,
+  closing the standalone-writer hole. The `begin_tx` trait method is then removed if no non-test
+  caller remains (verified at implementation time).
+
+The MCP `request` wire tool is **not** changed. `--atomic` is a `kkernel` CLI concern; the wire
+contract in ADR-016/ADR-023 and the agent-facing tool description are untouched.
+
+---
+
+## Per-fork decisions
+
+### D1 — Mechanism for cross-op atomicity
+
+**Decision: reuse `atomic_unit` as the single transaction boundary; enlist real handlers in it
+via an ambient write context.**
+
+A new in-process entry point (working name `dispatch_request_atomic`) opens one `atomic_unit`
+and dispatches the file's ops **inside** the resulting transaction. Each op runs through its
+normal verb handler. The handler's store-level `with_writer` (and, critically, its reads — see
+"read-your-writes" below) resolve to the ambient transaction's connection for the duration of the
+unit, instead of opening their own writer or reading from the concurrent reader pool. When no
+atomic unit is active (every existing code path), `with_writer` behaves exactly as it does today.
+
+The ambient context is scoped strictly to the atomic unit (a task-local or an extension of the
+existing open-transaction registry from ADR-091), set on entry and cleared on exit. It is never
+observable outside the unit.
+
+**Read-your-writes requirement.** Inside the unit, op _N_ must observe op _N-1_'s uncommitted
+writes (e.g. a `link` that references an entity created by an earlier op in the same file). Under
+WAL, the concurrent reader-pool connections do not see the writer's open transaction. Therefore,
+while an atomic unit is active, a handler's reads MUST route to the ambient transaction
+connection, not the reader pool. This is a correctness requirement, not an optimization, and has
+a dedicated acceptance test.
+
+**Alternatives considered:**
+
+- **(a) Thread a `SqlTransaction` handle through `dispatch_request_local` → the registry →
+  every handler signature (the ADR-067 sketch).** Rejected. The blast radius is every handler
+  signature in every pack, plus the runtime service methods those handlers call. The ambient-
+  context approach achieves the same enlistment by changing the store-level `with_writer`/reader
+  seam — the same, already-migrated surface ADR-067 touched — without rewriting handler
+  signatures.
+- **(b) Compile write-shaped ops to raw `SqlStatement`s and run them directly in one
+  `atomic_unit`, bypassing handlers.** Rejected. Verb handlers own non-trivial logic (identifier
+  generation, dedup, endpoint validation, FTS/vector index maintenance, secret masking).
+  Re-deriving that as raw SQL in the bulk-apply crate duplicates it and guarantees drift. The
+  standing lesson from the fold-gate work is explicit: reuse the insert logic behind the seam;
+  do not duplicate it into the consuming crate.
+- **(c) Writer lease — the writer task grants an exclusive long-lived transaction slot held
+  across the whole dispatch.** Rejected as the general mechanism. Holding the single writer's
+  `BEGIN IMMEDIATE` open across N arbitrary verb dispatches — each potentially doing slow reads,
+  ANN recall, or service calls — reintroduces exactly the long-held-write-lock starvation that
+  ADR-067 eliminated. A lease is only safe if what runs under it is bounded to fast DML, which is
+  what D3's write-verb restriction already enforces; at that point the lease is just `atomic_unit`
+  with extra machinery. The `atomic_unit` seam is the lease, minus the wedge risk.
+- **(d) Savepoint-per-op composition.** Adopted as a **component of the chosen design**, not an
+  alternative to it. Inside the one `atomic_unit`, each op is wrapped in a named SAVEPOINT so a
+  failure rolls the unit back to a known point and reports the failing op index. This is the same
+  SAVEPOINT-per-request hierarchy ADR-067 already uses for per-op isolation, reused here for
+  attribution.
+
+### D2 — Unit of atomicity for `--ops-file`
+
+**Decision: whole-file, opt-in via `--atomic`, default off (per-op, unchanged). Bounded by a
+configurable op-count guard.**
+
+- **Whole-file, not per-chunk.** The 100-op chunk is a transport-framing constant; all-or-nothing
+  across a chunk boundary is not a semantically meaningful unit. A cleansing file is atomic as a
+  whole or not at all.
+- **Opt-in.** `--atomic` is off by default. Idempotent mass updates keep today's non-atomic,
+  per-op-independent behavior with no latency change.
+- **Bounded.** A whole-file atomic unit holds the single writer for the full duration of the
+  unit. The load harness that qualified ADR-067 already shows multi-second write-slot tails under
+  concurrency, so an unbounded 10k-op atomic file is a product-visible stall for every other
+  writer on the process. Under `--atomic`, a file exceeding a configurable maximum op count
+  (recommended default on the order of a few thousand ops; final value tuned against the harness)
+  is **rejected before execution** with a clear error directing the caller to split the file or
+  run without `--atomic`. This keeps the maximum writer-hold predictable and bounded.
+
+**Alternatives considered:**
+
+- **Per-chunk atomicity (all-or-nothing per 100).** Rejected: the boundary is arbitrary and would
+  silently change if the chunk constant changed. It also gives the caller no guarantee they can
+  reason about ("ops 1..100 committed but 101..137 did not" is not all-or-nothing).
+- **Always atomic (no flag).** Rejected: it would impose the whole-file writer-hold and the
+  write-verb restriction on the common idempotent-update case, and would break callers who rely
+  on partial progress of a large idempotent file.
+
+### D3 — Admissible verbs under `--atomic`
+
+**Decision: restrict `--atomic` to write-shaped verbs; reject read/query verbs at parse time.**
+
+Only mutation verbs may appear in an `--atomic` file (create, update, delete, link, merge,
+remember, and the task-lifecycle and message mutations, plus the propose/review/withdraw
+governance verbs). Read/search/recall/query/traverse/list/get verbs are rejected before the unit
+opens, with an error naming the offending line and verb.
+
+Rationale: the atomic unit holds the single writer's transaction open for its whole duration.
+Restricting the unit to fast DML keeps that hold short and predictable and prevents a slow read
+(ANN recall, large search) from extending the write-lock hold — the precise failure ADR-067
+removed. Handler-internal reads (endpoint validation, dedup lookups) are fine: they are fast,
+run on the ambient transaction connection, and are necessary for read-your-writes.
+
+**Alternative considered: allow arbitrary verbs inside the unit.** Rejected: it reintroduces the
+long-held-write-lock wedge and conflates "atomic mutation" with "read-modify-write transaction,"
+a materially larger and riskier feature that issue #195 does not ask for.
+
+### Daemon coexistence under `--atomic`
+
+Bulk apply runs in-process and does not traverse the daemon. When a live daemon is serving
+the same database file, an `--atomic` run therefore holds a **cross-process**
+`BEGIN IMMEDIATE` on that file for the duration of the unit, while the daemon's write owner
+continues to operate inside its own process. The single-writer guarantee is per-process; the
+two processes coordinate through SQLite's file-level write lock.
+
+**Decision: accept bounded cross-process coexistence; do not route `--atomic` through the
+daemon.**
+
+- This coexistence is not new. The non-atomic bulk apply already writes cross-process
+  against a live daemon today — each op takes its own short-lived write lock. `--atomic`
+  changes the **duration** of the hold, not its existence, and the duration is exactly what
+  the D2 op-count guard bounds.
+- Expected daemon-side behavior during the atomic window: daemon writes wait on the
+  configured `busy_timeout` and proceed when the unit commits. A window shorter than the
+  busy timeout delays daemon writes without failing them; a window that exceeds it surfaces
+  `SQLITE_BUSY` to daemon callers. The op-count guard default is therefore sized (from
+  harness measurement) so the worst-case hold stays well inside the default busy timeout,
+  and the `--atomic` documentation directs operators to run large atomic cleanses in a
+  maintenance window or against an idle daemon.
+- **Alternative considered: route `--atomic` through the daemon when one is live, so the
+  daemon's write owner holds the unit.** Rejected for this ADR. It requires a new daemon
+  bulk-transaction protocol surface, reintroduces the transport frame cap that in-process
+  bulk apply exists to avoid, and creates a behavioral fork (flag semantics differ by
+  daemon liveness). If operational experience shows the bounded window is insufficient,
+  daemon-routed atomicity can be a follow-up that reuses this ADR's ambient-context
+  machinery unchanged.
+- **Alternative considered: refuse `--atomic` when a live daemon is detected.** Rejected:
+  liveness detection is racy (a daemon may start mid-unit), and a hard refusal blocks the
+  legitimate bounded case the guard already covers.
+
+### D4 — Error response shape for partial-failure rollback
+
+**Decision: additive envelope. Non-atomic batches unchanged; atomic-unit abort reported
+explicitly.**
+
+- Non-atomic (default) responses are **byte-identical** to today: each op yields its own
+  `{ok, tool, result | error}` and a failure never aborts siblings.
+- Under `--atomic`, on the first failing op the whole unit rolls back. The response reports:
+  - the failing op's index and its error,
+  - that the unit was rolled back (no op committed),
+  - the remaining ops marked not-committed rather than succeeded.
+
+  A representative shape (final field names settled in implementation):
+
+  ```json
+  {
+    "atomic": true,
+    "committed": false,
+    "failed_op_index": 47,
+    "error": "<message from the failing op>",
+    "ops": [ { "index": 0, "committed": false, "rolled_back": true }, ... ]
+  }
+  ```
+
+- On full success, `{ "atomic": true, "committed": true, ... }` with the per-op results.
+
+The `atomic`, `committed`, `failed_op_index`, and `rolled_back` fields are **additive**; they
+appear only on the atomic path. No field is removed or repurposed on the non-atomic path, so no
+existing consumer breaks.
+
+**Alternative considered: reuse the existing per-op `ok/error` array with no new fields.**
+Rejected: a caller could not distinguish "this op failed but siblings committed" (non-atomic)
+from "this op failed so the whole unit rolled back" (atomic). The distinction is the entire point
+of the feature and must be explicit in the envelope.
+
+### D5 — Fate of `begin_tx()`
+
+**Decision: convert the single live caller to `atomic_unit`, closing the standalone-writer hole;
+then remove the `begin_tx` trait method if no non-test caller remains.**
+
+The session-mirror ingest path (`write_events_and_cursor`) is a clean `atomic_unit` shape: it
+opens a transaction, performs a sequence of DML statements (session upsert, message insert,
+cursor advance), and commits once, with no branch-on-read logic that needs a live incremental
+handle. It converts directly: the loop body becomes the `atomic_unit` closure; the cursor advance
+is the last statement in the closure; the all-or-nothing contract is preserved because
+`atomic_unit` commits once at the end or rolls the whole closure back.
+
+Once converted, `begin_tx` has no live production caller. The standalone-writer hole is closed by
+**removing the caller**, independent of whether the method itself is deleted. Implementation then:
+
+1. Greps for any remaining non-test caller of `begin_tx` and of the `SqlTransaction` trait.
+2. If none remains and the `SqlTransaction` handle is not load-bearing forward-deployed
+   infrastructure elsewhere, removes `begin_tx` from `SqlAccess` and its `SqlBridge`
+   implementation, and collapses the now-dead `SqlTransaction` machinery.
+3. If `SqlTransaction`/the open-transaction registry is genuinely forward-deployed
+   infrastructure, keeps the trait but leaves `begin_tx` with **no production caller** and a doc
+   note that production atomicity goes through `atomic_unit`. Either way, the competing-writer
+   hole is closed because the live caller is gone.
+
+Removing a method from `SqlAccess` touches the storage trait surface (the trait declaration, the
+`SqlBridge` implementation, and test callers). This trait is internal to the runtime; there is no
+external SDK consuming it, so the change is contained.
+
+**Alternatives considered:**
+
+- **(i) Migrate `begin_tx` onto the writer task as a lease.** Rejected for the same reason the
+  lease was rejected in D1: a live incremental transaction handle held across caller-driven calls
+  is exactly the long-held-lock shape ADR-067 removed, and the one live caller does not need an
+  incremental handle — it needs one atomic closure, which `atomic_unit` already provides.
+- **(iii) Keep `begin_tx` standalone as a permanent documented exemption.** Rejected. As long as a
+  live caller opens a standalone `BEGIN IMMEDIATE` outside the writer, the single-writer guarantee
+  has a hole under concurrency. The exemption only made sense while there was no seam to move the
+  caller to; `atomic_unit` is that seam.
+
+### D6 — Document structure (F5)
+
+**Decision: confirm the split.** This follow-up ADR carries the design (D1–D5). A **separate,
+small ADR-067 amendment** records the now-final write-path facts as merged: `begin_tx` as the sole
+converted-away live caller, the top-level maintenance seam
+(`execute_script_top_level`) as shipped, and any unmanaged write site surfaced during the
+inventory (e.g. an orphan-sweep path in the vector store) dispositioned MIGRATE or EXEMPT.
+
+Rationale: the amendment is a documentation-truth correction to an already-accepted ADR and can
+land immediately and independently; the design ADR is a forward decision that goes through the
+normal design-review gate. Keeping them separate matches the repository convention of not bundling
+a documentation correction with a design change, and lets neither block the other.
+
+**Alternative considered: one combined document.** Rejected: it couples an immediately-landable
+inventory correction to a design that needs review, and mixes "record what merged" with "decide
+what to build."
+
+---
+
+## Migration steps
+
+1. Add the ambient write-context scope (task-local or an extension of the open-transaction
+   registry) and teach the store-level `with_writer` and reader seams to resolve to the ambient
+   transaction connection when a unit is active. No behavior change when no unit is active.
+2. Add the in-process `dispatch_request_atomic` entry that opens one `atomic_unit`, sets the
+   ambient context, dispatches the file's ops inside it with a SAVEPOINT per op, and clears the
+   context on exit.
+3. Add `--atomic` to `exec --ops-file`. Under the flag: reject read-shaped verbs at parse time
+   (D3); reject files over the op-count guard (D2); route the whole file through
+   `dispatch_request_atomic`.
+4. Implement the additive atomic failure envelope (D4).
+5. Convert `write_events_and_cursor` (session-mirror ingest) from `begin_tx` to `atomic_unit`
+   (D5), preserving the cursor-advances-only-on-commit contract.
+6. Grep for remaining non-test `begin_tx`/`SqlTransaction` callers; remove `begin_tx` from
+   `SqlAccess` and its implementation if none remains, else document the no-live-caller state.
+7. Land the companion ADR-067 amendment separately (D6).
+
+Schema is unchanged; no migration file is required. Pack rules are unchanged; this is additive.
+
+---
+
+## Acceptance criteria
+
+- **Atomic rollback end-to-end.** An `--atomic` ops-file with a deliberate mid-file failure
+  (e.g. a valid op followed by an op that must fail, followed by more valid ops) leaves the
+  database **unchanged**: none of the file's writes are present after the run, and the response
+  reports the failing op index with `committed: false`.
+- **Read-your-writes within a unit.** An `--atomic` file where a later op references an entity
+  created by an earlier op in the same file succeeds, proving later ops observe earlier
+  uncommitted writes through the ambient transaction connection.
+- **Write-verb restriction.** An `--atomic` file containing a read/recall/query verb is rejected
+  before any write occurs, naming the offending line and verb.
+- **Op-count guard.** An `--atomic` file exceeding the configured maximum op count is rejected
+  before execution with an actionable error.
+- **Non-atomic parity.** With `--atomic` absent, bulk apply output and per-op semantics are
+  byte-identical to the pre-change behavior (per-op independence preserved; a failing op does not
+  abort siblings).
+- **Single-writer concurrency test (mandatory).** Concurrent session-mirror ingest plus normal
+  write traffic, with the single-writer task active, shows **no competing writer**: after
+  converting ingest to `atomic_unit`, no standalone `BEGIN IMMEDIATE` is issued outside the writer
+  owner on any concurrent path. This path is not exercised by the general write-load harness and
+  must be covered explicitly.
+- **Daemon coexistence under `--atomic`.** With a live daemon serving the same database file
+  and carrying concurrent write traffic, an `--atomic` run within the op-count guard
+  commits successfully, the daemon's concurrent writes complete (delayed at most by the
+  atomic window, none lost, no corruption), and any daemon-side `SQLITE_BUSY` is observed
+  only if the window is deliberately driven past the busy timeout. This cross-process case
+  is covered by neither the general write-load harness nor the in-process test suite and
+  must be exercised explicitly.
+- **Revert-companion test.** The key session-ingest and atomic-rollback tests demonstrably
+  **fail** against the pre-change shape (standalone `begin_tx`, per-op non-atomic bulk apply),
+  proving the tests are non-vacuous.
+- **Session-ingest no-partial-state preserved.** The existing regression that asserts the mirror
+  cursor advances only when row writes commit passes after the `atomic_unit` conversion.
+
+---
+
+## Open questions
+
+1. **Ambient-context carrier.** Task-local versus extending the existing open-transaction
+   registry. Both scope the context to the unit; the registry already tracks open transactions
+   and may be the more coherent home. A short implementation spike should pick one and confirm it
+   composes with the reader-routing requirement.
+2. **Op-count guard default.** The exact maximum-ops threshold for `--atomic` should be set from a
+   harness measurement of writer-hold time versus op count, not guessed. Ships configurable with a
+   conservative default.
+3. **`SqlTransaction` retention.** Whether the `SqlTransaction` trait and the open-transaction
+   registry are forward-deployed infrastructure worth keeping after `begin_tx`'s last caller is
+   gone, or dead machinery to collapse. Resolved by the implementation-time grep in migration
+   step 6.
+
+---
+
+## References
+
+- ADR-067 — Write-Owner Daemon: single-writer task, the `atomic_unit` seam, per-request SAVEPOINT
+  isolation, and the `--ops-file` cross-op atomicity deferral this ADR resolves.
+- ADR-005 — Storage capability traits: `SqlAccess`, `atomic_unit`, `begin_tx`, `SqlTransaction`.
+- ADR-016 — Request DSL and the per-op independence contract this ADR preserves on the non-atomic
+  path.
+- ADR-091 — Bounded read-transaction lifetime and WAL checkpoint escalation; its Plank 0 open-transaction registry is the candidate ambient-context carrier.
+- Issue #195 — true cross-op atomicity for `exec --ops-file` bulk apply.

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -279,10 +279,17 @@ configurable op-count guard.**
 synchronous DML. The v1 admissible set is the DML-only mutations; embedding-bearing verbs and all
 read verbs are rejected at parse time.**
 
-- **v1 admissible:** `update`, `delete`, `link`, `merge`, and the task-lifecycle and message
-  mutations (`gtd.*` transitions, `comm` mutations), plus the governance verbs
+- **v1 admissible (explicit per-verb list, never a pack-level category):** `update`, `delete`,
+  `link`, `merge`, the task-lifecycle transitions (`gtd.transition`, `gtd.complete` —
+  property-only status mutations that trigger no reindex), and the governance verbs
   (`propose`/`review`/`withdraw`) — the verbs whose prepare is validation and identifier
   resolution only and whose apply is pure DML.
+- **v1 rejected — note-creating mutations.** `comm.send`, `comm.reply`, and `comm.ingest` are
+  **not** DML-only today: each creates a message note, and note creation awaits embedding before
+  its vector insert (`crates/khive-runtime/src/operations.rs`). `gtd.assign` is rejected for the
+  same reason (it creates a task note). All are treated exactly like `create` and
+  `memory.remember` below — rejected at parse time as embedding-bearing until a note prepare/apply
+  seam exists.
 - **`update` and `merge` caveat (verified at source).** Under the current handlers, `update`
   triggers a reindex when name or description change, and that reindex awaits embedding
   (`reindex_entity` in `crates/khive-runtime/src/curation.rs`); property-only updates skip
@@ -458,7 +465,7 @@ inventory correction to a design that needs review.
    passes flag-off. This near-shipped twice in one day; the warning must live in the code the next
    consumer reads, not only in this ADR.
 1. Add a per-verb `prepare`/apply seam to the v1 admissible verbs (`update`, `delete`, `link`,
-   `merge`, the task-lifecycle and message mutations, the governance verbs): `prepare` runs the
+   `merge`, `gtd.transition`, `gtd.complete`, the governance verbs): `prepare` runs the
    existing async validation/identifier work and returns a materialized write plan (the
    `SqlStatement`s plus any post-commit side effect); apply issues those statements on a provided
    writer with no transaction control of its own.
@@ -494,9 +501,9 @@ Schema is unchanged; no migration file is required. Pack rules gain only additiv
   suspension error and aborts the unit — it must fail loudly, not silently succeed or wedge. This
   is the guard that a future change admitting an embedding-bearing verb without hoisting its
   embedding is caught by a test, not discovered in production on the single-writer path.
-- **Embedding-bearing verb rejected.** An `--atomic` file containing `create` or `memory.remember`
-  is rejected before execution, naming the line and verb and stating embedding-bearing verbs are
-  not yet atomic-eligible.
+- **Embedding-bearing verb rejected.** An `--atomic` file containing `create`, `memory.remember`,
+  `gtd.assign`, `comm.send`, or `comm.reply` is rejected before execution, naming the line and
+  verb and stating embedding-bearing verbs are not yet atomic-eligible.
 - **Read verb rejected.** An `--atomic` file containing a read/recall/query verb is rejected before
   any write occurs, naming the line and verb.
 - **Op-count guard.** An `--atomic` file exceeding the configured maximum op count is rejected
@@ -506,6 +513,16 @@ Schema is unchanged; no migration file is required. Pack rules gain only additiv
   up front or the unit rolls back in-transaction (the link op's affected-row/existence guard fails
   once X is gone). After the run, the database contains neither the edge nor a partial subset of
   the file's writes.
+- **Merge rewires see earlier in-file writes.** An `--atomic` file of the form
+  `[link(from, Z), merge(into, from)]` commits with the new edge rewired to `into`: the merge
+  plan's predicated rewire statements are evaluated inside the transaction and therefore cover
+  the edge the earlier op inserted. No live edge remains on the merged-away entity. This pins the
+  predicate-based-plan rule — a plan that pre-enumerated edge rows at prepare time fails this
+  test.
+- **Zero-row apply fails the unit.** An `--atomic` file of the form `[delete(X, hard), update(X)]`
+  does **not** report success: the update's affected-row guard observes zero rows inside the
+  transaction, the op fails, and the whole unit rolls back (X is restored, `atomic.committed` is
+  false). This pins the affected-row-guard rule.
 - **Non-atomic parity.** With `--atomic` absent, bulk apply output and per-op semantics are
   byte-identical to the pre-change behavior (per-op independence preserved; a failing op does not
   abort siblings).

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -1,9 +1,9 @@
-# ADR-099: Cross-Op Atomicity for Bulk Apply — Atomic Units over the Single-Writer Seam
+# ADR-099: Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam
 
 **Status**: Accepted (2026-07-06)
 **Date**: 2026-07-06
 **Issue**: #195 (true cross-op atomicity for `exec --ops-file` bulk apply)
-**Depends on**: ADR-067 (Write-Owner Daemon — single-writer task and the `atomic_unit` seam), ADR-005 (storage capability traits), ADR-016 (request DSL), ADR-091 (bounded read-transaction lifetime; Plank 0 open-transaction registry)
+**Depends on**: ADR-067 (Write-Owner Daemon — single-writer task and the `atomic_unit` seam), ADR-005 (storage capability traits), ADR-016 (request DSL)
 **Amends**: none (a companion ADR-067 amendment records the now-final write-path inventory; see D6)
 
 ---
@@ -13,90 +13,109 @@
 ### What bulk apply does today
 
 The `exec --ops-file` command reads a newline-delimited file of `{"tool": ..., "args": ...}`
-operations, groups them into chunks of 100, and dispatches each chunk as a **parallel batch**
-through the same in-process dispatch path the `request` tool uses (`apply_ops_file` →
-`dispatch_request_local` in `crates/kkernel/src/exec.rs`). The daemon fast-path is deliberately
-bypassed for bulk apply, so the ops run against an in-process runtime.
+operations, groups them into chunks of 100, and dispatches each chunk as a **parallel batch** of
+independent ops through the same in-process dispatch path the `request` tool uses (`apply_ops_file`
+→ `dispatch_request_local` in `crates/kkernel/src/exec.rs`). The daemon fast-path is deliberately
+bypassed for bulk apply, so the ops run against an in-process runtime. The ops-file JSON form is
+independent ops: `$prev` substitution is not available, so one op cannot reference an identifier
+produced by an earlier op in the same file unless that identifier is caller-known.
 
-Each op inside a chunk dispatches through its own verb handler, and each handler acquires a
-write path and commits independently. Two consequences follow:
+Each op inside a chunk dispatches through its own verb handler, and each handler acquires a write
+path and commits independently. Two consequences follow:
 
 1. **No rollback across ops.** A failure in op 47 of a 100-op chunk leaves ops 1..46 committed.
    There is no rollback across ops within a chunk, and none across chunks.
 2. **Chunk boundaries are a transport artifact.** The chunk size of 100 exists to bound frame
-   size, not to define a meaningful unit of work. All-or-nothing "per chunk" would make the
-   atomic boundary depend on an arbitrary transport constant.
+   size, not to define a meaningful unit of work.
 
-This is acceptable for idempotent mass updates (the original bulk-apply value: one process
-instead of N spawns, parse-first safety, dry-run preview). It is **not** acceptable for
-cleansing operations that require all-or-nothing semantics, which is the stated end goal of
-issue #195.
+This is acceptable for idempotent mass updates (the original bulk-apply value: one process instead
+of N spawns, parse-first safety, dry-run preview). It is **not** acceptable for cleansing
+operations that require all-or-nothing semantics — the salience-recalibration and mass-cleanse use
+cases that motivate issue #195. Those are mass mutations over existing rows (`update` / `delete` /
+`link`), not create-then-reference chains with intra-file dependencies.
 
-### What the single-writer work already gives us
+### The transaction seam that shipped with ADR-067, and its hard constraint
 
-ADR-067 introduced a single write-owner task and, as part of that work, shipped a
-transaction-enlisted execution seam on the `SqlAccess` trait
+ADR-067 shipped a transaction-enlisted execution seam on the `SqlAccess` trait
 (`crates/khive-storage/src/sql.rs`):
 
 ```rust
 async fn atomic_unit(&self, op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>>;
 ```
 
-`atomic_unit` runs a caller-supplied closure **inside one open write transaction**. Where the
-single-writer task is active, the closure runs on that task's transaction for the request, so it
-cannot compete with the writer for the SQLite write lock. Where no writer task applies (flag off,
-no async runtime, or an in-memory pool), the closure runs under a manual
-`BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on a writer handle — byte-identical to the pre-ADR-067
-behavior. The closure must issue DML only; the transaction boundary is owned entirely by
-`atomic_unit`. This seam is already in production use by the fold-gate write path.
+`atomic_unit` runs a caller-supplied closure inside one open write transaction. It has a **hard
+constraint that governs this entire ADR**: on the single-writer path (the production daemon), the
+closure is executed on the writer task's connection through a single-poll driver
+(`block_on_sync`, `crates/khive-db/src/sql_bridge.rs`). That driver returns a typed error if the
+closure's future ever reaches a real suspension point. The closure may therefore issue only
+**synchronous DML** against the provided writer (the `InlineWriter`, whose methods are pure
+rusqlite calls that never await). A closure that performs asynchronous work — embedding, ANN
+warming, a network or channel round-trip — suspends, hits the error path, and fails.
 
-This ADR builds the cross-op atomicity of issue #195 **on that existing seam**, rather than
-introducing a new transaction primitive or threading a transaction handle through every verb
-handler signature.
+This constraint is not incidental; it exists because the writer task drives the closure inside a
+synchronous `spawn_blocking` context and must not block that context on external async work while
+holding the single write connection. It is the correct constraint, and this ADR is designed to
+honor it rather than to relax it.
 
-### The remaining standalone-writer hole
+> **Design invariant — the Synchronous-DML Atomic-Unit contract (call it the _atomic-unit
+> suspend-free invariant_):** any closure passed to `SqlAccess::atomic_unit` must complete on its
+> first poll — it may issue only synchronous DML against the provided writer and must never reach a
+> real suspension point (no embedding, no ANN warming, no service or channel `await`). On the
+> single-writer path a violation fails loudly through `block_on_sync`; on the flag-off path it
+> would silently succeed, so the invariant is a correctness contract the caller must uphold, not
+> something the type system enforces. Every decision in this ADR that touches the seam (D1, D3, D5)
+> is justified against this invariant, and migration step 0 writes it into the seam's own
+> doc-comments so the next consumer is warned in the code, not only here.
 
-The `SqlAccess` trait also exposes `begin_tx(options)`, which returns a live
-`Box<dyn SqlTransaction>` (a handle supporting incremental `execute`, then `commit`/`rollback`).
-Unlike `atomic_unit`, `begin_tx` opens a **standalone connection** and issues its own
-`BEGIN IMMEDIATE` outside the single-writer task. It is the one remaining write path that can
-compete with the writer for the WAL write lock.
+**Consequence for the design:** the cross-op atomic unit cannot dispatch full verb handlers
+inside `atomic_unit`, because real write handlers suspend. `create_entity` awaits
+`embed_document_with_model` before its vector insert (`crates/khive-runtime/src/operations.rs`);
+`memory.remember` embeds and then invalidates and warms ANN state
+(`crates/khive-pack-memory/src/handlers/remember.rs`). Any design that wraps those handlers in one
+`atomic_unit` would either hit the suspension error on the daemon path or behave differently
+depending on whether the single-writer flag is on — an unacceptable liveness-dependent fork.
 
-An exhaustive audit of the current tree finds exactly **one live production caller** of
-`begin_tx`: the session-mirror ingest path (`write_events_and_cursor` in
-`crates/khive-pack-session/src/mirror/ingest.rs`), which opens a transaction, loops over parsed
+### The remaining standalone-writer hole in this ADR's scope
+
+The `SqlAccess` trait also exposes `begin_tx(options)`, which opens a **standalone connection** and
+issues its own `BEGIN IMMEDIATE` outside the single-writer task. Within this ADR's scope, its one
+live production caller is the session-mirror ingest path (`write_events_and_cursor` in
+`crates/khive-pack-session/src/mirror/ingest.rs`): it opens a transaction, loops over parsed
 session events inserting session/message rows and advancing a file cursor, and commits once. Its
 no-partial-state contract (the cursor advances only if the row writes commit) is covered by a
-regression test in the same file. All other references to `begin_tx` are tests, or comments in
-the brain pack explaining why that code uses `atomic_unit` instead.
+regression test in the same file. All other `begin_tx` references are tests or explanatory
+comments.
 
-Closing this hole is in scope here because the same mechanism that gives bulk apply its atomic
-unit also gives session-mirror ingest a home that does not open a competing connection.
+A second unmanaged write path — the vector store's `orphan_sweep`, which opens its own
+`BEGIN IMMEDIATE` outside the writer task — is **out of scope here**. Its conversion is tracked
+and in flight as a separate change under the companion ADR-067 amendment (D6). This ADR's
+competing-writer statements and acceptance criteria are therefore scoped specifically to the
+`begin_tx` / session-ingest path and make no claim about `orphan_sweep`.
 
 ---
 
 ## Decision
 
-Add cross-op atomicity as an **opt-in restricted atomic unit** built on the existing
-`atomic_unit` seam, and retire the last standalone-writer caller onto the same seam.
+Add cross-op atomicity as an **opt-in, prepared-write-plan** unit, and retire the session-ingest
+`begin_tx` caller onto the same `atomic_unit` seam.
 
-Concretely:
-
-- **D1**: Bulk apply gains an `--atomic` flag. Under `--atomic`, the whole file is executed as
-  one atomic unit: all ops commit, or none do. The default (no flag) is unchanged per-op
-  behavior.
-- **D2**: The atomic unit executes through the **real verb handlers**, enlisted in one shared
-  `atomic_unit` transaction via an ambient write context — not by threading a transaction handle
-  through every handler signature, and not by compiling ops to raw SQL that bypasses handler
-  logic.
-- **D3**: Under `--atomic`, only **write-shaped verbs** are admissible; read/query/recall verbs
-  are rejected at parse time. This bounds the work held inside the open transaction to fast DML
-  and preserves the single-writer latency guarantees ADR-067 established.
-- **D4**: The failure envelope is **additive**. Non-atomic batches are byte-identical to today.
-  An atomic unit that aborts reports the failing op index and marks every op rolled back.
-- **D5**: `begin_tx`'s single live caller (session-mirror ingest) is converted to `atomic_unit`,
-  closing the standalone-writer hole. The `begin_tx` trait method is then removed if no non-test
-  caller remains (verified at implementation time).
+- **D1 (mechanism)**: `--atomic` runs in two phases. First, an **async prepare pass** materializes
+  each admissible op into a synchronous write plan (all suspension-bearing work — validation,
+  identifier generation, and, for verbs that need it, embedding — happens here, outside any
+  transaction). Second, a **single `atomic_unit`** applies every plan as synchronous DML under a
+  per-op SAVEPOINT, committing all or rolling back all. `atomic_unit` therefore only ever runs
+  synchronous DML, honoring its `block_on_sync` contract identically on the flag-on and flag-off
+  paths.
+- **D2 (unit)**: whole-file, opt-in via `--atomic`, default off (per-op, unchanged), bounded by a
+  configurable op-count guard.
+- **D3 (admissible verbs)**: only verbs that expose a prepare/apply seam are admissible; the v1
+  set is the DML-only mutations. Embedding-bearing verbs and all read verbs are rejected at parse
+  time. Including embedding-bearing verbs is a named extension path, not v1.
+- **D4 (error shape)**: the CLI response preserves the existing `results` + `summary` shape and
+  adds an `atomic` block; nothing is removed or repurposed.
+- **D5 (`begin_tx`)**: convert the session-ingest caller to `atomic_unit` (its closure is verified
+  suspension-free), closing that standalone-writer hole; remove the trait method if no non-test
+  caller remains.
 
 The MCP `request` wire tool is **not** changed. `--atomic` is a `kkernel` CLI concern; the wire
 contract in ADR-016/ADR-023 and the agent-facing tool description are untouched.
@@ -107,53 +126,126 @@ contract in ADR-016/ADR-023 and the agent-facing tool description are untouched.
 
 ### D1 — Mechanism for cross-op atomicity
 
-**Decision: reuse `atomic_unit` as the single transaction boundary; enlist real handlers in it
-via an ambient write context.**
+**Decision: two-phase — async prepare (materialize per-op write plans outside any transaction),
+then one synchronous `atomic_unit` that applies all plans as DML with a per-op SAVEPOINT.**
 
-A new in-process entry point (working name `dispatch_request_atomic`) opens one `atomic_unit`
-and dispatches the file's ops **inside** the resulting transaction. Each op runs through its
-normal verb handler. The handler's store-level `with_writer` (and, critically, its reads — see
-"read-your-writes" below) resolve to the ambient transaction's connection for the duration of the
-unit, instead of opening their own writer or reading from the concurrent reader pool. When no
-atomic unit is active (every existing code path), `with_writer` behaves exactly as it does today.
+The atomic path never dispatches a full verb handler inside `atomic_unit`. Instead:
 
-The ambient context is scoped strictly to the atomic unit (a task-local or an extension of the
-existing open-transaction registry from ADR-091), set on entry and cleared on exit. It is never
-observable outside the unit.
+1. **Prepare pass (async, per op, outside any transaction).** Each admissible op runs its verb's
+   `prepare` step — the same validation, identifier generation, secret masking, and (for verbs
+   that require it) embedding computation the handler does today — and produces a materialized
+   **write plan**: the concrete set of `SqlStatement`s that op will apply (base rows, FTS rows,
+   and any precomputed vector rows), plus a record of any post-commit side effect (e.g. ANN warm)
+   to run after the transaction. The ops-file is independent ops (no `$prev`), so prepare never
+   needs to _reference_ another op's output — but prepare-time validations can still be
+   invalidated by an earlier op in the same file naming the same caller-known identifier; plans
+   therefore carry in-transaction guards, per the validation-staleness rules below.
+2. **Commit pass (synchronous, one `atomic_unit`).** The runner opens one `atomic_unit`; inside
+   the closure — which drives only the `InlineWriter` and therefore never suspends — it applies
+   each op's plan under a named SAVEPOINT (`op_<n>`). On plan success the SAVEPOINT is released; on
+   the first plan error the whole unit rolls back and the failing op index is recorded. The unit
+   commits all plans or none.
+3. **Post-commit pass (async).** Deferred side effects recorded in prepare (ANN warming / index
+   maintenance) run once, after the commit, outside the transaction.
 
-**Read-your-writes requirement.** Inside the unit, op _N_ must observe op _N-1_'s uncommitted
-writes (e.g. a `link` that references an entity created by an earlier op in the same file). Under
-WAL, the concurrent reader-pool connections do not see the writer's open transaction. Therefore,
-while an atomic unit is active, a handler's reads MUST route to the ambient transaction
-connection, not the reader pool. This is a correctness requirement, not an optimization, and has
-a dedicated acceptance test.
+The commit-pass closure is, by construction, DML-only, so it satisfies the _atomic-unit
+suspend-free invariant_: behavior is identical whether or not the single-writer flag is on. This
+is the whole reason the previous draft's "dispatch real handlers inside `atomic_unit`" mechanism
+was rejected — it violated the invariant. Two-phase relocates every suspension-bearing step
+(embedding, ANN) to the prepare and post-commit passes, leaving only synchronous DML under the
+transaction. It also keeps the SQLite write transaction open only for the DML apply, never across
+embedding or ANN work, which is what makes the writer-hold and daemon-coexistence bounds (D2,
+"Daemon coexistence") honest.
+
+The handler-logic-duplication objection is answered by **refactoring** each admissible verb to
+expose its own `prepare` → apply seam, reusing the handler's existing compute and statement
+generation. The bulk-apply crate calls that seam; it does not re-derive identifier generation,
+validation, or index maintenance. This is the same "transaction-enlisted execute-only" pattern the
+codebase already uses where a durable append must enlist in a caller-owned transaction: expose a
+step that runs statements on a provided writer and opens no transaction of its own, and let the
+caller wrap N of them in one unit.
+
+**This two-phase shape is the chosen mechanism. Its two known weak points, examined rather than
+assumed away:**
+
+- **Prepare/commit staleness.** In two-phase, an op's write plan is materialized in the prepare
+  pass, before the transaction opens. Staleness therefore has two distinct classes, and they are
+  handled differently:
+
+  **Content-derived staleness** (a precomputed value goes stale): if a _later_ op in the same file
+  mutates the same target, an earlier op's precomputed value can be committed against content the
+  later op overwrote — e.g. an embedding computed for content C, committed while a later op sets
+  the content to C'. **v1 is immune to this class:** the v1 admissible set is DML-only (D3), so
+  the prepare pass computes no embeddings and materializes only parameterized statements; there is
+  nothing content-derived to go stale. The hazard exists **only** for the deferred
+  embedding-bearing extension, and it is a hard precondition on that extension: before any
+  embedding-bearing verb is admitted, the atomic runner must detect intra-file write-write
+  conflicts on the same target (reject, or recompute the loser's embedding in target order).
+
+  **Validation staleness** (a prepare-time validation goes stale): prepare validates each op
+  against **pre-transaction** state, but ops in one file can name the same caller-known
+  identifier, so an earlier op in the commit pass can invalidate what a later op's prepare
+  checked. This class is NOT excluded by DML-only scoping, and `graph_edges` has no foreign-key
+  enforcement (endpoint integrity is handler-validation only), so SQLite will happily commit the
+  inconsistency. Concrete v1 hazards: a file `[delete(X, hard), link(A, X)]` would commit a
+  dangling edge; `[link(from, Z), merge(into, from)]` would strand a live edge on the merged-away
+  entity if merge's plan pre-enumerated edge rows at prepare; `[delete(X), update(X)]` would
+  report a committed success whose UPDATE affected zero rows. **v1 closes this class with two
+  mandatory plan rules:**
+
+  1. **Predicate-based plans wherever a write's scope depends on current state.** A plan whose
+     effect covers "all rows matching a condition" must be materialized as a predicated statement
+     evaluated **inside** the transaction (e.g. merge's edge rewire is
+     `UPDATE graph_edges SET source_id = :into WHERE source_id = :from`), never as a
+     prepare-time-enumerated row list. In-transaction evaluation sees every earlier op's writes,
+     so this rule eliminates the merge-rewire hazard structurally.
+  2. **Affected-row guards wherever prepare assumed row existence.** Any plan statement whose
+     prepare-time validation asserted that a target row exists (an edge insert's endpoint check, an
+     update's target check, a delete's target check) carries an expected-effect guard checked in
+     apply: if the affected-row count (or an in-transaction existence probe for inserts whose
+     validity depends on another row) does not match what prepare assumed, the op **fails inside
+     the unit** and the whole unit rolls back. A prepare-time validation is thus a plan
+     _hypothesis_, re-verified under the transaction, never a commitment.
+
+  The immunity claim is deliberately narrow: DML-only scoping buys immunity to **content-derived**
+  staleness only; **validation** staleness is closed by the two plan rules above, and the
+  dangling-edge acceptance criterion pins the worst case. (A conservative alternative — rejecting
+  any `--atomic` file with two ops naming the same target — was considered and rejected for v1:
+  same-target sequences like transition-then-complete are legitimate, and the guard rules make
+  them safe rather than forbidden.)
+- **Refactoring surface of "the handler's own factored code."** Each admissible verb must grow a
+  `prepare`/apply split. For the v1 DML-only set the split is small: those handlers already reduce
+  to "validate and resolve identifiers, then execute statements," so `prepare` returns the
+  statements and `apply` runs them. The cost is real but bounded to the v1 verb list, and it is a
+  factoring of existing code, not new logic. The embedding-bearing extension is where the split
+  becomes a genuine per-handler refactor (hoisting embedding out of the write), which is the second
+  reason it is deferred out of v1.
+
+Neither weak point sinks two-phase; both are contained by scoping v1 to DML-only verbs, and both
+are stated as explicit gates on the extension. That is why two-phase is chosen over the rejected
+alternatives below.
 
 **Alternatives considered:**
 
-- **(a) Thread a `SqlTransaction` handle through `dispatch_request_local` → the registry →
-  every handler signature (the ADR-067 sketch).** Rejected. The blast radius is every handler
-  signature in every pack, plus the runtime service methods those handlers call. The ambient-
-  context approach achieves the same enlistment by changing the store-level `with_writer`/reader
-  seam — the same, already-migrated surface ADR-067 touched — without rewriting handler
-  signatures.
-- **(b) Compile write-shaped ops to raw `SqlStatement`s and run them directly in one
-  `atomic_unit`, bypassing handlers.** Rejected. Verb handlers own non-trivial logic (identifier
-  generation, dedup, endpoint validation, FTS/vector index maintenance, secret masking).
-  Re-deriving that as raw SQL in the bulk-apply crate duplicates it and guarantees drift. The
-  standing lesson from the fold-gate work is explicit: reuse the insert logic behind the seam;
-  do not duplicate it into the consuming crate.
-- **(c) Writer lease — the writer task grants an exclusive long-lived transaction slot held
-  across the whole dispatch.** Rejected as the general mechanism. Holding the single writer's
-  `BEGIN IMMEDIATE` open across N arbitrary verb dispatches — each potentially doing slow reads,
-  ANN recall, or service calls — reintroduces exactly the long-held-write-lock starvation that
-  ADR-067 eliminated. A lease is only safe if what runs under it is bounded to fast DML, which is
-  what D3's write-verb restriction already enforces; at that point the lease is just `atomic_unit`
-  with extra machinery. The `atomic_unit` seam is the lease, minus the wedge risk.
-- **(d) Savepoint-per-op composition.** Adopted as a **component of the chosen design**, not an
-  alternative to it. Inside the one `atomic_unit`, each op is wrapped in a named SAVEPOINT so a
-  failure rolls the unit back to a known point and reports the failing op index. This is the same
-  SAVEPOINT-per-request hierarchy ADR-067 already uses for per-op isolation, reused here for
-  attribution.
+- **(a) Dispatch full verb handlers inside one `atomic_unit` (the previous draft's mechanism).**
+  Rejected — unsupported by the shipped seam. Real handlers suspend (embedding, ANN warm);
+  `atomic_unit`'s flag-on driver (`block_on_sync`) returns an error on suspension, and the flag-off
+  path would silently permit it, producing liveness-dependent behavior. This is the blocker that
+  forced this redesign.
+- **(b) Redesign `atomic_unit`/`WriterTask` to drive async closures on the writer connection.**
+  Rejected. Allowing the writer task to `await` external work while holding the single write
+  connection reintroduces exactly the long-held-write-lock starvation ADR-067 eliminated: an
+  embedding call inside the held transaction would pin the write lock for the embedding latency.
+  It also enlarges the most safety-critical seam in the storage layer for a CLI feature.
+- **(c) Compile ops to raw SQL directly in the bulk-apply crate, bypassing handlers.** Rejected.
+  It duplicates handler logic (identifier generation, dedup, endpoint validation, FTS/vector index
+  maintenance, secret masking) and guarantees drift. The prepare/apply seam gives the same
+  synchronous-DML result while reusing the handler's own code.
+- **(d) Unbounded writer lease across arbitrary dispatch.** Rejected — the general lease holds the
+  writer's transaction open across arbitrary async dispatch, the wedge shape ADR-067 removed. The
+  two-phase design is the bounded, DML-only realization of the same intent.
+- **(e) Savepoint-per-op.** Adopted as a component of the chosen design (the per-op SAVEPOINT in
+  the commit pass), not an alternative to it.
 
 ### D2 — Unit of atomicity for `--ops-file`
 
@@ -165,221 +257,277 @@ configurable op-count guard.**
   whole or not at all.
 - **Opt-in.** `--atomic` is off by default. Idempotent mass updates keep today's non-atomic,
   per-op-independent behavior with no latency change.
-- **Bounded.** A whole-file atomic unit holds the single writer for the full duration of the
-  unit. The load harness that qualified ADR-067 already shows multi-second write-slot tails under
-  concurrency, so an unbounded 10k-op atomic file is a product-visible stall for every other
-  writer on the process. Under `--atomic`, a file exceeding a configurable maximum op count
-  (recommended default on the order of a few thousand ops; final value tuned against the harness)
-  is **rejected before execution** with a clear error directing the caller to split the file or
-  run without `--atomic`. This keeps the maximum writer-hold predictable and bounded.
+- **Bounded.** The commit pass holds the single writer for the duration of the DML apply. Because
+  embedding and ANN work are hoisted out of the transaction (D1), the hold is a clean, near-linear
+  function of the plan's DML statement count — no embedding latency inside the window. Even so, an
+  unbounded 10k-op atomic file is a multi-second exclusive DML hold and a product-visible stall for
+  every other writer on the process. Under `--atomic`, a file exceeding a configurable maximum op
+  count (recommended default on the order of a few thousand ops; final value tuned against the
+  load harness) is **rejected before execution** with a clear error directing the caller to split
+  the file or run without `--atomic`.
 
 **Alternatives considered:**
 
-- **Per-chunk atomicity (all-or-nothing per 100).** Rejected: the boundary is arbitrary and would
-  silently change if the chunk constant changed. It also gives the caller no guarantee they can
-  reason about ("ops 1..100 committed but 101..137 did not" is not all-or-nothing).
-- **Always atomic (no flag).** Rejected: it would impose the whole-file writer-hold and the
-  write-verb restriction on the common idempotent-update case, and would break callers who rely
-  on partial progress of a large idempotent file.
+- **Per-chunk atomicity (all-or-nothing per 100).** Rejected: the boundary is arbitrary and gives
+  the caller no guarantee they can reason about.
+- **Always atomic (no flag).** Rejected: it would impose the whole-file writer-hold and the verb
+  restriction on the common idempotent-update case and break callers relying on partial progress.
 
 ### D3 — Admissible verbs under `--atomic`
 
-**Decision: restrict `--atomic` to write-shaped verbs; reject read/query verbs at parse time.**
+**Decision: admit only verbs that expose a prepare/apply seam whose in-transaction phase is
+synchronous DML. The v1 admissible set is the DML-only mutations; embedding-bearing verbs and all
+read verbs are rejected at parse time.**
 
-Only mutation verbs may appear in an `--atomic` file (create, update, delete, link, merge,
-remember, and the task-lifecycle and message mutations, plus the propose/review/withdraw
-governance verbs). Read/search/recall/query/traverse/list/get verbs are rejected before the unit
-opens, with an error naming the offending line and verb.
+- **v1 admissible:** `update`, `delete`, `link`, `merge`, and the task-lifecycle and message
+  mutations (`gtd.*` transitions, `comm` mutations), plus the governance verbs
+  (`propose`/`review`/`withdraw`) — the verbs whose prepare is validation and identifier
+  resolution only and whose apply is pure DML.
+- **`update` and `merge` caveat (verified at source).** Under the current handlers, `update`
+  triggers a reindex when name or description change, and that reindex awaits embedding
+  (`reindex_entity` in `crates/khive-runtime/src/curation.rs`); property-only updates skip
+  reindex entirely (covered by an existing regression test). `merge` already performs its
+  vector re-insert **after** its transaction, precisely because embedding is async — the
+  handler's own documentation states this. So the codebase already contains the pattern this
+  design needs: row and FTS DML commit inside the transaction; embedding reindex runs as a
+  post-commit side effect, under reindex's existing best-effort warn-and-continue contract (a
+  failed re-embed leaves a stale vector, never a failed write). Under `--atomic`, `update` and
+  `merge` follow that same split: their write plans carry the row/FTS DML; any needed reindex
+  is recorded as a post-commit side effect and computes its embedding from the **committed**
+  row content, which also means no prepare-time embedding exists to go stale. The v1 prepare
+  pass therefore still computes no embeddings, and the staleness-immunity claim in D1 holds.
+- **v1 rejected — embedding-bearing:** `create` (entity/note/document) and `memory.remember`
+  compute embeddings and warm ANN as part of the write. They are excluded from `--atomic` v1
+  because their prepare seam (hoisting embedding out of the transaction) is not yet built. An
+  `--atomic` file containing one is rejected before execution with an error naming the line and
+  verb and stating that embedding-bearing verbs are not yet atomic-eligible.
+- **v1 rejected — reads:** `search` / `recall` / `query` / `traverse` / `list` / `get` /
+  `neighbors` / `context` and the other read verbs are rejected: they do not belong in an
+  all-or-nothing write unit, and (per the prepare/apply model) they have no write plan to apply.
 
-Rationale: the atomic unit holds the single writer's transaction open for its whole duration.
-Restricting the unit to fast DML keeps that hold short and predictable and prevents a slow read
-(ANN recall, large search) from extending the write-lock hold — the precise failure ADR-067
-removed. Handler-internal reads (endpoint validation, dedup lookups) are fine: they are fast,
-run on the ambient transaction connection, and are necessary for read-your-writes.
+The admissibility of a verb is a static property — does its apply phase honor the _atomic-unit
+suspend-free invariant_ (reduce to synchronous DML with no in-transaction await)? — declared per
+verb as pack metadata. The parser consults that metadata and rejects any inadmissible op before
+the prepare pass runs. This is additive pack metadata, not a change to handler signatures. The
+admissibility flag is the design-time expression of the same invariant the suspend-trap regression
+test enforces at runtime (Acceptance criteria).
 
-**Alternative considered: allow arbitrary verbs inside the unit.** Rejected: it reintroduces the
-long-held-write-lock wedge and conflates "atomic mutation" with "read-modify-write transaction,"
-a materially larger and riskier feature that issue #195 does not ask for.
+**Extension path (not v1):** embedding-bearing verbs become admissible once their handlers hoist
+embedding computation into the prepare pass so the transaction still applies only synchronous DML.
+This is deliberately deferred: it is a larger per-handler refactor, and the #195 driver
+(salience recalibration, mass cleanse) is satisfied by the DML-only set.
+
+**Alternative considered: admit all write verbs and hold the transaction across their embedding.**
+Rejected: it holds the write lock across embedding/ANN latency, making the writer-hold and
+daemon-coexistence bounds dishonest, and it conflicts with the `atomic_unit` suspension contract.
 
 ### Daemon coexistence under `--atomic`
 
-Bulk apply runs in-process and does not traverse the daemon. When a live daemon is serving
-the same database file, an `--atomic` run therefore holds a **cross-process**
-`BEGIN IMMEDIATE` on that file for the duration of the unit, while the daemon's write owner
-continues to operate inside its own process. The single-writer guarantee is per-process; the
-two processes coordinate through SQLite's file-level write lock.
+Bulk apply runs in-process and does not traverse the daemon. When a live daemon is serving the same
+database file, an `--atomic` run holds a **cross-process** `BEGIN IMMEDIATE` on that file for the
+duration of the commit pass, while the daemon's write owner operates inside its own process. The
+single-writer guarantee is per-process; the two processes coordinate through SQLite's file-level
+write lock.
 
-**Decision: accept bounded cross-process coexistence; do not route `--atomic` through the
-daemon.**
+**Decision: accept bounded cross-process coexistence; do not route `--atomic` through the daemon.**
 
-- This coexistence is not new. The non-atomic bulk apply already writes cross-process
-  against a live daemon today — each op takes its own short-lived write lock. `--atomic`
-  changes the **duration** of the hold, not its existence, and the duration is exactly what
-  the D2 op-count guard bounds.
-- Expected daemon-side behavior during the atomic window: daemon writes wait on the
-  configured `busy_timeout` and proceed when the unit commits. A window shorter than the
-  busy timeout delays daemon writes without failing them; a window that exceeds it surfaces
-  `SQLITE_BUSY` to daemon callers. The op-count guard default is therefore sized (from
-  harness measurement) so the worst-case hold stays well inside the default busy timeout,
-  and the `--atomic` documentation directs operators to run large atomic cleanses in a
-  maintenance window or against an idle daemon.
-- **Alternative considered: route `--atomic` through the daemon when one is live, so the
-  daemon's write owner holds the unit.** Rejected for this ADR. It requires a new daemon
-  bulk-transaction protocol surface, reintroduces the transport frame cap that in-process
-  bulk apply exists to avoid, and creates a behavioral fork (flag semantics differ by
-  daemon liveness). If operational experience shows the bounded window is insufficient,
-  daemon-routed atomicity can be a follow-up that reuses this ADR's ambient-context
-  machinery unchanged.
-- **Alternative considered: refuse `--atomic` when a live daemon is detected.** Rejected:
-  liveness detection is racy (a daemon may start mid-unit), and a hard refusal blocks the
-  legitimate bounded case the guard already covers.
+- This coexistence is not new. The non-atomic bulk apply already writes cross-process against a
+  live daemon today — each op takes its own short-lived write lock. `--atomic` changes the
+  **duration** of the hold, not its existence, and the duration is exactly what the D2 op-count
+  guard bounds. Because embedding is hoisted out of the transaction (D1), the held window is
+  DML-only, so the guard's op-count-to-duration relationship is clean and the bound is honest.
+- Expected daemon-side behavior during the window: daemon writes wait on the configured
+  `busy_timeout` and proceed when the unit commits. A window shorter than the busy timeout delays
+  daemon writes without failing them; a window that exceeds it surfaces `SQLITE_BUSY` to daemon
+  callers. The op-count guard default is therefore sized (from harness measurement) so the
+  worst-case DML hold stays well inside the default busy timeout, and the `--atomic` documentation
+  directs operators to run large atomic cleanses in a maintenance window or against an idle daemon.
+- **Alternative considered: route `--atomic` through the daemon when one is live.** Rejected for
+  this ADR. It requires a new daemon bulk-transaction protocol surface, reintroduces the transport
+  frame cap that in-process bulk apply exists to avoid, and creates a behavioral fork (semantics
+  differ by daemon liveness). If operational experience shows the bounded window is insufficient,
+  daemon-routed atomicity can be a follow-up.
+- **Alternative considered: refuse `--atomic` when a live daemon is detected.** Rejected: liveness
+  detection is racy and a hard refusal blocks the legitimate bounded case the guard covers.
 
 ### D4 — Error response shape for partial-failure rollback
 
-**Decision: additive envelope. Non-atomic batches unchanged; atomic-unit abort reported
-explicitly.**
+**Decision: preserve the existing `results` + `summary` shape and add an `atomic` block. Pin the
+field names.**
 
-- Non-atomic (default) responses are **byte-identical** to today: each op yields its own
-  `{ok, tool, result | error}` and a failure never aborts siblings.
-- Under `--atomic`, on the first failing op the whole unit rolls back. The response reports:
-  - the failing op's index and its error,
-  - that the unit was rolled back (no op committed),
-  - the remaining ops marked not-committed rather than succeeded.
+The non-atomic (default) CLI output is **unchanged**. The `--atomic` output is the same
+`results` + `summary` shape plus one additive top-level `atomic` object:
 
-  A representative shape (final field names settled in implementation):
+```json
+{
+  "results": [ { "ok": true,  "tool": "update", "result": { ... } },
+               { "ok": false, "tool": "delete", "error": "..." },
+               { "ok": false, "tool": "update", "error": "unit rolled back" } ],
+  "summary": { "total": 3, "succeeded": 0, "failed": 3 },
+  "atomic":  { "committed": false, "rolled_back": true, "failed_op_index": 1,
+               "error": "<message from the failing op>" }
+}
+```
 
-  ```json
-  {
-    "atomic": true,
-    "committed": false,
-    "failed_op_index": 47,
-    "error": "<message from the failing op>",
-    "ops": [ { "index": 0, "committed": false, "rolled_back": true }, ... ]
-  }
-  ```
+- On full success: `"atomic": { "committed": true, "rolled_back": false, "failed_op_index": null }`,
+  and `results`/`summary` carry the per-op outcomes as usual.
+- On abort: `committed=false`, `rolled_back=true`, `failed_op_index` = the zero-based index of the
+  first failing op, `error` = that op's error message. Because the unit rolled back, no op is
+  reported as `succeeded` in `summary`; each entry in `results` reflects not-committed. The
+  failing op's `results` entry carries its real error; the others carry a uniform "unit rolled
+  back" marker so a reader can distinguish the cause from the collateral.
+- The `atomic` object appears only on the `--atomic` path. `results` and `summary` retain the exact
+  meaning ADR-016 defines; no field is removed or repurposed. This is the `kkernel exec`
+  CLI-printed shape and does not alter the MCP `request` wire envelope.
 
-- On full success, `{ "atomic": true, "committed": true, ... }` with the per-op results.
-
-The `atomic`, `committed`, `failed_op_index`, and `rolled_back` fields are **additive**; they
-appear only on the atomic path. No field is removed or repurposed on the non-atomic path, so no
-existing consumer breaks.
-
-**Alternative considered: reuse the existing per-op `ok/error` array with no new fields.**
-Rejected: a caller could not distinguish "this op failed but siblings committed" (non-atomic)
-from "this op failed so the whole unit rolled back" (atomic). The distinction is the entire point
-of the feature and must be explicit in the envelope.
+**Alternative considered: a separate `ops` array instead of `results`.** Rejected: it diverges from
+the established `results`/`summary` contract for no benefit; the additive `atomic` block carries
+everything the atomic path needs.
 
 ### D5 — Fate of `begin_tx()`
 
-**Decision: convert the single live caller to `atomic_unit`, closing the standalone-writer hole;
-then remove the `begin_tx` trait method if no non-test caller remains.**
+**Decision: convert the session-ingest caller to `atomic_unit`, closing that standalone-writer
+hole; then remove the `begin_tx` trait method if no non-test caller remains.**
 
 The session-mirror ingest path (`write_events_and_cursor`) is a clean `atomic_unit` shape: it
-opens a transaction, performs a sequence of DML statements (session upsert, message insert,
-cursor advance), and commits once, with no branch-on-read logic that needs a live incremental
-handle. It converts directly: the loop body becomes the `atomic_unit` closure; the cursor advance
-is the last statement in the closure; the all-or-nothing contract is preserved because
-`atomic_unit` commits once at the end or rolls the whole closure back.
+performs a sequence of DML statements (session upsert, message insert, cursor advance) and commits
+once, with no branch-on-read logic that needs a live incremental handle. It converts by moving the
+loop body into the `atomic_unit` closure; the cursor advance is the closure's last statement; the
+all-or-nothing contract is preserved because `atomic_unit` commits once or rolls the whole closure
+back.
 
-Once converted, `begin_tx` has no live production caller. The standalone-writer hole is closed by
-**removing the caller**, independent of whether the method itself is deleted. Implementation then:
+**Suspension-safety (verified — this closure must satisfy the _atomic-unit suspend-free
+invariant_).** The converted closure drives **only** the provided writer with inline-built
+`SqlStatement`s: it issues session and message INSERTs and the cursor UPDATE and does no embedding,
+no ANN warming, and no other `await` on an external service. On the single-writer path the closure
+therefore resolves on its first poll and satisfies the invariant; on the flag-off path it runs
+under the manual transaction identically. The conversion is admissible precisely because the ingest
+write is already pure sequential DML. The implementation must keep it that way: no embedding or
+service call may be introduced inside the closure, and the acceptance suite includes a test that
+the closure does not suspend.
+
+Once converted, `begin_tx` has no live production caller **in this ADR's scope**. The hole is closed
+by removing the caller, independent of whether the method is deleted. Implementation then:
 
 1. Greps for any remaining non-test caller of `begin_tx` and of the `SqlTransaction` trait.
-2. If none remains and the `SqlTransaction` handle is not load-bearing forward-deployed
-   infrastructure elsewhere, removes `begin_tx` from `SqlAccess` and its `SqlBridge`
-   implementation, and collapses the now-dead `SqlTransaction` machinery.
-3. If `SqlTransaction`/the open-transaction registry is genuinely forward-deployed
-   infrastructure, keeps the trait but leaves `begin_tx` with **no production caller** and a doc
-   note that production atomicity goes through `atomic_unit`. Either way, the competing-writer
-   hole is closed because the live caller is gone.
+2. If none remains and `SqlTransaction` is not load-bearing forward-deployed infrastructure,
+   removes `begin_tx` from `SqlAccess` and its `SqlBridge` implementation and collapses the dead
+   machinery.
+3. If `SqlTransaction` is genuinely forward-deployed infrastructure, keeps the trait but leaves
+   `begin_tx` with no production caller and a doc note that production atomicity goes through
+   `atomic_unit`. Either way the competing-writer hole from this path is closed.
 
-Removing a method from `SqlAccess` touches the storage trait surface (the trait declaration, the
-`SqlBridge` implementation, and test callers). This trait is internal to the runtime; there is no
-external SDK consuming it, so the change is contained.
+Removing a method from `SqlAccess` touches the storage trait surface (declaration, `SqlBridge`
+implementation, test callers). The trait is internal to the runtime; no external SDK consumes it,
+so the change is contained.
 
 **Alternatives considered:**
 
-- **(i) Migrate `begin_tx` onto the writer task as a lease.** Rejected for the same reason the
-  lease was rejected in D1: a live incremental transaction handle held across caller-driven calls
-  is exactly the long-held-lock shape ADR-067 removed, and the one live caller does not need an
-  incremental handle — it needs one atomic closure, which `atomic_unit` already provides.
-- **(iii) Keep `begin_tx` standalone as a permanent documented exemption.** Rejected. As long as a
-  live caller opens a standalone `BEGIN IMMEDIATE` outside the writer, the single-writer guarantee
-  has a hole under concurrency. The exemption only made sense while there was no seam to move the
-  caller to; `atomic_unit` is that seam.
+- **(i) Migrate `begin_tx` onto the writer task as a lease.** Rejected: a live incremental handle
+  held across caller-driven calls is the long-held-lock shape ADR-067 removed, and the one live
+  caller needs one atomic closure, which `atomic_unit` already provides.
+- **(iii) Keep `begin_tx` standalone as a permanent exemption.** Rejected: as long as a live caller
+  opens a standalone `BEGIN IMMEDIATE` outside the writer, the single-writer guarantee has a hole.
+  `atomic_unit` is the seam to move the caller to.
 
-### D6 — Document structure (F5)
+### D6 — Document structure
 
 **Decision: confirm the split.** This follow-up ADR carries the design (D1–D5). A **separate,
-small ADR-067 amendment** records the now-final write-path facts as merged: `begin_tx` as the sole
-converted-away live caller, the top-level maintenance seam
-(`execute_script_top_level`) as shipped, and any unmanaged write site surfaced during the
-inventory (e.g. an orphan-sweep path in the vector store) dispositioned MIGRATE or EXEMPT.
+small ADR-067 amendment** records the now-final write-path facts as merged: the session-ingest
+`begin_tx` conversion, the `orphan_sweep` residual and its separately-tracked conversion, and the
+top-level maintenance seam (`execute_script_top_level`) as shipped.
 
 Rationale: the amendment is a documentation-truth correction to an already-accepted ADR and can
-land immediately and independently; the design ADR is a forward decision that goes through the
-normal design-review gate. Keeping them separate matches the repository convention of not bundling
-a documentation correction with a design change, and lets neither block the other.
+land independently; the design ADR is a forward decision that goes through the design-review gate.
+Keeping them separate matches the repository convention of not bundling a documentation correction
+with a design change, and lets neither block the other. `orphan_sweep`'s conversion is tracked
+under that amendment as its own change and is **not** absorbed into this ADR's migration steps.
 
 **Alternative considered: one combined document.** Rejected: it couples an immediately-landable
-inventory correction to a design that needs review, and mixes "record what merged" with "decide
-what to build."
+inventory correction to a design that needs review.
 
 ---
 
 ## Migration steps
 
-1. Add the ambient write-context scope (task-local or an extension of the open-transaction
-   registry) and teach the store-level `with_writer` and reader seams to resolve to the ambient
-   transaction connection when a unit is active. No behavior change when no unit is active.
-2. Add the in-process `dispatch_request_atomic` entry that opens one `atomic_unit`, sets the
-   ambient context, dispatches the file's ops inside it with a SAVEPOINT per op, and clears the
-   context on exit.
-3. Add `--atomic` to `exec --ops-file`. Under the flag: reject read-shaped verbs at parse time
-   (D3); reject files over the op-count guard (D2); route the whole file through
-   `dispatch_request_atomic`.
-4. Implement the additive atomic failure envelope (D4).
+0. **Warn the seam in its own code.** Add a doc-comment to `SqlAccess::atomic_unit` (the trait
+   declaration in `crates/khive-storage/src/sql.rs`) and to its `SqlBridge` implementation
+   (`crates/khive-db/src/sql_bridge.rs`) stating the _atomic-unit suspend-free invariant_
+   explicitly: the closure must complete on its first poll and may issue only synchronous DML; any
+   real `await` (embedding, ANN, service, channel) fails on the single-writer path and silently
+   passes flag-off. This near-shipped twice in one day; the warning must live in the code the next
+   consumer reads, not only in this ADR.
+1. Add a per-verb `prepare`/apply seam to the v1 admissible verbs (`update`, `delete`, `link`,
+   `merge`, the task-lifecycle and message mutations, the governance verbs): `prepare` runs the
+   existing async validation/identifier work and returns a materialized write plan (the
+   `SqlStatement`s plus any post-commit side effect); apply issues those statements on a provided
+   writer with no transaction control of its own.
+2. Add per-verb atomic-admissibility metadata and the parse-time rejection for inadmissible verbs
+   (embedding-bearing and read verbs) under `--atomic`.
+3. Add the atomic runner: an in-process entry that runs the prepare pass over the file, opens one
+   `atomic_unit`, applies each plan under a per-op SAVEPOINT, commits or rolls back, then runs the
+   post-commit side effects.
+4. Add `--atomic` to `exec --ops-file`: enforce the op-count guard (D2), route the file through the
+   atomic runner, and print the additive `atomic` envelope (D4).
 5. Convert `write_events_and_cursor` (session-mirror ingest) from `begin_tx` to `atomic_unit`
-   (D5), preserving the cursor-advances-only-on-commit contract.
+   (D5), preserving the cursor-advances-only-on-commit contract and its suspension-free property.
 6. Grep for remaining non-test `begin_tx`/`SqlTransaction` callers; remove `begin_tx` from
    `SqlAccess` and its implementation if none remains, else document the no-live-caller state.
-7. Land the companion ADR-067 amendment separately (D6).
+7. Land the companion ADR-067 amendment separately (D6). `orphan_sweep` conversion is tracked
+   there, not here.
 
-Schema is unchanged; no migration file is required. Pack rules are unchanged; this is additive.
+Schema is unchanged; no migration file is required. Pack rules gain only additive per-verb metadata.
 
 ---
 
 ## Acceptance criteria
 
-- **Atomic rollback end-to-end.** An `--atomic` ops-file with a deliberate mid-file failure
-  (e.g. a valid op followed by an op that must fail, followed by more valid ops) leaves the
-  database **unchanged**: none of the file's writes are present after the run, and the response
-  reports the failing op index with `committed: false`.
-- **Read-your-writes within a unit.** An `--atomic` file where a later op references an entity
-  created by an earlier op in the same file succeeds, proving later ops observe earlier
-  uncommitted writes through the ambient transaction connection.
-- **Write-verb restriction.** An `--atomic` file containing a read/recall/query verb is rejected
-  before any write occurs, naming the offending line and verb.
+- **Atomic rollback end-to-end.** An `--atomic` ops-file of admissible verbs with a deliberate
+  mid-file failure leaves the database **unchanged**: none of the file's writes are present after
+  the run, and the response reports `atomic.committed=false` with `failed_op_index` set to the
+  first failing op.
+- **Suspend-trap regression test (fails loudly, never silently).** Two paired assertions enforce
+  the _atomic-unit suspend-free invariant_: (a) the real commit-pass closure over admissible DML
+  verbs resolves on its first poll and commits, proving the happy path is genuinely synchronous;
+  and (b) a closure that deliberately routes a _suspending_ future (a real embedding-bearing
+  handler, or a stand-in that awaits) through the atomic path returns the `block_on_sync`
+  suspension error and aborts the unit — it must fail loudly, not silently succeed or wedge. This
+  is the guard that a future change admitting an embedding-bearing verb without hoisting its
+  embedding is caught by a test, not discovered in production on the single-writer path.
+- **Embedding-bearing verb rejected.** An `--atomic` file containing `create` or `memory.remember`
+  is rejected before execution, naming the line and verb and stating embedding-bearing verbs are
+  not yet atomic-eligible.
+- **Read verb rejected.** An `--atomic` file containing a read/recall/query verb is rejected before
+  any write occurs, naming the line and verb.
 - **Op-count guard.** An `--atomic` file exceeding the configured maximum op count is rejected
   before execution with an actionable error.
+- **No dangling edge from intra-file validation staleness.** An `--atomic` file of the form
+  `[delete(X, hard), link(A, X)]` must **not** commit a dangling edge: the run is either rejected
+  up front or the unit rolls back in-transaction (the link op's affected-row/existence guard fails
+  once X is gone). After the run, the database contains neither the edge nor a partial subset of
+  the file's writes.
 - **Non-atomic parity.** With `--atomic` absent, bulk apply output and per-op semantics are
   byte-identical to the pre-change behavior (per-op independence preserved; a failing op does not
   abort siblings).
+- **Envelope contract.** On both success and abort, the `--atomic` output preserves `results` and
+  `summary` per ADR-016 and adds the `atomic` block with the pinned field names (D4).
+- **Session-ingest suspension-free.** A test asserts the converted `write_events_and_cursor`
+  closure does not suspend (drives only synchronous DML), so it is `block_on_sync`-safe on the
+  single-writer path.
 - **Single-writer concurrency test (mandatory).** Concurrent session-mirror ingest plus normal
-  write traffic, with the single-writer task active, shows **no competing writer**: after
-  converting ingest to `atomic_unit`, no standalone `BEGIN IMMEDIATE` is issued outside the writer
-  owner on any concurrent path. This path is not exercised by the general write-load harness and
-  must be covered explicitly.
-- **Daemon coexistence under `--atomic`.** With a live daemon serving the same database file
-  and carrying concurrent write traffic, an `--atomic` run within the op-count guard
-  commits successfully, the daemon's concurrent writes complete (delayed at most by the
-  atomic window, none lost, no corruption), and any daemon-side `SQLITE_BUSY` is observed
-  only if the window is deliberately driven past the busy timeout. This cross-process case
-  is covered by neither the general write-load harness nor the in-process test suite and
-  must be exercised explicitly.
-- **Revert-companion test.** The key session-ingest and atomic-rollback tests demonstrably
-  **fail** against the pre-change shape (standalone `begin_tx`, per-op non-atomic bulk apply),
-  proving the tests are non-vacuous.
+  write traffic, with the single-writer task active, shows **no standalone `BEGIN IMMEDIATE` from
+  the session-ingest path** outside the writer owner after conversion. This path is not exercised
+  by the general write-load harness and must be covered explicitly. (This criterion is scoped to
+  the session-ingest path; `orphan_sweep` is out of scope, tracked under the ADR-067 amendment.)
+- **Daemon coexistence under `--atomic`.** With a live daemon serving the same database file and
+  carrying concurrent write traffic, an `--atomic` run within the op-count guard commits
+  successfully, the daemon's concurrent writes complete (delayed at most by the window, none lost,
+  no corruption), and any daemon-side `SQLITE_BUSY` is observed only if the window is deliberately
+  driven past the busy timeout. This cross-process case is covered by neither the general
+  write-load harness nor the in-process suite and must be exercised explicitly.
+- **Revert-companion test.** The key session-ingest and atomic-rollback tests demonstrably **fail**
+  against the pre-change shape (standalone `begin_tx`; per-op non-atomic bulk apply), proving the
+  tests are non-vacuous.
 - **Session-ingest no-partial-state preserved.** The existing regression that asserts the mirror
   cursor advances only when row writes commit passes after the `atomic_unit` conversion.
 
@@ -387,26 +535,28 @@ Schema is unchanged; no migration file is required. Pack rules are unchanged; th
 
 ## Open questions
 
-1. **Ambient-context carrier.** Task-local versus extending the existing open-transaction
-   registry. Both scope the context to the unit; the registry already tracks open transactions
-   and may be the more coherent home. A short implementation spike should pick one and confirm it
-   composes with the reader-routing requirement.
+1. **v1 admissible-set boundary — resolved at source.** `update` does embed on a name or
+   description change (via `reindex_entity`), and `merge` reindexes as well; property-only
+   updates skip reindex. Resolution adopted in D3: the reindex embedding moves to the
+   post-commit pass, following the pattern `merge` already uses today (its vector re-insert
+   runs after its transaction) and reindex's existing best-effort contract. Migration step 1
+   implements this split per verb; any verb whose embedding cannot be deferred post-commit is
+   moved to the deferred embedding-bearing set instead.
 2. **Op-count guard default.** The exact maximum-ops threshold for `--atomic` should be set from a
-   harness measurement of writer-hold time versus op count, not guessed. Ships configurable with a
-   conservative default.
-3. **`SqlTransaction` retention.** Whether the `SqlTransaction` trait and the open-transaction
-   registry are forward-deployed infrastructure worth keeping after `begin_tx`'s last caller is
-   gone, or dead machinery to collapse. Resolved by the implementation-time grep in migration
-   step 6.
+   harness measurement of DML-only writer-hold time versus op count, not guessed. Ships configurable
+   with a conservative default.
+3. **`SqlTransaction` retention.** Whether the `SqlTransaction` trait is forward-deployed
+   infrastructure worth keeping after `begin_tx`'s last caller is gone, or dead machinery to
+   collapse. Resolved by the implementation-time grep in migration step 6.
 
 ---
 
 ## References
 
-- ADR-067 — Write-Owner Daemon: single-writer task, the `atomic_unit` seam, per-request SAVEPOINT
-  isolation, and the `--ops-file` cross-op atomicity deferral this ADR resolves.
+- ADR-067 — Write-Owner Daemon: single-writer task, the `atomic_unit` seam and its synchronous-DML
+  (`block_on_sync`) contract, per-request SAVEPOINT isolation, and the `--ops-file` cross-op
+  atomicity deferral this ADR resolves.
 - ADR-005 — Storage capability traits: `SqlAccess`, `atomic_unit`, `begin_tx`, `SqlTransaction`.
-- ADR-016 — Request DSL and the per-op independence contract this ADR preserves on the non-atomic
-  path.
-- ADR-091 — Bounded read-transaction lifetime and WAL checkpoint escalation; its Plank 0 open-transaction registry is the candidate ambient-context carrier.
+- ADR-016 — Request DSL and the `results`/`summary` response contract this ADR preserves and
+  extends on the CLI atomic path.
 - Issue #195 — true cross-op atomicity for `exec --ops-file` bulk apply.

--- a/docs/adr/ADR-099-bulk-apply-atomic-units.md
+++ b/docs/adr/ADR-099-bulk-apply-atomic-units.md
@@ -290,19 +290,24 @@ read verbs are rejected at parse time.**
   same reason (it creates a task note). All are treated exactly like `create` and
   `memory.remember` below — rejected at parse time as embedding-bearing until a note prepare/apply
   seam exists.
-- **`update` and `merge` caveat (verified at source).** Under the current handlers, `update`
-  triggers a reindex when name or description change, and that reindex awaits embedding
-  (`reindex_entity` in `crates/khive-runtime/src/curation.rs`); property-only updates skip
-  reindex entirely (covered by an existing regression test). `merge` already performs its
-  vector re-insert **after** its transaction, precisely because embedding is async — the
-  handler's own documentation states this. So the codebase already contains the pattern this
-  design needs: row and FTS DML commit inside the transaction; embedding reindex runs as a
-  post-commit side effect, under reindex's existing best-effort warn-and-continue contract (a
-  failed re-embed leaves a stale vector, never a failed write). Under `--atomic`, `update` and
-  `merge` follow that same split: their write plans carry the row/FTS DML; any needed reindex
-  is recorded as a post-commit side effect and computes its embedding from the **committed**
-  row content, which also means no prepare-time embedding exists to go stale. The v1 prepare
-  pass therefore still computes no embeddings, and the staleness-immunity claim in D1 holds.
+- **`update` and `merge` caveat (verified at source) — applies to BOTH substrates.** Under the
+  current handlers, an entity `update` triggers a reindex when name or description change, and a
+  **note** `update` triggers a reindex when note name or content change (`reindex_entity` /
+  `reindex_note` in `crates/khive-runtime/src/curation.rs`); both reindex paths await embedding.
+  Property-only updates on either substrate skip reindex entirely (covered by existing
+  regression tests). `merge` already performs its vector re-insert **after** its transaction,
+  precisely because embedding is async — the handler's own documentation states this. So the
+  codebase already contains the pattern this design needs: row and FTS DML commit inside the
+  transaction; embedding reindex runs as a post-commit side effect, under reindex's existing
+  best-effort warn-and-continue contract (a failed re-embed leaves a stale vector, never a
+  failed write). Under `--atomic`, `update` (entity **and** note shapes) and `merge` follow that
+  same split: their write plans carry the row/FTS DML; any needed reindex — entity or note — is
+  recorded as a post-commit side effect and computes its embedding from the **committed** row
+  content, which also means no prepare-time embedding exists to go stale. The v1 prepare pass
+  therefore still computes no embeddings, and the staleness-immunity claim in D1 holds. The
+  admissibility metadata for `update` covers the whole verb only because this split is a
+  precondition of admitting it: an implementation that runs any reindex inside the transaction
+  violates the suspend-free invariant and must fail the suspend-trap test.
 - **v1 rejected — embedding-bearing:** `create` (entity/note/document) and `memory.remember`
   compute embeddings and warm ANN as part of the write. They are excluded from `--atomic` v1
   because their prepare seam (hoisting embedding out of the transaction) is not yet built. An
@@ -519,6 +524,13 @@ Schema is unchanged; no migration file is required. Pack rules gain only additiv
   the edge the earlier op inserted. No live edge remains on the merged-away entity. This pins the
   predicate-based-plan rule — a plan that pre-enumerated edge rows at prepare time fails this
   test.
+- **Note-content update reindexes post-commit only.** An `--atomic` file containing
+  `update(kind="note", content=...)` commits with the note's row and FTS DML inside the unit and
+  its embedding reindex deferred to the post-commit pass: no embedding computation occurs inside
+  the transaction (the suspend-trap assertion covers this path), and after the run the note's
+  vector reflects the committed content. This pins the note shape of the `update` caveat — an
+  implementation whose admissibility metadata admits `update` while running `reindex_note`
+  in-transaction fails this test.
 - **Zero-row apply fails the unit.** An `--atomic` file of the form `[delete(X, hard), update(X)]`
   does **not** report success: the update's affected-row guard observes zero rows inside the
   transaction, the op fails, and the whole unit rolls back (X is restored, `atomic.committed` is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -122,6 +122,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-094](ADR-094-lifecycle-telemetry-events.md)             | Sequencing-Assertable Lifecycle Telemetry Events (Proposed)                                                     |
 | [ADR-095](ADR-095-verb-surface-consolidation.md)             | Verb-Surface Consolidation and Field-Validation Governance (Proposed)                                           |
 | [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | Warm Daemon Per-Request Identity — Serving Many Attribution Identities Over One Shared Backend (Accepted)       |
+| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Atomic Units over the Single-Writer Seam (Accepted)                         |
 
 ## Closed Taxonomies — Quick Reference
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -122,7 +122,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-094](ADR-094-lifecycle-telemetry-events.md)             | Sequencing-Assertable Lifecycle Telemetry Events (Proposed)                                                     |
 | [ADR-095](ADR-095-verb-surface-consolidation.md)             | Verb-Surface Consolidation and Field-Validation Governance (Proposed)                                           |
 | [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | Warm Daemon Per-Request Identity — Serving Many Attribution Identities Over One Shared Backend (Accepted)       |
-| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Atomic Units over the Single-Writer Seam (Accepted)                         |
+| [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam (Accepted)                 |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
Docs-only PR (no code changes).

## ADR-099 (new): Cross-Op Atomicity for Bulk Apply — Atomic Units over the Single-Writer Seam
Resolves the design deferral recorded in ADR-067's "Issue #195 — decision" section.

- Opt-in `--atomic` on `exec --ops-file`: the whole file executes as one `atomic_unit`; default (no flag) behavior unchanged and byte-identical.
- Real verb handlers enlisted via an ambient write context at the store-level writer/reader seam — no handler-signature threading, no raw-SQL bypass.
- Write-shaped verbs only under `--atomic` (read/query rejected at parse time) to bound the writer hold; SAVEPOINT per op for failure attribution.
- Read-your-writes requirement: handler reads route to the ambient transaction connection during a unit (WAL reader pools cannot see the open writer transaction).
- Daemon coexistence: bounded cross-process `BEGIN IMMEDIATE` accepted knowingly (op-count guard sized against the busy timeout); daemon-routed atomicity and refuse-on-live-daemon considered and rejected with rationale.
- Additive error envelope; no MCP wire change.
- `begin_tx()` retirement: its sole live production caller (session-mirror ingest) converts to `atomic_unit`; the trait method is removed only if an implementation-time grep (evidence to be included verbatim in the implementation PR body) finds no non-test caller and the transaction registry is not load-bearing elsewhere.
- Acceptance criteria include: atomic rollback end-to-end, read-your-writes, write-verb restriction, op-count guard, non-atomic byte-parity, a dedicated session-ingest concurrency test, a daemon-coexistence test, and revert-companion tests.

## ADR-067 Amendment 1: write-path inventory as merged
Documentation-truth correction after PR #670 landed Component A:

- Records the two seams the implementation added beyond the original text (`SqlAccess::atomic_unit`, `SqlWriter::execute_script_top_level`).
- Corrects the migration inventory with function-name anchors (line numbers drifted), including: `begin_tx`'s sole live caller (deferred to ADR-099), the vector-store `orphan_sweep` unmanaged write path (dispositioned MIGRATE), and the by-design exemptions (periodic checkpoint, startup DDL).
- Clarifies the Issue-195 dependency wording: bulk apply is in-process, so the dependency is the `atomic_unit` seam, not the daemon-resident task.

Implementation follows in a separate PR per the migration steps in ADR-099.