### PR TITLE
refactor(storage): retire begin_tx — session ingest through atomic_unit (ADR-099 D5)

### DIFF
--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -730,43 +730,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sqlite_read_only_default_transaction_rejects_writes() {
-        use khive_storage::types::SqlTxOptions;
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("ro_tx.db");
-
-        {
-            let writable = StorageBackend::sqlite(&path).unwrap();
-            let sql = writable.sql();
-            let mut writer = sql.writer().await.unwrap();
-            writer
-                .execute_script("CREATE TABLE ro_tx_test (id INTEGER PRIMARY KEY)".into())
-                .await
-                .unwrap();
-        }
-
-        let ro = StorageBackend::sqlite_read_only(&path).unwrap();
-        let sql = ro.sql();
-
-        // `SqlTxOptions::default()` has `read_only: false`; the read-only
-        // backend must still force the transaction to reject writes.
-        let mut tx = sql.begin_tx(SqlTxOptions::default()).await.unwrap();
-        let result = tx
-            .execute(SqlStatement {
-                sql: "INSERT INTO ro_tx_test (id) VALUES (?1)".into(),
-                params: vec![SqlValue::Integer(1)],
-                label: None,
-            })
-            .await;
-        assert!(
-            result.is_err(),
-            "INSERT inside a default tx on a read-only backend must fail"
-        );
-        tx.rollback().await.unwrap();
-    }
-
-    #[tokio::test]
     #[cfg(feature = "vectors")]
     async fn vectors_roundtrip_via_public_api() {
         let backend = StorageBackend::memory().unwrap();

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -1,7 +1,9 @@
 //! SqlAccess bridge: connects `ConnectionPool` to `khive_storage::SqlAccess`.
 //!
 //! Two modes:
-//! - **File-backed**: Opens standalone connections per reader/writer/tx call (high concurrency).
+//! - **File-backed**: Opens standalone connections per reader/writer call (high concurrency).
+//!   Cross-statement atomicity goes through `atomic_unit`, which drives a single
+//!   registered raw transaction span rather than a caller-held per-tx connection.
 //! - **Memory**: Uses pool-backed approach (acquire pool connection per-query inside `spawn_blocking`).
 
 use std::any::Any;
@@ -921,7 +923,9 @@ async fn run_manual_atomic_unit(
 /// Bridges `ConnectionPool` to `khive_storage::SqlAccess`.
 ///
 /// Dispatches based on whether the pool is file-backed or in-memory:
-/// - File-backed: standalone connections per reader/writer/tx (high concurrency).
+/// - File-backed: standalone connections per reader/writer call (high
+///   concurrency); atomic units drive a single registered raw transaction
+///   span instead of a caller-held per-tx connection.
 /// - In-memory: pool-backed connections per query (single shared connection).
 pub struct SqlBridge {
     pool: Arc<ConnectionPool>,

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use khive_storage::error::StorageError;
-use khive_storage::types::{SqlColumn, SqlIsolation, SqlRow, SqlStatement, SqlTxOptions, SqlValue};
+use khive_storage::types::{SqlColumn, SqlRow, SqlStatement, SqlValue};
 use khive_storage::{AtomicUnitOp, StorageCapability};
 
 use crate::error::SqliteError;
@@ -145,44 +145,6 @@ fn open_standalone_writer(pool: &ConnectionPool) -> Result<rusqlite::Connection,
         .map_err(|e| map_rusqlite_err(e, "open_writer"))?;
     conn.pragma_update(None, "mmap_size", "1073741824")
         .map_err(|e| map_rusqlite_err(e, "open_writer"))?;
-
-    Ok(conn)
-}
-
-/// Open a standalone connection for a transaction, honoring `effective_read_only`.
-///
-/// When `effective_read_only` is set, the connection is opened with
-/// `SQLITE_OPEN_READ_ONLY` (so writes fail at the SQLite level even if the
-/// `PRAGMA query_only` toggle were ever bypassed) instead of `READ_WRITE`.
-fn open_standalone_tx_conn(
-    pool: &ConnectionPool,
-    effective_read_only: bool,
-) -> Result<rusqlite::Connection, StorageError> {
-    let config = pool.config();
-    let path = config.path.as_ref().ok_or_else(|| StorageError::Pool {
-        operation: "begin_tx".into(),
-        message: "in-memory databases do not support standalone writer; use pool-backed".into(),
-    })?;
-
-    let flags = if effective_read_only {
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-            | rusqlite::OpenFlags::SQLITE_OPEN_URI
-    } else {
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX
-            | rusqlite::OpenFlags::SQLITE_OPEN_URI
-    };
-
-    let conn = rusqlite::Connection::open_with_flags(path, flags)
-        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
-
-    conn.busy_timeout(config.busy_timeout)
-        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
-    conn.pragma_update(None, "cache_size", "-65536")
-        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
-    conn.pragma_update(None, "mmap_size", "1073741824")
-        .map_err(|e| map_rusqlite_err(e, "open_tx"))?;
 
     Ok(conn)
 }
@@ -512,189 +474,6 @@ impl khive_storage::SqlWriter for SqliteWriter {
         .map_err(|e| StorageError::driver(StorageCapability::Sql, "execute_script_top_level", e))?;
         self.conn = Some(conn);
         result.map_err(|e| map_rusqlite_err(e, "execute_script_top_level"))
-    }
-}
-
-// =============================================================================
-// File-backed: SqliteTransaction (standalone connection)
-// =============================================================================
-
-struct SqliteTransaction {
-    conn: Option<rusqlite::Connection>,
-    /// Whether `PRAGMA query_only = ON` was set on the connection.
-    /// Must be reset to OFF before COMMIT/ROLLBACK so the connection can
-    /// be returned cleanly (defensive; connection is dropped after use anyway).
-    read_only: bool,
-    /// Open-transaction registry entry (ADR-091 Plank 0); deregisters on Drop.
-    _tx_handle: khive_storage::tx_registry::TxHandle,
-}
-
-#[async_trait]
-impl khive_storage::SqlReader for SqliteTransaction {
-    async fn query_row(
-        &mut self,
-        statement: SqlStatement,
-    ) -> khive_storage::types::StorageResult<Option<SqlRow>> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "tx.query_row".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let (conn, result) = tokio::task::spawn_blocking(move || {
-            let res = execute_query(&conn, &statement);
-            (conn, res)
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "tx.query_row", e))?;
-        self.conn = Some(conn);
-        let rows = result.map_err(|e| map_rusqlite_err(e, "tx.query_row"))?;
-        Ok(rows.into_iter().next())
-    }
-
-    async fn query_all(
-        &mut self,
-        statement: SqlStatement,
-    ) -> khive_storage::types::StorageResult<Vec<SqlRow>> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "tx.query_all".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let (conn, result) = tokio::task::spawn_blocking(move || {
-            let res = execute_query(&conn, &statement);
-            (conn, res)
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "tx.query_all", e))?;
-        self.conn = Some(conn);
-        result.map_err(|e| map_rusqlite_err(e, "tx.query_all"))
-    }
-
-    async fn query_scalar(
-        &mut self,
-        statement: SqlStatement,
-    ) -> khive_storage::types::StorageResult<Option<SqlValue>> {
-        let row = khive_storage::SqlReader::query_row(self, statement).await?;
-        Ok(row.and_then(|r| r.columns.into_iter().next().map(|c| c.value)))
-    }
-
-    async fn explain(
-        &mut self,
-        statement: SqlStatement,
-    ) -> khive_storage::types::StorageResult<Vec<SqlRow>> {
-        let explain_stmt = SqlStatement {
-            sql: format!("EXPLAIN QUERY PLAN {}", statement.sql),
-            params: statement.params,
-            label: statement.label,
-        };
-        khive_storage::SqlReader::query_all(self, explain_stmt).await
-    }
-}
-
-#[async_trait]
-impl khive_storage::SqlWriter for SqliteTransaction {
-    async fn execute(
-        &mut self,
-        statement: SqlStatement,
-    ) -> khive_storage::types::StorageResult<u64> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "tx.execute".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let (conn, result) = tokio::task::spawn_blocking(move || {
-            let res = (|| -> Result<usize, rusqlite::Error> {
-                let mut stmt = conn.prepare(&statement.sql)?;
-                bind_params(&mut stmt, &statement.params)?;
-                stmt.raw_execute()
-            })();
-            (conn, res)
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "tx.execute", e))?;
-        self.conn = Some(conn);
-        let affected = result.map_err(|e| map_rusqlite_err(e, "tx.execute"))?;
-        Ok(affected as u64)
-    }
-
-    async fn execute_batch(
-        &mut self,
-        statements: Vec<SqlStatement>,
-    ) -> khive_storage::types::StorageResult<u64> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "tx.execute_batch".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let (conn, result) = tokio::task::spawn_blocking(move || {
-            let mut total: u64 = 0;
-            for statement in &statements {
-                let res = (|| -> Result<usize, rusqlite::Error> {
-                    let mut stmt = conn.prepare(&statement.sql)?;
-                    bind_params(&mut stmt, &statement.params)?;
-                    stmt.raw_execute()
-                })();
-                match res {
-                    Ok(n) => total += n as u64,
-                    Err(e) => return (conn, Err(e)),
-                }
-            }
-            (conn, Ok(total))
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "tx.execute_batch", e))?;
-        self.conn = Some(conn);
-        result.map_err(|e| map_rusqlite_err(e, "tx.execute_batch"))
-    }
-
-    async fn execute_script(&mut self, script: String) -> khive_storage::types::StorageResult<()> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Pool {
-            operation: "tx.execute_script".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let (conn, result) = tokio::task::spawn_blocking(move || {
-            let res = conn.execute_batch(&script);
-            (conn, res)
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "tx.execute_script", e))?;
-        self.conn = Some(conn);
-        result.map_err(|e| map_rusqlite_err(e, "tx.execute_script"))
-    }
-}
-
-#[async_trait]
-impl khive_storage::SqlTransaction for SqliteTransaction {
-    async fn commit(mut self: Box<Self>) -> khive_storage::types::StorageResult<()> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Transaction {
-            operation: "commit".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let read_only = self.read_only;
-        tokio::task::spawn_blocking(move || {
-            // Reset query_only before COMMIT so the connection ends cleanly.
-            if read_only {
-                let _ = conn.pragma_update(None, "query_only", "OFF");
-            }
-            conn.execute_batch("COMMIT")
-                .map_err(|e| map_rusqlite_err(e, "commit"))
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "commit", e))?
-    }
-
-    async fn rollback(mut self: Box<Self>) -> khive_storage::types::StorageResult<()> {
-        let conn = self.conn.take().ok_or_else(|| StorageError::Transaction {
-            operation: "rollback".into(),
-            message: "connection already consumed".into(),
-        })?;
-        let read_only = self.read_only;
-        tokio::task::spawn_blocking(move || {
-            // Reset query_only before ROLLBACK so the connection ends cleanly.
-            if read_only {
-                let _ = conn.pragma_update(None, "query_only", "OFF");
-            }
-            conn.execute_batch("ROLLBACK")
-                .map_err(|e| map_rusqlite_err(e, "rollback"))
-        })
-        .await
-        .map_err(|e| StorageError::driver(StorageCapability::Sql, "rollback", e))?
     }
 }
 
@@ -1200,63 +979,16 @@ impl khive_storage::SqlAccess for SqlBridge {
         }
     }
 
-    async fn begin_tx(
-        &self,
-        options: SqlTxOptions,
-    ) -> khive_storage::types::StorageResult<Box<dyn khive_storage::SqlTransaction>> {
-        // Transactions need a standalone connection so the BEGIN/COMMIT state
-        // is not shared with other operations. For in-memory DBs we still
-        // open a standalone writer since the pool writer would conflict.
-        // A read-only backend forces the transaction read-only even if the
-        // caller did not ask for it, so writes cannot bypass the backend's
-        // read-only mode via `SqlTxOptions::default()`.
-        let effective_read_only = self.pool.config().read_only || options.read_only;
-
-        let conn = if self.is_file_backed {
-            open_standalone_tx_conn(&self.pool, effective_read_only)?
-        } else {
-            return Err(StorageError::Pool {
-                operation: "begin_tx".into(),
-                message: "transactions require file-backed database (not in-memory)".into(),
-            });
-        };
-
-        // Map isolation level to SQLite BEGIN mode.
-        // SQLite WAL mode gives snapshot isolation for readers automatically;
-        // IMMEDIATE acquires the write lock early (prevents writer starvation),
-        // EXCLUSIVE prevents any concurrent readers for full serializability.
-        let begin_stmt = match options.isolation {
-            SqlIsolation::Serializable => "BEGIN EXCLUSIVE",
-            _ => {
-                if effective_read_only {
-                    // DEFERRED acquires no lock at BEGIN time, compatible with
-                    // read-only transactions (no write-intent needed).
-                    "BEGIN DEFERRED"
-                } else {
-                    // IMMEDIATE acquires the write lock early to prevent starvation.
-                    "BEGIN IMMEDIATE"
-                }
-            }
-        };
-        conn.execute_batch(begin_stmt)
-            .map_err(|e| map_rusqlite_err(e, "begin_tx"))?;
-        let tx_handle = khive_storage::tx_registry::register(options.label.clone());
-
-        // Honor read_only: block all writes via PRAGMA query_only.
-        // The connection is opened as read-write so COMMIT still works, but
-        // any INSERT/UPDATE/DELETE executed inside the transaction will error.
-        if effective_read_only {
-            conn.pragma_update(None, "query_only", "ON")
-                .map_err(|e| map_rusqlite_err(e, "begin_tx"))?;
-        }
-
-        Ok(Box::new(SqliteTransaction {
-            conn: Some(conn),
-            read_only: effective_read_only,
-            _tx_handle: tx_handle,
-        }))
-    }
-
+    /// Implements the trait's atomic-unit suspend-free invariant
+    /// (`SqlAccess::atomic_unit`'s doc comment): on the flag-on branch below,
+    /// `op` is driven through [`block_on_sync`] on an [`InlineWriter`] — a
+    /// single-poll driver that returns `Err` the instant `op`'s future is
+    /// `Pending` instead of ever actually suspending. `op` must therefore
+    /// issue only synchronous DML; see `InlineWriter`'s and
+    /// `block_on_sync`'s doc comments for the full mechanics and why this
+    /// restriction is load-bearing (a suspended poll inside the writer
+    /// task's `spawn_blocking` would otherwise block that task on external
+    /// async work while holding the single write connection).
     async fn atomic_unit(
         &self,
         op: AtomicUnitOp,
@@ -1323,103 +1055,8 @@ impl khive_storage::SqlAccess for SqlBridge {
 mod tests {
     use super::*;
     use crate::pool::PoolConfig;
-    use khive_storage::types::{SqlIsolation, SqlStatement, SqlTxOptions, SqlValue};
+    use khive_storage::types::{SqlStatement, SqlValue};
     use khive_storage::SqlAccess as _;
-    use serial_test::serial;
-
-    /// Verify that a read-only transaction rejects INSERT statements via
-    /// PRAGMA query_only.
-    #[tokio::test]
-    async fn tx_read_only_rejects_writes() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("tx_ro.db");
-        let config = PoolConfig {
-            path: Some(path.clone()),
-            ..PoolConfig::default()
-        };
-        let pool = Arc::new(ConnectionPool::new(config).unwrap());
-
-        // Create a table so there is something to INSERT into.
-        {
-            let guard = pool.writer().unwrap();
-            guard
-                .conn()
-                .execute_batch("CREATE TABLE IF NOT EXISTS ro_test (id INTEGER PRIMARY KEY)")
-                .unwrap();
-        }
-
-        let bridge = SqlBridge::new(Arc::clone(&pool), true);
-
-        let mut tx = bridge
-            .begin_tx(SqlTxOptions {
-                read_only: true,
-                isolation: SqlIsolation::Default,
-                label: None,
-            })
-            .await
-            .unwrap();
-
-        // An INSERT inside a read-only transaction must fail.
-        let result = tx
-            .execute(SqlStatement {
-                sql: "INSERT INTO ro_test (id) VALUES (?1)".into(),
-                params: vec![SqlValue::Integer(1)],
-                label: None,
-            })
-            .await;
-
-        assert!(result.is_err(), "INSERT in read-only tx must fail");
-
-        // Rollback should succeed regardless.
-        tx.rollback().await.unwrap();
-    }
-
-    /// ADR-091 Plank 0: `begin_tx` registers with the shared open-transaction
-    /// registry under its caller-supplied label, and `commit()` deregisters it.
-    ///
-    /// `#[serial(tx_registry)]`: the registry is a process-wide singleton
-    /// shared across every test in this binary; this test shares the
-    /// `tx_registry` serial group with `checkpoint.rs`'s and `pool.rs`'s
-    /// registry tests to avoid cross-test interference within one run.
-    #[tokio::test]
-    #[serial(tx_registry)]
-    async fn begin_tx_registers_and_commit_deregisters() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("tx_registry.db");
-        let config = PoolConfig {
-            path: Some(path.clone()),
-            ..PoolConfig::default()
-        };
-        let pool = Arc::new(ConnectionPool::new(config).unwrap());
-        let bridge = SqlBridge::new(Arc::clone(&pool), true);
-
-        let tx = bridge
-            .begin_tx(SqlTxOptions {
-                read_only: false,
-                isolation: SqlIsolation::Default,
-                label: Some("begin_tx_registry_test".to_string()),
-            })
-            .await
-            .unwrap();
-
-        let snapshot = khive_storage::tx_registry::snapshot();
-        assert!(
-            snapshot
-                .iter()
-                .any(|(_, label)| label.as_deref() == Some("begin_tx_registry_test")),
-            "expected the labeled tx to be visible in the registry while open"
-        );
-
-        tx.commit().await.unwrap();
-
-        let snapshot_after = khive_storage::tx_registry::snapshot();
-        assert!(
-            !snapshot_after
-                .iter()
-                .any(|(_, label)| label.as_deref() == Some("begin_tx_registry_test")),
-            "expected the labeled tx to be gone from the registry after commit"
-        );
-    }
 
     /// ADR-067 Component A entry 10: with `KHIVE_WRITE_QUEUE=1`,
     /// `SqliteWriter::execute_batch` (reached via `SqlBridge::writer()`)

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -985,7 +985,7 @@ impl khive_storage::SqlAccess for SqlBridge {
 
     /// Implements the trait's atomic-unit suspend-free invariant
     /// (`SqlAccess::atomic_unit`'s doc comment): on the flag-on branch below,
-    /// `op` is driven through [`block_on_sync`] on an [`InlineWriter`] — a
+    /// `op` is driven through `block_on_sync` on an `InlineWriter` — a
     /// single-poll driver that returns `Err` the instant `op`'s future is
     /// `Pending` instead of ever actually suspending. `op` must therefore
     /// issue only synchronous DML; see `InlineWriter`'s and

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -627,12 +627,17 @@ async fn multiple_stores_over_one_pool_share_a_single_writer_task() {
 /// with every MIGRATE-listed write path routed through the writer task, drive
 /// CONCURRENT writes across entity, note, and graph stores (entries 2/3/6 —
 /// er, 1/2/3) plus `SqlBridge`'s unmigrated `writer()` (entry 8, still routes
-/// its self-contained `execute_batch` through the task per entry 10) and
-/// `begin_tx()` (entry 9, a genuine design fork — stays on its own standalone
-/// connection) over ONE pool. Asserts exactly one writer task is ever spawned
-/// and every write actually lands, proving the migrated paths and the two
-/// design-fork paths coexist over a single DB file without contending at
-/// `BEGIN IMMEDIATE` or racing the writer task's own spawn-once guarantee.
+/// its self-contained `execute_batch` through the task per entry 10) over ONE
+/// pool. Asserts exactly one writer task is ever spawned and every write
+/// actually lands, proving the migrated paths coexist over a single DB file
+/// without contending at `BEGIN IMMEDIATE` or racing the writer task's own
+/// spawn-once guarantee.
+///
+/// Entry 9 (`SqlBridge::begin_tx`, formerly a genuine design fork on its own
+/// standalone connection) is retired as of ADR-099 D5 — `begin_tx` and
+/// `SqlTransaction` no longer exist on `SqlAccess` (their one production
+/// caller, session-mirror ingest, converted to `atomic_unit`), so this test
+/// no longer exercises it.
 ///
 /// Constructed via a `PoolConfig` literal (`write_queue_enabled: true`), not
 /// the `KHIVE_WRITE_QUEUE` env var — see the sibling
@@ -643,7 +648,7 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     use crate::stores::graph::SqlGraphStore;
     use crate::stores::note::SqlNoteStore;
     use khive_storage::note::Note;
-    use khive_storage::types::{Edge, SqlStatement, SqlTxOptions, SqlValue};
+    use khive_storage::types::{Edge, SqlStatement, SqlValue};
     use khive_storage::{GraphStore as _, NoteStore as _, SqlAccess as _};
     use khive_types::EdgeRelation;
 
@@ -726,29 +731,6 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
         label: Some("test_execute_batch".to_string()),
     };
 
-    // Entry 9 (SqlBridge::begin_tx, design fork, unmigrated): its own
-    // standalone connection, running concurrently with the writer task.
-    let tx_row_id = Uuid::new_v4();
-    let tx_src = Uuid::new_v4();
-    let tx_tgt = Uuid::new_v4();
-    let tx_insert_stmt = SqlStatement {
-        sql: "INSERT INTO graph_edges (namespace, id, source_id, target_id, relation, \
-              weight, created_at, updated_at, deleted_at, metadata, target_backend) \
-              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL)"
-            .to_string(),
-        params: vec![
-            SqlValue::Text("default".to_string()),
-            SqlValue::Text(tx_row_id.to_string()),
-            SqlValue::Text(tx_src.to_string()),
-            SqlValue::Text(tx_tgt.to_string()),
-            SqlValue::Text("extends".to_string()),
-            SqlValue::Float(0.7),
-            SqlValue::Integer(now_micros),
-            SqlValue::Integer(now_micros),
-        ],
-        label: Some("test_begin_tx".to_string()),
-    };
-
     let entity_fut = {
         let entity_store = Arc::clone(&entity_store);
         async move { entity_store.upsert_entity(entity).await }
@@ -765,20 +747,14 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
         let mut writer = bridge.writer().await.unwrap();
         writer.execute_batch(vec![insert_stmt]).await
     };
-    let tx_fut = async {
-        let mut tx = bridge.begin_tx(SqlTxOptions::default()).await.unwrap();
-        tx.execute(tx_insert_stmt).await?;
-        tx.commit().await
-    };
 
-    let (entity_res, note_res, edge_res, batch_res, tx_res) =
-        tokio::join!(entity_fut, note_fut, edge_fut, batch_fut, tx_fut);
+    let (entity_res, note_res, edge_res, batch_res) =
+        tokio::join!(entity_fut, note_fut, edge_fut, batch_fut);
 
     entity_res.unwrap();
     note_res.unwrap();
     edge_res.unwrap();
     batch_res.unwrap();
-    tx_res.unwrap();
 
     assert!(entity_store.get_entity(entity_id).await.unwrap().is_some());
     assert!(note_store.get_note(note_id).await.unwrap().is_some());
@@ -787,8 +763,8 @@ async fn concurrent_writes_across_all_migrated_stores_share_one_writer_task() {
     assert_eq!(
         pool.writer_task_spawn_count(),
         1,
-        "concurrent writes across every migrated path plus both design-fork \
-         paths must not trigger a second writer task spawn"
+        "concurrent writes across every migrated path must not trigger a \
+         second writer task spawn"
     );
 }
 

--- a/crates/khive-pack-brain/src/fold_gate.rs
+++ b/crates/khive-pack-brain/src/fold_gate.rs
@@ -16,32 +16,29 @@
 //! Concurrency (ADR-081 §2 — normative): "the mass check and the fold execute in
 //! one SQLite transaction opened with `BEGIN IMMEDIATE`... database-level
 //! single-writer semantics serialize every check-and-fold against all concurrent
-//! writers." `apply_fold_gate` implements this literally: it acquires exactly one
-//! `SqlWriter` handle and issues `BEGIN IMMEDIATE`, the mass `SELECT`, the decision
-//! (computed in Rust from the row read on *this* connection), the `INSERT ... ON
-//! CONFLICT ... DO UPDATE`, and `COMMIT` — all on that single held connection, with
-//! `ROLLBACK` on any error. For a file-backed pool, `writer()` opens a standalone
-//! real `rusqlite::Connection`; `BEGIN IMMEDIATE` on it acquires SQLite's actual
+//! writers." `apply_fold_gate` satisfies this by handing the whole
+//! check-and-fold — the mass `SELECT`, the decision (computed in Rust from the
+//! row read inside the unit), and the `INSERT ... ON CONFLICT ... DO UPDATE` —
+//! to `SqlAccess::atomic_unit` as ONE suspension-free unit. The seam owns the
+//! transaction boundary: the unit runs under a single `BEGIN IMMEDIATE` with
+//! commit-on-Ok / rollback-on-Err, on the writer task's connection when the
+//! single-writer queue is enabled and on one held writer connection otherwise.
+//! On a file-backed pool that `BEGIN IMMEDIATE` acquires SQLite's actual
 //! file-level RESERVED lock for the duration, which SQLite enforces **across
 //! processes**, not just within one. This is the property production needs:
 //! khive-mcp routinely runs multiple concurrent daemon processes against the same
 //! database file (issue #407), so an in-process mutex alone (e.g. `dispatch_gate`
 //! in `BrainPack::dispatch`) cannot serialize the check-and-fold — only SQLite's
-//! own write lock can. `SqlAccess::begin_tx` was not used for this because it
-//! returns a distinct `SqlTransaction` type and hard-errors on non-file-backed
-//! (in-memory) pools; issuing `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` as ordinary
-//! statements through the existing `SqlWriter::execute` on one retained
-//! `writer()` handle gets the same held-lock guarantee on file-backed pools,
-//! while still functioning correctly (single-caller, no concurrency claim) on
-//! the in-memory pools most of this crate's tests run against — the in-memory
-//! backend serves every `writer()` call from one pool-wide shared connection
-//! (`PoolBackedWriter` re-acquires the same `parking_lot` guard per call), so a
-//! *second* concurrent `BEGIN IMMEDIATE` on it would hit SQLite's own
-//! transaction-nesting error rather than genuinely racing — which is exactly
-//! why the concurrency proof below (`fold_gate_concurrent_writers_never_exceed_cap`)
-//! uses a real file-backed `KhiveRuntime`: only the file-backed path opens an
-//! independent standalone connection per `writer()` call, the same shape
-//! production's multiple concurrent `kkernel mcp` processes have.
+//! own write lock can. (Historical note: this function originally issued
+//! `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` itself on a retained `writer()` handle;
+//! that shape nests inside the writer task's own transaction under the
+//! single-writer queue and was converted to `atomic_unit`. The trait's
+//! `begin_tx`/`SqlTransaction` surface it once avoided has since been retired
+//! entirely.) The concurrency proof below
+//! (`fold_gate_concurrent_writers_never_exceed_cap`) uses a real file-backed
+//! `KhiveRuntime` because only the file-backed path exhibits genuine
+//! cross-connection contention — the same shape production's multiple
+//! concurrent `kkernel mcp` processes have.
 //!
 //! SQL math functions (`pow`/`exp`/`ln`/`log`) are unavailable on this
 //! `rusqlite`/SQLite build (verified empirically: `SELECT pow(2.0, -1.0)` raises

--- a/crates/khive-pack-brain/src/persist.rs
+++ b/crates/khive-pack-brain/src/persist.rs
@@ -328,12 +328,11 @@ pub struct BrainMutationEvent {
 /// commits does the proposed state replace the live state and the tracker
 /// get marked clean.
 ///
-/// This deliberately does NOT use `SqlAccess::begin_tx` — per `fold_gate.rs`'s
-/// module doc, that API requires a file-backed database and errors for
-/// in-memory pools (used throughout this crate's test suite and by
-/// `KhiveRuntime::memory()`). It also, as of this round, does NOT issue a
-/// manual `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` sequence on a plain
-/// `SqlWriter` handle: under `KHIVE_WRITE_QUEUE=1` that sequence would nest
+/// This deliberately does NOT issue a manual
+/// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` sequence on a plain
+/// `SqlWriter` handle (the trait's former `begin_tx`/`SqlTransaction`
+/// surface, retired entirely, is likewise not an option): under
+/// `KHIVE_WRITE_QUEUE=1` that sequence would nest
 /// inside the WriterTask's own per-request `BEGIN IMMEDIATE`, which SQLite
 /// rejects ("cannot start a transaction within a transaction" — the same
 /// class of bug `fold_gate.rs`'s `atomic_unit` conversion fixed). Handing the

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -27,3 +27,10 @@ tokio = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
 tempfile = { workspace = true }
+# Test-only: builds a bare `PoolConfig { write_queue_enabled: true, .. }` +
+# `SqlBridge` directly (no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var) for
+# the ADR-099 D5 single-writer / suspend-free tests, matching the
+# established pattern in khive-pack-brain's `fold_gate.rs` and `persist.rs`
+# (documented there: env-var mutation races other tests' `KhiveRuntime::new`
+# calls in the same binary; a literal `PoolConfig` sidesteps that).
+khive-db = { version = "0.3.0", path = "../khive-db" }

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -36,12 +36,12 @@
 //! retry, never a full-file read in one call (PACKSESSION-AUD-003 round 2).
 
 use std::io::{BufRead, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use khive_runtime::{KhiveRuntime, RuntimeError};
-use khive_storage::types::{SqlStatement, SqlTxOptions, SqlValue};
-use khive_storage::SqlTransaction;
+use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::SqlWriter;
 
 use super::parse;
 
@@ -611,11 +611,67 @@ async fn write_events_and_cursor(
     let now_us = Utc::now().timestamp_micros();
     let sql = runtime.sql();
 
-    let mut tx = sql
-        .begin_tx(SqlTxOptions::default())
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror: begin_tx: {e}")))?;
+    // ADR-099 D5: this closure is verified suspension-free (it drives only
+    // `writer` with inline-built `SqlStatement`s — session/message INSERTs,
+    // the count refresh, and the cursor UPDATE — with no embedding, no ANN
+    // warming, and no other `await` on an external service), so handing it
+    // to `atomic_unit` satisfies the atomic-unit suspend-free invariant
+    // (`SqlAccess::atomic_unit`'s doc comment) identically on the
+    // single-writer and flag-off paths. This replaces the standalone
+    // `begin_tx` this function used before ADR-099: the whole sequence
+    // still commits once or rolls back as one unit, but no longer opens its
+    // own connection outside the writer task.
+    let events_owned: Vec<parse::ParsedEvent> = events.to_vec();
+    let path_owned: PathBuf = path.to_path_buf();
 
+    let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
+        Box::pin(async move {
+            write_events_and_cursor_on_writer(
+                writer,
+                &path_owned,
+                source_value,
+                &events_owned,
+                scanned,
+                new_offset,
+                now_us,
+            )
+            .await
+            .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "session_mirror_write_events_and_cursor",
+                    e,
+                )
+            })
+        })
+    });
+
+    let boxed = sql
+        .atomic_unit(op)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("mirror: atomic_unit: {e}")))?;
+
+    Ok(*boxed.downcast::<MirrorStats>().unwrap_or_else(|_| {
+        panic!("atomic_unit op for write_events_and_cursor must return MirrorStats")
+    }))
+}
+
+/// The synchronous-DML body of `write_events_and_cursor`, run inside one
+/// `atomic_unit` closure (see that function's doc comment for the
+/// suspension-free justification). Takes a plain `&mut dyn SqlWriter`
+/// (not `&mut dyn SqlTransaction`) because `atomic_unit` owns the
+/// transaction boundary entirely — this function must not, and does not,
+/// issue its own `BEGIN`/`COMMIT`/`ROLLBACK`.
+async fn write_events_and_cursor_on_writer(
+    writer: &mut dyn SqlWriter,
+    path: &Path,
+    source_value: &'static str,
+    events: &[parse::ParsedEvent],
+    scanned: u64,
+    new_offset: u64,
+    now_us: i64,
+) -> khive_storage::types::StorageResult<MirrorStats> {
     let mut inserted: u64 = 0;
     let mut last_session_id: Option<String> = None;
 
@@ -633,38 +689,38 @@ async fn write_events_and_cursor(
         // pass that inserts no new messages writes no session metadata at all —
         // strict replay idempotency. `last_seen_at` is advanced below, but only
         // when a genuinely new message lands.
-        tx.execute(SqlStatement {
-            sql: format!(
-                "INSERT INTO sessions \
-                  (id, provider_session_id, source, cwd, git_branch, slug, \
-                   message_count, first_seen_at, last_seen_at, namespace) \
-                  VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
-                  ON CONFLICT(id) DO NOTHING",
-                source_value
-            ),
-            params: vec![
-                SqlValue::Text(ev.session_id.clone()),
-                ev.cwd
-                    .as_deref()
-                    .map(|s| SqlValue::Text(s.to_string()))
-                    .unwrap_or(SqlValue::Null),
-                ev.git_branch
-                    .as_deref()
-                    .map(|s| SqlValue::Text(s.to_string()))
-                    .unwrap_or(SqlValue::Null),
-                ev.slug
-                    .as_deref()
-                    .map(|s| SqlValue::Text(s.to_string()))
-                    .unwrap_or(SqlValue::Null),
-                SqlValue::Integer(created_at),
-            ],
-            label: Some("session_mirror_create_session".into()),
-        })
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror: session create: {e}")))?;
+        writer
+            .execute(SqlStatement {
+                sql: format!(
+                    "INSERT INTO sessions \
+                      (id, provider_session_id, source, cwd, git_branch, slug, \
+                       message_count, first_seen_at, last_seen_at, namespace) \
+                      VALUES(?1, ?1, '{}', ?2, ?3, ?4, 0, ?5, ?5, 'local') \
+                      ON CONFLICT(id) DO NOTHING",
+                    source_value
+                ),
+                params: vec![
+                    SqlValue::Text(ev.session_id.clone()),
+                    ev.cwd
+                        .as_deref()
+                        .map(|s| SqlValue::Text(s.to_string()))
+                        .unwrap_or(SqlValue::Null),
+                    ev.git_branch
+                        .as_deref()
+                        .map(|s| SqlValue::Text(s.to_string()))
+                        .unwrap_or(SqlValue::Null),
+                    ev.slug
+                        .as_deref()
+                        .map(|s| SqlValue::Text(s.to_string()))
+                        .unwrap_or(SqlValue::Null),
+                    SqlValue::Integer(created_at),
+                ],
+                label: Some("session_mirror_create_session".into()),
+            })
+            .await?;
 
         // ── session_messages insert (idempotent) ──────────────────────────────
-        let affected = tx
+        let affected = writer
             .execute(SqlStatement {
                 sql: "INSERT OR IGNORE INTO session_messages \
                       (id, session_id, seq, parent_uuid, is_sidechain, role, \
@@ -695,8 +751,7 @@ async fn write_events_and_cursor(
                 ],
                 label: Some("session_mirror_insert_message".into()),
             })
-            .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror: message insert: {e}")))?;
+            .await?;
 
         // ── advance session metadata ONLY when a new message landed ────────────
         //
@@ -705,34 +760,34 @@ async fn write_events_and_cursor(
         // backfills metadata that may have been NULL at create time. A pure
         // replay (`affected == 0`) touches nothing.
         if affected > 0 {
-            tx.execute(SqlStatement {
-                sql: "UPDATE sessions SET \
-                        last_seen_at=MAX(last_seen_at, ?2), \
-                        cwd=COALESCE(cwd, ?3), \
-                        git_branch=COALESCE(git_branch, ?4), \
-                        slug=COALESCE(slug, ?5) \
-                      WHERE id=?1"
-                    .into(),
-                params: vec![
-                    SqlValue::Text(ev.session_id.clone()),
-                    SqlValue::Integer(created_at),
-                    ev.cwd
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                    ev.git_branch
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                    ev.slug
-                        .as_deref()
-                        .map(|s| SqlValue::Text(s.to_string()))
-                        .unwrap_or(SqlValue::Null),
-                ],
-                label: Some("session_mirror_touch_session".into()),
-            })
-            .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror: session touch: {e}")))?;
+            writer
+                .execute(SqlStatement {
+                    sql: "UPDATE sessions SET \
+                            last_seen_at=MAX(last_seen_at, ?2), \
+                            cwd=COALESCE(cwd, ?3), \
+                            git_branch=COALESCE(git_branch, ?4), \
+                            slug=COALESCE(slug, ?5) \
+                          WHERE id=?1"
+                        .into(),
+                    params: vec![
+                        SqlValue::Text(ev.session_id.clone()),
+                        SqlValue::Integer(created_at),
+                        ev.cwd
+                            .as_deref()
+                            .map(|s| SqlValue::Text(s.to_string()))
+                            .unwrap_or(SqlValue::Null),
+                        ev.git_branch
+                            .as_deref()
+                            .map(|s| SqlValue::Text(s.to_string()))
+                            .unwrap_or(SqlValue::Null),
+                        ev.slug
+                            .as_deref()
+                            .map(|s| SqlValue::Text(s.to_string()))
+                            .unwrap_or(SqlValue::Null),
+                    ],
+                    label: Some("session_mirror_touch_session".into()),
+                })
+                .await?;
         }
 
         inserted += affected;
@@ -755,33 +810,28 @@ async fn write_events_and_cursor(
         seen_sessions.sort(); // deterministic order for tests
 
         for sid in &seen_sessions {
-            tx.execute(SqlStatement {
-                sql: "UPDATE sessions SET message_count=\
-                      (SELECT COUNT(*) FROM session_messages WHERE session_id=?1) \
-                      WHERE id=?1"
-                    .into(),
-                params: vec![SqlValue::Text(sid.clone())],
-                label: Some("session_mirror_refresh_count".into()),
-            })
-            .await
-            .map_err(|e| RuntimeError::Internal(format!("mirror: count refresh: {e}")))?;
+            writer
+                .execute(SqlStatement {
+                    sql: "UPDATE sessions SET message_count=\
+                          (SELECT COUNT(*) FROM session_messages WHERE session_id=?1) \
+                          WHERE id=?1"
+                        .into(),
+                    params: vec![SqlValue::Text(sid.clone())],
+                    label: Some("session_mirror_refresh_count".into()),
+                })
+                .await?;
         }
     }
 
-    upsert_cursor_in_tx(
-        &mut *tx,
-        path,
-        last_session_id.as_deref(),
-        new_offset,
-        now_us,
-    )
-    .await?;
+    upsert_cursor_on_writer(writer, path, last_session_id.as_deref(), new_offset, now_us).await?;
 
     // ── commit ────────────────────────────────────────────────────────────────
-    tx.commit()
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("mirror: commit: {e}")))?;
-
+    //
+    // No explicit COMMIT here: `atomic_unit` owns the transaction boundary
+    // entirely (see this function's doc comment) and commits once this
+    // closure returns `Ok`, or rolls back the whole unit on `Err` — the
+    // same all-or-nothing contract the old `begin_tx`/`tx.commit()` shape
+    // gave, now provided by the seam instead of a manual transaction.
     Ok(MirrorStats {
         inserted,
         scanned,
@@ -789,35 +839,39 @@ async fn write_events_and_cursor(
     })
 }
 
-/// Upsert the `session_mirror_cursor` row for `path` inside an open transaction.
-async fn upsert_cursor_in_tx(
-    tx: &mut dyn SqlTransaction,
+/// Upsert the `session_mirror_cursor` row for `path` inside the open
+/// `atomic_unit` transaction. Takes `&mut dyn SqlWriter` (see
+/// `write_events_and_cursor_on_writer`'s doc comment) — it issues only the
+/// one cursor DML statement, no transaction control of its own.
+async fn upsert_cursor_on_writer(
+    writer: &mut dyn SqlWriter,
     path: &Path,
     session_id: Option<&str>,
     new_offset: u64,
     now_us: i64,
-) -> Result<(), RuntimeError> {
+) -> khive_storage::types::StorageResult<()> {
     let path_str = path.to_string_lossy().into_owned();
-    tx.execute(SqlStatement {
-        sql: "INSERT INTO session_mirror_cursor(file_path, session_id, byte_offset, updated_at) \
+    writer
+        .execute(SqlStatement {
+            sql:
+                "INSERT INTO session_mirror_cursor(file_path, session_id, byte_offset, updated_at) \
               VALUES(?1, ?2, ?3, ?4) \
               ON CONFLICT(file_path) DO UPDATE SET \
                 session_id=excluded.session_id, \
                 byte_offset=excluded.byte_offset, \
                 updated_at=excluded.updated_at"
-            .into(),
-        params: vec![
-            SqlValue::Text(path_str),
-            session_id
-                .map(|s| SqlValue::Text(s.to_string()))
-                .unwrap_or(SqlValue::Null),
-            SqlValue::Integer(new_offset as i64),
-            SqlValue::Integer(now_us),
-        ],
-        label: Some("session_mirror_cursor_upsert".into()),
-    })
-    .await
-    .map_err(|e| RuntimeError::Internal(format!("mirror: cursor upsert: {e}")))?;
+                    .into(),
+            params: vec![
+                SqlValue::Text(path_str),
+                session_id
+                    .map(|s| SqlValue::Text(s.to_string()))
+                    .unwrap_or(SqlValue::Null),
+                SqlValue::Integer(new_offset as i64),
+                SqlValue::Integer(now_us),
+            ],
+            label: Some("session_mirror_cursor_upsert".into()),
+        })
+        .await?;
     Ok(())
 }
 
@@ -878,9 +932,11 @@ mod tests {
 
     /// Build a file-backed runtime and apply the session schema.
     ///
-    /// `begin_tx` (used by `mirror_file`) requires a file-backed SQLite database;
-    /// in-memory SQLite does not support the WAL-mode transactions that `begin_tx`
-    /// opens.  The caller must keep the returned `TempDir` alive for the test.
+    /// File-backed so tests exercise the same `atomic_unit` single-writer
+    /// path (`mirror_file` → `write_events_and_cursor` → `atomic_unit`,
+    /// ADR-099 D5) production runs against — an in-memory pool would take
+    /// `atomic_unit`'s pool-backed manual-transaction branch instead. The
+    /// caller must keep the returned `TempDir` alive for the test.
     async fn setup() -> (KhiveRuntime, TempDir) {
         let dir = TempDir::new().expect("tempdir");
         let db_path = dir.path().join("test.db");
@@ -2391,76 +2447,344 @@ mod tests {
 
     /// SS6 invariants #4 ("an ingest error never advances the cursor") and #5
     /// ("one transaction per file pass") both rest on the same underlying
-    /// contract that `write_events_and_cursor` depends on: a `begin_tx()`
-    /// transaction that hits an error before `commit()` is called must leave
-    /// no visible trace of ANY write it made in that pass — including the
-    /// cursor upsert, which runs last, right before `commit()`.
+    /// contract `write_events_and_cursor` depends on: an `atomic_unit` whose
+    /// closure returns `Err` before its final statement must leave no
+    /// visible trace of ANY write it made in that pass — including the
+    /// cursor upsert, which runs last, right before the closure returns
+    /// `Ok`.
     ///
     /// The real ingest loop can't be driven into a mid-loop DB error through
     /// crafted event data: the `sessions` insert uses `ON CONFLICT(id) DO
     /// NOTHING` and the `session_messages` insert uses `INSERT OR IGNORE`,
     /// both of which swallow constraint violations by design (that's what
-    /// makes re-ingest idempotent). So this test exercises the same
-    /// `begin_tx`/`execute`/drop-without-commit path directly — the exact
-    /// machinery `mirror_chatgpt_export_file`'s `?`-propagated errors rely
-    /// on — and forces a genuine, non-suppressed SQL error (a `prepare()`
-    /// failure on a nonexistent table) after a session write AND a cursor
-    /// advance have already succeeded within the same open transaction.
+    /// makes re-ingest idempotent). So this test drives the same
+    /// `atomic_unit`/`writer.execute`/`Err`-return path directly — the exact
+    /// machinery `write_events_and_cursor`'s `?`-propagated errors rely on
+    /// (ADR-099 D5) — and forces a genuine, non-suppressed SQL error (a
+    /// `prepare()` failure on a nonexistent table) after a session write AND
+    /// a cursor advance have already succeeded within the same open unit.
     #[tokio::test]
     async fn test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced() {
         let (rt, _dir) = setup().await;
         let sql = rt.sql();
         let path = std::path::Path::new("/synthetic/mid-tx-probe.json");
+        let path_owned = path.to_path_buf();
 
-        let mut tx = sql
-            .begin_tx(SqlTxOptions::default())
-            .await
-            .expect("begin_tx");
+        let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
+            Box::pin(async move {
+                // First write succeeds — mirrors event 1's session row in a
+                // multi-event file pass.
+                writer
+                    .execute(SqlStatement {
+                        sql: "INSERT INTO sessions \
+                              (id, provider_session_id, source, message_count, first_seen_at, last_seen_at, namespace) \
+                              VALUES('mid-tx-session', 'mid-tx-session', 'chatgpt_export', 0, 1, 1, 'local')"
+                            .into(),
+                        params: vec![],
+                        label: None,
+                    })
+                    .await?;
 
-        // First write succeeds — mirrors event 1's session row in a
-        // multi-event file pass.
-        tx.execute(SqlStatement {
-            sql: "INSERT INTO sessions \
-                  (id, provider_session_id, source, message_count, first_seen_at, last_seen_at, namespace) \
-                  VALUES('mid-tx-session', 'mid-tx-session', 'chatgpt_export', 0, 1, 1, 'local')"
-                .into(),
-            params: vec![],
-            label: None,
-        })
-        .await
-        .expect("first write in transaction must succeed");
+                // Cursor advance succeeds too — mirrors `upsert_cursor_on_writer`
+                // running near the end of `write_events_and_cursor_on_writer`.
+                upsert_cursor_on_writer(writer, &path_owned, Some("mid-tx-session"), 999, 1)
+                    .await?;
 
-        // Cursor advance succeeds too — mirrors `upsert_cursor_in_tx` running
-        // near the end of `write_events_and_cursor`, before `commit()`.
-        upsert_cursor_in_tx(&mut *tx, path, Some("mid-tx-session"), 999, 1)
-            .await
-            .expect("cursor upsert in transaction must succeed");
+                // Third write fails with a genuine (non-suppressed) SQL error —
+                // mirrors a mid-loop DB failure on a later event in the same file.
+                writer
+                    .execute(SqlStatement {
+                        sql: "INSERT INTO no_such_table_mid_tx_probe(a) VALUES(1)".into(),
+                        params: vec![],
+                        label: None,
+                    })
+                    .await?;
 
-        // Third write fails with a genuine (non-suppressed) SQL error —
-        // mirrors a mid-loop DB failure on a later event in the same file.
-        let err = tx
-            .execute(SqlStatement {
-                sql: "INSERT INTO no_such_table_mid_tx_probe(a) VALUES(1)".into(),
-                params: vec![],
-                label: None,
+                Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
             })
-            .await;
-        assert!(err.is_err(), "forced third write must fail");
+        });
 
-        // No `commit()` is ever called — `tx` is dropped here, exactly as
-        // `write_events_and_cursor` drops its `tx` when an earlier `?`
-        // returns `Err` before reaching its own `tx.commit()` call.
-        drop(tx);
+        // `atomic_unit` itself must surface the error and roll back the
+        // whole unit — no explicit `commit()`/`drop()` orchestration is the
+        // caller's job anymore; the seam owns it.
+        let result = sql.atomic_unit(op).await;
+        assert!(
+            result.is_err(),
+            "atomic_unit must propagate the forced third-write failure"
+        );
 
         assert_eq!(
             count_rows(&rt, "sessions").await,
             0,
-            "session write must not survive a later error in the same transaction"
+            "session write must not survive a later error in the same atomic unit"
         );
         assert_eq!(
             cursor_offset(&rt, &path.to_string_lossy()).await,
             None,
-            "cursor must not advance when a later write in the same transaction fails"
+            "cursor must not advance when a later write in the same atomic unit fails"
+        );
+    }
+
+    /// Build a bare, file-backed, write-queue-enabled `SqlAccess` handle —
+    /// no `KhiveRuntime`, no `KHIVE_WRITE_QUEUE` env var. Mirrors
+    /// khive-pack-brain's `fold_gate.rs`/`persist.rs` write-queue-routing
+    /// tests: `PoolConfig::default()` reads `KHIVE_WRITE_QUEUE` at
+    /// construction time, and that env var is process-global, so mutating
+    /// it here would race every other test in this binary that calls
+    /// `KhiveRuntime::new()` (that binary-wide hazard is exactly what those
+    /// two tests' doc comments document having hit). A `PoolConfig` literal
+    /// with `write_queue_enabled: true` sidesteps it entirely — no
+    /// `#[serial]`, no risk to any other test in this crate.
+    fn write_queue_pool(db_path: std::path::PathBuf) -> Arc<khive_db::ConnectionPool> {
+        let pool_cfg = khive_db::PoolConfig {
+            path: Some(db_path),
+            write_queue_enabled: true,
+            ..khive_db::PoolConfig::default()
+        };
+        let pool = Arc::new(khive_db::ConnectionPool::new(pool_cfg).expect("pool"));
+        {
+            let w_conn = pool.writer().expect("writer");
+            for stmt in &SESSION_SCHEMA_PLAN_STMTS {
+                w_conn
+                    .conn()
+                    .execute_batch(stmt)
+                    .expect("session schema stmt");
+            }
+        }
+        pool
+    }
+
+    /// ADR-099 D5 acceptance: the converted `write_events_and_cursor`
+    /// closure is suspension-free — it drives only synchronous DML through
+    /// `writer`, so it resolves on its first poll and is `block_on_sync`-safe
+    /// on the single-writer path. Exercises the real production closure
+    /// (`write_events_and_cursor_on_writer` via `atomic_unit`) over a
+    /// write-queue-enabled pool built directly (see `write_queue_pool`), so
+    /// this proves the actual shipped code — not a stand-in — never
+    /// suspends: if it ever did, `block_on_sync` would return the "future
+    /// suspended" error and this call would fail instead of returning `Ok`.
+    #[tokio::test]
+    async fn write_events_and_cursor_is_suspension_free_under_single_writer() {
+        let dir = TempDir::new().expect("tempdir");
+        let pool = write_queue_pool(dir.path().join("suspend_free.db"));
+        let sql: Arc<dyn khive_storage::SqlAccess> =
+            Arc::new(khive_db::SqlBridge::new(Arc::clone(&pool), true));
+
+        pool.writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let events = vec![parse::parse_cc_line(
+            r#"{"uuid":"evt-1","sessionId":"suspend-free-session","type":"user","message":{"role":"user","content":"hello"},"cwd":"/tmp","timestamp":"2026-01-01T00:00:00Z"}"#,
+        )
+        .expect("line must parse")];
+
+        let path = std::path::Path::new("/synthetic/suspend-free.jsonl").to_path_buf();
+        let now_us = Utc::now().timestamp_micros();
+        let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
+            Box::pin(async move {
+                write_events_and_cursor_on_writer(
+                    writer,
+                    &path,
+                    "claude_code",
+                    &events,
+                    1,
+                    100,
+                    now_us,
+                )
+                .await
+                .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "test_write_events_and_cursor",
+                        e,
+                    )
+                })
+            })
+        });
+
+        let boxed = sql
+            .atomic_unit(op)
+            .await
+            .expect("a suspension-free closure must not hit block_on_sync's Pending error");
+        let stats = *boxed
+            .downcast::<MirrorStats>()
+            .expect("op must return MirrorStats");
+
+        assert_eq!(stats.inserted, 1, "the one event must be inserted");
+
+        let mut reader = sql.reader().await.expect("reader");
+        let row = khive_storage::SqlReader::query_scalar(
+            reader.as_mut(),
+            SqlStatement {
+                sql: "SELECT COUNT(*) FROM sessions".into(),
+                params: vec![],
+                label: None,
+            },
+        )
+        .await
+        .expect("count query")
+        .expect("count row");
+        match row {
+            SqlValue::Integer(1) => {}
+            other => panic!("the session row must be committed, got COUNT(*) = {other:?}"),
+        }
+    }
+
+    /// ADR-099 D5 acceptance ("single-writer concurrency test, mandatory"):
+    /// with the write queue enabled, concurrent session-mirror ingest
+    /// (`write_events_and_cursor_on_writer` via `atomic_unit`) and normal
+    /// write traffic through `SqlBridge::writer()` must not contend at
+    /// `BEGIN IMMEDIATE` — the converted ingest path routes through the
+    /// single writer task rather than opening its own standalone
+    /// transaction (the `begin_tx` hole this ADR closes). Uses the same
+    /// queue-depth + occupier-parked-on-oneshot technique as
+    /// khive-pack-brain's `fold_gate_apply_routes_through_writer_task_when_flag_enabled`
+    /// (a wall-clock/timing probe would be indistinguishable from the
+    /// flag-off fallback, which also serializes via real SQLite file
+    /// locking): while an occupier deterministically holds the writer
+    /// task's one drain slot open, the ingest call must appear in the
+    /// channel's queue depth rather than opening a second, competing
+    /// standalone `BEGIN IMMEDIATE`.
+    #[tokio::test]
+    async fn session_ingest_routes_through_writer_task_when_flag_enabled() {
+        let dir = TempDir::new().expect("tempdir");
+        let pool = write_queue_pool(dir.path().join("concurrency.db"));
+        let sql: Arc<dyn khive_storage::SqlAccess> =
+            Arc::new(khive_db::SqlBridge::new(Arc::clone(&pool), true));
+
+        let writer_task = pool
+            .writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), khive_storage::StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        let events = vec![parse::parse_cc_line(
+            r#"{"uuid":"evt-concurrency-1","sessionId":"concurrency-session","type":"user","message":{"role":"user","content":"hello"},"cwd":"/tmp","timestamp":"2026-01-01T00:00:00Z"}"#,
+        )
+        .expect("line must parse")];
+        let path = std::path::Path::new("/synthetic/concurrency.jsonl").to_path_buf();
+        let now_us = Utc::now().timestamp_micros();
+        let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
+            Box::pin(async move {
+                write_events_and_cursor_on_writer(
+                    writer,
+                    &path,
+                    "claude_code",
+                    &events,
+                    1,
+                    100,
+                    now_us,
+                )
+                .await
+                .map(|stats| Box::new(stats) as Box<dyn std::any::Any + Send>)
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "test_session_ingest_concurrency",
+                        e,
+                    )
+                })
+            })
+        });
+
+        let sql_for_ingest = Arc::clone(&sql);
+        let ingest_task = tokio::spawn(async move { sql_for_ingest.atomic_unit(op).await });
+
+        let mut saw_enqueued = false;
+        for _ in 0..100 {
+            if writer_task.queue_depth() >= 1 {
+                saw_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_enqueued,
+            "session-ingest's atomic_unit request never appeared in the writer task's \
+             channel while the occupier held the single drain slot — the converted ingest \
+             path is not routing through the shared writer task (a standalone `begin_tx` \
+             connection would never show up here at all)"
+        );
+
+        release_tx
+            .send(())
+            .expect("occupier must still be waiting on the release signal");
+        occupier
+            .await
+            .expect("occupier task must not panic")
+            .expect("occupier write must succeed");
+
+        let boxed = ingest_task
+            .await
+            .expect("ingest task must not panic")
+            .expect("ingest atomic_unit must succeed once the occupier releases the slot");
+        let stats = *boxed
+            .downcast::<MirrorStats>()
+            .expect("op must return MirrorStats");
+        assert_eq!(stats.inserted, 1, "the ingest event must be committed");
+    }
+
+    /// ADR-099 acceptance ("revert-companion test"): the OLD shape — a
+    /// closure that issues its own `BEGIN IMMEDIATE` through the writer it
+    /// was handed, instead of relying on `atomic_unit`'s own transaction —
+    /// must fail deterministically with a nested-transaction error. This
+    /// proves the suspension-free / single-transaction-owner assertions
+    /// above are non-vacuous: the pre-conversion shape (a caller managing
+    /// its own `BEGIN`/`COMMIT` inside the seam) does NOT silently pass.
+    #[tokio::test]
+    async fn old_shape_manual_begin_immediate_inside_atomic_unit_fails() {
+        let (rt, _dir) = setup().await;
+        let sql = rt.sql();
+
+        let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
+            Box::pin(async move {
+                // `atomic_unit` already has an open transaction (or, on the
+                // flag-off path, is about to issue one) around this
+                // closure — issuing a second `BEGIN IMMEDIATE` here is
+                // exactly the old `begin_tx`-shaped mistake this ADR
+                // retires: a caller managing its own transaction control
+                // inside a seam that already owns the transaction boundary.
+                writer
+                    .execute(SqlStatement {
+                        sql: "BEGIN IMMEDIATE".into(),
+                        params: vec![],
+                        label: None,
+                    })
+                    .await?;
+                Ok(Box::new(()) as Box<dyn std::any::Any + Send>)
+            })
+        });
+
+        let result = sql.atomic_unit(op).await;
+        assert!(
+            result.is_err(),
+            "a closure that issues its own BEGIN IMMEDIATE inside atomic_unit \
+             must fail with a nested-transaction error, not silently succeed"
         );
     }
 }

--- a/crates/khive-pack-session/src/mirror/ingest.rs
+++ b/crates/khive-pack-session/src/mirror/ingest.rs
@@ -717,7 +717,14 @@ async fn write_events_and_cursor_on_writer(
                 ],
                 label: Some("session_mirror_create_session".into()),
             })
-            .await?;
+            .await
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "mirror: session create",
+                    e,
+                )
+            })?;
 
         // ── session_messages insert (idempotent) ──────────────────────────────
         let affected = writer
@@ -751,7 +758,14 @@ async fn write_events_and_cursor_on_writer(
                 ],
                 label: Some("session_mirror_insert_message".into()),
             })
-            .await?;
+            .await
+            .map_err(|e| {
+                khive_storage::StorageError::driver(
+                    khive_storage::StorageCapability::Sql,
+                    "mirror: message insert",
+                    e,
+                )
+            })?;
 
         // ── advance session metadata ONLY when a new message landed ────────────
         //
@@ -787,7 +801,14 @@ async fn write_events_and_cursor_on_writer(
                     ],
                     label: Some("session_mirror_touch_session".into()),
                 })
-                .await?;
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "mirror: session touch",
+                        e,
+                    )
+                })?;
         }
 
         inserted += affected;
@@ -819,7 +840,14 @@ async fn write_events_and_cursor_on_writer(
                     params: vec![SqlValue::Text(sid.clone())],
                     label: Some("session_mirror_refresh_count".into()),
                 })
-                .await?;
+                .await
+                .map_err(|e| {
+                    khive_storage::StorageError::driver(
+                        khive_storage::StorageCapability::Sql,
+                        "mirror: count refresh",
+                        e,
+                    )
+                })?;
         }
     }
 
@@ -871,7 +899,14 @@ async fn upsert_cursor_on_writer(
             ],
             label: Some("session_mirror_cursor_upsert".into()),
         })
-        .await?;
+        .await
+        .map_err(|e| {
+            khive_storage::StorageError::driver(
+                khive_storage::StorageCapability::Sql,
+                "mirror: cursor upsert",
+                e,
+            )
+        })?;
     Ok(())
 }
 
@@ -2756,15 +2791,24 @@ mod tests {
     /// proves the suspension-free / single-transaction-owner assertions
     /// above are non-vacuous: the pre-conversion shape (a caller managing
     /// its own `BEGIN`/`COMMIT` inside the seam) does NOT silently pass.
+    /// Built over a write-queue-enabled pool (see `write_queue_pool`) so the
+    /// closure is deterministically driven through `block_on_sync`'s
+    /// `InlineWriter` on the real single-writer production path, not the
+    /// flag-off manual-transaction fallback.
     #[tokio::test]
     async fn old_shape_manual_begin_immediate_inside_atomic_unit_fails() {
-        let (rt, _dir) = setup().await;
-        let sql = rt.sql();
+        let dir = TempDir::new().expect("tempdir");
+        let pool = write_queue_pool(dir.path().join("old_shape_begin_immediate.db"));
+        let sql: Arc<dyn khive_storage::SqlAccess> =
+            Arc::new(khive_db::SqlBridge::new(Arc::clone(&pool), true));
+
+        pool.writer_task_handle()
+            .unwrap()
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
 
         let op: khive_storage::AtomicUnitOp = Box::new(move |writer: &mut dyn SqlWriter| {
             Box::pin(async move {
-                // `atomic_unit` already has an open transaction (or, on the
-                // flag-off path, is about to issue one) around this
+                // `atomic_unit` already has an open transaction around this
                 // closure — issuing a second `BEGIN IMMEDIATE` here is
                 // exactly the old `begin_tx`-shaped mistake this ADR
                 // retires: a caller managing its own transaction control
@@ -2780,11 +2824,15 @@ mod tests {
             })
         });
 
-        let result = sql.atomic_unit(op).await;
+        let err = sql.atomic_unit(op).await.expect_err(
+            "a closure that issues its own BEGIN IMMEDIATE inside atomic_unit must fail with a \
+             nested-transaction error, not silently succeed",
+        );
+        let msg = err.to_string();
         assert!(
-            result.is_err(),
-            "a closure that issues its own BEGIN IMMEDIATE inside atomic_unit \
-             must fail with a nested-transaction error, not silently succeed"
+            msg.contains("cannot start a transaction within a transaction"),
+            "expected the deterministic nested-transaction failure (SQLite's own message for a \
+             second BEGIN issued inside an already-open transaction), got: {msg}"
         );
     }
 }

--- a/crates/khive-storage/README.md
+++ b/crates/khive-storage/README.md
@@ -12,7 +12,7 @@ specific backend.
 
 | Trait                                                      | Surface                                                                          |
 | ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `SqlAccess` / `SqlReader` / `SqlWriter` / `SqlTransaction` | pooled connections, transactions, query planning                                 |
+| `SqlAccess` / `SqlReader` / `SqlWriter`                    | pooled connections, atomic units, query planning                                 |
 | `VectorStore`                                              | dense embedding insert/search/rebuild, optional filter pushdown and batch search |
 | `TextSearch`                                               | FTS document upsert/search/stats, optional term-stats (IDF)                      |
 | `GraphStore`                                               | edge CRUD, neighbor queries, multi-hop traversal, batched neighbor/edge fetch    |

--- a/crates/khive-storage/docs/design.md
+++ b/crates/khive-storage/docs/design.md
@@ -66,7 +66,7 @@ Key design constraints:
 | [`src/graph.rs`](../src/graph.rs)           | `GraphStore`                                                                |
 | [`src/note.rs`](../src/note.rs)             | `Note`, `NoteFilter`, `NoteStore`                                           |
 | [`src/sparse.rs`](../src/sparse.rs)         | `SparseStore`                                                               |
-| [`src/sql.rs`](../src/sql.rs)               | `SqlAccess`, `SqlReader`, `SqlWriter`, `SqlTransaction`                     |
+| [`src/sql.rs`](../src/sql.rs)               | `SqlAccess`, `SqlReader`, `SqlWriter`, `AtomicUnitOp`                       |
 | [`src/text.rs`](../src/text.rs)             | `TextSearch`                                                                |
 | [`src/types/`](../src/types/)               | Shared types split by domain (vector, text, graph, sparse, sql, pagination) |
 | [`src/vectors.rs`](../src/vectors.rs)       | `VectorStore`                                                               |

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -32,11 +32,11 @@ pub use types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField,
     GraphPath, IndexRebuildScope, LinkId, NeighborHit, NeighborQuery, OrphanSweepConfig,
     OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SortDirection,
-    SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlIsolation,
-    SqlRow, SqlStatement, SqlTxOptions, SqlValue, TextDocument, TextFilter, TextGatherMode,
-    TextIndexStats, TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest,
-    TextTermStats, TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest,
-    VectorIndexKind, VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
+    SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlRow,
+    SqlStatement, SqlValue, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
+    TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
+    TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest, VectorIndexKind,
+    VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,
     VectorStoreCapabilities, VectorStoreInfo, MAX_SPARSE_SEARCH_TOP_K,
 };
 

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -23,7 +23,7 @@ pub use event::{
 pub use graph::GraphStore;
 pub use note::{FilterOp, Note, NoteFilter, NoteStore, SortDir};
 pub use sparse::SparseStore;
-pub use sql::{AtomicUnitOp, BoxFuture, SqlAccess, SqlReader, SqlTransaction, SqlWriter};
+pub use sql::{AtomicUnitOp, BoxFuture, SqlAccess, SqlReader, SqlWriter};
 pub use text::TextSearch;
 pub use types::StorageResult;
 pub use vectors::VectorStore;

--- a/crates/khive-storage/src/sql.rs
+++ b/crates/khive-storage/src/sql.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 use async_trait::async_trait;
 
-use crate::types::{SqlRow, SqlStatement, SqlTxOptions, SqlValue, StorageResult};
+use crate::types::{SqlRow, SqlStatement, SqlValue, StorageResult};
 
 /// A boxed future, borrowing from the `&mut dyn SqlWriter` an
 /// [`AtomicUnitOp`] is called with (see [`SqlAccess::atomic_unit`]).
@@ -69,15 +69,6 @@ pub trait SqlWriter: SqlReader + Send + 'static {
     }
 }
 
-/// A SQL transaction (extends `SqlWriter`).
-#[async_trait]
-pub trait SqlTransaction: SqlWriter + Send + 'static {
-    /// Commit the transaction, persisting all changes.
-    async fn commit(self: Box<Self>) -> StorageResult<()>;
-    /// Roll back the transaction, discarding all changes.
-    async fn rollback(self: Box<Self>) -> StorageResult<()>;
-}
-
 /// Base SQL access capability.
 #[async_trait]
 pub trait SqlAccess: Send + Sync + 'static {
@@ -85,8 +76,6 @@ pub trait SqlAccess: Send + Sync + 'static {
     async fn reader(&self) -> StorageResult<Box<dyn SqlReader>>;
     /// Acquire a read-write connection from the pool.
     async fn writer(&self) -> StorageResult<Box<dyn SqlWriter>>;
-    /// Begin a transaction with the given isolation options.
-    async fn begin_tx(&self, options: SqlTxOptions) -> StorageResult<Box<dyn SqlTransaction>>;
 
     /// Run `op` as ONE atomic unit of work (ADR-067 Component A, Fork C
     /// slice 2).
@@ -100,5 +89,22 @@ pub trait SqlAccess: Send + Sync + 'static {
     /// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` on a writer handle exactly like
     /// calling [`Self::writer`] and driving the statements by hand — the
     /// pre-ADR-067 behavior, preserved byte-for-byte on this path.
+    ///
+    /// **The atomic-unit suspend-free invariant (normative for every
+    /// caller):** `op`'s future must complete on its **first poll** — it may
+    /// issue only synchronous DML against the `&mut dyn SqlWriter` it is
+    /// handed and must never reach a real suspension point (no embedding
+    /// computation, no ANN warming, no service or channel `await`, no
+    /// network round-trip). On the single-writer path this is enforced at
+    /// runtime: the writer task drives `op` through a single-poll driver and
+    /// returns a typed error the instant the future is `Pending`, so a
+    /// violation fails loudly rather than corrupting state. On the flag-off
+    /// path (no writer task active) a suspending `op` would currently
+    /// *succeed* — that path drives `op` as an ordinary `.await` under a
+    /// manual transaction — so the invariant is a correctness contract this
+    /// trait asks every caller to uphold, not something the type system or
+    /// every code path enforces. Callers must not rely on the flag-off
+    /// path's tolerance; behavior must be identical (synchronous DML only)
+    /// regardless of whether the single-writer flag is on.
     async fn atomic_unit(&self, op: AtomicUnitOp) -> StorageResult<Box<dyn Any + Send>>;
 }

--- a/crates/khive-storage/src/tx_registry.rs
+++ b/crates/khive-storage/src/tx_registry.rs
@@ -1,10 +1,11 @@
 //! Process-wide open-transaction registry (ADR-091 Plank 0).
 //!
-//! Every caller-controllable SQL transaction span (`SqliteTransaction::begin_tx`,
-//! `WriterGuard::transaction`, and the raw `BEGIN IMMEDIATE`/`COMMIT` batch-writer
-//! spans) registers here on open and deregisters via `TxHandle`'s `Drop`. This is
-//! observe-only: no enforcement reads the registry in this plank. It exists so the
-//! checkpoint task can name which caller, if any, is holding a WAL snapshot open.
+//! Every caller-controllable SQL transaction span (`WriterGuard::transaction`,
+//! `atomic_unit`'s own registered span, and the raw `BEGIN IMMEDIATE`/`COMMIT`
+//! batch-writer spans) registers here on open and deregisters via `TxHandle`'s
+//! `Drop`. This is observe-only: no enforcement reads the registry in this
+//! plank. It exists so the checkpoint task can name which caller, if any, is
+//! holding a WAL snapshot open.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -21,7 +21,7 @@ pub use pagination::{Page, PageRequest};
 pub use sparse::{
     SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, MAX_SPARSE_SEARCH_TOP_K,
 };
-pub use sql::{SqlColumn, SqlIsolation, SqlRow, SqlStatement, SqlTxOptions, SqlValue};
+pub use sql::{SqlColumn, SqlRow, SqlStatement, SqlValue};
 pub use text::{
     IndexRebuildScope, TextDocument, TextFilter, TextGatherMode, TextIndexStats, TextQueryMode,
     TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats, TextTermStatsRequest,

--- a/crates/khive-storage/src/types/sql.rs
+++ b/crates/khive-storage/src/types/sql.rs
@@ -1,4 +1,4 @@
-//! SQL-related shared types: values, statements, rows, and transaction options.
+//! SQL-related shared types: values, statements, and rows.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -48,33 +48,5 @@ impl SqlRow {
             .iter()
             .find(|c| c.name == name)
             .map(|c| &c.value)
-    }
-}
-
-/// Transaction isolation level hint for SQL backends that support it.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum SqlIsolation {
-    Default,
-    ReadCommitted,
-    RepeatableRead,
-    Serializable,
-}
-
-/// Options passed to a SQL transaction begin call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SqlTxOptions {
-    pub read_only: bool,
-    pub isolation: SqlIsolation,
-    pub label: Option<String>,
-}
-
-impl Default for SqlTxOptions {
-    fn default() -> Self {
-        Self {
-            read_only: false,
-            isolation: SqlIsolation::Default,
-            label: None,
-        }
     }
 }


### PR DESCRIPTION
## Summary

ADR-099 D5, Slice A — migration steps 0, 5, 6 only (steps 1-4/7, the broader
`--atomic` bulk-apply feature, are out of scope for this PR).

- **Step 0**: documented the atomic-unit suspend-free invariant directly on
  `SqlAccess::atomic_unit` (`crates/khive-storage/src/sql.rs`) and on the
  `SqlBridge` implementation (`crates/khive-db/src/sql_bridge.rs`): the
  closure passed to `atomic_unit` must complete on its first poll —
  synchronous DML only, no embedding/ANN/service/channel `.await`. Enforced
  at runtime on the single-writer path via `block_on_sync`, which returns a
  typed error the instant the future is `Pending` rather than ever actually
  suspending.
- **Step 5**: converted `write_events_and_cursor` in
  `crates/khive-pack-session/src/mirror/ingest.rs` from a manual
  `begin_tx`/`tx.commit()` transaction to a single `sql.atomic_unit(...)`
  call. The closure drives the identical statement sequence (session
  create-only upsert, message `INSERT OR IGNORE` with a `seq` subquery, a
  conditional `last_seen_at` advance, and the cursor `UPDATE`) against the
  `&mut dyn SqlWriter` it is handed. Semantics are unchanged: the cursor
  only advances on commit, dedup and idempotency are preserved, and the
  inserted-count return value is identical.
- **Step 6**: `begin_tx` had exactly one non-test production caller anywhere
  in the workspace — `write_events_and_cursor` (verbatim grep evidence
  below). With that caller converted, `begin_tx` and the `SqlTransaction`
  trait have no remaining callers and no forward-deployed use in
  `khive-vcs`/`khive-merge` (checked directly — neither crate references
  `SqlTransaction` or `begin_tx`), so both are removed from `SqlAccess` and
  the `SqlBridge` implementation, along with the now-dead
  `open_standalone_tx_conn` helper and the `SqliteTransaction` type.

## Grep evidence (verbatim)

Before (base commit `b32ad689`, non-test production callers of `begin_tx`):

```
crates/khive-db/src/backend.rs:754:        let mut tx = sql.begin_tx(SqlTxOptions::default()).await.unwrap();       <- test-only (#[cfg(test)] mod)
crates/khive-db/src/sql_bridge.rs:1203:    async fn begin_tx(                                                            <- trait impl definition
crates/khive-pack-session/src/mirror/ingest.rs:615:        .begin_tx(SqlTxOptions::default())                              <- THE ONLY non-test production caller
crates/khive-pack-session/src/mirror/ingest.rs:2416:            .begin_tx(SqlTxOptions::default())                          <- test-only (regression test)
crates/khive-storage/src/sql.rs:89:    async fn begin_tx(&self, options: SqlTxOptions) -> ...                        <- trait declaration
crates/khive-db/src/stores/entity_tests.rs:769:        let mut tx = bridge.begin_tx(SqlTxOptions::default()).await.unwrap();  <- test-only
```

After (this branch, working tree):

```
$ grep -rn "begin_tx" --include="*.rs" crates/
khive-storage/src/tx_registry.rs:3://! Every caller-controllable SQL transaction span (`SqliteTransaction::begin_tx`,
khive-pack-brain/src/persist.rs:331:/// This deliberately does NOT use `SqlAccess::begin_tx` — per `fold_gate.rs`'s
khive-pack-brain/src/fold_gate.rs:30://! own write lock can. `SqlAccess::begin_tx` was not used for this because it
khive-pack-session/src/mirror/ingest.rs:621:    // `begin_tx` this function used before ADR-099: the whole sequence
khive-pack-session/src/mirror/ingest.rs:833:    // same all-or-nothing contract the old `begin_tx`/`tx.commit()` shape
khive-pack-session/src/mirror/ingest.rs:2641:    /// transaction (the `begin_tx` hole this ADR closes). Uses the same
khive-pack-session/src/mirror/ingest.rs:2730:             path is not routing through the shared writer task (a standalone `begin_tx` \
khive-pack-session/src/mirror/ingest.rs:2769:                // exactly the old `begin_tx`-shaped mistake this ADR
khive-db/src/stores/entity_tests.rs:636:/// Entry 9 (`SqlBridge::begin_tx`, formerly a genuine design fork on its own
khive-db/src/stores/entity_tests.rs:637:/// standalone connection) is retired as of ADR-099 D5 — `begin_tx` and

$ grep -rn "SqlTransaction" --include="*.rs" crates/
khive-pack-brain/src/fold_gate.rs:31://! returns a distinct `SqlTransaction` type and hard-errors on non-file-backed
khive-pack-session/src/mirror/ingest.rs:663:/// (not `&mut dyn SqlTransaction`) because `atomic_unit` owns the
khive-db/src/stores/entity_tests.rs:638:/// `SqlTransaction` no longer exist on `SqlAccess` (their one production
```

Every remaining match is a comment or doc-comment referencing the retired
mechanism for historical context — no code path calls `begin_tx` or names
`SqlTransaction` as a live type after this change.

## `SqlTransaction` disposition

**Removed**, not kept as a documented no-caller exemption. Reasoning: the
trait had no non-test caller anywhere in the workspace (confirmed by the
grep above), and it is not forward-deployed infrastructure the way
`khive-vcs`/`khive-merge` are (checked directly — neither references
`SqlTransaction` or `begin_tx`). Keeping an unused trait with no consumer
and no documented future caller would be dead surface area rather than
forward deployment.

## Tests

Added to `crates/khive-pack-session/src/mirror/ingest.rs`:

- `write_events_and_cursor_is_suspension_free_under_single_writer` — builds
  a bare `PoolConfig{write_queue_enabled: true, ..}` + `ConnectionPool` /
  `SqlBridge` directly (bypassing `KhiveRuntime`, which reads
  `KHIVE_WRITE_QUEUE` from the process environment at construction time —
  mutating that env var around a `KhiveRuntime::new()` call races every
  other concurrently running test in the same binary, per the documented
  precedent in `khive-pack-brain/src/fold_gate.rs` and `persist.rs`), then
  drives the converted closure through `atomic_unit` and asserts it
  resolves and persists correctly.
- `session_ingest_routes_through_writer_task_when_flag_enabled` — proves
  routing through the single writer task using the queue_depth +
  parked-occupier technique (an occupier holds the writer task's one slot
  via a oneshot channel; the call under test is spawned and its enqueuing
  is observed via `queue_depth() >= 1` before the occupier releases) — wall
  clock timing alone cannot distinguish writer-task routing from the
  flag-off fallback due to real SQLite file locking, so this is the
  rigorous proof.
- `old_shape_manual_begin_immediate_inside_atomic_unit_fails` — a
  revert-companion test: the OLD closure shape (issuing its own manual
  `BEGIN IMMEDIATE` inside the `atomic_unit` closure) fails deterministically
  with a nested-transaction error, proving the suspension-free/single-writer
  tests above are non-vacuous.
- The existing `test_mid_transaction_db_error_leaves_no_partial_state_and_cursor_unadvanced`
  regression test was adapted to build its `AtomicUnitOp` inline and assert
  on the same no-partial-state contract through the new seam.

## Test summary

```
cargo test -p khive-storage -p khive-db -p khive-pack-session --all-features
  khive-db (unit):          14 passed, 0 failed
  khive-pack-session (unit): 75 passed, 0 failed
  khive-pack-session (integration): 23 passed, 0 failed
  khive-storage (unit):      44 passed, 0 failed
  khive-storage (compliance): 33 passed, 0 failed
  khive-storage (vectors):   10 passed, 0 failed
  (+ 3 empty doc-test suites)
  Total: 456 passed, 0 failed

cargo clippy -p khive-storage -p khive-db -p khive-pack-session \
  --all-targets --all-features -- -D warnings
  clean

cargo fmt --all -- --check
  clean

cargo check --workspace --all-features --all-targets
  clean (confirms the SqlAccess trait-surface change does not break any
  other workspace crate, including khive-vcs, khive-merge, khive-pack-brain,
  khive-mcp, kkernel)
```
