### PR TITLE
feat(runtime): ADR-099 B1 — atomic plan seams + admissibility metadata + parse-time rejection

### DIFF
--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 description = "Request DSL — parses verb-dispatch strings (function-call, JSON, and future LNDL / pipe / bash-style syntaxes) into a transport-agnostic ParsedRequest AST"
 
 [dependencies]
+khive-types = { version = "0.3.0", path = "../khive-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/khive-request/src/atomic.rs
+++ b/crates/khive-request/src/atomic.rs
@@ -1,0 +1,140 @@
+//! ADR-099 migration step 2 — parse-time rejection of atomic-inadmissible
+//! verbs.
+//!
+//! `--atomic` bulk apply (ADR-099 migration step 4, not yet built) must
+//! reject an inadmissible op **before any execution**. This module exposes
+//! that check as a pure function over already-parsed ops so the future
+//! `--atomic` runner can call it without re-deriving the admissible set —
+//! the set itself lives in `khive_types::pack` (shared pack metadata, ADR-099
+//! D3: admissibility is a static per-verb property, "declared per verb as
+//! pack metadata").
+
+use khive_types::pack::{atomic_admissibility, AtomicRejectionReason, ATOMIC_ADMISSIBLE_VERBS};
+
+use crate::types::ParsedOp;
+
+/// One rejected op inside a would-be `--atomic` file: its zero-based index in
+/// the op list, its tool name, and why it was rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AtomicRejection {
+    pub op_index: usize,
+    pub tool: String,
+    pub reason: AtomicRejectionReason,
+}
+
+impl std::fmt::Display for AtomicRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let why = match self.reason {
+            AtomicRejectionReason::EmbeddingBearing => {
+                "embedding-bearing verbs are not yet atomic-eligible"
+            }
+            AtomicRejectionReason::Read => "read verbs have no write plan to apply",
+            AtomicRejectionReason::Unlisted => "not on the v1 atomic-admissible verb list",
+        };
+        write!(
+            f,
+            "op {} (`{}`) is not atomic-admissible: {}. Admissible verbs: {}",
+            self.op_index,
+            self.tool,
+            why,
+            ATOMIC_ADMISSIBLE_VERBS.join(", ")
+        )
+    }
+}
+
+/// Check every op's tool name against the ADR-099 v1 admissible verb set.
+///
+/// Returns every rejection found (not just the first), so a caller preparing
+/// to reject the whole file up front can report every offending line in one
+/// pass, naming the line and verb per op (ADR-099 acceptance criteria). An
+/// empty result means every op in `ops` is atomic-admissible.
+///
+/// This function is pure: it performs no I/O and does not execute any op. It
+/// is the seam the future `--atomic` runner (ADR-099 migration step 4) calls
+/// before the prepare pass begins.
+pub fn check_atomic_admissible(ops: &[ParsedOp]) -> Vec<AtomicRejection> {
+    ops.iter()
+        .enumerate()
+        .filter_map(|(op_index, op)| {
+            atomic_admissibility(&op.tool).map(|reason| AtomicRejection {
+                op_index,
+                tool: op.tool.clone(),
+                reason,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn op(tool: &str) -> ParsedOp {
+        ParsedOp {
+            tool: tool.to_string(),
+            args: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn all_admissible_ops_pass_with_no_rejections() {
+        let ops = vec![op("update"), op("delete"), op("link"), op("merge")];
+        assert!(check_atomic_admissible(&ops).is_empty());
+    }
+
+    #[test]
+    fn embedding_bearing_verb_named_in_rejection() {
+        let ops = vec![op("update"), op("create"), op("delete")];
+        let rejections = check_atomic_admissible(&ops);
+        assert_eq!(rejections.len(), 1);
+        assert_eq!(rejections[0].op_index, 1);
+        assert_eq!(rejections[0].tool, "create");
+        assert_eq!(
+            rejections[0].reason,
+            AtomicRejectionReason::EmbeddingBearing
+        );
+    }
+
+    #[test]
+    fn read_verb_named_in_rejection_before_any_write() {
+        let ops = vec![op("search"), op("update")];
+        let rejections = check_atomic_admissible(&ops);
+        assert_eq!(rejections.len(), 1);
+        assert_eq!(rejections[0].op_index, 0);
+        assert_eq!(rejections[0].tool, "search");
+        assert_eq!(rejections[0].reason, AtomicRejectionReason::Read);
+    }
+
+    #[test]
+    fn every_offending_line_is_reported_not_just_the_first() {
+        let ops = vec![op("create"), op("update"), op("comm.send"), op("search")];
+        let rejections = check_atomic_admissible(&ops);
+        let indices: Vec<usize> = rejections.iter().map(|r| r.op_index).collect();
+        assert_eq!(indices, vec![0, 2, 3]);
+    }
+
+    #[test]
+    fn rejection_display_names_verb_and_lists_admissible_set() {
+        let rejection = AtomicRejection {
+            op_index: 2,
+            tool: "create".to_string(),
+            reason: AtomicRejectionReason::EmbeddingBearing,
+        };
+        let msg = rejection.to_string();
+        assert!(msg.contains("op 2"));
+        assert!(msg.contains("`create`"));
+        assert!(
+            msg.contains("update"),
+            "must list the admissible set: {msg}"
+        );
+    }
+
+    #[test]
+    fn all_v1_admissible_verbs_from_the_ordered_ops_file_pass() {
+        // ADR-099 D3's full v1 list, exercised through the ops-file shape
+        // (tool name only — the parse-time check does not need args).
+        let ops: Vec<ParsedOp> = ATOMIC_ADMISSIBLE_VERBS.iter().map(|v| op(v)).collect();
+        assert!(check_atomic_admissible(&ops).is_empty());
+    }
+}

--- a/crates/khive-request/src/lib.rs
+++ b/crates/khive-request/src/lib.rs
@@ -1,9 +1,11 @@
 //! `khive-request` — transport-agnostic DSL parser for verb-dispatch requests.
 
+pub mod atomic;
 mod conflict;
 mod parser;
 mod types;
 
+pub use atomic::{check_atomic_admissible, AtomicRejection};
 pub use conflict::write_keys_for_op_pub;
 pub use parser::parse_request;
 pub use types::{

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -18,15 +18,42 @@
 //! 1. **Predicate-based plans** — a plan whose effect covers "all rows
 //!    matching a condition" carries that condition as a statement evaluated
 //!    inside the transaction, never as a prepare-time-enumerated row list
-//!    (`predicate`).
+//!    (`PlanPredicate`).
 //! 2. **Affected-row guards** — any statement whose prepare-time validation
 //!    assumed a target row exists carries an expected-effect guard, checked
 //!    in-transaction; a mismatch fails the op and rolls back the whole unit
-//!    (`guard`).
+//!    (`PlanStatement::guard`).
+//!
+//! A guard is attached to the exact [`PlanStatement`] it validates, never to
+//! the plan as a whole: the storage layer returns affected-row counts
+//! per-statement (`SqlWriter::execute`) or as a batch total
+//! (`SqlWriter::execute_batch`), so a plan-level guard field cannot tell a
+//! future runner which statement's count it is checking without an implicit
+//! ordering convention. Each plan therefore carries `Vec<PlanStatement>`
+//! (or, for `merge`, the split `rewires`/`lifecycle` fields below) so the
+//! runner contract is: apply each statement individually, and where
+//! `guard.is_some()`, check that *statement's own* affected-row count before
+//! moving to the next.
 
 use uuid::Uuid;
 
 use khive_storage::SqlStatement;
+
+/// One statement in a plan, paired with the guard (if any) that validates
+/// it. **Runner contract:** a present `guard` is checked against the
+/// affected-row count of applying `statement` alone (`SqlWriter::execute`'s
+/// return value for this statement), not a batch total and not another
+/// statement's count. `guard: None` means prepare made no row-existence
+/// assumption about this particular statement (e.g. a cascade delete that
+/// may legitimately touch zero rows).
+#[derive(Debug, Clone)]
+pub struct PlanStatement {
+    /// The DML to apply inside the atomic unit.
+    pub statement: SqlStatement,
+    /// The expected-effect guard for `statement`, if prepare's validation
+    /// assumed a target row exists for it.
+    pub guard: Option<AffectedRowGuard>,
+}
 
 /// The predicate a prepare pass validated a plan's target against, replayed
 /// as a statement evaluated **inside** the transaction (ADR-099 D1, rule 1:
@@ -111,11 +138,11 @@ pub enum PostCommitEffect {
 pub struct UpdatePlan {
     /// The id of the entity or note being updated.
     pub target_id: Uuid,
-    /// Row + FTS DML statements to apply inside the atomic unit.
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the row-update statement (prepare assumed the target row
-    /// exists).
-    pub guard: AffectedRowGuard,
+    /// Row + FTS DML statements to apply inside the atomic unit, in order.
+    /// The row-update statement carries the existence guard; any FTS-mirror
+    /// statement that follows it is unguarded (its target row's existence
+    /// was already asserted by the row-update statement's own guard).
+    pub statements: Vec<PlanStatement>,
     /// Deferred reindex, if the update changed name/description/content.
     pub post_commit: PostCommitEffect,
 }
@@ -126,45 +153,52 @@ pub struct DeletePlan {
     /// The id of the entity or note being deleted.
     pub target_id: Uuid,
     /// Row DML (and, for a hard delete, incident-edge cascade DML) to apply
-    /// inside the atomic unit.
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the delete statement (prepare assumed the target row
-    /// exists).
-    pub guard: AffectedRowGuard,
+    /// inside the atomic unit, in order. The target-row delete statement
+    /// carries the existence guard; a cascade edge-delete statement (hard
+    /// delete only) is unguarded — it may legitimately affect zero rows if
+    /// the target had no incident edges.
+    pub statements: Vec<PlanStatement>,
 }
 
-/// Write plan for a `link` op (create a typed directed edge).
+/// Write plan for a `link` op (create a typed directed edge). Endpoint
+/// existence is checked **structurally**, not via an unanchored plan-level
+/// guard: `statement` is a guarded `INSERT ... SELECT ... WHERE EXISTS`
+/// shape whose `SELECT` re-probes both endpoints inside the transaction, so
+/// the runner's affected-row check on this one statement *is* the
+/// in-transaction existence probe (ADR-099 acceptance criteria's
+/// dangling-edge case — `[delete(X, hard), link(A, X)]` — is closed by this
+/// guard failing once X is gone, regardless of statement ordering
+/// convention).
 #[derive(Debug, Clone)]
 pub struct LinkPlan {
     pub source_id: Uuid,
     pub target_id: Uuid,
-    /// Edge-insert DML to apply inside the atomic unit.
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the endpoint-existence check (prepare validated both
-    /// endpoints exist; ADR-099 acceptance criteria's dangling-edge case —
-    /// `[delete(X, hard), link(A, X)]` — is closed by this guard failing
-    /// in-transaction once X is gone).
-    pub guard: AffectedRowGuard,
+    /// The guarded `INSERT ... SELECT ... WHERE EXISTS(...)` statement:
+    /// its affected-row count is the endpoint-existence probe.
+    pub statement: PlanStatement,
 }
 
-/// Write plan for a `merge` op (deduplicate two entities). The edge rewire is
-/// **predicate-based** (ADR-099 D1 rule 1) — `predicate` holds the
-/// `UPDATE graph_edges SET source_id = :into WHERE source_id = :from`-shaped
-/// statement evaluated inside the transaction, so it structurally sees any
-/// earlier op's edge writes in the same file (ADR-099 acceptance criteria:
-/// "merge rewires see earlier in-file writes").
+/// Write plan for a `merge` op (deduplicate two entities). Rewires and
+/// lifecycle writes are split into separate fields precisely so a guard is
+/// never ambiguous between them: the edge rewire is **predicate-based**
+/// (ADR-099 D1 rule 1) and may touch zero or many rows depending on earlier
+/// in-file writes, so it is never guarded; the `from`/`into` entity
+/// lifecycle write assumes both rows exist, so it always is.
 #[derive(Debug, Clone)]
 pub struct MergePlan {
     pub into_id: Uuid,
     pub from_id: Uuid,
-    /// The predicated edge-rewire statement(s), plus the `from` entity's
-    /// soft-delete/tombstone DML.
-    pub statements: Vec<SqlStatement>,
-    /// The in-transaction predicate the rewire is evaluated against.
-    pub predicate: PlanPredicate,
-    /// Guard on the merge target existing (prepare assumed `into`/`from`
-    /// both exist).
-    pub guard: AffectedRowGuard,
+    /// Predicate-based edge-rewire statement(s)
+    /// (`UPDATE graph_edges SET source_id = :into WHERE source_id = :from`-
+    /// shaped), evaluated inside the transaction so they structurally see
+    /// any earlier op's edge writes in the same file (ADR-099 acceptance
+    /// criteria: "merge rewires see earlier in-file writes"). Never
+    /// guarded — a rewire touching zero rows is a legitimate outcome.
+    pub rewires: Vec<PlanPredicate>,
+    /// The `from` entity's soft-delete/tombstone DML (and any other
+    /// lifecycle write prepare assumed a target row exists for). Always
+    /// guarded — prepare validated `into`/`from` both exist.
+    pub lifecycle: Vec<PlanStatement>,
 }
 
 /// Write plan for a `gtd.transition` op (explicit task lifecycle change).
@@ -172,22 +206,21 @@ pub struct MergePlan {
 pub struct GtdTransitionPlan {
     pub task_id: Uuid,
     /// Status-column DML to apply inside the atomic unit. Property-only
-    /// status mutation — triggers no reindex (ADR-099 D3).
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the transition statement (prepare validated the current
-    /// status and the requested transition were legal).
-    pub guard: AffectedRowGuard,
+    /// status mutation — triggers no reindex (ADR-099 D3). The transition
+    /// statement carries the guard (prepare validated the current status
+    /// and the requested transition were legal).
+    pub statements: Vec<PlanStatement>,
 }
 
 /// Write plan for a `gtd.complete` op (task lifecycle terminal transition).
 #[derive(Debug, Clone)]
 pub struct GtdCompletePlan {
     pub task_id: Uuid,
-    /// Status + `completed_at` DML to apply inside the atomic unit.
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the completion statement (prepare validated the task was in
-    /// a completable state).
-    pub guard: AffectedRowGuard,
+    /// Status + `completed_at` DML to apply inside the atomic unit, in
+    /// order. The status-update statement carries the guard (prepare
+    /// validated the task was in a completable state); the `completed_at`
+    /// write targets the same already-guarded row and is unguarded.
+    pub statements: Vec<PlanStatement>,
 }
 
 /// Which governance verb (`propose` / `review` / `withdraw`) a
@@ -205,11 +238,10 @@ pub enum GovernanceOp {
 pub struct GovernancePlan {
     pub op: GovernanceOp,
     pub proposal_id: Uuid,
-    /// Event-log + status DML to apply inside the atomic unit.
-    pub statements: Vec<SqlStatement>,
-    /// Guard on the lifecycle-state check (prepare validated the proposal
-    /// was in a state admitting this transition).
-    pub guard: AffectedRowGuard,
+    /// Event-log + status DML to apply inside the atomic unit. The
+    /// lifecycle-state-check statement carries the guard (prepare validated
+    /// the proposal was in a state admitting this transition).
+    pub statements: Vec<PlanStatement>,
 }
 
 #[cfg(test)]
@@ -221,6 +253,20 @@ mod tests {
             sql: "UPDATE t SET x = ? WHERE id = ?".to_string(),
             params: vec![],
             label: Some(label.to_string()),
+        }
+    }
+
+    fn guarded(label: &str, guard: AffectedRowGuard) -> PlanStatement {
+        PlanStatement {
+            statement: stmt(label),
+            guard: Some(guard),
+        }
+    }
+
+    fn unguarded(label: &str) -> PlanStatement {
+        PlanStatement {
+            statement: stmt(label),
+            guard: None,
         }
     }
 
@@ -241,16 +287,19 @@ mod tests {
     }
 
     #[test]
-    fn update_plan_carries_predicate_free_guard_and_post_commit() {
+    fn update_plan_guard_is_anchored_to_the_row_statement_not_the_fts_mirror() {
         let id = Uuid::new_v4();
         let plan = UpdatePlan {
             target_id: id,
-            statements: vec![stmt("update-row")],
-            guard: AffectedRowGuard::exactly(1),
+            statements: vec![
+                guarded("update-row", AffectedRowGuard::exactly(1)),
+                unguarded("update-fts-mirror"),
+            ],
             post_commit: PostCommitEffect::ReindexEntity { entity_id: id },
         };
         assert_eq!(plan.target_id, id);
-        assert_eq!(plan.guard, AffectedRowGuard::exactly(1));
+        assert_eq!(plan.statements[0].guard, Some(AffectedRowGuard::exactly(1)));
+        assert_eq!(plan.statements[1].guard, None);
         assert_eq!(
             plan.post_commit,
             PostCommitEffect::ReindexEntity { entity_id: id }
@@ -258,39 +307,43 @@ mod tests {
     }
 
     #[test]
-    fn delete_plan_guard_requires_exactly_one_row() {
+    fn delete_plan_guard_is_anchored_to_the_target_row_not_the_cascade() {
         let plan = DeletePlan {
             target_id: Uuid::new_v4(),
-            statements: vec![stmt("delete-row")],
-            guard: AffectedRowGuard::exactly(1),
+            statements: vec![
+                guarded("delete-row", AffectedRowGuard::exactly(1)),
+                unguarded("cascade-edges"),
+            ],
         };
-        assert!(plan.guard.holds_for(1));
-        assert!(!plan.guard.holds_for(0));
+        let row_guard = plan.statements[0].guard.expect("row delete is guarded");
+        assert!(row_guard.holds_for(1));
+        assert!(!row_guard.holds_for(0));
+        assert_eq!(plan.statements[1].guard, None);
     }
 
     #[test]
-    fn link_plan_carries_both_endpoints_and_existence_guard() {
+    fn link_plan_guard_is_the_endpoint_existence_probe_itself() {
         let source = Uuid::new_v4();
         let target = Uuid::new_v4();
         let plan = LinkPlan {
             source_id: source,
             target_id: target,
-            statements: vec![stmt("insert-edge")],
-            guard: AffectedRowGuard::exactly(1),
+            statement: guarded("insert-edge-where-exists", AffectedRowGuard::exactly(1)),
         };
         assert_eq!(plan.source_id, source);
         assert_eq!(plan.target_id, target);
-        // Dangling-edge acceptance criterion: once the target row is gone,
-        // an in-transaction existence check affects 0 rows and the guard
-        // must fail, not silently pass.
-        assert!(!plan.guard.holds_for(0));
+        // Dangling-edge acceptance criterion: once an endpoint row is gone,
+        // the guarded INSERT...WHERE EXISTS affects 0 rows and the guard
+        // on *that exact statement* must fail, not silently pass.
+        let guard = plan.statement.guard.expect("link insert is guarded");
+        assert!(!guard.holds_for(0));
     }
 
     #[test]
-    fn merge_plan_predicate_is_evaluated_in_transaction_not_prepare_enumerated() {
+    fn merge_plan_rewires_are_never_guarded_lifecycle_writes_always_are() {
         let into = Uuid::new_v4();
         let from = Uuid::new_v4();
-        let predicate = PlanPredicate {
+        let rewire = PlanPredicate {
             description: "source_id = :from".to_string(),
             statement: SqlStatement {
                 sql: "UPDATE graph_edges SET source_id = ? WHERE source_id = ?".to_string(),
@@ -301,41 +354,48 @@ mod tests {
         let plan = MergePlan {
             into_id: into,
             from_id: from,
-            statements: vec![predicate.statement.clone()],
-            predicate,
-            guard: AffectedRowGuard::at_least_one(),
+            rewires: vec![rewire],
+            lifecycle: vec![guarded(
+                "tombstone-from-entity",
+                AffectedRowGuard::exactly(1),
+            )],
         };
         assert_eq!(plan.into_id, into);
         assert_eq!(plan.from_id, from);
-        assert_eq!(plan.predicate.description, "source_id = :from");
+        assert_eq!(plan.rewires[0].description, "source_id = :from");
         // A predicate-based rewire may legitimately touch zero or many rows
-        // depending on how many edges an earlier in-file op inserted; the
-        // guard only requires the merge itself to have found its targets.
-        assert!(plan.guard.holds_for(0) || plan.guard.expected_min == 1);
+        // depending on how many edges an earlier in-file op inserted — the
+        // type carries no guard field for it at all.
+        let lifecycle_guard = plan.lifecycle[0].guard.expect("lifecycle write is guarded");
+        assert!(!lifecycle_guard.holds_for(0));
     }
 
     #[test]
     fn gtd_transition_plan_triggers_no_reindex_by_construction() {
         let plan = GtdTransitionPlan {
             task_id: Uuid::new_v4(),
-            statements: vec![stmt("update-status")],
-            guard: AffectedRowGuard::exactly(1),
+            statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
         };
         // Property-only status mutation — the type carries no post-commit
         // field at all, which is the structural guarantee (ADR-099 D3: task
         // transitions "trigger no reindex").
         assert_eq!(plan.statements.len(), 1);
+        assert!(plan.statements[0].guard.is_some());
     }
 
     #[test]
-    fn gtd_complete_plan_guard_requires_target_row() {
+    fn gtd_complete_plan_guard_is_anchored_to_the_status_write() {
         let plan = GtdCompletePlan {
             task_id: Uuid::new_v4(),
-            statements: vec![stmt("update-status"), stmt("update-completed-at")],
-            guard: AffectedRowGuard::exactly(1),
+            statements: vec![
+                guarded("update-status", AffectedRowGuard::exactly(1)),
+                unguarded("update-completed-at"),
+            ],
         };
         assert_eq!(plan.statements.len(), 2);
-        assert!(plan.guard.holds_for(1));
+        let guard = plan.statements[0].guard.expect("status write is guarded");
+        assert!(guard.holds_for(1));
+        assert_eq!(plan.statements[1].guard, None);
     }
 
     #[test]
@@ -348,10 +408,10 @@ mod tests {
             let plan = GovernancePlan {
                 op,
                 proposal_id: Uuid::new_v4(),
-                statements: vec![stmt("governance-event")],
-                guard: AffectedRowGuard::exactly(1),
+                statements: vec![guarded("governance-event", AffectedRowGuard::exactly(1))],
             };
             assert_eq!(plan.op, op);
+            assert!(plan.statements[0].guard.is_some());
         }
     }
 

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -1,0 +1,367 @@
+//! ADR-099 (cross-op atomicity for bulk apply) — prepared write-plan types.
+//!
+//! Migration step 1 (ADR-099) calls for a per-verb `prepare`/apply seam: the
+//! async prepare pass materializes a synchronous write plan outside any
+//! transaction, and the commit pass later applies that plan's statements as
+//! DML under a per-op SAVEPOINT. This module defines the plan *shapes* only —
+//! one family per v1 admissible verb group (`update`, `delete`, `link`,
+//! `merge`, `gtd.transition`, `gtd.complete`, the governance verbs). Nothing
+//! in this module is wired into a live handler or the dispatch path yet; that
+//! wiring (the actual `prepare` implementations, the atomic runner, and the
+//! `--atomic` CLI surface) is later ADR-099 migration work (steps 1 cont'd,
+//! 3, 4). These types exist so that work has a shared, plain-data target.
+//!
+//! Every plan is deliberately inert: plain data, no async, no embedding
+//! reference. See ADR-099 D1's two validation-staleness rules, which every
+//! plan's fields exist to satisfy:
+//!
+//! 1. **Predicate-based plans** — a plan whose effect covers "all rows
+//!    matching a condition" carries that condition as a statement evaluated
+//!    inside the transaction, never as a prepare-time-enumerated row list
+//!    (`predicate`).
+//! 2. **Affected-row guards** — any statement whose prepare-time validation
+//!    assumed a target row exists carries an expected-effect guard, checked
+//!    in-transaction; a mismatch fails the op and rolls back the whole unit
+//!    (`guard`).
+
+use uuid::Uuid;
+
+use khive_storage::SqlStatement;
+
+/// The predicate a prepare pass validated a plan's target against, replayed
+/// as a statement evaluated **inside** the transaction (ADR-099 D1, rule 1:
+/// "predicate-based plans wherever a write's scope depends on current
+/// state"). Carrying the predicate rather than a prepare-time-enumerated row
+/// list is what lets a later op in the same file (e.g. an intervening
+/// `link`) be visible to this plan's apply.
+#[derive(Debug, Clone)]
+pub struct PlanPredicate {
+    /// Human-readable description of the condition, for diagnostics (e.g.
+    /// `"source_id = :from"`).
+    pub description: String,
+    /// The in-transaction statement whose scope is evaluated against
+    /// current (committed-so-far) state, not prepare-time state.
+    pub statement: SqlStatement,
+}
+
+/// An affected-row guard (ADR-099 D1, rule 2): the row-count prepare assumed
+/// its target write would affect, re-verified in-transaction. A prepare-time
+/// validation is a plan *hypothesis*, never a commitment — if the guard does
+/// not hold at apply time, the op fails inside the atomic unit and the whole
+/// unit rolls back (ADR-099 acceptance criteria: "zero-row apply fails the
+/// unit").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AffectedRowGuard {
+    /// Minimum affected-row count for the guard to hold (inclusive).
+    pub expected_min: u64,
+    /// Maximum affected-row count for the guard to hold (inclusive), or
+    /// `None` for "no upper bound" (e.g. a predicate-based rewire that may
+    /// touch any number of rows).
+    pub expected_max: Option<u64>,
+}
+
+impl AffectedRowGuard {
+    /// A guard requiring exactly `n` affected rows (the common case for a
+    /// single-target `update`/`delete`/`link` statement).
+    pub fn exactly(n: u64) -> Self {
+        Self {
+            expected_min: n,
+            expected_max: Some(n),
+        }
+    }
+
+    /// A guard requiring at least one affected row and no upper bound (the
+    /// shape for a predicate-based rewire that may touch any number of rows,
+    /// e.g. `merge`'s edge rewire).
+    pub fn at_least_one() -> Self {
+        Self {
+            expected_min: 1,
+            expected_max: None,
+        }
+    }
+
+    /// Whether an observed affected-row count satisfies this guard.
+    pub fn holds_for(&self, affected: u64) -> bool {
+        affected >= self.expected_min
+            && self.expected_max.map(|max| affected <= max).unwrap_or(true)
+    }
+}
+
+/// A deferred side effect recorded during prepare and run once, after the
+/// atomic unit commits (ADR-099 D1, "post-commit pass"). v1's admissible set
+/// computes no embeddings during prepare (D3's `update`/`merge` caveat), so
+/// the only post-commit effects are reindex kicks computed from the
+/// **committed** row content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PostCommitEffect {
+    /// No deferred side effect for this op.
+    None,
+    /// Re-embed and re-warm the given entity's vector row from its committed
+    /// content (ADR-099 D3 `update` caveat: entity name/description change).
+    ReindexEntity { entity_id: Uuid },
+    /// Re-embed and re-warm the given note's vector row from its committed
+    /// content (ADR-099 D3 `update` caveat: note name/content change).
+    ReindexNote { note_id: Uuid },
+}
+
+/// Write plan for an `update` op (entity or note shape — ADR-099 D3's
+/// `update` caveat covers both substrates the same way: row/FTS DML in the
+/// plan, any reindex deferred to `post_commit`).
+#[derive(Debug, Clone)]
+pub struct UpdatePlan {
+    /// The id of the entity or note being updated.
+    pub target_id: Uuid,
+    /// Row + FTS DML statements to apply inside the atomic unit.
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the row-update statement (prepare assumed the target row
+    /// exists).
+    pub guard: AffectedRowGuard,
+    /// Deferred reindex, if the update changed name/description/content.
+    pub post_commit: PostCommitEffect,
+}
+
+/// Write plan for a `delete` op (soft or hard).
+#[derive(Debug, Clone)]
+pub struct DeletePlan {
+    /// The id of the entity or note being deleted.
+    pub target_id: Uuid,
+    /// Row DML (and, for a hard delete, incident-edge cascade DML) to apply
+    /// inside the atomic unit.
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the delete statement (prepare assumed the target row
+    /// exists).
+    pub guard: AffectedRowGuard,
+}
+
+/// Write plan for a `link` op (create a typed directed edge).
+#[derive(Debug, Clone)]
+pub struct LinkPlan {
+    pub source_id: Uuid,
+    pub target_id: Uuid,
+    /// Edge-insert DML to apply inside the atomic unit.
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the endpoint-existence check (prepare validated both
+    /// endpoints exist; ADR-099 acceptance criteria's dangling-edge case —
+    /// `[delete(X, hard), link(A, X)]` — is closed by this guard failing
+    /// in-transaction once X is gone).
+    pub guard: AffectedRowGuard,
+}
+
+/// Write plan for a `merge` op (deduplicate two entities). The edge rewire is
+/// **predicate-based** (ADR-099 D1 rule 1) — `predicate` holds the
+/// `UPDATE graph_edges SET source_id = :into WHERE source_id = :from`-shaped
+/// statement evaluated inside the transaction, so it structurally sees any
+/// earlier op's edge writes in the same file (ADR-099 acceptance criteria:
+/// "merge rewires see earlier in-file writes").
+#[derive(Debug, Clone)]
+pub struct MergePlan {
+    pub into_id: Uuid,
+    pub from_id: Uuid,
+    /// The predicated edge-rewire statement(s), plus the `from` entity's
+    /// soft-delete/tombstone DML.
+    pub statements: Vec<SqlStatement>,
+    /// The in-transaction predicate the rewire is evaluated against.
+    pub predicate: PlanPredicate,
+    /// Guard on the merge target existing (prepare assumed `into`/`from`
+    /// both exist).
+    pub guard: AffectedRowGuard,
+}
+
+/// Write plan for a `gtd.transition` op (explicit task lifecycle change).
+#[derive(Debug, Clone)]
+pub struct GtdTransitionPlan {
+    pub task_id: Uuid,
+    /// Status-column DML to apply inside the atomic unit. Property-only
+    /// status mutation — triggers no reindex (ADR-099 D3).
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the transition statement (prepare validated the current
+    /// status and the requested transition were legal).
+    pub guard: AffectedRowGuard,
+}
+
+/// Write plan for a `gtd.complete` op (task lifecycle terminal transition).
+#[derive(Debug, Clone)]
+pub struct GtdCompletePlan {
+    pub task_id: Uuid,
+    /// Status + `completed_at` DML to apply inside the atomic unit.
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the completion statement (prepare validated the task was in
+    /// a completable state).
+    pub guard: AffectedRowGuard,
+}
+
+/// Which governance verb (`propose` / `review` / `withdraw`) a
+/// [`GovernancePlan`] applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceOp {
+    Propose,
+    Review,
+    Withdraw,
+}
+
+/// Write plan for a governance op (`propose`, `review`, or `withdraw` — the
+/// event-sourced change-proposal lifecycle, ADR-046).
+#[derive(Debug, Clone)]
+pub struct GovernancePlan {
+    pub op: GovernanceOp,
+    pub proposal_id: Uuid,
+    /// Event-log + status DML to apply inside the atomic unit.
+    pub statements: Vec<SqlStatement>,
+    /// Guard on the lifecycle-state check (prepare validated the proposal
+    /// was in a state admitting this transition).
+    pub guard: AffectedRowGuard,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stmt(label: &str) -> SqlStatement {
+        SqlStatement {
+            sql: "UPDATE t SET x = ? WHERE id = ?".to_string(),
+            params: vec![],
+            label: Some(label.to_string()),
+        }
+    }
+
+    #[test]
+    fn affected_row_guard_exactly_holds_only_for_n() {
+        let g = AffectedRowGuard::exactly(1);
+        assert!(!g.holds_for(0));
+        assert!(g.holds_for(1));
+        assert!(!g.holds_for(2));
+    }
+
+    #[test]
+    fn affected_row_guard_at_least_one_has_no_upper_bound() {
+        let g = AffectedRowGuard::at_least_one();
+        assert!(!g.holds_for(0));
+        assert!(g.holds_for(1));
+        assert!(g.holds_for(1_000));
+    }
+
+    #[test]
+    fn update_plan_carries_predicate_free_guard_and_post_commit() {
+        let id = Uuid::new_v4();
+        let plan = UpdatePlan {
+            target_id: id,
+            statements: vec![stmt("update-row")],
+            guard: AffectedRowGuard::exactly(1),
+            post_commit: PostCommitEffect::ReindexEntity { entity_id: id },
+        };
+        assert_eq!(plan.target_id, id);
+        assert_eq!(plan.guard, AffectedRowGuard::exactly(1));
+        assert_eq!(
+            plan.post_commit,
+            PostCommitEffect::ReindexEntity { entity_id: id }
+        );
+    }
+
+    #[test]
+    fn delete_plan_guard_requires_exactly_one_row() {
+        let plan = DeletePlan {
+            target_id: Uuid::new_v4(),
+            statements: vec![stmt("delete-row")],
+            guard: AffectedRowGuard::exactly(1),
+        };
+        assert!(plan.guard.holds_for(1));
+        assert!(!plan.guard.holds_for(0));
+    }
+
+    #[test]
+    fn link_plan_carries_both_endpoints_and_existence_guard() {
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let plan = LinkPlan {
+            source_id: source,
+            target_id: target,
+            statements: vec![stmt("insert-edge")],
+            guard: AffectedRowGuard::exactly(1),
+        };
+        assert_eq!(plan.source_id, source);
+        assert_eq!(plan.target_id, target);
+        // Dangling-edge acceptance criterion: once the target row is gone,
+        // an in-transaction existence check affects 0 rows and the guard
+        // must fail, not silently pass.
+        assert!(!plan.guard.holds_for(0));
+    }
+
+    #[test]
+    fn merge_plan_predicate_is_evaluated_in_transaction_not_prepare_enumerated() {
+        let into = Uuid::new_v4();
+        let from = Uuid::new_v4();
+        let predicate = PlanPredicate {
+            description: "source_id = :from".to_string(),
+            statement: SqlStatement {
+                sql: "UPDATE graph_edges SET source_id = ? WHERE source_id = ?".to_string(),
+                params: vec![],
+                label: Some("merge-rewire".to_string()),
+            },
+        };
+        let plan = MergePlan {
+            into_id: into,
+            from_id: from,
+            statements: vec![predicate.statement.clone()],
+            predicate,
+            guard: AffectedRowGuard::at_least_one(),
+        };
+        assert_eq!(plan.into_id, into);
+        assert_eq!(plan.from_id, from);
+        assert_eq!(plan.predicate.description, "source_id = :from");
+        // A predicate-based rewire may legitimately touch zero or many rows
+        // depending on how many edges an earlier in-file op inserted; the
+        // guard only requires the merge itself to have found its targets.
+        assert!(plan.guard.holds_for(0) || plan.guard.expected_min == 1);
+    }
+
+    #[test]
+    fn gtd_transition_plan_triggers_no_reindex_by_construction() {
+        let plan = GtdTransitionPlan {
+            task_id: Uuid::new_v4(),
+            statements: vec![stmt("update-status")],
+            guard: AffectedRowGuard::exactly(1),
+        };
+        // Property-only status mutation — the type carries no post-commit
+        // field at all, which is the structural guarantee (ADR-099 D3: task
+        // transitions "trigger no reindex").
+        assert_eq!(plan.statements.len(), 1);
+    }
+
+    #[test]
+    fn gtd_complete_plan_guard_requires_target_row() {
+        let plan = GtdCompletePlan {
+            task_id: Uuid::new_v4(),
+            statements: vec![stmt("update-status"), stmt("update-completed-at")],
+            guard: AffectedRowGuard::exactly(1),
+        };
+        assert_eq!(plan.statements.len(), 2);
+        assert!(plan.guard.holds_for(1));
+    }
+
+    #[test]
+    fn governance_plan_covers_all_three_lifecycle_ops() {
+        for op in [
+            GovernanceOp::Propose,
+            GovernanceOp::Review,
+            GovernanceOp::Withdraw,
+        ] {
+            let plan = GovernancePlan {
+                op,
+                proposal_id: Uuid::new_v4(),
+                statements: vec![stmt("governance-event")],
+                guard: AffectedRowGuard::exactly(1),
+            };
+            assert_eq!(plan.op, op);
+        }
+    }
+
+    #[test]
+    fn plans_are_plain_data_no_async_no_embedding() {
+        // Compile-time property, asserted here as documentation: every plan
+        // type above derives only Debug/Clone/PartialEq, never Future or any
+        // embedding-provider trait. If a future edit adds an async method or
+        // an embedding-model field to one of these types, this comment is
+        // the marker to revert it — plans must stay inert data (ADR-099 D1).
+        let _ = PostCommitEffect::None;
+    }
+}

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Wraps `StorageBackend` and query compilation into a single Rust API surface.
 
+pub mod atomic_plan;
 pub mod config;
 pub mod curation;
 #[cfg(unix)]
@@ -22,6 +23,10 @@ pub mod runtime;
 pub mod secret_gate;
 pub mod validation;
 
+pub use atomic_plan::{
+    AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan, GtdCompletePlan, GtdTransitionPlan,
+    LinkPlan, MergePlan, PlanPredicate, PostCommitEffect, UpdatePlan,
+};
 pub use curation::{
     entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,
     EntityDedupMergePolicy, EntityPatch, MergeSummary, NotePatch,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -25,7 +25,7 @@ pub mod validation;
 
 pub use atomic_plan::{
     AffectedRowGuard, DeletePlan, GovernanceOp, GovernancePlan, GtdCompletePlan, GtdTransitionPlan,
-    LinkPlan, MergePlan, PlanPredicate, PostCommitEffect, UpdatePlan,
+    LinkPlan, MergePlan, PlanPredicate, PlanStatement, PostCommitEffect, UpdatePlan,
 };
 pub use curation::{
     entity_fts_document, note_fts_document, ContentMergeStrategy, EdgeListFilter, EdgePatch,

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -335,6 +335,89 @@ pub trait Pack {
     const VALIDATION_RULES: &'static [&'static str] = &[];
 }
 
+/// ADR-099 D3 — the v1 atomic-admissible verb set for `--atomic` bulk apply.
+///
+/// This is an EXPLICIT per-verb allowlist, never derived from [`VerbCategory`]
+/// or any other classification ("never a pack-level category", ADR-099 D3).
+/// Every verb here has a prepare/apply seam whose in-transaction phase reduces
+/// to synchronous DML — the atomic-unit suspend-free invariant
+/// (`SqlAccess::atomic_unit` in `khive-storage`). Extending this list is a
+/// design decision (ADR-099 amendment), not a code-review-only change; the
+/// `atomic_admissible_list_matches_adr` test below pins this exact set so an
+/// edit here forces the editor to touch that test and its ADR citation.
+pub const ATOMIC_ADMISSIBLE_VERBS: &[&str] = &[
+    "update",
+    "delete",
+    "link",
+    "merge",
+    "gtd.transition",
+    "gtd.complete",
+    "propose",
+    "review",
+    "withdraw",
+];
+
+/// Verbs rejected under `--atomic` because their write still computes an
+/// embedding synchronously and no prepare/apply seam hoists that embedding
+/// out of the transaction yet (ADR-099 D3, "v1 rejected — embedding-bearing").
+const ATOMIC_EMBEDDING_BEARING_VERBS: &[&str] = &[
+    "create",
+    "memory.remember",
+    "gtd.assign",
+    "comm.send",
+    "comm.reply",
+    "comm.ingest",
+];
+
+/// Read verbs rejected under `--atomic` — they produce no write plan to apply
+/// (ADR-099 D3, "v1 rejected — reads").
+const ATOMIC_READ_VERBS: &[&str] = &[
+    "search",
+    "recall",
+    "query",
+    "traverse",
+    "list",
+    "get",
+    "neighbors",
+    "context",
+    "stats",
+    "verbs",
+];
+
+/// Why a verb was rejected from an `--atomic` op list (ADR-099 D3, migration
+/// step 2). Distinguishes the two named rejection classes from a generic
+/// "not yet admitted" fallback so callers can produce an actionable message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AtomicRejectionReason {
+    /// The verb still computes an embedding synchronously in its write path.
+    EmbeddingBearing,
+    /// The verb is a read — it has no write plan to apply.
+    Read,
+    /// Neither on the v1 admissible list nor a known rejected category (e.g.
+    /// a verb added after this list was written). Rejected by default —
+    /// admissibility is opt-in, never inferred.
+    Unlisted,
+}
+
+/// Static admissibility classification for `verb_name` under ADR-099
+/// `--atomic` bulk apply.
+///
+/// Returns `None` when the verb is admissible; `Some(reason)` names why it is
+/// rejected. Default-deny: a verb name absent from every list here is
+/// [`AtomicRejectionReason::Unlisted`], never silently admitted.
+pub fn atomic_admissibility(verb_name: &str) -> Option<AtomicRejectionReason> {
+    if ATOMIC_ADMISSIBLE_VERBS.contains(&verb_name) {
+        return None;
+    }
+    if ATOMIC_EMBEDDING_BEARING_VERBS.contains(&verb_name) {
+        return Some(AtomicRejectionReason::EmbeddingBearing);
+    }
+    if ATOMIC_READ_VERBS.contains(&verb_name) {
+        return Some(AtomicRejectionReason::Read);
+    }
+    Some(AtomicRejectionReason::Unlisted)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,5 +527,87 @@ mod tests {
                 "{name:?} must be Standard (not AlwaysVerbose)"
             );
         }
+    }
+
+    // ── ADR-099 D3 atomic admissibility ────────────────────────────────────
+
+    // Drift-pin: a hardcoded copy of the ADR-099 D3 v1 admissible list. If
+    // someone edits `ATOMIC_ADMISSIBLE_VERBS`, this test fails until they also
+    // update this literal — forcing a look at ADR-099 D3 ("Decision: admit
+    // only verbs that expose a prepare/apply seam...") before the set changes.
+    #[test]
+    fn atomic_admissible_list_matches_adr099_d3() {
+        let adr_099_d3_v1_admissible_set: &[&str] = &[
+            "update",
+            "delete",
+            "link",
+            "merge",
+            "gtd.transition",
+            "gtd.complete",
+            "propose",
+            "review",
+            "withdraw",
+        ];
+        assert_eq!(
+            ATOMIC_ADMISSIBLE_VERBS, adr_099_d3_v1_admissible_set,
+            "ATOMIC_ADMISSIBLE_VERBS drifted from ADR-099 D3's explicit v1 list"
+        );
+    }
+
+    #[test]
+    fn atomic_admissible_verbs_are_admitted() {
+        for verb in ATOMIC_ADMISSIBLE_VERBS {
+            assert_eq!(
+                atomic_admissibility(verb),
+                None,
+                "{verb:?} is on the v1 admissible list and must be admitted"
+            );
+        }
+    }
+
+    #[test]
+    fn atomic_embedding_bearing_verbs_rejected_named() {
+        for verb in [
+            "create",
+            "memory.remember",
+            "gtd.assign",
+            "comm.send",
+            "comm.reply",
+        ] {
+            assert_eq!(
+                atomic_admissibility(verb),
+                Some(AtomicRejectionReason::EmbeddingBearing),
+                "{verb:?} must be rejected as embedding-bearing (ADR-099 acceptance criteria)"
+            );
+        }
+    }
+
+    #[test]
+    fn atomic_read_verbs_rejected() {
+        for verb in [
+            "search",
+            "recall",
+            "query",
+            "traverse",
+            "list",
+            "get",
+            "neighbors",
+            "context",
+        ] {
+            assert_eq!(
+                atomic_admissibility(verb),
+                Some(AtomicRejectionReason::Read),
+                "{verb:?} must be rejected as a read verb"
+            );
+        }
+    }
+
+    #[test]
+    fn atomic_unknown_verb_defaults_to_unlisted_rejection() {
+        assert_eq!(
+            atomic_admissibility("some_future_verb_nobody_classified_yet"),
+            Some(AtomicRejectionReason::Unlisted),
+            "an unrecognized verb must default-deny, never silently admit"
+        );
     }
 }

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -1304,6 +1304,127 @@ default = true
         );
     }
 
+    // ── ADR-099 B1 inertness (golden shape) ────────────────────────────────────
+    //
+    // B1 adds only new, unconsumed types (khive-types atomic admissibility
+    // metadata, khive-runtime atomic-plan data, khive-request's parse-time
+    // check). None of them are wired into `dispatch_request_local` or
+    // `apply_ops_file` — this test pins the non-atomic response envelope's
+    // shape so a later slice that DOES wire `--atomic` in cannot silently
+    // change today's default (non-atomic) output. The op sequence below
+    // (create → update → link → get) is the representative mix named in the
+    // task: a create, a mutation, a graph edge, and a read, run back-to-back
+    // through the same in-process dispatch path bulk apply uses.
+    #[tokio::test]
+    async fn non_atomic_dispatch_envelope_shape_is_unchanged_by_adr099_b1() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let server = isolated_server(&db_path);
+
+        async fn dispatch(server: &KhiveMcpServer, ops: &str) -> serde_json::Value {
+            let params = RequestParams {
+                ops: ops.to_string(),
+                presentation: None,
+                presentation_per_op: None,
+                save_to: None,
+                format: None,
+                format_per_op: None,
+            };
+            let raw = server
+                .dispatch_request_local(params)
+                .await
+                .unwrap_or_else(|e| panic!("dispatch {ops:?} failed: {e}"));
+            serde_json::from_str(&raw).expect("valid JSON")
+        }
+
+        // create
+        let created = dispatch(
+            &server,
+            r#"create(kind="concept", name="ADR-099-B1-inertness")"#,
+        )
+        .await;
+        assert_golden_envelope_shape(&created, "create");
+        let entity_id = created["results"][0]["result"]["id"]
+            .as_str()
+            .expect("create must return an id")
+            .to_string();
+
+        // update
+        let updated = dispatch(
+            &server,
+            &format!(r#"update(id="{entity_id}", description="updated by inertness test")"#),
+        )
+        .await;
+        assert_golden_envelope_shape(&updated, "update");
+
+        // link (self-referential edge is rejected by endpoint validation for
+        // most relations, so create a second entity as the link target)
+        let target = dispatch(&server, r#"create(kind="concept", name="link-target")"#).await;
+        let target_id = target["results"][0]["result"]["id"]
+            .as_str()
+            .expect("create must return an id")
+            .to_string();
+        let linked = dispatch(
+            &server,
+            &format!(
+                r#"link(source_id="{entity_id}", target_id="{target_id}", relation="extends")"#
+            ),
+        )
+        .await;
+        assert_golden_envelope_shape(&linked, "link");
+
+        // get (read)
+        let got = dispatch(&server, &format!(r#"get(id="{entity_id}")"#)).await;
+        assert_golden_envelope_shape(&got, "get");
+
+        // Every op above succeeded end-to-end with zero surprises in the
+        // envelope shape — this is the inertness pin: no `atomic` key
+        // appeared anywhere, `summary` kept exactly its 4 pre-existing
+        // fields on every response, and every op's own result still nests
+        // under `results[0].result` as before.
+    }
+
+    /// Asserts a `dispatch_request_local` response matches the pre-ADR-099-B1
+    /// golden shape: exactly the top-level keys `results` and `summary` (no
+    /// additive `atomic` block — that is a future, opt-in-only slice), a
+    /// `summary` with exactly `total`/`succeeded`/`failed`/`aborted`, and a
+    /// successful single-op `results[0]` carrying `ok`/`tool`/`result`.
+    fn assert_golden_envelope_shape(resp: &serde_json::Value, expected_tool: &str) {
+        let top_level_keys: std::collections::BTreeSet<&str> = resp
+            .as_object()
+            .expect("response must be a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            top_level_keys,
+            std::collections::BTreeSet::from(["results", "summary"]),
+            "non-atomic envelope must carry exactly results+summary, no `atomic` block: {resp}"
+        );
+
+        let summary_keys: std::collections::BTreeSet<&str> = resp["summary"]
+            .as_object()
+            .expect("summary must be an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            summary_keys,
+            std::collections::BTreeSet::from(["total", "succeeded", "failed", "aborted"]),
+            "summary shape must be unchanged: {resp}"
+        );
+        assert_eq!(resp["summary"]["total"], serde_json::json!(1));
+        assert_eq!(resp["summary"]["succeeded"], serde_json::json!(1));
+        assert_eq!(resp["summary"]["failed"], serde_json::json!(0));
+
+        assert_eq!(resp["results"][0]["ok"], serde_json::json!(true));
+        assert_eq!(resp["results"][0]["tool"], serde_json::json!(expected_tool));
+        assert!(
+            resp["results"][0].get("result").is_some(),
+            "results[0] must carry a `result` field: {resp}"
+        );
+    }
+
     #[tokio::test]
     async fn ops_file_dry_run_writes_nothing() {
         let db_file = NamedTempFile::new().expect("temp db");


### PR DESCRIPTION
## Summary

Implements ADR-099 migration steps 1-2 (sub-slice B1): the plain-data plan
types and admissibility metadata that later sub-slices (B2 prepare/apply
wiring, B3 `--atomic` CLI surface) will consume. Zero behavior change —
nothing added here is called from any live dispatch path yet.

## Deliverables → ADR-099 mapping

| Deliverable | ADR-099 reference | Where |
|---|---|---|
| Per-verb write-plan types (`UpdatePlan`, `DeletePlan`, `LinkPlan`, `MergePlan`, `GtdTransitionPlan`, `GtdCompletePlan`, `GovernancePlan`, `PlanPredicate`, `AffectedRowGuard`, `PostCommitEffect`) | D1 (two-phase mechanism), migration step 1 | `crates/khive-runtime/src/atomic_plan.rs` |
| v1 admissible-verb allowlist + rejection-reason classification (`ATOMIC_ADMISSIBLE_VERBS`, `atomic_admissibility()`, `AtomicRejectionReason`) | D3 (admissible verbs, explicit per-verb list) | `crates/khive-types/src/pack.rs` |
| Parse-time rejection as a pure function (`check_atomic_admissible`) | Migration step 2; "expose the check as a pure function the B3 surface will call" | `crates/khive-request/src/atomic.rs` |
| Inertness pin (non-atomic envelope shape unchanged) | Acceptance criteria: "non-atomic parity" | `crates/kkernel/src/exec.rs` |

## Design notes / ADR ambiguities resolved

- **Admissibility metadata placement**: ADR-099 says admissibility is
  "declared per verb as pack metadata" but "never a pack-level category."
  Rather than adding a required field to every pack's `HandlerDef` array
  (huge blast radius across every existing `HANDLERS` const, for a
  zero-behavior-change slice), I followed the existing
  `HandlerDef::presentation_policy()` precedent in the same file: a
  centralized, explicit `match`/allowlist function in `khive-types::pack`,
  shared by every pack and every consumer (khive-request, and later the
  `--atomic` runner) without touching any pack's own verb table.
- **Plan type home**: the ADR doesn't pin a file for the plan types (only
  for the `atomic_unit` seam and its invariant, already landed in Slice A).
  Placed in `khive-runtime` (new `atomic_plan.rs`) because that crate
  already hosts the real per-verb business logic these plans will
  eventually be produced from (`operations.rs`, `curation.rs`) and already
  depends on `khive-storage` for `SqlStatement`.
- **`SqlStatement` lacks `PartialEq`**: dropped `PartialEq` from the plan
  structs that embed `SqlStatement`/`Vec<SqlStatement>` (kept it on
  `AffectedRowGuard`, `PostCommitEffect`, `GovernanceOp`); tests assert on
  individual fields instead of whole-struct equality.
- **Rejected-verb categorization beyond the ADR's 5-verb acceptance list**:
  the acceptance criteria names 5 embedding-bearing verbs to test
  (`create`, `memory.remember`, `gtd.assign`, `comm.send`, `comm.reply`);
  D3's prose also names `comm.ingest` in the same class, so it's included
  in the internal classification list (not required by the acceptance
  test, but consistent with the ADR's own narrative).
- **Inertness ("golden") test**: implemented as a structural shape pin
  (exact top-level keys, exact `summary` keys, exact single-op result
  shape) run through the real `dispatch_request_local` path over a
  create→update→link→get sequence, rather than a byte-diff against a
  pre-change binary (not available in a single working tree). This proves
  B1's additions are inert without requiring a stored fixture file.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (scoped to touched crates, see verbatim results below)
- [x] `cargo check --workspace`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [x] Scoped tests for every touched crate

### Verbatim `test result:` lines

```
running 19 tests
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 95 tests
test result: ok. 95 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 623 tests
test result: ok. 618 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 2.43s

running 59 tests
test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.56s

running 88 tests
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 20 tests
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 34 tests
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 178 tests
test result: ok. 178 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.90s

running 6 tests
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
```

(covers `khive-types`, `khive-request`, `khive-runtime` incl. new
`atomic_plan` module, and `kkernel` incl. the new inertness test, across
all their unit + integration test binaries)

Not marking ready — awaiting codex review per repo convention.