### PR TITLE
fix(backup): installer resolves stores.conf under set -u

### DIFF
--- a/deploy/backup/install-backup.sh
+++ b/deploy/backup/install-backup.sh
@@ -20,12 +20,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+BACKUP_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 # shellcheck source=./lib.sh
-. "${SCRIPT_DIR}/lib.sh"
+. "${BACKUP_SCRIPT_DIR}/lib.sh"
 
-TEMPLATE="${SCRIPT_DIR}/com.khive.backup.plist.template"
-BACKUP_SH="${KHIVE_BACKUP_SCRIPT_PATH:-${SCRIPT_DIR}/khive-backup.sh}"
+TEMPLATE="${BACKUP_SCRIPT_DIR}/com.khive.backup.plist.template"
+BACKUP_SH="${KHIVE_BACKUP_SCRIPT_PATH:-${BACKUP_SCRIPT_DIR}/khive-backup.sh}"
 PLIST_BUDDY="/usr/libexec/PlistBuddy"
 LOG_DIR="${HOME}/Library/Logs/khive-backup"
 UID_NUM="$(id -u)"

--- a/deploy/backup/test_backup.sh
+++ b/deploy/backup/test_backup.sh
@@ -559,6 +559,22 @@ STATUS_OUT="$("${INSTALL_SH}" status t1 fixture 2>&1)"
 assert_not_contains "status output contains no CHANGE_ME remote credential leakage" "${STATUS_OUT}" "backup-host-password"
 assert_contains "status output reports the plist path" "${STATUS_OUT}" "com.khive.backup.t1.fixture.plist"
 
+echo "=== test: installer resolves the default stores.conf when KHIVE_BACKUP_CONF is unset ==="
+# Regression: install-backup.sh sources lib.sh, whose resolve_stores_conf
+# falls back to "${BACKUP_SCRIPT_DIR}/stores.conf" when KHIVE_BACKUP_CONF is
+# not set. The installer must define BACKUP_SCRIPT_DIR (the name lib.sh reads,
+# shared with khive-backup.sh / restore-drill.sh) — a mismatched local name
+# leaves it unbound, so under `set -u` every installer command that needs the
+# registry dies before doing anything. Every other install test exports
+# KHIVE_BACKUP_CONF, so only this one exercises the default-path branch. An
+# unknown store name is used deliberately: it drives resolve_stores_conf (the
+# code that needs BACKUP_SCRIPT_DIR) to completion, then fails cleanly at
+# row lookup — no plist is written, so this test mutates nothing.
+DEFAULT_CONF_OUT="$(env -u KHIVE_BACKUP_CONF KHIVE_BACKUP_INSTALL_TEST=1 "${INSTALL_SH}" install t1 __nosuch_store__ 2>&1 || true)"
+assert_not_contains "installer does not die on an unbound script-dir variable" "${DEFAULT_CONF_OUT}" "unbound variable"
+assert_not_contains "installer resolves a real registry path, not the empty-path 'not found' error" "${DEFAULT_CONF_OUT}" "store registry not found:  "
+assert_contains "installer reaches store-row lookup against the default registry" "${DEFAULT_CONF_OUT}" "no store named '__nosuch_store__'"
+
 echo "=== test: uninstall removes the plist ==="
 "${INSTALL_SH}" uninstall t1 fixture >/tmp/khive-test-uninstall.out 2>&1 \
   || fail "uninstall should succeed: $(cat /tmp/khive-test-uninstall.out)"


### PR DESCRIPTION
## Problem

`install-backup.sh` defined a local `SCRIPT_DIR`, but the sourced `lib.sh`
reads `BACKUP_SCRIPT_DIR` (the canonical name, shared with `khive-backup.sh`
and `restore-drill.sh`) inside `resolve_stores_conf` when `KHIVE_BACKUP_CONF`
is unset. Under `set -u`, the name mismatch left `BACKUP_SCRIPT_DIR` unbound,
so every `install <tier> <store>` invocation died at `lib.sh:73` before it
could resolve the store registry:

```
lib.sh: line 73: BACKUP_SCRIPT_DIR: unbound variable
ERROR: store registry not found:  (set KHIVE_BACKUP_CONF to override)
```

Found while enabling the launchd cadence on merged `main` (`install` is the
subcommand that hits the failing path; `status` does not). The test suite
masked it because every existing install test exports `KHIVE_BACKUP_CONF`,
bypassing the default-path branch entirely.

## Fix

Rename the installer's directory variable to `BACKUP_SCRIPT_DIR` (4 lines).
`KHIVE_BACKUP_SCRIPT_PATH` is left untouched.

## Regression test

Adds a test that drives the default-path branch with an *unknown* store name:
it reaches store-row lookup (proving the registry resolved from the default
path) and fails cleanly there, writing no plist. A/B check confirms the test
FAILs on the pre-fix installer (3 assertions) and passes with the fix.

Suite: 83 passed, 0 failed (was 80 + 3 new).