### PR TITLE
feat(runtime,kkernel): ADR-099 B3 — the --atomic CLI surface for exec --ops-file

### DIFF
--- a/EDGE_CONFLICT_SQL_AUDIT.md
+++ b/EDGE_CONFLICT_SQL_AUDIT.md
@@ -1,0 +1,66 @@
+# Edge Conflict SQL Audit (ADR-099 B3 r9)
+
+Exhaustive workspace grep for every hand-written statement touching
+`graph_edges`'s natural-key uniqueness (`UNIQUE(namespace, source_id,
+target_id, relation)`) or symmetric-relation conflict resolution — i.e.
+every site that could drift out of sync with the shared conflict-arm text.
+Commands run:
+
+```
+grep -rn "ON CONFLICT" . --include="*.rs" --include="*.sql"
+grep -rn "UPDATE graph_edges SET\|INSERT INTO graph_edges\|DELETE FROM graph_edges" . --include="*.rs"
+grep -rn "target_backend = excluded.target_backend\|target_backend = ?" . --include="*.rs"
+```
+
+(paths below are relative to the crate workspace root, i.e. `crates/…`)
+
+## Shared source-of-truth constants (the target every consumer below is measured against)
+
+- `khive-db/src/stores/graph.rs:49` — `EDGE_NATURAL_KEY_CONFLICT_SET`: the
+  `INSERT ... ON CONFLICT` SET-list text (weight/updated_at/deleted_at/
+  metadata/target_backend).
+- `khive-db/src/stores/graph.rs:214-228` — `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`
+  / `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
+  `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`:
+  the probe-then-branch DML canonical `update_edge_symmetric_dml` binds.
+
+## Sites and disposition
+
+| # | Site | Consumes shared builder/constant? | Disposition |
+|---|------|-----------------------------------|-------------|
+| 1 | `khive-db/src/stores/graph.rs:65-79` `edge_upsert_statement` | Yes — SQL text interpolates `{EDGE_NATURAL_KEY_CONFLICT_SET}` for both `ON CONFLICT` arms. | OK — this IS the source-of-truth builder. |
+| 2 | `khive-db/src/stores/graph.rs:120-149` `edge_insert_guarded_by_endpoints_statement` (atomic guarded `link`) | Yes — same `{EDGE_NATURAL_KEY_CONFLICT_SET}` interpolation (fixed r7, codex r7 High finding 2). | OK. |
+| 3 | `khive-db/src/stores/graph.rs:850-877` `batch_upsert_edges` (backs `upsert_edges`/`link_many`) | **Fixed this round.** Previously hand-wrote the full `INSERT ... ON CONFLICT` (including both conflict arms) as an inline literal. Now calls `edge_upsert_statement(edge)` + `bind_params` per row — the SAME builder site 1 uses. | OK (was the codex r8 High finding 2 site; closed). |
+| 4 | `khive-db/src/stores/graph.rs:214-263` `EDGE_SYMMETRIC_*_SQL` constants + their `edge_symmetric_*_statement` plan-shape builders | N/A — this IS the shared source of truth `operations.rs`'s canonical path binds directly. | OK. |
+| 5 | `khive-runtime/src/operations.rs:3747-3830` `update_edge_symmetric_dml` (canonical, non-atomic `update_edge`'s symmetric branch) | Yes — binds `khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` / `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` / `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` directly via `rusqlite::params!` (different binding mechanism than the async `SqlStatement`/`SqlValue` path, but the SQL TEXT is the shared constant). | OK — this is the documented control-group path; untouched. |
+| 6 | `khive-db/src/stores/graph.rs:374-448` `edge_symmetric_delete_if_conflict_statement` / `edge_symmetric_refresh_or_update_inplace_statement` (atomic-only) | N/A — deliberately a DIFFERENT, self-guarding commit-time shape (fixed this round, r9): the refresh statement now gates its natural-key arm on `changes() = 1` rather than reusing `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`/`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` verbatim, because those two assume a single-transaction probe-then-branch that atomic's prepare/commit split cannot safely reproduce (see the doc comment immediately above these builders). | **Justified-distinct.** Structurally different requirement (commit-time-only, no prepare-time branch), not an accidental copy. |
+| 7 | `khive-runtime/src/curation.rs:1082-1160` `merge_entity_sql`'s edge rewire (entity `merge`, case a/b) | **No.** Hand-writes `SELECT id FROM graph_edges WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 AND relation = ?4 AND id != ?5` (line ~1110, byte-for-byte `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`), `DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2` (line ~1131, byte-for-byte `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL`), and `UPDATE graph_edges SET weight = ?1, updated_at = ?2, deleted_at = NULL, target_backend = ?3, metadata = ?4 WHERE namespace = ?5 AND id = ?6` (line ~1135, byte-for-byte `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`) as fresh string literals instead of the existing constants. | **Not justified — a real duplication gap, out of this round's approved scope.** `merge` is not in ADR-099's v1 atomic-admissible set (deferred separately), so it was outside codex r8's reviewed diff, but it is the same drift class findings 1/2 target. Flagging for a follow-up round rather than fixing here: this brief's approved scope is limited to `update`'s symmetric-write correctness (task 1) and `batch_upsert_edges` (task 2); touching `merge_entity_sql` was not requested and would expand the diff beyond what was scoped. |
+| 8 | `khive-runtime/src/curation.rs:1538-1600` `merge_note_sql`'s edge rewire (note `merge`, case a/b) | **No.** Same three hand-copied literals as #7 (this is the note-merge sibling of the entity-merge rewire) — `SELECT id FROM graph_edges WHERE namespace = ...` conflict probe, `DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2`, and the `UPDATE graph_edges SET weight = ..., target_backend = ?3, metadata = ?4 ...` refresh, each retyped a second time from #7's already-duplicated text (so this is actually the *fourth* copy of the conflict-probe/refresh text in the workspace, counting the two canonical constants and #7). | Same disposition as #7 — real gap, flagged for follow-up, not fixed this round (same out-of-scope reasoning). |
+| 9 | `khive-runtime/src/atomic_prepare.rs:1331,1344` (`MergePlan` entity-merge edge rewire, ADR-099 atomic-merge draft) | N/A — `UPDATE graph_edges SET source_id = ?1, updated_at = ?2 WHERE source_id = ?3` / the `target_id` sibling. No `weight`/`metadata`/`target_backend`/natural-key conflict arm at all — this is a blind endpoint rewire (merge is deferred/unreachable through `--atomic`; see this crate's `prepare_merge` doc comment), not a conflict-arm statement. | Not applicable — different SQL shape, not a natural-key conflict site. |
+| 10 | `khive-db/src/stores/graph.rs:168,179,188` (`edge_soft_delete_statement`, `edge_hard_delete_statement`, `purge_incident_edges_statement`) | N/A — plain delete/soft-delete DML, no conflict arm. | Not applicable. |
+| 11 | `khive-runtime/src/atomic_prepare.rs:2097` (delete-plan soft-delete statement) | N/A — `deleted_at` tombstone only. | Not applicable. |
+| 12 | `khive-runtime/src/atomic_runner.rs:535,560` and `khive-runtime/src/atomic_plan.rs:407` | N/A — `#[cfg(test)]`-only fixture SQL in unit tests exercising the runner mechanism generically (not edge-specific production behavior). | Not applicable (test-only). |
+| 13 | `khive-db/src/stores/entity_tests.rs:717` | N/A — test fixture seeding a `graph_edges` row directly. | Not applicable (test-only). |
+
+## Summary
+
+- **Fixed this round:** site 3 (`batch_upsert_edges`) — the codex r8 High
+  finding 2 target. No other production `INSERT`-shaped natural-key
+  conflict arm remains outside `edge_upsert_statement`/
+  `edge_insert_guarded_by_endpoints_statement`, both of which interpolate
+  the single `EDGE_NATURAL_KEY_CONFLICT_SET` constant.
+- **New gap surfaced by this audit, not fixed (out of approved scope):**
+  sites 7 and 8 (`curation.rs`'s entity/note `merge` edge rewire) hand-copy
+  the `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` /
+  `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
+  `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` text a third and fourth time
+  instead of referencing the constants directly. Recommended follow-up:
+  have both call sites bind the existing `khive_db::stores::graph::
+  EDGE_SYMMETRIC_*_SQL` constants (same pattern `operations.rs`'s
+  `update_edge_symmetric_dml` already uses at site 5) instead of retyping
+  the literal SQL strings.
+- Every other `ON CONFLICT` / `graph_edges` DML site in the workspace is
+  either the shared source of truth itself, a structurally distinct
+  self-guarding atomic statement (justified-distinct, site 6), a
+  non-conflict-arm statement (delete/soft-delete/rewire), or test-only
+  fixture code.

--- a/crates/khive-db/src/sql_bridge.rs
+++ b/crates/khive-db/src/sql_bridge.rs
@@ -45,7 +45,12 @@ fn row_to_sql_row(row: &rusqlite::Row<'_>, col_count: usize, col_names: &[String
 }
 
 /// Bind `SqlValue` parameters to a rusqlite statement.
-fn bind_params(
+///
+/// `pub(crate)` (ADR-099 B3 r6 structural cut): reused by the pure
+/// `*_statement` builders in `stores::{entity,note,graph,text,vectors}` so
+/// that every store's async execution path and the ADR-099 `--atomic`
+/// prepare path bind params identically — one implementation, not two.
+pub(crate) fn bind_params(
     stmt: &mut rusqlite::Statement<'_>,
     params: &[SqlValue],
 ) -> Result<(), rusqlite::Error> {

--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -7,12 +7,15 @@ use uuid::Uuid;
 
 use khive_storage::entity::{Entity, EntityFilter};
 use khive_storage::error::StorageError;
-use khive_storage::types::{BatchWriteSummary, DeleteMode, Page, PageRequest};
+use khive_storage::types::{
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SqlStatement, SqlValue,
+};
 use khive_storage::EntityStore;
 use khive_storage::StorageCapability;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
@@ -21,6 +24,92 @@ fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
 
 fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Entities, op, e)
+}
+
+// ---------------------------------------------------------------------------
+// Pure statement builders (ADR-099 B3 r6 structural cut)
+//
+// These carry NO I/O — they turn an already-computed `Entity` (or a bare id)
+// into the exact `SqlStatement` this store executes. `upsert_entity` and
+// `delete_entity` below call them and execute the result; ADR-099's atomic
+// prepare path (`khive-runtime`) calls them too, to build the same statement
+// for its own guarded, synchronous apply. One statement generator, two
+// execution mechanisms (async trait dispatch vs. synchronous atomic unit) —
+// per ADR-099's accepted "handler-logic-duplication objection" text, the
+// bulk-apply path reuses the handler's existing statement generation instead
+// of re-deriving it.
+// ---------------------------------------------------------------------------
+
+/// The exact `INSERT OR REPLACE` this store's `upsert_entity` issues.
+pub fn entity_upsert_statement(entity: &Entity) -> SqlStatement {
+    let properties_str = entity
+        .properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    let tags_str = serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
+    SqlStatement {
+        sql: "INSERT OR REPLACE INTO entities \
+              (id, namespace, kind, entity_type, name, description, properties, tags, \
+               created_at, updated_at, deleted_at, merged_into, merge_event_id) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(entity.id.to_string()),
+            SqlValue::Text(entity.namespace.clone()),
+            SqlValue::Text(entity.kind.clone()),
+            match &entity.entity_type {
+                Some(t) => SqlValue::Text(t.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(entity.name.clone()),
+            match &entity.description {
+                Some(d) => SqlValue::Text(d.clone()),
+                None => SqlValue::Null,
+            },
+            match properties_str {
+                Some(p) => SqlValue::Text(p),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(tags_str),
+            SqlValue::Integer(entity.created_at),
+            SqlValue::Integer(entity.updated_at),
+            match entity.deleted_at {
+                Some(d) => SqlValue::Integer(d),
+                None => SqlValue::Null,
+            },
+            match entity.merged_into {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+            match entity.merge_event_id {
+                Some(u) => SqlValue::Text(u.to_string()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("entity-upsert".to_string()),
+    }
+}
+
+/// The exact soft-delete `UPDATE` this store's `delete_entity(Soft)` issues.
+pub fn entity_soft_delete_statement(id: Uuid, deleted_at: i64) -> SqlStatement {
+    SqlStatement {
+        sql: "UPDATE entities SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL".to_string(),
+        params: vec![
+            SqlValue::Integer(deleted_at),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("entity-delete-soft".to_string()),
+    }
+}
+
+/// The exact hard-delete `DELETE` this store's `delete_entity(Hard)` issues
+/// (no `deleted_at` predicate — purges live and already-tombstoned rows).
+pub fn entity_hard_delete_statement(id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM entities WHERE id = ?1".to_string(),
+        params: vec![SqlValue::Text(id.to_string())],
+        label: Some("entity-delete-hard".to_string()),
+    }
 }
 
 /// An EntityStore backed by SQLite. Namespace is the caller's responsibility.
@@ -391,39 +480,11 @@ fn build_entity_where(
 #[async_trait]
 impl EntityStore for SqlEntityStore {
     async fn upsert_entity(&self, entity: Entity) -> Result<(), StorageError> {
-        let namespace = entity.namespace.clone();
-        let id_str = entity.id.to_string();
-        let properties_str = entity
-            .properties
-            .as_ref()
-            .map(|v| serde_json::to_string(v).unwrap_or_default());
-        let tags_str = serde_json::to_string(&entity.tags).unwrap_or_else(|_| "[]".to_string());
-
-        let merged_into_str = entity.merged_into.map(|u| u.to_string());
-        let merge_event_id_str = entity.merge_event_id.map(|u| u.to_string());
-
+        let statement = entity_upsert_statement(&entity);
         self.with_writer("upsert_entity", move |conn| {
-            conn.execute(
-                "INSERT OR REPLACE INTO entities \
-                 (id, namespace, kind, entity_type, name, description, properties, tags, \
-                  created_at, updated_at, deleted_at, merged_into, merge_event_id) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                rusqlite::params![
-                    id_str,
-                    namespace,
-                    entity.kind,
-                    entity.entity_type,
-                    entity.name,
-                    entity.description,
-                    properties_str,
-                    tags_str,
-                    entity.created_at,
-                    entity.updated_at,
-                    entity.deleted_at,
-                    merged_into_str,
-                    merge_event_id_str,
-                ],
-            )?;
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            stmt.raw_execute()?;
             Ok(())
         })
         .await
@@ -488,28 +549,23 @@ impl EntityStore for SqlEntityStore {
     }
 
     async fn delete_entity(&self, id: Uuid, mode: DeleteMode) -> Result<bool, StorageError> {
-        let id_str = id.to_string();
-
         match mode {
             DeleteMode::Soft => {
+                let now = chrono::Utc::now().timestamp_micros();
+                let statement = entity_soft_delete_statement(id, now);
                 self.with_writer("delete_entity_soft", move |conn| {
-                    let now = chrono::Utc::now().timestamp_micros();
-                    let deleted = conn.execute(
-                        "UPDATE entities SET deleted_at = ?1 \
-                         WHERE id = ?2 AND deleted_at IS NULL",
-                        rusqlite::params![now, id_str],
-                    )?;
-                    Ok(deleted > 0)
+                    let mut stmt = conn.prepare(&statement.sql)?;
+                    bind_params(&mut stmt, &statement.params)?;
+                    Ok(stmt.raw_execute()? > 0)
                 })
                 .await
             }
             DeleteMode::Hard => {
+                let statement = entity_hard_delete_statement(id);
                 self.with_writer("delete_entity_hard", move |conn| {
-                    let deleted = conn.execute(
-                        "DELETE FROM entities WHERE id = ?1",
-                        rusqlite::params![id_str],
-                    )?;
-                    Ok(deleted > 0)
+                    let mut stmt = conn.prepare(&statement.sql)?;
+                    bind_params(&mut stmt, &statement.params)?;
+                    Ok(stmt.raw_execute()? > 0)
                 })
                 .await
             }

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -331,29 +331,17 @@ fn batch_append_events_dml(
     })
 }
 
-/// Insert `event` (and any derived `event_observations` rows) through the
-/// `khive-storage` `SqlWriter` seam, on a transaction the CALLER already
-/// opened and controls the commit/rollback boundary for. Issues no
-/// `BEGIN`/`COMMIT`/`ROLLBACK` of its own.
-///
-/// This exists alongside `insert_event_with_observations` (the raw
-/// `rusqlite::Connection` path `SqlEventStore::append_event` uses, which
-/// opens its own `BEGIN IMMEDIATE`/`COMMIT` for the ordinary
-/// caller-owns-nothing case) rather than replacing it: the two run on
-/// different connection abstractions — a standalone `rusqlite::Connection`
-/// vs. a `Box<dyn SqlWriter>` — so they cannot share one function body. What
-/// they DO share is `decode_event_observations` (reused verbatim below) and
-/// the fact that this crate remains the only place that knows the
-/// `events`/`event_observations` insert shape. Callers that need the event
-/// append to be part of a larger atomic unit — e.g. ADR-081's brain fold
-/// gate (`khive-pack-brain/src/fold_gate.rs`), which holds its own
-/// `BEGIN IMMEDIATE` transaction on a `SqlWriter` for the dedup claim + mass
-/// fold and needs the feedback event to land in that same transaction — call
-/// this instead of duplicating the insert shape into their own crate.
-pub async fn append_event_on_writer(
-    writer: &mut dyn SqlWriter,
-    event: &Event,
-) -> Result<(), StorageError> {
+/// Pure statement builder (ADR-099 B3 r6 structural cut): the exact
+/// `events` row insert plus every derived `event_observations` insert for
+/// `event`, as plain [`SqlStatement`]s with no I/O. This is the ONE place
+/// that knows the `events`/`event_observations` insert shape at the
+/// statement-text level; both [`append_event_on_writer`] below (the async
+/// `SqlWriter` execution path) and `khive-runtime`'s ADR-099 `--atomic`
+/// prepare path (which needs plain-data statements it can fold into a
+/// synchronous commit-phase plan, not an async writer call) build on this
+/// function rather than each hand-writing the INSERT text — the divergence
+/// that produced the ADR-099 B3 round-4 finding this cut fixes.
+pub fn event_insert_statements(event: &Event) -> Result<Vec<SqlStatement>, rusqlite::Error> {
     let id_str = event.id.to_string();
     let substrate_str = event.substrate.name().to_string();
     let kind_str = event.kind.name().to_string();
@@ -364,62 +352,86 @@ pub async fn append_event_on_writer(
     let aggregate_str = event.aggregate_id.map(|u| u.to_string());
     let profile_state_version = event.profile_state_version.map(|v| v as i64);
 
-    writer
-        .execute(SqlStatement {
-            sql: "INSERT INTO events \
-                  (id, namespace, verb, substrate, actor, kind, outcome, payload, payload_schema_version, \
-                   profile_state_version, duration_us, target_id, session_id, aggregate_kind, aggregate_id, created_at) \
-                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
+    let mut statements = vec![SqlStatement {
+        sql: "INSERT INTO events \
+              (id, namespace, verb, substrate, actor, kind, outcome, payload, payload_schema_version, \
+               profile_state_version, duration_us, target_id, session_id, aggregate_kind, aggregate_id, created_at) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
+            .into(),
+        params: vec![
+            SqlValue::Text(id_str),
+            SqlValue::Text(event.namespace.clone()),
+            SqlValue::Text(event.verb.clone()),
+            SqlValue::Text(substrate_str),
+            SqlValue::Text(event.actor.clone()),
+            SqlValue::Text(kind_str),
+            SqlValue::Text(outcome_str),
+            SqlValue::Text(payload_str),
+            SqlValue::Integer(event.payload_schema_version as i64),
+            profile_state_version
+                .map(SqlValue::Integer)
+                .unwrap_or(SqlValue::Null),
+            SqlValue::Integer(event.duration_us),
+            target_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
+            session_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
+            event
+                .aggregate_kind
+                .clone()
+                .map(SqlValue::Text)
+                .unwrap_or(SqlValue::Null),
+            aggregate_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
+            SqlValue::Integer(event.created_at),
+        ],
+        label: Some("event_insert_on_writer".into()),
+    }];
+
+    for observation in decode_event_observations(event)? {
+        statements.push(SqlStatement {
+            sql: "INSERT INTO event_observations \
+                  (event_id, entity_id, referent_kind, role, position) \
+                  VALUES (?1, ?2, ?3, ?4, ?5)"
                 .into(),
             params: vec![
-                SqlValue::Text(id_str),
-                SqlValue::Text(event.namespace.clone()),
-                SqlValue::Text(event.verb.clone()),
-                SqlValue::Text(substrate_str),
-                SqlValue::Text(event.actor.clone()),
-                SqlValue::Text(kind_str),
-                SqlValue::Text(outcome_str),
-                SqlValue::Text(payload_str),
-                SqlValue::Integer(event.payload_schema_version as i64),
-                profile_state_version
-                    .map(SqlValue::Integer)
-                    .unwrap_or(SqlValue::Null),
-                SqlValue::Integer(event.duration_us),
-                target_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
-                session_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
-                event
-                    .aggregate_kind
-                    .clone()
-                    .map(SqlValue::Text)
-                    .unwrap_or(SqlValue::Null),
-                aggregate_str.map(SqlValue::Text).unwrap_or(SqlValue::Null),
-                SqlValue::Integer(event.created_at),
+                SqlValue::Text(observation.event_id.to_string()),
+                SqlValue::Text(observation.entity_id.to_string()),
+                SqlValue::Text(observation.referent_kind.name().to_string()),
+                SqlValue::Text(observation.role.name().to_string()),
+                SqlValue::Integer(observation.position as i64),
             ],
-            label: Some("event_insert_on_writer".into()),
-        })
-        .await?;
-
-    for observation in
-        decode_event_observations(event).map_err(|e| map_err(e, "decode_event_observations"))?
-    {
-        writer
-            .execute(SqlStatement {
-                sql: "INSERT INTO event_observations \
-                      (event_id, entity_id, referent_kind, role, position) \
-                      VALUES (?1, ?2, ?3, ?4, ?5)"
-                    .into(),
-                params: vec![
-                    SqlValue::Text(observation.event_id.to_string()),
-                    SqlValue::Text(observation.entity_id.to_string()),
-                    SqlValue::Text(observation.referent_kind.name().to_string()),
-                    SqlValue::Text(observation.role.name().to_string()),
-                    SqlValue::Integer(observation.position as i64),
-                ],
-                label: Some("event_observation_insert_on_writer".into()),
-            })
-            .await?;
+            label: Some("event_observation_insert_on_writer".into()),
+        });
     }
 
+    Ok(statements)
+}
+
+/// Insert `event` (and any derived `event_observations` rows) through the
+/// `khive-storage` `SqlWriter` seam, on a transaction the CALLER already
+/// opened and controls the commit/rollback boundary for. Issues no
+/// `BEGIN`/`COMMIT`/`ROLLBACK` of its own.
+///
+/// This exists alongside `insert_event_with_observations` (the raw
+/// `rusqlite::Connection` path `SqlEventStore::append_event` uses, which
+/// opens its own `BEGIN IMMEDIATE`/`COMMIT` for the ordinary
+/// caller-owns-nothing case) rather than replacing it: the two run on
+/// different connection abstractions — a standalone `rusqlite::Connection`
+/// vs. a `Box<dyn SqlWriter>` — so they cannot share one function body. Both
+/// build on [`event_insert_statements`] for the actual insert shape.
+/// Callers that need the event append to be part of a larger atomic unit —
+/// e.g. ADR-081's brain fold gate (`khive-pack-brain/src/fold_gate.rs`),
+/// which holds its own `BEGIN IMMEDIATE` transaction on a `SqlWriter` for
+/// the dedup claim + mass fold and needs the feedback event to land in that
+/// same transaction — call this instead of duplicating the insert shape
+/// into their own crate.
+pub async fn append_event_on_writer(
+    writer: &mut dyn SqlWriter,
+    event: &Event,
+) -> Result<(), StorageError> {
+    let statements =
+        event_insert_statements(event).map_err(|e| map_err(e, "decode_event_observations"))?;
+    for statement in statements {
+        writer.execute(statement).await?;
+    }
     Ok(())
 }
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -10,7 +10,7 @@ use khive_storage::error::StorageError;
 use khive_storage::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSortField,
     GraphPath, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SortDirection, SortOrder,
-    TraversalRequest,
+    SqlStatement, SqlValue, TraversalRequest,
 };
 use khive_storage::GraphStore;
 use khive_storage::LinkId;
@@ -19,6 +19,7 @@ use khive_types::EdgeRelation;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
 
 /// Map a rusqlite error to `StorageError` with `Graph` capability.
@@ -28,6 +29,100 @@ fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
 
 fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Graph, op, e)
+}
+
+// ---------------------------------------------------------------------------
+// Pure statement builders (ADR-099 B3 r6 structural cut) — see entity.rs's
+// sibling block for the full rationale. `upsert_edge`/`delete_edge` below and
+// `purge_incident_edges` (plus ADR-099's atomic prepare path in
+// `khive-runtime`, and `khive-runtime::operations::update_edge`'s
+// non-symmetric branch) all call these.
+// ---------------------------------------------------------------------------
+
+/// The exact natural-key-upserting `INSERT ... ON CONFLICT` this store's
+/// `upsert_edge` issues. Canonicalizes symmetric-relation endpoints first,
+/// matching `upsert_edge`'s own call to `canonical_edge_endpoints`.
+pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
+    let (source_id, target_id) =
+        canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+    let metadata_str = edge
+        .metadata
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "INSERT INTO graph_edges \
+              (namespace, id, source_id, target_id, relation, weight, \
+               created_at, updated_at, deleted_at, metadata, target_backend) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
+              ON CONFLICT(namespace, id) DO UPDATE SET \
+                  source_id = excluded.source_id, \
+                  target_id = excluded.target_id, \
+                  relation = excluded.relation, \
+                  weight = excluded.weight, \
+                  updated_at = excluded.updated_at, \
+                  deleted_at = NULL, \
+                  metadata = excluded.metadata, \
+                  target_backend = excluded.target_backend \
+              ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
+                  weight = excluded.weight, \
+                  updated_at = excluded.updated_at, \
+                  deleted_at = NULL, \
+                  metadata = excluded.metadata, \
+                  target_backend = excluded.target_backend"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(edge.namespace.clone()),
+            SqlValue::Text(Uuid::from(edge.id).to_string()),
+            SqlValue::Text(source_id.to_string()),
+            SqlValue::Text(target_id.to_string()),
+            SqlValue::Text(edge.relation.to_string()),
+            SqlValue::Float(edge.weight),
+            SqlValue::Integer(edge.created_at.timestamp_micros()),
+            SqlValue::Integer(edge.updated_at.timestamp_micros()),
+            match edge.deleted_at {
+                Some(t) => SqlValue::Integer(t.timestamp_micros()),
+                None => SqlValue::Null,
+            },
+            match metadata_str {
+                Some(m) => SqlValue::Text(m),
+                None => SqlValue::Null,
+            },
+            match &edge.target_backend {
+                Some(b) => SqlValue::Text(b.clone()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("edge-upsert".to_string()),
+    }
+}
+
+/// The exact soft-delete `UPDATE` this store's `delete_edge(Soft)` issues.
+pub fn edge_soft_delete_statement(id: Uuid, now: i64) -> SqlStatement {
+    SqlStatement {
+        sql: "UPDATE graph_edges SET deleted_at = ?2, updated_at = ?2 \
+              WHERE id = ?1 AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![SqlValue::Text(id.to_string()), SqlValue::Integer(now)],
+        label: Some("edge-delete-soft".to_string()),
+    }
+}
+
+/// The exact hard-delete `DELETE` this store's `delete_edge(Hard)` issues.
+pub fn edge_hard_delete_statement(id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM graph_edges WHERE id = ?1".to_string(),
+        params: vec![SqlValue::Text(id.to_string())],
+        label: Some("edge-delete-hard".to_string()),
+    }
+}
+
+/// The exact cascade `DELETE` this store's `purge_incident_edges` issues.
+pub fn purge_incident_edges_statement(node_id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1".to_string(),
+        params: vec![SqlValue::Text(node_id.to_string())],
+        label: Some("edge-purge-incident".to_string()),
+    }
 }
 
 /// A GraphStore backed by SQLite tables.
@@ -474,54 +569,11 @@ fn batch_upsert_edges(
 #[async_trait]
 impl GraphStore for SqlGraphStore {
     async fn upsert_edge(&self, edge: Edge) -> Result<(), StorageError> {
-        let namespace = edge.namespace.clone();
-        let id_str = Uuid::from(edge.id).to_string();
-        let (source_id, target_id) =
-            canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
-        let src_str = source_id.to_string();
-        let tgt_str = target_id.to_string();
-        let relation_str = edge.relation.to_string();
-        let metadata_str = edge
-            .metadata
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|e| StorageError::driver(StorageCapability::Graph, "upsert_edge", e))?;
+        let statement = edge_upsert_statement(&edge);
         self.with_writer("upsert_edge", move |conn| {
-            conn.execute(
-                "INSERT INTO graph_edges \
-                 (namespace, id, source_id, target_id, relation, weight, \
-                  created_at, updated_at, deleted_at, metadata, target_backend) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
-                 ON CONFLICT(namespace, id) DO UPDATE SET \
-                     source_id = excluded.source_id, \
-                     target_id = excluded.target_id, \
-                     relation = excluded.relation, \
-                     weight = excluded.weight, \
-                     updated_at = excluded.updated_at, \
-                     deleted_at = NULL, \
-                     metadata = excluded.metadata, \
-                     target_backend = excluded.target_backend \
-                 ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
-                     weight = excluded.weight, \
-                     updated_at = excluded.updated_at, \
-                     deleted_at = NULL, \
-                     metadata = excluded.metadata, \
-                     target_backend = excluded.target_backend",
-                rusqlite::params![
-                    namespace,
-                    id_str,
-                    src_str,
-                    tgt_str,
-                    relation_str,
-                    edge.weight,
-                    edge.created_at.timestamp_micros(),
-                    edge.updated_at.timestamp_micros(),
-                    edge.deleted_at.map(|t| t.timestamp_micros()),
-                    metadata_str,
-                    edge.target_backend,
-                ],
-            )?;
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            stmt.raw_execute()?;
             Ok(())
         })
         .await
@@ -903,21 +955,17 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn delete_edge(&self, id: LinkId, mode: DeleteMode) -> Result<bool, StorageError> {
-        let id_str = Uuid::from(id).to_string();
-
+        let id = Uuid::from(id);
+        let statement = match mode {
+            DeleteMode::Soft => {
+                edge_soft_delete_statement(id, chrono::Utc::now().timestamp_micros())
+            }
+            DeleteMode::Hard => edge_hard_delete_statement(id),
+        };
         self.with_writer("delete_edge", move |conn| {
-            let affected = match mode {
-                DeleteMode::Soft => conn.execute(
-                    "UPDATE graph_edges SET deleted_at = ?2, updated_at = ?2 \
-                     WHERE id = ?1 AND deleted_at IS NULL",
-                    rusqlite::params![id_str, chrono::Utc::now().timestamp_micros()],
-                )?,
-                DeleteMode::Hard => conn.execute(
-                    "DELETE FROM graph_edges WHERE id = ?1",
-                    rusqlite::params![id_str],
-                )?,
-            };
-            Ok(affected > 0)
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }
@@ -1438,16 +1486,14 @@ impl GraphStore for SqlGraphStore {
     }
 
     async fn purge_incident_edges(&self, node_id: Uuid) -> Result<u64, StorageError> {
-        let id_str = node_id.to_string();
         // No namespace filter: UUID v4 is globally unique. Hard-delete cascade must
         // remove ALL incident edges regardless of which namespace they were written in
         // (ADR-002 no-dangling-references, ADR-007 by-ID contract).
+        let statement = purge_incident_edges_statement(node_id);
         self.with_writer("purge_incident_edges", move |conn| {
-            let affected = conn.execute(
-                "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1",
-                rusqlite::params![id_str],
-            )?;
-            Ok(affected as u64)
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? as u64)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -39,6 +39,19 @@ fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
 // non-symmetric branch) all call these.
 // ---------------------------------------------------------------------------
 
+/// The natural-key conflict arm's `SET` list — shared, textually, between
+/// [`edge_upsert_statement`] and [`edge_insert_guarded_by_endpoints_statement`]
+/// (ADR-099 B3 r7, codex r7 High finding 2) so the two can never silently
+/// diverge again: the atomic link path previously hand-duplicated this SET
+/// list without `target_backend = excluded.target_backend`, so a re-link of
+/// an edge that had a cross-backend `target_backend` stamp behaved
+/// differently under `--atomic` than under canonical `link`.
+const EDGE_NATURAL_KEY_CONFLICT_SET: &str = "weight = excluded.weight, \
+     updated_at = excluded.updated_at, \
+     deleted_at = NULL, \
+     metadata = excluded.metadata, \
+     target_backend = excluded.target_backend";
+
 /// The exact natural-key-upserting `INSERT ... ON CONFLICT` this store's
 /// `upsert_edge` issues. Canonicalizes symmetric-relation endpoints first,
 /// matching `upsert_edge`'s own call to `canonical_edge_endpoints`.
@@ -50,7 +63,8 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
         .as_ref()
         .map(|v| serde_json::to_string(v).unwrap_or_default());
     SqlStatement {
-        sql: "INSERT INTO graph_edges \
+        sql: format!(
+            "INSERT INTO graph_edges \
               (namespace, id, source_id, target_id, relation, weight, \
                created_at, updated_at, deleted_at, metadata, target_backend) \
               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
@@ -58,18 +72,10 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
                   source_id = excluded.source_id, \
                   target_id = excluded.target_id, \
                   relation = excluded.relation, \
-                  weight = excluded.weight, \
-                  updated_at = excluded.updated_at, \
-                  deleted_at = NULL, \
-                  metadata = excluded.metadata, \
-                  target_backend = excluded.target_backend \
+                  {EDGE_NATURAL_KEY_CONFLICT_SET} \
               ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
-                  weight = excluded.weight, \
-                  updated_at = excluded.updated_at, \
-                  deleted_at = NULL, \
-                  metadata = excluded.metadata, \
-                  target_backend = excluded.target_backend"
-            .to_string(),
+                  {EDGE_NATURAL_KEY_CONFLICT_SET}"
+        ),
         params: vec![
             SqlValue::Text(edge.namespace.clone()),
             SqlValue::Text(Uuid::from(edge.id).to_string()),
@@ -93,6 +99,66 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
             },
         ],
         label: Some("edge-upsert".to_string()),
+    }
+}
+
+/// The atomic `link` op's variant of [`edge_upsert_statement`] (ADR-099 B3
+/// r7, codex r7 High finding 2). Shares the SAME
+/// [`EDGE_NATURAL_KEY_CONFLICT_SET`] conflict-arm text — the two builders
+/// cannot diverge on write behavior — but wraps the `INSERT` in a guarded
+/// `SELECT ... WHERE EXISTS(...)` that re-probes both endpoints for
+/// existence INSIDE the transaction, at commit time, rather than trusting
+/// prepare-time validation alone.
+///
+/// This guard is atomic-`link`-specific, not a `edge_upsert_statement`
+/// concern: `LinkPlan`'s own doc comment (`khive-runtime::atomic_plan`)
+/// records why it must be commit-time, not prepare-time — a `link` op's
+/// async prepare pass (`validate_edge_relation_endpoints`) can run and pass
+/// BEFORE an earlier op in the SAME atomic unit (e.g. `delete(X, hard)`)
+/// removes that very endpoint; only a commit-time, in-transaction guard
+/// closes that intra-batch ordering hazard (ADR-099 acceptance criteria:
+/// `[delete(X, hard), link(A, X)]` must fail, not silently create a
+/// dangling edge). Canonical `link` has no equivalent need — it executes
+/// and commits standalone, with no other op's write interleaved between its
+/// own validation and its own write.
+#[allow(clippy::too_many_arguments)]
+pub fn edge_insert_guarded_by_endpoints_statement(
+    namespace: &str,
+    edge_id: Uuid,
+    source_id: Uuid,
+    target_id: Uuid,
+    relation: EdgeRelation,
+    weight: f64,
+    now: i64,
+    metadata: Option<&str>,
+) -> SqlStatement {
+    SqlStatement {
+        sql: format!(
+            "INSERT INTO graph_edges \
+              (namespace, id, source_id, target_id, relation, weight, \
+               created_at, updated_at, metadata) \
+              SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8 \
+              WHERE (EXISTS (SELECT 1 FROM entities WHERE id = ?3 AND deleted_at IS NULL) \
+                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?3 AND deleted_at IS NULL)) \
+                AND (EXISTS (SELECT 1 FROM entities WHERE id = ?4 AND deleted_at IS NULL) \
+                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL)) \
+              ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
+                  {EDGE_NATURAL_KEY_CONFLICT_SET}"
+        ),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(edge_id.to_string()),
+            SqlValue::Text(source_id.to_string()),
+            SqlValue::Text(target_id.to_string()),
+            SqlValue::Text(relation.as_str().to_string()),
+            SqlValue::Float(weight),
+            SqlValue::Integer(now),
+            match metadata {
+                Some(m) => SqlValue::Text(m.to_string()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("atomic-link-insert-edge-where-exists".to_string()),
     }
 }
 
@@ -257,6 +323,119 @@ pub fn edge_symmetric_update_inplace_statement(
             SqlValue::Text(id.to_string()),
         ],
         label: Some("edge-symmetric-update-inplace".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symmetric-relation update DML — atomic-only, commit-time self-guarding
+// variant (ADR-099 B3 r7, codex r7 High finding 3).
+//
+// The four builders above are still what canonical `update_edge_symmetric_dml`
+// binds: it probes and branches synchronously INSIDE its own writer-task
+// transaction, with no other op interleaved between its probe and its write,
+// so its branch has no staleness exposure and is left untouched (control
+// group — canonical's tests must stay green).
+//
+// The atomic path is structurally different: its conflict probe runs in the
+// async PREPARE phase, which for a multi-op `--atomic` unit completes for
+// EVERY op before the synchronous COMMIT phase begins for ANY of them. An
+// earlier op in the SAME atomic unit (e.g. a `delete` or another symmetric
+// `update` touching the same natural key) can change the conflict landscape
+// between this op's prepare-time probe and its own statements finally
+// executing at commit time — codex r7 flagged this as a real staleness
+// window, not just an SQL-text duplication concern.
+//
+// The two builders below close it: instead of a Rust-level `if let
+// Some(conflict) { ... } else { ... }` that hand-picks ONE of three
+// statements at prepare time (the "second hand-assembled branch" codex
+// flagged), the atomic plan ALWAYS carries both statements, in order, and
+// each is a self-guarding, commit-time predicate that re-evaluates conflict
+// state fresh against whatever the transaction's state actually is when it
+// runs — not what prepare's probe said:
+//
+// 1. [`edge_symmetric_delete_if_conflict_statement`]: deletes the requested
+//    (non-canonical) row IF AND ONLY IF a differently-id'd canonical row
+//    exists at the target natural key at THIS moment (guard: 0 or 1 rows).
+// 2. [`edge_symmetric_refresh_or_update_inplace_statement`]: a single
+//    `UPDATE` matching either the still-live requested row (id match, if
+//    statement 1 didn't fire) or the canonical row (natural-key match, if
+//    it did) — always exactly 1 row (guard: exactly 1). `target_backend` is
+//    updated only for the natural-key match (the absorbed-conflict case);
+//    a `CASE WHEN id = :requested_id` guards that, replicating
+//    [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`]'s "leave `target_backend`
+//    untouched" behavior for the in-place case with the SAME statement that
+//    also replicates [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`]'s explicit
+//    `target_backend` set for the absorbed case.
+//
+// No probe, no branch, no read at all is needed to APPLY this pair — only
+// to compute the atomic plan's advisory `target_id` for post-commit result
+// rendering (an informational read, not a write-correctness concern); see
+// `khive-runtime::atomic_prepare::prepare_update_edge`'s doc comment.
+pub fn edge_symmetric_delete_if_conflict_statement(
+    namespace: &str,
+    id: Uuid,
+    canon_src: Uuid,
+    canon_tgt: Uuid,
+    relation: EdgeRelation,
+) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM graph_edges \
+              WHERE namespace = ?1 AND id = ?2 \
+                AND EXISTS ( \
+                  SELECT 1 FROM graph_edges \
+                  WHERE namespace = ?1 AND source_id = ?3 AND target_id = ?4 \
+                    AND relation = ?5 AND id != ?2 \
+                )"
+        .to_string(),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(id.to_string()),
+            SqlValue::Text(canon_src.to_string()),
+            SqlValue::Text(canon_tgt.to_string()),
+            SqlValue::Text(relation.to_string()),
+        ],
+        label: Some("edge-symmetric-delete-if-conflict".to_string()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn edge_symmetric_refresh_or_update_inplace_statement(
+    namespace: &str,
+    id: Uuid,
+    canon_src: Uuid,
+    canon_tgt: Uuid,
+    relation: EdgeRelation,
+    weight: f64,
+    updated_at_micros: i64,
+    metadata: Option<&str>,
+    target_backend: Option<&str>,
+) -> SqlStatement {
+    SqlStatement {
+        sql: "UPDATE graph_edges SET \
+              source_id = ?3, target_id = ?4, relation = ?5, \
+              weight = ?6, updated_at = ?7, deleted_at = NULL, metadata = ?8, \
+              target_backend = CASE WHEN id = ?2 THEN target_backend ELSE ?9 END \
+              WHERE namespace = ?1 \
+                AND (id = ?2 OR (source_id = ?3 AND target_id = ?4 AND relation = ?5))"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(id.to_string()),
+            SqlValue::Text(canon_src.to_string()),
+            SqlValue::Text(canon_tgt.to_string()),
+            SqlValue::Text(relation.to_string()),
+            SqlValue::Float(weight),
+            SqlValue::Integer(updated_at_micros),
+            match metadata {
+                Some(m) => SqlValue::Text(m.to_string()),
+                None => SqlValue::Null,
+            },
+            match target_backend {
+                Some(b) => SqlValue::Text(b.to_string()),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("edge-symmetric-refresh-or-update-inplace".to_string()),
     }
 }
 

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -104,7 +104,7 @@ pub fn edge_upsert_statement(edge: &Edge) -> SqlStatement {
 
 /// The atomic `link` op's variant of [`edge_upsert_statement`] (ADR-099 B3
 /// r7, codex r7 High finding 2). Shares the SAME
-/// [`EDGE_NATURAL_KEY_CONFLICT_SET`] conflict-arm text — the two builders
+/// `EDGE_NATURAL_KEY_CONFLICT_SET` conflict-arm text — the two builders
 /// cannot diverge on write behavior — but wraps the `INSERT` in a guarded
 /// `SELECT ... WHERE EXISTS(...)` that re-probes both endpoints for
 /// existence INSIDE the transaction, at commit time, rather than trusting

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -125,6 +125,141 @@ pub fn purge_incident_edges_statement(node_id: Uuid) -> SqlStatement {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Symmetric-relation update DML (ADR-099 B3 r6 second pass) — the SQL text
+// `khive-runtime::operations::KhiveRuntime::update_edge_symmetric_dml` (the
+// synchronous raw-connection commit-time path, run inside the writer-task/
+// pool-mutex transaction) and ADR-099's atomic `prepare_update_edge` symmetric
+// branch (the async plan-time path) both bind. `upsert_edge` cannot be used
+// here: it resolves `ON CONFLICT(namespace, id)` first and cannot detect a
+// natural-key collision at (namespace, source_id, target_id, relation) with a
+// *different* id, which is exactly the case a symmetric-relation endpoint
+// canonicalization can produce.
+//
+// The two call sites bind these against different parameter-passing
+// mechanisms — `conn.execute`/`conn.query_row` with `rusqlite::params!` in the
+// synchronous path (it must run inside an existing transaction on a borrowed
+// `&rusqlite::Connection`, so it cannot go through the `SqlStatement`/
+// `SqlValue` plan-shape khive-storage abstracts elsewhere) vs. `SqlValue`
+// plan params for the async `PlanStatement` path — but the SQL TEXT itself
+// (the `EDGE_SYMMETRIC_*_SQL` constants below) is the single source of truth
+// for both, closing the class of drift that produced the ADR-099 B3 round-4
+// codex REJECT (a hand-copied SQL literal silently diverging from canonical).
+pub const EDGE_SYMMETRIC_CONFLICT_PROBE_SQL: &str = "SELECT id FROM graph_edges \
+     WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
+     AND relation = ?4 AND id != ?5";
+
+pub const EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL: &str =
+    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2";
+
+pub const EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL: &str = "UPDATE graph_edges SET \
+     weight = ?1, updated_at = ?2, deleted_at = NULL, \
+     target_backend = ?3, metadata = ?4 \
+     WHERE namespace = ?5 AND id = ?6";
+
+pub const EDGE_SYMMETRIC_UPDATE_INPLACE_SQL: &str = "UPDATE graph_edges SET \
+     source_id = ?1, target_id = ?2, relation = ?3, \
+     weight = ?4, updated_at = ?5, metadata = ?6 \
+     WHERE namespace = ?7 AND id = ?8";
+
+/// Plan-shape builder for [`EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] — the
+/// async prepare-time conflict probe.
+pub fn edge_symmetric_conflict_probe_statement(
+    namespace: &str,
+    canon_src: Uuid,
+    canon_tgt: Uuid,
+    relation: EdgeRelation,
+    exclude_id: Uuid,
+) -> SqlStatement {
+    SqlStatement {
+        sql: EDGE_SYMMETRIC_CONFLICT_PROBE_SQL.to_string(),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(canon_src.to_string()),
+            SqlValue::Text(canon_tgt.to_string()),
+            SqlValue::Text(relation.to_string()),
+            SqlValue::Text(exclude_id.to_string()),
+        ],
+        label: Some("edge-symmetric-conflict-probe".to_string()),
+    }
+}
+
+/// Plan-shape builder for [`EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL`] —
+/// case (b): a canonical row already exists, delete the requested row.
+pub fn edge_symmetric_delete_noncanonical_statement(namespace: &str, id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL.to_string(),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("edge-symmetric-delete-noncanonical".to_string()),
+    }
+}
+
+/// Plan-shape builder for [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`] —
+/// case (b) continued: refresh the surviving canonical row.
+#[allow(clippy::too_many_arguments)]
+pub fn edge_symmetric_refresh_canonical_statement(
+    namespace: &str,
+    existing_id: Uuid,
+    weight: f64,
+    updated_at_micros: i64,
+    target_backend: Option<&str>,
+    metadata: Option<&str>,
+) -> SqlStatement {
+    SqlStatement {
+        sql: EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL.to_string(),
+        params: vec![
+            SqlValue::Float(weight),
+            SqlValue::Integer(updated_at_micros),
+            match target_backend {
+                Some(b) => SqlValue::Text(b.to_string()),
+                None => SqlValue::Null,
+            },
+            match metadata {
+                Some(m) => SqlValue::Text(m.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(existing_id.to_string()),
+        ],
+        label: Some("edge-symmetric-refresh-canonical".to_string()),
+    }
+}
+
+/// Plan-shape builder for [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`] —
+/// case (a): no conflict, update the requested row in place.
+#[allow(clippy::too_many_arguments)]
+pub fn edge_symmetric_update_inplace_statement(
+    namespace: &str,
+    id: Uuid,
+    canon_src: Uuid,
+    canon_tgt: Uuid,
+    relation: EdgeRelation,
+    weight: f64,
+    updated_at_micros: i64,
+    metadata: Option<&str>,
+) -> SqlStatement {
+    SqlStatement {
+        sql: EDGE_SYMMETRIC_UPDATE_INPLACE_SQL.to_string(),
+        params: vec![
+            SqlValue::Text(canon_src.to_string()),
+            SqlValue::Text(canon_tgt.to_string()),
+            SqlValue::Text(relation.to_string()),
+            SqlValue::Float(weight),
+            SqlValue::Integer(updated_at_micros),
+            match metadata {
+                Some(m) => SqlValue::Text(m.to_string()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("edge-symmetric-update-inplace".to_string()),
+    }
+}
+
 /// A GraphStore backed by SQLite tables.
 pub struct SqlGraphStore {
     pool: Arc<ConnectionPool>,

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -357,20 +357,47 @@ pub fn edge_symmetric_update_inplace_statement(
 //    (non-canonical) row IF AND ONLY IF a differently-id'd canonical row
 //    exists at the target natural key at THIS moment (guard: 0 or 1 rows).
 // 2. [`edge_symmetric_refresh_or_update_inplace_statement`]: a single
-//    `UPDATE` matching either the still-live requested row (id match, if
-//    statement 1 didn't fire) or the canonical row (natural-key match, if
-//    it did) — always exactly 1 row (guard: exactly 1). `target_backend` is
-//    updated only for the natural-key match (the absorbed-conflict case);
-//    a `CASE WHEN id = :requested_id` guards that, replicating
-//    [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`]'s "leave `target_backend`
-//    untouched" behavior for the in-place case with the SAME statement that
-//    also replicates [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`]'s explicit
-//    `target_backend` set for the absorbed case.
+//    `UPDATE` that no longer trusts an `id = ?2 OR natural-key` predicate
+//    (ADR-099 B3 r9, codex r8 Blocker finding 1 — that predicate could
+//    match the WRONG row: if a different op earlier in the SAME atomic unit
+//    had already deleted the requested edge, statement 1 above no-ops (its
+//    "0 rows" result is indistinguishable at the Rust level from "no
+//    conflict existed"), yet the natural-key arm could still hit a
+//    pre-existing canonical row that this update never causally touched).
+//    The fix ties the natural-key arm to `changes()` — SQLite's per-
+//    connection scalar reporting the row count of the most recently
+//    COMPLETED statement, i.e. statement 1's own result, evaluated fresh at
+//    THIS statement's execution, not at prepare time:
+//    - `id = ?2 AND changes() = 0`: statement 1 deleted nothing, so the
+//      requested row is still live under its own id — update it in place.
+//    - `source_id = ?3 AND target_id = ?4 AND relation = ?5 AND id != ?2
+//      AND changes() = 1`: statement 1 just deleted the requested row
+//      BECAUSE a conflict existed — refresh that surviving canonical row.
+//    These two arms are mutually exclusive and, together with statement 1's
+//    own guard, jointly exhaustive: if the requested row no longer existed
+//    when statement 1 ran (the same-unit race above), statement 1 affects 0
+//    rows for a reason unrelated to conflict absorption, `id = ?2` no
+//    longer matches anything (the row is gone), and the natural-key arm's
+//    `changes() = 1` guard is false — so this statement affects ZERO rows
+//    and the plan's `AffectedRowGuard::exactly(1)` on it fails the op,
+//    aborting the whole atomic unit rather than silently mutating an
+//    unrelated row. `target_backend` is updated only in the natural-key
+//    (absorbed-conflict) arm — the same `changes() = 1` condition, via a
+//    `CASE`, replicating [`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`]'s "leave
+//    `target_backend` untouched" behavior for the in-place case with the
+//    SAME statement that also replicates
+//    [`EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`]'s explicit `target_backend`
+//    set for the absorbed case.
 //
-// No probe, no branch, no read at all is needed to APPLY this pair — only
-// to compute the atomic plan's advisory `target_id` for post-commit result
-// rendering (an informational read, not a write-correctness concern); see
-// `khive-runtime::atomic_prepare::prepare_update_edge`'s doc comment.
+// No probe, no branch, no read at all is needed to APPLY this pair. Which
+// row this plan actually touched is derived post-commit by the caller via a
+// fresh natural-key lookup (`khive-runtime::KhiveRuntime::list_edges`,
+// filtered on the canonicalized endpoints/relation — the same mechanism the
+// atomic `link` op's own result rendering already uses) — ADR-099 B3 r9
+// removed the prior prepare-time advisory `target_id` probe entirely
+// (codex r8 Blocker finding 1, second half): a value computed before the
+// SAME atomic unit's other ops have run is not a fact this plan can stand
+// behind, so result rendering no longer trusts it.
 pub fn edge_symmetric_delete_if_conflict_statement(
     namespace: &str,
     id: Uuid,
@@ -414,10 +441,14 @@ pub fn edge_symmetric_refresh_or_update_inplace_statement(
         sql: "UPDATE graph_edges SET \
               source_id = ?3, target_id = ?4, relation = ?5, \
               weight = ?6, updated_at = ?7, deleted_at = NULL, metadata = ?8, \
-              target_backend = CASE WHEN id = ?2 THEN target_backend ELSE ?9 END \
+              target_backend = CASE WHEN changes() = 1 THEN ?9 ELSE target_backend END \
               WHERE namespace = ?1 \
-                AND (id = ?2 OR (source_id = ?3 AND target_id = ?4 AND relation = ?5))"
-            .to_string(),
+                AND ( \
+                  (id = ?2 AND changes() = 0) \
+                  OR (source_id = ?3 AND target_id = ?4 AND relation = ?5 \
+                      AND id != ?2 AND changes() = 1) \
+                )"
+        .to_string(),
         params: vec![
             SqlValue::Text(namespace.to_string()),
             SqlValue::Text(id.to_string()),
@@ -815,6 +846,16 @@ fn canonical_edge_endpoints(
 /// unlike `upsert_entities`/`upsert_notes`'s partial-success accounting) —
 /// the caller's transaction wrapper (either the legacy `with_writer` closure
 /// or `WriteRequest::execute_and_reply`) issues the ROLLBACK.
+///
+/// Per-row DML comes from [`edge_upsert_statement`] — the SAME builder
+/// singleton `upsert_edge` calls (ADR-099 B3 r9, codex r8 High finding 2:
+/// this function previously hand-wrote a second, textually-independent copy
+/// of the natural-key conflict arms here, the exact drift class round 7's
+/// [`EDGE_NATURAL_KEY_CONFLICT_SET`] extraction was meant to close for good
+/// — a future change to that constant would have silently stopped reaching
+/// this batch path). `bind_params` is the same `SqlStatement` -> rusqlite
+/// binding `upsert_edge` uses; there is now exactly one literal for the
+/// edge natural-key conflict arms in the whole workspace.
 fn batch_upsert_edges(
     conn: &rusqlite::Connection,
     edges: &[Edge],
@@ -823,52 +864,10 @@ fn batch_upsert_edges(
     let mut affected = 0u64;
 
     for edge in edges {
-        let id_str = Uuid::from(edge.id).to_string();
-        let (canon_src, canon_tgt) =
-            canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
-        let src_str = canon_src.to_string();
-        let tgt_str = canon_tgt.to_string();
-        let relation_str = edge.relation.to_string();
-        let metadata_str = edge
-            .metadata
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-        conn.execute(
-            "INSERT INTO graph_edges \
-             (namespace, id, source_id, target_id, relation, weight, \
-              created_at, updated_at, deleted_at, metadata, target_backend) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
-             ON CONFLICT(namespace, id) DO UPDATE SET \
-                 source_id = excluded.source_id, \
-                 target_id = excluded.target_id, \
-                 relation = excluded.relation, \
-                 weight = excluded.weight, \
-                 updated_at = excluded.updated_at, \
-                 deleted_at = NULL, \
-                 metadata = excluded.metadata, \
-                 target_backend = excluded.target_backend \
-             ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
-                 weight = excluded.weight, \
-                 updated_at = excluded.updated_at, \
-                 deleted_at = NULL, \
-                 metadata = excluded.metadata, \
-                 target_backend = excluded.target_backend",
-            rusqlite::params![
-                edge.namespace.as_str(),
-                id_str,
-                src_str,
-                tgt_str,
-                relation_str,
-                edge.weight,
-                edge.created_at.timestamp_micros(),
-                edge.updated_at.timestamp_micros(),
-                edge.deleted_at.map(|t| t.timestamp_micros()),
-                metadata_str,
-                edge.target_backend.as_deref(),
-            ],
-        )?;
+        let statement = edge_upsert_statement(edge);
+        let mut stmt = conn.prepare(&statement.sql)?;
+        bind_params(&mut stmt, &statement.params)?;
+        stmt.raw_execute()?;
         affected += 1;
     }
 

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -7,12 +7,15 @@ use uuid::Uuid;
 
 use khive_storage::error::StorageError;
 use khive_storage::note::{FilterOp, Note, NoteFilter, SortDir};
-use khive_storage::types::{BatchWriteSummary, DeleteMode, Page, PageRequest, SqlValue};
+use khive_storage::types::{
+    BatchWriteSummary, DeleteMode, Page, PageRequest, SqlStatement, SqlValue,
+};
 use khive_storage::NoteStore;
 use khive_storage::StorageCapability;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
 
 fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
@@ -21,6 +24,84 @@ fn map_err(e: rusqlite::Error, op: &'static str) -> StorageError {
 
 fn map_sqlite_err(e: SqliteError, op: &'static str) -> StorageError {
     StorageError::driver(StorageCapability::Notes, op, e)
+}
+
+// ---------------------------------------------------------------------------
+// Pure statement builders (ADR-099 B3 r6 structural cut) — see entity.rs's
+// sibling block for the full rationale. `upsert_note`/`delete_note` below
+// and ADR-099's atomic prepare path (`khive-runtime`) both call these.
+// ---------------------------------------------------------------------------
+
+/// The exact `INSERT OR REPLACE` this store's `upsert_note` issues.
+pub fn note_upsert_statement(note: &Note) -> SqlStatement {
+    let properties_str = note
+        .properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "INSERT OR REPLACE INTO notes \
+              (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+               properties, created_at, updated_at, deleted_at) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(note.id.to_string()),
+            SqlValue::Text(note.namespace.clone()),
+            SqlValue::Text(note.kind.to_string()),
+            SqlValue::Text(note.status.clone()),
+            match &note.name {
+                Some(n) => SqlValue::Text(n.clone()),
+                None => SqlValue::Null,
+            },
+            SqlValue::Text(note.content.clone()),
+            match note.salience {
+                Some(s) => SqlValue::Float(s),
+                None => SqlValue::Null,
+            },
+            match note.decay_factor {
+                Some(d) => SqlValue::Float(d),
+                None => SqlValue::Null,
+            },
+            match note.expires_at {
+                Some(e) => SqlValue::Integer(e),
+                None => SqlValue::Null,
+            },
+            match properties_str {
+                Some(p) => SqlValue::Text(p),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(note.created_at),
+            SqlValue::Integer(note.updated_at),
+            match note.deleted_at {
+                Some(d) => SqlValue::Integer(d),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("note-upsert".to_string()),
+    }
+}
+
+/// The exact soft-delete `UPDATE` this store's `delete_note(Soft)` issues.
+pub fn note_soft_delete_statement(id: Uuid, deleted_at: i64) -> SqlStatement {
+    SqlStatement {
+        sql: "UPDATE notes SET status = 'deleted', deleted_at = ?1 \
+              WHERE id = ?2 AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![
+            SqlValue::Integer(deleted_at),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("note-delete-soft".to_string()),
+    }
+}
+
+/// The exact hard-delete `DELETE` this store's `delete_note(Hard)` issues.
+pub fn note_hard_delete_statement(id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: "DELETE FROM notes WHERE id = ?1".to_string(),
+        params: vec![SqlValue::Text(id.to_string())],
+        label: Some("note-delete-hard".to_string()),
+    }
 }
 
 /// A NoteStore backed by SQLite. Namespace is the caller's responsibility.
@@ -401,37 +482,11 @@ fn build_note_filter_where(
 #[async_trait]
 impl NoteStore for SqlNoteStore {
     async fn upsert_note(&self, note: Note) -> Result<(), StorageError> {
-        let namespace = note.namespace.clone();
-        let id_str = note.id.to_string();
-        let kind_str = note.kind.to_string();
-        let status_str = note.status.clone();
-        let properties_str = note
-            .properties
-            .as_ref()
-            .map(|v| serde_json::to_string(v).unwrap_or_default());
-
+        let statement = note_upsert_statement(&note);
         self.with_writer("upsert_note", move |conn| {
-            conn.execute(
-                "INSERT OR REPLACE INTO notes \
-                 (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
-                  properties, created_at, updated_at, deleted_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                rusqlite::params![
-                    id_str,
-                    namespace,
-                    kind_str,
-                    status_str,
-                    note.name,
-                    note.content,
-                    note.salience,
-                    note.decay_factor,
-                    note.expires_at,
-                    properties_str,
-                    note.created_at,
-                    note.updated_at,
-                    note.deleted_at,
-                ],
-            )?;
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            stmt.raw_execute()?;
             Ok(())
         })
         .await
@@ -621,26 +676,23 @@ impl NoteStore for SqlNoteStore {
     }
 
     async fn delete_note(&self, id: Uuid, mode: DeleteMode) -> Result<bool, StorageError> {
-        let id_str = id.to_string();
-
         match mode {
             DeleteMode::Soft => {
+                let now = chrono::Utc::now().timestamp_micros();
+                let statement = note_soft_delete_statement(id, now);
                 self.with_writer("delete_note_soft", move |conn| {
-                    let now = chrono::Utc::now().timestamp_micros();
-                    let deleted = conn.execute(
-                        "UPDATE notes SET status = 'deleted', deleted_at = ?1 \
-                         WHERE id = ?2 AND deleted_at IS NULL",
-                        rusqlite::params![now, id_str],
-                    )?;
-                    Ok(deleted > 0)
+                    let mut stmt = conn.prepare(&statement.sql)?;
+                    bind_params(&mut stmt, &statement.params)?;
+                    Ok(stmt.raw_execute()? > 0)
                 })
                 .await
             }
             DeleteMode::Hard => {
+                let statement = note_hard_delete_statement(id);
                 self.with_writer("delete_note_hard", move |conn| {
-                    let deleted =
-                        conn.execute("DELETE FROM notes WHERE id = ?1", rusqlite::params![id_str])?;
-                    Ok(deleted > 0)
+                    let mut stmt = conn.prepare(&statement.sql)?;
+                    bind_params(&mut stmt, &statement.params)?;
+                    Ok(stmt.raw_execute()? > 0)
                 })
                 .await
             }

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -9,9 +9,9 @@ use uuid::Uuid;
 use khive_score::DeterministicScore;
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteSummary, IndexRebuildScope, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
-    TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
-    TextTermStatsRequest,
+    BatchWriteSummary, IndexRebuildScope, SqlStatement, SqlValue, TextDocument, TextFilter,
+    TextGatherMode, TextIndexStats, TextQueryMode, TextSearchHit, TextSearchOptions,
+    TextSearchRequest, TextTermStats, TextTermStatsRequest,
 };
 use khive_storage::StorageCapability;
 use khive_storage::TextSearch;
@@ -19,7 +19,25 @@ use khive_types::SubstrateKind;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
 use crate::writer_task::WriterTaskHandle;
+
+/// The exact `DELETE` this store's `delete_document` issues, for a given
+/// FTS table (ADR-099 B3 r6 structural cut — see `entity.rs`'s sibling
+/// block). `table` must already be a trusted, sanitized table name (this
+/// mirrors `delete_document`'s own pre-existing lack of a placeholder for
+/// table names — `format!` is required since table identifiers cannot be
+/// bound as SQL parameters).
+pub fn delete_document_statement(table: &str, namespace: &str, subject_id: Uuid) -> SqlStatement {
+    SqlStatement {
+        sql: format!("DELETE FROM {table} WHERE namespace = ?1 AND subject_id = ?2"),
+        params: vec![
+            SqlValue::Text(namespace.to_string()),
+            SqlValue::Text(subject_id.to_string()),
+        ],
+        label: Some(format!("fts-delete-{table}")),
+    }
+}
 
 /// Ensure the FTS5 virtual table for `table_key` exists.
 ///
@@ -544,17 +562,12 @@ impl TextSearch for Fts5TextSearch {
         namespace: &str,
         subject_id: Uuid,
     ) -> Result<bool, StorageError> {
-        let namespace = namespace.to_string();
-        let table = self.table_name.clone();
+        let statement = delete_document_statement(&self.table_name, namespace, subject_id);
 
         self.with_writer("fts_delete", move |conn| {
-            let sql = format!(
-                "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
-                table
-            );
-            let deleted =
-                conn.execute(&sql, rusqlite::params![namespace, subject_id.to_string()])?;
-            Ok(deleted > 0)
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/vectors.rs
+++ b/crates/khive-db/src/stores/vectors.rs
@@ -9,8 +9,9 @@ use uuid::Uuid;
 use khive_score::DeterministicScore;
 use khive_storage::error::StorageError;
 use khive_storage::types::{
-    BatchWriteSummary, IndexRebuildScope, OrphanSweepConfig, OrphanSweepResult, VectorIndexKind,
-    VectorRecord, VectorSearchHit, VectorSearchRequest, VectorStoreCapabilities, VectorStoreInfo,
+    BatchWriteSummary, IndexRebuildScope, OrphanSweepConfig, OrphanSweepResult, SqlStatement,
+    SqlValue, VectorIndexKind, VectorRecord, VectorSearchHit, VectorSearchRequest,
+    VectorStoreCapabilities, VectorStoreInfo,
 };
 use khive_storage::StorageCapability;
 use khive_storage::StorageResult;
@@ -19,6 +20,22 @@ use khive_types::SubstrateKind;
 
 use crate::error::SqliteError;
 use crate::pool::ConnectionPool;
+use crate::sql_bridge::bind_params;
+
+/// The exact `DELETE` this store's `delete` issues, for a given vector table
+/// (ADR-099 B3 r6 structural cut — see `stores::entity`'s sibling block).
+/// `table` must already be a trusted, sanitized table name (mirrors
+/// `delete`'s own pre-existing lack of a placeholder for table names).
+pub fn delete_vector_statement(table: &str, subject_id: Uuid, namespace: &str) -> SqlStatement {
+    SqlStatement {
+        sql: format!("DELETE FROM {table} WHERE subject_id = ?1 AND namespace = ?2"),
+        params: vec![
+            SqlValue::Text(subject_id.to_string()),
+            SqlValue::Text(namespace.to_string()),
+        ],
+        label: Some(format!("vec-delete-{table}")),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Test-only failpoint: force an error between DELETE and INSERT to exercise
@@ -937,17 +954,12 @@ impl VectorStore for SqliteVecStore {
     }
 
     async fn delete(&self, subject_id: Uuid) -> Result<bool, StorageError> {
-        let table = self.table_name.clone();
-        let namespace = self.namespace.clone();
+        let statement = delete_vector_statement(&self.table_name, subject_id, &self.namespace);
 
         self.with_writer("vec_delete", move |conn| {
-            let sql = format!(
-                "DELETE FROM {} WHERE subject_id = ?1 AND namespace = ?2",
-                table
-            );
-            let deleted =
-                conn.execute(&sql, rusqlite::params![subject_id.to_string(), &namespace])?;
-            Ok(deleted > 0)
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -40,7 +40,16 @@ use crate::GtdPack;
 /// `OnceLock`, because each `KhiveRuntime::memory()` in tests creates a fresh
 /// in-memory database that needs its own schema bootstrap.  In production the
 /// DDL is idempotent and cheap (SQLite skips `IF NOT EXISTS` tables instantly).
-async fn ensure_audit_schema(runtime: &KhiveRuntime) {
+/// `pub` (rather than the module-private visibility every other helper in
+/// this file uses): the ADR-099 `--atomic` CLI surface's `gtd.transition`/
+/// `gtd.complete` prepare functions live in `kkernel` (a crate that already
+/// depends on both `khive-runtime` and `khive-pack-gtd` — see that crate's
+/// `atomic_apply` module doc for the crate-direction rationale), and the B3
+/// fix round (GAP-5) applies this exact function as a deferred post-commit
+/// effect so atomic transitions/completes write the same best-effort
+/// lifecycle audit row the canonical handlers do, rather than re-deriving
+/// the DDL/INSERT here a second time.
+pub async fn ensure_audit_schema(runtime: &KhiveRuntime) {
     let Ok(mut w) = runtime.sql().writer().await else {
         tracing::warn!("gtd: failed to acquire SQL writer for audit schema (non-fatal)");
         return;
@@ -91,7 +100,11 @@ async fn ensure_audit_schema(runtime: &KhiveRuntime) {
 ///
 /// Best-effort: failures are logged and swallowed.  The note's successful
 /// write has already happened; a missing audit row is degraded, not a failure.
-async fn write_audit_record(
+///
+/// `pub` for the same reason as `ensure_audit_schema` above — the ADR-099
+/// `--atomic` surface's `kkernel`-side post-commit pass calls this directly
+/// (B3 fix round, GAP-5) rather than re-deriving the INSERT.
+pub async fn write_audit_record(
     runtime: &KhiveRuntime,
     note_id: Uuid,
     from: &str,

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -507,7 +507,7 @@ async fn atomic_gtd_transition(
     Ok(affected)
 }
 
-/// The exact conditional-UPDATE DML [`atomic_gtd_transition`] issues, as a
+/// The exact conditional-UPDATE DML `atomic_gtd_transition` issues, as a
 /// plain [`SqlStatement`] — the single source of truth shared with the
 /// ADR-099 `--atomic` `gtd.transition`/`gtd.complete` prepare functions in
 /// `kkernel` (`crate::atomic_apply`, that crate — not this one — since

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -482,12 +482,6 @@ async fn atomic_gtd_transition(
     new_props: &serde_json::Value,
     updated_at: i64,
 ) -> Result<u64, RuntimeError> {
-    let props_str = serde_json::to_string(new_props)
-        .map_err(|e| RuntimeError::Internal(format!("serialize props: {e}")))?;
-    let id_str = note_id.as_hyphenated().to_string();
-    let target_owned = target.to_string();
-    let current_owned = expected_current.to_string();
-
     // The conditional UPDATE runs as a single SQLite statement, which is atomic
     // on its own — no explicit transaction is needed because we never split the
     // read-check from the write. The WHERE predicate goes through json_extract
@@ -498,30 +492,215 @@ async fn atomic_gtd_transition(
     // terminal state) by the time the WHERE predicate is evaluated, the predicate
     // fails and rows_affected = 0. Caller distinguishes the rows-affected-0 loser
     // path from the pre-load terminal-state error returned by `load_task`.
+    let statement =
+        gtd_transition_statement(note_id, expected_current, target, new_props, updated_at)?;
     let sql = runtime.sql();
     let mut writer = sql
         .writer()
         .await
         .map_err(|e| RuntimeError::Internal(format!("sql writer: {e}")))?;
     let affected = writer
-        .execute(SqlStatement {
-            sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
-                  WHERE id = ?3 \
-                  AND json_extract(properties, '$.status') = ?4 \
-                  AND deleted_at IS NULL"
-                .to_string(),
-            params: vec![
-                SqlValue::Text(props_str),
-                SqlValue::Integer(updated_at),
-                SqlValue::Text(id_str),
-                SqlValue::Text(current_owned),
-            ],
-            label: Some(format!("gtd_atomic_transition_{target_owned}")),
-        })
+        .execute(statement)
         .await
         .map_err(|e| RuntimeError::Internal(format!("atomic transition update: {e}")))?;
 
     Ok(affected)
+}
+
+/// The exact conditional-UPDATE DML [`atomic_gtd_transition`] issues, as a
+/// plain [`SqlStatement`] — the single source of truth shared with the
+/// ADR-099 `--atomic` `gtd.transition`/`gtd.complete` prepare functions in
+/// `kkernel` (`crate::atomic_apply`, that crate — not this one — since
+/// `kkernel` depends on both `khive-runtime` and `khive-pack-gtd`). Canonical
+/// executes it immediately via the writer above; the atomic path turns it
+/// into a `PlanStatement` for the synchronous commit pass instead.
+pub fn gtd_transition_statement(
+    note_id: Uuid,
+    expected_current: &str,
+    target: &str,
+    new_props: &serde_json::Value,
+    updated_at: i64,
+) -> Result<SqlStatement, RuntimeError> {
+    let props_str = serde_json::to_string(new_props)
+        .map_err(|e| RuntimeError::Internal(format!("serialize props: {e}")))?;
+    Ok(SqlStatement {
+        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
+              WHERE id = ?3 \
+              AND json_extract(properties, '$.status') = ?4 \
+              AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(props_str),
+            SqlValue::Integer(updated_at),
+            SqlValue::Text(note_id.as_hyphenated().to_string()),
+            SqlValue::Text(expected_current.to_string()),
+        ],
+        label: Some(format!("gtd_atomic_transition_{target}")),
+    })
+}
+
+/// Outcome of [`prepare_transition`]'s decide step: either nothing to write
+/// (the idempotent `current == target` case, canonical's early return) or a
+/// fully computed patched `properties` value ready to apply — via
+/// `atomic_gtd_transition` (canonical, immediate) or
+/// [`gtd_transition_statement`] (ADR-099 atomic, deferred to the commit
+/// pass).
+pub enum TransitionDecision {
+    NoOp {
+        note: khive_storage::note::Note,
+        current: String,
+        target: String,
+    },
+    Write {
+        note: khive_storage::note::Note,
+        current: String,
+        target: String,
+        props: Value,
+        updated_at: i64,
+        transition_note: Option<String>,
+    },
+}
+
+/// Decide step of `gtd.transition` (ADR-099 B3 r6 second pass): normalizes
+/// and validates the target status, secret-gates the caller-supplied
+/// transition note, loads the task, and either returns the idempotent no-op
+/// case or the fully computed patch — all WITHOUT writing. `GtdPack::
+/// handle_transition` and the ADR-099 `--atomic` `gtd.transition` prepare
+/// function in `kkernel` both call this ONE function; only the apply
+/// mechanism differs.
+pub async fn prepare_transition(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    raw_id: &str,
+    raw_status: &str,
+    note_arg: Option<&str>,
+) -> Result<TransitionDecision, RuntimeError> {
+    let target = normalize_status(raw_status);
+    if !is_valid_status(target) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "invalid status {raw_status:?} — valid: inbox, next, waiting, someday, active, done, cancelled \
+             (aliases: in_progress, todo, blocked, later, finished)"
+        )));
+    }
+    if let Some(n) = note_arg {
+        khive_runtime::secret_gate::check(n)?;
+    }
+
+    let (note, current) = load_task(runtime, token, raw_id).await?;
+
+    if current == target {
+        return Ok(TransitionDecision::NoOp {
+            note,
+            current,
+            target: target.to_string(),
+        });
+    }
+    if is_terminal(&current) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "task {} is in terminal state {current:?}; no further transitions allowed",
+            short_id(note.id)
+        )));
+    }
+    if !can_transition(&current, target) {
+        let allowed = allowed_transitions(&current);
+        let allowed_display = if allowed.is_empty() {
+            "(none)".to_string()
+        } else {
+            allowed.join(", ")
+        };
+        return Err(RuntimeError::InvalidInput(format!(
+            "cannot transition from {current:?} to {target:?}; \
+             allowed from {current:?}: {allowed_display}. Full lifecycle: {TASK_LIFECYCLE_HELP}"
+        )));
+    }
+
+    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    if let Some(obj) = props.as_object_mut() {
+        obj.insert("status".into(), json!(target.to_string()));
+        if let Some(n) = note_arg {
+            obj.insert("transition_note".into(), json!(n));
+        }
+        if target == "done" {
+            obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+        }
+    }
+    let updated_at = Utc::now().timestamp_micros();
+
+    Ok(TransitionDecision::Write {
+        note,
+        current,
+        target: target.to_string(),
+        props,
+        updated_at,
+        transition_note: note_arg.map(str::to_string),
+    })
+}
+
+/// Outcome of [`prepare_complete`]'s decide step: the fully computed patched
+/// `properties` value ready to apply. Unlike [`TransitionDecision`], there is
+/// no idempotent no-op case — `complete()` always writes when it succeeds.
+pub struct CompleteDecision {
+    pub note: khive_storage::note::Note,
+    pub current: String,
+    pub target: &'static str,
+    pub props: Value,
+    pub updated_at: i64,
+    pub completed_at: String,
+}
+
+/// Decide step of `gtd.complete` (ADR-099 B3 r6 second pass) — same split as
+/// [`prepare_transition`] above: validates the target terminal status,
+/// secret-gates the caller-supplied result, loads the task, checks the
+/// terminal/actionable guards, and computes the patched `properties` value,
+/// all WITHOUT writing. `GtdPack::handle_complete` and the ADR-099 `--atomic`
+/// `gtd.complete` prepare function in `kkernel` both call this ONE function.
+pub async fn prepare_complete(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    raw_id: &str,
+    status_arg: Option<&str>,
+    result_arg: Option<&str>,
+) -> Result<CompleteDecision, RuntimeError> {
+    let target = complete_target_status(status_arg)?;
+
+    if let Some(result) = result_arg {
+        khive_runtime::secret_gate::check(result)?;
+    }
+
+    let (note, current) = load_task(runtime, token, raw_id).await?;
+
+    if is_terminal(&current) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "task {} is in terminal state {current:?}; no further transitions allowed",
+            short_id(note.id)
+        )));
+    }
+    if !is_actionable(&current) {
+        return Err(RuntimeError::InvalidInput(format!(
+            "complete: task in {current:?}; transition to 'next' or 'active' first, \
+             or use transition(status=done) explicitly"
+        )));
+    }
+
+    let completed_at = Utc::now().to_rfc3339();
+    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    if let Some(obj) = props.as_object_mut() {
+        obj.insert("status".into(), json!(target));
+        obj.insert("completed_at".into(), json!(completed_at));
+        if let Some(result) = result_arg {
+            obj.insert("result".into(), json!(result));
+        }
+    }
+    let updated_at = Utc::now().timestamp_micros();
+
+    Ok(CompleteDecision {
+        note,
+        current,
+        target,
+        props,
+        updated_at,
+        completed_at,
+    })
 }
 
 // ── handlers ─────────────────────────────────────────────────────────────────
@@ -829,48 +1008,32 @@ impl GtdPack {
     ) -> Result<Value, RuntimeError> {
         let p: CompleteParams = deser(params)?;
 
-        // CC-1: validate the target terminal status before any DB work.
-        // Accepts "done" (default) or "cancelled"; rejects anything else.
-        let target = complete_target_status(p.status.as_deref())?;
-
-        // Secret gate: scan free-text result before any DB interaction.
-        if let Some(ref result) = p.result {
-            khive_runtime::secret_gate::check(result)?;
-        }
-
-        let (mut note, current) = load_task(self.runtime(), token, &p.id).await?;
-
-        if is_terminal(&current) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "task {} is in terminal state {current:?}; no further transitions allowed",
-                short_id(note.id)
-            )));
-        }
-        // UE2-H1: complete() is restricted to actionable states (next, active) only.
-        // Tasks in inbox/waiting/someday must be explicitly transitioned to an
-        // actionable state first. Use transition(status=done) to bypass this check.
-        if !is_actionable(&current) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "complete: task in {current:?}; transition to 'next' or 'active' first, \
-                 or use transition(status=done) explicitly"
-            )));
-        }
-
-        let completed_at = Utc::now().to_rfc3339();
-        let mut props = note.properties.take().unwrap_or(json!({}));
-        if let Some(obj) = props.as_object_mut() {
-            // CC-1: write the caller-supplied target (done or cancelled).
-            obj.insert("status".into(), json!(target));
-            obj.insert("completed_at".into(), json!(completed_at));
-            if let Some(ref result) = p.result {
-                obj.insert("result".into(), json!(result));
-            }
-        }
+        // Decide step (ADR-099 B3 r6 second pass): validates the target
+        // terminal status, secret-gates the result, loads the task, checks
+        // the terminal/actionable guards, and computes the patched
+        // `properties` value — the SAME function the ADR-099 `--atomic`
+        // `gtd.complete` prepare path in `kkernel` calls.
+        let decision = prepare_complete(
+            self.runtime(),
+            token,
+            &p.id,
+            p.status.as_deref(),
+            p.result.as_deref(),
+        )
+        .await?;
+        let CompleteDecision {
+            mut note,
+            current,
+            target,
+            props,
+            updated_at,
+            completed_at,
+        } = decision;
         note.properties = Some(props);
         // notes.status is row-visibility (always "active" for live rows);
         // GTD status lives in properties.status and W1-G's remap surfaces it
         // at data.status in the response.
-        note.updated_at = Utc::now().timestamp_micros();
+        note.updated_at = updated_at;
 
         // ue-dsl-parallel C2: atomic transition — use a conditional SQL UPDATE
         // so that a concurrent complete() on the same task loses the race
@@ -1010,98 +1173,81 @@ impl GtdPack {
         params: Value,
     ) -> Result<Value, RuntimeError> {
         let p: TransitionParams = deser(params)?;
-        let target = normalize_status(&p.status);
-        if !is_valid_status(target) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "invalid status {status:?} — valid: inbox, next, waiting, someday, active, done, cancelled \
-                 (aliases: in_progress, todo, blocked, later, finished)",
-                status = p.status
-            )));
-        }
-        // Secret gate: scan the caller-supplied transition note before any write.
-        if let Some(ref n) = p.note {
-            khive_runtime::secret_gate::check(n)?;
-        }
 
-        let (mut note, current) = load_task(self.runtime(), token, &p.id).await?;
+        // Decide step (ADR-099 B3 r6 second pass): normalizes/validates the
+        // target status, secret-gates the transition note, loads the task,
+        // and either returns the idempotent no-op case or the fully computed
+        // patch — the SAME function the ADR-099 `--atomic` `gtd.transition`
+        // prepare path in `kkernel` calls.
+        let decision =
+            prepare_transition(self.runtime(), token, &p.id, &p.status, p.note.as_deref()).await?;
 
-        if current == target {
-            // Idempotent — no write, no transition.
-            return Ok(json!({
-                "transitioned": false,
-                "id": short_id(note.id),
-                "full_id": note.id.as_hyphenated().to_string(),
-                "from": current,
-                "to": target,
-                "note": "already in target status",
-            }));
-        }
-        if is_terminal(&current) {
-            return Err(RuntimeError::InvalidInput(format!(
-                "task {} is in terminal state {current:?}; no further transitions allowed",
-                short_id(note.id)
-            )));
-        }
-        if !can_transition(&current, target) {
-            let allowed = allowed_transitions(&current);
-            let allowed_display = if allowed.is_empty() {
-                "(none)".to_string()
-            } else {
-                allowed.join(", ")
-            };
-            return Err(RuntimeError::InvalidInput(format!(
-                "cannot transition from {current:?} to {target:?}; \
-                 allowed from {current:?}: {allowed_display}. Full lifecycle: {TASK_LIFECYCLE_HELP}"
-            )));
-        }
-
-        let mut props = note.properties.take().unwrap_or(json!({}));
-        if let Some(obj) = props.as_object_mut() {
-            obj.insert("status".into(), json!(target.to_string()));
-            if let Some(ref n) = p.note {
-                obj.insert("transition_note".into(), json!(n));
+        let (note, current, target) = match decision {
+            TransitionDecision::NoOp {
+                note,
+                current,
+                target,
+            } => {
+                // Idempotent — no write, no transition.
+                return Ok(json!({
+                    "transitioned": false,
+                    "id": short_id(note.id),
+                    "full_id": note.id.as_hyphenated().to_string(),
+                    "from": current,
+                    "to": target,
+                    "note": "already in target status",
+                }));
             }
-            if target == "done" {
-                obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+            TransitionDecision::Write {
+                mut note,
+                current,
+                target,
+                props,
+                updated_at,
+                transition_note,
+            } => {
+                note.properties = Some(props);
+                // notes.status is row-visibility (always "active" for live
+                // rows); GTD status lives in properties.status and W1-G's
+                // remap surfaces it at data.status in the response.
+                note.updated_at = updated_at;
+
+                // ue-dsl-parallel C2: atomic transition — conditional SQL
+                // UPDATE so concurrent transitions in the same parallel
+                // batch only one wins.
+                let rows_affected = atomic_gtd_transition(
+                    self.runtime(),
+                    note.id,
+                    &current,
+                    &target,
+                    note.properties.as_ref().unwrap(),
+                    note.updated_at,
+                )
+                .await?;
+
+                if rows_affected == 0 {
+                    let (_, actual_now) = load_task(self.runtime(), token, &p.id).await?;
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "task {} is in terminal state {actual_now:?}; no further transitions allowed",
+                        short_id(note.id)
+                    )));
+                }
+
+                // Write lifecycle audit record (best-effort).
+                ensure_audit_schema(self.runtime()).await;
+                write_audit_record(
+                    self.runtime(),
+                    note.id,
+                    &current,
+                    &target,
+                    transition_note.as_deref(),
+                    token.namespace().as_str(),
+                )
+                .await;
+
+                (note, current, target)
             }
-        }
-        note.properties = Some(props);
-        // notes.status is row-visibility (always "active" for live rows);
-        // GTD status lives in properties.status and W1-G's remap surfaces it
-        // at data.status in the response.
-        note.updated_at = Utc::now().timestamp_micros();
-
-        // ue-dsl-parallel C2: atomic transition — conditional SQL UPDATE so
-        // concurrent transitions in the same parallel batch only one wins.
-        let rows_affected = atomic_gtd_transition(
-            self.runtime(),
-            note.id,
-            &current,
-            target,
-            note.properties.as_ref().unwrap(),
-            note.updated_at,
-        )
-        .await?;
-
-        if rows_affected == 0 {
-            let (_, actual_now) = load_task(self.runtime(), token, &p.id).await?;
-            return Err(RuntimeError::InvalidInput(format!(
-                "task {} is in terminal state {actual_now:?}; no further transitions allowed",
-                short_id(note.id)
-            )));
-        }
-
-        // Write lifecycle audit record (best-effort).
-        ensure_audit_schema(self.runtime()).await;
-        write_audit_record(
-            self.runtime(),
-            note.id,
-            &current,
-            target,
-            p.note.as_deref(),
-            token.namespace().as_str(),
-        )
-        .await;
+        };
 
         let task = render_task(&note);
         Ok(json!({
@@ -1110,7 +1256,7 @@ impl GtdPack {
             "full_id": task["full_id"],
             "from": current,
             "to": target,
-            "is_terminal": is_terminal(target),
+            "is_terminal": is_terminal(&target),
             "title": task["title"],
             "priority": task["priority"],
             "assignee": task["assignee"],

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -192,9 +192,15 @@ struct NextParams {
     assignee: Option<String>,
 }
 
+/// ADR-099 B3: `pub` (not module-private) SPECIFICALLY so `kkernel`'s
+/// `--atomic` validation seam (`atomic_apply::validate_atomic_args`) can
+/// deserialize an op's args through the SAME canonical struct
+/// `handle_complete` uses, reproducing `deny_unknown_fields` rejection with
+/// zero duplicated field lists. Fields stay private — the atomic seam only
+/// needs the `Result<_, _>` outcome, never field access.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct CompleteParams {
+pub struct CompleteParams {
     id: String,
     #[serde(default)]
     result: Option<String>,
@@ -233,9 +239,11 @@ struct TasksParams {
     offset: Option<u32>,
 }
 
+/// ADR-099 B3: `pub` for the same reason as `CompleteParams` above —
+/// reused by the atomic seam to validate `gtd.transition` args.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct TransitionParams {
+pub struct TransitionParams {
     id: String,
     status: String,
     #[serde(default)]

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -261,7 +261,13 @@ fn short_id(uuid: Uuid) -> String {
     uuid.as_hyphenated().to_string().chars().take(8).collect()
 }
 
-pub(crate) async fn resolve_uuid(
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 3): the
+/// `--atomic` seam in `kkernel` reuses this exact resolver (full UUID or 8+
+/// hex prefix, namespace-scoped via `resolve_prefix`) to resolve `gtd.transition`
+/// / `gtd.complete` `id` args before atomic prepare, matching what
+/// `handle_transition`/`handle_complete` use — reproducing canonical short-id
+/// acceptance without a duplicated resolution helper.
+pub async fn resolve_uuid(
     s: &str,
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -344,7 +350,13 @@ fn priority_rank(props: Option<&Value>) -> u8 {
 }
 
 /// Build the response object for any task-shaped operation.
-fn render_task(note: &khive_storage::note::Note) -> Value {
+///
+/// `pub` (widened from private, ADR-099 B3 fix round 5, finding 4): the
+/// `--atomic` seam in `kkernel` reuses this exact renderer, post-commit, to
+/// build the `result` payload for a committed `gtd.transition`/`gtd.complete`
+/// op — matching `handle_transition`/`handle_complete`'s response shape
+/// field-for-field without a duplicated renderer.
+pub fn render_task(note: &khive_storage::note::Note) -> Value {
     let props = note.properties.clone().unwrap_or(json!({}));
     let title = note
         .name

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -388,22 +388,6 @@ pub(crate) fn parse_direction(s: Option<&str>) -> Result<Direction, RuntimeError
     }
 }
 
-pub(crate) fn merge_entry_metadata(
-    metadata: Option<Value>,
-    dependency_kind: Option<String>,
-) -> Result<Option<Value>, RuntimeError> {
-    let Some(dk) = dependency_kind else {
-        return Ok(metadata);
-    };
-    let mut obj = metadata.unwrap_or_else(|| serde_json::json!({}));
-    let map = obj
-        .as_object_mut()
-        .ok_or_else(|| RuntimeError::InvalidInput("metadata must be a JSON object".into()))?;
-    map.entry("dependency_kind".to_string())
-        .or_insert_with(|| serde_json::json!(dk));
-    Ok(Some(obj))
-}
-
 pub(crate) fn parse_relation(s: &str) -> Result<EdgeRelation, RuntimeError> {
     s.parse::<EdgeRelation>().map_err(|_| {
         let valid = EdgeRelation::ALL

--- a/crates/khive-pack-kg/src/handlers/common.rs
+++ b/crates/khive-pack-kg/src/handlers/common.rs
@@ -88,8 +88,13 @@ pub(crate) fn validate_entity_type(
 // ---- Granular `kind` discriminator ----
 
 /// Resolved shape of a `kind` discriminator string.
+///
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 1): the
+/// `--atomic` seam in `kkernel` reuses [`resolve_kind_spec`] and this type to
+/// resolve a caller-supplied `delete(kind=...)` the SAME way `handle_delete`
+/// does, rather than re-deriving kind-vocabulary resolution.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum KindSpec {
+pub enum KindSpec {
     Entity { specific: Option<String> },
     Note { specific: Option<String> },
     Edge,
@@ -110,10 +115,10 @@ impl KindSpec {
 }
 
 /// Resolve a wire-level `kind` value into a [`KindSpec`].
-pub(crate) fn resolve_kind_spec(
-    raw: &str,
-    registry: &VerbRegistry,
-) -> Result<KindSpec, RuntimeError> {
+///
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 1) —
+/// see [`KindSpec`]'s doc comment.
+pub fn resolve_kind_spec(raw: &str, registry: &VerbRegistry) -> Result<KindSpec, RuntimeError> {
     let normalized = raw.trim().to_ascii_lowercase();
 
     match normalized.as_str() {
@@ -267,7 +272,11 @@ pub(crate) async fn resolve_uuid_async(
 /// primary-namespace-only `resolve_prefix` and was invisible for any row
 /// stamped with a non-primary namespace (#391 §3). Exact copy of
 /// `resolve_uuid_async` except the prefix branch.
-pub(crate) async fn resolve_uuid_unfiltered(
+///
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 3) — so
+/// kkernel's `--atomic` seam can resolve KG ids (full UUID / 8+ hex prefix /
+/// entity-name) with the exact same semantics as the canonical handlers.
+pub async fn resolve_uuid_unfiltered(
     s: &str,
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -292,7 +301,11 @@ pub(crate) async fn resolve_uuid_unfiltered(
 /// `resolve_uuid_unfiltered`, including soft-deleted rows — used by the
 /// hard-delete by-ID path (#391 §3). Exact copy of
 /// `resolve_uuid_including_deleted` except the prefix branch.
-pub(crate) async fn resolve_uuid_unfiltered_including_deleted(
+///
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 3) — for
+/// the same reason as `resolve_uuid_unfiltered` above; used by the atomic
+/// hard-delete id-resolution path.
+pub async fn resolve_uuid_unfiltered_including_deleted(
     s: &str,
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -631,7 +644,10 @@ pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, 
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))
 }
 
-pub(crate) fn normalize_entity_timestamps(mut v: Value) -> Value {
+/// `pub` (widened from `pub(crate)`, ADR-099 B3 fix round 5, finding 4) — so
+/// kkernel's `--atomic` seam can render update/delete result payloads with
+/// the same timestamp normalization as the canonical handlers.
+pub fn normalize_entity_timestamps(mut v: Value) -> Value {
     if let Some(obj) = v.as_object_mut() {
         for field in &["created_at", "updated_at", "deleted_at", "expires_at"] {
             if let Some(val) = obj.get_mut(*field) {

--- a/crates/khive-pack-kg/src/handlers/link.rs
+++ b/crates/khive-pack-kg/src/handlers/link.rs
@@ -2,11 +2,11 @@
 
 use serde_json::{json, Value};
 
-use khive_runtime::{LinkSpec, NamespaceToken, RuntimeError};
+use khive_runtime::{merge_entry_metadata, LinkSpec, NamespaceToken, RuntimeError};
 
 use super::common::{
-    deser, enrich_allowlist_error, format_edge_output, merge_entry_metadata, parse_relation,
-    resolve_uuid_unfiltered, to_json, validate_weight, LinkParams,
+    deser, enrich_allowlist_error, format_edge_output, parse_relation, resolve_uuid_unfiltered,
+    to_json, validate_weight, LinkParams,
 };
 use crate::KgPack;
 

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -25,12 +25,20 @@ pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relati
 /// `kkernel::atomic_apply::validate_atomic_args`.
 pub use params::{DeleteParams, LinkParams, UpdateParams};
 
+/// ADR-099 B3 fix round 5 (findings 1, 3, 4): re-exported as real `pub`
+/// paths so `kkernel`'s `--atomic` seam can resolve kinds/ids and render
+/// result payloads through the exact canonical logic `handle_update`/
+/// `handle_delete`/`handle_link` use, rather than reimplementing it.
+pub use common::{
+    normalize_entity_timestamps, resolve_kind_spec, resolve_uuid_unfiltered,
+    resolve_uuid_unfiltered_including_deleted, KindSpec,
+};
+
 #[cfg(test)]
 pub(crate) use common::{
-    ensure_note_kind, normalize_entity_timestamps, normalize_entity_timestamps_array,
-    resolve_kind_spec, tags_match_any, valid_relations_for_entity_pair, validate_weight,
-    walk_timestamps, KindSpec, ListParams, ProposeParams, ReviewParams, SearchParams,
-    WithdrawParams,
+    ensure_note_kind, normalize_entity_timestamps_array, tags_match_any,
+    valid_relations_for_entity_pair, validate_weight, walk_timestamps, ListParams, ProposeParams,
+    ReviewParams, SearchParams, WithdrawParams,
 };
 
 #[cfg(test)]

--- a/crates/khive-pack-kg/src/handlers/mod.rs
+++ b/crates/khive-pack-kg/src/handlers/mod.rs
@@ -16,11 +16,20 @@ mod update;
 
 pub(crate) use common::{canonical_entity_kind, canonical_note_kind, parse_relation};
 
+/// ADR-099 B3: re-exported as a real `pub` path (not `pub(crate)`) so
+/// `kkernel`'s `--atomic` validation seam can reach the SAME canonical
+/// param structs `handle_update`/`handle_delete`/`handle_link` deserialize
+/// through, reproducing their `#[serde(deny_unknown_fields)]` rejection
+/// without a duplicated per-verb key list. `kkernel` already depends on
+/// this crate directly (no crate-graph inversion); see
+/// `kkernel::atomic_apply::validate_atomic_args`.
+pub use params::{DeleteParams, LinkParams, UpdateParams};
+
 #[cfg(test)]
 pub(crate) use common::{
     ensure_note_kind, normalize_entity_timestamps, normalize_entity_timestamps_array,
     resolve_kind_spec, tags_match_any, valid_relations_for_entity_pair, validate_weight,
-    walk_timestamps, KindSpec, ListParams, ProposeParams, ReviewParams, SearchParams, UpdateParams,
+    walk_timestamps, KindSpec, ListParams, ProposeParams, ReviewParams, SearchParams,
     WithdrawParams,
 };
 

--- a/crates/khive-pack-kg/src/handlers/params.rs
+++ b/crates/khive-pack-kg/src/handlers/params.rs
@@ -87,9 +87,15 @@ pub(crate) struct ListParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct StatsParams {}
 
+/// ADR-099 B3: this struct is `pub` (not `pub(crate)`) SPECIFICALLY so
+/// `kkernel`'s `--atomic` validation seam (`atomic_apply::validate_atomic_args`)
+/// can deserialize an op's args through the SAME canonical struct
+/// `handle_update` uses, reproducing `deny_unknown_fields` rejection with
+/// zero duplicated field lists. Fields stay `pub(crate)` — the atomic seam
+/// only needs the `Result<_, _>` outcome, never field access.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct UpdateParams {
+pub struct UpdateParams {
     pub(crate) id: String,
     pub(crate) kind: Option<String>,
     pub(crate) name: Option<Value>,
@@ -106,9 +112,11 @@ pub(crate) struct UpdateParams {
     pub(crate) entity_kind: Option<Value>,
 }
 
+/// ADR-099 B3: `pub` for the same reason as `UpdateParams` above — reused
+/// by the atomic seam to validate `delete` args.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct DeleteParams {
+pub struct DeleteParams {
     pub(crate) id: String,
     pub(crate) kind: Option<String>,
     pub(crate) hard: Option<bool>,
@@ -155,9 +163,13 @@ pub(crate) struct BulkLinkEntry {
     pub(crate) dependency_kind: Option<String>,
 }
 
+/// ADR-099 B3: `pub` for the same reason as `UpdateParams` above — reused
+/// by the atomic seam to validate `link` args. `BulkLinkEntry` (the type of
+/// `links` below) stays `pub(crate)`: the `links` field itself is
+/// `pub(crate)`, so it never appears in `LinkParams`'s public surface.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LinkParams {
+pub struct LinkParams {
     pub(crate) source_id: Option<String>,
     pub(crate) target_id: Option<String>,
     pub(crate) relation: Option<String>,

--- a/crates/khive-request/src/atomic.rs
+++ b/crates/khive-request/src/atomic.rs
@@ -24,12 +24,24 @@ pub struct AtomicRejection {
 
 impl std::fmt::Display for AtomicRejection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let why = match self.reason {
+        let why: std::borrow::Cow<'static, str> = match self.reason {
             AtomicRejectionReason::EmbeddingBearing => {
-                "embedding-bearing verbs are not yet atomic-eligible"
+                "embedding-bearing verbs are not yet atomic-eligible".into()
             }
-            AtomicRejectionReason::Read => "read verbs have no write plan to apply",
-            AtomicRejectionReason::Unlisted => "not on the v1 atomic-admissible verb list",
+            AtomicRejectionReason::Read => "read verbs have no write plan to apply".into(),
+            AtomicRejectionReason::Unlisted => "not on the v1 atomic-admissible verb list".into(),
+            AtomicRejectionReason::KnownUnimplemented if self.tool == "merge" => {
+                "merge is not yet supported under --atomic (admissible per ADR-099 D3, but \
+                 full-parity field-folding/index-cleanup/edge-conflict-resolution is deferred \
+                 this slice); use the non-atomic merge verb instead"
+                    .into()
+            }
+            AtomicRejectionReason::KnownUnimplemented => format!(
+                "admissible per ADR-099 D3 but has no --atomic prepare/apply seam implemented \
+                 in this slice yet; use the non-atomic {:?} verb instead",
+                self.tool
+            )
+            .into(),
         };
         write!(
             f,
@@ -79,7 +91,9 @@ mod tests {
 
     #[test]
     fn all_admissible_ops_pass_with_no_rejections() {
-        let ops = vec![op("update"), op("delete"), op("link"), op("merge")];
+        // `merge` is deferred (B3 fix round, Leo refinement) — see
+        // `known_unimplemented_verbs_rejected_before_any_write` below.
+        let ops = vec![op("update"), op("delete"), op("link")];
         assert!(check_atomic_admissible(&ops).is_empty());
     }
 
@@ -133,8 +147,62 @@ mod tests {
     #[test]
     fn all_v1_admissible_verbs_from_the_ordered_ops_file_pass() {
         // ADR-099 D3's full v1 list, exercised through the ops-file shape
-        // (tool name only — the parse-time check does not need args).
-        let ops: Vec<ParsedOp> = ATOMIC_ADMISSIBLE_VERBS.iter().map(|v| op(v)).collect();
+        // (tool name only — the parse-time check does not need args),
+        // EXCLUDING the governance verbs: those are still on
+        // ATOMIC_ADMISSIBLE_VERBS (conceptually admissible per the ADR) but
+        // are rejected at this same static layer as known-unimplemented (B3
+        // fix round, codex REJECT Medium finding) — see the dedicated test
+        // below.
+        let ops: Vec<ParsedOp> = ATOMIC_ADMISSIBLE_VERBS
+            .iter()
+            .filter(|v| !khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS.contains(v))
+            .map(|v| op(v))
+            .collect();
         assert!(check_atomic_admissible(&ops).is_empty());
+    }
+
+    #[test]
+    fn known_unimplemented_verbs_rejected_before_any_write() {
+        // B3 fix round (codex REJECT, Medium finding + Leo refinement on
+        // Blocker 2): propose/review/withdraw AND (deferred) merge must all
+        // be rejected at THIS pre-runtime static check — not admitted here
+        // and left to fail later inside `atomic_prepare::prepare_op` after a
+        // runtime has already been constructed.
+        let ops: Vec<ParsedOp> = khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS
+            .iter()
+            .map(|v| op(v))
+            .collect();
+        let rejections = check_atomic_admissible(&ops);
+        assert_eq!(rejections.len(), ops.len());
+        for rejection in &rejections {
+            assert_eq!(
+                rejection.reason,
+                AtomicRejectionReason::KnownUnimplemented,
+                "rejection: {rejection:?}"
+            );
+            let msg = rejection.to_string();
+            assert!(
+                msg.contains("use the non-atomic") && msg.contains("instead"),
+                "display must name the non-atomic verb as the supported route: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn known_unimplemented_merge_names_non_atomic_merge_as_the_supported_route() {
+        // Leo refinement (2026-07-07): merge's rejection message must be
+        // specific and actionable, naming the non-atomic merge verb (the
+        // blessed defer shape), not just the generic
+        // "no --atomic prepare/apply seam yet" phrasing governance verbs use.
+        let rejection = AtomicRejection {
+            op_index: 0,
+            tool: "merge".to_string(),
+            reason: AtomicRejectionReason::KnownUnimplemented,
+        };
+        let msg = rejection.to_string();
+        assert!(
+            msg.contains("use the non-atomic merge verb instead"),
+            "display: {msg}"
+        );
     }
 }

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -118,7 +118,8 @@ impl AffectedRowGuard {
 /// atomic unit commits (ADR-099 D1, "post-commit pass"). v1's admissible set
 /// computes no embeddings during prepare (D3's `update`/`merge` caveat), so
 /// the only post-commit effects are reindex kicks computed from the
-/// **committed** row content.
+/// **committed** row content — plus, since the B3 fix round (GAP-5), the
+/// best-effort GTD lifecycle audit row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PostCommitEffect {
     /// No deferred side effect for this op.
@@ -129,6 +130,25 @@ pub enum PostCommitEffect {
     /// Re-embed and re-warm the given note's vector row from its committed
     /// content (ADR-099 D3 `update` caveat: note name/content change).
     ReindexNote { note_id: Uuid },
+    /// Append one `gtd_lifecycle_audit` row for a committed `gtd.transition`
+    /// or `gtd.complete` (B3 fix round GAP-5): canonical `handle_transition`/
+    /// `handle_complete` call `ensure_audit_schema` + `write_audit_record`
+    /// (`khive-pack-gtd::handlers`) as a best-effort side write — a failed
+    /// audit insert must never roll back an already-committed transition.
+    /// Carries exactly the fields `write_audit_record` needs. Applied
+    /// outside `khive-runtime` (crate-direction: `khive-pack-gtd` depends on
+    /// `khive-runtime`, not the other way around) — this crate's own
+    /// `apply_post_commit_effects` treats this variant as a no-op; the
+    /// `kkernel` caller that owns both crates applies it by calling the
+    /// canonical `ensure_audit_schema`/`write_audit_record` functions
+    /// directly.
+    GtdAudit {
+        task_id: Uuid,
+        from_status: String,
+        to_status: String,
+        note: Option<String>,
+        namespace: String,
+    },
 }
 
 /// Write plan for an `update` op (entity or note shape — ADR-099 D3's
@@ -208,8 +228,16 @@ pub struct GtdTransitionPlan {
     /// Status-column DML to apply inside the atomic unit. Property-only
     /// status mutation — triggers no reindex (ADR-099 D3). The transition
     /// statement carries the guard (prepare validated the current status
-    /// and the requested transition were legal).
+    /// and the requested transition were legal). Empty for an idempotent
+    /// no-op (`current == target` after `normalize_status`, GAP-5/GAP-6 fix
+    /// round) — canonical performs no write in that case either
+    /// (`handlers.rs:995-1005`).
     pub statements: Vec<PlanStatement>,
+    /// Deferred lifecycle audit row (GAP-5 fix round) — `PostCommitEffect::
+    /// None` for the idempotent no-op case, matching canonical's early
+    /// return before its own `ensure_audit_schema`/`write_audit_record`
+    /// call.
+    pub post_commit: PostCommitEffect,
 }
 
 /// Write plan for a `gtd.complete` op (task lifecycle terminal transition).
@@ -221,6 +249,9 @@ pub struct GtdCompletePlan {
     /// validated the task was in a completable state); the `completed_at`
     /// write targets the same already-guarded row and is unguarded.
     pub statements: Vec<PlanStatement>,
+    /// Deferred lifecycle audit row (GAP-5 fix round) — mirrors
+    /// `handle_complete`'s best-effort `write_audit_record` call.
+    pub post_commit: PostCommitEffect,
 }
 
 /// Which governance verb (`propose` / `review` / `withdraw`) a
@@ -375,12 +406,57 @@ mod tests {
         let plan = GtdTransitionPlan {
             task_id: Uuid::new_v4(),
             statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
+            post_commit: PostCommitEffect::None,
         };
-        // Property-only status mutation — the type carries no post-commit
-        // field at all, which is the structural guarantee (ADR-099 D3: task
-        // transitions "trigger no reindex").
+        // Property-only status mutation — the type carries no *reindex*
+        // post-commit variant it can ever construct (ADR-099 D3: task
+        // transitions "trigger no reindex"); it carries only the best-effort
+        // `GtdAudit` lifecycle-audit effect added in the B3 fix round
+        // (GAP-5), which triggers no embedding/reindex work either.
         assert_eq!(plan.statements.len(), 1);
         assert!(plan.statements[0].guard.is_some());
+        assert_eq!(plan.post_commit, PostCommitEffect::None);
+    }
+
+    #[test]
+    fn gtd_transition_plan_idempotent_noop_carries_no_statements_and_no_audit() {
+        // GAP-6 (B3 fix round 4): current == target after normalize_status
+        // is an idempotent no-op — canonical performs no write and (since it
+        // never reaches its own `write_audit_record` call) writes no audit
+        // row either.
+        let plan = GtdTransitionPlan {
+            task_id: Uuid::new_v4(),
+            statements: vec![],
+            post_commit: PostCommitEffect::None,
+        };
+        assert!(plan.statements.is_empty());
+        assert_eq!(plan.post_commit, PostCommitEffect::None);
+    }
+
+    #[test]
+    fn gtd_transition_plan_carries_gtd_audit_post_commit_effect() {
+        let task_id = Uuid::new_v4();
+        let plan = GtdTransitionPlan {
+            task_id,
+            statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
+            post_commit: PostCommitEffect::GtdAudit {
+                task_id,
+                from_status: "inbox".to_string(),
+                to_status: "next".to_string(),
+                note: Some("handed off".to_string()),
+                namespace: "local".to_string(),
+            },
+        };
+        assert_eq!(
+            plan.post_commit,
+            PostCommitEffect::GtdAudit {
+                task_id,
+                from_status: "inbox".to_string(),
+                to_status: "next".to_string(),
+                note: Some("handed off".to_string()),
+                namespace: "local".to_string(),
+            }
+        );
     }
 
     #[test]
@@ -391,6 +467,7 @@ mod tests {
                 guarded("update-status", AffectedRowGuard::exactly(1)),
                 unguarded("update-completed-at"),
             ],
+            post_commit: PostCommitEffect::None,
         };
         assert_eq!(plan.statements.len(), 2);
         let guard = plan.statements[0].guard.expect("status write is guarded");

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -151,12 +151,32 @@ pub enum PostCommitEffect {
     },
 }
 
+/// The natural key a committed symmetric edge update's surviving row must
+/// be looked up by (ADR-099 B3 r9, codex r8 Blocker finding 1, second
+/// half). `khive-db`'s `edge_symmetric_refresh_or_update_inplace_statement`
+/// pair never trusts a prepare-time-computed target id (see that builder's
+/// doc comment); a caller rendering this op's result derives the actual
+/// surviving id by querying `graph_edges`'s own
+/// `UNIQUE(namespace, source_id, target_id, relation)` constraint (e.g. via
+/// `KhiveRuntime::list_edges` filtered on these fields — the same mechanism
+/// the atomic `link` op's own result rendering already uses), strictly
+/// after commit.
+#[derive(Debug, Clone)]
+pub struct EdgeNaturalKey {
+    pub namespace: String,
+    pub canon_source_id: Uuid,
+    pub canon_target_id: Uuid,
+    pub relation: khive_storage::EdgeRelation,
+}
+
 /// Write plan for an `update` op (entity or note shape — ADR-099 D3's
 /// `update` caveat covers both substrates the same way: row/FTS DML in the
 /// plan, any reindex deferred to `post_commit`).
 #[derive(Debug, Clone)]
 pub struct UpdatePlan {
-    /// The id of the entity or note being updated.
+    /// The id of the entity or note being updated. For a symmetric edge
+    /// update this is the CALLER's requested id — advisory only, never the
+    /// basis for post-commit result rendering (see [`EdgeNaturalKey`]).
     pub target_id: Uuid,
     /// Row + FTS DML statements to apply inside the atomic unit, in order.
     /// The row-update statement carries the existence guard; any FTS-mirror
@@ -165,6 +185,12 @@ pub struct UpdatePlan {
     pub statements: Vec<PlanStatement>,
     /// Deferred reindex, if the update changed name/description/content.
     pub post_commit: PostCommitEffect,
+    /// `Some` only for a symmetric edge update — the natural key a caller
+    /// must use to derive the committed surviving row post-commit, rather
+    /// than trusting `target_id`. `None` for every other update shape
+    /// (entity, note, non-symmetric edge), where `target_id` alone is
+    /// already an exact, non-advisory identifier.
+    pub edge_natural_key: Option<EdgeNaturalKey>,
 }
 
 /// Write plan for a `delete` op (soft or hard).
@@ -327,6 +353,7 @@ mod tests {
                 unguarded("update-fts-mirror"),
             ],
             post_commit: PostCommitEffect::ReindexEntity { entity_id: id },
+            edge_natural_key: None,
         };
         assert_eq!(plan.target_id, id);
         assert_eq!(plan.statements[0].guard, Some(AffectedRowGuard::exactly(1)));

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -20,7 +20,7 @@
 //! apply path is a changeset-interpreter (`apply_worker`) over a dedicated
 //! `proposals_open` table, not a small number of guarded DML statements — a
 //! faithful, non-stub atomic prepare for them is separate follow-on work.
-//! [`prepare_governance_unimplemented`] fails loudly, before any write,
+//! `prepare_governance_unimplemented` fails loudly, before any write,
 //! naming this as a known scope gap rather than silently no-opping.
 //!
 //! `merge` is likewise on the v1 admissible list but is deferred (B3 fix

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -47,7 +47,6 @@ use crate::atomic_plan::{
     AffectedRowGuard, DeletePlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
 };
 use crate::atomic_runner::AtomicOpPlan;
-use crate::curation::{merge_properties, EntityDedupMergePolicy};
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{
     canonical_edge_endpoints, merge_dependency_kind, validate_edge_metadata, validate_edge_weight,
@@ -55,10 +54,16 @@ use crate::operations::{
 };
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
+use khive_db::stores::entity::{
+    entity_hard_delete_statement, entity_soft_delete_statement, entity_upsert_statement,
+};
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_soft_delete_statement, edge_upsert_statement,
     purge_incident_edges_statement,
+};
+use khive_db::stores::note::{
+    note_hard_delete_statement, note_soft_delete_statement, note_upsert_statement,
 };
 
 // ---------------------------------------------------------------------------
@@ -190,10 +195,21 @@ fn optional_f64(args: &Value, key: &str) -> RuntimeResult<Option<f64>> {
     }
 }
 
-fn properties_string(properties: &Option<Value>) -> Option<String> {
-    properties
-        .as_ref()
-        .map(|v| serde_json::to_string(v).unwrap_or_default())
+/// Tri-state patch extraction for `Option<Option<f64>>`-shaped fields
+/// (`NotePatch::salience` / `NotePatch::decay_factor`): key absent -> `None`
+/// (untouched), key present as JSON `null` -> `Some(None)` (clear), key
+/// present as a number -> `Some(Some(v))` (set). Preserves the atomic path's
+/// pre-existing `contains_key`-based clear/set/untouched semantics now that
+/// range validation itself has moved into curation.rs's `prepare_update_note`.
+fn optional_f64_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<f64>>> {
+    match obj(args)?.get(key) {
+        None => Ok(None),
+        Some(Value::Null) => Ok(Some(None)),
+        Some(v) => v
+            .as_f64()
+            .map(|f| Some(Some(f)))
+            .ok_or_else(|| RuntimeError::InvalidInput(format!("{key} must be a number"))),
+    }
 }
 
 /// Every registered embedding model's vector table name, in the exact format
@@ -530,91 +546,33 @@ async fn prepare_update(
     // half of GAP-4 — a spurious no-op reported as success) is implemented
     // in full.
     match runtime.resolve_by_id(token, id).await? {
-        Some(Resolved::Entity(entity)) => {
+        Some(Resolved::Entity(_)) => {
+            // Decide step lives in curation.rs's `prepare_update_entity` —
+            // the SAME function canonical `update_entity` calls. Only the
+            // arg-extraction (raw JSON -> `EntityPatch`) and the plan-shape
+            // wiring (domain object -> `PlanStatement` via the shared
+            // `entity_upsert_statement` builder) are atomic-path-specific.
             reject_inapplicable_update_fields(args, "entity")?;
             let name = entity_name_patch(args)?;
             let description = optional_string_patch(args, "description")?;
             let properties = optional_properties(args, "properties")?;
             let tags = optional_tags(args)?;
 
-            if let Some(ref n) = name {
-                crate::secret_gate::check(n)?;
-            }
-            if let Some(Some(ref d)) = description {
-                crate::secret_gate::check(d)?;
-            }
-            if let Some(ref p) = properties {
-                crate::secret_gate::check_json(p)?;
-            }
-            if let Some(ref t) = tags {
-                crate::secret_gate::check_tags(t)?;
-            }
-
-            let mut final_name = entity.name.clone();
-            let mut final_description = entity.description.clone();
-            let mut final_properties = entity.properties.clone();
-            let mut final_tags = entity.tags.clone();
-            let mut text_changed = false;
-            // Mirrors curation.rs update_entity's `changed_fields` tracking
-            // (curation.rs:226-248): pushed whenever the patch key was
-            // present, independent of whether the value actually differs —
-            // feeds the `EntityUpdated` event payload below.
-            let mut changed_fields: Vec<&'static str> = Vec::new();
-
-            if let Some(n) = name {
-                text_changed |= final_name != n;
-                final_name = n;
-                changed_fields.push("name");
-            }
-            if let Some(d) = description {
-                text_changed |= final_description != d;
-                final_description = d;
-                changed_fields.push("description");
-            }
-            if let Some(p) = properties {
-                let (merged, _) = merge_properties(
-                    &final_properties,
-                    &Some(p),
-                    EntityDedupMergePolicy::PreferFrom,
-                );
-                final_properties = merged;
-                changed_fields.push("properties");
-            }
-            if let Some(t) = tags {
-                final_tags = t;
-                changed_fields.push("tags");
-            }
-
-            let updated_at = chrono::Utc::now().timestamp_micros();
-            let statement = SqlStatement {
-                sql: "UPDATE entities SET name = ?1, description = ?2, properties = ?3, \
-                      tags = ?4, updated_at = ?5 WHERE id = ?6 AND deleted_at IS NULL"
-                    .to_string(),
-                params: vec![
-                    SqlValue::Text(final_name),
-                    match final_description {
-                        Some(d) => SqlValue::Text(d),
-                        None => SqlValue::Null,
+            let (entity, text_changed, changed_fields) = runtime
+                .prepare_update_entity(
+                    token,
+                    id,
+                    crate::curation::EntityPatch {
+                        name,
+                        description,
+                        properties,
+                        tags,
                     },
-                    match properties_string(&final_properties) {
-                        Some(p) => SqlValue::Text(p),
-                        None => SqlValue::Null,
-                    },
-                    SqlValue::Text(
-                        serde_json::to_string(&final_tags).unwrap_or_else(|_| "[]".into()),
-                    ),
-                    SqlValue::Integer(updated_at),
-                    SqlValue::Text(id.to_string()),
-                ],
-                label: Some("atomic-update-entity".to_string()),
-            };
-            let post_commit = if text_changed {
-                PostCommitEffect::ReindexEntity { entity_id: id }
-            } else {
-                PostCommitEffect::None
-            };
+                )
+                .await?;
+
             let mut statements = vec![PlanStatement {
-                statement,
+                statement: entity_upsert_statement(&entity),
                 guard: Some(AffectedRowGuard::exactly(1)),
             }];
             // GAP-1 (B3 fix round): curation.rs's `update_entity` appends an
@@ -633,103 +591,45 @@ async fn prepare_update(
                     "changed_fields": changed_fields,
                 }),
             )?);
+            let post_commit = if text_changed {
+                PostCommitEffect::ReindexEntity { entity_id: id }
+            } else {
+                PostCommitEffect::None
+            };
             Ok(AtomicOpPlan::Update(UpdatePlan {
                 target_id: id,
                 statements,
                 post_commit,
             }))
         }
-        Some(Resolved::Note(note)) => {
+        Some(Resolved::Note(_)) => {
+            // Decide step lives in curation.rs's `prepare_update_note` — the
+            // SAME function canonical `update_note` calls, including the
+            // salience/decay_factor range validation. `optional_f64_patch`
+            // below preserves the pre-existing atomic tri-state semantics
+            // (key absent = untouched, key null = clear, key present = set)
+            // when constructing the `NotePatch`.
             reject_inapplicable_update_fields(args, "note")?;
             let name = optional_string_patch(args, "name")?;
             let content = optional_str(args, "content").map(|s| s.to_string());
             let properties = optional_properties(args, "properties")?;
-            let salience = optional_f64(args, "salience")?;
-            let decay_factor = optional_f64(args, "decay_factor")?;
+            let salience = optional_f64_patch(args, "salience")?;
+            let decay_factor = optional_f64_patch(args, "decay_factor")?;
 
-            if let Some(ref c) = content {
-                crate::secret_gate::check(c)?;
-            }
-            if let Some(Some(ref n)) = name {
-                crate::secret_gate::check(n)?;
-            }
-            if let Some(ref p) = properties {
-                crate::secret_gate::check_json(p)?;
-            }
+            let (note, text_changed) = runtime
+                .prepare_update_note(
+                    token,
+                    id,
+                    crate::curation::NotePatch::new(
+                        name,
+                        content,
+                        salience,
+                        decay_factor,
+                        properties,
+                    ),
+                )
+                .await?;
 
-            let mut final_name = note.name.clone();
-            let mut final_content = note.content.clone();
-            let mut final_properties = note.properties.clone();
-            let mut final_salience = note.salience;
-            let mut final_decay = note.decay_factor;
-            let mut text_changed = false;
-
-            if let Some(n) = name {
-                text_changed |= final_name != n;
-                final_name = n;
-            }
-            if let Some(c) = content {
-                text_changed |= final_content != c;
-                final_content = c;
-            }
-            if let Some(p) = properties {
-                let (merged, _) = merge_properties(
-                    &final_properties,
-                    &Some(p),
-                    EntityDedupMergePolicy::PreferFrom,
-                );
-                final_properties = merged;
-            }
-            if obj(args)?.contains_key("salience") {
-                if let Some(s) = salience {
-                    if !s.is_finite() || !(0.0..=1.0).contains(&s) {
-                        return Err(RuntimeError::InvalidInput(format!(
-                            "salience must be a finite value in [0.0, 1.0]; got {s}"
-                        )));
-                    }
-                }
-                final_salience = salience;
-            }
-            if obj(args)?.contains_key("decay_factor") {
-                if let Some(d) = decay_factor {
-                    if !d.is_finite() || d < 0.0 {
-                        return Err(RuntimeError::InvalidInput(format!(
-                            "decay_factor must be a finite value >= 0.0; got {d}"
-                        )));
-                    }
-                }
-                final_decay = decay_factor;
-            }
-
-            let updated_at = chrono::Utc::now().timestamp_micros();
-            let statement = SqlStatement {
-                sql: "UPDATE notes SET name = ?1, content = ?2, properties = ?3, \
-                      salience = ?4, decay_factor = ?5, updated_at = ?6 \
-                      WHERE id = ?7 AND deleted_at IS NULL"
-                    .to_string(),
-                params: vec![
-                    match final_name {
-                        Some(n) => SqlValue::Text(n),
-                        None => SqlValue::Null,
-                    },
-                    SqlValue::Text(final_content),
-                    match properties_string(&final_properties) {
-                        Some(p) => SqlValue::Text(p),
-                        None => SqlValue::Null,
-                    },
-                    match final_salience {
-                        Some(s) => SqlValue::Float(s),
-                        None => SqlValue::Null,
-                    },
-                    match final_decay {
-                        Some(d) => SqlValue::Float(d),
-                        None => SqlValue::Null,
-                    },
-                    SqlValue::Integer(updated_at),
-                    SqlValue::Text(id.to_string()),
-                ],
-                label: Some("atomic-update-note".to_string()),
-            };
             let post_commit = if text_changed {
                 PostCommitEffect::ReindexNote { note_id: id }
             } else {
@@ -738,7 +638,7 @@ async fn prepare_update(
             Ok(AtomicOpPlan::Update(UpdatePlan {
                 target_id: id,
                 statements: vec![PlanStatement {
-                    statement,
+                    statement: note_upsert_statement(&note),
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }],
                 post_commit,
@@ -1048,39 +948,27 @@ pub async fn prepare_delete(
                 }
             }
             let namespace = entity.namespace.clone();
+            // Storage parity: `entity_soft_delete_statement`/
+            // `entity_hard_delete_statement` are the SAME khive-db builders
+            // khive-db's own `SqlEntityStore::delete_entity` calls — no DML
+            // text is hand-duplicated here.
             let mut statements = if hard {
-                // Storage parity with the non-atomic hard-delete DML
-                // (entity.rs `DELETE FROM entities WHERE id = ?1`, no
-                // `deleted_at` predicate) — purges live AND already-tombstoned
-                // rows alike.
                 vec![PlanStatement {
-                    statement: SqlStatement {
-                        sql: "DELETE FROM entities WHERE id = ?1".to_string(),
-                        params: vec![SqlValue::Text(id.to_string())],
-                        label: Some("atomic-delete-entity-hard".to_string()),
-                    },
+                    statement: entity_hard_delete_statement(id),
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }]
             } else {
                 let deleted_at = chrono::Utc::now().timestamp_micros();
                 vec![PlanStatement {
-                    statement: SqlStatement {
-                        sql: "UPDATE entities SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL"
-                            .to_string(),
-                        params: vec![SqlValue::Integer(deleted_at), SqlValue::Text(id.to_string())],
-                        label: Some("atomic-delete-entity-soft".to_string()),
-                    },
+                    statement: entity_soft_delete_statement(id, deleted_at),
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }]
             };
             if hard {
+                // Same builder canonical `delete_entity`'s hard-delete
+                // cascade calls (`graph.purge_incident_edges`).
                 statements.push(PlanStatement {
-                    statement: SqlStatement {
-                        sql: "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1"
-                            .to_string(),
-                        params: vec![SqlValue::Text(id.to_string())],
-                        label: Some("atomic-delete-entity-cascade-edges".to_string()),
-                    },
+                    statement: purge_incident_edges_statement(id),
                     guard: None,
                 });
             }
@@ -1136,43 +1024,24 @@ pub async fn prepare_delete(
                 }
             }
             let namespace = note.namespace.clone();
+            // Storage parity: `note_soft_delete_statement`/
+            // `note_hard_delete_statement` are the SAME khive-db builders
+            // khive-db's own `SqlNoteStore::delete_note` calls.
             let mut statements = if hard {
-                // Storage parity with the non-atomic hard-delete DML
-                // (note.rs `DELETE FROM notes WHERE id = ?1`, no
-                // `deleted_at` predicate) — purges live AND already-tombstoned
-                // rows alike.
                 vec![PlanStatement {
-                    statement: SqlStatement {
-                        sql: "DELETE FROM notes WHERE id = ?1".to_string(),
-                        params: vec![SqlValue::Text(id.to_string())],
-                        label: Some("atomic-delete-note-hard".to_string()),
-                    },
+                    statement: note_hard_delete_statement(id),
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }]
             } else {
                 let deleted_at = chrono::Utc::now().timestamp_micros();
                 vec![PlanStatement {
-                    statement: SqlStatement {
-                        sql: "UPDATE notes SET status = 'deleted', deleted_at = ?1 \
-                              WHERE id = ?2 AND deleted_at IS NULL"
-                            .to_string(),
-                        params: vec![
-                            SqlValue::Integer(deleted_at),
-                            SqlValue::Text(id.to_string()),
-                        ],
-                        label: Some("atomic-delete-note-soft".to_string()),
-                    },
+                    statement: note_soft_delete_statement(id, deleted_at),
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }]
             };
             if hard {
                 statements.push(PlanStatement {
-                    statement: SqlStatement {
-                        sql: "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1"
-                            .to_string(),
-                        params: vec![SqlValue::Text(id.to_string())],
-                        label: Some("atomic-delete-note-cascade-edges".to_string()),
-                    },
+                    statement: purge_incident_edges_statement(id),
                     guard: None,
                 });
             }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1,0 +1,788 @@
+//! ADR-099 migration step 1 (cont'd) / B3 — the per-verb async prepare pass
+//! for the KG-substrate v1 admissible verbs (`update`, `delete`, `link`,
+//! `merge`). Each `prepare_*` function reads current state (async, outside
+//! any transaction) and returns a plain-data [`crate::atomic_runner::AtomicOpPlan`]
+//! ([`crate::atomic_plan`], B1) for the synchronous commit pass ([`crate::
+//! atomic_runner::run_atomic_unit`], B2) to apply.
+//!
+//! `gtd.transition` / `gtd.complete` prepare is deliberately **not** here:
+//! their lifecycle vocabulary (`is_terminal`, `can_transition`, ...) lives in
+//! `khive-pack-gtd`, a crate that depends on `khive-runtime` — not the other
+//! way around. Reproducing that dependency here would invert the crate
+//! graph, so their prepare functions live in `kkernel` (which already
+//! depends on both `khive-runtime` and `khive-pack-gtd`), calling back into
+//! the plain [`PlanStatement`]/[`AffectedRowGuard`] shapes exported from this
+//! module's sibling, [`crate::atomic_plan`].
+//!
+//! `propose` / `review` / `withdraw` (the ADR-046 event-sourced governance
+//! lifecycle) are on the v1 admissible list ([`khive_types::pack::
+//! ATOMIC_ADMISSIBLE_VERBS`]) but have no prepare implementation here: their
+//! apply path is a changeset-interpreter (`apply_worker`) over a dedicated
+//! `proposals_open` table, not a small number of guarded DML statements — a
+//! faithful, non-stub atomic prepare for them is separate follow-on work.
+//! [`prepare_governance_unimplemented`] fails loudly, before any write,
+//! naming this as a known scope gap rather than silently no-opping.
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_storage::types::SqlValue;
+use khive_storage::{EdgeRelation, SqlStatement};
+
+use crate::atomic_plan::{
+    AffectedRowGuard, DeletePlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
+};
+use crate::atomic_runner::AtomicOpPlan;
+use crate::curation::{merge_properties, EntityDedupMergePolicy};
+use crate::error::{RuntimeError, RuntimeResult};
+use crate::operations::{
+    canonical_edge_endpoints, validate_edge_metadata, validate_edge_weight, Resolved,
+};
+use crate::runtime::{KhiveRuntime, NamespaceToken};
+
+// ---------------------------------------------------------------------------
+// arg extraction helpers
+// ---------------------------------------------------------------------------
+
+fn obj(args: &Value) -> RuntimeResult<&serde_json::Map<String, Value>> {
+    args.as_object()
+        .ok_or_else(|| RuntimeError::InvalidInput("op args must be a JSON object".into()))
+}
+
+fn require_str<'a>(args: &'a Value, key: &str) -> RuntimeResult<&'a str> {
+    obj(args)?
+        .get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RuntimeError::InvalidInput(format!("missing required field {key:?}")))
+}
+
+fn require_uuid(args: &Value, key: &str) -> RuntimeResult<Uuid> {
+    let raw = require_str(args, key)?;
+    Uuid::parse_str(raw)
+        .map_err(|_| RuntimeError::InvalidInput(format!("{key} must be a full UUID; got {raw:?}")))
+}
+
+fn optional_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    obj(args).ok()?.get(key).and_then(|v| v.as_str())
+}
+
+/// Three-way patch semantics for a nullable string field (mirrors
+/// `khive-pack-kg::handlers::common::optional_string_patch`, reimplemented
+/// here rather than imported — that module is `pub(crate)` to a sibling
+/// crate with no dependency edge back to `khive-runtime`):
+/// key absent -> `None` (leave unchanged); key present and JSON `null` ->
+/// `Some(None)` (clear); key present and a string -> `Some(Some(s))` (set).
+fn optional_string_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<String>>> {
+    match obj(args)?.get(key) {
+        None => Ok(None),
+        Some(Value::Null) => Ok(Some(None)),
+        Some(Value::String(s)) => Ok(Some(Some(s.clone()))),
+        Some(_) => Err(RuntimeError::InvalidInput(format!(
+            "{key} must be a string or null"
+        ))),
+    }
+}
+
+fn optional_tags(args: &Value) -> RuntimeResult<Option<Vec<String>>> {
+    match obj(args)?.get("tags") {
+        None => Ok(None),
+        Some(Value::Array(items)) => {
+            let mut tags = Vec::with_capacity(items.len());
+            for item in items {
+                let s = item.as_str().ok_or_else(|| {
+                    RuntimeError::InvalidInput("tags must be an array of strings".into())
+                })?;
+                tags.push(s.to_string());
+            }
+            Ok(Some(tags))
+        }
+        Some(_) => Err(RuntimeError::InvalidInput(
+            "tags must be an array of strings".into(),
+        )),
+    }
+}
+
+fn optional_f64(args: &Value, key: &str) -> RuntimeResult<Option<f64>> {
+    match obj(args)?.get(key) {
+        None => Ok(None),
+        Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_f64()
+            .map(Some)
+            .ok_or_else(|| RuntimeError::InvalidInput(format!("{key} must be a number"))),
+    }
+}
+
+fn properties_string(properties: &Option<Value>) -> Option<String> {
+    properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default())
+}
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+/// Build the prepared [`AtomicOpPlan`] for one KG-substrate admissible op
+/// (`update`, `delete`, `link`, `merge`). Returns a loud [`RuntimeError`] for
+/// `propose`/`review`/`withdraw` (known scope gap, see module doc) and any
+/// other verb (the CLI boundary must reject those before calling this — a
+/// verb reaching here is either KG-substrate-admissible or a bug upstream).
+pub async fn prepare_op(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    tool: &str,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    match tool {
+        "update" => prepare_update(runtime, token, args).await,
+        "delete" => prepare_delete(runtime, token, args).await,
+        "link" => prepare_link(runtime, token, args).await,
+        "merge" => prepare_merge(runtime, token, args).await,
+        "propose" | "review" | "withdraw" => prepare_governance_unimplemented(tool),
+        other => Err(RuntimeError::InvalidInput(format!(
+            "{other:?} has no atomic_prepare::prepare_op implementation; the CLI \
+             admissibility check should have rejected this before prepare"
+        ))),
+    }
+}
+
+fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
+    Err(RuntimeError::InvalidInput(format!(
+        "{tool:?} is on the ADR-099 v1 admissible verb list but has no --atomic \
+         prepare/apply implementation yet: its lifecycle (ADR-046) is an \
+         event-sourced changeset-interpreter over a dedicated `proposals_open` \
+         table, not a small guarded-DML plan — a faithful non-stub atomic \
+         prepare for it is tracked as ADR-099 follow-up work, not implemented \
+         in slice B3. No write was attempted."
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+async fn prepare_update(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let id = require_uuid(args, "id")?;
+    match runtime.resolve_by_id(token, id).await? {
+        Some(Resolved::Entity(entity)) => {
+            let name = optional_str(args, "name").map(|s| s.to_string());
+            let description = optional_string_patch(args, "description")?;
+            let properties = obj(args)?.get("properties").cloned();
+            let tags = optional_tags(args)?;
+
+            if let Some(ref n) = name {
+                crate::secret_gate::check(n)?;
+            }
+            if let Some(Some(ref d)) = description {
+                crate::secret_gate::check(d)?;
+            }
+            if let Some(ref p) = properties {
+                crate::secret_gate::check_json(p)?;
+            }
+            if let Some(ref t) = tags {
+                crate::secret_gate::check_tags(t)?;
+            }
+
+            let mut final_name = entity.name.clone();
+            let mut final_description = entity.description.clone();
+            let mut final_properties = entity.properties.clone();
+            let mut final_tags = entity.tags.clone();
+            let mut text_changed = false;
+
+            if let Some(n) = name {
+                text_changed |= final_name != n;
+                final_name = n;
+            }
+            if let Some(d) = description {
+                text_changed |= final_description != d;
+                final_description = d;
+            }
+            if let Some(p) = properties {
+                let (merged, _) = merge_properties(
+                    &final_properties,
+                    &Some(p),
+                    EntityDedupMergePolicy::PreferFrom,
+                );
+                final_properties = merged;
+            }
+            if let Some(t) = tags {
+                final_tags = t;
+            }
+
+            let updated_at = chrono::Utc::now().timestamp_micros();
+            let statement = SqlStatement {
+                sql: "UPDATE entities SET name = ?1, description = ?2, properties = ?3, \
+                      tags = ?4, updated_at = ?5 WHERE id = ?6 AND deleted_at IS NULL"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(final_name),
+                    match final_description {
+                        Some(d) => SqlValue::Text(d),
+                        None => SqlValue::Null,
+                    },
+                    match properties_string(&final_properties) {
+                        Some(p) => SqlValue::Text(p),
+                        None => SqlValue::Null,
+                    },
+                    SqlValue::Text(
+                        serde_json::to_string(&final_tags).unwrap_or_else(|_| "[]".into()),
+                    ),
+                    SqlValue::Integer(updated_at),
+                    SqlValue::Text(id.to_string()),
+                ],
+                label: Some("atomic-update-entity".to_string()),
+            };
+            let post_commit = if text_changed {
+                PostCommitEffect::ReindexEntity { entity_id: id }
+            } else {
+                PostCommitEffect::None
+            };
+            Ok(AtomicOpPlan::Update(UpdatePlan {
+                target_id: id,
+                statements: vec![PlanStatement {
+                    statement,
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }],
+                post_commit,
+            }))
+        }
+        Some(Resolved::Note(note)) => {
+            let name = optional_string_patch(args, "name")?;
+            let content = optional_str(args, "content").map(|s| s.to_string());
+            let properties = obj(args)?.get("properties").cloned();
+            let salience = optional_f64(args, "salience")?;
+            let decay_factor = optional_f64(args, "decay_factor")?;
+
+            if let Some(ref c) = content {
+                crate::secret_gate::check(c)?;
+            }
+            if let Some(Some(ref n)) = name {
+                crate::secret_gate::check(n)?;
+            }
+            if let Some(ref p) = properties {
+                crate::secret_gate::check_json(p)?;
+            }
+
+            let mut final_name = note.name.clone();
+            let mut final_content = note.content.clone();
+            let mut final_properties = note.properties.clone();
+            let mut final_salience = note.salience;
+            let mut final_decay = note.decay_factor;
+            let mut text_changed = false;
+
+            if let Some(n) = name {
+                text_changed |= final_name != n;
+                final_name = n;
+            }
+            if let Some(c) = content {
+                text_changed |= final_content != c;
+                final_content = c;
+            }
+            if let Some(p) = properties {
+                let (merged, _) = merge_properties(
+                    &final_properties,
+                    &Some(p),
+                    EntityDedupMergePolicy::PreferFrom,
+                );
+                final_properties = merged;
+            }
+            if obj(args)?.contains_key("salience") {
+                if let Some(s) = salience {
+                    if !s.is_finite() || !(0.0..=1.0).contains(&s) {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "salience must be a finite value in [0.0, 1.0]; got {s}"
+                        )));
+                    }
+                }
+                final_salience = salience;
+            }
+            if obj(args)?.contains_key("decay_factor") {
+                if let Some(d) = decay_factor {
+                    if !d.is_finite() || d < 0.0 {
+                        return Err(RuntimeError::InvalidInput(format!(
+                            "decay_factor must be a finite value >= 0.0; got {d}"
+                        )));
+                    }
+                }
+                final_decay = decay_factor;
+            }
+
+            let updated_at = chrono::Utc::now().timestamp_micros();
+            let statement = SqlStatement {
+                sql: "UPDATE notes SET name = ?1, content = ?2, properties = ?3, \
+                      salience = ?4, decay_factor = ?5, updated_at = ?6 \
+                      WHERE id = ?7 AND deleted_at IS NULL"
+                    .to_string(),
+                params: vec![
+                    match final_name {
+                        Some(n) => SqlValue::Text(n),
+                        None => SqlValue::Null,
+                    },
+                    SqlValue::Text(final_content),
+                    match properties_string(&final_properties) {
+                        Some(p) => SqlValue::Text(p),
+                        None => SqlValue::Null,
+                    },
+                    match final_salience {
+                        Some(s) => SqlValue::Float(s),
+                        None => SqlValue::Null,
+                    },
+                    match final_decay {
+                        Some(d) => SqlValue::Float(d),
+                        None => SqlValue::Null,
+                    },
+                    SqlValue::Integer(updated_at),
+                    SqlValue::Text(id.to_string()),
+                ],
+                label: Some("atomic-update-note".to_string()),
+            };
+            let post_commit = if text_changed {
+                PostCommitEffect::ReindexNote { note_id: id }
+            } else {
+                PostCommitEffect::None
+            };
+            Ok(AtomicOpPlan::Update(UpdatePlan {
+                target_id: id,
+                statements: vec![PlanStatement {
+                    statement,
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }],
+                post_commit,
+            }))
+        }
+        Some(_) => Err(RuntimeError::InvalidInput(format!(
+            "update target {id} must be an entity or note"
+        ))),
+        None => Err(RuntimeError::NotFound(format!("entity/note {id}"))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+async fn prepare_delete(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let id = require_uuid(args, "id")?;
+    let hard = obj(args)?
+        .get("hard")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    match runtime.resolve_by_id(token, id).await? {
+        Some(Resolved::Entity(_)) => {
+            let mut statements = if hard {
+                vec![PlanStatement {
+                    statement: SqlStatement {
+                        sql: "DELETE FROM entities WHERE id = ?1 AND deleted_at IS NULL"
+                            .to_string(),
+                        params: vec![SqlValue::Text(id.to_string())],
+                        label: Some("atomic-delete-entity-hard".to_string()),
+                    },
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }]
+            } else {
+                let deleted_at = chrono::Utc::now().timestamp_micros();
+                vec![PlanStatement {
+                    statement: SqlStatement {
+                        sql: "UPDATE entities SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL"
+                            .to_string(),
+                        params: vec![SqlValue::Integer(deleted_at), SqlValue::Text(id.to_string())],
+                        label: Some("atomic-delete-entity-soft".to_string()),
+                    },
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }]
+            };
+            if hard {
+                statements.push(PlanStatement {
+                    statement: SqlStatement {
+                        sql: "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1"
+                            .to_string(),
+                        params: vec![SqlValue::Text(id.to_string())],
+                        label: Some("atomic-delete-entity-cascade-edges".to_string()),
+                    },
+                    guard: None,
+                });
+            }
+            Ok(AtomicOpPlan::Delete(DeletePlan {
+                target_id: id,
+                statements,
+            }))
+        }
+        Some(Resolved::Note(_)) => {
+            let mut statements = if hard {
+                vec![PlanStatement {
+                    statement: SqlStatement {
+                        sql: "DELETE FROM notes WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                        params: vec![SqlValue::Text(id.to_string())],
+                        label: Some("atomic-delete-note-hard".to_string()),
+                    },
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }]
+            } else {
+                let deleted_at = chrono::Utc::now().timestamp_micros();
+                vec![PlanStatement {
+                    statement: SqlStatement {
+                        sql: "UPDATE notes SET status = 'deleted', deleted_at = ?1 \
+                              WHERE id = ?2 AND deleted_at IS NULL"
+                            .to_string(),
+                        params: vec![
+                            SqlValue::Integer(deleted_at),
+                            SqlValue::Text(id.to_string()),
+                        ],
+                        label: Some("atomic-delete-note-soft".to_string()),
+                    },
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }]
+            };
+            if hard {
+                statements.push(PlanStatement {
+                    statement: SqlStatement {
+                        sql: "DELETE FROM graph_edges WHERE source_id = ?1 OR target_id = ?1"
+                            .to_string(),
+                        params: vec![SqlValue::Text(id.to_string())],
+                        label: Some("atomic-delete-note-cascade-edges".to_string()),
+                    },
+                    guard: None,
+                });
+            }
+            Ok(AtomicOpPlan::Delete(DeletePlan {
+                target_id: id,
+                statements,
+            }))
+        }
+        Some(_) => Err(RuntimeError::InvalidInput(format!(
+            "delete target {id} must be an entity or note"
+        ))),
+        None => Err(RuntimeError::NotFound(format!("entity/note {id}"))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// link
+// ---------------------------------------------------------------------------
+
+fn parse_edge_relation(raw: &str) -> RuntimeResult<EdgeRelation> {
+    raw.parse::<EdgeRelation>()
+        .map_err(|e| RuntimeError::InvalidInput(format!("unknown edge relation {raw:?}: {e}")))
+}
+
+async fn prepare_link(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let source_id = require_uuid(args, "source_id")?;
+    let target_id = require_uuid(args, "target_id")?;
+    let relation = parse_edge_relation(require_str(args, "relation")?)?;
+    let weight = optional_f64(args, "weight")?.unwrap_or(1.0);
+    let metadata = obj(args)?.get("metadata").cloned();
+
+    validate_edge_weight(weight)?;
+    validate_edge_metadata(relation, metadata.as_ref())?;
+    runtime
+        .validate_edge_relation_endpoints(token, source_id, target_id, relation)
+        .await?;
+
+    let (canon_source, canon_target) = canonical_edge_endpoints(relation, source_id, target_id);
+    let edge_id = Uuid::new_v4();
+    let namespace = token.namespace().as_str().to_string();
+    let now = chrono::Utc::now().timestamp_micros();
+    let metadata_str = metadata.map(|m| serde_json::to_string(&m).unwrap_or_default());
+
+    let statement = SqlStatement {
+        sql: "INSERT INTO graph_edges \
+              (namespace, id, source_id, target_id, relation, weight, created_at, updated_at, metadata) \
+              SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8 \
+              WHERE (EXISTS (SELECT 1 FROM entities WHERE id = ?3 AND deleted_at IS NULL) \
+                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?3 AND deleted_at IS NULL)) \
+                AND (EXISTS (SELECT 1 FROM entities WHERE id = ?4 AND deleted_at IS NULL) \
+                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL))"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(namespace),
+            SqlValue::Text(edge_id.to_string()),
+            SqlValue::Text(canon_source.to_string()),
+            SqlValue::Text(canon_target.to_string()),
+            SqlValue::Text(relation.as_str().to_string()),
+            SqlValue::Float(weight),
+            SqlValue::Integer(now),
+            match metadata_str {
+                Some(m) => SqlValue::Text(m),
+                None => SqlValue::Null,
+            },
+        ],
+        label: Some("atomic-link-insert-edge-where-exists".to_string()),
+    };
+
+    Ok(AtomicOpPlan::Link(LinkPlan {
+        source_id: canon_source,
+        target_id: canon_target,
+        statement: PlanStatement {
+            statement,
+            guard: Some(AffectedRowGuard::exactly(1)),
+        },
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// merge (entity-only, ADR-099 B3 scope decision — see final report)
+// ---------------------------------------------------------------------------
+
+async fn prepare_merge(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    let into_id = require_uuid(args, "into_id")?;
+    let from_id = require_uuid(args, "from_id")?;
+    if into_id == from_id {
+        return Err(RuntimeError::InvalidInput(
+            "cannot merge an entity into itself".into(),
+        ));
+    }
+
+    let entities = runtime.entities(token)?;
+    entities
+        .get_entity(into_id)
+        .await?
+        .ok_or_else(|| RuntimeError::NotFound(format!("entity {into_id}")))?;
+    entities
+        .get_entity(from_id)
+        .await?
+        .ok_or_else(|| RuntimeError::NotFound(format!("entity {from_id}")))?;
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let rewires = vec![
+        crate::atomic_plan::PlanPredicate {
+            description: "source_id = :from".to_string(),
+            statement: SqlStatement {
+                sql: "UPDATE graph_edges SET source_id = ?1, updated_at = ?2 WHERE source_id = ?3"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(into_id.to_string()),
+                    SqlValue::Integer(now),
+                    SqlValue::Text(from_id.to_string()),
+                ],
+                label: Some("atomic-merge-rewire-source".to_string()),
+            },
+        },
+        crate::atomic_plan::PlanPredicate {
+            description: "target_id = :from".to_string(),
+            statement: SqlStatement {
+                sql: "UPDATE graph_edges SET target_id = ?1, updated_at = ?2 WHERE target_id = ?3"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(into_id.to_string()),
+                    SqlValue::Integer(now),
+                    SqlValue::Text(from_id.to_string()),
+                ],
+                label: Some("atomic-merge-rewire-target".to_string()),
+            },
+        },
+    ];
+    let lifecycle = vec![PlanStatement {
+        statement: SqlStatement {
+            sql: "UPDATE entities SET deleted_at = ?1, merged_into = ?2 \
+                  WHERE id = ?3 AND deleted_at IS NULL"
+                .to_string(),
+            params: vec![
+                SqlValue::Integer(now),
+                SqlValue::Text(into_id.to_string()),
+                SqlValue::Text(from_id.to_string()),
+            ],
+            label: Some("atomic-merge-tombstone-from-entity".to_string()),
+        },
+        guard: Some(AffectedRowGuard::exactly(1)),
+    }];
+
+    Ok(AtomicOpPlan::Merge(MergePlan {
+        into_id,
+        from_id,
+        rewires,
+        lifecycle,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// post-commit effects
+// ---------------------------------------------------------------------------
+
+/// Run every deferred [`PostCommitEffect`] after a committed atomic unit,
+/// outside any transaction (ADR-099 D1 phase 3). Re-fetches each target's
+/// now-committed row and reuses the existing `reindex_entity`/`reindex_note`
+/// (FTS + embedding, same as the non-atomic path) for exact parity.
+pub async fn apply_post_commit_effects(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    effects: Vec<PostCommitEffect>,
+) -> RuntimeResult<()> {
+    for effect in effects {
+        match effect {
+            PostCommitEffect::None => {}
+            PostCommitEffect::ReindexEntity { entity_id } => {
+                if let Some(entity) = runtime.entities(token)?.get_entity(entity_id).await? {
+                    runtime.reindex_entity(token, &entity).await?;
+                }
+            }
+            PostCommitEffect::ReindexNote { note_id } => {
+                if let Some(note) = runtime.notes(token)?.get_note(note_id).await? {
+                    runtime.reindex_note(token, &note).await?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+    use serde_json::json;
+
+    use khive_types::Namespace;
+
+    use crate::embedder_registry::EmbedderProvider;
+    use crate::runtime::RuntimeConfig;
+
+    const STUB_MODEL: &str = "stub-adr099-b3";
+    const STUB_DIMS: usize = 4;
+
+    struct StubService;
+
+    #[async_trait]
+    impl EmbeddingService for StubService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, EmbedError> {
+            Ok(texts.iter().map(|_| vec![0.5_f32; STUB_DIMS]).collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            STUB_MODEL
+        }
+    }
+
+    struct StubProvider;
+
+    #[async_trait]
+    impl EmbedderProvider for StubProvider {
+        fn name(&self) -> &str {
+            STUB_MODEL
+        }
+
+        fn dimensions(&self) -> usize {
+            STUB_DIMS
+        }
+
+        async fn build(&self) -> RuntimeResult<std::sync::Arc<dyn EmbeddingService>> {
+            Ok(std::sync::Arc::new(StubService))
+        }
+    }
+
+    fn scratch_runtime() -> KhiveRuntime {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("atomic_prepare_reindex.db");
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        std::mem::forget(dir);
+        rt
+    }
+
+    /// ADR-099 B3 acceptance test 3: updating a note's content inside an
+    /// atomic unit must, after commit, leave the note recallable via FTS
+    /// under its NEW content and its vector row refreshed — parity with the
+    /// non-atomic `update_note` -> `reindex_note` path.
+    #[tokio::test]
+    async fn atomic_update_note_content_is_fts_and_vector_reindexed_post_commit() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        let mut note = khive_storage::note::Note::new("local", "observation", "original content");
+        note.name = Some("reindex-target".to_string());
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        // Sanity: no vector row yet for the stub model.
+        let vec_store = runtime
+            .vectors_for_model(&token, STUB_MODEL)
+            .expect("vec store");
+        assert_eq!(vec_store.count().await.expect("count before"), 0);
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": note_id.to_string(), "content": "freshly-updated-content-xyz"}),
+        )
+        .await
+        .expect("prepare update");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        let post_commit = match outcome {
+            crate::atomic_runner::AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected Committed, got {other:?}"),
+        };
+        assert_eq!(
+            post_commit,
+            vec![PostCommitEffect::ReindexNote { note_id }],
+            "content change must schedule exactly one ReindexNote post-commit effect"
+        );
+
+        apply_post_commit_effects(&runtime, &token, post_commit)
+            .await
+            .expect("apply post-commit effects");
+
+        // FTS: the note must be recallable under its NEW content.
+        let doc = runtime
+            .text_for_notes(&token)
+            .expect("text store")
+            .get_document("local", note_id)
+            .await
+            .expect("get_document")
+            .expect("document must be indexed after post-commit reindex");
+        assert!(
+            doc.body.contains("freshly-updated-content-xyz"),
+            "FTS body must reflect the committed content: {:?}",
+            doc.body
+        );
+
+        // Vector: a row must now exist for the registered stub model.
+        assert_eq!(
+            vec_store.count().await.expect("count after"),
+            1,
+            "post-commit reindex must have inserted a vector row for the stub model"
+        );
+    }
+}

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -41,6 +41,7 @@ use uuid::Uuid;
 
 use khive_storage::types::SqlValue;
 use khive_storage::{EdgeRelation, SqlStatement};
+use khive_types::{EventKind, EventOutcome, SubstrateKind};
 
 use crate::atomic_plan::{
     AffectedRowGuard, DeletePlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
@@ -233,6 +234,102 @@ async fn push_index_purge_statements(
     Ok(())
 }
 
+/// Event-store append parity for the three canonical handlers that emit a
+/// lifecycle event AFTER their row mutation: `update_entity` -> `EntityUpdated`
+/// (curation.rs:257-273), `delete_entity` -> `EntityDeleted`
+/// (operations.rs:3543-3558), `delete_note` -> `NoteDeleted`
+/// (operations.rs:3326-3340). `update_note` and `link` append no event
+/// (parity boundary verified by the GAP-1 sweep) and must never call this.
+///
+/// Placement decision (matches canonical's error semantics, ADR-099 B3 GAP-1
+/// fix round): all three canonical sites call
+/// `event_store.append_event(event).await.map_err(...)?` — the `?` makes a
+/// failed append a hard `RuntimeError`, never swallowed/logged-and-continue.
+/// `append_event`'s body (`khive-db::stores::event::insert_event_with_
+/// observations`) is two plain, deterministic `INSERT`s (`events`, then
+/// `event_observations` for the target-row observation) computed entirely
+/// from data already on hand at prepare time — no embedding call, no other
+/// suspending/async computation, unlike the `ReindexEntity`/`ReindexNote`
+/// post-commit effects this same module defers for exactly that reason. A
+/// fatal, purely-SQL-expressible effect is the `PlanStatement`-inside-the-
+/// atomic-unit case (not `PostCommitEffect`, which this module reserves for
+/// best-effort or non-SQL work): committing the event row atomically with
+/// the mutation it describes only STRENGTHENS canonical's guarantee (the
+/// non-atomic handlers write the event in a *separate* transaction, ordered
+/// but not atomic with the row mutation).
+///
+/// Returned statements are unguarded — appended after the plan's own guarded
+/// row statement, so [`apply_plan`]'s stop-on-first-failure contract means
+/// they are only reached once that row mutation's guard has already held
+/// (mirroring canonical's `if deleted { append_event(...) }` /
+/// unconditional-after-`upsert_entity` shape).
+fn event_append_statements(
+    namespace: &str,
+    verb: &str,
+    kind: EventKind,
+    substrate: SubstrateKind,
+    target_id: Uuid,
+    payload: Value,
+    label_prefix: &str,
+) -> Vec<PlanStatement> {
+    let event_id = Uuid::new_v4();
+    let created_at = chrono::Utc::now().timestamp_micros();
+    let referent_kind = if substrate == SubstrateKind::Note {
+        "note"
+    } else {
+        "entity"
+    };
+
+    let event_stmt = PlanStatement {
+        statement: SqlStatement {
+            sql: "INSERT INTO events \
+                  (id, namespace, verb, substrate, actor, kind, outcome, payload, \
+                   payload_schema_version, profile_state_version, duration_us, target_id, \
+                   session_id, aggregate_kind, aggregate_id, created_at) \
+                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
+                .to_string(),
+            params: vec![
+                SqlValue::Text(event_id.to_string()),
+                SqlValue::Text(namespace.to_string()),
+                SqlValue::Text(verb.to_string()),
+                SqlValue::Text(substrate.name().to_string()),
+                SqlValue::Text(String::new()),
+                SqlValue::Text(kind.name().to_string()),
+                SqlValue::Text(EventOutcome::Success.name().to_string()),
+                SqlValue::Text(payload.to_string()),
+                SqlValue::Integer(1),
+                SqlValue::Null,
+                SqlValue::Integer(0),
+                SqlValue::Text(target_id.to_string()),
+                SqlValue::Null,
+                SqlValue::Null,
+                SqlValue::Null,
+                SqlValue::Integer(created_at),
+            ],
+            label: Some(format!("{label_prefix}-event")),
+        },
+        guard: None,
+    };
+    let observation_stmt = PlanStatement {
+        statement: SqlStatement {
+            sql: "INSERT INTO event_observations \
+                  (event_id, entity_id, referent_kind, role, position) \
+                  VALUES (?1, ?2, ?3, ?4, ?5)"
+                .to_string(),
+            params: vec![
+                SqlValue::Text(event_id.to_string()),
+                SqlValue::Text(target_id.to_string()),
+                SqlValue::Text(referent_kind.to_string()),
+                SqlValue::Text("target".to_string()),
+                SqlValue::Integer(0),
+            ],
+            label: Some(format!("{label_prefix}-event-observation")),
+        },
+        guard: None,
+    };
+    vec![event_stmt, observation_stmt]
+}
+
 // ---------------------------------------------------------------------------
 // dispatch
 // ---------------------------------------------------------------------------
@@ -394,14 +491,21 @@ async fn prepare_update(
             let mut final_properties = entity.properties.clone();
             let mut final_tags = entity.tags.clone();
             let mut text_changed = false;
+            // Mirrors curation.rs update_entity's `changed_fields` tracking
+            // (curation.rs:226-248): pushed whenever the patch key was
+            // present, independent of whether the value actually differs —
+            // feeds the `EntityUpdated` event payload below.
+            let mut changed_fields: Vec<&'static str> = Vec::new();
 
             if let Some(n) = name {
                 text_changed |= final_name != n;
                 final_name = n;
+                changed_fields.push("name");
             }
             if let Some(d) = description {
                 text_changed |= final_description != d;
                 final_description = d;
+                changed_fields.push("description");
             }
             if let Some(p) = properties {
                 let (merged, _) = merge_properties(
@@ -410,9 +514,11 @@ async fn prepare_update(
                     EntityDedupMergePolicy::PreferFrom,
                 );
                 final_properties = merged;
+                changed_fields.push("properties");
             }
             if let Some(t) = tags {
                 final_tags = t;
+                changed_fields.push("tags");
             }
 
             let updated_at = chrono::Utc::now().timestamp_micros();
@@ -443,12 +549,30 @@ async fn prepare_update(
             } else {
                 PostCommitEffect::None
             };
+            let mut statements = vec![PlanStatement {
+                statement,
+                guard: Some(AffectedRowGuard::exactly(1)),
+            }];
+            // GAP-1 (B3 fix round): curation.rs's `update_entity` appends an
+            // `EntityUpdated` event unconditionally after `upsert_entity`
+            // succeeds, regardless of `text_changed` — match that here, not
+            // just on the reindex-triggering subset of updates.
+            statements.extend(event_append_statements(
+                &entity.namespace,
+                "update",
+                EventKind::EntityUpdated,
+                SubstrateKind::Entity,
+                id,
+                serde_json::json!({
+                    "id": id,
+                    "namespace": entity.namespace,
+                    "changed_fields": changed_fields,
+                }),
+                "atomic-update-entity",
+            ));
             Ok(AtomicOpPlan::Update(UpdatePlan {
                 target_id: id,
-                statements: vec![PlanStatement {
-                    statement,
-                    guard: Some(AffectedRowGuard::exactly(1)),
-                }],
+                statements,
                 post_commit,
             }))
         }
@@ -645,6 +769,21 @@ async fn prepare_delete(
                 "atomic-delete-entity",
             )
             .await?;
+            // GAP-1 (B3 fix round): operations.rs's `delete_entity` appends
+            // an `EntityDeleted` event after a successful row delete, on
+            // BOTH soft and hard delete (`if deleted { append_event(...) }`,
+            // where `deleted` is true whenever the guarded row statement
+            // above affected a row — `apply_plan` never reaches this
+            // statement otherwise, so no `if` is needed here).
+            statements.extend(event_append_statements(
+                &namespace,
+                "delete",
+                EventKind::EntityDeleted,
+                SubstrateKind::Entity,
+                id,
+                serde_json::json!({"id": id, "namespace": namespace, "hard": hard}),
+                "atomic-delete-entity",
+            ));
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -706,6 +845,19 @@ async fn prepare_delete(
                 "atomic-delete-note",
             )
             .await?;
+            // GAP-1 (B3 fix round): operations.rs's `delete_note` appends a
+            // `NoteDeleted` event after a successful row delete, on BOTH
+            // soft and hard delete — same reasoning as the entity branch
+            // above.
+            statements.extend(event_append_statements(
+                &namespace,
+                "delete",
+                EventKind::NoteDeleted,
+                SubstrateKind::Note,
+                id,
+                serde_json::json!({"id": id, "namespace": namespace, "hard": hard}),
+                "atomic-delete-note",
+            ));
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -1922,6 +2074,298 @@ mod tests {
             vec_store.count().await.expect("count after"),
             0,
             "vector rows for both records must be purged after hard delete"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // GAP-1 (B3 fix round): event-store append parity
+    // ------------------------------------------------------------------
+
+    /// Fetch every event of `kind` targeting `target_id`, via the same
+    /// `EventStore::query_events` surface `--atomic` callers would use to
+    /// verify parity — not a raw SQL probe.
+    async fn events_for_target(
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        target_id: Uuid,
+        kind: EventKind,
+    ) -> Vec<khive_storage::Event> {
+        let event_store = runtime.events(token).expect("event store");
+        let filter = khive_storage::EventFilter {
+            kinds: vec![kind],
+            ..Default::default()
+        };
+        let page = event_store
+            .query_events(filter, khive_storage::types::PageRequest::default())
+            .await
+            .expect("query_events");
+        page.items
+            .into_iter()
+            .filter(|e| e.target_id == Some(target_id))
+            .collect()
+    }
+
+    /// GAP-1: atomic `update(id=<entity>, name=...)` must append an
+    /// `EntityUpdated` event, matching `curation::update_entity`
+    /// (curation.rs:257-273) — the event is appended unconditionally after
+    /// a successful row update, not only on the reindex-triggering subset.
+    #[tokio::test]
+    async fn atomic_update_entity_appends_entity_updated_event() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entity = khive_storage::Entity::new("local", "concept", "gap1-entity");
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": entity_id.to_string(), "name": "gap1-entity-renamed"}),
+        )
+        .await
+        .expect("prepare update");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+
+        let events = events_for_target(&runtime, &token, entity_id, EventKind::EntityUpdated).await;
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one EntityUpdated event for {entity_id}"
+        );
+        assert_eq!(events[0].namespace, "local");
+        assert_eq!(events[0].payload["id"], json!(entity_id.to_string()));
+        assert_eq!(
+            events[0].payload["changed_fields"],
+            json!(["name"]),
+            "changed_fields must name exactly the patched fields"
+        );
+    }
+
+    /// GAP-1: atomic soft AND hard delete of an entity must each append an
+    /// `EntityDeleted` event, matching `operations::delete_entity`
+    /// (operations.rs:3543-3558), which fires on both delete modes.
+    #[tokio::test]
+    async fn atomic_delete_entity_appends_entity_deleted_event_soft_and_hard() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        for hard in [false, true] {
+            let entity =
+                khive_storage::Entity::new("local", "concept", format!("gap1-entity-hard-{hard}"));
+            let entity_id = entity.id;
+            runtime
+                .entities(&token)
+                .expect("entities store")
+                .upsert_entity(entity)
+                .await
+                .expect("seed entity");
+
+            let args = if hard {
+                json!({"id": entity_id.to_string(), "hard": true})
+            } else {
+                json!({"id": entity_id.to_string()})
+            };
+            let plan = prepare_delete(&runtime, &token, &args)
+                .await
+                .unwrap_or_else(|e| panic!("prepare delete (hard={hard}): {e}"));
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .unwrap_or_else(|e| panic!("delete commit (hard={hard}): {e}"));
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected a clean delete commit (hard={hard}): {outcome:?}"
+            );
+
+            let events =
+                events_for_target(&runtime, &token, entity_id, EventKind::EntityDeleted).await;
+            assert_eq!(
+                events.len(),
+                1,
+                "expected exactly one EntityDeleted event for {entity_id} (hard={hard})"
+            );
+            assert_eq!(events[0].payload["hard"], json!(hard));
+        }
+    }
+
+    /// GAP-1: atomic soft AND hard delete of a note must each append a
+    /// `NoteDeleted` event, matching `operations::delete_note`
+    /// (operations.rs:3326-3340), which fires on both delete modes.
+    #[tokio::test]
+    async fn atomic_delete_note_appends_note_deleted_event_soft_and_hard() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        for hard in [false, true] {
+            let mut note = khive_storage::note::Note::new(
+                "local",
+                "observation",
+                format!("gap1-note-content-hard-{hard}"),
+            );
+            note.name = Some(format!("gap1-note-hard-{hard}"));
+            let note_id = note.id;
+            runtime
+                .notes(&token)
+                .expect("notes store")
+                .upsert_note(note)
+                .await
+                .expect("seed note");
+
+            let args = if hard {
+                json!({"id": note_id.to_string(), "hard": true})
+            } else {
+                json!({"id": note_id.to_string()})
+            };
+            let plan = prepare_delete(&runtime, &token, &args)
+                .await
+                .unwrap_or_else(|e| panic!("prepare delete (hard={hard}): {e}"));
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .unwrap_or_else(|e| panic!("delete commit (hard={hard}): {e}"));
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected a clean delete commit (hard={hard}): {outcome:?}"
+            );
+
+            let events = events_for_target(&runtime, &token, note_id, EventKind::NoteDeleted).await;
+            assert_eq!(
+                events.len(),
+                1,
+                "expected exactly one NoteDeleted event for {note_id} (hard={hard})"
+            );
+            assert_eq!(events[0].payload["hard"], json!(hard));
+        }
+    }
+
+    /// GAP-1 parity boundary: atomic `update` of a NOTE must append NO
+    /// event — canonical `update_note` never calls `append_event` (verified
+    /// by the sweep; unlike `update_entity`, which always does).
+    #[tokio::test]
+    async fn atomic_update_note_appends_no_event() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut note = khive_storage::note::Note::new("local", "observation", "gap1-note-noevent");
+        note.name = Some("gap1-note-noevent".to_string());
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": note_id.to_string(), "content": "gap1-note-noevent, revised"}),
+        )
+        .await
+        .expect("prepare update");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+
+        let event_store = runtime.events(&token).expect("event store");
+        let page = event_store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::types::PageRequest::default(),
+            )
+            .await
+            .expect("query_events");
+        assert!(
+            page.items.iter().all(|e| e.target_id != Some(note_id)),
+            "update_note must append no event; found: {:?}",
+            page.items
+                .iter()
+                .filter(|e| e.target_id == Some(note_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// GAP-1 parity boundary: atomic `link` must append NO event —
+    /// canonical `link` never calls `append_event` (verified by the sweep).
+    #[tokio::test]
+    async fn atomic_link_appends_no_event() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let source = khive_storage::Entity::new("local", "concept", "gap1-link-source");
+        let target = khive_storage::Entity::new("local", "concept", "gap1-link-target");
+        let (source_id, target_id) = (source.id, target.id);
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(source)
+            .await
+            .expect("seed source");
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(target)
+            .await
+            .expect("seed target");
+
+        let plan = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": source_id.to_string(),
+                "target_id": target_id.to_string(),
+                "relation": "extends",
+            }),
+        )
+        .await
+        .expect("prepare link");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+
+        let event_store = runtime.events(&token).expect("event store");
+        let page = event_store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::types::PageRequest::default(),
+            )
+            .await
+            .expect("query_events");
+        assert!(
+            page.items.is_empty(),
+            "link must append no event; found: {:?}",
+            page.items
         );
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 
 use khive_storage::types::SqlValue;
 use khive_storage::{EdgeRelation, SqlStatement};
-use khive_types::{EventKind, EventOutcome, SubstrateKind};
+use khive_types::{EventKind, SubstrateKind};
 
 use crate::atomic_plan::{
     AffectedRowGuard, DeletePlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
@@ -54,6 +54,12 @@ use crate::operations::{
     Resolved,
 };
 use crate::runtime::{KhiveRuntime, NamespaceToken};
+
+use khive_db::stores::event::event_insert_statements;
+use khive_db::stores::graph::{
+    edge_hard_delete_statement, edge_soft_delete_statement, edge_upsert_statement,
+    purge_incident_edges_statement,
+};
 
 // ---------------------------------------------------------------------------
 // arg extraction helpers
@@ -290,19 +296,31 @@ async fn push_index_purge_statements(
     Ok(())
 }
 
-/// Event-store append parity for the three canonical handlers that emit a
+/// Event-store append parity for the canonical handlers that emit a
 /// lifecycle event AFTER their row mutation: `update_entity` -> `EntityUpdated`
 /// (curation.rs:257-273), `delete_entity` -> `EntityDeleted`
 /// (operations.rs:3543-3558), `delete_note` -> `NoteDeleted`
-/// (operations.rs:3326-3340). `update_note` and `link` append no event
+/// (operations.rs:3326-3340), `update_edge` -> `EdgeUpdated`
+/// (operations.rs:3968-3983), `delete_edge` -> `EdgeDeleted`
+/// (operations.rs:4042-4056). `update_note` and `link` append no event
 /// (parity boundary verified by the GAP-1 sweep) and must never call this.
 ///
+/// ADR-099 B3 r6 (Leo condition 2, "one event implementation"): builds the
+/// `Event` exactly as each canonical site does
+/// (`khive_storage::event::Event::new(...).with_target(...).with_payload(...)`)
+/// and turns it into plain-data `SqlStatement`s via
+/// [`khive_db::stores::event::event_insert_statements`] — the SAME builder
+/// [`khive_db::stores::event::append_event_on_writer`] (the async execution
+/// path every canonical `event_store.append_event(...)` call ultimately
+/// reaches) uses. There is exactly one place that knows the
+/// `events`/`event_observations` insert shape; this function only adapts its
+/// output into unguarded [`PlanStatement`]s for the atomic-unit plan.
+///
 /// Placement decision (matches canonical's error semantics, ADR-099 B3 GAP-1
-/// fix round): all three canonical sites call
+/// fix round): all canonical sites call
 /// `event_store.append_event(event).await.map_err(...)?` — the `?` makes a
 /// failed append a hard `RuntimeError`, never swallowed/logged-and-continue.
-/// `append_event`'s body (`khive-db::stores::event::insert_event_with_
-/// observations`) is two plain, deterministic `INSERT`s (`events`, then
+/// The insert is two-to-N plain, deterministic `INSERT`s (`events`, then
 /// `event_observations` for the target-row observation) computed entirely
 /// from data already on hand at prepare time — no embedding call, no other
 /// suspending/async computation, unlike the `ReindexEntity`/`ReindexNote`
@@ -326,64 +344,19 @@ fn event_append_statements(
     substrate: SubstrateKind,
     target_id: Uuid,
     payload: Value,
-    label_prefix: &str,
-) -> Vec<PlanStatement> {
-    let event_id = Uuid::new_v4();
-    let created_at = chrono::Utc::now().timestamp_micros();
-    let referent_kind = if substrate == SubstrateKind::Note {
-        "note"
-    } else {
-        "entity"
-    };
-
-    let event_stmt = PlanStatement {
-        statement: SqlStatement {
-            sql: "INSERT INTO events \
-                  (id, namespace, verb, substrate, actor, kind, outcome, payload, \
-                   payload_schema_version, profile_state_version, duration_us, target_id, \
-                   session_id, aggregate_kind, aggregate_id, created_at) \
-                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
-                .to_string(),
-            params: vec![
-                SqlValue::Text(event_id.to_string()),
-                SqlValue::Text(namespace.to_string()),
-                SqlValue::Text(verb.to_string()),
-                SqlValue::Text(substrate.name().to_string()),
-                SqlValue::Text(String::new()),
-                SqlValue::Text(kind.name().to_string()),
-                SqlValue::Text(EventOutcome::Success.name().to_string()),
-                SqlValue::Text(payload.to_string()),
-                SqlValue::Integer(1),
-                SqlValue::Null,
-                SqlValue::Integer(0),
-                SqlValue::Text(target_id.to_string()),
-                SqlValue::Null,
-                SqlValue::Null,
-                SqlValue::Null,
-                SqlValue::Integer(created_at),
-            ],
-            label: Some(format!("{label_prefix}-event")),
-        },
-        guard: None,
-    };
-    let observation_stmt = PlanStatement {
-        statement: SqlStatement {
-            sql: "INSERT INTO event_observations \
-                  (event_id, entity_id, referent_kind, role, position) \
-                  VALUES (?1, ?2, ?3, ?4, ?5)"
-                .to_string(),
-            params: vec![
-                SqlValue::Text(event_id.to_string()),
-                SqlValue::Text(target_id.to_string()),
-                SqlValue::Text(referent_kind.to_string()),
-                SqlValue::Text("target".to_string()),
-                SqlValue::Integer(0),
-            ],
-            label: Some(format!("{label_prefix}-event-observation")),
-        },
-        guard: None,
-    };
-    vec![event_stmt, observation_stmt]
+) -> RuntimeResult<Vec<PlanStatement>> {
+    let event = khive_storage::event::Event::new(namespace.to_string(), verb, kind, substrate, "")
+        .with_target(target_id)
+        .with_payload(payload);
+    let statements = event_insert_statements(&event)
+        .map_err(|e| RuntimeError::Internal(format!("event_insert_statements: {e}")))?;
+    Ok(statements
+        .into_iter()
+        .map(|statement| PlanStatement {
+            statement,
+            guard: None,
+        })
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -484,12 +457,38 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
             };
             (bad, "name, content, salience, decay_factor, properties")
         }
+        // ADR-099 B3 r6: closes the round-4 codex REJECT (High) — `update`
+        // admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS` but this
+        // validator previously had no "edge" arm at all, so an edge update
+        // carrying an entity/note-only field (e.g. `name`) silently skipped
+        // the guard instead of being rejected, mirroring
+        // `khive-pack-kg::handlers::update::reject_inapplicable_fields`'s
+        // `KindSpec::Edge` arm.
+        "edge" => {
+            let bad = if present("name") {
+                Some("name")
+            } else if present("description") {
+                Some("description")
+            } else if present("content") {
+                Some("content")
+            } else if present("tags") {
+                Some("tags")
+            } else if present("salience") {
+                Some("salience")
+            } else if present("decay_factor") {
+                Some("decay_factor")
+            } else {
+                None
+            };
+            (bad, "relation, weight, properties")
+        }
         _ => (None, ""),
     };
     if let Some(field) = bad_field {
         let substrate_label = match substrate {
             "entity" => "an entity",
             "note" => "a note",
+            "edge" => "an edge",
             other => other,
         };
         return Err(RuntimeError::InvalidInput(format!(
@@ -633,8 +632,7 @@ async fn prepare_update(
                     "namespace": entity.namespace,
                     "changed_fields": changed_fields,
                 }),
-                "atomic-update-entity",
-            ));
+            )?);
             Ok(AtomicOpPlan::Update(UpdatePlan {
                 target_id: id,
                 statements,
@@ -747,10 +745,230 @@ async fn prepare_update(
             }))
         }
         Some(_) => Err(RuntimeError::InvalidInput(format!(
-            "update target {id} must be an entity or note"
+            "update target {id} must be an entity, note, or edge"
         ))),
-        None => Err(RuntimeError::NotFound(format!("entity/note {id}"))),
+        // `Resolved` (khive-runtime::operations) has no `Edge` variant — an
+        // id that isn't an entity/note/pack-private/event record is checked
+        // against the graph store directly, mirroring
+        // `khive-pack-kg::handlers::KgPack::infer_kind_from_uuid`'s own
+        // entity/note-then-edge fallback order (ADR-099 B3 r6, closes the
+        // round-4 codex REJECT: `update` admits `kind="edge"` but this
+        // function previously had no path that could ever build a plan for
+        // one).
+        None => match runtime.get_edge(token, id).await? {
+            Some(edge) => prepare_update_edge(runtime, id, edge, args).await,
+            None => Err(RuntimeError::NotFound(format!("entity/note/edge {id}"))),
+        },
     }
+}
+
+/// Edge branch of `prepare_update` (ADR-099 B3 r6). Mirrors
+/// `khive-runtime::operations::KhiveRuntime::update_edge`'s patch semantics
+/// exactly: `relation`/`weight`/`properties` are the only applicable fields
+/// (`reject_inapplicable_update_fields`'s `"edge"` arm enforces this before
+/// any mutation), a changed `relation` is endpoint-validated first, `weight`
+/// is range-checked, and `properties` REPLACES `metadata` wholesale (no
+/// merge — `update_edge` does `edge.metadata = Some(props)`, unlike the
+/// entity/note branches' `merge_properties`).
+///
+/// DML shape:
+/// - non-symmetric relation: a single [`edge_upsert_statement`] call on the
+///   patched `Edge` — bit-for-bit the same builder `update_edge`'s own
+///   non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
+///   (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is
+///   exact by construction.
+/// - symmetric relation (`competes_with`, `composed_with`): `update_edge`
+///   does NOT use the upsert builder here — its comment explains why
+///   (`upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
+///   detect a natural-key collision with a *different* id). It instead runs
+///   a conflict PROBE then branches: no conflict -> update the row in place;
+///   conflict -> delete the requested (non-canonical) row and refresh the
+///   surviving canonical row. That probe is a plain read with no side
+///   effects, so it runs here in the async prepare phase (same treatment
+///   `resolve_kg_ids_in_args` already gives id resolution) and the two
+///   branches below reproduce `update_edge_symmetric_dml`'s exact SQL text,
+///   so the resulting plan is fully static for the synchronous commit pass.
+async fn prepare_update_edge(
+    runtime: &KhiveRuntime,
+    id: Uuid,
+    mut edge: khive_storage::types::Edge,
+    args: &Value,
+) -> RuntimeResult<AtomicOpPlan> {
+    reject_inapplicable_update_fields(args, "edge")?;
+
+    let relation_raw = optional_str(args, "relation");
+    let weight = optional_f64(args, "weight")?;
+    let properties = optional_properties(args, "properties")?;
+
+    if let Some(ref p) = properties {
+        crate::secret_gate::check_json(p)?;
+    }
+
+    let namespace = edge.namespace.clone();
+    let record_tok = NamespaceToken::for_namespace(
+        khive_types::Namespace::parse(&namespace)
+            .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
+    );
+
+    let mut changed_fields: Vec<&'static str> = Vec::new();
+    if let Some(raw) = relation_raw {
+        let relation = parse_edge_relation(raw)?;
+        runtime
+            .validate_edge_relation_endpoints(&record_tok, edge.source_id, edge.target_id, relation)
+            .await?;
+        edge.relation = relation;
+        changed_fields.push("relation");
+    }
+    if let Some(w) = weight {
+        if !w.is_finite() || !(0.0..=1.0).contains(&w) {
+            return Err(RuntimeError::InvalidInput(format!(
+                "edge weight must be a finite value in [0.0, 1.0]; got {w}"
+            )));
+        }
+        edge.weight = w;
+        changed_fields.push("weight");
+    }
+    if let Some(p) = properties {
+        edge.metadata = Some(p);
+        changed_fields.push("properties");
+    }
+
+    let (canon_src, canon_tgt) =
+        canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+    let now = chrono::Utc::now();
+
+    let mut statements: Vec<PlanStatement> = Vec::new();
+    let mut surviving_id = id;
+
+    if edge.relation.is_symmetric() {
+        // Conflict probe (read-only, async — see doc comment above).
+        let mut reader = runtime
+            .sql()
+            .reader()
+            .await
+            .map_err(RuntimeError::Storage)?;
+        let conflict_id = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT id FROM graph_edges WHERE namespace = ?1 AND source_id = ?2 \
+                      AND target_id = ?3 AND relation = ?4 AND id != ?5"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(namespace.clone()),
+                    SqlValue::Text(canon_src.to_string()),
+                    SqlValue::Text(canon_tgt.to_string()),
+                    SqlValue::Text(edge.relation.to_string()),
+                    SqlValue::Text(id.to_string()),
+                ],
+                label: Some("atomic-update-edge-conflict-probe".to_string()),
+            })
+            .await
+            .map_err(RuntimeError::Storage)?
+            .and_then(|v| match v {
+                SqlValue::Text(s) => Uuid::parse_str(&s).ok(),
+                _ => None,
+            });
+
+        let metadata_str = edge
+            .metadata
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+        if let Some(existing_id) = conflict_id {
+            // Case (b), mirrors `update_edge_symmetric_dml`: delete the
+            // requested (non-canonical) row, refresh the surviving row.
+            surviving_id = existing_id;
+            statements.push(PlanStatement {
+                statement: SqlStatement {
+                    sql: "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2".to_string(),
+                    params: vec![
+                        SqlValue::Text(namespace.clone()),
+                        SqlValue::Text(id.to_string()),
+                    ],
+                    label: Some("atomic-update-edge-symmetric-delete-noncanonical".to_string()),
+                },
+                guard: Some(AffectedRowGuard::exactly(1)),
+            });
+            statements.push(PlanStatement {
+                statement: SqlStatement {
+                    sql: "UPDATE graph_edges SET \
+                          weight = ?1, updated_at = ?2, deleted_at = NULL, \
+                          target_backend = ?3, metadata = ?4 \
+                          WHERE namespace = ?5 AND id = ?6"
+                        .to_string(),
+                    params: vec![
+                        SqlValue::Float(edge.weight),
+                        SqlValue::Integer(now.timestamp_micros()),
+                        match &edge.target_backend {
+                            Some(b) => SqlValue::Text(b.clone()),
+                            None => SqlValue::Null,
+                        },
+                        match metadata_str {
+                            Some(m) => SqlValue::Text(m),
+                            None => SqlValue::Null,
+                        },
+                        SqlValue::Text(namespace.clone()),
+                        SqlValue::Text(existing_id.to_string()),
+                    ],
+                    label: Some("atomic-update-edge-symmetric-refresh-canonical".to_string()),
+                },
+                guard: Some(AffectedRowGuard::exactly(1)),
+            });
+        } else {
+            // Case (a): no conflict — update source/target/relation/weight
+            // in place, preserving the original edge id.
+            statements.push(PlanStatement {
+                statement: SqlStatement {
+                    sql: "UPDATE graph_edges SET \
+                          source_id = ?1, target_id = ?2, relation = ?3, \
+                          weight = ?4, updated_at = ?5, metadata = ?6 \
+                          WHERE namespace = ?7 AND id = ?8"
+                        .to_string(),
+                    params: vec![
+                        SqlValue::Text(canon_src.to_string()),
+                        SqlValue::Text(canon_tgt.to_string()),
+                        SqlValue::Text(edge.relation.to_string()),
+                        SqlValue::Float(edge.weight),
+                        SqlValue::Integer(now.timestamp_micros()),
+                        match metadata_str {
+                            Some(m) => SqlValue::Text(m),
+                            None => SqlValue::Null,
+                        },
+                        SqlValue::Text(namespace.clone()),
+                        SqlValue::Text(id.to_string()),
+                    ],
+                    label: Some("atomic-update-edge-inplace".to_string()),
+                },
+                guard: Some(AffectedRowGuard::exactly(1)),
+            });
+        }
+    } else {
+        // Non-symmetric: bit-for-bit the same builder `graph.upsert_edge`
+        // calls — see doc comment above.
+        edge.updated_at = now;
+        statements.push(PlanStatement {
+            statement: edge_upsert_statement(&edge),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        });
+    }
+
+    // Mirrors `update_edge`'s unconditional post-mutation `EdgeUpdated`
+    // event append (operations.rs:3968-3983), keyed on the ORIGINAL
+    // `edge_id` the caller supplied — canonical does the same (the event
+    // target is `edge_id`, not the post-absorption surviving id).
+    statements.extend(event_append_statements(
+        &namespace,
+        "update",
+        EventKind::EdgeUpdated,
+        SubstrateKind::Entity,
+        id,
+        serde_json::json!({"id": id, "namespace": namespace, "changed_fields": changed_fields}),
+    )?);
+
+    Ok(AtomicOpPlan::Update(UpdatePlan {
+        target_id: surviving_id,
+        statements,
+        post_commit: PostCommitEffect::None,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -765,14 +983,18 @@ async fn prepare_update(
 /// `khive_pack_kg::handlers::KindSpec` itself: the kkernel seam does the
 /// pack-aware `resolve_kind_spec` resolution (which needs a `VerbRegistry`,
 /// unreachable from this crate) and passes down only what `prepare_delete`
-/// needs to enforce the mismatch check. `KindSpec::Edge`/`Event`/`Proposal`
-/// are rejected at the kkernel seam BEFORE `prepare_delete` is ever called
-/// — those substrates are not v1-admissible for atomic delete (this enum
-/// intentionally has no variant for them, so a rejected kind can never be
-/// constructed here).
+/// needs to enforce the mismatch check.
+///
+/// `Edge` was added in ADR-099 B3 r6, closing the round-4 codex REJECT
+/// (High): `delete` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`, but
+/// this enum previously had no variant for it, so the kkernel seam rejected
+/// `delete(kind="edge", ...)` before `prepare_delete` was ever reached —
+/// admissible-but-unimplemented. `Event`/`Proposal` remain rejected at the
+/// kkernel seam (not v1-admissible for atomic delete at all).
 pub enum AtomicDeleteKind {
     Entity { specific: Option<String> },
     Note { specific: Option<String> },
+    Edge,
 }
 
 /// `expected_kind`: `None` when the caller omitted `kind` (no check, parity
@@ -820,6 +1042,9 @@ pub async fn prepare_delete(
                 Some(AtomicDeleteKind::Entity { specific: None }) => {}
                 Some(AtomicDeleteKind::Note { .. }) => {
                     return Err(RuntimeError::NotFound(format!("note {id}")));
+                }
+                Some(AtomicDeleteKind::Edge) => {
+                    return Err(RuntimeError::NotFound(format!("edge {id}")));
                 }
             }
             let namespace = entity.namespace.clone();
@@ -886,8 +1111,7 @@ pub async fn prepare_delete(
                 SubstrateKind::Entity,
                 id,
                 serde_json::json!({"id": id, "namespace": namespace, "hard": hard}),
-                "atomic-delete-entity",
-            ));
+            )?);
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -906,6 +1130,9 @@ pub async fn prepare_delete(
                 Some(AtomicDeleteKind::Note { specific: None }) => {}
                 Some(AtomicDeleteKind::Entity { .. }) => {
                     return Err(RuntimeError::NotFound(format!("entity {id}")));
+                }
+                Some(AtomicDeleteKind::Edge) => {
+                    return Err(RuntimeError::NotFound(format!("edge {id}")));
                 }
             }
             let namespace = note.namespace.clone();
@@ -974,18 +1201,90 @@ pub async fn prepare_delete(
                 SubstrateKind::Note,
                 id,
                 serde_json::json!({"id": id, "namespace": namespace, "hard": hard}),
-                "atomic-delete-note",
-            ));
+            )?);
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
             }))
         }
         Some(_) => Err(RuntimeError::InvalidInput(format!(
-            "delete target {id} must be an entity or note"
+            "delete target {id} must be an entity, note, or edge"
         ))),
-        None => Err(RuntimeError::NotFound(format!("entity/note {id}"))),
+        // `Resolved` has no `Edge` variant (same reasoning as
+        // `prepare_update`'s fallback above) — probe the graph store
+        // directly. ADR-099 B3 r6: closes the round-4 codex REJECT (High).
+        None => match &expected_kind {
+            Some(AtomicDeleteKind::Entity { .. }) => {
+                Err(RuntimeError::NotFound(format!("entity/note {id}")))
+            }
+            Some(AtomicDeleteKind::Note { .. }) => {
+                Err(RuntimeError::NotFound(format!("entity/note {id}")))
+            }
+            Some(AtomicDeleteKind::Edge) | None => {
+                let edge = if hard {
+                    runtime.get_edge_including_deleted(token, id).await?
+                } else {
+                    runtime.get_edge(token, id).await?
+                };
+                match edge {
+                    Some(edge) => prepare_delete_edge(id, edge, hard).await,
+                    None => Err(RuntimeError::NotFound(format!("entity/note/edge {id}"))),
+                }
+            }
+        },
     }
+}
+
+/// Edge branch of `prepare_delete` (ADR-099 B3 r6). Mirrors
+/// `khive-runtime::operations::KhiveRuntime::delete_edge` exactly: hard
+/// delete cascades `purge_incident_edges` (any `annotates` edge — or any
+/// other edge — pointing AT this edge as a node) BEFORE deleting the edge
+/// row itself, then a soft or hard delete statement, then an unconditional
+/// `EdgeDeleted` event (edges are never FTS/vector-indexed, so unlike the
+/// entity/note branches there is no index purge here — `delete_edge` has
+/// none either).
+async fn prepare_delete_edge(
+    id: Uuid,
+    edge: khive_storage::types::Edge,
+    hard: bool,
+) -> RuntimeResult<AtomicOpPlan> {
+    let namespace = edge.namespace.clone();
+    let mut statements: Vec<PlanStatement> = Vec::new();
+
+    if hard {
+        // Mirrors `delete_edge`'s `graph.purge_incident_edges(edge_id)` —
+        // unguarded: zero incident edges is a legitimate outcome, not a
+        // failure (same reasoning as the entity/note cascade-edges
+        // statements above).
+        statements.push(PlanStatement {
+            statement: purge_incident_edges_statement(id),
+            guard: None,
+        });
+        statements.push(PlanStatement {
+            statement: edge_hard_delete_statement(id),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        });
+    } else {
+        let now = chrono::Utc::now().timestamp_micros();
+        statements.push(PlanStatement {
+            statement: edge_soft_delete_statement(id, now),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        });
+    }
+
+    statements.extend(event_append_statements(
+        &namespace,
+        "delete",
+        EventKind::EdgeDeleted,
+        SubstrateKind::Entity,
+        id,
+        serde_json::json!({"id": id, "namespace": namespace, "hard": hard}),
+    )?);
+
+    Ok(AtomicOpPlan::Delete(DeletePlan {
+        target_id: id,
+        statements,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -2375,6 +2674,263 @@ mod tests {
                 events.len(),
                 1,
                 "expected exactly one NoteDeleted event for {note_id} (hard={hard})"
+            );
+            assert_eq!(events[0].payload["hard"], json!(hard));
+        }
+    }
+
+    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `update`
+    /// admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this asserts
+    /// `prepare_update` actually builds a plan for one — a non-symmetric
+    /// relation (`extends`) exercises the `edge_upsert_statement` reuse
+    /// branch — and that the committed row + `EdgeUpdated` event match
+    /// canonical `update_edge`'s shape (weight persisted, relation
+    /// unchanged, exactly one event).
+    #[tokio::test]
+    async fn atomic_update_edge_patches_weight_and_appends_edge_updated_event() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "GapEdgeA");
+        let b = khive_storage::Entity::new("local", "concept", "GapEdgeB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.4, None)
+            .await
+            .expect("seed edge");
+        let edge_id = Uuid::from(edge.id);
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": edge_id.to_string(), "weight": 0.75}),
+        )
+        .await
+        .expect("prepare update edge");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "expected a clean edge update commit: {outcome:?}"
+        );
+
+        let updated = runtime
+            .get_edge(&token, edge_id)
+            .await
+            .expect("get_edge")
+            .expect("edge still present");
+        assert_eq!(updated.weight, 0.75, "weight patch must persist");
+        assert_eq!(updated.relation, EdgeRelation::Extends);
+
+        let events = events_for_target(&runtime, &token, edge_id, EventKind::EdgeUpdated).await;
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one EdgeUpdated event for {edge_id}"
+        );
+        assert_eq!(
+            events[0].payload["changed_fields"],
+            json!(["weight"]),
+            "changed_fields must name exactly the patched field"
+        );
+    }
+
+    /// ADR-099 B3 r6: the symmetric-relation conflict-absorption branch of
+    /// `prepare_update_edge` — mirrors `update_edge_symmetric_dml`'s case
+    /// (b): changing a non-symmetric edge's `relation` to a symmetric one
+    /// whose canonical natural key collides with an ALREADY-EXISTING
+    /// symmetric edge between the same two entities must delete the
+    /// requested (non-canonical) row and refresh the surviving canonical
+    /// row in place, rather than raising a uniqueness error.
+    #[tokio::test]
+    async fn atomic_update_edge_symmetric_conflict_absorbs_into_surviving_row() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "GapEdgeSymA");
+        let b = khive_storage::Entity::new("local", "concept", "GapEdgeSymB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        // The non-canonical edge under test: A -> B, non-symmetric relation.
+        let requested_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed requested edge");
+        let requested_id = Uuid::from(requested_edge.id);
+
+        // The pre-existing canonical row this update will collide with once
+        // `relation` becomes `competes_with` (symmetric).
+        let canonical_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .expect("seed canonical edge");
+        let canonical_id = Uuid::from(canonical_edge.id);
+        assert_ne!(requested_id, canonical_id);
+
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+        )
+        .await
+        .expect("prepare update edge (symmetric conflict)");
+        // The plan must target the SURVIVING (canonical) row, not the
+        // requested one — mirrors `update_edge`'s `edge = self.get_edge(&record_tok, surviving_uuid)`.
+        match &plan {
+            AtomicOpPlan::Update(p) => assert_eq!(p.target_id, canonical_id),
+            other => panic!("expected an Update plan, got {other:?}"),
+        }
+
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "expected a clean symmetric-conflict-absorption commit: {outcome:?}"
+        );
+
+        // The requested (non-canonical) row must be gone.
+        let requested_after = runtime
+            .get_edge_including_deleted(&token, requested_id)
+            .await
+            .expect("get_edge_including_deleted");
+        assert!(
+            requested_after.is_none(),
+            "the non-canonical requested row must be deleted, not just tombstoned"
+        );
+
+        // The surviving canonical row must carry the patch.
+        let surviving = runtime
+            .get_edge(&token, canonical_id)
+            .await
+            .expect("get_edge")
+            .expect("surviving canonical row must remain");
+        assert_eq!(surviving.weight, 0.9);
+        assert_eq!(surviving.relation, EdgeRelation::CompetesWith);
+
+        // Event target is the CALLER-supplied id, not the surviving id —
+        // mirrors `update_edge`'s event using `edge_id` (the caller's
+        // original argument), not the post-absorption id.
+        let events =
+            events_for_target(&runtime, &token, requested_id, EventKind::EdgeUpdated).await;
+        assert_eq!(events.len(), 1);
+    }
+
+    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `update`
+    /// rejects an entity/note-only field (`name`) on an edge target,
+    /// mirroring `khive-pack-kg::handlers::update::reject_inapplicable_fields`'s
+    /// `KindSpec::Edge` arm — before this fix `reject_inapplicable_update_fields`
+    /// had no `"edge"` match arm at all, so the field was silently dropped.
+    #[tokio::test]
+    async fn atomic_update_edge_rejects_entity_only_field_name() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "GapEdgeRejectA");
+        let b = khive_storage::Entity::new("local", "concept", "GapEdgeRejectB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+        let edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.5, None)
+            .await
+            .expect("seed edge");
+        let edge_id = Uuid::from(edge.id);
+
+        let err = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": edge_id.to_string(), "name": "not-a-valid-edge-field"}),
+        )
+        .await
+        .expect_err("edge update with an entity-only field must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("name") && message.contains("edge"),
+            "error must name the offending field and the substrate: {message}"
+        );
+    }
+
+    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `delete`
+    /// admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this asserts
+    /// `prepare_delete` actually builds a plan for one on both soft and
+    /// hard delete, matching `operations::delete_edge`'s row-mode DML and
+    /// unconditional `EdgeDeleted` event.
+    #[tokio::test]
+    async fn atomic_delete_edge_soft_and_hard_appends_edge_deleted_event() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        for hard in [false, true] {
+            let entities = runtime.entities(&token).expect("entities store");
+            let a = khive_storage::Entity::new("local", "concept", format!("GapEdgeDelA{hard}"));
+            let b = khive_storage::Entity::new("local", "concept", format!("GapEdgeDelB{hard}"));
+            let (a_id, b_id) = (a.id, b.id);
+            entities.upsert_entity(a).await.expect("seed a");
+            entities.upsert_entity(b).await.expect("seed b");
+            let edge = runtime
+                .link(&token, a_id, b_id, EdgeRelation::Extends, 0.5, None)
+                .await
+                .expect("seed edge");
+            let edge_id = Uuid::from(edge.id);
+
+            let args = if hard {
+                json!({"id": edge_id.to_string(), "hard": true})
+            } else {
+                json!({"id": edge_id.to_string()})
+            };
+            let plan = prepare_delete(&runtime, &token, &args, None)
+                .await
+                .unwrap_or_else(|e| panic!("prepare delete edge (hard={hard}): {e}"));
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .unwrap_or_else(|e| panic!("edge delete commit (hard={hard}): {e}"));
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected a clean edge delete commit (hard={hard}): {outcome:?}"
+            );
+
+            let after = runtime
+                .get_edge_including_deleted(&token, edge_id)
+                .await
+                .expect("get_edge_including_deleted");
+            if hard {
+                assert!(after.is_none(), "hard delete must purge the row entirely");
+            } else {
+                assert!(
+                    after.as_ref().is_some_and(|e| e.deleted_at.is_some()),
+                    "soft delete must tombstone, not purge"
+                );
+            }
+
+            let events = events_for_target(&runtime, &token, edge_id, EventKind::EdgeDeleted).await;
+            assert_eq!(
+                events.len(),
+                1,
+                "expected exactly one EdgeDeleted event for {edge_id} (hard={hard})"
             );
             assert_eq!(events[0].payload["hard"], json!(hard));
         }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1142,23 +1142,18 @@ async fn prepare_link(
     let target_id = require_uuid(args, "target_id")?;
     let relation = parse_edge_relation(require_str(args, "relation")?)?;
     let weight = optional_f64(args, "weight")?.unwrap_or(1.0);
-    let mut metadata = obj(args)?.get("metadata").cloned();
+    let metadata = obj(args)?.get("metadata").cloned();
 
-    // Top-level `dependency_kind` param merges into `metadata` (codex REJECT
-    // High finding — link.rs handler's `merge_entry_metadata` parity): only
-    // fills the key when metadata doesn't already carry one. `link.rs` is a
-    // sibling-crate `pub(crate)` fn (no dependency edge back to
-    // khive-runtime), so this three-line merge is reimplemented here rather
-    // than imported — same pattern as `parse_merge_strategy` above.
-    if let Some(dk) = optional_str(args, "dependency_kind") {
-        let mut m = metadata.unwrap_or_else(|| serde_json::json!({}));
-        let map = m
-            .as_object_mut()
-            .ok_or_else(|| RuntimeError::InvalidInput("metadata must be a JSON object".into()))?;
-        map.entry("dependency_kind".to_string())
-            .or_insert_with(|| serde_json::json!(dk));
-        metadata = Some(m);
-    }
+    // Top-level `dependency_kind` param merges into `metadata`: only fills
+    // the key when metadata doesn't already carry one. Calls the SAME
+    // `khive_runtime::merge_entry_metadata` `khive-pack-kg`'s canonical
+    // `handle_link` calls — relocated down to this crate (ADR-099 B3 r6
+    // second pass) so both sides depend on one function instead of each
+    // maintaining their own copy.
+    let mut metadata = crate::merge_entry_metadata(
+        metadata,
+        optional_str(args, "dependency_kind").map(String::from),
+    )?;
 
     validate_edge_weight(weight)?;
     runtime

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -276,14 +276,101 @@ fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
 // update
 // ---------------------------------------------------------------------------
 
+/// Mirrors `khive-pack-kg::handlers::update::reject_inapplicable_fields`
+/// (GAP-4, B3 fix round 4): a hard `InvalidInput` when a caller passes a
+/// field that does not apply to the resolved substrate (e.g. `salience` on
+/// an entity, or `description`/`tags` on a note). That function is
+/// `pub(crate)` to a sibling crate with no dependency edge back to
+/// `khive-runtime` (`khive-pack-kg` depends on `khive-runtime`, not the
+/// other way around), so its exact field-applicability check list and error
+/// message shape are reimplemented here rather than imported — same pattern
+/// as `optional_string_patch` above. Presence is checked directly on the raw
+/// args object (this module has no `UpdateParams` struct); a JSON `null`
+/// value is treated as absent, matching `Option<T>` deserialization
+/// semantics for the fields update.rs's checklist covers.
+fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeResult<()> {
+    let o = obj(args)?;
+    let present = |k: &str| o.get(k).is_some_and(|v| !v.is_null());
+    let (bad_field, valid): (Option<&str>, &str) = match substrate {
+        "entity" => {
+            let bad = if present("content") {
+                Some("content")
+            } else if present("salience") {
+                Some("salience")
+            } else if present("decay_factor") {
+                Some("decay_factor")
+            } else if present("relation") {
+                Some("relation")
+            } else if present("weight") {
+                Some("weight")
+            } else {
+                None
+            };
+            (bad, "name, description, tags, properties")
+        }
+        "note" => {
+            let bad = if present("description") {
+                Some("description")
+            } else if present("tags") {
+                Some("tags")
+            } else if present("relation") {
+                Some("relation")
+            } else if present("weight") {
+                Some("weight")
+            } else {
+                None
+            };
+            (bad, "name, content, salience, decay_factor, properties")
+        }
+        _ => (None, ""),
+    };
+    if let Some(field) = bad_field {
+        let substrate_label = match substrate {
+            "entity" => "an entity",
+            "note" => "a note",
+            other => other,
+        };
+        return Err(RuntimeError::InvalidInput(format!(
+            "field '{field}' is not valid for {substrate_label}; valid fields: {valid}"
+        )));
+    }
+    Ok(())
+}
+
 async fn prepare_update(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     args: &Value,
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
+
+    // GAP-4 (B3 fix round 4): mirrors update.rs's entity_kind immutability
+    // guard (update.rs:160-164), which the pre-fix atomic prepare never
+    // checked at all — entity_kind is a legacy top-level field, independent
+    // of the `kind` substrate discriminator handled elsewhere.
+    if obj(args)?.get("entity_kind").is_some_and(|v| !v.is_null()) {
+        return Err(RuntimeError::InvalidInput(
+            "entity_kind is immutable; to change kind, delete then re-create the entity, \
+             or use merge() if this is a deduplication correction"
+                .into(),
+        ));
+    }
+
+    // NOTE (GAP-4 scope, B3 fix round 4): update.rs also rejects a caller-
+    // supplied `kind=<specific>` that contradicts the resolved substrate's
+    // ACTUAL kind (update.rs:200-201, :229-234) with a `NotFound`. That
+    // check depends on `VerbRegistry::all_entity_kinds()`/
+    // `all_note_kinds()` (every loaded pack's granular vocab) and pack-
+    // private `EntityKind`/`NoteKind` parsing — neither is reachable from
+    // `khive-runtime` without either threading the registry through this
+    // call or duplicating pack-private vocab here, and no acceptance test
+    // in this fix round exercises it. Deferred, not silently dropped: the
+    // field-applicability rejection immediately below (the MAJOR-severity
+    // half of GAP-4 — a spurious no-op reported as success) is implemented
+    // in full.
     match runtime.resolve_by_id(token, id).await? {
         Some(Resolved::Entity(entity)) => {
+            reject_inapplicable_update_fields(args, "entity")?;
             let name = optional_str(args, "name").map(|s| s.to_string());
             let description = optional_string_patch(args, "description")?;
             let properties = obj(args)?.get("properties").cloned();
@@ -366,6 +453,7 @@ async fn prepare_update(
             }))
         }
         Some(Resolved::Note(note)) => {
+            reject_inapplicable_update_fields(args, "note")?;
             let name = optional_string_patch(args, "name")?;
             let content = optional_str(args, "content").map(|s| s.to_string());
             let properties = obj(args)?.get("properties").cloned();
@@ -697,6 +785,20 @@ async fn prepare_link(
     let now = chrono::Utc::now().timestamp_micros();
     let metadata_str = metadata.map(|m| serde_json::to_string(&m).unwrap_or_default());
 
+    // GAP-2 (B3 fix round 4): a plain `INSERT` here rejects a re-link of an
+    // already-linked (or soft-deleted) triple with a `graph_edges`
+    // `UNIQUE(namespace, source_id, target_id, relation)` violation, rolling
+    // back the whole atomic unit. Canonical `link` -> `upsert_edge`
+    // (`khive-db/src/stores/graph.rs`, natural-key `ON CONFLICT` arm) instead
+    // upserts: it updates `weight`/`updated_at`/`metadata` and resurrects
+    // `deleted_at = NULL`. The `ON CONFLICT` arm below mirrors that natural-key
+    // arm's exact `SET` list (it intentionally does NOT touch
+    // `target_backend`, which this atomic INSERT never populates in the
+    // first place — that column is left untouched on conflict rather than
+    // reset to NULL). SQLite accepts `INSERT ... SELECT ... WHERE ... ON
+    // CONFLICT ... DO UPDATE`; the guarded `exactly(1)` check below still
+    // holds for both the fresh-insert and the upsert-update outcome, and
+    // still correctly reports 0 affected rows when an endpoint is missing.
     let statement = SqlStatement {
         sql: "INSERT INTO graph_edges \
               (namespace, id, source_id, target_id, relation, weight, created_at, updated_at, metadata) \
@@ -704,7 +806,12 @@ async fn prepare_link(
               WHERE (EXISTS (SELECT 1 FROM entities WHERE id = ?3 AND deleted_at IS NULL) \
                      OR EXISTS (SELECT 1 FROM notes WHERE id = ?3 AND deleted_at IS NULL)) \
                 AND (EXISTS (SELECT 1 FROM entities WHERE id = ?4 AND deleted_at IS NULL) \
-                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL))"
+                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL)) \
+              ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
+                  weight = excluded.weight, \
+                  updated_at = excluded.updated_at, \
+                  deleted_at = NULL, \
+                  metadata = excluded.metadata"
             .to_string(),
         params: vec![
             SqlValue::Text(namespace),
@@ -848,6 +955,14 @@ pub async fn apply_post_commit_effects(
                     runtime.reindex_note(token, &note).await?;
                 }
             }
+            PostCommitEffect::GtdAudit { .. } => {
+                // GAP-5 (B3 fix round 4): applied by the `kkernel` caller's
+                // own post-commit pass, not here — `khive-pack-gtd` (owner
+                // of `ensure_audit_schema`/`write_audit_record`) depends on
+                // `khive-runtime`, not the other way around, so this crate
+                // cannot act on the effect itself. See `PostCommitEffect::
+                // GtdAudit`'s doc comment.
+            }
         }
     }
     Ok(())
@@ -919,6 +1034,115 @@ mod tests {
         .expect("runtime");
         std::mem::forget(dir);
         rt
+    }
+
+    /// GAP-4 (B3 fix round 4): atomic `update` must reject a field that
+    /// does not apply to the resolved substrate — parity with
+    /// `khive-pack-kg::handlers::update::reject_inapplicable_fields`
+    /// (update.rs:195). The pre-fix atomic prepare silently ignored
+    /// `salience` on an entity: it would set every entity field to its
+    /// CURRENT value, bump `updated_at`, satisfy the `exactly(1)` guard,
+    /// and commit — a spurious no-op reported as success.
+    #[tokio::test]
+    async fn atomic_update_entity_rejects_note_only_field_salience() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entity = khive_storage::Entity::new("local", "concept", "GapFourEntity");
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+
+        let err = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": entity_id.to_string(), "salience": 0.9}),
+        )
+        .await
+        .expect_err("salience on an entity must be rejected, not silently accepted");
+        assert!(
+            matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("salience") && msg.contains("not valid for an entity")),
+            "expected an InvalidInput naming the offending field, got: {err:?}"
+        );
+
+        // A valid entity update (name/description/tags) must still work.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({
+                "id": entity_id.to_string(),
+                "name": "GapFourEntity-renamed",
+                "description": "updated description",
+                "tags": ["a", "b"],
+            }),
+        )
+        .await
+        .expect("a valid entity field set must still be accepted");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+        let entity = runtime
+            .get_entity(&token, entity_id)
+            .await
+            .expect("get_entity");
+        assert_eq!(entity.name, "GapFourEntity-renamed");
+    }
+
+    /// GAP-4 (B3 fix round 4): symmetric note-substrate case — `description`
+    /// and `tags` are entity-only fields; passing either for a note must be
+    /// rejected the same way update.rs rejects them.
+    #[tokio::test]
+    async fn atomic_update_note_rejects_entity_only_field_description() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let mut note = khive_storage::note::Note::new("local", "observation", "gap-4 note content");
+        note.name = Some("gap-four-note".to_string());
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        let err = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": note_id.to_string(), "description": "entities have descriptions, notes don't"}),
+        )
+        .await
+        .expect_err("description on a note must be rejected, not silently accepted");
+        assert!(
+            matches!(err, RuntimeError::InvalidInput(ref msg) if msg.contains("description") && msg.contains("not valid for a note")),
+            "expected an InvalidInput naming the offending field, got: {err:?}"
+        );
+
+        // A valid note update (content) must still work.
+        let plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": note_id.to_string(), "content": "gap-4 note content, revised"}),
+        )
+        .await
+        .expect("a valid note field must still be accepted");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
     }
 
     /// ADR-099 B3 acceptance test 3: updating a note's content inside an
@@ -1236,6 +1460,243 @@ mod tests {
                 "inferred dependency_kind for (service, service) must persist: {json_str}"
             );
         }
+    }
+
+    /// Raw natural-key probe of `graph_edges` (namespace, source_id,
+    /// target_id, relation) — returns `(weight, metadata_json, deleted_at)`
+    /// for exactly the ONE row a UNIQUE(namespace, source_id, target_id,
+    /// relation) constraint permits. `None` means no row at all.
+    async fn probe_edge_natural_key(
+        runtime: &KhiveRuntime,
+        namespace: &str,
+        source_id: Uuid,
+        target_id: Uuid,
+        relation: &str,
+    ) -> (usize, Option<f64>, Option<String>, Option<i64>) {
+        let mut reader = runtime.sql().reader().await.expect("reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT weight, metadata, deleted_at FROM graph_edges \
+                      WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 AND relation = ?4"
+                    .to_string(),
+                params: vec![
+                    SqlValue::Text(namespace.to_string()),
+                    SqlValue::Text(source_id.to_string()),
+                    SqlValue::Text(target_id.to_string()),
+                    SqlValue::Text(relation.to_string()),
+                ],
+                label: Some("test-probe-edge-natural-key".to_string()),
+            })
+            .await
+            .expect("probe edge natural key");
+        let count = rows.len();
+        let Some(row) = rows.into_iter().next() else {
+            return (count, None, None, None);
+        };
+        let weight = match row.get("weight") {
+            Some(SqlValue::Float(f)) => Some(*f),
+            Some(SqlValue::Integer(i)) => Some(*i as f64),
+            _ => None,
+        };
+        let metadata = match row.get("metadata") {
+            Some(SqlValue::Text(s)) => Some(s.clone()),
+            _ => None,
+        };
+        let deleted_at = match row.get("deleted_at") {
+            Some(SqlValue::Integer(i)) => Some(*i),
+            _ => None,
+        };
+        (count, weight, metadata, deleted_at)
+    }
+
+    /// GAP-2 (B3 fix round 4): atomic `link` must be an upsert, exactly like
+    /// canonical `link` -> `upsert_edge`'s natural-key `ON CONFLICT` arm —
+    /// re-linking an already-linked triple must SUCCEED and update
+    /// weight/metadata, not hit the `UNIQUE(namespace, source_id, target_id,
+    /// relation)` constraint and roll back the whole atomic unit.
+    #[tokio::test]
+    async fn atomic_link_of_already_linked_triple_upserts_weight_and_metadata() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+
+        let a = khive_storage::Entity::new("local", "concept", "GapTwoA");
+        let b = khive_storage::Entity::new("local", "concept", "GapTwoB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        // (a) a fresh link still works.
+        let plan1 = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": a_id.to_string(),
+                "target_id": b_id.to_string(),
+                "relation": "extends",
+                "weight": 0.5,
+            }),
+        )
+        .await
+        .expect("prepare first link");
+        let outcome1 = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan1])
+            .await
+            .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome1,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "fresh link must commit: {outcome1:?}"
+        );
+        let (count, weight, _metadata, deleted_at) =
+            probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
+        assert_eq!(count, 1, "exactly one edge row after the fresh link");
+        assert_eq!(weight, Some(0.5));
+        assert!(deleted_at.is_none());
+
+        // (b) re-linking the SAME triple with a different weight/metadata
+        // must SUCCEED (not a constraint-violation rollback) and UPDATE the
+        // existing row in place — natural key stays unique.
+        let plan2 = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": a_id.to_string(),
+                "target_id": b_id.to_string(),
+                "relation": "extends",
+                "weight": 0.9,
+                "metadata": {"note": "relinked"},
+            }),
+        )
+        .await
+        .expect("prepare second link");
+        let outcome2 = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan2])
+            .await
+            .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome2,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "re-link of an already-linked triple must upsert, not roll back: {outcome2:?}"
+        );
+        let (count, weight, metadata, deleted_at) =
+            probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
+        assert_eq!(
+            count, 1,
+            "the natural-key UNIQUE constraint must still hold exactly one row (upsert, not a second insert)"
+        );
+        assert_eq!(weight, Some(0.9), "weight must be updated to the new value");
+        assert!(
+            metadata
+                .as_deref()
+                .is_some_and(|m| m.contains(r#""note":"relinked""#)),
+            "metadata must be updated to the new value: {metadata:?}"
+        );
+        assert!(deleted_at.is_none());
+    }
+
+    /// GAP-2 (B3 fix round 4): atomic `link` of a SOFT-DELETED triple must
+    /// resurrect it (`deleted_at = NULL`), matching `upsert_edge`'s
+    /// natural-key `ON CONFLICT ... DO UPDATE SET deleted_at = NULL`.
+    #[tokio::test]
+    async fn atomic_link_of_soft_deleted_triple_resurrects_it() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+
+        let a = khive_storage::Entity::new("local", "concept", "GapTwoResurrectA");
+        let b = khive_storage::Entity::new("local", "concept", "GapTwoResurrectB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        let plan = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": a_id.to_string(),
+                "target_id": b_id.to_string(),
+                "relation": "extends",
+            }),
+        )
+        .await
+        .expect("prepare link");
+        let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+            .await
+            .expect("seam call ok");
+        assert!(matches!(
+            outcome,
+            crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+        ));
+
+        // Soft-delete the edge row directly (natural-key UPDATE — mirrors
+        // what `delete_edge(hard=false)` does to this same row).
+        {
+            let mut writer = runtime.sql().writer().await.expect("writer");
+            let affected = writer
+                .execute(SqlStatement {
+                    sql: "UPDATE graph_edges SET deleted_at = ?1 \
+                          WHERE namespace = ?2 AND source_id = ?3 AND target_id = ?4 AND relation = ?5"
+                        .to_string(),
+                    params: vec![
+                        SqlValue::Integer(chrono::Utc::now().timestamp_micros()),
+                        SqlValue::Text("local".to_string()),
+                        SqlValue::Text(a_id.to_string()),
+                        SqlValue::Text(b_id.to_string()),
+                        SqlValue::Text("extends".to_string()),
+                    ],
+                    label: Some("test-soft-delete-edge".to_string()),
+                })
+                .await
+                .expect("soft delete edge");
+            assert_eq!(affected, 1, "soft-delete must touch exactly the seeded row");
+        }
+        let (_, _, _, deleted_at) =
+            probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
+        assert!(
+            deleted_at.is_some(),
+            "row must be soft-deleted before the resurrect attempt"
+        );
+
+        // Re-link the same triple: must resurrect (deleted_at -> NULL), not
+        // fail on the UNIQUE constraint of the still-present soft-deleted row.
+        let plan_relink = prepare_link(
+            &runtime,
+            &token,
+            &json!({
+                "source_id": a_id.to_string(),
+                "target_id": b_id.to_string(),
+                "relation": "extends",
+                "weight": 0.75,
+            }),
+        )
+        .await
+        .expect("prepare resurrecting link");
+        let outcome_relink =
+            crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan_relink])
+                .await
+                .expect("seam call ok");
+        assert!(
+            matches!(
+                outcome_relink,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ),
+            "re-linking a soft-deleted triple must resurrect it, not roll back: {outcome_relink:?}"
+        );
+        let (count, weight, _, deleted_at) =
+            probe_edge_natural_key(&runtime, "local", a_id, b_id, "extends").await;
+        assert_eq!(count, 1);
+        assert_eq!(weight, Some(0.75));
+        assert!(
+            deleted_at.is_none(),
+            "re-link must resurrect the soft-deleted row (deleted_at -> NULL)"
+        );
     }
 
     /// B3 fix round 3 (codex r2 Blocker 1): atomic delete of an entity AND a

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -59,8 +59,10 @@ use khive_db::stores::entity::{
 };
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::graph::{
-    edge_hard_delete_statement, edge_soft_delete_statement, edge_upsert_statement,
-    purge_incident_edges_statement,
+    edge_hard_delete_statement, edge_soft_delete_statement,
+    edge_symmetric_conflict_probe_statement, edge_symmetric_delete_noncanonical_statement,
+    edge_symmetric_refresh_canonical_statement, edge_symmetric_update_inplace_statement,
+    edge_upsert_statement, purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
     note_hard_delete_statement, note_soft_delete_statement, note_upsert_statement,
@@ -741,26 +743,24 @@ async fn prepare_update_edge(
     let mut surviving_id = id;
 
     if edge.relation.is_symmetric() {
-        // Conflict probe (read-only, async — see doc comment above).
+        // Conflict probe (read-only, async — see doc comment above). Same SQL
+        // text `update_edge_symmetric_dml` (operations.rs, the synchronous
+        // commit-time counterpart) runs inside its transaction — see the
+        // `EDGE_SYMMETRIC_*_SQL` doc comment in khive-db for why a single
+        // bridge type isn't used for both call sites.
         let mut reader = runtime
             .sql()
             .reader()
             .await
             .map_err(RuntimeError::Storage)?;
         let conflict_id = reader
-            .query_scalar(SqlStatement {
-                sql: "SELECT id FROM graph_edges WHERE namespace = ?1 AND source_id = ?2 \
-                      AND target_id = ?3 AND relation = ?4 AND id != ?5"
-                    .to_string(),
-                params: vec![
-                    SqlValue::Text(namespace.clone()),
-                    SqlValue::Text(canon_src.to_string()),
-                    SqlValue::Text(canon_tgt.to_string()),
-                    SqlValue::Text(edge.relation.to_string()),
-                    SqlValue::Text(id.to_string()),
-                ],
-                label: Some("atomic-update-edge-conflict-probe".to_string()),
-            })
+            .query_scalar(edge_symmetric_conflict_probe_statement(
+                &namespace,
+                canon_src,
+                canon_tgt,
+                edge.relation,
+                id,
+            ))
             .await
             .map_err(RuntimeError::Storage)?
             .and_then(|v| match v {
@@ -778,66 +778,34 @@ async fn prepare_update_edge(
             // requested (non-canonical) row, refresh the surviving row.
             surviving_id = existing_id;
             statements.push(PlanStatement {
-                statement: SqlStatement {
-                    sql: "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2".to_string(),
-                    params: vec![
-                        SqlValue::Text(namespace.clone()),
-                        SqlValue::Text(id.to_string()),
-                    ],
-                    label: Some("atomic-update-edge-symmetric-delete-noncanonical".to_string()),
-                },
+                statement: edge_symmetric_delete_noncanonical_statement(&namespace, id),
                 guard: Some(AffectedRowGuard::exactly(1)),
             });
             statements.push(PlanStatement {
-                statement: SqlStatement {
-                    sql: "UPDATE graph_edges SET \
-                          weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                          target_backend = ?3, metadata = ?4 \
-                          WHERE namespace = ?5 AND id = ?6"
-                        .to_string(),
-                    params: vec![
-                        SqlValue::Float(edge.weight),
-                        SqlValue::Integer(now.timestamp_micros()),
-                        match &edge.target_backend {
-                            Some(b) => SqlValue::Text(b.clone()),
-                            None => SqlValue::Null,
-                        },
-                        match metadata_str {
-                            Some(m) => SqlValue::Text(m),
-                            None => SqlValue::Null,
-                        },
-                        SqlValue::Text(namespace.clone()),
-                        SqlValue::Text(existing_id.to_string()),
-                    ],
-                    label: Some("atomic-update-edge-symmetric-refresh-canonical".to_string()),
-                },
+                statement: edge_symmetric_refresh_canonical_statement(
+                    &namespace,
+                    existing_id,
+                    edge.weight,
+                    now.timestamp_micros(),
+                    edge.target_backend.as_deref(),
+                    metadata_str.as_deref(),
+                ),
                 guard: Some(AffectedRowGuard::exactly(1)),
             });
         } else {
             // Case (a): no conflict — update source/target/relation/weight
             // in place, preserving the original edge id.
             statements.push(PlanStatement {
-                statement: SqlStatement {
-                    sql: "UPDATE graph_edges SET \
-                          source_id = ?1, target_id = ?2, relation = ?3, \
-                          weight = ?4, updated_at = ?5, metadata = ?6 \
-                          WHERE namespace = ?7 AND id = ?8"
-                        .to_string(),
-                    params: vec![
-                        SqlValue::Text(canon_src.to_string()),
-                        SqlValue::Text(canon_tgt.to_string()),
-                        SqlValue::Text(edge.relation.to_string()),
-                        SqlValue::Float(edge.weight),
-                        SqlValue::Integer(now.timestamp_micros()),
-                        match metadata_str {
-                            Some(m) => SqlValue::Text(m),
-                            None => SqlValue::Null,
-                        },
-                        SqlValue::Text(namespace.clone()),
-                        SqlValue::Text(id.to_string()),
-                    ],
-                    label: Some("atomic-update-edge-inplace".to_string()),
-                },
+                statement: edge_symmetric_update_inplace_statement(
+                    &namespace,
+                    id,
+                    canon_src,
+                    canon_tgt,
+                    edge.relation,
+                    edge.weight,
+                    now.timestamp_micros(),
+                    metadata_str.as_deref(),
+                ),
                 guard: Some(AffectedRowGuard::exactly(1)),
             });
         }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -167,19 +167,53 @@ fn purge_index_row_statement(
     }
 }
 
+/// `true` iff a table named `table` currently exists in the backing SQLite
+/// database (`sqlite_master` probe, read-only — safe in async prepare, does
+/// NOT open/create the vector store, so it cannot lazily create the table
+/// itself).
+async fn vector_table_exists(runtime: &KhiveRuntime, table: &str) -> RuntimeResult<bool> {
+    let mut reader = runtime
+        .sql()
+        .reader()
+        .await
+        .map_err(RuntimeError::Storage)?;
+    let row = reader
+        .query_scalar(SqlStatement {
+            sql: "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1".to_string(),
+            params: vec![SqlValue::Text(table.to_string())],
+            label: Some("atomic-delete-vec-table-exists".to_string()),
+        })
+        .await
+        .map_err(RuntimeError::Storage)?;
+    Ok(row.is_some())
+}
+
 /// Append the FTS + every registered model's vector-row purge for `subject_id`
 /// (scoped to the RECORD's own namespace, matching `delete_entity`/
 /// `delete_note`'s `record_tok`/`record_ns` convention — NOT the caller
 /// token's namespace, ADR-007 rule 2 by-ID namespace-agnosticism) onto
 /// `statements`.
-fn push_index_purge_statements(
+///
+/// FTS tables (`fts_entities`/`fts_notes`) always exist (created at schema
+/// migration time) so their purge is unconditional. `vec_*` tables are
+/// created LAZILY on first vector-store open (`vectors_for_model` ->
+/// `CREATE VIRTUAL TABLE IF NOT EXISTS`, khive-db backend.rs) — a default
+/// runtime registers embedding models before any vector table necessarily
+/// exists, so a raw unconditional `DELETE FROM vec_*` can hit `no such
+/// table` on a fresh DB (codex r2 Blocker 1). Only push the vec purge for
+/// tables that actually exist: absence means the record definitionally has
+/// no vector row for that model, so skipping is data-parity-correct (the
+/// non-atomic path would lazily create the table then delete zero rows —
+/// same DATA outcome, the only difference is an init side-effect this
+/// read-only prepare pass must not perform).
+async fn push_index_purge_statements(
     runtime: &KhiveRuntime,
     statements: &mut Vec<PlanStatement>,
     fts_table: &str,
     namespace: &str,
     subject_id: Uuid,
     label_prefix: &str,
-) {
+) -> RuntimeResult<()> {
     statements.push(purge_index_row_statement(
         fts_table,
         namespace,
@@ -187,13 +221,16 @@ fn push_index_purge_statements(
         &format!("{label_prefix}-purge-fts"),
     ));
     for vec_table in vector_table_names(runtime) {
-        statements.push(purge_index_row_statement(
-            &vec_table,
-            namespace,
-            subject_id,
-            &format!("{label_prefix}-purge-vec-{vec_table}"),
-        ));
+        if vector_table_exists(runtime, &vec_table).await? {
+            statements.push(purge_index_row_statement(
+                &vec_table,
+                namespace,
+                subject_id,
+                &format!("{label_prefix}-purge-vec-{vec_table}"),
+            ));
+        }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -454,14 +491,30 @@ async fn prepare_delete(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    match runtime.resolve_by_id(token, id).await? {
+    // codex r2 High finding 2: `delete(id, hard=true)` is the public purge
+    // route AFTER a prior soft delete (operations.rs hard-delete resolves
+    // INCLUDING already-tombstoned rows). Live-only `resolve_by_id` would
+    // never find an already-soft-deleted record, so hard delete must resolve
+    // through the including-deleted variant; soft delete keeps the live-only
+    // resolve (a soft delete of an already-tombstoned row is a no-op,
+    // matching non-atomic behavior).
+    let resolved = if hard {
+        runtime.resolve_by_id_including_deleted(token, id).await?
+    } else {
+        runtime.resolve_by_id(token, id).await?
+    };
+
+    match resolved {
         Some(Resolved::Entity(entity)) => {
             let namespace = entity.namespace.clone();
             let mut statements = if hard {
+                // Storage parity with the non-atomic hard-delete DML
+                // (entity.rs `DELETE FROM entities WHERE id = ?1`, no
+                // `deleted_at` predicate) — purges live AND already-tombstoned
+                // rows alike.
                 vec![PlanStatement {
                     statement: SqlStatement {
-                        sql: "DELETE FROM entities WHERE id = ?1 AND deleted_at IS NULL"
-                            .to_string(),
+                        sql: "DELETE FROM entities WHERE id = ?1".to_string(),
                         params: vec![SqlValue::Text(id.to_string())],
                         label: Some("atomic-delete-entity-hard".to_string()),
                     },
@@ -492,7 +545,9 @@ async fn prepare_delete(
             }
             // FTS + vector index purge (operations.rs delete_entity parity,
             // codex REJECT Blocker 1): both soft AND hard delete clean
-            // indexes; only hard additionally cascades edges above.
+            // indexes (hard delete of an already-tombstoned record must
+            // still purge indexes — Finding 2); only hard additionally
+            // cascades edges above.
             push_index_purge_statements(
                 runtime,
                 &mut statements,
@@ -500,7 +555,8 @@ async fn prepare_delete(
                 &namespace,
                 id,
                 "atomic-delete-entity",
-            );
+            )
+            .await?;
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -509,9 +565,13 @@ async fn prepare_delete(
         Some(Resolved::Note(note)) => {
             let namespace = note.namespace.clone();
             let mut statements = if hard {
+                // Storage parity with the non-atomic hard-delete DML
+                // (note.rs `DELETE FROM notes WHERE id = ?1`, no
+                // `deleted_at` predicate) — purges live AND already-tombstoned
+                // rows alike.
                 vec![PlanStatement {
                     statement: SqlStatement {
-                        sql: "DELETE FROM notes WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                        sql: "DELETE FROM notes WHERE id = ?1".to_string(),
                         params: vec![SqlValue::Text(id.to_string())],
                         label: Some("atomic-delete-note-hard".to_string()),
                     },
@@ -546,7 +606,9 @@ async fn prepare_delete(
             }
             // FTS + vector index purge (operations.rs delete_note parity,
             // codex REJECT Blocker 1): both soft AND hard delete clean
-            // indexes; only hard additionally cascades edges above.
+            // indexes (hard delete of an already-tombstoned record must
+            // still purge indexes — Finding 2); only hard additionally
+            // cascades edges above.
             push_index_purge_statements(
                 runtime,
                 &mut statements,
@@ -554,7 +616,8 @@ async fn prepare_delete(
                 &namespace,
                 id,
                 "atomic-delete-note",
-            );
+            )
+            .await?;
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -1173,5 +1236,231 @@ mod tests {
                 "inferred dependency_kind for (service, service) must persist: {json_str}"
             );
         }
+    }
+
+    /// B3 fix round 3 (codex r2 Blocker 1): atomic delete of an entity AND a
+    /// note must SUCCEED even when the registered embedding model's `vec_*`
+    /// table has never been lazily created (a fresh DB registers models
+    /// before any vector store is opened) — the raw purge DML must skip
+    /// tables that don't exist rather than hit `no such table` and roll
+    /// back the whole atomic unit. FTS purge still fires (those tables
+    /// always exist) and the delete itself is a clean commit.
+    #[tokio::test]
+    async fn atomic_delete_succeeds_when_vec_table_never_created() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        // Seed via raw upsert ONLY — never call reindex_entity/reindex_note
+        // or vectors_for_model, so the stub model's `vec_*` table is never
+        // lazily created (opening the vector store is what creates it).
+        let entity = khive_storage::Entity::new("local", "concept", "no-vec-table-entity");
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity)
+            .await
+            .expect("seed entity");
+
+        let mut note = khive_storage::note::Note::new("local", "observation", "no-vec-table-note");
+        note.name = Some("no-vec-table-note".to_string());
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed note");
+
+        for (id, kind) in [(entity_id, "entity"), (note_id, "note")] {
+            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}))
+                .await
+                .unwrap_or_else(|e| panic!("prepare delete ({kind}) must not fail: {e}"));
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("atomic delete ({kind}) must not hit `no such table`: {e}")
+                });
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected a clean commit ({kind}): {outcome:?}"
+            );
+        }
+
+        assert!(
+            runtime
+                .get_entity_including_deleted(&token, entity_id)
+                .await
+                .expect("get entity")
+                .expect("entity row still present (soft delete)")
+                .deleted_at
+                .is_some(),
+            "entity must be soft-deleted"
+        );
+        assert!(
+            runtime
+                .get_note_including_deleted(&token, note_id)
+                .await
+                .expect("get note")
+                .expect("note row still present (soft delete)")
+                .deleted_at
+                .is_some(),
+            "note must be soft-deleted"
+        );
+    }
+
+    /// B3 fix round 3 (codex r2 High finding 2): atomic hard delete must be
+    /// able to purge a record that was ALREADY soft-deleted — parity with
+    /// `delete(id, hard=true)` being the public purge route after a prior
+    /// soft delete (the non-atomic hard path resolves including deleted
+    /// rows and its DML carries no `deleted_at` predicate).
+    #[tokio::test]
+    async fn atomic_hard_delete_purges_already_soft_deleted_entity_and_note() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        let entity =
+            khive_storage::Entity::new("local", "concept", "tombstoned-entity-hard-delete");
+        let entity_id = entity.id;
+        runtime
+            .entities(&token)
+            .expect("entities store")
+            .upsert_entity(entity.clone())
+            .await
+            .expect("seed entity");
+        runtime
+            .reindex_entity(&token, &entity)
+            .await
+            .expect("seed index rows");
+
+        let mut note =
+            khive_storage::note::Note::new("local", "observation", "tombstoned-note-hard-delete");
+        note.name = Some("tombstoned-note-hard-delete".to_string());
+        let note_id = note.id;
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .upsert_note(note.clone())
+            .await
+            .expect("seed note");
+        runtime
+            .reindex_note(&token, &note)
+            .await
+            .expect("seed index rows");
+
+        // First: SOFT delete both (via atomic prepare) so they're tombstoned
+        // going into the hard-delete attempt below.
+        for id in [entity_id, note_id] {
+            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}))
+                .await
+                .expect("prepare soft delete");
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("soft delete commit");
+            assert!(matches!(
+                outcome,
+                crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+            ));
+        }
+        assert!(
+            runtime
+                .get_entity_including_deleted(&token, entity_id)
+                .await
+                .expect("get entity")
+                .expect("entity present")
+                .deleted_at
+                .is_some(),
+            "entity must be soft-deleted before the hard-delete attempt"
+        );
+        assert!(
+            runtime
+                .get_note_including_deleted(&token, note_id)
+                .await
+                .expect("get note")
+                .expect("note present")
+                .deleted_at
+                .is_some(),
+            "note must be soft-deleted before the hard-delete attempt"
+        );
+
+        // Now: HARD delete the already-tombstoned records.
+        for (id, kind) in [(entity_id, "entity"), (note_id, "note")] {
+            let plan = prepare_delete(
+                &runtime,
+                &token,
+                &json!({"id": id.to_string(), "hard": true}),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "prepare hard delete ({kind}) of an already-soft-deleted record \
+                         must resolve it: {e}"
+                )
+            });
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .unwrap_or_else(|e| panic!("hard delete ({kind}) commit failed: {e}"));
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected a clean hard-delete commit ({kind}): {outcome:?}"
+            );
+        }
+
+        assert!(
+            runtime
+                .get_entity_including_deleted(&token, entity_id)
+                .await
+                .expect("get entity")
+                .is_none(),
+            "entity row must be fully purged after hard delete"
+        );
+        assert!(
+            runtime
+                .get_note_including_deleted(&token, note_id)
+                .await
+                .expect("get note")
+                .is_none(),
+            "note row must be fully purged after hard delete"
+        );
+        assert!(
+            runtime
+                .text(&token)
+                .expect("text store")
+                .get_document("local", entity_id)
+                .await
+                .expect("get_document")
+                .is_none(),
+            "entity FTS row must be purged after hard delete"
+        );
+        assert!(
+            runtime
+                .text_for_notes(&token)
+                .expect("text store")
+                .get_document("local", note_id)
+                .await
+                .expect("get_document")
+                .is_none(),
+            "note FTS row must be purged after hard delete"
+        );
+        let vec_store = runtime
+            .vectors_for_model(&token, STUB_MODEL)
+            .expect("vec store");
+        assert_eq!(
+            vec_store.count().await.expect("count after"),
+            0,
+            "vector rows for both records must be purged after hard delete"
+        );
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -44,7 +44,8 @@ use khive_storage::{EdgeRelation, SqlStatement};
 use khive_types::{EventKind, SubstrateKind};
 
 use crate::atomic_plan::{
-    AffectedRowGuard, DeletePlan, LinkPlan, MergePlan, PlanStatement, PostCommitEffect, UpdatePlan,
+    AffectedRowGuard, DeletePlan, EdgeNaturalKey, LinkPlan, MergePlan, PlanStatement,
+    PostCommitEffect, UpdatePlan,
 };
 use crate::atomic_runner::AtomicOpPlan;
 use crate::error::{RuntimeError, RuntimeResult};
@@ -60,8 +61,7 @@ use khive_db::stores::entity::{
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::graph::{
     edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
-    edge_soft_delete_statement, edge_symmetric_conflict_probe_statement,
-    edge_symmetric_delete_if_conflict_statement,
+    edge_soft_delete_statement, edge_symmetric_delete_if_conflict_statement,
     edge_symmetric_refresh_or_update_inplace_statement, edge_upsert_statement,
     purge_incident_edges_statement,
 };
@@ -640,6 +640,7 @@ pub async fn prepare_update(
                 target_id: id,
                 statements,
                 post_commit,
+                edge_natural_key: None,
             }))
         }
         Some(Resolved::Note(note)) => {
@@ -699,6 +700,7 @@ pub async fn prepare_update(
                     guard: Some(AffectedRowGuard::exactly(1)),
                 }],
                 post_commit,
+                edge_natural_key: None,
             }))
         }
         Some(_) => Err(RuntimeError::InvalidInput(format!(
@@ -757,12 +759,13 @@ pub async fn prepare_update(
 ///   [`edge_symmetric_refresh_or_update_inplace_statement`] — each carries
 ///   its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
 ///   conflict condition fresh inside the transaction, so the write is
-///   correct regardless of what this prepare-time probe returns. The probe
-///   itself is kept, but demoted to computing `surviving_id` only — a pure
-///   informational value used for this plan's `target_id` (post-commit
-///   result rendering), not a write-correctness input; see the inline
-///   comment at its call site for the (vanishingly rare, informational-only)
-///   residual staleness this leaves.
+///   correct regardless of prepare-time state. ADR-099 B3 r9 (codex r8
+///   Blocker finding 1) removed the prepare-time conflict probe entirely —
+///   this function no longer reads any state to guess a surviving id; the
+///   plan instead carries `edge_natural_key` (the plain canonicalized
+///   endpoints/relation this update targets), letting a post-commit caller
+///   derive the actual surviving id from the committed row, never from a
+///   value computed before the rest of this atomic unit has even run.
 async fn prepare_update_edge(
     runtime: &KhiveRuntime,
     id: Uuid,
@@ -813,7 +816,7 @@ async fn prepare_update_edge(
     let now = chrono::Utc::now();
 
     let mut statements: Vec<PlanStatement> = Vec::new();
-    let mut surviving_id = id;
+    let mut edge_natural_key: Option<EdgeNaturalKey> = None;
 
     if edge.relation.is_symmetric() {
         // ADR-099 B3 r7 (codex r7 High finding 3): the WRITE for a symmetric
@@ -859,38 +862,16 @@ async fn prepare_update_edge(
             guard: Some(AffectedRowGuard::exactly(1)),
         });
 
-        // `surviving_id` here is advisory only, used solely for this plan's
-        // `target_id` (post-commit result rendering — a pure informational
-        // READ, not a write-correctness concern; see this function's doc
-        // comment). A best-effort probe is enough for it: if an intra-batch
-        // race (vanishingly rare — it requires a SECOND op in this SAME
-        // atomic unit to touch this exact symmetric edge's natural key
-        // between this probe and commit) makes it stale, the two statements
-        // above still write to the CORRECT row regardless of what this
-        // probe returns; only the post-commit result payload could, in that
-        // exact race, echo back the pre-collision row's content.
-        let mut reader = runtime
-            .sql()
-            .reader()
-            .await
-            .map_err(RuntimeError::Storage)?;
-        let conflict_id = reader
-            .query_scalar(edge_symmetric_conflict_probe_statement(
-                &namespace,
-                canon_src,
-                canon_tgt,
-                edge.relation,
-                id,
-            ))
-            .await
-            .map_err(RuntimeError::Storage)?
-            .and_then(|v| match v {
-                SqlValue::Text(s) => Uuid::parse_str(&s).ok(),
-                _ => None,
-            });
-        if let Some(existing_id) = conflict_id {
-            surviving_id = existing_id;
-        }
+        // No prepare-time read needed: the two statements above are
+        // self-guarding at commit time (see their doc comment). Post-commit
+        // result rendering derives the actual surviving id from THIS
+        // natural key, never from a value computed here.
+        edge_natural_key = Some(EdgeNaturalKey {
+            namespace: namespace.clone(),
+            canon_source_id: canon_src,
+            canon_target_id: canon_tgt,
+            relation: edge.relation,
+        });
     } else {
         // Non-symmetric: bit-for-bit the same builder `graph.upsert_edge`
         // calls — see doc comment above.
@@ -915,9 +896,10 @@ async fn prepare_update_edge(
     )?);
 
     Ok(AtomicOpPlan::Update(UpdatePlan {
-        target_id: surviving_id,
+        target_id: id,
         statements,
         post_commit: PostCommitEffect::None,
+        edge_natural_key,
     }))
 }
 
@@ -2690,10 +2672,25 @@ mod tests {
         )
         .await
         .expect("prepare update edge (symmetric conflict)");
-        // The plan must target the SURVIVING (canonical) row, not the
-        // requested one — mirrors `update_edge`'s `edge = self.get_edge(&record_tok, surviving_uuid)`.
+        // ADR-099 B3 r9: the plan no longer computes a prepare-time
+        // advisory surviving id (`target_id` is just the requested id) —
+        // it carries `edge_natural_key` so a post-commit caller can derive
+        // the real surviving id itself. Assert the plan carries the RIGHT
+        // natural key to look up; the actual surviving row's identity is
+        // verified against the DB after commit, below.
+        let (canon_src, canon_tgt) =
+            canonical_edge_endpoints(EdgeRelation::CompetesWith, a_id, b_id);
         match &plan {
-            AtomicOpPlan::Update(p) => assert_eq!(p.target_id, canonical_id),
+            AtomicOpPlan::Update(p) => {
+                assert_eq!(p.target_id, requested_id);
+                let key = p
+                    .edge_natural_key
+                    .as_ref()
+                    .expect("symmetric edge update must carry edge_natural_key");
+                assert_eq!(key.canon_source_id, canon_src);
+                assert_eq!(key.canon_target_id, canon_tgt);
+                assert_eq!(key.relation, EdgeRelation::CompetesWith);
+            }
             other => panic!("expected an Update plan, got {other:?}"),
         }
 
@@ -2733,6 +2730,102 @@ mod tests {
         let events =
             events_for_target(&runtime, &token, requested_id, EventKind::EdgeUpdated).await;
         assert_eq!(events.len(), 1);
+    }
+
+    /// ADR-099 B3 r9 (codex r8 Blocker finding 1): the same-unit race codex
+    /// named — `[delete(X), update(X -> competes_with)]` where an
+    /// ALREADY-EXISTING canonical row sits at the post-update natural key.
+    /// Both ops' async prepare passes run before either commits, so at
+    /// prepare time `X` still exists and both plans build. At commit time
+    /// `delete(X)` removes it FIRST; `update(X -> competes_with)`'s own
+    /// commit-time statements must then fail loud (its target no longer
+    /// exists) rather than silently absorbing into the pre-existing
+    /// canonical row it never causally touched. The whole atomic unit must
+    /// roll back — parity with canonical `update_edge`'s `NotFound` for a
+    /// missing edge, expressed here as the unit-level abort ADR-099
+    /// specifies for any op whose commit-time guard fails.
+    #[tokio::test]
+    async fn atomic_update_edge_symmetric_same_unit_delete_race_aborts_the_unit() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+        let a = khive_storage::Entity::new("local", "concept", "GapEdgeRaceA");
+        let b = khive_storage::Entity::new("local", "concept", "GapEdgeRaceB");
+        let (a_id, b_id) = (a.id, b.id);
+        entities.upsert_entity(a).await.expect("seed a");
+        entities.upsert_entity(b).await.expect("seed b");
+
+        // The row op 1 will try to update — deleted by op 0 in the SAME unit.
+        let requested_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::Extends, 0.2, None)
+            .await
+            .expect("seed requested edge");
+        let requested_id = Uuid::from(requested_edge.id);
+
+        // The pre-existing canonical row the buggy `id = ?2 OR natural-key`
+        // predicate used to silently absorb into.
+        let canonical_edge = runtime
+            .link(&token, a_id, b_id, EdgeRelation::CompetesWith, 0.6, None)
+            .await
+            .expect("seed canonical edge");
+        let canonical_id = Uuid::from(canonical_edge.id);
+
+        let delete_plan = prepare_delete(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "hard": true}),
+            None,
+        )
+        .await
+        .expect("prepare delete edge");
+        let update_plan = prepare_update(
+            &runtime,
+            &token,
+            &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+            None,
+        )
+        .await
+        .expect("prepare update edge (both prepares run before either commits)");
+
+        let outcome = crate::atomic_runner::run_atomic_unit(
+            runtime.sql().as_ref(),
+            vec![delete_plan, update_plan],
+        )
+        .await
+        .expect("the seam call itself must not error — the unit rolls back cleanly");
+        match outcome {
+            crate::atomic_runner::AtomicRunOutcome::RolledBack {
+                failed_op_index, ..
+            } => {
+                assert_eq!(
+                    failed_op_index, 1,
+                    "op 1 (the update) must be the one whose guard fails"
+                );
+            }
+            other => panic!("expected the whole unit to roll back, got {other:?}"),
+        }
+
+        // Whole-unit rollback: op 0's delete must be undone too.
+        let requested_after = runtime
+            .get_edge(&token, requested_id)
+            .await
+            .expect("get_edge");
+        assert!(
+            requested_after.is_some(),
+            "delete(X) must have rolled back along with the failed update"
+        );
+        // The pre-existing canonical row must be completely untouched.
+        let canonical_after = runtime
+            .get_edge(&token, canonical_id)
+            .await
+            .expect("get_edge")
+            .expect("canonical row must still be present");
+        assert_eq!(
+            canonical_after.weight, 0.6,
+            "the pre-existing canonical row must never have been touched by the aborted update"
+        );
     }
 
     /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `update`

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -81,26 +81,82 @@ fn optional_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
     obj(args).ok()?.get(key).and_then(|v| v.as_str())
 }
 
-/// Three-way patch semantics for a nullable string field (mirrors
-/// `khive-pack-kg::handlers::common::optional_string_patch`, reimplemented
-/// here rather than imported — that module is `pub(crate)` to a sibling
-/// crate with no dependency edge back to `khive-runtime`):
-/// key absent -> `None` (leave unchanged); key present and JSON `null` ->
-/// `Some(None)` (clear); key present and a string -> `Some(Some(s))` (set).
+/// Nullable-string patch semantics (ADR-099 B3 fix round 5, finding 2 —
+/// codex r3 REJECT). Mirrors the *actually reachable* behavior of
+/// `khive-pack-kg::handlers::common::optional_string_patch`/
+/// `description_patch`, reimplemented here rather than imported (that
+/// module is `pub(crate)` to a sibling crate with no dependency edge back to
+/// `khive-runtime`). Canonical's field type is `Option<Value>`
+/// (`UpdateParams.name`/`.description`); serde_json's derived
+/// `Deserialize` for `Option<T>` intercepts a literal JSON `null` at the
+/// OUTER Option boundary and maps it straight to Rust `None` — REGARDLESS
+/// of the inner type `T` — so canonical's own `Some(Value::Null) =>
+/// Ok(Some(None))` "clear" arm is unreachable through normal struct
+/// deserialization (empirically verified against the live `handle_update`:
+/// `update(name=null)` / `update(description=null)` are no-ops, not
+/// clears). This module reads raw, un-deserialized JSON, so it must
+/// replicate that collapse explicitly: key absent OR JSON `null` -> `None`
+/// (leave unchanged, no-op); key present as a string -> `Some(Some(s))`
+/// (set); any other JSON type -> a hard error (canonical's still-reachable
+/// non-null-non-string rejection).
 fn optional_string_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<String>>> {
     match obj(args)?.get(key) {
-        None => Ok(None),
-        Some(Value::Null) => Ok(Some(None)),
+        None | Some(Value::Null) => Ok(None),
         Some(Value::String(s)) => Ok(Some(Some(s.clone()))),
-        Some(_) => Err(RuntimeError::InvalidInput(format!(
-            "{key} must be a string or null"
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "{key} must be a string or null, got: {other}"
         ))),
     }
 }
 
+/// Strict string-or-absent-or-null patch for entity `name` (ADR-099 B3 fix
+/// round 5, finding 1 of codex r3's High finding 2 — the actual violation:
+/// `optional_str`'s `.as_str()` silently drops a non-string, non-null value
+/// like `name: 123` as absent, reporting success for an invalid update.
+/// Canonical validates entity `name` via `string_value` (common.rs:819) on
+/// `UpdateParams.name: Option<Value>` — null collapses to absent at the
+/// struct-deserialize boundary (see `optional_string_patch` doc above), so
+/// `string_value`'s reachable behavior is: absent/null -> unchanged;
+/// non-null string -> set; any other JSON type -> hard error. This mirrors
+/// exactly that, reading raw JSON instead of a deserialized struct.
+fn entity_name_patch(args: &Value) -> RuntimeResult<Option<String>> {
+    match obj(args)?.get("name") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(other) => Err(RuntimeError::InvalidInput(format!(
+            "name must be a string, got: {other}"
+        ))),
+    }
+}
+
+/// Nullable-JSON-value patch for `properties` (ADR-099 B3 fix round 5,
+/// finding 2): canonical `properties: Option<Value>` on `UpdateParams`
+/// collapses a literal JSON `null` to Rust `None` at the struct-deserialize
+/// boundary (same gotcha as `optional_string_patch` above), so
+/// `properties=null` is canonically a no-op (leave existing properties
+/// unchanged) — NOT a stored JSON `null`. This module reads raw JSON, so it
+/// must replicate that collapse: key absent OR JSON `null` -> `None` (no
+/// merge); any other JSON value -> `Some(value)` (merge), matching
+/// canonical's un-typed pass-through (no further shape validation at this
+/// layer either way).
+fn optional_properties(args: &Value, key: &str) -> RuntimeResult<Option<Value>> {
+    match obj(args)?.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => Ok(Some(v.clone())),
+    }
+}
+
+/// `tags` patch (ADR-099 B3 fix round 5, finding 2): canonical
+/// `tags: Option<Vec<String>>` on `UpdateParams` collapses a literal JSON
+/// `null` to Rust `None` at the struct-deserialize boundary (same gotcha),
+/// so `tags=null` is canonically a no-op (leave existing tags unchanged) —
+/// the pre-fix version of this function instead ERRORED on null, which is
+/// the exact divergence codex flagged. A non-array, non-null value is still
+/// a hard error (mirrors the type failure `UpdateParams` deserialization
+/// would itself produce for a malformed `tags`).
 fn optional_tags(args: &Value) -> RuntimeResult<Option<Vec<String>>> {
     match obj(args)?.get("tags") {
-        None => Ok(None),
+        None | Some(Value::Null) => Ok(None),
         Some(Value::Array(items)) => {
             let mut tags = Vec::with_capacity(items.len());
             for item in items {
@@ -347,7 +403,16 @@ pub async fn prepare_op(
 ) -> RuntimeResult<AtomicOpPlan> {
     match tool {
         "update" => prepare_update(runtime, token, args).await,
-        "delete" => prepare_delete(runtime, token, args).await,
+        // `expected_kind: None` here — callers that need `delete(kind=...)`
+        // parity (ADR-099 B3 fix round 5, finding 1) must resolve the kind
+        // spec themselves (it needs a `VerbRegistry`, unreachable from this
+        // crate — see `AtomicDeleteKind`'s doc comment) and call
+        // `prepare_delete` directly with the resolved value; `kkernel`'s
+        // `--atomic` seam does exactly this and bypasses this dispatch arm
+        // for "delete". A caller reaching `prepare_op("delete", ...)`
+        // without going through that seam gets kind-unchecked behavior,
+        // same as before this fix round.
+        "delete" => prepare_delete(runtime, token, args, None).await,
         "link" => prepare_link(runtime, token, args).await,
         "merge" => prepare_merge(runtime, token, args).await,
         "propose" | "review" | "withdraw" => prepare_governance_unimplemented(tool),
@@ -468,9 +533,9 @@ async fn prepare_update(
     match runtime.resolve_by_id(token, id).await? {
         Some(Resolved::Entity(entity)) => {
             reject_inapplicable_update_fields(args, "entity")?;
-            let name = optional_str(args, "name").map(|s| s.to_string());
+            let name = entity_name_patch(args)?;
             let description = optional_string_patch(args, "description")?;
-            let properties = obj(args)?.get("properties").cloned();
+            let properties = optional_properties(args, "properties")?;
             let tags = optional_tags(args)?;
 
             if let Some(ref n) = name {
@@ -580,7 +645,7 @@ async fn prepare_update(
             reject_inapplicable_update_fields(args, "note")?;
             let name = optional_string_patch(args, "name")?;
             let content = optional_str(args, "content").map(|s| s.to_string());
-            let properties = obj(args)?.get("properties").cloned();
+            let properties = optional_properties(args, "properties")?;
             let salience = optional_f64(args, "salience")?;
             let decay_factor = optional_f64(args, "decay_factor")?;
 
@@ -692,10 +757,35 @@ async fn prepare_update(
 // delete
 // ---------------------------------------------------------------------------
 
-async fn prepare_delete(
+/// Caller-supplied delete-kind expectation, resolved via the canonical
+/// `resolve_kind_spec` at the kkernel `--atomic` seam (ADR-099 B3 fix round
+/// 5, finding 1 — codex r3 REJECT Blocker). `khive-runtime` must not depend
+/// on `khive-pack-kg` (packs depend on the runtime, not the other way
+/// around), so this is a plain substrate-level shape rather than
+/// `khive_pack_kg::handlers::KindSpec` itself: the kkernel seam does the
+/// pack-aware `resolve_kind_spec` resolution (which needs a `VerbRegistry`,
+/// unreachable from this crate) and passes down only what `prepare_delete`
+/// needs to enforce the mismatch check. `KindSpec::Edge`/`Event`/`Proposal`
+/// are rejected at the kkernel seam BEFORE `prepare_delete` is ever called
+/// — those substrates are not v1-admissible for atomic delete (this enum
+/// intentionally has no variant for them, so a rejected kind can never be
+/// constructed here).
+pub enum AtomicDeleteKind {
+    Entity { specific: Option<String> },
+    Note { specific: Option<String> },
+}
+
+/// `expected_kind`: `None` when the caller omitted `kind` (no check, parity
+/// with canonical's own optional discriminator); `Some(_)` enforces an
+/// exact-parity mismatch check against the resolved record's actual
+/// substrate/specific kind (ADR-099 B3 fix round 5, finding 1), mirroring
+/// `handle_delete`'s `entity.kind != *expected` / `note.kind != *expected`
+/// checks (update.rs:319, :348).
+pub async fn prepare_delete(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     args: &Value,
+    expected_kind: Option<AtomicDeleteKind>,
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
     let hard = obj(args)?
@@ -718,6 +808,20 @@ async fn prepare_delete(
 
     match resolved {
         Some(Resolved::Entity(entity)) => {
+            match &expected_kind {
+                None => {}
+                Some(AtomicDeleteKind::Entity {
+                    specific: Some(expected),
+                }) => {
+                    if &entity.kind != expected {
+                        return Err(RuntimeError::NotFound(format!("{expected} {id}")));
+                    }
+                }
+                Some(AtomicDeleteKind::Entity { specific: None }) => {}
+                Some(AtomicDeleteKind::Note { .. }) => {
+                    return Err(RuntimeError::NotFound(format!("note {id}")));
+                }
+            }
             let namespace = entity.namespace.clone();
             let mut statements = if hard {
                 // Storage parity with the non-atomic hard-delete DML
@@ -790,6 +894,20 @@ async fn prepare_delete(
             }))
         }
         Some(Resolved::Note(note)) => {
+            match &expected_kind {
+                None => {}
+                Some(AtomicDeleteKind::Note {
+                    specific: Some(expected),
+                }) => {
+                    if &note.kind != expected {
+                        return Err(RuntimeError::NotFound(format!("{expected} {id}")));
+                    }
+                }
+                Some(AtomicDeleteKind::Note { specific: None }) => {}
+                Some(AtomicDeleteKind::Entity { .. }) => {
+                    return Err(RuntimeError::NotFound(format!("entity {id}")));
+                }
+            }
             let namespace = note.namespace.clone();
             let mut statements = if hard {
                 // Storage parity with the non-atomic hard-delete DML
@@ -1422,6 +1540,7 @@ mod tests {
                 &runtime,
                 &token,
                 &json!({"id": note_id.to_string(), "hard": hard}),
+                None,
             )
             .await
             .expect("prepare delete");
@@ -1503,6 +1622,7 @@ mod tests {
                 &runtime,
                 &token,
                 &json!({"id": entity_id.to_string(), "hard": hard}),
+                None,
             )
             .await
             .expect("prepare delete");
@@ -1889,7 +2009,7 @@ mod tests {
             .expect("seed note");
 
         for (id, kind) in [(entity_id, "entity"), (note_id, "note")] {
-            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}))
+            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}), None)
                 .await
                 .unwrap_or_else(|e| panic!("prepare delete ({kind}) must not fail: {e}"));
             let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
@@ -1973,7 +2093,7 @@ mod tests {
         // First: SOFT delete both (via atomic prepare) so they're tombstoned
         // going into the hard-delete attempt below.
         for id in [entity_id, note_id] {
-            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}))
+            let plan = prepare_delete(&runtime, &token, &json!({"id": id.to_string()}), None)
                 .await
                 .expect("prepare soft delete");
             let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
@@ -2011,6 +2131,7 @@ mod tests {
                 &runtime,
                 &token,
                 &json!({"id": id.to_string(), "hard": true}),
+                None,
             )
             .await
             .unwrap_or_else(|e| {
@@ -2180,7 +2301,7 @@ mod tests {
             } else {
                 json!({"id": entity_id.to_string()})
             };
-            let plan = prepare_delete(&runtime, &token, &args)
+            let plan = prepare_delete(&runtime, &token, &args, None)
                 .await
                 .unwrap_or_else(|e| panic!("prepare delete (hard={hard}): {e}"));
             let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
@@ -2235,7 +2356,7 @@ mod tests {
             } else {
                 json!({"id": note_id.to_string()})
             };
-            let plan = prepare_delete(&runtime, &token, &args)
+            let plan = prepare_delete(&runtime, &token, &args, None)
                 .await
                 .unwrap_or_else(|e| panic!("prepare delete (hard={hard}): {e}"));
             let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -22,6 +22,19 @@
 //! faithful, non-stub atomic prepare for them is separate follow-on work.
 //! [`prepare_governance_unimplemented`] fails loudly, before any write,
 //! naming this as a known scope gap rather than silently no-opping.
+//!
+//! `merge` is likewise on the v1 admissible list but is deferred (B3 fix
+//! round, Leo refinement 2026-07-07): full-parity field folding, survivor
+//! index reindex, loser index purge, provenance, and same-kind rejection are
+//! achievable as static DML, but `curation::merge_entity_sql`'s graceful
+//! edge-conflict resolution is not (it is per-row procedural, incompatible
+//! with ADR-099 D1's static predicate/guard plan shape) — rather than ship a
+//! partially-scoped atomic merge, it is rejected at the same pre-runtime
+//! static guard as governance
+//! ([`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`]). `prepare_merge`
+//! below is therefore unreachable through `--atomic`; it remains only as the
+//! pre-fix-round direct-prepare implementation, exercised by this module's
+//! own tests, and as defense in depth.
 
 use serde_json::Value;
 use uuid::Uuid;
@@ -36,7 +49,8 @@ use crate::atomic_runner::AtomicOpPlan;
 use crate::curation::{merge_properties, EntityDedupMergePolicy};
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::{
-    canonical_edge_endpoints, validate_edge_metadata, validate_edge_weight, Resolved,
+    canonical_edge_endpoints, merge_dependency_kind, validate_edge_metadata, validate_edge_weight,
+    Resolved,
 };
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
@@ -117,6 +131,69 @@ fn properties_string(properties: &Option<Value>) -> Option<String> {
     properties
         .as_ref()
         .map(|v| serde_json::to_string(v).unwrap_or_default())
+}
+
+/// Every registered embedding model's vector table name, in the exact format
+/// `curation::merge_entity_sql` uses (`"vec_{sanitize_key(model_name)}"`) —
+/// reused here so atomic delete/merge purge the same tables the non-atomic
+/// paths do.
+fn vector_table_names(runtime: &KhiveRuntime) -> Vec<String> {
+    runtime
+        .registered_embedding_model_names()
+        .iter()
+        .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
+        .collect()
+}
+
+/// A guarded (`guard: None` — best-effort mirror, matching the non-atomic
+/// index-cleanup calls which don't assert a row existed) `DELETE` statement
+/// against one FTS or vector table for a single subject, scoped by namespace.
+fn purge_index_row_statement(
+    table: &str,
+    namespace: &str,
+    subject_id: Uuid,
+    label: &str,
+) -> PlanStatement {
+    PlanStatement {
+        statement: SqlStatement {
+            sql: format!("DELETE FROM {table} WHERE namespace = ?1 AND subject_id = ?2"),
+            params: vec![
+                SqlValue::Text(namespace.to_string()),
+                SqlValue::Text(subject_id.to_string()),
+            ],
+            label: Some(label.to_string()),
+        },
+        guard: None,
+    }
+}
+
+/// Append the FTS + every registered model's vector-row purge for `subject_id`
+/// (scoped to the RECORD's own namespace, matching `delete_entity`/
+/// `delete_note`'s `record_tok`/`record_ns` convention — NOT the caller
+/// token's namespace, ADR-007 rule 2 by-ID namespace-agnosticism) onto
+/// `statements`.
+fn push_index_purge_statements(
+    runtime: &KhiveRuntime,
+    statements: &mut Vec<PlanStatement>,
+    fts_table: &str,
+    namespace: &str,
+    subject_id: Uuid,
+    label_prefix: &str,
+) {
+    statements.push(purge_index_row_statement(
+        fts_table,
+        namespace,
+        subject_id,
+        &format!("{label_prefix}-purge-fts"),
+    ));
+    for vec_table in vector_table_names(runtime) {
+        statements.push(purge_index_row_statement(
+            &vec_table,
+            namespace,
+            subject_id,
+            &format!("{label_prefix}-purge-vec-{vec_table}"),
+        ));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -378,7 +455,8 @@ async fn prepare_delete(
         .unwrap_or(false);
 
     match runtime.resolve_by_id(token, id).await? {
-        Some(Resolved::Entity(_)) => {
+        Some(Resolved::Entity(entity)) => {
+            let namespace = entity.namespace.clone();
             let mut statements = if hard {
                 vec![PlanStatement {
                     statement: SqlStatement {
@@ -412,12 +490,24 @@ async fn prepare_delete(
                     guard: None,
                 });
             }
+            // FTS + vector index purge (operations.rs delete_entity parity,
+            // codex REJECT Blocker 1): both soft AND hard delete clean
+            // indexes; only hard additionally cascades edges above.
+            push_index_purge_statements(
+                runtime,
+                &mut statements,
+                "fts_entities",
+                &namespace,
+                id,
+                "atomic-delete-entity",
+            );
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
             }))
         }
-        Some(Resolved::Note(_)) => {
+        Some(Resolved::Note(note)) => {
+            let namespace = note.namespace.clone();
             let mut statements = if hard {
                 vec![PlanStatement {
                     statement: SqlStatement {
@@ -454,6 +544,17 @@ async fn prepare_delete(
                     guard: None,
                 });
             }
+            // FTS + vector index purge (operations.rs delete_note parity,
+            // codex REJECT Blocker 1): both soft AND hard delete clean
+            // indexes; only hard additionally cascades edges above.
+            push_index_purge_statements(
+                runtime,
+                &mut statements,
+                "fts_notes",
+                &namespace,
+                id,
+                "atomic-delete-note",
+            );
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
@@ -484,15 +585,50 @@ async fn prepare_link(
     let target_id = require_uuid(args, "target_id")?;
     let relation = parse_edge_relation(require_str(args, "relation")?)?;
     let weight = optional_f64(args, "weight")?.unwrap_or(1.0);
-    let metadata = obj(args)?.get("metadata").cloned();
+    let mut metadata = obj(args)?.get("metadata").cloned();
+
+    // Top-level `dependency_kind` param merges into `metadata` (codex REJECT
+    // High finding — link.rs handler's `merge_entry_metadata` parity): only
+    // fills the key when metadata doesn't already carry one. `link.rs` is a
+    // sibling-crate `pub(crate)` fn (no dependency edge back to
+    // khive-runtime), so this three-line merge is reimplemented here rather
+    // than imported — same pattern as `parse_merge_strategy` above.
+    if let Some(dk) = optional_str(args, "dependency_kind") {
+        let mut m = metadata.unwrap_or_else(|| serde_json::json!({}));
+        let map = m
+            .as_object_mut()
+            .ok_or_else(|| RuntimeError::InvalidInput("metadata must be a JSON object".into()))?;
+        map.entry("dependency_kind".to_string())
+            .or_insert_with(|| serde_json::json!(dk));
+        metadata = Some(m);
+    }
 
     validate_edge_weight(weight)?;
-    validate_edge_metadata(relation, metadata.as_ref())?;
     runtime
         .validate_edge_relation_endpoints(token, source_id, target_id, relation)
         .await?;
 
     let (canon_source, canon_target) = canonical_edge_endpoints(relation, source_id, target_id);
+
+    // Endpoint-kind `dependency_kind` inference for `depends_on` edges
+    // (codex REJECT High finding — operations.rs `link()` parity): only
+    // applies when both endpoints resolve as entities and the key is still
+    // absent after the top-level-param merge above. Runs against the
+    // CANONICAL endpoints, exactly mirroring `KhiveRuntime::link`'s own
+    // ordering (canonicalize, then infer).
+    if relation == EdgeRelation::DependsOn {
+        metadata = match (
+            runtime.resolve_edge_endpoint(token, canon_source).await?,
+            runtime.resolve_edge_endpoint(token, canon_target).await?,
+        ) {
+            (Some(Resolved::Entity(src_e)), Some(Resolved::Entity(tgt_e))) => {
+                merge_dependency_kind(&src_e.kind, &tgt_e.kind, metadata)
+            }
+            _ => metadata,
+        };
+    }
+
+    validate_edge_metadata(relation, metadata.as_ref())?;
     let edge_id = Uuid::new_v4();
     let namespace = token.namespace().as_str().to_string();
     let now = chrono::Utc::now().timestamp_micros();
@@ -537,6 +673,17 @@ async fn prepare_link(
 // merge (entity-only, ADR-099 B3 scope decision — see final report)
 // ---------------------------------------------------------------------------
 
+// NOTE (B3 fix round, Leo refinement 2026-07-07): full atomic-merge parity
+// (field folding, survivor FTS/vector reindex, loser index purge, merge
+// provenance, same-kind rejection) was drafted and unit-tested in this round,
+// but was reverted in favor of deferring atomic `merge` entirely at the
+// pre-runtime admissibility guard (`khive_types::pack::
+// ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`, alongside `propose`/`review`/`withdraw`)
+// — see the fix-round report for the full rationale. This function is
+// therefore back to its pre-fix-round shape: it still produces a plan (kept
+// for the existing direct-prepare test coverage below and as defense in
+// depth), but the CLI's `--atomic` surface never reaches it, since
+// `check_atomic_admissible` rejects `merge` before any runtime is built.
 async fn prepare_merge(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -784,5 +931,247 @@ mod tests {
             1,
             "post-commit reindex must have inserted a vector row for the stub model"
         );
+    }
+
+    /// B3 fix round (codex REJECT Blocker 1): atomic delete must purge the
+    /// note's FTS row and vector row for BOTH soft and hard delete — parity
+    /// with `KhiveRuntime::delete_note`'s index-cleanup contract.
+    #[tokio::test]
+    async fn atomic_delete_note_purges_fts_and_vector_indexes_soft_and_hard() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        for hard in [false, true] {
+            let mut note =
+                khive_storage::note::Note::new("local", "observation", "purge-target content");
+            note.name = Some(format!("purge-target-hard-{hard}"));
+            let note_id = note.id;
+            runtime
+                .notes(&token)
+                .expect("notes store")
+                .upsert_note(note.clone())
+                .await
+                .expect("seed note");
+            runtime
+                .reindex_note(&token, &note)
+                .await
+                .expect("seed index rows");
+
+            let vec_store = runtime
+                .vectors_for_model(&token, STUB_MODEL)
+                .expect("vec store");
+            assert_eq!(
+                vec_store.count().await.expect("count before"),
+                1,
+                "seeded note must have a vector row before delete (hard={hard})"
+            );
+            assert!(
+                runtime
+                    .text_for_notes(&token)
+                    .expect("text store")
+                    .get_document("local", note_id)
+                    .await
+                    .expect("get_document")
+                    .is_some(),
+                "seeded note must have an FTS row before delete (hard={hard})"
+            );
+
+            let plan = prepare_delete(
+                &runtime,
+                &token,
+                &json!({"id": note_id.to_string(), "hard": hard}),
+            )
+            .await
+            .expect("prepare delete");
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("seam call ok");
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected commit (hard={hard}): {outcome:?}"
+            );
+
+            assert!(
+                runtime
+                    .text_for_notes(&token)
+                    .expect("text store")
+                    .get_document("local", note_id)
+                    .await
+                    .expect("get_document")
+                    .is_none(),
+                "FTS row must be purged after atomic delete (hard={hard})"
+            );
+            assert_eq!(
+                vec_store.count().await.expect("count after"),
+                0,
+                "vector row must be purged after atomic delete (hard={hard})"
+            );
+        }
+    }
+
+    /// B3 fix round (codex REJECT Blocker 1): atomic delete must purge the
+    /// entity's FTS row and vector row for BOTH soft and hard delete — parity
+    /// with `KhiveRuntime::delete_entity`'s index-cleanup contract.
+    #[tokio::test]
+    async fn atomic_delete_entity_purges_fts_and_vector_indexes_soft_and_hard() {
+        let runtime = scratch_runtime();
+        runtime.register_embedder(StubProvider);
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        for hard in [false, true] {
+            let entity =
+                khive_storage::Entity::new("local", "concept", format!("purge-target-hard-{hard}"));
+            let entity_id = entity.id;
+            runtime
+                .entities(&token)
+                .expect("entities store")
+                .upsert_entity(entity.clone())
+                .await
+                .expect("seed entity");
+            runtime
+                .reindex_entity(&token, &entity)
+                .await
+                .expect("seed index rows");
+
+            let vec_store = runtime
+                .vectors_for_model(&token, STUB_MODEL)
+                .expect("vec store");
+            assert_eq!(
+                vec_store.count().await.expect("count before"),
+                1,
+                "seeded entity must have a vector row before delete (hard={hard})"
+            );
+            assert!(
+                runtime
+                    .text(&token)
+                    .expect("text store")
+                    .get_document("local", entity_id)
+                    .await
+                    .expect("get_document")
+                    .is_some(),
+                "seeded entity must have an FTS row before delete (hard={hard})"
+            );
+
+            let plan = prepare_delete(
+                &runtime,
+                &token,
+                &json!({"id": entity_id.to_string(), "hard": hard}),
+            )
+            .await
+            .expect("prepare delete");
+            let outcome = crate::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("seam call ok");
+            assert!(
+                matches!(
+                    outcome,
+                    crate::atomic_runner::AtomicRunOutcome::Committed { .. }
+                ),
+                "expected commit (hard={hard}): {outcome:?}"
+            );
+
+            assert!(
+                runtime
+                    .text(&token)
+                    .expect("text store")
+                    .get_document("local", entity_id)
+                    .await
+                    .expect("get_document")
+                    .is_none(),
+                "FTS row must be purged after atomic delete (hard={hard})"
+            );
+            assert_eq!(
+                vec_store.count().await.expect("count after"),
+                0,
+                "vector row must be purged after atomic delete (hard={hard})"
+            );
+        }
+    }
+
+    /// B3 fix round (codex REJECT High finding): atomic link must persist an
+    /// explicit top-level `dependency_kind` param into edge metadata, and
+    /// must infer one for `depends_on` edges when absent — parity with
+    /// `link.rs`'s `merge_entry_metadata` and `operations.rs`'s
+    /// `infer_dependency_kind` table.
+    #[tokio::test]
+    async fn atomic_link_persists_explicit_dependency_kind_and_infers_when_absent() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let entities = runtime.entities(&token).expect("entities store");
+
+        fn metadata_json(plan: &AtomicOpPlan) -> String {
+            let link_plan = match plan {
+                AtomicOpPlan::Link(p) => p,
+                other => panic!("expected an AtomicOpPlan::Link, got {other:?}"),
+            };
+            match link_plan.statement.statement.params.last() {
+                Some(SqlValue::Text(s)) => s.clone(),
+                other => panic!("expected the metadata param to be SqlValue::Text, got {other:?}"),
+            }
+        }
+
+        // (a) explicit top-level `dependency_kind` param persists in metadata.
+        {
+            let svc = khive_storage::Entity::new("local", "service", "SvcA");
+            let proj = khive_storage::Entity::new("local", "project", "ProjB");
+            let (svc_id, proj_id) = (svc.id, proj.id);
+            entities.upsert_entity(svc).await.expect("seed svc");
+            entities.upsert_entity(proj).await.expect("seed proj");
+
+            let plan = prepare_link(
+                &runtime,
+                &token,
+                &json!({
+                    "source_id": svc_id.to_string(),
+                    "target_id": proj_id.to_string(),
+                    "relation": "depends_on",
+                    "dependency_kind": "artifact",
+                }),
+            )
+            .await
+            .expect("prepare link");
+            let json_str = metadata_json(&plan);
+            assert!(
+                json_str.contains(r#""dependency_kind":"artifact""#),
+                "explicit dependency_kind param must persist: {json_str}"
+            );
+        }
+
+        // (b) `depends_on` with no explicit dependency_kind infers from
+        // endpoint kinds: (service, service) -> "runtime".
+        {
+            let svc_a = khive_storage::Entity::new("local", "service", "SvcC");
+            let svc_b = khive_storage::Entity::new("local", "service", "SvcD");
+            let (a_id, b_id) = (svc_a.id, svc_b.id);
+            entities.upsert_entity(svc_a).await.expect("seed svc a");
+            entities.upsert_entity(svc_b).await.expect("seed svc b");
+
+            let plan = prepare_link(
+                &runtime,
+                &token,
+                &json!({
+                    "source_id": a_id.to_string(),
+                    "target_id": b_id.to_string(),
+                    "relation": "depends_on",
+                }),
+            )
+            .await
+            .expect("prepare link");
+            let json_str = metadata_json(&plan);
+            assert!(
+                json_str.contains(r#""dependency_kind":"runtime""#),
+                "inferred dependency_kind for (service, service) must persist: {json_str}"
+            );
+        }
     }
 }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -59,10 +59,11 @@ use khive_db::stores::entity::{
 };
 use khive_db::stores::event::event_insert_statements;
 use khive_db::stores::graph::{
-    edge_hard_delete_statement, edge_soft_delete_statement,
-    edge_symmetric_conflict_probe_statement, edge_symmetric_delete_noncanonical_statement,
-    edge_symmetric_refresh_canonical_statement, edge_symmetric_update_inplace_statement,
-    edge_upsert_statement, purge_incident_edges_statement,
+    edge_hard_delete_statement, edge_insert_guarded_by_endpoints_statement,
+    edge_soft_delete_statement, edge_symmetric_conflict_probe_statement,
+    edge_symmetric_delete_if_conflict_statement,
+    edge_symmetric_refresh_or_update_inplace_statement, edge_upsert_statement,
+    purge_incident_edges_statement,
 };
 use khive_db::stores::note::{
     note_hard_delete_statement, note_soft_delete_statement, note_upsert_statement,
@@ -393,7 +394,17 @@ pub async fn prepare_op(
     args: &Value,
 ) -> RuntimeResult<AtomicOpPlan> {
     match tool {
-        "update" => prepare_update(runtime, token, args).await,
+        // `expected_kind: None` here — same reasoning as the `"delete"` arm
+        // immediately below: callers that need `update(kind=...)` parity
+        // (ADR-099 B3 r7, codex r7 Blocker finding 1) must resolve the kind
+        // spec themselves (it needs a `VerbRegistry`, unreachable from this
+        // crate — see `AtomicUpdateKind`'s doc comment) and call
+        // `prepare_update` directly with the resolved value; `kkernel`'s
+        // `--atomic` seam does exactly this and bypasses this dispatch arm
+        // for "update". A caller reaching `prepare_op("update", ...)`
+        // without going through that seam gets kind-unchecked behavior,
+        // same as delete's pre-existing arm.
+        "update" => prepare_update(runtime, token, args, None).await,
         // `expected_kind: None` here — callers that need `delete(kind=...)`
         // parity (ADR-099 B3 fix round 5, finding 1) must resolve the kind
         // spec themselves (it needs a `VerbRegistry`, unreachable from this
@@ -516,10 +527,32 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
     Ok(())
 }
 
-async fn prepare_update(
+/// Caller-supplied update-kind expectation, resolved via the canonical
+/// `resolve_kind_spec` at the kkernel `--atomic` seam — the exact same
+/// pattern [`AtomicDeleteKind`] uses (ADR-099 B3 r7, codex r7 Blocker
+/// finding 1: `update(kind="document", id=<concept>)` was canonically
+/// `NotFound` but the atomic path ignored the explicit kind and mutated the
+/// resolved entity anyway). `khive-runtime` must not depend on
+/// `khive-pack-kg`, so this is a plain substrate-level shape rather than
+/// `khive_pack_kg::handlers::KindSpec` itself — the kkernel seam does the
+/// pack-aware resolution and passes down only what `prepare_update` needs
+/// to enforce the mismatch check.
+pub enum AtomicUpdateKind {
+    Entity { specific: Option<String> },
+    Note { specific: Option<String> },
+    Edge,
+}
+
+/// `expected_kind`: `None` when the caller omitted `kind` (no check, parity
+/// with canonical's own optional discriminator); `Some(_)` enforces an
+/// exact-parity mismatch check against the resolved record's actual
+/// substrate/specific kind, mirroring `handle_update`'s
+/// `entity.kind != *k` / note kind checks (update.rs:200-201, :229-234).
+pub async fn prepare_update(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     args: &Value,
+    expected_kind: Option<AtomicUpdateKind>,
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
 
@@ -535,20 +568,25 @@ async fn prepare_update(
         ));
     }
 
-    // NOTE (GAP-4 scope, B3 fix round 4): update.rs also rejects a caller-
-    // supplied `kind=<specific>` that contradicts the resolved substrate's
-    // ACTUAL kind (update.rs:200-201, :229-234) with a `NotFound`. That
-    // check depends on `VerbRegistry::all_entity_kinds()`/
-    // `all_note_kinds()` (every loaded pack's granular vocab) and pack-
-    // private `EntityKind`/`NoteKind` parsing — neither is reachable from
-    // `khive-runtime` without either threading the registry through this
-    // call or duplicating pack-private vocab here, and no acceptance test
-    // in this fix round exercises it. Deferred, not silently dropped: the
-    // field-applicability rejection immediately below (the MAJOR-severity
-    // half of GAP-4 — a spurious no-op reported as success) is implemented
-    // in full.
     match runtime.resolve_by_id(token, id).await? {
-        Some(Resolved::Entity(_)) => {
+        Some(Resolved::Entity(entity)) => {
+            match &expected_kind {
+                None => {}
+                Some(AtomicUpdateKind::Entity {
+                    specific: Some(expected),
+                }) => {
+                    if &entity.kind != expected {
+                        return Err(RuntimeError::NotFound(format!("entity {id}")));
+                    }
+                }
+                Some(AtomicUpdateKind::Entity { specific: None }) => {}
+                Some(AtomicUpdateKind::Note { .. }) => {
+                    return Err(RuntimeError::NotFound(format!("note {id}")));
+                }
+                Some(AtomicUpdateKind::Edge) => {
+                    return Err(RuntimeError::NotFound(format!("edge {id}")));
+                }
+            }
             // Decide step lives in curation.rs's `prepare_update_entity` —
             // the SAME function canonical `update_entity` calls. Only the
             // arg-extraction (raw JSON -> `EntityPatch`) and the plan-shape
@@ -604,7 +642,24 @@ async fn prepare_update(
                 post_commit,
             }))
         }
-        Some(Resolved::Note(_)) => {
+        Some(Resolved::Note(note)) => {
+            match &expected_kind {
+                None => {}
+                Some(AtomicUpdateKind::Note {
+                    specific: Some(expected),
+                }) => {
+                    if &note.kind != expected {
+                        return Err(RuntimeError::NotFound(format!("note {id}")));
+                    }
+                }
+                Some(AtomicUpdateKind::Note { specific: None }) => {}
+                Some(AtomicUpdateKind::Entity { .. }) => {
+                    return Err(RuntimeError::NotFound(format!("entity {id}")));
+                }
+                Some(AtomicUpdateKind::Edge) => {
+                    return Err(RuntimeError::NotFound(format!("edge {id}")));
+                }
+            }
             // Decide step lives in curation.rs's `prepare_update_note` — the
             // SAME function canonical `update_note` calls, including the
             // salience/decay_factor range validation. `optional_f64_patch`
@@ -657,9 +712,17 @@ async fn prepare_update(
         // round-4 codex REJECT: `update` admits `kind="edge"` but this
         // function previously had no path that could ever build a plan for
         // one).
-        None => match runtime.get_edge(token, id).await? {
-            Some(edge) => prepare_update_edge(runtime, id, edge, args).await,
-            None => Err(RuntimeError::NotFound(format!("entity/note/edge {id}"))),
+        None => match &expected_kind {
+            Some(AtomicUpdateKind::Entity { .. }) => {
+                Err(RuntimeError::NotFound(format!("entity/note {id}")))
+            }
+            Some(AtomicUpdateKind::Note { .. }) => {
+                Err(RuntimeError::NotFound(format!("entity/note {id}")))
+            }
+            Some(AtomicUpdateKind::Edge) | None => match runtime.get_edge(token, id).await? {
+                Some(edge) => prepare_update_edge(runtime, id, edge, args).await,
+                None => Err(RuntimeError::NotFound(format!("entity/note/edge {id}"))),
+            },
         },
     }
 }
@@ -682,14 +745,24 @@ async fn prepare_update(
 /// - symmetric relation (`competes_with`, `composed_with`): `update_edge`
 ///   does NOT use the upsert builder here — its comment explains why
 ///   (`upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
-///   detect a natural-key collision with a *different* id). It instead runs
-///   a conflict PROBE then branches: no conflict -> update the row in place;
-///   conflict -> delete the requested (non-canonical) row and refresh the
-///   surviving canonical row. That probe is a plain read with no side
-///   effects, so it runs here in the async prepare phase (same treatment
-///   `resolve_kg_ids_in_args` already gives id resolution) and the two
-///   branches below reproduce `update_edge_symmetric_dml`'s exact SQL text,
-///   so the resulting plan is fully static for the synchronous commit pass.
+///   detect a natural-key collision with a *different* id). Canonical
+///   (`update_edge_symmetric_dml`) runs a conflict probe and branches in
+///   Rust inside a single uninterrupted transaction, which is safe there.
+///   This atomic path (ADR-099 B3 r7, codex r7 High finding 3) does NOT
+///   branch on a prepare-time probe: the prepare/commit phase split means a
+///   different op in the SAME atomic unit could change the conflict
+///   landscape between this probe and commit, so a Rust-level branch here
+///   would be stale by construction. Instead it always emits BOTH
+///   statements from [`edge_symmetric_delete_if_conflict_statement`] and
+///   [`edge_symmetric_refresh_or_update_inplace_statement`] — each carries
+///   its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
+///   conflict condition fresh inside the transaction, so the write is
+///   correct regardless of what this prepare-time probe returns. The probe
+///   itself is kept, but demoted to computing `surviving_id` only — a pure
+///   informational value used for this plan's `target_id` (post-commit
+///   result rendering), not a write-correctness input; see the inline
+///   comment at its call site for the (vanishingly rare, informational-only)
+///   residual staleness this leaves.
 async fn prepare_update_edge(
     runtime: &KhiveRuntime,
     id: Uuid,
@@ -743,11 +816,59 @@ async fn prepare_update_edge(
     let mut surviving_id = id;
 
     if edge.relation.is_symmetric() {
-        // Conflict probe (read-only, async — see doc comment above). Same SQL
-        // text `update_edge_symmetric_dml` (operations.rs, the synchronous
-        // commit-time counterpart) runs inside its transaction — see the
-        // `EDGE_SYMMETRIC_*_SQL` doc comment in khive-db for why a single
-        // bridge type isn't used for both call sites.
+        // ADR-099 B3 r7 (codex r7 High finding 3): the WRITE for a symmetric
+        // relation no longer branches on a prepare-time probe result — it
+        // ALWAYS carries both self-guarding, commit-time-predicate
+        // statements (see their doc comment in khive-db's graph.rs for the
+        // full rationale). This closes the staleness window a prepare-time
+        // probe exposed atomic to (an earlier op in the SAME atomic unit
+        // could change the conflict landscape before commit) without
+        // touching canonical's own probe-then-branch `update_edge_symmetric_dml`
+        // (which has no such exposure — single transaction, no interleaving
+        // — and stays as the control-group, tests untouched).
+        let metadata_str = edge
+            .metadata
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+
+        statements.push(PlanStatement {
+            statement: edge_symmetric_delete_if_conflict_statement(
+                &namespace,
+                id,
+                canon_src,
+                canon_tgt,
+                edge.relation,
+            ),
+            guard: Some(AffectedRowGuard {
+                expected_min: 0,
+                expected_max: Some(1),
+            }),
+        });
+        statements.push(PlanStatement {
+            statement: edge_symmetric_refresh_or_update_inplace_statement(
+                &namespace,
+                id,
+                canon_src,
+                canon_tgt,
+                edge.relation,
+                edge.weight,
+                now.timestamp_micros(),
+                metadata_str.as_deref(),
+                edge.target_backend.as_deref(),
+            ),
+            guard: Some(AffectedRowGuard::exactly(1)),
+        });
+
+        // `surviving_id` here is advisory only, used solely for this plan's
+        // `target_id` (post-commit result rendering — a pure informational
+        // READ, not a write-correctness concern; see this function's doc
+        // comment). A best-effort probe is enough for it: if an intra-batch
+        // race (vanishingly rare — it requires a SECOND op in this SAME
+        // atomic unit to touch this exact symmetric edge's natural key
+        // between this probe and commit) makes it stale, the two statements
+        // above still write to the CORRECT row regardless of what this
+        // probe returns; only the post-commit result payload could, in that
+        // exact race, echo back the pre-collision row's content.
         let mut reader = runtime
             .sql()
             .reader()
@@ -767,47 +888,8 @@ async fn prepare_update_edge(
                 SqlValue::Text(s) => Uuid::parse_str(&s).ok(),
                 _ => None,
             });
-
-        let metadata_str = edge
-            .metadata
-            .as_ref()
-            .map(|v| serde_json::to_string(v).unwrap_or_default());
-
         if let Some(existing_id) = conflict_id {
-            // Case (b), mirrors `update_edge_symmetric_dml`: delete the
-            // requested (non-canonical) row, refresh the surviving row.
             surviving_id = existing_id;
-            statements.push(PlanStatement {
-                statement: edge_symmetric_delete_noncanonical_statement(&namespace, id),
-                guard: Some(AffectedRowGuard::exactly(1)),
-            });
-            statements.push(PlanStatement {
-                statement: edge_symmetric_refresh_canonical_statement(
-                    &namespace,
-                    existing_id,
-                    edge.weight,
-                    now.timestamp_micros(),
-                    edge.target_backend.as_deref(),
-                    metadata_str.as_deref(),
-                ),
-                guard: Some(AffectedRowGuard::exactly(1)),
-            });
-        } else {
-            // Case (a): no conflict — update source/target/relation/weight
-            // in place, preserving the original edge id.
-            statements.push(PlanStatement {
-                statement: edge_symmetric_update_inplace_statement(
-                    &namespace,
-                    id,
-                    canon_src,
-                    canon_tgt,
-                    edge.relation,
-                    edge.weight,
-                    now.timestamp_micros(),
-                    metadata_str.as_deref(),
-                ),
-                guard: Some(AffectedRowGuard::exactly(1)),
-            });
         }
     } else {
         // Non-symmetric: bit-for-bit the same builder `graph.upsert_edge`
@@ -1186,49 +1268,30 @@ async fn prepare_link(
     let now = chrono::Utc::now().timestamp_micros();
     let metadata_str = metadata.map(|m| serde_json::to_string(&m).unwrap_or_default());
 
-    // GAP-2 (B3 fix round 4): a plain `INSERT` here rejects a re-link of an
-    // already-linked (or soft-deleted) triple with a `graph_edges`
-    // `UNIQUE(namespace, source_id, target_id, relation)` violation, rolling
-    // back the whole atomic unit. Canonical `link` -> `upsert_edge`
-    // (`khive-db/src/stores/graph.rs`, natural-key `ON CONFLICT` arm) instead
-    // upserts: it updates `weight`/`updated_at`/`metadata` and resurrects
-    // `deleted_at = NULL`. The `ON CONFLICT` arm below mirrors that natural-key
-    // arm's exact `SET` list (it intentionally does NOT touch
-    // `target_backend`, which this atomic INSERT never populates in the
-    // first place — that column is left untouched on conflict rather than
-    // reset to NULL). SQLite accepts `INSERT ... SELECT ... WHERE ... ON
-    // CONFLICT ... DO UPDATE`; the guarded `exactly(1)` check below still
-    // holds for both the fresh-insert and the upsert-update outcome, and
-    // still correctly reports 0 affected rows when an endpoint is missing.
-    let statement = SqlStatement {
-        sql: "INSERT INTO graph_edges \
-              (namespace, id, source_id, target_id, relation, weight, created_at, updated_at, metadata) \
-              SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8 \
-              WHERE (EXISTS (SELECT 1 FROM entities WHERE id = ?3 AND deleted_at IS NULL) \
-                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?3 AND deleted_at IS NULL)) \
-                AND (EXISTS (SELECT 1 FROM entities WHERE id = ?4 AND deleted_at IS NULL) \
-                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL)) \
-              ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
-                  weight = excluded.weight, \
-                  updated_at = excluded.updated_at, \
-                  deleted_at = NULL, \
-                  metadata = excluded.metadata"
-            .to_string(),
-        params: vec![
-            SqlValue::Text(namespace),
-            SqlValue::Text(edge_id.to_string()),
-            SqlValue::Text(canon_source.to_string()),
-            SqlValue::Text(canon_target.to_string()),
-            SqlValue::Text(relation.as_str().to_string()),
-            SqlValue::Float(weight),
-            SqlValue::Integer(now),
-            match metadata_str {
-                Some(m) => SqlValue::Text(m),
-                None => SqlValue::Null,
-            },
-        ],
-        label: Some("atomic-link-insert-edge-where-exists".to_string()),
-    };
+    // ADR-099 B3 r7 (codex r7 High finding 2): the guarded `INSERT ...
+    // SELECT ... WHERE EXISTS(...)` shape is kept (it is load-bearing —
+    // `LinkPlan`'s own doc comment records why: it re-probes both endpoints
+    // INSIDE the transaction, closing the intra-batch hazard where an
+    // earlier op in the SAME atomic unit, e.g. `delete(X, hard)`, could
+    // invalidate this op's prepare-time endpoint validation before commit).
+    // What changed: the conflict-arm SET list is no longer a second
+    // hand-assembled literal — `edge_insert_guarded_by_endpoints_statement`
+    // shares the SAME `EDGE_NATURAL_KEY_CONFLICT_SET` text
+    // `edge_upsert_statement` (canonical `link`'s builder) uses, so the two
+    // cannot silently diverge again (the prior bug: this atomic literal
+    // never set `target_backend = excluded.target_backend`, so a re-link of
+    // an edge carrying a cross-backend `target_backend` stamp behaved
+    // differently under `--atomic`).
+    let statement = edge_insert_guarded_by_endpoints_statement(
+        &namespace,
+        edge_id,
+        canon_source,
+        canon_target,
+        relation,
+        weight,
+        now,
+        metadata_str.as_deref(),
+    );
 
     Ok(AtomicOpPlan::Link(LinkPlan {
         source_id: canon_source,
@@ -1463,6 +1526,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": entity_id.to_string(), "salience": 0.9}),
+            None,
         )
         .await
         .expect_err("salience on an entity must be rejected, not silently accepted");
@@ -1481,6 +1545,7 @@ mod tests {
                 "description": "updated description",
                 "tags": ["a", "b"],
             }),
+            None,
         )
         .await
         .expect("a valid entity field set must still be accepted");
@@ -1521,7 +1586,8 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": note_id.to_string(), "description": "entities have descriptions, notes don't"}),
-        )
+                None,
+            )
         .await
         .expect_err("description on a note must be rejected, not silently accepted");
         assert!(
@@ -1534,6 +1600,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": note_id.to_string(), "content": "gap-4 note content, revised"}),
+            None,
         )
         .await
         .expect("a valid note field must still be accepted");
@@ -1578,6 +1645,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": note_id.to_string(), "content": "freshly-updated-content-xyz"}),
+            None,
         )
         .await
         .expect("prepare update");
@@ -2380,6 +2448,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": entity_id.to_string(), "name": "gap1-entity-renamed"}),
+            None,
         )
         .await
         .expect("prepare update");
@@ -2541,6 +2610,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": edge_id.to_string(), "weight": 0.75}),
+            None,
         )
         .await
         .expect("prepare update edge");
@@ -2616,6 +2686,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": requested_id.to_string(), "relation": "competes_with", "weight": 0.9}),
+            None,
         )
         .await
         .expect("prepare update edge (symmetric conflict)");
@@ -2691,6 +2762,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": edge_id.to_string(), "name": "not-a-valid-edge-field"}),
+            None,
         )
         .await
         .expect_err("edge update with an entity-only field must be rejected");
@@ -2791,6 +2863,7 @@ mod tests {
             &runtime,
             &token,
             &json!({"id": note_id.to_string(), "content": "gap1-note-noevent, revised"}),
+            None,
         )
         .await
         .expect("prepare update");

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -888,6 +888,159 @@ mod tests {
     // Post-commit effect collection (UpdatePlan's reindex caveat, D3)
     // ------------------------------------------------------------------
 
+    // ------------------------------------------------------------------
+    // 7. Daemon coexistence (ADR-099 B3 acceptance test 5)
+    // ------------------------------------------------------------------
+
+    /// An atomic unit must go through the SAME `WriterTaskHandle` queue as
+    /// an ordinary single-row write — not a separate connection that would
+    /// let it silently bypass single-writer serialization (ADR-067
+    /// Component A). This reuses the deterministic occupier pattern from
+    /// `khive-db::stores::graph_tests::upsert_edge_routes_through_writer_task_when_flag_enabled`
+    /// (Slice A): an occupier closure parks on a oneshot inside the writer
+    /// task's one drain slot, so both the atomic unit's `atomic_unit` call
+    /// and a concurrent ordinary `upsert_entity` call are forced to queue
+    /// behind it. `queue_depth` reaching 2 while both are pending, then
+    /// draining to 0 once the occupier releases and both complete, is the
+    /// proof that `run_atomic_unit` "discriminates" through the real queue
+    /// gauge rather than opening a competing connection.
+    #[tokio::test]
+    async fn atomic_unit_and_concurrent_normal_write_share_the_same_writer_queue() {
+        let pool = scratch_pool("daemon_coexistence");
+        seed_schema(&pool);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        insert_entity(&pool, a, "alpha");
+
+        let writer_task = pool
+            .writer_task_handle()
+            .expect("writer task lookup")
+            .expect("writer task must be spawned with the flag on for a file-backed pool");
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = {
+            let writer_task = writer_task.clone();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |_conn| {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.blocking_recv();
+                        Ok::<(), StorageError>(())
+                    })
+                    .await
+            })
+        };
+
+        started_rx
+            .await
+            .expect("occupier must signal it has started running inside the writer task");
+        assert_eq!(
+            writer_task.queue_depth(),
+            0,
+            "channel must start empty once the occupier has been dequeued and is running"
+        );
+
+        // The atomic unit: renames `a`.
+        let bridge = SqlBridge::new(StdArc::clone(&pool), true);
+        let atomic_plans = vec![rename_plan(a, "alpha-atomic", "rename-a-atomic")];
+        let atomic_task = tokio::spawn(async move { run_atomic_unit(&bridge, atomic_plans).await });
+
+        // A concurrent ORDINARY write, routed through the SAME
+        // `WriterTaskHandle::send` the real `with_writer` path uses
+        // (khive-db's own `graph_tests` occupier test asserts this for
+        // `upsert_edge`) — NOT a second `pool.try_writer()` connection,
+        // which would open a competing SQLite handle and contend on the
+        // file lock the occupier's `BEGIN IMMEDIATE` already holds,
+        // producing a `DatabaseBusy` false failure unrelated to the queue
+        // this test is actually proving something about.
+        let normal_write_task = {
+            let writer_task = writer_task.clone();
+            let b_str = b.to_string();
+            tokio::spawn(async move {
+                writer_task
+                    .send(move |conn| {
+                        conn.execute(
+                            "INSERT INTO entities \
+                             (id, namespace, kind, name, created_at, updated_at) \
+                             VALUES (?1, 'local', 'concept', ?2, 0, 0)",
+                            rusqlite::params![b_str, "bravo"],
+                        )
+                        .map_err(|e| StorageError::Internal(e.to_string()))
+                    })
+                    .await
+            })
+        };
+
+        // Both the atomic unit's `atomic_unit` call and (best-effort) the
+        // ordinary write must appear in the SAME queue while the occupier
+        // holds the slot — this is the coexistence proof: neither one opens
+        // a side-channel connection that would let it skip the queue.
+        let mut saw_both_enqueued = false;
+        for _ in 0..200 {
+            if writer_task.queue_depth() >= 2 {
+                saw_both_enqueued = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            saw_both_enqueued,
+            "expected BOTH the atomic unit's atomic_unit() call and the \
+             concurrent ordinary write to appear in the writer task's queue \
+             while the occupier held the single drain slot (queue_depth \
+             should have reached 2) — observed {}; run_atomic_unit is not \
+             sharing the same queue as an ordinary write",
+            writer_task.queue_depth()
+        );
+
+        release_tx.send(()).expect("release occupier");
+        occupier
+            .await
+            .expect("occupier task join")
+            .expect("occupier op ok");
+
+        let atomic_outcome = atomic_task
+            .await
+            .expect("atomic task join")
+            .expect("seam call ok");
+        assert!(
+            matches!(atomic_outcome, AtomicRunOutcome::Committed { .. }),
+            "atomic unit must commit once the occupier releases: {atomic_outcome:?}"
+        );
+        normal_write_task
+            .await
+            .expect("normal write task join")
+            .expect("normal write op ok");
+
+        assert!(
+            entity_exists(&pool, a),
+            "a must exist (renamed) after commit"
+        );
+        {
+            // Scoped: the `WriterGuard` returned by `try_writer()` holds a
+            // non-reentrant `parking_lot::Mutex` for as long as it lives.
+            // Left unscoped, it would still be held when `entity_exists`
+            // below tries to check out the same writer, deadlocking (in
+            // practice, timing out after `checkout_timeout`) against itself
+            // rather than against anything the writer task/occupier hold.
+            let writer = pool.try_writer().expect("writer");
+            let renamed: String = writer
+                .conn()
+                .query_row(
+                    "SELECT name FROM entities WHERE id = ?1",
+                    rusqlite::params![a.to_string()],
+                    |row| row.get(0),
+                )
+                .expect("query renamed entity");
+            assert_eq!(renamed, "alpha-atomic");
+        }
+        assert!(
+            entity_exists(&pool, b),
+            "the concurrent ordinary write must also have landed"
+        );
+    }
+
     #[tokio::test]
     async fn post_commit_effects_are_collected_in_op_order_and_only_for_update() {
         let pool = scratch_pool("post_commit_collection");

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -107,9 +107,11 @@ impl AtomicOpPlan {
 
     /// The deferred post-commit effect this op's plan recorded, if any.
     ///
-    /// Only [`UpdatePlan`] carries a [`PostCommitEffect`] field in v1 (the
-    /// `update` reindex caveat, ADR-099 D3): every other admissible verb's
-    /// apply is pure DML with no deferred side effect. `merge`'s existing
+    /// [`UpdatePlan`] carries a [`PostCommitEffect`] field for the `update`
+    /// reindex caveat (ADR-099 D3). Since the B3 fix round (GAP-5),
+    /// [`GtdTransitionPlan`]/[`GtdCompletePlan`] also carry one, for the
+    /// best-effort lifecycle audit row. Every other admissible verb's apply
+    /// is pure DML with no deferred side effect. `merge`'s existing
     /// post-transaction vector re-insert (D3: "merge already performs its
     /// vector re-insert after its transaction") is the handler's own
     /// pre-existing behavior outside this plan shape — [`MergePlan`] itself
@@ -117,6 +119,12 @@ impl AtomicOpPlan {
     fn post_commit_effect(&self) -> Option<PostCommitEffect> {
         match self {
             AtomicOpPlan::Update(p) if p.post_commit != PostCommitEffect::None => {
+                Some(p.post_commit.clone())
+            }
+            AtomicOpPlan::GtdTransition(p) if p.post_commit != PostCommitEffect::None => {
+                Some(p.post_commit.clone())
+            }
+            AtomicOpPlan::GtdComplete(p) if p.post_commit != PostCommitEffect::None => {
                 Some(p.post_commit.clone())
             }
             _ => None,

--- a/crates/khive-runtime/src/atomic_runner.rs
+++ b/crates/khive-runtime/src/atomic_runner.rs
@@ -518,6 +518,7 @@ mod tests {
                 guard: Some(AffectedRowGuard::exactly(1)),
             }],
             post_commit: PostCommitEffect::None,
+            edge_natural_key: None,
         })
     }
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1726,7 +1726,11 @@ fn merge_option_string_field(
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).
-fn merge_properties(
+/// `pub(crate)` (widened from private, ADR-099 B3): the atomic prepare pass
+/// (`crate::atomic_prepare`) reuses this exact properties-merge semantics when
+/// building an `update` write plan's row statement, matching `update_entity`/
+/// `update_note`'s own patch behavior byte-for-byte.
+pub(crate) fn merge_properties(
     into: &Option<Value>,
     from: &Option<Value>,
     strategy: EntityDedupMergePolicy,

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1687,14 +1687,22 @@ fn merge_note_sql(
 // Merge helpers (pure functions — easier to unit test)
 // ---------------------------------------------------------------------------
 
-fn merge_string_field(into: &str, from: &str, strategy: EntityDedupMergePolicy) -> String {
+/// `pub(crate)` (widened, ADR-099 B3 fix round): `crate::atomic_prepare::prepare_merge`
+/// reuses this exact field-fold semantics for atomic/non-atomic parity.
+pub(crate) fn merge_string_field(
+    into: &str,
+    from: &str,
+    strategy: EntityDedupMergePolicy,
+) -> String {
     match strategy {
         EntityDedupMergePolicy::PreferInto | EntityDedupMergePolicy::Union => into.to_string(),
         EntityDedupMergePolicy::PreferFrom => from.to_string(),
     }
 }
 
-fn merge_option_string_field(
+/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
+/// `crate::atomic_prepare::prepare_merge` for atomic/non-atomic parity.
+pub(crate) fn merge_option_string_field(
     into: &Option<String>,
     from: &Option<String>,
     strategy: EntityDedupMergePolicy,
@@ -1796,7 +1804,9 @@ fn merge_json(into: &Value, from: &Value, strategy: EntityDedupMergePolicy) -> (
     }
 }
 
-fn union_tags(into: &[String], from: &[String]) -> (Vec<String>, usize) {
+/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
+/// `crate::atomic_prepare::prepare_merge` for atomic/non-atomic parity.
+pub(crate) fn union_tags(into: &[String], from: &[String]) -> (Vec<String>, usize) {
     let mut seen: HashSet<&str> = into.iter().map(|s| s.as_str()).collect();
     let mut result: Vec<String> = into.to_vec();
     let mut added = 0usize;

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -195,12 +195,24 @@ impl KhiveRuntime {
     ///
     /// Returns `RuntimeError::NotFound` if the entity does not exist or belongs to a different
     /// namespace. Namespace isolation is enforced at the runtime layer.
-    pub async fn update_entity(
+    /// Decide step of `update_entity` (ADR-099 B3 r6 second pass): secret-gates
+    /// the patch, fetches the current row, and computes the resulting `Entity`
+    /// plus `text_changed` (drives reindex) and `changed_fields` (the event
+    /// payload) — WITHOUT writing anything. This is the ONE place that decides
+    /// what a patched entity looks like: `update_entity` below calls it then
+    /// applies the result via `store.upsert_entity` (unchanged execution
+    /// mechanism), and the ADR-099 `--atomic` prepare path
+    /// (`khive-runtime::atomic_prepare::prepare_update`) calls this SAME
+    /// function, turning the result into a `PlanStatement` via
+    /// `khive_db::stores::entity::entity_upsert_statement` — the identical
+    /// builder `upsert_entity` calls internally. No entity-patch decision
+    /// logic is duplicated between the two paths.
+    pub(crate) async fn prepare_update_entity(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         patch: EntityPatch,
-    ) -> RuntimeResult<Entity> {
+    ) -> RuntimeResult<(Entity, bool, Vec<&'static str>)> {
         // Secret gate: scan incoming text fields, properties, and tags.
         if let Some(ref name) = patch.name {
             crate::secret_gate::check(name)?;
@@ -248,6 +260,19 @@ impl KhiveRuntime {
         }
 
         entity.updated_at = chrono::Utc::now().timestamp_micros();
+        Ok((entity, text_changed, changed_fields))
+    }
+
+    pub async fn update_entity(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        patch: EntityPatch,
+    ) -> RuntimeResult<Entity> {
+        let (entity, text_changed, changed_fields) =
+            self.prepare_update_entity(token, id, patch).await?;
+
+        let store = self.entities(token)?;
         store.upsert_entity(entity.clone()).await?;
 
         if text_changed {
@@ -552,13 +577,19 @@ impl KhiveRuntime {
         Ok(())
     }
 
-    /// Patch-style note update.
-    pub async fn update_note(
+    /// Decide step of `update_note` (ADR-099 B3 r6 second pass) — same split
+    /// as `prepare_update_entity` above: secret-gates the patch, fetches the
+    /// current row, computes the resulting `Note` plus `text_changed`
+    /// (drives reindex), without writing. `update_note` and the ADR-099
+    /// `--atomic` `prepare_update` Note branch both call this ONE function;
+    /// the DML itself is `khive_db::stores::note::note_upsert_statement`,
+    /// the same builder `upsert_note` calls internally.
+    pub(crate) async fn prepare_update_note(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         patch: NotePatch,
-    ) -> RuntimeResult<khive_storage::note::Note> {
+    ) -> RuntimeResult<(khive_storage::note::Note, bool)> {
         // Secret gate: scan incoming text fields and structured properties.
         if let Some(ref content) = patch.content {
             crate::secret_gate::check(content)?;
@@ -621,6 +652,19 @@ impl KhiveRuntime {
         }
 
         note.updated_at = chrono::Utc::now().timestamp_micros();
+        Ok((note, text_changed))
+    }
+
+    /// Patch-style note update.
+    pub async fn update_note(
+        &self,
+        token: &NamespaceToken,
+        id: Uuid,
+        patch: NotePatch,
+    ) -> RuntimeResult<khive_storage::note::Note> {
+        let (note, text_changed) = self.prepare_update_note(token, id, patch).await?;
+
+        let store = self.notes(token)?;
         store.upsert_note(note.clone()).await?;
 
         if text_changed {

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 //! Wraps `StorageBackend` and query compilation into a single Rust API surface.
 
 pub mod atomic_plan;
+pub mod atomic_prepare;
 pub mod atomic_runner;
 pub mod config;
 pub mod curation;

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -70,7 +70,9 @@ pub use operations::{
     arm_fts_fail, arm_fts_fail_many, arm_fts_fail_many_partial, arm_rollback_cleanup_fail,
     arm_vector_fail, arm_vector_fail_after,
 };
-pub use operations::{EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved};
+pub use operations::{
+    merge_entry_metadata, EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved,
+};
 pub use pack::{
     resolve_explicit_namespace, DispatchHook, HandlerDef, KindHook, NoteKindSpec,
     NoteLifecycleSpec, PackByIdResolver, PackFactory, PackLoadError, PackRegistration,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -496,7 +496,7 @@ pub(crate) fn merge_dependency_kind(
 
 /// Merge a caller-supplied top-level `dependency_kind` param into an edge's
 /// `metadata` object, filling the key only if `metadata` doesn't already
-/// carry one. This is distinct from [`merge_dependency_kind`] above (which
+/// carry one. This is distinct from `merge_dependency_kind` above (which
 /// infers a default from endpoint entity kinds when no explicit value was
 /// given at all) — this one folds in an EXPLICIT `dependency_kind` argument
 /// the caller passed alongside `metadata`.

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -494,6 +494,39 @@ pub(crate) fn merge_dependency_kind(
     Some(obj)
 }
 
+/// Merge a caller-supplied top-level `dependency_kind` param into an edge's
+/// `metadata` object, filling the key only if `metadata` doesn't already
+/// carry one. This is distinct from [`merge_dependency_kind`] above (which
+/// infers a default from endpoint entity kinds when no explicit value was
+/// given at all) — this one folds in an EXPLICIT `dependency_kind` argument
+/// the caller passed alongside `metadata`.
+///
+/// `pub` (ADR-099 B3 r6 second pass): the single source both
+/// `khive-pack-kg::handlers::link::handle_link` (via `khive_runtime::
+/// merge_entry_metadata`) and `crate::atomic_prepare::prepare_link` call —
+/// previously duplicated as a hand-copied 8-line block in `atomic_prepare.rs`
+/// (pack-kg's copy lived at `handlers/common.rs`, a `pub(crate)` fn in a
+/// crate `khive-runtime` cannot depend on, so it was re-typed by hand rather
+/// than imported). Relocating the canonical copy down to `khive-runtime`
+/// lets `khive-pack-kg` depend on it instead (packs depend on
+/// `khive-runtime`, never the reverse), closing the duplication in the
+/// direction the crate graph actually allows.
+pub fn merge_entry_metadata(
+    metadata: Option<serde_json::Value>,
+    dependency_kind: Option<String>,
+) -> RuntimeResult<Option<serde_json::Value>> {
+    let Some(dk) = dependency_kind else {
+        return Ok(metadata);
+    };
+    let mut obj = metadata.unwrap_or_else(|| serde_json::json!({}));
+    let map = obj
+        .as_object_mut()
+        .ok_or_else(|| RuntimeError::InvalidInput("metadata must be a JSON object".into()))?;
+    map.entry("dependency_kind".to_string())
+        .or_insert_with(|| serde_json::json!(dk));
+    Ok(Some(obj))
+}
+
 /// Valid `dependency_kind` values for `depends_on` edges.
 const VALID_DEPENDENCY_KINDS: &[&str] = &["build", "runtime", "data", "artifact", "tooling"];
 

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -3699,6 +3699,17 @@ impl KhiveRuntime {
     /// Returns `Ok(Some(existing_id))` when a canonical conflict was absorbed (the
     /// requested edge was deleted, the existing canonical row refreshed), or
     /// `Ok(None)` when the requested edge was updated in place.
+    ///
+    /// DML text is the single source of truth shared with ADR-099's atomic
+    /// `prepare_update_edge` symmetric branch:
+    /// [`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] /
+    /// `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
+    /// `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` /
+    /// `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` — this function binds them against
+    /// `rusqlite::params!` (it runs inside an existing transaction on a
+    /// borrowed `&rusqlite::Connection`), the atomic path binds the same text
+    /// via `SqlValue` plan params; see the constants' doc comment in
+    /// `khive-db` for why a single bridge type isn't used for both.
     #[allow(clippy::too_many_arguments)]
     fn update_edge_symmetric_dml(
         conn: &rusqlite::Connection,
@@ -3711,16 +3722,22 @@ impl KhiveRuntime {
         metadata: Option<String>,
         target_backend: Option<String>,
     ) -> Result<Option<String>, SqliteError> {
-        let now_ts = chrono::Utc::now().timestamp();
+        // `updated_at` is stored in MICROSECONDS on `graph_edges` (every other
+        // write path — `edge_upsert_statement`, `edge_soft_delete_statement` —
+        // uses `timestamp_micros()`; the column is read back via
+        // `micros_to_datetime`). `timestamp()` (seconds) here was a
+        // pre-existing bug in this raw-SQL path, found while unifying it with
+        // the ADR-099 atomic builder (which already used `timestamp_micros()`
+        // correctly) — fixed as part of this extraction, not a behavior the
+        // atomic path needed to special-case around.
+        let now_ts = chrono::Utc::now().timestamp_micros();
 
         // Check for a conflicting canonical row (same namespace + natural key,
         // different id). This catches conflicts whether or not endpoints were
         // flipped — Bug 2 fix.
         let conflict_id: Option<String> = conn
             .query_row(
-                "SELECT id FROM graph_edges \
-                 WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
-                 AND relation = ?4 AND id != ?5",
+                khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
                 rusqlite::params![
                     &ns,
                     &canon_src_str,
@@ -3739,16 +3756,13 @@ impl KhiveRuntime {
             // id so the caller can re-fetch it (Bug 1 fix: do not return the
             // deleted edge's id).
             conn.execute(
-                "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+                khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                 rusqlite::params![&ns, &edge_id_str],
             )
             .map_err(SqliteError::Rusqlite)?;
             let affected = conn
                 .execute(
-                    "UPDATE graph_edges SET \
-                     weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                     target_backend = ?3, metadata = ?4 \
-                     WHERE namespace = ?5 AND id = ?6",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
                     rusqlite::params![weight, now_ts, target_backend, metadata, &ns, &existing_id],
                 )
                 .map_err(SqliteError::Rusqlite)?;
@@ -3763,10 +3777,7 @@ impl KhiveRuntime {
             // preserving the original edge UUID.
             let affected = conn
                 .execute(
-                    "UPDATE graph_edges SET \
-                     source_id = ?1, target_id = ?2, relation = ?3, \
-                     weight = ?4, updated_at = ?5, metadata = ?6 \
-                     WHERE namespace = ?7 AND id = ?8",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_UPDATE_INPLACE_SQL,
                     rusqlite::params![
                         &canon_src_str,
                         &canon_tgt_str,
@@ -4642,6 +4653,56 @@ mod tests {
             .await
             .unwrap();
         assert!((updated.weight - 0.5).abs() < 0.001);
+    }
+
+    /// Regression test (ADR-099 B3 r6 second pass): `update_edge_symmetric_dml`
+    /// previously stored `updated_at` via `chrono::Utc::now().timestamp()`
+    /// (SECONDS) while every other `graph_edges` write path
+    /// (`edge_upsert_statement`, `edge_soft_delete_statement`) uses
+    /// `timestamp_micros()` — a genuine pre-existing bug, found while
+    /// unifying this raw-SQL path with the ADR-099 atomic builder (which
+    /// already used `timestamp_micros()` correctly) onto the shared
+    /// `EDGE_SYMMETRIC_*_SQL` text. A seconds value misread as microseconds
+    /// round-trips to a date a few minutes after the Unix epoch, not "now".
+    #[tokio::test]
+    async fn update_edge_symmetric_relation_stores_microsecond_updated_at() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::CompetesWith, 1.0, None)
+            .await
+            .unwrap();
+        let edge_id: Uuid = edge.id.into();
+
+        let before = chrono::Utc::now();
+        let updated = rt
+            .update_edge(
+                &tok,
+                edge_id,
+                crate::curation::EdgePatch {
+                    weight: Some(0.5),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let drift = (updated.updated_at - before).num_seconds().abs();
+        assert!(
+            drift < 60,
+            "updated_at must round-trip as a recent timestamp (micros, not \
+             seconds); got {:?}, expected within 60s of {:?}",
+            updated.updated_at,
+            before
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -509,7 +509,7 @@ pub(crate) fn validate_edge_weight(weight: f64) -> RuntimeResult<()> {
 /// Currently enforces:
 /// - `dependency_kind` is only valid on `depends_on` edges.
 /// - `dependency_kind`, when present, must be one of the five governed values.
-fn validate_edge_metadata(
+pub(crate) fn validate_edge_metadata(
     relation: EdgeRelation,
     metadata: Option<&serde_json::Value>,
 ) -> RuntimeResult<()> {
@@ -1141,7 +1141,12 @@ impl KhiveRuntime {
     ///
     /// Returns `Ok(())` when valid; otherwise `InvalidInput` or `NotFound` with
     /// the same messages as the previous inline block (byte-identical behaviour).
-    async fn validate_edge_relation_endpoints(
+    ///
+    /// `pub(crate)` (widened from private, ADR-099 B3): the atomic prepare pass
+    /// (`crate::atomic_prepare`) reuses this exact endpoint-type validation
+    /// during its async prepare step, before building a `LinkPlan` — see
+    /// ADR-099 D1's "reusing the handler's existing compute" principle.
+    pub(crate) async fn validate_edge_relation_endpoints(
         &self,
         token: &NamespaceToken,
         source_id: Uuid,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -452,7 +452,11 @@ pub(crate) fn canonical_edge_endpoints(
 }
 
 /// Infer the default `dependency_kind` from endpoint entity kinds.
-fn infer_dependency_kind(src_kind: &str, tgt_kind: &str) -> Option<&'static str> {
+///
+/// `pub(crate)` (widened, ADR-099 B3 fix round): `crate::atomic_prepare::prepare_link`
+/// reuses this exact inference table so `--atomic link` matches the non-atomic
+/// `link()` byte-for-byte, rather than re-deriving the table.
+pub(crate) fn infer_dependency_kind(src_kind: &str, tgt_kind: &str) -> Option<&'static str> {
     match (src_kind, tgt_kind) {
         ("project", "project") => Some("build"),
         ("service", "service") => Some("runtime"),
@@ -469,7 +473,10 @@ fn infer_dependency_kind(src_kind: &str, tgt_kind: &str) -> Option<&'static str>
 /// preserved. If the key is absent and the endpoint pair has a known default,
 /// the inferred value is added. Returns `metadata` unchanged for all other
 /// cases (no matching default, or metadata already has the key).
-fn merge_dependency_kind(
+///
+/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
+/// `crate::atomic_prepare::prepare_link` for atomic/non-atomic parity.
+pub(crate) fn merge_dependency_kind(
     src_kind: &str,
     tgt_kind: &str,
     metadata: Option<serde_json::Value>,

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -369,6 +369,38 @@ const ATOMIC_EMBEDDING_BEARING_VERBS: &[&str] = &[
     "comm.ingest",
 ];
 
+/// Verbs that ADR-099 D3 lists as conceptually admissible (they remain on
+/// [`ATOMIC_ADMISSIBLE_VERBS`] — the ADR intends each to eventually gain a
+/// prepare/apply seam) but for which no *full-parity* seam exists yet in this
+/// slice, so they are rejected up front rather than admitted with a gap:
+///
+/// - `propose` / `review` / `withdraw` (ADR-046's event-sourced change-proposal
+///   lifecycle): their apply path is a changeset-interpreter over a dedicated
+///   `proposals_open` table, not a small number of guarded DML statements —
+///   no prepare implementation exists at all.
+/// - `merge`: a full-parity atomic prepare (field folding, survivor FTS/vector
+///   reindex, loser index purge, merge provenance, same-kind rejection,
+///   graceful edge-conflict resolution — see `curation::merge_entity_sql`) was
+///   drafted and unit-tested in the B3 fix round, but deferred rather than
+///   shipped: `curation.rs`'s edge-rewire conflict handling does per-row
+///   procedural branching (read, canonicalize, probe for a conflicting
+///   triple, delete-and-refresh vs. update-in-place) that cannot be expressed
+///   as ADR-099 D1's static predicate/guard plan shape, so full parity is not
+///   achievable without either accepting a documented behavioral gap or a
+///   design change to the plan model — bias-toward-defer (Leo directive,
+///   fix-round refinement) over shipping a partially-scoped atomic merge.
+///   `merge` stays admissible under the *non-atomic* verb.
+///
+/// B3 fix round (codex REJECT, Medium finding — governance verbs): this set
+/// previously passed the static pre-runtime admissibility check (since it's a
+/// subset of `ATOMIC_ADMISSIBLE_VERBS`) and only failed later, inside
+/// `atomic_prepare::prepare_op`, AFTER `KhiveRuntime::new` had already run.
+/// `atomic_admissibility` now checks this set FIRST so the CLI boundary
+/// (`khive_request::atomic::check_atomic_admissible`) rejects these verbs
+/// before any runtime is built or any write attempted — the same
+/// before-any-write guarantee every other rejection class gets.
+pub const ATOMIC_KNOWN_UNIMPLEMENTED_VERBS: &[&str] = &["propose", "review", "withdraw", "merge"];
+
 /// Read verbs rejected under `--atomic` — they produce no write plan to apply
 /// (ADR-099 D3, "v1 rejected — reads").
 const ATOMIC_READ_VERBS: &[&str] = &[
@@ -411,6 +443,13 @@ pub enum AtomicRejectionReason {
     /// a verb added after this list was written). Rejected by default —
     /// admissibility is opt-in, never inferred.
     Unlisted,
+    /// On [`ATOMIC_ADMISSIBLE_VERBS`] per ADR-099 D3 (conceptually admissible,
+    /// intended to gain a seam) but has no prepare/apply implementation in
+    /// this slice yet ([`ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`]). Rejected at the
+    /// same pre-runtime static-guard stage as every other rejection reason —
+    /// never silently no-opped, never deferred until after a runtime/write
+    /// attempt.
+    KnownUnimplemented,
 }
 
 /// Static admissibility classification for `verb_name` under ADR-099
@@ -419,7 +458,16 @@ pub enum AtomicRejectionReason {
 /// Returns `None` when the verb is admissible; `Some(reason)` names why it is
 /// rejected. Default-deny: a verb name absent from every list here is
 /// [`AtomicRejectionReason::Unlisted`], never silently admitted.
+///
+/// `ATOMIC_KNOWN_UNIMPLEMENTED_VERBS` is checked BEFORE the general
+/// admissible-list membership check (B3 fix round, Medium finding): those
+/// verbs are members of `ATOMIC_ADMISSIBLE_VERBS`, so checking membership
+/// first would admit them (`None`) and defer their rejection to prepare time,
+/// after a runtime has already been constructed.
 pub fn atomic_admissibility(verb_name: &str) -> Option<AtomicRejectionReason> {
+    if ATOMIC_KNOWN_UNIMPLEMENTED_VERBS.contains(&verb_name) {
+        return Some(AtomicRejectionReason::KnownUnimplemented);
+    }
     if ATOMIC_ADMISSIBLE_VERBS.contains(&verb_name) {
         return None;
     }
@@ -571,10 +619,37 @@ mod tests {
     #[test]
     fn atomic_admissible_verbs_are_admitted() {
         for verb in ATOMIC_ADMISSIBLE_VERBS {
+            // Governance verbs are on ATOMIC_ADMISSIBLE_VERBS per ADR-099 D3
+            // (conceptually admissible) but are checked separately below:
+            // they are rejected at this same static layer for a distinct
+            // reason (KnownUnimplemented), not admitted (None).
+            if ATOMIC_KNOWN_UNIMPLEMENTED_VERBS.contains(verb) {
+                continue;
+            }
             assert_eq!(
                 atomic_admissibility(verb),
                 None,
                 "{verb:?} is on the v1 admissible list and must be admitted"
+            );
+        }
+    }
+
+    #[test]
+    fn atomic_known_unimplemented_verbs_rejected_before_runtime() {
+        // B3 fix round (codex REJECT, Medium finding): propose/review/withdraw
+        // remain on ATOMIC_ADMISSIBLE_VERBS (ADR-099 D3 intends them to gain a
+        // seam) but must be rejected at this SAME static pre-runtime guard —
+        // not admitted here and only failed later inside
+        // `atomic_prepare::prepare_op` after a runtime was already built.
+        for verb in ATOMIC_KNOWN_UNIMPLEMENTED_VERBS {
+            assert!(
+                ATOMIC_ADMISSIBLE_VERBS.contains(verb),
+                "{verb:?} must remain on ATOMIC_ADMISSIBLE_VERBS per ADR-099 D3"
+            );
+            assert_eq!(
+                atomic_admissibility(verb),
+                Some(AtomicRejectionReason::KnownUnimplemented),
+                "{verb:?} must be rejected as known-unimplemented, not admitted"
             );
         }
     }

--- a/crates/khive-types/src/pack.rs
+++ b/crates/khive-types/src/pack.rs
@@ -384,6 +384,20 @@ const ATOMIC_READ_VERBS: &[&str] = &[
     "verbs",
 ];
 
+/// Conservative default maximum op count for one `--atomic` unit (ADR-099
+/// migration step 7 / B3). The ADR does not pin an exact number — D2 defers
+/// the precise threshold to harness measurement ("a recommended default on
+/// the order of a few thousand ops ... configurable with a conservative
+/// default", Open Question 2) — so this constant is an explicit interim
+/// choice, not a value read out of the ADR text. Rationale for 2000: it is
+/// inside D2's "a few thousand" band, comfortably bounds the duration of the
+/// single cross-process `BEGIN IMMEDIATE` hold an atomic unit takes on the
+/// daemon's writer lock (ADR-099 D5 daemon-coexistence), and is cheap to
+/// override per invocation (`kkernel exec --atomic --atomic-max-ops N`)
+/// without touching this default. Revisit once the load-harness (ADR-067
+/// Component A) has real per-op-count latency data under contention.
+pub const ATOMIC_MAX_OPS_DEFAULT: usize = 2000;
+
 /// Why a verb was rejected from an `--atomic` op list (ADR-099 D3, migration
 /// step 2). Distinguishes the two named rejection classes from a generic
 /// "not yet admitted" fallback so callers can produce an actionable message.

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -244,12 +244,67 @@ fn describe_failure(failure: &AtomicOpFailure) -> String {
     }
 }
 
+/// ADR-099 B3 parity fix: reject unknown/typo'd arg keys on the five v1
+/// atomic-admissible write verbs, BEFORE building any plan.
+///
+/// Canonical (non-atomic) `handle_update`/`handle_delete`/`handle_link`
+/// (`khive-pack-kg`) and `handle_transition`/`handle_complete`
+/// (`khive-pack-gtd`) all deserialize their args through a
+/// `#[serde(deny_unknown_fields)]` param struct, so a typo like
+/// `conten` (for `content`) is rejected with `bad params: unknown field
+/// 'conten'` rather than silently ignored. The pre-fix `--atomic` path had
+/// no equivalent gate: each `prepare_*` fn only read the keys it knew
+/// about via `obj(args)?.get(...)`, so a typo'd key was dropped on the
+/// floor and the op reported `ok:true` with every OTHER field reset to its
+/// current value — the caller's intended change silently lost.
+///
+/// This is Approach A (reuse, not reimplement): `kkernel` already depends
+/// on both `khive-pack-kg` and `khive-pack-gtd` directly (see
+/// `kkernel/Cargo.toml`) — no crate-graph inversion is needed to reach
+/// their param structs, which are now re-exported `pub` (widened from
+/// `pub(crate)`/private specifically for this seam; see the doc comments
+/// on `UpdateParams`/`DeleteParams`/`LinkParams`
+/// [`khive_pack_kg::handlers::params`] and
+/// `TransitionParams`/`CompleteParams` [`khive_pack_gtd::handlers`]).
+/// Deserializing an op's args through the SAME struct the canonical
+/// handler uses reproduces its `deny_unknown_fields` rejection AND its
+/// exact error message shape for free, with no duplicated key list to
+/// drift out of sync. The deserialized value is discarded — the
+/// `prepare_*` fns below still read from the raw `Value` map unchanged;
+/// this is a pure additive gate in front of them.
+///
+/// `merge`, `create`, and the read/governance verbs are out of scope here:
+/// `merge` and the embedding-bearing/read/governance verbs are already
+/// rejected earlier, at `check_atomic_admissible` (before this function is
+/// ever reached) or are not part of the v1 admissible set at all.
+fn validate_atomic_args(tool: &str, args: &Value) -> anyhow::Result<()> {
+    fn reject<T: serde::de::DeserializeOwned>(args: &Value) -> anyhow::Result<()> {
+        serde_json::from_value::<T>(args.clone())
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("bad params: {e}"))
+    }
+
+    match tool {
+        // kg substrate verbs — `UpdateParams` covers both update-entity and
+        // update-note (the canonical handler resolves which from `id`, not
+        // from a separate struct); same struct, so one branch covers both.
+        "update" => reject::<khive_pack_kg::handlers::UpdateParams>(args),
+        "delete" => reject::<khive_pack_kg::handlers::DeleteParams>(args),
+        "link" => reject::<khive_pack_kg::handlers::LinkParams>(args),
+        // gtd verbs.
+        "gtd.transition" => reject::<khive_pack_gtd::handlers::TransitionParams>(args),
+        "gtd.complete" => reject::<khive_pack_gtd::handlers::CompleteParams>(args),
+        _ => Ok(()),
+    }
+}
+
 async fn prepare_one(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     tool: &str,
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
+    validate_atomic_args(tool, args)?;
     match tool {
         "gtd.transition" => prepare_gtd_transition(runtime, token, args)
             .await
@@ -517,6 +572,98 @@ async fn prepare_gtd_complete(
             namespace: token.namespace().as_str().to_string(),
         },
     }))
+}
+
+/// ADR-099 B3 fix (deny_unknown_fields parity): `validate_atomic_args`
+/// unit coverage. These are syntactic-only checks (no runtime/db needed) —
+/// full end-to-end "typo doesn't mutate the row" coverage lives in
+/// `kkernel::exec::tests::atomic_update_unknown_field_is_rejected_and_does_not_mutate_row`.
+#[cfg(test)]
+mod validate_atomic_args_tests {
+    use super::validate_atomic_args;
+    use serde_json::json;
+
+    #[test]
+    fn update_rejects_unknown_field() {
+        let err = validate_atomic_args("update", &json!({"id": "x", "conten": "hello"}))
+            .expect_err("typo'd `conten` must be rejected");
+        assert!(err.to_string().contains("unknown field"), "error: {err}");
+    }
+
+    #[test]
+    fn update_accepts_well_formed_args() {
+        validate_atomic_args("update", &json!({"id": "x", "content": "hello"}))
+            .expect("well-formed update args must be accepted");
+    }
+
+    #[test]
+    fn delete_rejects_unknown_field() {
+        let err = validate_atomic_args("delete", &json!({"id": "x", "hardd": true}))
+            .expect_err("typo'd `hardd` must be rejected");
+        assert!(err.to_string().contains("unknown field"), "error: {err}");
+    }
+
+    #[test]
+    fn delete_accepts_well_formed_args() {
+        validate_atomic_args("delete", &json!({"id": "x", "hard": true}))
+            .expect("well-formed delete args must be accepted");
+    }
+
+    #[test]
+    fn link_rejects_unknown_field() {
+        let err = validate_atomic_args(
+            "link",
+            &json!({
+                "source_id": "a",
+                "target_id": "b",
+                "relation": "extends",
+                "targt_backend": "x",
+            }),
+        )
+        .expect_err("typo'd `targt_backend` must be rejected");
+        assert!(err.to_string().contains("unknown field"), "error: {err}");
+    }
+
+    #[test]
+    fn link_accepts_well_formed_args() {
+        validate_atomic_args(
+            "link",
+            &json!({"source_id": "a", "target_id": "b", "relation": "extends"}),
+        )
+        .expect("well-formed link args must be accepted");
+    }
+
+    #[test]
+    fn gtd_transition_rejects_unknown_field() {
+        let err = validate_atomic_args(
+            "gtd.transition",
+            &json!({"id": "x", "status": "next", "notee": "typo"}),
+        )
+        .expect_err("typo'd `notee` must be rejected");
+        assert!(err.to_string().contains("unknown field"), "error: {err}");
+    }
+
+    #[test]
+    fn gtd_transition_accepts_well_formed_args() {
+        validate_atomic_args(
+            "gtd.transition",
+            &json!({"id": "x", "status": "next", "note": "ok"}),
+        )
+        .expect("well-formed gtd.transition args must be accepted");
+    }
+
+    #[test]
+    fn gtd_complete_rejects_unknown_field() {
+        let err = validate_atomic_args("gtd.complete", &json!({"id": "x", "resutl": "typo"}))
+            .expect_err("typo'd `resutl` must be rejected");
+        assert!(err.to_string().contains("unknown field"), "error: {err}");
+    }
+
+    #[test]
+    fn gtd_complete_accepts_well_formed_args() {
+        validate_atomic_args("gtd.complete", &json!({"id": "x", "result": "ok"}))
+            .expect("well-formed gtd.complete args must be accepted");
+    }
 }
 
 #[cfg(test)]

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -618,6 +618,39 @@ async fn build_op_result(
         // Canonical shape: `normalize_entity_timestamps(to_json(&updated))`
         // (update.rs:209-211 entity, :242-244 note) — the full updated
         // entity/note row with ISO-8601 timestamps.
+        // ADR-099 B3 r9 (codex r8 Blocker finding 1, second half): a
+        // symmetric edge update carries `edge_natural_key` and MUST be
+        // rendered from a fresh post-commit natural-key lookup, never from
+        // `p.target_id` — that field is prepare-time-only (the caller's
+        // requested id), and the SAME staleness that made the write path
+        // unsafe to branch on at prepare time makes it unsafe to render
+        // from too. This mirrors the `link` arm below exactly (same
+        // reasoning, same `list_edges` mechanism).
+        ("update", AtomicOpPlan::Update(p)) if p.edge_natural_key.is_some() => {
+            let key = p.edge_natural_key.as_ref().expect("checked by guard above");
+            let edges = runtime
+                .list_edges(
+                    token,
+                    EdgeListFilter {
+                        source_id: Some(key.canon_source_id),
+                        target_id: Some(key.canon_target_id),
+                        relations: vec![key.relation],
+                        ..Default::default()
+                    },
+                    1,
+                )
+                .await?;
+            let edge = edges.into_iter().next().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "atomic update result: committed symmetric edge not found by natural key \
+                     ({}, {}, {})",
+                    key.canon_source_id,
+                    key.canon_target_id,
+                    key.relation
+                )
+            })?;
+            Ok(serde_json::to_value(&edge)?)
+        }
         ("update", AtomicOpPlan::Update(p)) => match runtime
             .resolve_by_id(token, p.target_id)
             .await?
@@ -630,15 +663,15 @@ async fn build_op_result(
             Some(Resolved::Note(note)) => Ok(khive_pack_kg::handlers::normalize_entity_timestamps(
                 serde_json::to_value(&note)?,
             )),
-            // ADR-099 B3 r6: `Resolved` has no `Edge` variant, so an edge
-            // update's `p.target_id` (the SURVIVING edge id — see
-            // `prepare_update_edge`'s symmetric-conflict-absorption branch,
-            // which may differ from the caller's original `id`) falls
-            // through here. Canonical shape: `to_json(&edge)` with no
-            // `normalize_entity_timestamps` wrapper (update.rs:220 —
-            // entity/note timestamps are ISO-8601 strings needing
-            // normalization; `Edge`'s `created_at`/`updated_at` already
-            // serialize as RFC3339 via its own `Serialize` impl).
+            // ADR-099 B3 r6: `Resolved` has no `Edge` variant, so a
+            // non-symmetric edge update's `p.target_id` (unambiguous — see
+            // `prepare_update_edge`'s non-symmetric branch, which never
+            // changes the edge's own id) falls through here. Canonical
+            // shape: `to_json(&edge)` with no `normalize_entity_timestamps`
+            // wrapper (update.rs:220 — entity/note timestamps are ISO-8601
+            // strings needing normalization; `Edge`'s `created_at`/
+            // `updated_at` already serialize as RFC3339 via its own
+            // `Serialize` impl).
             None => {
                 let edge = runtime.get_edge(token, p.target_id).await?.ok_or_else(|| {
                     anyhow::anyhow!(

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -1,0 +1,380 @@
+//! ADR-099 Slice B3 — the `--atomic` execution path for `kkernel exec
+//! --ops-file`.
+//!
+//! This module is the CLI-boundary orchestrator: it runs the parse-time
+//! admissibility check ([`khive_request::atomic::check_atomic_admissible`],
+//! B1) and the op-count guard BEFORE building any runtime or touching the
+//! database, then drives the async prepare pass (KG-substrate verbs via
+//! [`khive_runtime::atomic_prepare::prepare_op`]; `gtd.transition` /
+//! `gtd.complete` via the two `prepare_gtd_*` functions below, kept in this
+//! crate because their lifecycle vocabulary lives in `khive-pack-gtd`, which
+//! depends on `khive-runtime` — not the other way around), the synchronous
+//! commit pass ([`khive_runtime::atomic_runner::run_atomic_unit`], B2), and
+//! finally the async post-commit reindex pass
+//! ([`khive_runtime::atomic_prepare::apply_post_commit_effects`]).
+//!
+//! `propose` / `review` / `withdraw` are admissible per
+//! [`khive_types::pack::ATOMIC_ADMISSIBLE_VERBS`] but have no prepare
+//! implementation (`khive_runtime::atomic_prepare::prepare_op` fails loudly
+//! for them, before any write — see that module's doc comment).
+//!
+//! The returned envelope is additive-only and lives entirely outside
+//! `dispatch_request_local`'s response shape: non-atomic `--ops-file` runs
+//! (and every other exec path) are untouched by this module.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use khive_pack_gtd::schema::{allowed_transitions, can_transition, is_actionable, is_terminal};
+use khive_runtime::atomic_plan::{
+    AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement,
+};
+use khive_runtime::atomic_runner::{AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
+use khive_runtime::{KhiveConfig, KhiveRuntime, NamespaceToken, RuntimeConfig};
+use khive_storage::types::SqlValue;
+use khive_storage::SqlStatement;
+
+use crate::exec::OpsFileEntry;
+
+/// Run `ops` as ONE ADR-099 atomic unit against a freshly built in-process
+/// runtime. Returns the additive result envelope
+/// (`{"results", "summary", "atomic"}`) on success or a rolled-back run; the
+/// only `Err` cases are the parse-time admissibility rejection, the
+/// op-count guard, an unsupported multi-backend config, or a genuine
+/// `atomic_unit` seam failure (`AtomicRunnerError`) — every one of these
+/// happens before any write.
+pub(crate) async fn execute_atomic_ops_file(
+    ops: Vec<OpsFileEntry>,
+    cfg: RuntimeConfig,
+    khive_cfg: &KhiveConfig,
+    max_ops: usize,
+) -> Result<Value> {
+    // ── parse-time admissibility (before any runtime / any write) ──────────
+    let parsed_for_check: Vec<khive_request::ParsedOp> = ops
+        .iter()
+        .map(|op| khive_request::ParsedOp {
+            tool: op.tool.clone(),
+            args: std::collections::BTreeMap::new(),
+        })
+        .collect();
+    let rejections = khive_request::atomic::check_atomic_admissible(&parsed_for_check);
+    if !rejections.is_empty() {
+        let messages: Vec<String> = rejections.iter().map(|r| r.to_string()).collect();
+        anyhow::bail!(
+            "--atomic rejected {} op(s) before any write:\n{}",
+            messages.len(),
+            messages.join("\n")
+        );
+    }
+
+    // ── op-count guard (before any runtime / any write) ─────────────────────
+    if ops.len() > max_ops {
+        anyhow::bail!(
+            "--atomic op count {} exceeds the configured maximum {max_ops}; \
+             split the file or raise --atomic-max-ops",
+            ops.len()
+        );
+    }
+
+    // ── v1 restriction: single-backend topology only ────────────────────────
+    if !khive_cfg.backends.is_empty() {
+        anyhow::bail!(
+            "--atomic does not support a multi-backend [[backends]] topology in v1; \
+             found {} declared backend(s)",
+            khive_cfg.backends.len()
+        );
+    }
+
+    let namespace = cfg.default_namespace.clone();
+    let runtime = KhiveRuntime::new(cfg).context("build in-process runtime for --atomic")?;
+    let token = runtime
+        .authorize(namespace)
+        .context("authorize namespace for --atomic")?;
+
+    // ── async prepare pass (reads only, no writes) ───────────────────────────
+    let mut plans: Vec<AtomicOpPlan> = Vec::with_capacity(ops.len());
+    for (op_index, op) in ops.iter().enumerate() {
+        let plan = prepare_one(&runtime, &token, &op.tool, &op.args)
+            .await
+            .with_context(|| format!("op {op_index} (`{}`) failed to prepare", op.tool))?;
+        plans.push(plan);
+    }
+
+    // ── synchronous commit pass (ADR-099 D1 phase 2, B2) ────────────────────
+    let outcome = khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), plans)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let total = ops.len();
+    let envelope = match outcome {
+        AtomicRunOutcome::Committed { post_commit } => {
+            khive_runtime::atomic_prepare::apply_post_commit_effects(&runtime, &token, post_commit)
+                .await
+                .context("post-commit reindex after atomic unit commit")?;
+            let results: Vec<Value> = ops
+                .iter()
+                .enumerate()
+                .map(|(idx, op)| json!({"ok": true, "tool": op.tool, "op_index": idx}))
+                .collect();
+            json!({
+                "results": results,
+                "summary": {"total": total, "succeeded": total, "failed": 0},
+                "atomic": {
+                    "committed": true,
+                    "rolled_back": false,
+                    "failed_op_index": Value::Null,
+                    "error": Value::Null,
+                },
+            })
+        }
+        AtomicRunOutcome::RolledBack {
+            failed_op_index,
+            failure,
+        } => {
+            let error_message = describe_failure(&failure);
+            let results: Vec<Value> = ops
+                .iter()
+                .enumerate()
+                .map(|(idx, op)| {
+                    if idx == failed_op_index {
+                        json!({"ok": false, "tool": op.tool, "op_index": idx, "error": error_message})
+                    } else {
+                        json!({"ok": false, "tool": op.tool, "op_index": idx, "error": "not applied: whole atomic unit rolled back"})
+                    }
+                })
+                .collect();
+            json!({
+                "results": results,
+                "summary": {"total": total, "succeeded": 0, "failed": total},
+                "atomic": {
+                    "committed": false,
+                    "rolled_back": true,
+                    "failed_op_index": failed_op_index,
+                    "error": error_message,
+                },
+            })
+        }
+    };
+
+    Ok(envelope)
+}
+
+fn describe_failure(failure: &AtomicOpFailure) -> String {
+    match failure {
+        AtomicOpFailure::GuardFailed {
+            statement_label,
+            expected,
+            observed,
+        } => format!(
+            "guard failed on statement {statement_label:?}: expected {}..{:?} affected rows, observed {observed}",
+            expected.expected_min, expected.expected_max
+        ),
+        AtomicOpFailure::SqlError {
+            statement_label,
+            message,
+        } => format!("sql error on statement {statement_label:?}: {message}"),
+    }
+}
+
+async fn prepare_one(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    tool: &str,
+    args: &Value,
+) -> anyhow::Result<AtomicOpPlan> {
+    match tool {
+        "gtd.transition" => prepare_gtd_transition(runtime, token, args)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}")),
+        "gtd.complete" => prepare_gtd_complete(runtime, token, args)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}")),
+        _ => khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, args)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GTD prepare (kept in kkernel — see module doc for the crate-direction
+// rationale)
+// ---------------------------------------------------------------------------
+
+fn require_str<'a>(args: &'a Value, key: &str) -> anyhow::Result<&'a str> {
+    args.as_object()
+        .and_then(|o| o.get(key))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing required field {key:?}"))
+}
+
+fn require_uuid(args: &Value, key: &str) -> anyhow::Result<Uuid> {
+    let raw = require_str(args, key)?;
+    Uuid::parse_str(raw).map_err(|_| anyhow::anyhow!("{key} must be a full UUID; got {raw:?}"))
+}
+
+/// Load a task note by id, verifying kind="task" and non-deleted — mirrors
+/// `khive-pack-gtd::handlers::load_task`'s checks (reimplemented here: that
+/// function is `pub(crate)` to the gtd pack crate).
+async fn load_task(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    id: Uuid,
+) -> anyhow::Result<khive_storage::note::Note> {
+    let note = runtime
+        .notes(token)?
+        .get_note(id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("task not found: {id}"))?;
+    if note.namespace != token.namespace().as_str() {
+        anyhow::bail!("task not found: {id}");
+    }
+    if note.kind != "task" {
+        anyhow::bail!("expected kind=\"task\", got {:?}", note.kind);
+    }
+    if note.deleted_at.is_some() {
+        anyhow::bail!("task deleted: {id}");
+    }
+    Ok(note)
+}
+
+fn task_status(props: Option<&Value>) -> String {
+    props
+        .and_then(|p| p.get("status"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("inbox")
+        .to_string()
+}
+
+/// Validate the target terminal status for `gtd.complete` (mirrors
+/// `khive-pack-gtd::handlers::complete_target_status`, private to that
+/// crate): accepts `None`/`"done"` -> `"done"`, `"cancelled"` -> itself.
+fn complete_target_status(status: Option<&str>) -> anyhow::Result<&'static str> {
+    match status {
+        None | Some("done") => Ok("done"),
+        Some("cancelled") => Ok("cancelled"),
+        Some(other) => {
+            anyhow::bail!("complete: status must be \"done\" or \"cancelled\"; got {other:?}")
+        }
+    }
+}
+
+async fn prepare_gtd_transition(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> anyhow::Result<AtomicOpPlan> {
+    let id = require_uuid(args, "id")?;
+    let target = require_str(args, "status")?;
+    let note = load_task(runtime, token, id).await?;
+    let current = task_status(note.properties.as_ref());
+
+    if is_terminal(&current) {
+        anyhow::bail!("task {id} is in terminal state {current:?}; no further transitions allowed");
+    }
+    if current != target && !can_transition(&current, target) {
+        let allowed = allowed_transitions(&current);
+        anyhow::bail!(
+            "cannot transition from {current:?} to {target:?}; allowed from {current:?}: {}",
+            if allowed.is_empty() {
+                "(none)".to_string()
+            } else {
+                allowed.join(", ")
+            }
+        );
+    }
+
+    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    if let Some(obj) = props.as_object_mut() {
+        obj.insert("status".into(), json!(target));
+        if target == "done" {
+            obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+        }
+    }
+    let updated_at = Utc::now().timestamp_micros();
+
+    let statement = SqlStatement {
+        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
+              WHERE id = ?3 AND json_extract(properties, '$.status') = ?4 \
+              AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(serde_json::to_string(&props)?),
+            SqlValue::Integer(updated_at),
+            SqlValue::Text(id.to_string()),
+            SqlValue::Text(current),
+        ],
+        label: Some("atomic-gtd-transition".to_string()),
+    };
+
+    Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
+        task_id: id,
+        statements: vec![PlanStatement {
+            statement,
+            guard: Some(AffectedRowGuard::exactly(1)),
+        }],
+    }))
+}
+
+async fn prepare_gtd_complete(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+) -> anyhow::Result<AtomicOpPlan> {
+    let id = require_uuid(args, "id")?;
+    let status_arg = args
+        .as_object()
+        .and_then(|o| o.get("status"))
+        .and_then(|v| v.as_str());
+    let target = complete_target_status(status_arg)?;
+    let result_arg = args
+        .as_object()
+        .and_then(|o| o.get("result"))
+        .and_then(|v| v.as_str());
+
+    let note = load_task(runtime, token, id).await?;
+    let current = task_status(note.properties.as_ref());
+
+    if is_terminal(&current) {
+        anyhow::bail!("task {id} is in terminal state {current:?}; no further transitions allowed");
+    }
+    if !is_actionable(&current) {
+        anyhow::bail!(
+            "complete: task in {current:?}; transition to 'next' or 'active' first, \
+             or use gtd.transition(status=done) explicitly"
+        );
+    }
+
+    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+    if let Some(obj) = props.as_object_mut() {
+        obj.insert("status".into(), json!(target));
+        obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+        if let Some(result) = result_arg {
+            obj.insert("result".into(), json!(result));
+        }
+    }
+    let updated_at = Utc::now().timestamp_micros();
+
+    let statement = SqlStatement {
+        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
+              WHERE id = ?3 AND json_extract(properties, '$.status') = ?4 \
+              AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![
+            SqlValue::Text(serde_json::to_string(&props)?),
+            SqlValue::Integer(updated_at),
+            SqlValue::Text(id.to_string()),
+            SqlValue::Text(current),
+        ],
+        label: Some("atomic-gtd-complete".to_string()),
+    };
+
+    Ok(AtomicOpPlan::GtdComplete(GtdCompletePlan {
+        task_id: id,
+        statements: vec![PlanStatement {
+            statement,
+            guard: Some(AffectedRowGuard::exactly(1)),
+        }],
+    }))
+}

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -390,7 +390,20 @@ async fn prepare_one(
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok((plan, args.clone()))
         }
-        "update" | "link" => {
+        "update" => {
+            let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
+            let expected_kind = update_expected_kind(&resolved, registry)?;
+            let plan = khive_runtime::atomic_prepare::prepare_update(
+                runtime,
+                token,
+                &resolved,
+                expected_kind,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, resolved))
+        }
+        "link" => {
             let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
             let plan = khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, &resolved)
                 .await
@@ -520,6 +533,49 @@ fn delete_expected_kind(
         khive_pack_kg::handlers::KindSpec::Event | khive_pack_kg::handlers::KindSpec::Proposal => {
             Err(anyhow::anyhow!(
                 "kind {raw:?} not supported under --atomic delete; only entity/note/edge \
+                 substrates are v1-admissible"
+            ))
+        }
+    }
+}
+
+/// Resolve a caller-supplied `update(kind=...)` string into the
+/// [`khive_runtime::atomic_prepare::AtomicUpdateKind`] `prepare_update`
+/// enforces, using the SAME canonical `resolve_kind_spec` the non-atomic
+/// `handle_update` calls (ADR-099 B3 r7, codex r7 Blocker finding 1). Exact
+/// mirror of [`delete_expected_kind`] above — same reasoning, same shape,
+/// differing only in which `AtomicOpPlan`-adjacent enum it targets. `kind`
+/// absent -> `Ok(None)` (no check, parity with canonical's own optional
+/// discriminator). `Event`/`Proposal` remain a fail-loud rejection BEFORE
+/// `prepare_update` (and therefore before any write): those substrates are
+/// not v1-admissible for atomic update at all.
+fn update_expected_kind(
+    args: &Value,
+    registry: &VerbRegistry,
+) -> anyhow::Result<Option<khive_runtime::atomic_prepare::AtomicUpdateKind>> {
+    let raw = match args
+        .as_object()
+        .and_then(|o| o.get("kind"))
+        .and_then(|v| v.as_str())
+    {
+        Some(k) => k,
+        None => return Ok(None),
+    };
+    let spec = khive_pack_kg::handlers::resolve_kind_spec(raw, registry)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    match spec {
+        khive_pack_kg::handlers::KindSpec::Entity { specific } => Ok(Some(
+            khive_runtime::atomic_prepare::AtomicUpdateKind::Entity { specific },
+        )),
+        khive_pack_kg::handlers::KindSpec::Note { specific } => Ok(Some(
+            khive_runtime::atomic_prepare::AtomicUpdateKind::Note { specific },
+        )),
+        khive_pack_kg::handlers::KindSpec::Edge => {
+            Ok(Some(khive_runtime::atomic_prepare::AtomicUpdateKind::Edge))
+        }
+        khive_pack_kg::handlers::KindSpec::Event | khive_pack_kg::handlers::KindSpec::Proposal => {
+            Err(anyhow::anyhow!(
+                "kind {raw:?} not supported under --atomic update; only entity/note/edge \
                  substrates are v1-admissible"
             ))
         }

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -51,9 +51,12 @@ use khive_runtime::atomic_plan::{
     AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement, PostCommitEffect,
 };
 use khive_runtime::atomic_runner::{AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
-use khive_runtime::{KhiveConfig, KhiveRuntime, NamespaceToken, RuntimeConfig};
+use khive_runtime::pack::{PackRegistry, VerbRegistry, VerbRegistryBuilder};
+use khive_runtime::{
+    EdgeListFilter, KhiveConfig, KhiveRuntime, NamespaceToken, Resolved, RuntimeConfig,
+};
 use khive_storage::types::SqlValue;
-use khive_storage::SqlStatement;
+use khive_storage::{EdgeRelation, SqlStatement};
 
 use crate::exec::OpsFileEntry;
 
@@ -112,19 +115,53 @@ pub(crate) async fn execute_atomic_ops_file(
         .authorize(namespace)
         .context("authorize namespace for --atomic")?;
 
+    // ADR-099 B3 fix round 5, finding 1: a `VerbRegistry` built from every
+    // discovered pack, reusing the REAL runtime just constructed above (via
+    // `.clone()` — `KhiveRuntime` derives `Clone`) rather than a second
+    // throwaway one (the pattern `kkernel::pack_introspect::build_registry`
+    // uses for introspection). This is what makes `resolve_kind_spec`
+    // reachable at this seam: `khive-runtime` cannot depend on
+    // `khive-pack-kg`/`khive-pack-gtd` (packs depend on the runtime, not
+    // vice versa), so `resolve_kind_spec`'s vocab lookup (granular
+    // entity_kind/note_kind names from every loaded pack) can only be done
+    // here, where both the runtime and the packs are visible.
+    let mut verb_registry_builder = VerbRegistryBuilder::new();
+    let pack_names: Vec<String> = PackRegistry::discovered_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    PackRegistry::register_packs(&pack_names, runtime.clone(), &mut verb_registry_builder)
+        .map_err(|n| anyhow::anyhow!("pack {n:?} declared in inventory but factory missing"))?;
+    let verb_registry = verb_registry_builder
+        .build()
+        .context("building VerbRegistry for --atomic kind resolution")?;
+
     // ── async prepare pass (reads only, no writes) ───────────────────────────
     let mut plans: Vec<AtomicOpPlan> = Vec::with_capacity(ops.len());
+    // ADR-099 B3 fix round 5, finding 4: the exact args each op's plan was
+    // built from (post id-resolution for update/delete/link — finding 3) —
+    // carried alongside the plan so the post-commit result-rendering pass
+    // can re-derive natural keys (e.g. a link's canonical edge lookup)
+    // without re-parsing the ops file.
+    let mut resolved_args_list: Vec<Value> = Vec::with_capacity(ops.len());
     for (op_index, op) in ops.iter().enumerate() {
-        let plan = prepare_one(&runtime, &token, &op.tool, &op.args)
-            .await
-            .with_context(|| format!("op {op_index} (`{}`) failed to prepare", op.tool))?;
+        let (plan, resolved_args) =
+            prepare_one(&runtime, &token, &verb_registry, &op.tool, &op.args)
+                .await
+                .with_context(|| format!("op {op_index} (`{}`) failed to prepare", op.tool))?;
         plans.push(plan);
+        resolved_args_list.push(resolved_args);
     }
 
     // ── synchronous commit pass (ADR-099 D1 phase 2, B2) ────────────────────
-    let outcome = khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), plans)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // `plans` is cloned here: `run_atomic_unit` consumes it by value, but the
+    // post-commit result-rendering pass below (finding 4) still needs each
+    // op's plan (target ids, canonical link endpoints, gtd post-commit
+    // effects) to build its `result` payload.
+    let outcome =
+        khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), plans.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let total = ops.len();
     let envelope = match outcome {
@@ -144,11 +181,31 @@ pub(crate) async fn execute_atomic_ops_file(
             khive_runtime::atomic_prepare::apply_post_commit_effects(&runtime, &token, post_commit)
                 .await
                 .context("post-commit reindex after atomic unit commit")?;
-            let results: Vec<Value> = ops
-                .iter()
-                .enumerate()
-                .map(|(idx, op)| json!({"ok": true, "tool": op.tool, "op_index": idx}))
-                .collect();
+            // ADR-099 B3 fix round 5, finding 4: render each committed op's
+            // canonical-shaped `result` payload (ADR-099 D4 requires
+            // `results[i].result`; the pre-fix envelope carried only
+            // `{ok, tool, op_index}`). Result rendering is itself a READ —
+            // safe post-commit, same reasoning as the reindex pass above.
+            let mut results: Vec<Value> = Vec::with_capacity(ops.len());
+            for (idx, op) in ops.iter().enumerate() {
+                let result = build_op_result(
+                    &runtime,
+                    &token,
+                    &op.tool,
+                    &op.args,
+                    &resolved_args_list[idx],
+                    &plans[idx],
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "op {idx} (`{}`) committed but result rendering failed",
+                        op.tool
+                    )
+                })?;
+                results
+                    .push(json!({"ok": true, "tool": op.tool, "op_index": idx, "result": result}));
+            }
             json!({
                 "results": results,
                 "summary": {"total": total, "succeeded": total, "failed": 0},
@@ -298,23 +355,369 @@ fn validate_atomic_args(tool: &str, args: &Value) -> anyhow::Result<()> {
     }
 }
 
+/// Returns `(plan, resolved_args)` — `resolved_args` is `args` for
+/// `gtd.transition`/`gtd.complete` (their own prepare fns resolve `id`
+/// internally via the canonical gtd resolver, finding 3) and for any tool
+/// with no id-bearing fields; for `update`/`delete`/`link` it is the
+/// id-rewritten form `resolve_kg_ids_in_args` produces, carried forward so
+/// the post-commit result-rendering pass (finding 4) can re-derive natural
+/// keys (e.g. a link's canonical edge lookup) without re-resolving ids.
 async fn prepare_one(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+    tool: &str,
+    args: &Value,
+) -> anyhow::Result<(AtomicOpPlan, Value)> {
+    validate_atomic_args(tool, args)?;
+    match tool {
+        "gtd.transition" => {
+            let plan = prepare_gtd_transition(runtime, token, args)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, args.clone()))
+        }
+        "gtd.complete" => {
+            let plan = prepare_gtd_complete(runtime, token, args)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, args.clone()))
+        }
+        "update" | "link" => {
+            let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
+            let plan = khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, &resolved)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, resolved))
+        }
+        "delete" => {
+            let resolved = resolve_kg_ids_in_args(runtime, token, tool, args).await?;
+            let expected_kind = delete_expected_kind(&resolved, registry)?;
+            let plan = khive_runtime::atomic_prepare::prepare_delete(
+                runtime,
+                token,
+                &resolved,
+                expected_kind,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, resolved))
+        }
+        _ => {
+            let plan = khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, args)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok((plan, args.clone()))
+        }
+    }
+}
+
+/// Rewrite an op's KG-substrate id fields (`id` for update/delete;
+/// `source_id`/`target_id` for link) to resolved full UUIDs before handing
+/// args to `khive_runtime::atomic_prepare`, which only accepts bare
+/// `Uuid::parse_str` (ADR-099 B3 fix round 5, finding 3 — codex r3 REJECT
+/// High). Canonical KG handlers resolve through `resolve_uuid_unfiltered`
+/// (full UUID -> 8+ hex prefix -> entity-name fallback, common.rs:270; the
+/// `_including_deleted` variant for hard delete, mirroring
+/// `handle_delete`'s `hard` branch at update.rs:268-271) — both are now
+/// `pub` specifically for this seam. Resolution is a READ, so it belongs in
+/// the async prepare phase; the suspend-free commit-phase invariant is
+/// untouched. A field that is absent or not a string is left unchanged —
+/// the downstream `prepare_*` fn's own "missing required field"/"must be a
+/// full UUID" error still fires with its existing message shape.
+async fn resolve_kg_ids_in_args(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     tool: &str,
     args: &Value,
-) -> anyhow::Result<AtomicOpPlan> {
-    validate_atomic_args(tool, args)?;
+) -> anyhow::Result<Value> {
+    let mut out = args.clone();
+    let hard = out
+        .as_object()
+        .and_then(|o| o.get("hard"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    async fn rewrite(
+        obj: &mut serde_json::Map<String, Value>,
+        key: &str,
+        runtime: &KhiveRuntime,
+        token: &NamespaceToken,
+        including_deleted: bool,
+    ) -> anyhow::Result<()> {
+        let Some(Value::String(raw)) = obj.get(key).cloned() else {
+            return Ok(());
+        };
+        let resolved = if including_deleted {
+            khive_pack_kg::handlers::resolve_uuid_unfiltered_including_deleted(&raw, runtime, token)
+                .await
+        } else {
+            khive_pack_kg::handlers::resolve_uuid_unfiltered(&raw, runtime, token).await
+        }
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        obj.insert(key.to_string(), json!(resolved.to_string()));
+        Ok(())
+    }
+
+    let obj = out
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("op args must be a JSON object"))?;
     match tool {
-        "gtd.transition" => prepare_gtd_transition(runtime, token, args)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}")),
-        "gtd.complete" => prepare_gtd_complete(runtime, token, args)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}")),
-        _ => khive_runtime::atomic_prepare::prepare_op(runtime, token, tool, args)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}")),
+        "update" => rewrite(obj, "id", runtime, token, false).await?,
+        "delete" => rewrite(obj, "id", runtime, token, hard).await?,
+        "link" => {
+            rewrite(obj, "source_id", runtime, token, false).await?;
+            rewrite(obj, "target_id", runtime, token, false).await?;
+        }
+        _ => {}
+    }
+    Ok(out)
+}
+
+/// Resolve a caller-supplied `delete(kind=...)` string into the
+/// [`khive_runtime::atomic_prepare::AtomicDeleteKind`] `prepare_delete`
+/// enforces, using the SAME canonical `resolve_kind_spec` the non-atomic
+/// `handle_delete` calls (ADR-099 B3 fix round 5, finding 1 — codex r3
+/// REJECT Blocker). `kind` absent -> `Ok(None)` (no check, parity with
+/// canonical's own optional discriminator). `kind` resolving to
+/// `Edge`/`Event`/`Proposal` -> a fail-loud rejection BEFORE `prepare_delete`
+/// (and therefore before any write): those substrates are not v1-admissible
+/// for atomic delete (`prepare_delete`'s own match arms only ever build a
+/// plan for `Resolved::Entity`/`Resolved::Note`).
+fn delete_expected_kind(
+    args: &Value,
+    registry: &VerbRegistry,
+) -> anyhow::Result<Option<khive_runtime::atomic_prepare::AtomicDeleteKind>> {
+    let raw = match args
+        .as_object()
+        .and_then(|o| o.get("kind"))
+        .and_then(|v| v.as_str())
+    {
+        Some(k) => k,
+        None => return Ok(None),
+    };
+    let spec = khive_pack_kg::handlers::resolve_kind_spec(raw, registry)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    match spec {
+        khive_pack_kg::handlers::KindSpec::Entity { specific } => Ok(Some(
+            khive_runtime::atomic_prepare::AtomicDeleteKind::Entity { specific },
+        )),
+        khive_pack_kg::handlers::KindSpec::Note { specific } => Ok(Some(
+            khive_runtime::atomic_prepare::AtomicDeleteKind::Note { specific },
+        )),
+        khive_pack_kg::handlers::KindSpec::Edge
+        | khive_pack_kg::handlers::KindSpec::Event
+        | khive_pack_kg::handlers::KindSpec::Proposal => Err(anyhow::anyhow!(
+            "kind {raw:?} not supported under --atomic delete; only entity/note substrates \
+             are v1-admissible"
+        )),
+    }
+}
+
+/// Extract `(from_status, to_status)` from a gtd lifecycle post-commit
+/// effect — used by [`build_op_result`] below.
+fn gtd_audit_from_to(effect: &PostCommitEffect) -> Option<(String, String)> {
+    match effect {
+        PostCommitEffect::GtdAudit {
+            from_status,
+            to_status,
+            ..
+        } => Some((from_status.clone(), to_status.clone())),
+        _ => None,
+    }
+}
+
+/// Render a committed op's canonical-shaped `result` payload (ADR-099 B3 fix
+/// round 5, finding 4 — codex r3 REJECT High: the pre-fix envelope carried
+/// only `{ok, tool, op_index}`, dropping the `results[i].result` ADR-099 D4
+/// specifies). Result rendering is a pure READ, run strictly after the
+/// commit pass — safe for the same reason the post-commit reindex pass is.
+///
+/// `original_args`: the op's args exactly as the caller supplied them
+/// (needed for delete's `id`/`kind` echo, and gtd.transition's raw
+/// `status`). `resolved_args`: the id-rewritten form `resolve_kg_ids_in_args`
+/// produced for update/delete/link (`== original_args` for gtd ops, whose
+/// own prepare fns resolve `id` internally).
+async fn build_op_result(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    tool: &str,
+    original_args: &Value,
+    resolved_args: &Value,
+    plan: &AtomicOpPlan,
+) -> anyhow::Result<Value> {
+    match (tool, plan) {
+        // Canonical shape: `normalize_entity_timestamps(to_json(&updated))`
+        // (update.rs:209-211 entity, :242-244 note) — the full updated
+        // entity/note row with ISO-8601 timestamps.
+        ("update", AtomicOpPlan::Update(p)) => match runtime
+            .resolve_by_id(token, p.target_id)
+            .await?
+        {
+            Some(Resolved::Entity(entity)) => {
+                Ok(khive_pack_kg::handlers::normalize_entity_timestamps(
+                    serde_json::to_value(&entity)?,
+                ))
+            }
+            Some(Resolved::Note(note)) => Ok(khive_pack_kg::handlers::normalize_entity_timestamps(
+                serde_json::to_value(&note)?,
+            )),
+            _ => anyhow::bail!(
+                "atomic update result: target {} not found post-commit",
+                p.target_id
+            ),
+        },
+        // Canonical shape: `{"deleted": deleted, "id": p.id, "kind": p.kind}`
+        // (update.rs:327/:356/:360) — `p.id`/`p.kind` are the CALLER's
+        // original strings (pre id-resolution), not the resolved UUID.
+        ("delete", AtomicOpPlan::Delete(_)) => {
+            let id_val = original_args
+                .as_object()
+                .and_then(|o| o.get("id"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let kind_val = original_args
+                .as_object()
+                .and_then(|o| o.get("kind"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            Ok(json!({"deleted": true, "id": id_val, "kind": kind_val}))
+        }
+        // Canonical shape: `to_json(&edge)` with `source_id`/`target_id`
+        // swapped back to the CALLER's order for a symmetric relation
+        // (link.rs:183-189). The atomic INSERT is a natural-key upsert, so
+        // the prepare-time-generated edge id may not be the committed row's
+        // id on a conflict — look the edge up post-commit by
+        // `(canonical_source, canonical_target, relation)` instead of
+        // trusting it.
+        ("link", AtomicOpPlan::Link(p)) => {
+            let relation_str = resolved_args
+                .as_object()
+                .and_then(|o| o.get("relation"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("atomic link result: missing relation"))?;
+            let relation: EdgeRelation = relation_str
+                .parse()
+                .map_err(|e| anyhow::anyhow!("atomic link result: unknown relation: {e}"))?;
+            let edges = runtime
+                .list_edges(
+                    token,
+                    EdgeListFilter {
+                        source_id: Some(p.source_id),
+                        target_id: Some(p.target_id),
+                        relations: vec![relation],
+                        ..Default::default()
+                    },
+                    1,
+                )
+                .await?;
+            let edge = edges.into_iter().next().ok_or_else(|| {
+                anyhow::anyhow!("atomic link result: committed edge not found by natural key")
+            })?;
+            let mut raw = serde_json::to_value(&edge)?;
+            if relation.is_symmetric() {
+                if let Some(obj) = raw.as_object_mut() {
+                    let orig_source = resolved_args
+                        .as_object()
+                        .and_then(|o| o.get("source_id"))
+                        .cloned()
+                        .unwrap_or(Value::Null);
+                    let orig_target = resolved_args
+                        .as_object()
+                        .and_then(|o| o.get("target_id"))
+                        .cloned()
+                        .unwrap_or(Value::Null);
+                    obj.insert("source_id".to_string(), orig_source);
+                    obj.insert("target_id".to_string(), orig_target);
+                }
+            }
+            Ok(raw)
+        }
+        // Canonical shapes: handlers.rs:1030-1037 (idempotent no-op) /
+        // :1107-1118 (transitioned). `p.statements.is_empty()` is exactly
+        // the idempotent-no-op signal `prepare_gtd_transition` encodes
+        // (current == target after `normalize_status`, GAP-6).
+        ("gtd.transition", AtomicOpPlan::GtdTransition(p)) => {
+            let note = runtime
+                .notes(token)?
+                .get_note(p.task_id)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("atomic gtd.transition result: task not found post-commit")
+                })?;
+            let task = khive_pack_gtd::handlers::render_task(&note);
+            if p.statements.is_empty() {
+                let raw_status = original_args
+                    .as_object()
+                    .and_then(|o| o.get("status"))
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("atomic gtd.transition result: missing status")
+                    })?;
+                let target = normalize_status(raw_status);
+                Ok(json!({
+                    "transitioned": false,
+                    "id": task["id"],
+                    "full_id": task["full_id"],
+                    "from": target,
+                    "to": target,
+                    "note": "already in target status",
+                }))
+            } else {
+                let (from_status, to_status) =
+                    gtd_audit_from_to(&p.post_commit).ok_or_else(|| {
+                        anyhow::anyhow!("atomic gtd.transition result: missing audit effect")
+                    })?;
+                Ok(json!({
+                    "transitioned": true,
+                    "id": task["id"],
+                    "full_id": task["full_id"],
+                    "from": from_status,
+                    "to": to_status,
+                    "is_terminal": is_terminal(&to_status),
+                    "title": task["title"],
+                    "priority": task["priority"],
+                    "assignee": task["assignee"],
+                    "due": task["due"],
+                }))
+            }
+        }
+        // Canonical shape: handlers.rs:918-926.
+        ("gtd.complete", AtomicOpPlan::GtdComplete(p)) => {
+            let note = runtime
+                .notes(token)?
+                .get_note(p.task_id)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("atomic gtd.complete result: task not found post-commit")
+                })?;
+            let task = khive_pack_gtd::handlers::render_task(&note);
+            let (from_status, to_status) = gtd_audit_from_to(&p.post_commit).ok_or_else(|| {
+                anyhow::anyhow!("atomic gtd.complete result: missing audit effect")
+            })?;
+            let completed_at = note
+                .properties
+                .as_ref()
+                .and_then(|props| props.get("completed_at"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("atomic gtd.complete result: missing completed_at")
+                })?;
+            Ok(json!({
+                "completed": true,
+                "id": task["id"],
+                "full_id": task["full_id"],
+                "from": from_status,
+                "to": to_status,
+                "completed_at": completed_at,
+                "is_terminal": is_terminal(&to_status),
+            }))
+        }
+        (other, _) => anyhow::bail!(
+            "atomic result rendering: no canonical-shape renderer for {other:?} \
+             (this is a bug — every v1 --atomic-admissible verb must have one)"
+        ),
     }
 }
 
@@ -330,9 +733,21 @@ fn require_str<'a>(args: &'a Value, key: &str) -> anyhow::Result<&'a str> {
         .ok_or_else(|| anyhow::anyhow!("missing required field {key:?}"))
 }
 
-fn require_uuid(args: &Value, key: &str) -> anyhow::Result<Uuid> {
+/// Resolve a gtd task id (full UUID or 8+ hex prefix), mirroring canonical
+/// GTD lifecycle verbs' resolution (`khive_pack_gtd::handlers::resolve_uuid`,
+/// handlers.rs:270 — ADR-099 B3 fix round 5, finding 3 — codex r3 REJECT
+/// High: the pre-fix version below (`require_uuid`) only accepted a bare
+/// full UUID, rejecting the short ids `gtd.assign` itself returns).
+async fn resolve_gtd_id(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    args: &Value,
+    key: &str,
+) -> anyhow::Result<Uuid> {
     let raw = require_str(args, key)?;
-    Uuid::parse_str(raw).map_err(|_| anyhow::anyhow!("{key} must be a full UUID; got {raw:?}"))
+    khive_pack_gtd::handlers::resolve_uuid(raw, runtime, token)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 /// Load a task note by id, verifying kind="task" and non-deleted — mirrors
@@ -386,7 +801,7 @@ async fn prepare_gtd_transition(
     token: &NamespaceToken,
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
-    let id = require_uuid(args, "id")?;
+    let id = resolve_gtd_id(runtime, token, args, "id").await?;
     let raw_status = require_str(args, "status")?;
 
     // GAP-3 (B3 fix round 4): parity with `handle_transition`
@@ -500,7 +915,7 @@ async fn prepare_gtd_complete(
     token: &NamespaceToken,
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
-    let id = require_uuid(args, "id")?;
+    let id = resolve_gtd_id(runtime, token, args, "id").await?;
     let status_arg = args
         .as_object()
         .and_then(|o| o.get("status"))

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -282,6 +282,18 @@ async fn prepare_gtd_transition(
 ) -> anyhow::Result<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
     let target = require_str(args, "status")?;
+    let note_arg = args
+        .as_object()
+        .and_then(|o| o.get("note"))
+        .and_then(|v| v.as_str());
+
+    // Parity with `khive-pack-gtd::handlers::handle_transition`
+    // (handlers.rs:988): secret-gate the caller-supplied transition note
+    // BEFORE any DB read/write (codex r2 High finding 3).
+    if let Some(n) = note_arg {
+        khive_runtime::secret_gate::check(n)?;
+    }
+
     let note = load_task(runtime, token, id).await?;
     let current = task_status(note.properties.as_ref());
 
@@ -303,6 +315,11 @@ async fn prepare_gtd_transition(
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
     if let Some(obj) = props.as_object_mut() {
         obj.insert("status".into(), json!(target));
+        // Parity with handlers.rs:1028 — persist the caller-supplied
+        // transition note under `properties.transition_note`.
+        if let Some(n) = note_arg {
+            obj.insert("transition_note".into(), json!(n));
+        }
         if target == "done" {
             obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
         }
@@ -348,6 +365,13 @@ async fn prepare_gtd_complete(
         .and_then(|o| o.get("result"))
         .and_then(|v| v.as_str());
 
+    // Parity with `khive-pack-gtd::handlers::handle_complete` (handlers.rs:803):
+    // secret-gate the caller-supplied result BEFORE any DB read/write
+    // (codex r2 High finding 3).
+    if let Some(result) = result_arg {
+        khive_runtime::secret_gate::check(result)?;
+    }
+
     let note = load_task(runtime, token, id).await?;
     let current = task_status(note.properties.as_ref());
 
@@ -392,4 +416,209 @@ async fn prepare_gtd_complete(
             guard: Some(AffectedRowGuard::exactly(1)),
         }],
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use khive_types::Namespace;
+
+    fn scratch_runtime() -> KhiveRuntime {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("atomic_apply_gtd.db");
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        std::mem::forget(dir);
+        rt
+    }
+
+    /// Seed a live GTD task note directly (bypassing `gtd.assign`'s handler,
+    /// which lives one crate over) with the flat properties shape
+    /// `load_task`/`task_status` expect: `kind = "task"`,
+    /// `properties.status`.
+    async fn seed_task(runtime: &KhiveRuntime, token: &NamespaceToken, status: &str) -> Uuid {
+        let mut note = khive_storage::note::Note::new("local", "task", "atomic-gtd-test-task");
+        note.name = Some("atomic-gtd-test-task".to_string());
+        note.properties = Some(json!({"status": status, "priority": "p2"}));
+        let id = note.id;
+        runtime
+            .notes(token)
+            .expect("notes store")
+            .upsert_note(note)
+            .await
+            .expect("seed task");
+        id
+    }
+
+    fn task_properties(note: &khive_storage::note::Note) -> &Value {
+        note.properties
+            .as_ref()
+            .expect("task must carry properties")
+    }
+
+    /// B3 fix round 3 (codex r2 High finding 3): atomic `gtd.transition`
+    /// must persist a caller-supplied `note` as `properties.transition_note`
+    /// — parity with `khive-pack-gtd::handlers::handle_transition`
+    /// (handlers.rs:1028), which the pre-fix atomic prepare silently
+    /// dropped (it never read the `note` arg at all).
+    #[tokio::test]
+    async fn atomic_gtd_transition_persists_transition_note() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+
+        let plan = prepare_gtd_transition(
+            &runtime,
+            &token,
+            &json!({"id": task_id.to_string(), "status": "next", "note": "handed off to reviewer"}),
+        )
+        .await
+        .expect("prepare transition");
+
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+
+        let note = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        let props = task_properties(&note);
+        assert_eq!(props.get("status").and_then(|v| v.as_str()), Some("next"));
+        assert_eq!(
+            props.get("transition_note").and_then(|v| v.as_str()),
+            Some("handed off to reviewer"),
+            "transition_note must be persisted into properties: {props:?}"
+        );
+    }
+
+    /// B3 fix round 3 (codex r2 High finding 3): a secret in the
+    /// `gtd.transition` `note` arg must be REJECTED at prepare, before any
+    /// DB write — parity with `handle_transition`'s pre-write secret_gate
+    /// check (handlers.rs:988).
+    #[tokio::test]
+    async fn atomic_gtd_transition_rejects_secret_in_note_before_any_write() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "inbox").await;
+
+        let err = prepare_gtd_transition(
+            &runtime,
+            &token,
+            &json!({
+                "id": task_id.to_string(),
+                "status": "next",
+                "note": "leaked key AKIAFAKEKEY1234567890",
+            }),
+        )
+        .await
+        .expect_err("a secret in the transition note must be rejected at prepare");
+        assert!(
+            err.to_string().contains("write blocked"),
+            "expected a secret_gate rejection, got: {err}"
+        );
+
+        // No write must have happened: status is still "inbox".
+        let note = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        assert_eq!(
+            task_properties(&note)
+                .get("status")
+                .and_then(|v| v.as_str()),
+            Some("inbox"),
+            "rejected prepare must not have mutated the task"
+        );
+    }
+
+    /// B3 fix round 3 (codex r2 High finding 3): a secret in the
+    /// `gtd.complete` `result` arg must be REJECTED at prepare, before any
+    /// DB write — parity with `handle_complete`'s pre-write secret_gate
+    /// check (handlers.rs:803); a clean result persists normally
+    /// (handlers.rs:832 parity).
+    #[tokio::test]
+    async fn atomic_gtd_complete_rejects_secret_in_result_and_persists_clean_result() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        // (a) secret in `result` rejected before any write.
+        let task_id = seed_task(&runtime, &token, "next").await;
+        let err = prepare_gtd_complete(
+            &runtime,
+            &token,
+            &json!({
+                "id": task_id.to_string(),
+                "result": "shipped using AKIAFAKEKEY1234567890",
+            }),
+        )
+        .await
+        .expect_err("a secret in the complete result must be rejected at prepare");
+        assert!(
+            err.to_string().contains("write blocked"),
+            "expected a secret_gate rejection, got: {err}"
+        );
+        let note = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        assert_eq!(
+            task_properties(&note)
+                .get("status")
+                .and_then(|v| v.as_str()),
+            Some("next"),
+            "rejected prepare must not have mutated the task"
+        );
+
+        // (b) a clean result persists.
+        let plan = prepare_gtd_complete(
+            &runtime,
+            &token,
+            &json!({"id": task_id.to_string(), "result": "shipped clean"}),
+        )
+        .await
+        .expect("prepare complete");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+
+        let note = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        let props = task_properties(&note);
+        assert_eq!(props.get("status").and_then(|v| v.as_str()), Some("done"));
+        assert_eq!(
+            props.get("result").and_then(|v| v.as_str()),
+            Some("shipped clean")
+        );
+    }
 }

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -14,9 +14,24 @@
 //! ([`khive_runtime::atomic_prepare::apply_post_commit_effects`]).
 //!
 //! `propose` / `review` / `withdraw` are admissible per
-//! [`khive_types::pack::ATOMIC_ADMISSIBLE_VERBS`] but have no prepare
-//! implementation (`khive_runtime::atomic_prepare::prepare_op` fails loudly
-//! for them, before any write — see that module's doc comment).
+//! [`khive_types::pack::ATOMIC_ADMISSIBLE_VERBS`] (ADR-099 D3 intends them to
+//! gain a seam) but have no prepare implementation yet. B3 fix round (codex
+//! REJECT, Medium finding): they are now rejected by the SAME pre-runtime
+//! `check_atomic_admissible` static guard above, as
+//! [`khive_types::pack::AtomicRejectionReason::KnownUnimplemented`] — never
+//! reaching `KhiveRuntime::new` or `prepare_one` at all. `prepare_op`'s own
+//! `prepare_governance_unimplemented` fallback (see that module's doc
+//! comment) is unreachable through this CLI path and remains only as
+//! defense-in-depth for any other caller of `prepare_op`.
+//!
+//! `merge` joined this same deferred bucket in the B3 fix round (Leo
+//! refinement, codex REJECT Blocker 2): a full-parity atomic merge prepare
+//! was drafted and unit-tested against `khive_runtime::atomic_prepare`
+//! directly, but its edge-conflict resolution cannot be expressed in
+//! ADR-099's static predicate/guard plan shape (see that crate's
+//! `atomic_prepare` module doc), so it is rejected here rather than shipped
+//! partially-scoped — `merge is not yet supported under --atomic; use the
+//! non-atomic merge verb` is the message callers see.
 //!
 //! The returned envelope is additive-only and lives entirely outside
 //! `dispatch_request_local`'s response shape: non-atomic `--ops-file` runs

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -6,11 +6,20 @@
 //! B1) and the op-count guard BEFORE building any runtime or touching the
 //! database, then drives the async prepare pass (KG-substrate verbs via
 //! [`khive_runtime::atomic_prepare::prepare_op`]; `gtd.transition` /
-//! `gtd.complete` via the two `prepare_gtd_*` functions below, kept in this
-//! crate because their lifecycle vocabulary lives in `khive-pack-gtd`, which
-//! depends on `khive-runtime` — not the other way around), the synchronous
-//! commit pass ([`khive_runtime::atomic_runner::run_atomic_unit`], B2), and
-//! finally the async post-commit reindex pass
+//! `gtd.complete` via the two `prepare_gtd_*` functions below — thin
+//! `AtomicOpPlan` adapters over the shared decide steps
+//! `khive_pack_gtd::handlers::prepare_transition` / `prepare_complete`,
+//! the SAME functions the canonical, non-atomic `handle_transition` /
+//! `handle_complete` call before applying (ADR-099 B3 r6 second pass). The
+//! adapters live in this crate rather than `khive-pack-gtd` purely because
+//! `AtomicOpPlan`/`PlanStatement` are `khive-runtime` atomic-plan vocabulary
+//! this CLI orchestrator owns; the decide LOGIC itself is not duplicated —
+//! it lives once, in `khive-pack-gtd::handlers::{prepare_transition,
+//! prepare_complete}`, consumed both by canonical `handle_transition` /
+//! `handle_complete` (which apply it directly) and by the two adapters
+//! below (which turn the same decision into an `AtomicOpPlan`)), the
+//! synchronous commit pass ([`khive_runtime::atomic_runner::run_atomic_unit`],
+//! B2), and finally the async post-commit reindex pass
 //! ([`khive_runtime::atomic_prepare::apply_post_commit_effects`]).
 //!
 //! `propose` / `review` / `withdraw` are admissible per
@@ -38,15 +47,12 @@
 //! (and every other exec path) are untouched by this module.
 
 use anyhow::{Context, Result};
-use chrono::Utc;
 use serde_json::{json, Value};
+#[cfg(test)]
 use uuid::Uuid;
 
 use khive_pack_gtd::handlers::{ensure_audit_schema, write_audit_record};
-use khive_pack_gtd::schema::{
-    allowed_transitions, can_transition, is_actionable, is_terminal, is_valid_status,
-    normalize_status,
-};
+use khive_pack_gtd::schema::{is_terminal, normalize_status};
 use khive_runtime::atomic_plan::{
     AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement, PostCommitEffect,
 };
@@ -55,8 +61,9 @@ use khive_runtime::pack::{PackRegistry, VerbRegistry, VerbRegistryBuilder};
 use khive_runtime::{
     EdgeListFilter, KhiveConfig, KhiveRuntime, NamespaceToken, Resolved, RuntimeConfig,
 };
-use khive_storage::types::SqlValue;
-use khive_storage::{EdgeRelation, SqlStatement};
+use khive_storage::EdgeRelation;
+#[cfg(test)]
+use khive_storage::{types::SqlValue, SqlStatement};
 
 use crate::exec::OpsFileEntry;
 
@@ -756,256 +763,114 @@ fn require_str<'a>(args: &'a Value, key: &str) -> anyhow::Result<&'a str> {
         .ok_or_else(|| anyhow::anyhow!("missing required field {key:?}"))
 }
 
-/// Resolve a gtd task id (full UUID or 8+ hex prefix), mirroring canonical
-/// GTD lifecycle verbs' resolution (`khive_pack_gtd::handlers::resolve_uuid`,
-/// handlers.rs:270 — ADR-099 B3 fix round 5, finding 3 — codex r3 REJECT
-/// High: the pre-fix version below (`require_uuid`) only accepted a bare
-/// full UUID, rejecting the short ids `gtd.assign` itself returns).
-async fn resolve_gtd_id(
-    runtime: &KhiveRuntime,
-    token: &NamespaceToken,
-    args: &Value,
-    key: &str,
-) -> anyhow::Result<Uuid> {
-    let raw = require_str(args, key)?;
-    khive_pack_gtd::handlers::resolve_uuid(raw, runtime, token)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))
-}
-
-/// Load a task note by id, verifying kind="task" and non-deleted — mirrors
-/// `khive-pack-gtd::handlers::load_task`'s checks (reimplemented here: that
-/// function is `pub(crate)` to the gtd pack crate).
-async fn load_task(
-    runtime: &KhiveRuntime,
-    token: &NamespaceToken,
-    id: Uuid,
-) -> anyhow::Result<khive_storage::note::Note> {
-    let note = runtime
-        .notes(token)?
-        .get_note(id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("task not found: {id}"))?;
-    if note.namespace != token.namespace().as_str() {
-        anyhow::bail!("task not found: {id}");
-    }
-    if note.kind != "task" {
-        anyhow::bail!("expected kind=\"task\", got {:?}", note.kind);
-    }
-    if note.deleted_at.is_some() {
-        anyhow::bail!("task deleted: {id}");
-    }
-    Ok(note)
-}
-
-fn task_status(props: Option<&Value>) -> String {
-    props
-        .and_then(|p| p.get("status"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("inbox")
-        .to_string()
-}
-
-/// Validate the target terminal status for `gtd.complete` (mirrors
-/// `khive-pack-gtd::handlers::complete_target_status`, private to that
-/// crate): accepts `None`/`"done"` -> `"done"`, `"cancelled"` -> itself.
-fn complete_target_status(status: Option<&str>) -> anyhow::Result<&'static str> {
-    match status {
-        None | Some("done") => Ok("done"),
-        Some("cancelled") => Ok("cancelled"),
-        Some(other) => {
-            anyhow::bail!("complete: status must be \"done\" or \"cancelled\"; got {other:?}")
-        }
-    }
-}
-
+/// Decide-step wiring for `gtd.transition` (ADR-099 B3 r6 second pass): both
+/// this function and `khive-pack-gtd`'s `handle_transition` call
+/// `khive_pack_gtd::handlers::prepare_transition` — the ONE place the
+/// normalize/validate/secret-gate/load/idempotent-check/lifecycle-guard
+/// decision logic lives. This function's only job is turning that decision
+/// into an `AtomicOpPlan`: the idempotent no-op case produces an empty
+/// statement list, and the write case turns the decided patch into a
+/// `PlanStatement` via `khive_pack_gtd::handlers::gtd_transition_statement`
+/// — the same DML builder canonical's `atomic_gtd_transition` calls.
 async fn prepare_gtd_transition(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
-    let id = resolve_gtd_id(runtime, token, args, "id").await?;
+    let raw_id = require_str(args, "id")?;
     let raw_status = require_str(args, "status")?;
-
-    // GAP-3 (B3 fix round 4): parity with `handle_transition`
-    // (handlers.rs:980-987) — normalize aliases (finished/completed->done,
-    // in_progress->active, todo->inbox, blocked->waiting, later->someday,
-    // ...) and reject an unknown status BEFORE any DB read/write. The
-    // pre-fix atomic prepare ran `can_transition` on the raw, unnormalized
-    // string with no `is_valid_status` gate at all.
-    let target = normalize_status(raw_status);
-    if !is_valid_status(target) {
-        anyhow::bail!(
-            "invalid status {raw_status:?} — valid: inbox, next, waiting, someday, active, done, \
-             cancelled (aliases: in_progress, todo, blocked, later, finished)"
-        );
-    }
-
     let note_arg = args
         .as_object()
         .and_then(|o| o.get("note"))
         .and_then(|v| v.as_str());
 
-    // Parity with `khive-pack-gtd::handlers::handle_transition`
-    // (handlers.rs:988): secret-gate the caller-supplied transition note
-    // BEFORE any DB read/write (codex r2 High finding 3).
-    if let Some(n) = note_arg {
-        khive_runtime::secret_gate::check(n)?;
-    }
+    let decision =
+        khive_pack_gtd::handlers::prepare_transition(runtime, token, raw_id, raw_status, note_arg)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    let note = load_task(runtime, token, id).await?;
-    let current = task_status(note.properties.as_ref());
-
-    // GAP-6 (B3 fix round 4): parity with `handle_transition`
-    // (handlers.rs:995-1005) — an idempotent transition (current == target
-    // after normalization) is checked BEFORE the terminal-state guard and
-    // performs NO write and NO audit row, exactly mirroring canonical's
-    // early return. The pre-fix atomic prepare only special-cased
-    // `current != target` inside the `can_transition` check, so a
-    // current==target call fell through to an unconditional (and
-    // unnecessary) `UPDATE`.
-    if current == target {
-        return Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
-            task_id: id,
-            statements: vec![],
-            post_commit: PostCommitEffect::None,
-        }));
-    }
-
-    if is_terminal(&current) {
-        anyhow::bail!("task {id} is in terminal state {current:?}; no further transitions allowed");
-    }
-    if !can_transition(&current, target) {
-        let allowed = allowed_transitions(&current);
-        anyhow::bail!(
-            "cannot transition from {current:?} to {target:?}; allowed from {current:?}: {}",
-            if allowed.is_empty() {
-                "(none)".to_string()
-            } else {
-                allowed.join(", ")
-            }
-        );
-    }
-
-    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
-    if let Some(obj) = props.as_object_mut() {
-        obj.insert("status".into(), json!(target));
-        // Parity with handlers.rs:1028 — persist the caller-supplied
-        // transition note under `properties.transition_note`.
-        if let Some(n) = note_arg {
-            obj.insert("transition_note".into(), json!(n));
+    match decision {
+        khive_pack_gtd::handlers::TransitionDecision::NoOp { note, .. } => {
+            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
+                task_id: note.id,
+                statements: vec![],
+                post_commit: PostCommitEffect::None,
+            }))
         }
-        if target == "done" {
-            obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
+        khive_pack_gtd::handlers::TransitionDecision::Write {
+            note,
+            current,
+            target,
+            props,
+            updated_at,
+            transition_note,
+        } => {
+            let statement = khive_pack_gtd::handlers::gtd_transition_statement(
+                note.id, &current, &target, &props, updated_at,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
+                task_id: note.id,
+                statements: vec![PlanStatement {
+                    statement,
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                }],
+                post_commit: PostCommitEffect::GtdAudit {
+                    task_id: note.id,
+                    from_status: current,
+                    to_status: target,
+                    note: transition_note,
+                    namespace: token.namespace().as_str().to_string(),
+                },
+            }))
         }
     }
-    let updated_at = Utc::now().timestamp_micros();
-
-    let statement = SqlStatement {
-        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
-              WHERE id = ?3 AND json_extract(properties, '$.status') = ?4 \
-              AND deleted_at IS NULL"
-            .to_string(),
-        params: vec![
-            SqlValue::Text(serde_json::to_string(&props)?),
-            SqlValue::Integer(updated_at),
-            SqlValue::Text(id.to_string()),
-            SqlValue::Text(current.clone()),
-        ],
-        label: Some("atomic-gtd-transition".to_string()),
-    };
-
-    Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
-        task_id: id,
-        statements: vec![PlanStatement {
-            statement,
-            guard: Some(AffectedRowGuard::exactly(1)),
-        }],
-        // GAP-5 (B3 fix round 4): mirrors handlers.rs:1062-1071's
-        // best-effort `write_audit_record` call.
-        post_commit: PostCommitEffect::GtdAudit {
-            task_id: id,
-            from_status: current,
-            to_status: target.to_string(),
-            note: note_arg.map(str::to_string),
-            namespace: token.namespace().as_str().to_string(),
-        },
-    }))
 }
 
+/// Decide-step wiring for `gtd.complete` — same pattern as
+/// [`prepare_gtd_transition`] above: `khive_pack_gtd::handlers::
+/// prepare_complete` is the single decide step both this function and
+/// `handle_complete` call.
 async fn prepare_gtd_complete(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
-    let id = resolve_gtd_id(runtime, token, args, "id").await?;
+    let raw_id = require_str(args, "id")?;
     let status_arg = args
         .as_object()
         .and_then(|o| o.get("status"))
         .and_then(|v| v.as_str());
-    let target = complete_target_status(status_arg)?;
     let result_arg = args
         .as_object()
         .and_then(|o| o.get("result"))
         .and_then(|v| v.as_str());
 
-    // Parity with `khive-pack-gtd::handlers::handle_complete` (handlers.rs:803):
-    // secret-gate the caller-supplied result BEFORE any DB read/write
-    // (codex r2 High finding 3).
-    if let Some(result) = result_arg {
-        khive_runtime::secret_gate::check(result)?;
-    }
+    let decision =
+        khive_pack_gtd::handlers::prepare_complete(runtime, token, raw_id, status_arg, result_arg)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    let note = load_task(runtime, token, id).await?;
-    let current = task_status(note.properties.as_ref());
-
-    if is_terminal(&current) {
-        anyhow::bail!("task {id} is in terminal state {current:?}; no further transitions allowed");
-    }
-    if !is_actionable(&current) {
-        anyhow::bail!(
-            "complete: task in {current:?}; transition to 'next' or 'active' first, \
-             or use gtd.transition(status=done) explicitly"
-        );
-    }
-
-    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
-    if let Some(obj) = props.as_object_mut() {
-        obj.insert("status".into(), json!(target));
-        obj.insert("completed_at".into(), json!(Utc::now().to_rfc3339()));
-        if let Some(result) = result_arg {
-            obj.insert("result".into(), json!(result));
-        }
-    }
-    let updated_at = Utc::now().timestamp_micros();
-
-    let statement = SqlStatement {
-        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
-              WHERE id = ?3 AND json_extract(properties, '$.status') = ?4 \
-              AND deleted_at IS NULL"
-            .to_string(),
-        params: vec![
-            SqlValue::Text(serde_json::to_string(&props)?),
-            SqlValue::Integer(updated_at),
-            SqlValue::Text(id.to_string()),
-            SqlValue::Text(current.clone()),
-        ],
-        label: Some("atomic-gtd-complete".to_string()),
-    };
+    let statement = khive_pack_gtd::handlers::gtd_transition_statement(
+        decision.note.id,
+        &decision.current,
+        decision.target,
+        &decision.props,
+        decision.updated_at,
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok(AtomicOpPlan::GtdComplete(GtdCompletePlan {
-        task_id: id,
+        task_id: decision.note.id,
         statements: vec![PlanStatement {
             statement,
             guard: Some(AffectedRowGuard::exactly(1)),
         }],
-        // GAP-5 (B3 fix round 4): mirrors handlers.rs:873-883's best-effort
-        // `write_audit_record` call — `complete` never persists a
-        // transition note (canonical passes `None`).
         post_commit: PostCommitEffect::GtdAudit {
-            task_id: id,
-            from_status: current,
-            to_status: target.to_string(),
+            task_id: decision.note.id,
+            from_status: decision.current,
+            to_status: decision.target.to_string(),
             note: None,
             namespace: token.namespace().as_str().to_string(),
         },

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -42,9 +42,13 @@ use chrono::Utc;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_pack_gtd::schema::{allowed_transitions, can_transition, is_actionable, is_terminal};
+use khive_pack_gtd::handlers::{ensure_audit_schema, write_audit_record};
+use khive_pack_gtd::schema::{
+    allowed_transitions, can_transition, is_actionable, is_terminal, is_valid_status,
+    normalize_status,
+};
 use khive_runtime::atomic_plan::{
-    AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement,
+    AffectedRowGuard, GtdCompletePlan, GtdTransitionPlan, PlanStatement, PostCommitEffect,
 };
 use khive_runtime::atomic_runner::{AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
 use khive_runtime::{KhiveConfig, KhiveRuntime, NamespaceToken, RuntimeConfig};
@@ -125,6 +129,18 @@ pub(crate) async fn execute_atomic_ops_file(
     let total = ops.len();
     let envelope = match outcome {
         AtomicRunOutcome::Committed { post_commit } => {
+            // GAP-5 (B3 fix round 4): `GtdAudit` effects are applied HERE,
+            // not inside `khive_runtime::atomic_prepare::apply_post_commit_effects`
+            // (crate-direction: `khive-pack-gtd` depends on `khive-runtime`,
+            // not the other way around — that function treats `GtdAudit` as
+            // a no-op, see its match arm). `kkernel` already depends on both
+            // crates, so it calls the SAME canonical `ensure_audit_schema`/
+            // `write_audit_record` functions the non-atomic `gtd.transition`/
+            // `gtd.complete` handlers call, rather than re-deriving the
+            // DDL/INSERT. Best-effort: errors are logged inside those
+            // functions and never propagated — a missing audit row must
+            // never fail an already-committed atomic unit.
+            apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
             khive_runtime::atomic_prepare::apply_post_commit_effects(&runtime, &token, post_commit)
                 .await
                 .context("post-commit reindex after atomic unit commit")?;
@@ -174,6 +190,41 @@ pub(crate) async fn execute_atomic_ops_file(
     };
 
     Ok(envelope)
+}
+
+/// Apply every [`PostCommitEffect::GtdAudit`] in `effects` by calling the
+/// SAME `ensure_audit_schema`/`write_audit_record` functions the canonical
+/// `handle_transition`/`handle_complete` handlers call (GAP-5, B3 fix round
+/// 4). Lives in `kkernel` rather than `khive-runtime::atomic_prepare`
+/// because those two functions are owned by `khive-pack-gtd`, which
+/// depends on `khive-runtime` — not the other way around; `kkernel` is the
+/// first crate in the dependency graph that can see both. Non-`GtdAudit`
+/// effects are ignored here (they are `khive_runtime::atomic_prepare::
+/// apply_post_commit_effects`'s job, called separately). Best-effort by
+/// construction: both callee functions log-and-swallow their own errors, so
+/// this function itself cannot fail.
+async fn apply_gtd_audit_post_commit_effects(runtime: &KhiveRuntime, effects: &[PostCommitEffect]) {
+    for effect in effects {
+        if let PostCommitEffect::GtdAudit {
+            task_id,
+            from_status,
+            to_status,
+            note,
+            namespace,
+        } = effect
+        {
+            ensure_audit_schema(runtime).await;
+            write_audit_record(
+                runtime,
+                *task_id,
+                from_status,
+                to_status,
+                note.as_deref(),
+                namespace,
+            )
+            .await;
+        }
+    }
 }
 
 fn describe_failure(failure: &AtomicOpFailure) -> String {
@@ -281,7 +332,22 @@ async fn prepare_gtd_transition(
     args: &Value,
 ) -> anyhow::Result<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
-    let target = require_str(args, "status")?;
+    let raw_status = require_str(args, "status")?;
+
+    // GAP-3 (B3 fix round 4): parity with `handle_transition`
+    // (handlers.rs:980-987) — normalize aliases (finished/completed->done,
+    // in_progress->active, todo->inbox, blocked->waiting, later->someday,
+    // ...) and reject an unknown status BEFORE any DB read/write. The
+    // pre-fix atomic prepare ran `can_transition` on the raw, unnormalized
+    // string with no `is_valid_status` gate at all.
+    let target = normalize_status(raw_status);
+    if !is_valid_status(target) {
+        anyhow::bail!(
+            "invalid status {raw_status:?} — valid: inbox, next, waiting, someday, active, done, \
+             cancelled (aliases: in_progress, todo, blocked, later, finished)"
+        );
+    }
+
     let note_arg = args
         .as_object()
         .and_then(|o| o.get("note"))
@@ -297,10 +363,26 @@ async fn prepare_gtd_transition(
     let note = load_task(runtime, token, id).await?;
     let current = task_status(note.properties.as_ref());
 
+    // GAP-6 (B3 fix round 4): parity with `handle_transition`
+    // (handlers.rs:995-1005) — an idempotent transition (current == target
+    // after normalization) is checked BEFORE the terminal-state guard and
+    // performs NO write and NO audit row, exactly mirroring canonical's
+    // early return. The pre-fix atomic prepare only special-cased
+    // `current != target` inside the `can_transition` check, so a
+    // current==target call fell through to an unconditional (and
+    // unnecessary) `UPDATE`.
+    if current == target {
+        return Ok(AtomicOpPlan::GtdTransition(GtdTransitionPlan {
+            task_id: id,
+            statements: vec![],
+            post_commit: PostCommitEffect::None,
+        }));
+    }
+
     if is_terminal(&current) {
         anyhow::bail!("task {id} is in terminal state {current:?}; no further transitions allowed");
     }
-    if current != target && !can_transition(&current, target) {
+    if !can_transition(&current, target) {
         let allowed = allowed_transitions(&current);
         anyhow::bail!(
             "cannot transition from {current:?} to {target:?}; allowed from {current:?}: {}",
@@ -335,7 +417,7 @@ async fn prepare_gtd_transition(
             SqlValue::Text(serde_json::to_string(&props)?),
             SqlValue::Integer(updated_at),
             SqlValue::Text(id.to_string()),
-            SqlValue::Text(current),
+            SqlValue::Text(current.clone()),
         ],
         label: Some("atomic-gtd-transition".to_string()),
     };
@@ -346,6 +428,15 @@ async fn prepare_gtd_transition(
             statement,
             guard: Some(AffectedRowGuard::exactly(1)),
         }],
+        // GAP-5 (B3 fix round 4): mirrors handlers.rs:1062-1071's
+        // best-effort `write_audit_record` call.
+        post_commit: PostCommitEffect::GtdAudit {
+            task_id: id,
+            from_status: current,
+            to_status: target.to_string(),
+            note: note_arg.map(str::to_string),
+            namespace: token.namespace().as_str().to_string(),
+        },
     }))
 }
 
@@ -404,7 +495,7 @@ async fn prepare_gtd_complete(
             SqlValue::Text(serde_json::to_string(&props)?),
             SqlValue::Integer(updated_at),
             SqlValue::Text(id.to_string()),
-            SqlValue::Text(current),
+            SqlValue::Text(current.clone()),
         ],
         label: Some("atomic-gtd-complete".to_string()),
     };
@@ -415,6 +506,16 @@ async fn prepare_gtd_complete(
             statement,
             guard: Some(AffectedRowGuard::exactly(1)),
         }],
+        // GAP-5 (B3 fix round 4): mirrors handlers.rs:873-883's best-effort
+        // `write_audit_record` call — `complete` never persists a
+        // transition note (canonical passes `None`).
+        post_commit: PostCommitEffect::GtdAudit {
+            task_id: id,
+            from_status: current,
+            to_status: target.to_string(),
+            note: None,
+            namespace: token.namespace().as_str().to_string(),
+        },
     }))
 }
 
@@ -619,6 +720,203 @@ mod tests {
         assert_eq!(
             props.get("result").and_then(|v| v.as_str()),
             Some("shipped clean")
+        );
+    }
+
+    /// GAP-3 (B3 fix round 4): atomic `gtd.transition(status="finished")`
+    /// on an active task must SUCCEED with the alias normalized to "done"
+    /// — parity with the `normalize_status`/`is_valid_status` gate in
+    /// `handle_transition` (handlers.rs:980-987). The pre-fix atomic
+    /// prepare ran `can_transition` on the raw unnormalized string, which
+    /// rejects "finished" outright (it is not itself a lifecycle state
+    /// name).
+    #[tokio::test]
+    async fn atomic_gtd_transition_normalizes_status_alias() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "active").await;
+
+        let plan = prepare_gtd_transition(
+            &runtime,
+            &token,
+            &json!({"id": task_id.to_string(), "status": "finished"}),
+        )
+        .await
+        .expect("prepare transition with aliased status must succeed");
+
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        assert!(matches!(outcome, AtomicRunOutcome::Committed { .. }));
+
+        let note = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        assert_eq!(
+            task_properties(&note)
+                .get("status")
+                .and_then(|v| v.as_str()),
+            Some("done"),
+            "the \"finished\" alias must normalize to \"done\", parity with canonical"
+        );
+    }
+
+    /// GAP-6 (B3 fix round 4): an idempotent `gtd.transition` (current ==
+    /// target after `normalize_status`) must perform NO write — parity with
+    /// `handle_transition`'s early return (handlers.rs:995-1005). The
+    /// pre-fix atomic prepare only special-cased `current != target` inside
+    /// its `can_transition` guard, so a current==target call fell through
+    /// to an unconditional `UPDATE` that bumped `updated_at` for nothing.
+    #[tokio::test]
+    async fn atomic_gtd_transition_idempotent_noop_performs_no_write() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+        let task_id = seed_task(&runtime, &token, "next").await;
+
+        let before = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must exist");
+        let updated_at_before = before.updated_at;
+
+        let plan = prepare_gtd_transition(
+            &runtime,
+            &token,
+            &json!({"id": task_id.to_string(), "status": "next"}),
+        )
+        .await
+        .expect("prepare idempotent transition must succeed (no-op, not an error)");
+
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        let post_commit = match outcome {
+            AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("idempotent no-op must still succeed as Committed, got {other:?}"),
+        };
+        assert!(
+            post_commit.is_empty(),
+            "an idempotent no-op transition must produce no post-commit effect (no audit row \
+             either — canonical never reaches its own write_audit_record call): {post_commit:?}"
+        );
+
+        let after = runtime
+            .notes(&token)
+            .expect("notes store")
+            .get_note(task_id)
+            .await
+            .expect("get_note")
+            .expect("task must still exist");
+        assert_eq!(
+            after.updated_at, updated_at_before,
+            "an idempotent transition must not touch updated_at — no write happened"
+        );
+    }
+
+    /// GAP-5 (B3 fix round 4): a committed atomic `gtd.transition` AND a
+    /// committed atomic `gtd.complete` must each write a
+    /// `gtd_lifecycle_audit` row — parity with `handle_transition`/
+    /// `handle_complete`'s best-effort `ensure_audit_schema` +
+    /// `write_audit_record` calls (handlers.rs:1062-1071, :873-883). The
+    /// pre-fix atomic prepare wrote no audit row at all.
+    #[tokio::test]
+    async fn atomic_gtd_transition_and_complete_write_lifecycle_audit_rows() {
+        let runtime = scratch_runtime();
+        let token = runtime
+            .authorize(Namespace::parse("local").expect("ns"))
+            .expect("authorize");
+
+        // (a) transition inbox -> next, with a transition note.
+        let transition_task = seed_task(&runtime, &token, "inbox").await;
+        let plan = prepare_gtd_transition(
+            &runtime,
+            &token,
+            &json!({"id": transition_task.to_string(), "status": "next", "note": "audit me"}),
+        )
+        .await
+        .expect("prepare transition");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        let post_commit = match outcome {
+            AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected Committed, got {other:?}"),
+        };
+        apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
+
+        // (b) complete next -> done.
+        let complete_task = seed_task(&runtime, &token, "next").await;
+        let plan = prepare_gtd_complete(
+            &runtime,
+            &token,
+            &json!({"id": complete_task.to_string(), "result": "shipped"}),
+        )
+        .await
+        .expect("prepare complete");
+        let outcome =
+            khive_runtime::atomic_runner::run_atomic_unit(runtime.sql().as_ref(), vec![plan])
+                .await
+                .expect("commit ok");
+        let post_commit = match outcome {
+            AtomicRunOutcome::Committed { post_commit } => post_commit,
+            other => panic!("expected Committed, got {other:?}"),
+        };
+        apply_gtd_audit_post_commit_effects(&runtime, &post_commit).await;
+
+        let mut reader = runtime.sql().reader().await.expect("reader");
+        let rows = reader
+            .query_all(SqlStatement {
+                sql: "SELECT note_id, from_state, to_state, namespace FROM gtd_lifecycle_audit \
+                      ORDER BY at ASC"
+                    .to_string(),
+                params: vec![],
+                label: Some("test-gtd-audit-rows".to_string()),
+            })
+            .await
+            .expect("query gtd_lifecycle_audit");
+        assert_eq!(
+            rows.len(),
+            2,
+            "both the transition and the complete must each write exactly one audit row: {rows:?}"
+        );
+
+        let transition_task_str = transition_task.to_string();
+        let complete_task_str = complete_task.to_string();
+
+        let transition_row_present = rows.iter().any(|r| {
+            matches!(r.get("note_id"), Some(SqlValue::Text(id)) if id == &transition_task_str)
+                && matches!(r.get("from_state"), Some(SqlValue::Text(s)) if s == "inbox")
+                && matches!(r.get("to_state"), Some(SqlValue::Text(s)) if s == "next")
+                && matches!(r.get("namespace"), Some(SqlValue::Text(ns)) if ns == "local")
+        });
+        assert!(
+            transition_row_present,
+            "expected an audit row for the transition op: {rows:?}"
+        );
+
+        let complete_row_present = rows.iter().any(|r| {
+            matches!(r.get("note_id"), Some(SqlValue::Text(id)) if id == &complete_task_str)
+                && matches!(r.get("from_state"), Some(SqlValue::Text(s)) if s == "next")
+                && matches!(r.get("to_state"), Some(SqlValue::Text(s)) if s == "done")
+                && matches!(r.get("namespace"), Some(SqlValue::Text(ns)) if ns == "local")
+        });
+        assert!(
+            complete_row_present,
+            "expected an audit row for the complete op: {rows:?}"
         );
     }
 }

--- a/crates/kkernel/src/atomic_apply.rs
+++ b/crates/kkernel/src/atomic_apply.rs
@@ -479,11 +479,13 @@ async fn resolve_kg_ids_in_args(
 /// enforces, using the SAME canonical `resolve_kind_spec` the non-atomic
 /// `handle_delete` calls (ADR-099 B3 fix round 5, finding 1 — codex r3
 /// REJECT Blocker). `kind` absent -> `Ok(None)` (no check, parity with
-/// canonical's own optional discriminator). `kind` resolving to
-/// `Edge`/`Event`/`Proposal` -> a fail-loud rejection BEFORE `prepare_delete`
+/// canonical's own optional discriminator). `kind` resolving to `Edge` maps
+/// to `AtomicDeleteKind::Edge` (ADR-099 B3 r6 — closes the round-4 codex
+/// REJECT: `Edge` used to be rejected here even though
+/// `ATOMIC_ADMISSIBLE_VERBS` already allows `delete(kind="edge")`).
+/// `Event`/`Proposal` remain a fail-loud rejection BEFORE `prepare_delete`
 /// (and therefore before any write): those substrates are not v1-admissible
-/// for atomic delete (`prepare_delete`'s own match arms only ever build a
-/// plan for `Resolved::Entity`/`Resolved::Note`).
+/// for atomic delete at all.
 fn delete_expected_kind(
     args: &Value,
     registry: &VerbRegistry,
@@ -505,12 +507,15 @@ fn delete_expected_kind(
         khive_pack_kg::handlers::KindSpec::Note { specific } => Ok(Some(
             khive_runtime::atomic_prepare::AtomicDeleteKind::Note { specific },
         )),
-        khive_pack_kg::handlers::KindSpec::Edge
-        | khive_pack_kg::handlers::KindSpec::Event
-        | khive_pack_kg::handlers::KindSpec::Proposal => Err(anyhow::anyhow!(
-            "kind {raw:?} not supported under --atomic delete; only entity/note substrates \
-             are v1-admissible"
-        )),
+        khive_pack_kg::handlers::KindSpec::Edge => {
+            Ok(Some(khive_runtime::atomic_prepare::AtomicDeleteKind::Edge))
+        }
+        khive_pack_kg::handlers::KindSpec::Event | khive_pack_kg::handlers::KindSpec::Proposal => {
+            Err(anyhow::anyhow!(
+                "kind {raw:?} not supported under --atomic delete; only entity/note/edge \
+                 substrates are v1-admissible"
+            ))
+        }
     }
 }
 
@@ -562,6 +567,24 @@ async fn build_op_result(
             Some(Resolved::Note(note)) => Ok(khive_pack_kg::handlers::normalize_entity_timestamps(
                 serde_json::to_value(&note)?,
             )),
+            // ADR-099 B3 r6: `Resolved` has no `Edge` variant, so an edge
+            // update's `p.target_id` (the SURVIVING edge id — see
+            // `prepare_update_edge`'s symmetric-conflict-absorption branch,
+            // which may differ from the caller's original `id`) falls
+            // through here. Canonical shape: `to_json(&edge)` with no
+            // `normalize_entity_timestamps` wrapper (update.rs:220 —
+            // entity/note timestamps are ISO-8601 strings needing
+            // normalization; `Edge`'s `created_at`/`updated_at` already
+            // serialize as RFC3339 via its own `Serialize` impl).
+            None => {
+                let edge = runtime.get_edge(token, p.target_id).await?.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "atomic update result: target {} not found post-commit",
+                        p.target_id
+                    )
+                })?;
+                Ok(serde_json::to_value(&edge)?)
+            }
             _ => anyhow::bail!(
                 "atomic update result: target {} not found post-commit",
                 p.target_id

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2701,4 +2701,429 @@ backend = "sessions"
             "envelope: {envelope}"
         );
     }
+
+    // ── ADR-099 B3 fix round 5 (codex r3 REJECT): delete kind parity, update
+    // null/type validation, canonical id resolution, per-op result payloads ──
+
+    /// Finding 1 [Blocker]: atomic `delete(id=<entity>, kind="note")` must be
+    /// REJECTED (no row deleted) — pre-fix, atomic ignored `kind` entirely
+    /// and deleted the entity anyway (a destructive wrong-substrate action).
+    /// `delete(id=<entity>, kind="entity")` and `kind` omitted must both
+    /// still succeed.
+    #[tokio::test]
+    async fn atomic_delete_rejects_kind_mismatch_and_accepts_matching_or_omitted_kind() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let khive_cfg = KhiveConfig::default();
+
+        let (mismatch_id, matching_id, omitted_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="KindMismatch"), create(kind="concept", name="KindMatching"), create(kind="concept", name="KindOmitted")]"#,
+            )
+            .await;
+            let id = |i: usize| {
+                resp["results"][i]["result"]["id"]
+                    .as_str()
+                    .expect("id")
+                    .to_string()
+            };
+            (id(0), id(1), id(2))
+        };
+
+        // (a) kind mismatch: entity, caller says "note" — must be rejected,
+        // entity must still be present afterward.
+        let ops = vec![atomic_op(
+            "delete",
+            serde_json::json!({"id": mismatch_id, "kind": "note"}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("delete(kind=\"note\") on an entity must be rejected");
+        assert!(
+            format!("{err:#}").contains("not found"),
+            "expected a NotFound-shaped rejection, error: {err:#}"
+        );
+        let server = isolated_server(&db_path);
+        let resp = dispatch_json(&server, &format!(r#"get(id="{mismatch_id}")"#)).await;
+        assert!(
+            resp["results"][0]["result"]["deleted_at"].is_null(),
+            "entity must NOT be deleted after a kind-mismatch rejection: {resp}"
+        );
+
+        // (b) matching kind: succeeds.
+        let ops = vec![atomic_op(
+            "delete",
+            serde_json::json!({"id": matching_id, "kind": "entity"}),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("delete(kind=\"entity\") on an entity must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        // (c) omitted kind: succeeds.
+        let ops = vec![atomic_op("delete", serde_json::json!({"id": omitted_id}))];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("delete with kind omitted must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+    }
+
+    /// Finding 2 [High]: atomic `update` null/type semantics must match
+    /// canonical's ACTUALLY REACHABLE behavior. Empirically verified against
+    /// the live `handle_update` (two scratch probe tests run directly
+    /// against `KgPack::handle_update`, then removed) that `name=null` and
+    /// `description=null` are canonical NO-OPS, not rejections: canonical's
+    /// field type is `Option<Value>`, and serde_json's derived
+    /// `Deserialize` for `Option<T>` intercepts a literal JSON `null` at the
+    /// OUTER Option boundary and maps it straight to Rust `None` —
+    /// regardless of the inner type — so canonical's own "reject null"/
+    /// "clear on null" arms in `string_value`/`optional_string_patch` are
+    /// unreachable through normal struct deserialization. This deliberately
+    /// does NOT implement the fix-round brief's literal expectation
+    /// ("`update(name=null)` REJECTED") — that expectation does not match
+    /// the live canonical system; see the final report for the full
+    /// evidence trail. What canonical DOES still reject is a non-null,
+    /// non-string `name` (e.g. `name: 123`) — pre-fix, atomic silently
+    /// treated that as absent too (reporting success for an invalid
+    /// update), which is the real violation this test locks down.
+    #[tokio::test]
+    async fn atomic_update_null_and_type_semantics_match_canonical_no_op_behavior() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let khive_cfg = KhiveConfig::default();
+
+        let entity_id = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"create(kind="concept", name="NullSemantics", description="orig-desc", properties={"k": "v"}, tags=["a", "b"])"#,
+            )
+            .await;
+            resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("id")
+                .to_string()
+        };
+
+        // (a) name: a non-null, non-string value must be REJECTED — the
+        // actual violation codex flagged (pre-fix: silently treated as
+        // absent, reporting success).
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": entity_id, "name": 123}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("name: 123 (non-null, non-string) must be rejected");
+        assert!(
+            format!("{err:#}").contains("name must be a string"),
+            "error: {err:#}"
+        );
+
+        // (b) name=null, description=null, properties=null, tags=null in one
+        // update: all four are canonical no-ops — the update must succeed
+        // and every field must be UNCHANGED afterward.
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({
+                "id": entity_id,
+                "name": null,
+                "description": null,
+                "properties": null,
+                "tags": null,
+            }),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("an all-null update must be a no-op success, not a rejection");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let resp = dispatch_json(&server, &format!(r#"get(id="{entity_id}")"#)).await;
+        let row = &resp["results"][0]["result"];
+        assert_eq!(
+            row["name"], "NullSemantics",
+            "name must be unchanged: {row}"
+        );
+        assert_eq!(
+            row["description"], "orig-desc",
+            "description must be unchanged: {row}"
+        );
+        assert_eq!(
+            row["properties"]["k"], "v",
+            "properties must be unchanged: {row}"
+        );
+        assert_eq!(
+            row["tags"],
+            serde_json::json!(["a", "b"]),
+            "tags must be unchanged: {row}"
+        );
+    }
+
+    /// Finding 3 [High]: an atomic ops-file using an 8-hex-prefix id for
+    /// `update` AND `gtd.transition` must succeed identically to canonical
+    /// (which accepts full UUID or an 8+ hex prefix); a non-existent prefix
+    /// must error with canonical's error shape ("no record matches
+    /// prefix"). Pre-fix, atomic did a bare `Uuid::parse_str` and rejected
+    /// any short id outright — the same ops-file that succeeds non-atomically
+    /// (e.g. against `gtd.assign`'s own short `id` output) would fail before
+    /// prepare under `--atomic`.
+    #[tokio::test]
+    async fn atomic_update_and_gtd_transition_accept_8_hex_prefix_ids() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let khive_cfg = KhiveConfig::default();
+
+        let (entity_full_id, task_full_id) = {
+            let server = isolated_server(&db_path);
+            let resp =
+                dispatch_json(&server, r#"create(kind="concept", name="PrefixEntity")"#).await;
+            let entity_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("entity id")
+                .to_string();
+            let resp =
+                dispatch_json(&server, r#"gtd.assign(title="PrefixTask", status="next")"#).await;
+            let task_id = resp["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("task full_id")
+                .to_string();
+            (entity_id, task_id)
+        };
+        let entity_prefix = &entity_full_id[..8];
+        let task_prefix = &task_full_id[..8];
+
+        // (a) 8-hex-prefix update and gtd.transition in the SAME atomic unit
+        // both succeed.
+        let ops = vec![
+            atomic_op(
+                "update",
+                serde_json::json!({"id": entity_prefix, "name": "PrefixEntity-renamed"}),
+            ),
+            atomic_op(
+                "gtd.transition",
+                serde_json::json!({"id": task_prefix, "status": "active"}),
+            ),
+        ];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("8-hex-prefix ids must resolve identically to canonical");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let resp = dispatch_json(&server, &format!(r#"get(id="{entity_full_id}")"#)).await;
+        assert_eq!(
+            resp["results"][0]["result"]["name"], "PrefixEntity-renamed",
+            "prefix-addressed update must have landed: {resp}"
+        );
+
+        // (b) a non-existent 8-hex prefix errors with canonical's error
+        // shape.
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": "deadbeef", "name": "should not resolve"}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("a non-existent prefix must be rejected");
+        assert!(
+            format!("{err:#}").contains("no record matches prefix"),
+            "error: {err:#}"
+        );
+    }
+
+    /// Finding 4 [High]: a committed atomic unit's success output must
+    /// carry a canonical-shaped `result` per op (ADR-099 D4), not just
+    /// `{ok, tool, op_index}`. Exercises all five v1-admissible verbs in one
+    /// unit and asserts the field the fix-round brief calls out for each:
+    /// updated name for `update`, the deleted marker for `delete`, edge
+    /// fields for `link`, and the transition/completion shape for the two
+    /// gtd verbs.
+    #[tokio::test]
+    async fn atomic_success_results_carry_canonical_shaped_result_per_op() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+        let khive_cfg = KhiveConfig::default();
+
+        // `transition_task_id` and `complete_task_id` are DELIBERATELY two
+        // separate tasks, not one task chained through both verbs: every
+        // op's prepare pass reads state BEFORE the atomic unit applies any
+        // statement (ADR-099 D1 — prepare is async/read-only, commit is the
+        // one synchronous pass), so a `gtd.transition` and a `gtd.complete`
+        // on the SAME task in the SAME unit would race against each other's
+        // as-yet-uncommitted write, not compose sequentially.
+        let (entity_id, doomed_id, source_id, target_id, transition_task_id, complete_task_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="ResultUpdate"), create(kind="concept", name="ResultDelete"), create(kind="concept", name="ResultLinkSource"), create(kind="concept", name="ResultLinkTarget")]"#,
+            )
+            .await;
+            let id = |i: usize| {
+                resp["results"][i]["result"]["id"]
+                    .as_str()
+                    .expect("id")
+                    .to_string()
+            };
+            let resp = dispatch_json(
+                &server,
+                r#"gtd.assign(title="ResultTransitionTask", status="next")"#,
+            )
+            .await;
+            let transition_task_id = resp["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("task full_id")
+                .to_string();
+            let resp = dispatch_json(
+                &server,
+                r#"gtd.assign(title="ResultCompleteTask", status="active")"#,
+            )
+            .await;
+            let complete_task_id = resp["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("task full_id")
+                .to_string();
+            (
+                id(0),
+                id(1),
+                id(2),
+                id(3),
+                transition_task_id,
+                complete_task_id,
+            )
+        };
+
+        let ops = vec![
+            atomic_op(
+                "update",
+                serde_json::json!({"id": entity_id, "name": "ResultUpdate-renamed"}),
+            ),
+            atomic_op("delete", serde_json::json!({"id": doomed_id})),
+            atomic_op(
+                "link",
+                serde_json::json!({
+                    "source_id": source_id,
+                    "target_id": target_id,
+                    "relation": "extends",
+                }),
+            ),
+            atomic_op(
+                "gtd.transition",
+                serde_json::json!({"id": transition_task_id, "status": "active"}),
+            ),
+            atomic_op(
+                "gtd.complete",
+                serde_json::json!({"id": complete_task_id, "result": "shipped"}),
+            ),
+        ];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("all five v1-admissible verbs must commit as one unit");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let results = envelope["results"].as_array().expect("results array");
+        assert_eq!(results.len(), 5, "envelope: {envelope}");
+
+        assert_eq!(
+            results[0]["result"]["name"], "ResultUpdate-renamed",
+            "update result must carry the updated name: {envelope}"
+        );
+
+        assert_eq!(
+            results[1]["result"]["deleted"], true,
+            "delete result: {envelope}"
+        );
+        assert_eq!(
+            results[1]["result"]["id"], doomed_id,
+            "delete result must echo the caller's id: {envelope}"
+        );
+
+        assert_eq!(
+            results[2]["result"]["relation"], "extends",
+            "link result must carry the edge's relation: {envelope}"
+        );
+        assert_eq!(
+            results[2]["result"]["source_id"], source_id,
+            "link result must carry source_id: {envelope}"
+        );
+        assert_eq!(
+            results[2]["result"]["target_id"], target_id,
+            "link result must carry target_id: {envelope}"
+        );
+
+        assert_eq!(
+            results[3]["result"]["transitioned"], true,
+            "gtd.transition result: {envelope}"
+        );
+        assert_eq!(
+            results[3]["result"]["to"], "active",
+            "gtd.transition result must carry the new status: {envelope}"
+        );
+
+        assert_eq!(
+            results[4]["result"]["completed"], true,
+            "gtd.complete result: {envelope}"
+        );
+        assert_eq!(
+            results[4]["result"]["to"], "done",
+            "gtd.complete result must carry the terminal status: {envelope}"
+        );
+    }
 }

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2243,5 +2243,77 @@ backend = "sessions"
                 "error: {err:#}"
             );
         }
+
+        // (e) governance verbs (`propose`/`review`/`withdraw`) — B3 fix round
+        // (codex REJECT, Medium finding): these are on the v1 admissible list
+        // (ADR-099 D3 intends them to gain a seam) but have no prepare/apply
+        // implementation in this slice yet. They must be rejected at this
+        // SAME pre-runtime static guard — never reaching `KhiveRuntime::new`
+        // or any write — not deferred to fail later inside `prepare_op`.
+        for verb in ["propose", "review", "withdraw"] {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![atomic_op(
+                verb,
+                serde_json::json!({"title": "x", "description": "y", "changeset": {}}),
+            )];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+            )
+            .await
+            .expect_err(&format!("{verb:?} must be rejected before any write"));
+            assert!(
+                format!("{err:#}").contains("no --atomic prepare/apply seam"),
+                "error for {verb:?}: {err:#}"
+            );
+            // No runtime/db file activity: the db stays empty (nothing else
+            // touched it, so a plain re-open with the same path must show a
+            // fresh, unwritten store).
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(&server, r#"list(kind="entity")"#).await;
+            assert_eq!(
+                resp["results"][0]["result"].as_array().unwrap().len(),
+                0,
+                "no write must have landed for {verb:?}"
+            );
+        }
+
+        // (f) `merge` — B3 fix round (Leo refinement, codex REJECT Blocker 2):
+        // deferred at this SAME pre-runtime static guard rather than shipped
+        // with partial parity. Must name the non-atomic merge verb as the
+        // supported route, and must not reach `KhiveRuntime::new`/any write.
+        {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![atomic_op(
+                "merge",
+                serde_json::json!({
+                    "into_id": uuid::Uuid::new_v4().to_string(),
+                    "from_id": uuid::Uuid::new_v4().to_string(),
+                }),
+            )];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+            )
+            .await
+            .expect_err("merge must be rejected before any write");
+            assert!(
+                format!("{err:#}").contains("use the non-atomic merge verb instead"),
+                "error: {err:#}"
+            );
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(&server, r#"list(kind="entity")"#).await;
+            assert_eq!(
+                resp["results"][0]["result"].as_array().unwrap().len(),
+                0,
+                "no write must have landed for merge"
+            );
+        }
     }
 }

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2145,6 +2145,111 @@ backend = "sessions"
         );
     }
 
+    /// ADR-099 B3 r9 (codex r8 Blocker finding 1, second half): the inverse
+    /// same-unit race codex named — `[link(A, B, competes_with), update(X
+    /// extends A-B -> competes_with)]`, where the CANONICAL row the update
+    /// conflict-absorbs into is created by an EARLIER op in the SAME
+    /// atomic unit (so it does not exist at either op's prepare time). The
+    /// commit must both write correctly (X deleted, the just-linked row
+    /// carries X's patch) and RENDER the correct surviving id — not X's
+    /// prepare-time-advisory id, which this fix round removed reliance on
+    /// entirely (`build_op_result` now derives it from a post-commit
+    /// natural-key lookup).
+    #[tokio::test]
+    async fn atomic_symmetric_update_absorbs_into_same_unit_link_and_renders_correct_id() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (a_id, b_id, x_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="LinkRaceA"), create(kind="concept", name="LinkRaceB")]"#,
+            )
+            .await;
+            let a_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("a id")
+                .to_string();
+            let b_id = resp["results"][1]["result"]["id"]
+                .as_str()
+                .expect("b id")
+                .to_string();
+
+            let link_resp = dispatch_json(
+                &server,
+                &format!(
+                    r#"link(source_id="{a_id}", target_id="{b_id}", relation="extends", weight=0.2)"#
+                ),
+            )
+            .await;
+            let x_id = link_resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("x id")
+                .to_string();
+            (a_id, b_id, x_id)
+        };
+
+        let ops = vec![
+            atomic_op(
+                "link",
+                serde_json::json!({
+                    "source_id": a_id,
+                    "target_id": b_id,
+                    "relation": "competes_with",
+                    "weight": 0.6,
+                }),
+            ),
+            atomic_op(
+                "update",
+                serde_json::json!({"id": x_id, "relation": "competes_with", "weight": 0.9}),
+            ),
+        ];
+
+        let khive_cfg = KhiveConfig::default();
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("atomic run must succeed");
+
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let linked_id = envelope["results"][0]["result"]["id"]
+            .as_str()
+            .expect("link result id")
+            .to_string();
+        let rendered_update_id = envelope["results"][1]["result"]["id"]
+            .as_str()
+            .expect("update result id")
+            .to_string();
+        assert_ne!(
+            rendered_update_id, x_id,
+            "the update's rendered result must NOT be X's stale requested id: {envelope}"
+        );
+        assert_eq!(
+            rendered_update_id, linked_id,
+            "the update's rendered result must be the surviving (just-linked) row: {envelope}"
+        );
+        assert_eq!(
+            envelope["results"][1]["result"]["weight"], 0.9,
+            "the surviving row must carry the update's patch: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let surviving_resp = dispatch_json(&server, &format!(r#"get(id="{linked_id}")"#)).await;
+        assert_eq!(
+            surviving_resp["results"][0]["result"]["weight"], 0.9,
+            "the committed row itself must carry the patch: {surviving_resp}"
+        );
+    }
+
     /// Acceptance test 2: every CLI-boundary rejection fires BEFORE any
     /// write — each sub-case asserts both the error and that the db stays
     /// empty (zero entities created).

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -2316,4 +2316,389 @@ backend = "sessions"
             );
         }
     }
+
+    // ── ADR-099 B3 fix: `--atomic` deny_unknown_fields parity ────────────────
+    //
+    // Canonical `update`/`delete`/`link`/`gtd.transition`/`gtd.complete`
+    // reject unknown/typo'd arg keys via `#[serde(deny_unknown_fields)]` on
+    // their param structs. Pre-fix, `--atomic` silently dropped unrecognized
+    // keys instead of rejecting the op — a typo like `conten` (for
+    // `content`) would report `ok:true` while quietly discarding the
+    // caller's intended change. These tests exercise the fix at the same
+    // `execute_atomic_ops_file` seam as the acceptance tests above, and are
+    // the end-to-end counterpart to the syntactic-only unit coverage in
+    // `atomic_apply::validate_atomic_args_tests`.
+
+    /// Sharp case called out explicitly: atomic `update(id=X,
+    /// conten="hello")` (typo of `content`) must be rejected AND must not
+    /// mutate the row — no `content` change, no `updated_at` bump. Pre-fix,
+    /// this silently discarded `conten`, reset every other field to its
+    /// current value, bumped `updated_at`, and reported `ok:true`.
+    #[tokio::test]
+    async fn atomic_update_entity_unknown_field_is_rejected_and_does_not_mutate_row() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (entity_id, updated_at_before) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"create(kind="concept", name="TypoGuardX", description="original")"#,
+            )
+            .await;
+            let id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("id")
+                .to_string();
+            let get_resp = dispatch_json(&server, &format!(r#"get(id="{id}")"#)).await;
+            let updated_at = get_resp["results"][0]["result"]["updated_at"].clone();
+            (id, updated_at)
+        };
+
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": entity_id, "conten": "hello"}),
+        )];
+        let khive_cfg = KhiveConfig::default();
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `conten` must be rejected, not silently dropped");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+
+        let server = isolated_server(&db_path);
+        let get_resp = dispatch_json(&server, &format!(r#"get(id="{entity_id}")"#)).await;
+        assert_eq!(
+            get_resp["results"][0]["result"]["description"], "original",
+            "a rejected op must not have mutated description: {get_resp}"
+        );
+        assert_eq!(
+            get_resp["results"][0]["result"]["updated_at"], updated_at_before,
+            "a rejected op must not bump updated_at (no write happened): {get_resp}"
+        );
+    }
+
+    /// update-note variant of the same parity fix: a typo'd key on a note
+    /// update must be rejected, and a well-formed note update still
+    /// succeeds (parity boundary — don't over-reject).
+    #[tokio::test]
+    async fn atomic_update_note_unknown_field_rejected_well_formed_succeeds() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let note_id = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"create(kind="observation", content="original note")"#,
+            )
+            .await;
+            resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("id")
+                .to_string()
+        };
+
+        // (a) unknown field rejected.
+        let khive_cfg = KhiveConfig::default();
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": note_id, "conten": "typo'd"}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `conten` on a note update must be rejected");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+
+        // (b) well-formed update still succeeds.
+        let ops = vec![atomic_op(
+            "update",
+            serde_json::json!({"id": note_id, "content": "updated note"}),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("a well-formed note update must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let get_resp = dispatch_json(&server, &format!(r#"get(id="{note_id}")"#)).await;
+        assert_eq!(
+            get_resp["results"][0]["result"]["content"], "updated note",
+            "the well-formed update must have landed: {get_resp}"
+        );
+    }
+
+    /// `delete`: a typo'd key (`hardd` for `hard`) must be rejected before
+    /// any write; a well-formed delete still succeeds.
+    #[tokio::test]
+    async fn atomic_delete_unknown_field_rejected_well_formed_succeeds() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let entity_id = {
+            let server = isolated_server(&db_path);
+            let resp =
+                dispatch_json(&server, r#"create(kind="concept", name="DeleteTypoGuard")"#).await;
+            resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("id")
+                .to_string()
+        };
+
+        // (a) unknown field rejected — entity must survive.
+        let khive_cfg = KhiveConfig::default();
+        let ops = vec![atomic_op(
+            "delete",
+            serde_json::json!({"id": entity_id, "hardd": true}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `hardd` must be rejected");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+        let server = isolated_server(&db_path);
+        let get_resp = dispatch_json(&server, &format!(r#"get(id="{entity_id}")"#)).await;
+        assert!(
+            get_resp["results"][0]["result"]["deleted_at"].is_null(),
+            "a rejected delete must not have deleted the entity: {get_resp}"
+        );
+
+        // (b) well-formed delete still succeeds.
+        let ops = vec![atomic_op("delete", serde_json::json!({"id": entity_id}))];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("a well-formed delete must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+    }
+
+    /// `link`: a typo'd key (`relatoin` for `relation`) must be rejected
+    /// before any write; a well-formed link still succeeds. (Distinct from
+    /// the Leo-accepted `target_backend` conflict-arm deferral — out of
+    /// scope here.)
+    #[tokio::test]
+    async fn atomic_link_unknown_field_rejected_well_formed_succeeds() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (a_id, b_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="LinkTypoA"), create(kind="concept", name="LinkTypoB")]"#,
+            )
+            .await;
+            let a_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("a id")
+                .to_string();
+            let b_id = resp["results"][1]["result"]["id"]
+                .as_str()
+                .expect("b id")
+                .to_string();
+            (a_id, b_id)
+        };
+
+        // (a) unknown field rejected.
+        let khive_cfg = KhiveConfig::default();
+        let ops = vec![atomic_op(
+            "link",
+            serde_json::json!({
+                "source_id": a_id,
+                "target_id": b_id,
+                "relation": "extends",
+                "relatoin": "extends",
+            }),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `relatoin` must be rejected");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+
+        // (b) well-formed link still succeeds.
+        let ops = vec![atomic_op(
+            "link",
+            serde_json::json!({"source_id": a_id, "target_id": b_id, "relation": "extends"}),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("a well-formed link must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+    }
+
+    /// `gtd.transition`: a typo'd key (`notee` for `note`) must be rejected
+    /// before any write (task status unchanged); a well-formed transition
+    /// still succeeds.
+    #[tokio::test]
+    async fn atomic_gtd_transition_unknown_field_rejected_well_formed_succeeds() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let task_id = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"gtd.assign(title="TransitionTypoGuard", status="inbox")"#,
+            )
+            .await;
+            // gtd.assign's `id` field is always the short hex form
+            // (handlers.rs:372) regardless of presentation mode — use
+            // `full_id`, the real UUID, so it round-trips through the
+            // atomic prepare path's UUID parse.
+            resp["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("full_id")
+                .to_string()
+        };
+
+        // (a) unknown field rejected — status must stay "inbox".
+        let khive_cfg = KhiveConfig::default();
+        let ops = vec![atomic_op(
+            "gtd.transition",
+            serde_json::json!({"id": task_id, "status": "next", "notee": "typo"}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `notee` must be rejected");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+
+        // (b) well-formed transition still succeeds.
+        let ops = vec![atomic_op(
+            "gtd.transition",
+            serde_json::json!({"id": task_id, "status": "next"}),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("a well-formed gtd.transition must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+    }
+
+    /// `gtd.complete`: a typo'd key (`resutl` for `result`) must be
+    /// rejected before any write (task status unchanged); a well-formed
+    /// complete still succeeds.
+    #[tokio::test]
+    async fn atomic_gtd_complete_unknown_field_rejected_well_formed_succeeds() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let task_id = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"gtd.assign(title="CompleteTypoGuard", status="next")"#,
+            )
+            .await;
+            // Same `full_id` note as the transition test above.
+            resp["results"][0]["result"]["full_id"]
+                .as_str()
+                .expect("full_id")
+                .to_string()
+        };
+
+        // (a) unknown field rejected.
+        let khive_cfg = KhiveConfig::default();
+        let ops = vec![atomic_op(
+            "gtd.complete",
+            serde_json::json!({"id": task_id, "resutl": "typo"}),
+        )];
+        let err = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect_err("typo'd `resutl` must be rejected");
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "error: {err:#}"
+        );
+
+        // (b) well-formed complete still succeeds.
+        let ops = vec![atomic_op(
+            "gtd.complete",
+            serde_json::json!({"id": task_id, "result": "shipped"}),
+        )];
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("a well-formed gtd.complete must succeed");
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+    }
 }

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -173,13 +173,32 @@ pub struct ExecArgs {
     /// without writing anything.  Only valid with `--ops-file`.
     #[arg(long, requires = "ops_file")]
     pub dry_run: bool,
+
+    /// Run the whole ops-file as ONE cross-op atomic unit (ADR-099): every op
+    /// commits or the whole file rolls back, with zero partial state either
+    /// way. Only valid with `--ops-file`. Only the v1 admissible verb set
+    /// (`update`, `delete`, `link`, `merge`, `gtd.transition`, `gtd.complete`)
+    /// may appear in the file — an embedding-bearing verb (`create`, ...), a
+    /// read verb, or an unlisted verb is rejected before any write. Without
+    /// this flag, `--ops-file` behavior is unchanged (chunked, best-effort,
+    /// per-op success/failure).
+    #[arg(long, requires = "ops_file")]
+    pub atomic: bool,
+
+    /// Maximum op count admitted into one `--atomic` unit (ADR-099 D2 defers
+    /// the exact threshold to harness measurement; see
+    /// `khive_types::pack::ATOMIC_MAX_OPS_DEFAULT` for the interim default
+    /// and its rationale). Rejected before any write when exceeded. Only
+    /// meaningful with `--atomic`.
+    #[arg(long, requires = "atomic")]
+    pub atomic_max_ops: Option<usize>,
 }
 
 /// A single parsed op entry from an ops-file line.
-#[derive(Debug)]
-struct OpsFileEntry {
-    tool: String,
-    args: serde_json::Value,
+#[derive(Debug, Clone)]
+pub(crate) struct OpsFileEntry {
+    pub(crate) tool: String,
+    pub(crate) args: serde_json::Value,
 }
 
 /// Parse a JSONL ops-file.
@@ -190,7 +209,7 @@ struct OpsFileEntry {
 /// Each line must be a JSON object `{"tool":"verb","args":{...}}`.  `"args"`
 /// is optional and defaults to an empty object.  Any other top-level keys are
 /// silently ignored so the format is forward-compatible.
-fn parse_ops_file(path: &PathBuf) -> Result<Vec<OpsFileEntry>> {
+pub(crate) fn parse_ops_file(path: &PathBuf) -> Result<Vec<OpsFileEntry>> {
     let file =
         std::fs::File::open(path).with_context(|| format!("open ops-file {}", path.display()))?;
     let reader = std::io::BufReader::new(file);
@@ -408,7 +427,16 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
             .await
         }
         ExecMode::OpsFile(path) => {
-            run_exec_ops_file(path, cfg, args.presentation, args.dry_run, args.db).await
+            run_exec_ops_file(
+                path,
+                cfg,
+                args.presentation,
+                args.dry_run,
+                args.db,
+                args.atomic,
+                args.atomic_max_ops,
+            )
+            .await
         }
     }
 }
@@ -603,12 +631,15 @@ fn build_local_fallback_server(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_exec_ops_file(
     path: PathBuf,
     cfg: RuntimeConfig,
     presentation: Option<String>,
     dry_run: bool,
     db: Option<String>,
+    atomic: bool,
+    atomic_max_ops: Option<usize>,
 ) -> Result<()> {
     // Parse the whole file first — fail before any writes if any line is bad.
     let ops = parse_ops_file(&path)?;
@@ -644,6 +675,19 @@ async fn run_exec_ops_file(
     let khive_cfg = KhiveConfig::load_with_home_fallback(None, cfg.db_path.as_deref())
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
         .unwrap_or_default();
+
+    if atomic {
+        let max_ops = atomic_max_ops.unwrap_or(khive_types::pack::ATOMIC_MAX_OPS_DEFAULT);
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(ops, cfg, &khive_cfg, max_ops)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&envelope).expect("serialize atomic envelope")
+        );
+        return Ok(());
+    }
+
     let server = build_local_fallback_server(cfg, &khive_cfg, db.as_deref())?;
 
     apply_ops_file(&server, ops, presentation).await
@@ -1446,7 +1490,7 @@ default = true
         };
 
         // dry_run=true → no writes.
-        run_exec_ops_file(path.clone(), cfg.clone(), None, true, None)
+        run_exec_ops_file(path.clone(), cfg.clone(), None, true, None, false, None)
             .await
             .unwrap();
 
@@ -1933,5 +1977,271 @@ backend = "sessions"
             count, 0,
             "nothing should be written when any line fails to parse"
         );
+    }
+
+    // ── ADR-099 B3: `--atomic` CLI surface acceptance tests ───────────────────
+
+    fn atomic_op(tool: &str, args: serde_json::Value) -> OpsFileEntry {
+        OpsFileEntry {
+            tool: tool.to_string(),
+            args,
+        }
+    }
+
+    async fn dispatch_json(server: &KhiveMcpServer, ops: &str) -> serde_json::Value {
+        // Verbose presentation: the default Agent mode truncates entity ids
+        // to an 8-char short form for readability, which the atomic prepare
+        // path (and every KG verb) rejects as "not a full UUID". Tests here
+        // need the real id back out so it can feed straight into `update`/
+        // `delete`/`link` args.
+        let params = RequestParams {
+            ops: ops.to_string(),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+            save_to: None,
+            format: None,
+            format_per_op: None,
+        };
+        let raw = server.dispatch_request_local(params).await.unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    fn atomic_cfg(db_path: &str) -> RuntimeConfig {
+        RuntimeConfig {
+            db_path: Some(PathBuf::from(db_path)),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..Default::default()
+        }
+    }
+
+    /// Acceptance test 1a: an all-success atomic ops-file run commits every
+    /// op as one unit and the results are visible afterward.
+    #[tokio::test]
+    async fn atomic_ops_file_success_commits_all_ops() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (x_id, y_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="AtomicX"), create(kind="concept", name="AtomicY")]"#,
+            )
+            .await;
+            let x_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("x id")
+                .to_string();
+            let y_id = resp["results"][1]["result"]["id"]
+                .as_str()
+                .expect("y id")
+                .to_string();
+            (x_id, y_id)
+        };
+
+        let ops = vec![
+            atomic_op(
+                "update",
+                serde_json::json!({"id": x_id, "name": "AtomicX-renamed"}),
+            ),
+            atomic_op(
+                "update",
+                serde_json::json!({"id": y_id, "name": "AtomicY-renamed"}),
+            ),
+        ];
+
+        let khive_cfg = KhiveConfig::default();
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("atomic run must succeed");
+
+        assert_eq!(
+            envelope["atomic"]["committed"], true,
+            "envelope: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let x_resp = dispatch_json(&server, &format!(r#"get(id="{x_id}")"#)).await;
+        let y_resp = dispatch_json(&server, &format!(r#"get(id="{y_id}")"#)).await;
+        assert_eq!(x_resp["results"][0]["result"]["name"], "AtomicX-renamed");
+        assert_eq!(y_resp["results"][0]["result"]["name"], "AtomicY-renamed");
+    }
+
+    /// Acceptance test 1b: a mid-unit failure rolls the WHOLE unit back —
+    /// zero partial state, including the op that "succeeded" before the
+    /// failing one.
+    ///
+    /// Shape: `x` and `y` both exist. Op 0 hard-deletes `x`. Op 1 links `y`
+    /// to `x`. At PREPARE time (before either op runs) `x` still exists, so
+    /// both plans build successfully. At COMMIT time op 0 removes `x` first,
+    /// then op 1's guarded `INSERT ... WHERE EXISTS` affects zero rows (the
+    /// dangling-edge guard, ADR-099 D1 rule 1) — the whole unit rolls back,
+    /// so `x`'s deletion is undone too.
+    #[tokio::test]
+    async fn atomic_ops_file_mid_unit_failure_rolls_back_whole_unit() {
+        let db_file = NamedTempFile::new().expect("temp db");
+        let db_path = db_file.path().to_str().expect("utf8").to_string();
+
+        let (x_id, y_id) = {
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(
+                &server,
+                r#"[create(kind="concept", name="RollbackX"), create(kind="concept", name="RollbackY")]"#,
+            )
+            .await;
+            let x_id = resp["results"][0]["result"]["id"]
+                .as_str()
+                .expect("x id")
+                .to_string();
+            let y_id = resp["results"][1]["result"]["id"]
+                .as_str()
+                .expect("y id")
+                .to_string();
+            (x_id, y_id)
+        };
+
+        let ops = vec![
+            atomic_op("delete", serde_json::json!({"id": x_id, "hard": true})),
+            atomic_op(
+                "link",
+                serde_json::json!({
+                    "source_id": y_id,
+                    "target_id": x_id,
+                    "relation": "extends",
+                }),
+            ),
+        ];
+
+        let khive_cfg = KhiveConfig::default();
+        let envelope = crate::atomic_apply::execute_atomic_ops_file(
+            ops,
+            atomic_cfg(&db_path),
+            &khive_cfg,
+            khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+        )
+        .await
+        .expect("the seam call itself must not error — the unit rolls back cleanly");
+
+        assert_eq!(
+            envelope["atomic"]["rolled_back"], true,
+            "envelope: {envelope}"
+        );
+        assert_eq!(
+            envelope["atomic"]["failed_op_index"], 1,
+            "envelope: {envelope}"
+        );
+
+        let server = isolated_server(&db_path);
+        let x_resp = dispatch_json(&server, &format!(r#"get(id="{x_id}")"#)).await;
+        assert!(
+            x_resp["results"][0]["result"]["deleted_at"].is_null(),
+            "x must NOT be deleted — the whole unit must have rolled back: {x_resp}"
+        );
+    }
+
+    /// Acceptance test 2: every CLI-boundary rejection fires BEFORE any
+    /// write — each sub-case asserts both the error and that the db stays
+    /// empty (zero entities created).
+    #[tokio::test]
+    async fn atomic_cli_boundary_rejections_happen_before_any_write() {
+        let khive_cfg = KhiveConfig::default();
+
+        // (a) embedding-bearing verb.
+        {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![atomic_op(
+                "create",
+                serde_json::json!({"kind": "concept", "name": "ShouldNotLand"}),
+            )];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+            )
+            .await
+            .expect_err("embedding-bearing verb must be rejected");
+            assert!(
+                format!("{err:#}").contains("embedding-bearing"),
+                "error: {err:#}"
+            );
+            let server = isolated_server(&db_path);
+            let resp = dispatch_json(&server, r#"list(kind="entity")"#).await;
+            assert_eq!(resp["results"][0]["result"].as_array().unwrap().len(), 0);
+        }
+
+        // (b) read verb.
+        {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![atomic_op("search", serde_json::json!({"query": "x"}))];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+            )
+            .await
+            .expect_err("read verbs must be rejected");
+            assert!(format!("{err:#}").contains("read"), "error: {err:#}");
+        }
+
+        // (c) unlisted verb.
+        {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![atomic_op("not_a_real_verb", serde_json::json!({}))];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                khive_types::pack::ATOMIC_MAX_OPS_DEFAULT,
+            )
+            .await
+            .expect_err("unlisted verbs must be rejected");
+            assert!(
+                format!("{err:#}").contains("not on the v1 atomic-admissible"),
+                "error: {err:#}"
+            );
+        }
+
+        // (d) op-count guard.
+        {
+            let db_file = NamedTempFile::new().expect("temp db");
+            let db_path = db_file.path().to_str().expect("utf8").to_string();
+            let ops = vec![
+                atomic_op(
+                    "update",
+                    serde_json::json!({"id": uuid::Uuid::new_v4().to_string()}),
+                ),
+                atomic_op(
+                    "update",
+                    serde_json::json!({"id": uuid::Uuid::new_v4().to_string()}),
+                ),
+                atomic_op(
+                    "update",
+                    serde_json::json!({"id": uuid::Uuid::new_v4().to_string()}),
+                ),
+            ];
+            let err = crate::atomic_apply::execute_atomic_ops_file(
+                ops,
+                atomic_cfg(&db_path),
+                &khive_cfg,
+                2,
+            )
+            .await
+            .expect_err("exceeding max_ops must be rejected");
+            assert!(
+                format!("{err:#}").contains("exceeds the configured maximum"),
+                "error: {err:#}"
+            );
+        }
     }
 }

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -1,5 +1,6 @@
 //! kkernel — khive admin/management library.
 
+mod atomic_apply;
 pub mod coordinator;
 pub mod dbpath;
 pub mod engine;


### PR DESCRIPTION
Slice B3 of ADR-099 (cross-op atomicity for bulk apply). Adds the operator-facing
`--atomic` surface on top of B1 (plan types + parse-time admissibility, #678) and B2
(the atomic runner, #680).

## What lands

- `kkernel exec --ops-file <path> --atomic [--atomic-max-ops N]`: parse the ops-file,
  build a per-op plan, and run the whole file as ONE atomic unit. Without `--atomic`,
  behavior is byte-identical to today.
- CLI-boundary orchestrator (`kkernel/src/atomic_apply.rs`): runs the admissibility check,
  the op-count guard, and the multi-backend rejection BEFORE any runtime is built or any
  row is written; then drives the async prepare pass, the synchronous commit pass, and the
  async post-commit reindex pass.
- Per-verb async prepare (`khive-runtime/src/atomic_prepare.rs`) for the KG-substrate
  admissible verbs (`update`, `delete`, `link`, `merge`); `gtd.transition` / `gtd.complete`
  prepare lives in kkernel (crate-direction rationale in the module doc). `propose` /
  `review` / `withdraw` are admissible but fail loud as unimplemented (their event-sourced
  lifecycle is not a small guarded-DML plan — tracked as follow-up).
- Additive `atomic` result envelope; the field never appears on non-atomic runs.
- Live post-commit reindex: note/entity content updates are re-embedded and FTS-refreshed
  after commit, reusing the existing reindex path for parity.
- Op-count guard default `ATOMIC_MAX_OPS_DEFAULT = 2000` (interim; the exact bound is
  deferred to measurement).

## Acceptance tests (scratch/temp DBs only)

1. e2e ops-file atomic run: all-or-nothing both ways (success commit; induced mid-unit
   failure leaves zero partial state).
2. CLI-boundary rejections (embedding verb / read verb / inadmissible op / op-count) each
   error before any write.
3. note-content post-commit reindex: updated note recallable via FTS + vector row refreshed.
4. non-atomic byte-parity: flag absent → envelope identical to pre-B3 golden.
5. daemon coexistence: atomic unit through the writer queue alongside concurrent normal
   writes; queue routing discriminates.

Plus the B2 runner suite (rollback, suspend-trap twin, staleness closure, dangling-edge,
merge-rewire, zero-row). `khive-types` 72, `khive-runtime` 629, `kkernel` 181+6+2; clippy
`-D warnings` clean; fmt clean.

## Review notes

Two deliberate v1 parity narrowings worth a reviewer's eye: atomic `merge` rewires edges
and tombstones the loser but does not fold the loser's properties into the survivor (the
non-atomic path does); atomic `link` is INSERT-only and does not auto-infer `dependency_kind`.
Both are called out for the review to judge as acceptable scope or gaps to close.


# Edge Conflict SQL Audit (ADR-099 B3 r9)

Exhaustive workspace grep for every hand-written statement touching
`graph_edges`'s natural-key uniqueness (`UNIQUE(namespace, source_id,
target_id, relation)`) or symmetric-relation conflict resolution — i.e.
every site that could drift out of sync with the shared conflict-arm text.
Commands run:

```
grep -rn "ON CONFLICT" . --include="*.rs" --include="*.sql"
grep -rn "UPDATE graph_edges SET\|INSERT INTO graph_edges\|DELETE FROM graph_edges" . --include="*.rs"
grep -rn "target_backend = excluded.target_backend\|target_backend = ?" . --include="*.rs"
```

(paths below are relative to the crate workspace root, i.e. `crates/…`)

## Shared source-of-truth constants (the target every consumer below is measured against)

- `khive-db/src/stores/graph.rs:49` — `EDGE_NATURAL_KEY_CONFLICT_SET`: the
  `INSERT ... ON CONFLICT` SET-list text (weight/updated_at/deleted_at/
  metadata/target_backend).
- `khive-db/src/stores/graph.rs:214-228` — `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`
  / `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
  `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL`:
  the probe-then-branch DML canonical `update_edge_symmetric_dml` binds.

## Sites and disposition

| # | Site | Consumes shared builder/constant? | Disposition |
|---|------|-----------------------------------|-------------|
| 1 | `khive-db/src/stores/graph.rs:65-79` `edge_upsert_statement` | Yes — SQL text interpolates `{EDGE_NATURAL_KEY_CONFLICT_SET}` for both `ON CONFLICT` arms. | OK — this IS the source-of-truth builder. |
| 2 | `khive-db/src/stores/graph.rs:120-149` `edge_insert_guarded_by_endpoints_statement` (atomic guarded `link`) | Yes — same `{EDGE_NATURAL_KEY_CONFLICT_SET}` interpolation (fixed r7, codex r7 High finding 2). | OK. |
| 3 | `khive-db/src/stores/graph.rs:850-877` `batch_upsert_edges` (backs `upsert_edges`/`link_many`) | **Fixed this round.** Previously hand-wrote the full `INSERT ... ON CONFLICT` (including both conflict arms) as an inline literal. Now calls `edge_upsert_statement(edge)` + `bind_params` per row — the SAME builder site 1 uses. | OK (was the codex r8 High finding 2 site; closed). |
| 4 | `khive-db/src/stores/graph.rs:214-263` `EDGE_SYMMETRIC_*_SQL` constants + their `edge_symmetric_*_statement` plan-shape builders | N/A — this IS the shared source of truth `operations.rs`'s canonical path binds directly. | OK. |
| 5 | `khive-runtime/src/operations.rs:3747-3830` `update_edge_symmetric_dml` (canonical, non-atomic `update_edge`'s symmetric branch) | Yes — binds `khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` / `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` / `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` / `EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` directly via `rusqlite::params!` (different binding mechanism than the async `SqlStatement`/`SqlValue` path, but the SQL TEXT is the shared constant). | OK — this is the documented control-group path; untouched. |
| 6 | `khive-db/src/stores/graph.rs:374-448` `edge_symmetric_delete_if_conflict_statement` / `edge_symmetric_refresh_or_update_inplace_statement` (atomic-only) | N/A — deliberately a DIFFERENT, self-guarding commit-time shape (fixed this round, r9): the refresh statement now gates its natural-key arm on `changes() = 1` rather than reusing `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`/`EDGE_SYMMETRIC_UPDATE_INPLACE_SQL` verbatim, because those two assume a single-transaction probe-then-branch that atomic's prepare/commit split cannot safely reproduce (see the doc comment immediately above these builders). | **Justified-distinct.** Structurally different requirement (commit-time-only, no prepare-time branch), not an accidental copy. |
| 7 | `khive-runtime/src/curation.rs:1082-1160` `merge_entity_sql`'s edge rewire (entity `merge`, case a/b) | **No.** Hand-writes `SELECT id FROM graph_edges WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 AND relation = ?4 AND id != ?5` (line ~1110, byte-for-byte `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`), `DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2` (line ~1131, byte-for-byte `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL`), and `UPDATE graph_edges SET weight = ?1, updated_at = ?2, deleted_at = NULL, target_backend = ?3, metadata = ?4 WHERE namespace = ?5 AND id = ?6` (line ~1135, byte-for-byte `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL`) as fresh string literals instead of the existing constants. | **Not justified — a real duplication gap, out of this round's approved scope.** `merge` is not in ADR-099's v1 atomic-admissible set (deferred separately), so it was outside codex r8's reviewed diff, but it is the same drift class findings 1/2 target. Flagging for a follow-up round rather than fixing here: this brief's approved scope is limited to `update`'s symmetric-write correctness (task 1) and `batch_upsert_edges` (task 2); touching `merge_entity_sql` was not requested and would expand the diff beyond what was scoped. |
| 8 | `khive-runtime/src/curation.rs:1538-1600` `merge_note_sql`'s edge rewire (note `merge`, case a/b) | **No.** Same three hand-copied literals as #7 (this is the note-merge sibling of the entity-merge rewire) — `SELECT id FROM graph_edges WHERE namespace = ...` conflict probe, `DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2`, and the `UPDATE graph_edges SET weight = ..., target_backend = ?3, metadata = ?4 ...` refresh, each retyped a second time from #7's already-duplicated text (so this is actually the *fourth* copy of the conflict-probe/refresh text in the workspace, counting the two canonical constants and #7). | Same disposition as #7 — real gap, flagged for follow-up, not fixed this round (same out-of-scope reasoning). |
| 9 | `khive-runtime/src/atomic_prepare.rs:1331,1344` (`MergePlan` entity-merge edge rewire, ADR-099 atomic-merge draft) | N/A — `UPDATE graph_edges SET source_id = ?1, updated_at = ?2 WHERE source_id = ?3` / the `target_id` sibling. No `weight`/`metadata`/`target_backend`/natural-key conflict arm at all — this is a blind endpoint rewire (merge is deferred/unreachable through `--atomic`; see this crate's `prepare_merge` doc comment), not a conflict-arm statement. | Not applicable — different SQL shape, not a natural-key conflict site. |
| 10 | `khive-db/src/stores/graph.rs:168,179,188` (`edge_soft_delete_statement`, `edge_hard_delete_statement`, `purge_incident_edges_statement`) | N/A — plain delete/soft-delete DML, no conflict arm. | Not applicable. |
| 11 | `khive-runtime/src/atomic_prepare.rs:2097` (delete-plan soft-delete statement) | N/A — `deleted_at` tombstone only. | Not applicable. |
| 12 | `khive-runtime/src/atomic_runner.rs:535,560` and `khive-runtime/src/atomic_plan.rs:407` | N/A — `#[cfg(test)]`-only fixture SQL in unit tests exercising the runner mechanism generically (not edge-specific production behavior). | Not applicable (test-only). |
| 13 | `khive-db/src/stores/entity_tests.rs:717` | N/A — test fixture seeding a `graph_edges` row directly. | Not applicable (test-only). |

## Summary

- **Fixed this round:** site 3 (`batch_upsert_edges`) — the codex r8 High
  finding 2 target. No other production `INSERT`-shaped natural-key
  conflict arm remains outside `edge_upsert_statement`/
  `edge_insert_guarded_by_endpoints_statement`, both of which interpolate
  the single `EDGE_NATURAL_KEY_CONFLICT_SET` constant.
- **New gap surfaced by this audit, not fixed (out of approved scope):**
  sites 7 and 8 (`curation.rs`'s entity/note `merge` edge rewire) hand-copy
  the `EDGE_SYMMETRIC_CONFLICT_PROBE_SQL` /
  `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
  `EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL` text a third and fourth time
  instead of referencing the constants directly. Recommended follow-up:
  have both call sites bind the existing `khive_db::stores::graph::
  EDGE_SYMMETRIC_*_SQL` constants (same pattern `operations.rs`'s
  `update_edge_symmetric_dml` already uses at site 5) instead of retyping
  the literal SQL strings.
- Every other `ON CONFLICT` / `graph_edges` DML site in the workspace is
  either the shared source of truth itself, a structurally distinct
  self-guarding atomic statement (justified-distinct, site 6), a
  non-conflict-arm statement (delete/soft-delete/rewire), or test-only
  fixture code.
