### PR TITLE
feat(kkernel): add -e shortcut for exec

### DIFF
--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -42,8 +42,21 @@ struct Args {
     #[arg(long, env = "KHIVE_LOG", default_value = "warn", global = true)]
     log: String,
 
+    /// Quick-shot: run a verb DSL expression, shorthand for `kkernel exec <OPS>`.
+    ///
+    /// `kkernel -e '<ops>'` is equivalent to `kkernel exec '<ops>'` with every
+    /// other `exec` flag at its default (db/namespace resolution, presentation,
+    /// output format, ...). For `exec`'s other flags (`--ops-file`, `--db`,
+    /// `--namespace`, `--presentation`, ...), use the full `kkernel exec`
+    /// subcommand instead. Mutually exclusive with a subcommand (clap subcommand
+    /// fields are not directly addressable via `conflicts_with`, so this is
+    /// enforced explicitly in `main()`, right after `Args::parse()`, with the
+    /// same `clap::Command::error(...).exit()` mechanism clap itself uses).
+    #[arg(short = 'e', long = "exec", value_name = "OPS")]
+    exec: Option<String>,
+
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -220,7 +233,17 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     init_tracing(&args.log);
 
-    match args.command {
+    // `-e/--exec` is the quick-shot equivalent of `exec <OPS>` — route it
+    // through the exact same clap parsing `exec` itself uses (`ExecArgs::parse_from`)
+    // so behavior (env bindings, defaults) is byte-identical to typing out the
+    // subcommand. `-e` and a subcommand are mutually exclusive; a `#[command(subcommand)]`
+    // field cannot be named in a plain `#[arg(conflicts_with = ...)]` (clap rejects that
+    // at startup with a debug_assert — verified empirically), so the conflict is enforced
+    // here instead, using the same `clap::Command::error(...).exit()` mechanism clap's own
+    // built-in conflict detection uses (matching exit code + message style).
+    let command = resolve_command(args.exec, args.command);
+
+    match command {
         Command::Sync(s) => cmd_sync(s).await,
         Command::Pack(p) => cmd_pack(p),
         Command::Kg(k) => kg::run_kg(k).await,
@@ -288,6 +311,63 @@ async fn main() -> Result<()> {
             }
         }
         Command::Backend(b) => cmd_backend(b),
+    }
+}
+
+/// Why `-e`/subcommand resolution failed — see [`resolve_command_result`].
+#[derive(Debug, PartialEq, Eq)]
+enum ResolveCommandError {
+    /// Neither `-e <OPS>` nor a subcommand was given.
+    Missing,
+    /// Both `-e <OPS>` and a subcommand were given.
+    Conflict,
+}
+
+/// Pure resolution of the effective `Command` from the two mutually exclusive
+/// top-level entry points: the `-e/--exec` quick-shot flag and a subcommand.
+/// Split out from [`resolve_command`] so the four cases are unit-testable
+/// without triggering `clap`'s process-exiting `.error(...).exit()` path.
+///
+/// - `-e <OPS>` alone → `Command::Exec`, parsed via `ExecArgs::parse_from(["exec",
+///   &ops])` so it is byte-identical to typing `exec <OPS>` (same defaults, same
+///   env-var bindings).
+/// - a subcommand alone → that subcommand, unchanged.
+/// - neither → `Err(ResolveCommandError::Missing)`.
+/// - both → `Err(ResolveCommandError::Conflict)`. clap's derive `conflicts_with`
+///   cannot name a `#[command(subcommand)]` field directly (it is not a plain
+///   `Arg` — confirmed via clap's own startup debug_assert), so this case is
+///   enforced here rather than declaratively on the field.
+fn resolve_command_result(
+    exec: Option<String>,
+    command: Option<Command>,
+) -> Result<Command, ResolveCommandError> {
+    match (exec, command) {
+        (Some(ops), None) => Ok(Command::Exec(exec::ExecArgs::parse_from(["exec", &ops]))),
+        (None, Some(cmd)) => Ok(cmd),
+        (None, None) => Err(ResolveCommandError::Missing),
+        (Some(_), Some(_)) => Err(ResolveCommandError::Conflict),
+    }
+}
+
+/// `main()`'s entry point into [`resolve_command_result`]: same resolution,
+/// but turns a `Missing`/`Conflict` error into a clap-style CLI error (matching
+/// exit code 2 and clap's own error-printing style) instead of returning it.
+fn resolve_command(exec: Option<String>, command: Option<Command>) -> Command {
+    use clap::{error::ErrorKind, CommandFactory};
+    match resolve_command_result(exec, command) {
+        Ok(cmd) => cmd,
+        Err(ResolveCommandError::Missing) => Args::command()
+            .error(
+                ErrorKind::MissingRequiredArgument,
+                "either provide -e/--exec <OPS> or a subcommand",
+            )
+            .exit(),
+        Err(ResolveCommandError::Conflict) => Args::command()
+            .error(
+                ErrorKind::ArgumentConflict,
+                "the argument '-e/--exec <OPS>' cannot be used with a subcommand",
+            )
+            .exit(),
     }
 }
 
@@ -672,6 +752,101 @@ mod tests {
         .expect("db check passes on a current db");
         let after = std::fs::read(&path).expect("read db after check");
         assert_eq!(before, after, "db check must not mutate the database");
+    }
+
+    // --- `-e` quick-shot shortcut for `exec` ---
+
+    #[test]
+    fn exec_shortcut_short_flag_parses_ops() {
+        let args = Args::parse_from(["kkernel", "-e", "stats()"]);
+        assert_eq!(args.exec.as_deref(), Some("stats()"));
+        assert!(args.command.is_none());
+    }
+
+    #[test]
+    fn exec_shortcut_long_flag_parses_ops() {
+        let args = Args::parse_from(["kkernel", "--exec", "stats()"]);
+        assert_eq!(args.exec.as_deref(), Some("stats()"));
+        assert!(args.command.is_none());
+    }
+
+    // `-e` and a subcommand both parse fine individually at the clap level
+    // (clap has no way to declare a `#[command(subcommand)]` field as a
+    // `conflicts_with` target — see `resolve_command_result`'s doc comment),
+    // so `kkernel -e 'x()' exec 'y()'` parses into `Args { exec: Some(..),
+    // command: Some(..) }` without a clap-level error. The conflict is instead
+    // enforced by `resolve_command_result`, exercised directly below (its
+    // process-exiting `main()` wrapper, `resolve_command`, is not unit-testable).
+    #[test]
+    fn exec_shortcut_conflicts_with_subcommand() {
+        let args = Args::parse_from(["kkernel", "-e", "stats()", "exec", "other()"]);
+        assert!(args.exec.is_some());
+        assert!(args.command.is_some());
+
+        let result = resolve_command_result(args.exec, args.command);
+        assert!(matches!(result, Err(ResolveCommandError::Conflict)));
+    }
+
+    #[test]
+    fn exec_shortcut_conflicts_with_subcommand_reverse_order() {
+        // Subcommand first, -e after — still rejected, though for a different
+        // reason than the `-e ... exec ...` order above: once `exec` starts
+        // consuming tokens, `-e` is not one of `ExecArgs`'s own flags, so this
+        // is a genuine clap-level "unexpected argument" parse error rather than
+        // reaching `resolve_command_result`'s conflict branch. Either order is
+        // still rejected, which is the acceptance-relevant behavior.
+        let bare = Args::try_parse_from(["kkernel", "pack", "list"]);
+        assert!(bare.is_ok(), "a bare subcommand alone must still parse");
+
+        let result = Args::try_parse_from(["kkernel", "exec", "other()", "-e", "stats()"]);
+        assert!(
+            result.is_err(),
+            "-e after a subcommand's own args must be rejected"
+        );
+    }
+
+    #[test]
+    fn resolve_command_result_missing_when_neither_given() {
+        let args = Args::parse_from(["kkernel"]);
+        let result = resolve_command_result(args.exec, args.command);
+        assert!(matches!(result, Err(ResolveCommandError::Missing)));
+    }
+
+    #[test]
+    fn resolve_command_result_exec_only_maps_to_exec_command() {
+        let args = Args::parse_from(["kkernel", "-e", "stats()"]);
+        let result = resolve_command_result(args.exec, args.command);
+        match result {
+            Ok(Command::Exec(e)) => assert_eq!(e.ops.as_deref(), Some("stats()")),
+            other => panic!("expected Ok(Command::Exec), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exec_shortcut_maps_to_same_ops_as_exec_subcommand() {
+        // `-e '<ops>'` must produce the identical ExecArgs the `exec` subcommand
+        // itself would parse from `exec '<ops>'` — the resolution logic in
+        // `main()` builds this via `exec::ExecArgs::parse_from(["exec", &ops])`.
+        let via_shortcut = exec::ExecArgs::parse_from(["exec", "stats()"]);
+        let via_subcommand = match Args::parse_from(["kkernel", "exec", "stats()"]).command {
+            Some(Command::Exec(e)) => e,
+            other => panic!("expected Command::Exec, got {other:?}"),
+        };
+        assert_eq!(via_shortcut.ops, via_subcommand.ops);
+        assert_eq!(via_shortcut.db, via_subcommand.db);
+        assert_eq!(via_shortcut.namespace, via_subcommand.namespace);
+        assert_eq!(via_shortcut.presentation, via_subcommand.presentation);
+    }
+
+    #[test]
+    fn bare_invocation_without_exec_or_subcommand_is_not_a_valid_parse_state() {
+        // clap itself allows `kkernel` with neither -e nor a subcommand to parse
+        // (both are optional at the clap level); main() is what turns that into
+        // an error via `Args::command().error(...).exit()`. This test pins the
+        // parse-level shape that main() branches on.
+        let args = Args::parse_from(["kkernel"]);
+        assert!(args.exec.is_none());
+        assert!(args.command.is_none());
     }
 
     // --- #603: multi-backend boot path consolidation ---

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -329,8 +329,10 @@ enum ResolveCommandError {
 /// without triggering `clap`'s process-exiting `.error(...).exit()` path.
 ///
 /// - `-e <OPS>` alone → `Command::Exec`, parsed via `ExecArgs::parse_from(["exec",
-///   &ops])` so it is byte-identical to typing `exec <OPS>` (same defaults, same
-///   env-var bindings).
+///   "--", &ops])` so it is byte-identical to typing `exec -- <OPS>` (same
+///   defaults, same env-var bindings). The `--` separator forces `ops` to bind
+///   as the positional OPS value even when it starts with `-` (without it,
+///   `-e '--pending-events'` would reparse as exec's `--pending-events` flag).
 /// - a subcommand alone → that subcommand, unchanged.
 /// - neither → `Err(ResolveCommandError::Missing)`.
 /// - both → `Err(ResolveCommandError::Conflict)`. clap's derive `conflicts_with`
@@ -342,7 +344,9 @@ fn resolve_command_result(
     command: Option<Command>,
 ) -> Result<Command, ResolveCommandError> {
     match (exec, command) {
-        (Some(ops), None) => Ok(Command::Exec(exec::ExecArgs::parse_from(["exec", &ops]))),
+        (Some(ops), None) => Ok(Command::Exec(exec::ExecArgs::parse_from([
+            "exec", "--", &ops,
+        ]))),
         (None, Some(cmd)) => Ok(cmd),
         (None, None) => Err(ResolveCommandError::Missing),
         (Some(_), Some(_)) => Err(ResolveCommandError::Conflict),
@@ -826,8 +830,11 @@ mod tests {
     fn exec_shortcut_maps_to_same_ops_as_exec_subcommand() {
         // `-e '<ops>'` must produce the identical ExecArgs the `exec` subcommand
         // itself would parse from `exec '<ops>'` — the resolution logic in
-        // `main()` builds this via `exec::ExecArgs::parse_from(["exec", &ops])`.
-        let via_shortcut = exec::ExecArgs::parse_from(["exec", "stats()"]);
+        // `main()` builds this via `exec::ExecArgs::parse_from(["exec", "--", &ops])`.
+        let via_shortcut = match resolve_command_result(Some("stats()".into()), None) {
+            Ok(Command::Exec(e)) => e,
+            other => panic!("expected Ok(Command::Exec), got {other:?}"),
+        };
         let via_subcommand = match Args::parse_from(["kkernel", "exec", "stats()"]).command {
             Some(Command::Exec(e)) => e,
             other => panic!("expected Command::Exec, got {other:?}"),
@@ -836,6 +843,20 @@ mod tests {
         assert_eq!(via_shortcut.db, via_subcommand.db);
         assert_eq!(via_shortcut.namespace, via_subcommand.namespace);
         assert_eq!(via_shortcut.presentation, via_subcommand.presentation);
+    }
+
+    #[test]
+    fn exec_shortcut_flag_like_ops_binds_as_ops_not_as_exec_flag() {
+        // Regression for the round-1 review finding: without the `--` separator
+        // in the synthetic argv, `-e '--pending-events'` reparsed as exec's
+        // `--pending-events` FLAG (running the pending-event drain with no ops)
+        // instead of binding as the OPS value.
+        let resolved = match resolve_command_result(Some("--pending-events".into()), None) {
+            Ok(Command::Exec(e)) => e,
+            other => panic!("expected Ok(Command::Exec), got {other:?}"),
+        };
+        assert_eq!(resolved.ops.as_deref(), Some("--pending-events"));
+        assert!(!resolved.pending_events);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `-e`/`--exec` top-level flag to `kkernel` as a quick-shot shortcut for `kkernel exec`: `kkernel -e '<ops>'` is equivalent to `kkernel exec '<ops>'` (same defaults, same DSL syntax). It does not support `exec`'s other flags (`--ops-file`, `--db`, `--namespace`, `--presentation`, ...) — use the full `exec` subcommand for those.

Implementation notes:
- `Args.command` changed from `Command` to `Option<Command>`; a new `Args.exec: Option<String>` field carries `-e`/`--exec`.
- clap's derive `conflicts_with` cannot target a `#[command(subcommand)]` field directly (verified via clap's own startup debug_assert), so the "exactly one of `-e` or a subcommand" rule is enforced in a small pure function, `resolve_command_result`, called from `main()`. Its process-exiting wrapper, `resolve_command`, converts a `Missing`/`Conflict` result into a clap-style CLI error (`Args::command().error(...).exit()`), matching clap's own exit code (2) and error-printing style.
- The `-e` path routes through `exec::ExecArgs::parse_from(["exec", &ops])` — the exact same clap parsing the `exec` subcommand itself uses — so behavior (env-var bindings, defaults) is byte-identical to typing out `exec <ops>`, and dispatch goes through the same `exec::run_exec` function; no duplicated logic.

## Acceptance

1. `kkernel -e 'stats()'` produces output identical to `kkernel exec 'stats()'` — verified end to end against a scratch SQLite DB (isolated `HOME`/`KHIVE_DB`): both exit 0 and produce byte-identical stdout `{"results":[{"ok":true,"result":{"edges":0,"entities":0,"notes":0},"tool":"stats"}],...}`.
2. Help text documents the shortcut — `kkernel --help` shows the `-e, --exec <OPS>` entry with a description of the equivalence and its scope (verified via `kkernel --help`).
3. Existing `exec` subcommand behavior is unchanged — all of `exec`'s existing flags (`--ops-file`, `--db`, `--namespace`, `--presentation`, `--output-format`, `--pending-events`, `--save-file`, `--dry-run`) are untouched; the full `exec.rs` test suite (parse-level, daemon-forward seam, strict-actor gate, ops-file bulk apply, config_id parity) still passes.
4. Sensible error behavior — `kkernel -e 'x()' exec 'y()'` and a bare `kkernel` (neither `-e` nor a subcommand) both exit with code 2 and a clap-style error message, verified against the built binary.

## Test plan

- [x] `cargo test -p kkernel` — all tests pass (new tests: `exec_shortcut_short_flag_parses_ops`, `exec_shortcut_long_flag_parses_ops`, `exec_shortcut_conflicts_with_subcommand`, `exec_shortcut_conflicts_with_subcommand_reverse_order`, `exec_shortcut_maps_to_same_ops_as_exec_subcommand`, `bare_invocation_without_exec_or_subcommand_is_not_a_valid_parse_state`, `resolve_command_result_missing_when_neither_given`, `resolve_command_result_exec_only_maps_to_exec_command`)
- [x] `cargo clippy -p kkernel --all-targets -- -D warnings` — clean
- [x] Manual end-to-end run against a scratch DB: `kkernel exec 'stats()'` vs `kkernel -e 'stats()'` produce identical stdout
- [x] Manual check of conflict/missing-arg exit codes against the built release binary