### PR TITLE
feat(pack-git): ADR-088 git-lifecycle pack v0 — commit/issue/PR ingestion with provenance edges

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -117,7 +117,7 @@ jobs:
             [prompt-cookbook]="10|Prompt Cookbook|Ready-to-use verb patterns for common agent workflows."
             [tips-and-tricks]="11|Tips and Tricks|Query craft, DSL round-trips, param gotchas, and troubleshooting for the request tool."
             [proof-graph-case-study]="12|Proof Graph Case Study|Mathlib ingested as a 320K-entity, 4.4M-edge khive graph: ingestion path and traversal at scale."
-            [api-reference]="13|API Reference|Full verb catalog for all 8 production packs: params, DSL examples, response envelope."
+            [api-reference]="13|API Reference|Full verb catalog for all 9 production packs: params, DSL examples, response envelope."
           )
 
           cat > "$SRC/index.md" <<'EOF'
@@ -254,7 +254,7 @@ jobs:
             echo
             echo "> A research knowledge graph runtime for AI agents: typed entities, a closed"
             echo "> 17-relation edge ontology, hybrid FTS+vector search, and GQL/SPARQL queries,"
-            echo "> all dispatched through one MCP tool (\`request\`). 73 verbs across 8 packs."
+            echo "> all dispatched through one MCP tool (\`request\`). 74 verbs across 9 packs."
             echo
             echo "## Docs"
             echo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,10 @@ khive gives your agent:
 9. **Brain** — Bayesian profile tuning from feedback signals
 10. **Session** — persist and resume agent-session records
 
-All 8 packs load by default. **74 public verbs** across the packs (regenerate via
-`request(ops="verbs()")` before editing this line).
+All 9 packs load by default. **74 public verbs** across the packs — the `git` pack
+(commit/issue/pull_request provenance notes, populated by a batch ingester, not agent-facing
+verbs) contributes no new verb (regenerate via `request(ops="verbs()")` before editing this
+line).
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,9 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 ```
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
-loads all 8 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session
-(74 verbs total — verified against the live `verbs()` registry, 2026-07-04; regenerate via
+loads all 9 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git
+(74 verbs total — git contributes commit/issue/pull_request note kinds and a batch ingester,
+no new verbs; verified against the live `verbs()` registry, 2026-07-07; regenerate via
 `request(ops="verbs()")` before editing this line).
 
 ### KG pack verbs (17 — ADR-017, ADR-046, ADR-089)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **74 verbs, 8 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge, session: all load by default                                                                          |
+| **74 verbs, 9 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge, session, git: all load by default                                                                     |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,20 +63,21 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 8 packs load by default, giving **74 verbs** out of the box (verified against the live
-`verbs()` registry, 2026-07-04; regenerate with `request(ops="verbs()")` before editing
+All 9 packs load by default, giving **74 verbs** out of the box (verified against the live
+`verbs()` registry, 2026-07-07; regenerate with `request(ops="verbs()")` before editing
 this table):
 
-| Pack          | Prefix       | Verbs | What it does                                          |
-| ------------- | ------------ | ----- | ----------------------------------------------------- |
-| **kg**        | _(bare)_     | 17    | Entities, edges, notes, graph queries                 |
-| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)         |
-| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall      |
-| **brain**     | `brain.`     | 14    | Bayesian user profiles + feedback loop                |
-| **comm**      | `comm.`      | 6     | Threaded messaging                                    |
-| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution                |
-| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search            |
-| **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export) |
+| Pack          | Prefix       | Verbs | What it does                                              |
+| ------------- | ------------ | ----- | --------------------------------------------------------- |
+| **kg**        | _(bare)_     | 17    | Entities, edges, notes, graph queries                     |
+| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)             |
+| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall          |
+| **brain**     | `brain.`     | 14    | Bayesian user profiles + feedback loop                    |
+| **comm**      | `comm.`      | 6     | Threaded messaging                                        |
+| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution                    |
+| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search                |
+| **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export)     |
+| **git**       | _(none)_     | 0     | Commit/issue/PR provenance notes via a batch ingester CLI |
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only: they auto-detect the record type.
@@ -244,7 +245,7 @@ global):
 kkernel --version   # confirms the binary and version you just installed
 ```
 
-All 8 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
+All 9 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
 MCP client discovers the `request` tool with the full 74-verb catalog.
 
 ### Alternative: npm
@@ -372,7 +373,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 74 verbs across 8
+**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 74 verbs across 9
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "khive-pack-template",
     "khive-pack-knowledge",
     "khive-pack-session",
+    "khive-pack-git",
     "khive-mcp",
     "khive-vcs",
     "khive-vcs-adapters",

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -23,6 +23,7 @@ khive-pack-comm = { version = "0.3.0", path = "../khive-pack-comm" }
 khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
 khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }

--- a/crates/khive-mcp/src/pack.rs
+++ b/crates/khive-mcp/src/pack.rs
@@ -14,6 +14,8 @@ pub use khive_pack_brain::BrainPack as _BrainPack;
 #[doc(hidden)]
 pub use khive_pack_comm::CommPack as _CommPack;
 #[doc(hidden)]
+pub use khive_pack_git::GitPack as _GitPack;
+#[doc(hidden)]
 pub use khive_pack_gtd::GtdPack as _GtdPack;
 #[doc(hidden)]
 pub use khive_pack_kg::KgPack as _KgPack;

--- a/crates/khive-pack-formal/README.md
+++ b/crates/khive-pack-formal/README.md
@@ -50,7 +50,7 @@ EdgeEndpointRule {
 `khive-pack-formal` sits in the pack tier on `khive-types` (`EdgeEndpointRule`,
 `EndpointKind`) and `khive-runtime` (`Pack`, `PackRuntime`, inventory
 registration); it `REQUIRES` [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
-for the underlying `concept` entity substrate. Unlike the eight packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
+for the underlying `concept` entity substrate. Unlike the nine packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
 is only force-linked into `kkernel` (the admin/reindex binary) — it is not part of
 the agent-facing MCP server's pack registry at all today. A deployment that
 ingests formal-math corpora (Lean/mathlib-style theorem/definition/proof graphs)

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "khive-pack-git"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Git-lifecycle pack — commit/issue/pull_request provenance notes over the notes substrate (ADR-088)"
+
+[dependencies]
+khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+inventory = { workspace = true }
+khive-storage = { version = "0.3.0", path = "../khive-storage" }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+tempfile = { workspace = true }

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -99,10 +99,17 @@ impl KindHook for CommitHook {
 const ISSUE_STATE_REASONS: &[&str] = &["completed", "not_planned", "reopened", "duplicate"];
 
 /// `KindHook` shared by `issue` and `pull_request` — both require
-/// `properties.number` and, when present, validate `properties.state_reason`.
-/// `issue`'s `state_reason` is governed to a fixed set (ADR-088 §3); v0 does
-/// not document a fixed set for `pull_request`'s `state_reason`, so it is only
-/// checked for non-emptiness there.
+/// `properties.number` and `properties.project_id`, and, when present,
+/// validate `properties.state_reason`. `issue`'s `state_reason` is governed
+/// to a fixed set (ADR-088 §3); v0 does not document a fixed set for
+/// `pull_request`'s `state_reason`, so it is only checked for non-emptiness
+/// there.
+///
+/// GitHub issue/PR numbers are repository-scoped, not globally unique — two
+/// different `project` entities in the same namespace can each have a `#1`.
+/// `properties.project_id` is the natural-key scoping field the ingester's
+/// `find_by_number` lookup filters on, so it is required and validated as a
+/// UUID here rather than left to the caller's discipline.
 #[derive(Debug)]
 pub struct IssueLikeHook {
     /// The note kind this instance validates: `"issue"` or `"pull_request"`.
@@ -124,6 +131,19 @@ impl KindHook for IssueLikeHook {
         if !number.is_u64() && !number.is_i64() {
             return Err(RuntimeError::InvalidInput(format!(
                 "{} properties.number must be an integer",
+                self.kind
+            )));
+        }
+
+        let project_id = props
+            .get("project_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(format!("{} requires properties.project_id", self.kind))
+            })?;
+        if Uuid::parse_str(project_id).is_err() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "{} properties.project_id {project_id:?} must be a UUID",
                 self.kind
             )));
         }

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -96,7 +96,7 @@ impl KindHook for CommitHook {
 }
 
 /// The governed `state_reason` value set for `issue` (ADR-088 §3).
-const ISSUE_STATE_REASONS: &[&str] = &["completed", "not_planned"];
+const ISSUE_STATE_REASONS: &[&str] = &["completed", "not_planned", "reopened", "duplicate"];
 
 /// `KindHook` shared by `issue` and `pull_request` — both require
 /// `properties.number` and, when present, validate `properties.state_reason`.

--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -1,0 +1,157 @@
+//! `KindHook` implementations for the three note kinds this pack contributes.
+//!
+//! Validation only — this pack introduces no new edges at `after_create` time.
+//! Provenance edges (`annotates` -> project / document / merging PR) are
+//! supplied by the caller (the ingester, see `src/ingest.rs`) as part of the
+//! generic `create(kind=..., annotates=[...])` call; the runtime's own
+//! `create_note` path validates and links them atomically, so no
+//! `after_create` edge-creation logic is needed here (unlike gtd's
+//! `TaskHook::after_create`).
+
+use async_trait::async_trait;
+use serde_json::Value;
+use uuid::Uuid;
+
+use khive_runtime::{KhiveRuntime, KindHook, RuntimeError};
+
+/// A 40-character lowercase-hex string, the shape of a full git commit SHA-1.
+fn is_40_hex(s: &str) -> bool {
+    s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn properties_obj(args: &Value) -> Result<&serde_json::Map<String, Value>, RuntimeError> {
+    args.get("properties")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            RuntimeError::InvalidInput(
+                "kind=commit|issue|pull_request requires a `properties` object".into(),
+            )
+        })
+}
+
+/// `KindHook` for the immutable `commit` note kind.
+///
+/// Validates `properties.sha` (required, 40-hex) and, when present,
+/// `properties.parents` (array of 40-hex strings). Commits have no lifecycle
+/// and no `after_create` edge work.
+#[derive(Debug, Default)]
+pub struct CommitHook;
+
+#[async_trait]
+impl KindHook for CommitHook {
+    async fn prepare_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let props = properties_obj(args)?;
+
+        let sha = props
+            .get("sha")
+            .and_then(Value::as_str)
+            .ok_or_else(|| RuntimeError::InvalidInput("commit requires properties.sha".into()))?;
+        if !is_40_hex(sha) {
+            return Err(RuntimeError::InvalidInput(format!(
+                "commit properties.sha {sha:?} must be a 40-character hex string"
+            )));
+        }
+
+        if let Some(parents) = props.get("parents") {
+            let arr = parents.as_array().ok_or_else(|| {
+                RuntimeError::InvalidInput("commit properties.parents must be an array".into())
+            })?;
+            for (idx, p) in arr.iter().enumerate() {
+                let s = p.as_str().ok_or_else(|| {
+                    RuntimeError::InvalidInput(format!(
+                        "commit properties.parents[{idx}] must be a string"
+                    ))
+                })?;
+                if !is_40_hex(s) {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "commit properties.parents[{idx}] {s:?} must be a 40-character hex string"
+                    )));
+                }
+            }
+        }
+
+        if let Some(short) = props.get("short_sha").and_then(Value::as_str) {
+            if short.is_empty() || !sha.starts_with(short) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "commit properties.short_sha {short:?} must be a non-empty prefix of sha {sha:?}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn after_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        _id: Uuid,
+        _args: &Value,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}
+
+/// The governed `state_reason` value set for `issue` (ADR-088 §3).
+const ISSUE_STATE_REASONS: &[&str] = &["completed", "not_planned"];
+
+/// `KindHook` shared by `issue` and `pull_request` — both require
+/// `properties.number` and, when present, validate `properties.state_reason`.
+/// `issue`'s `state_reason` is governed to a fixed set (ADR-088 §3); v0 does
+/// not document a fixed set for `pull_request`'s `state_reason`, so it is only
+/// checked for non-emptiness there.
+#[derive(Debug)]
+pub struct IssueLikeHook {
+    /// The note kind this instance validates: `"issue"` or `"pull_request"`.
+    pub kind: &'static str,
+}
+
+#[async_trait]
+impl KindHook for IssueLikeHook {
+    async fn prepare_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let props = properties_obj(args)?;
+
+        let number = props.get("number").ok_or_else(|| {
+            RuntimeError::InvalidInput(format!("{} requires properties.number", self.kind))
+        })?;
+        if !number.is_u64() && !number.is_i64() {
+            return Err(RuntimeError::InvalidInput(format!(
+                "{} properties.number must be an integer",
+                self.kind
+            )));
+        }
+
+        if let Some(reason) = props.get("state_reason").and_then(Value::as_str) {
+            if self.kind == "issue" && !ISSUE_STATE_REASONS.contains(&reason) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "issue properties.state_reason {reason:?} invalid — valid: {}",
+                    ISSUE_STATE_REASONS.join(", ")
+                )));
+            }
+            if reason.trim().is_empty() {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "{} properties.state_reason must not be empty when present",
+                    self.kind
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn after_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        _id: Uuid,
+        _args: &Value,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -661,6 +661,19 @@ async fn ingest_prs(
     // an older failing one in the raw list would push the cursor past the
     // failure and it would never be retried. Sort ascending first (stable —
     // ties keep gh's original relative order).
+    //
+    // Sorting alone does not cover a TIE: if a successful record and a
+    // failing record share the exact same `updated_at`, the success still
+    // advances the cursor to that timestamp, and an exclusive `updated >
+    // cursor` retry check would then see the failed record's `updated_at ==
+    // cursor` and treat it as not-new on the next pass — stranding it
+    // forever, sort or no sort. `is_new` below is therefore inclusive
+    // (`updated >= cursor`): every record at the cursor timestamp is
+    // re-examined on every subsequent pass until the cursor moves past it.
+    // That reprocessing is bounded (only records sharing the exact cursor
+    // value) and free (the natural-key lookup below turns every
+    // already-created one into a cheap no-op), so it converges the moment
+    // the last tied record either succeeds or the cursor advances.
     prs.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
 
     // `cursor_stalled` mirrors `ingest_commits`: once one PR fails to create,
@@ -674,7 +687,7 @@ async fn ingest_prs(
         let is_new = since
             .as_deref()
             .zip(pr.updated_at.as_deref())
-            .map(|(cursor, updated)| updated > cursor)
+            .map(|(cursor, updated)| updated >= cursor)
             .unwrap_or(true);
 
         if let Some(existing) =
@@ -795,7 +808,11 @@ async fn ingest_issues(
     // See `ingest_prs`: the frozen-cursor retry guarantee requires walking
     // records in nondecreasing updated_at order, which `gh issue list` does
     // not itself guarantee. Sort ascending first (stable — ties keep gh's
-    // original relative order).
+    // original relative order). Sorting doesn't cover a TIE between a
+    // successful and a failing record sharing the same `updated_at` — see
+    // `ingest_prs`'s comment on why `is_new` below is an inclusive
+    // (`updated >= cursor`) check, and why the resulting reprocessing of
+    // every record at the cursor timestamp is bounded and converges.
     issues.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
 
     // `cursor_stalled` mirrors `ingest_commits`/`ingest_prs`: a per-record
@@ -809,7 +826,7 @@ async fn ingest_issues(
         let is_new = since
             .as_deref()
             .zip(issue.updated_at.as_deref())
-            .map(|(cursor, updated)| updated > cursor)
+            .map(|(cursor, updated)| updated >= cursor)
             .unwrap_or(true);
 
         if find_by_number(runtime, token, "issue", project_id, issue.number)

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -584,9 +584,9 @@ struct GhPr {
 }
 
 fn gh_json(repo: &Path, args: &[&str]) -> Result<String> {
+    // gh has no `-C` flag (unlike git) — repo targeting is via working directory.
     let output = Command::new("gh")
-        .arg("-C")
-        .arg(repo)
+        .current_dir(repo)
         .args(args)
         .output()
         .context("spawning gh")?;

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -771,15 +771,20 @@ async fn ingest_issues(
             .into_iter()
             .map(|l| l.name)
             .collect();
-        let properties = json!({
+        let mut properties = json!({
             "number": issue.number,
             "title": issue.title,
             "author": issue.author.and_then(|a| a.login),
             "created_at": issue.created_at,
             "closed_at": issue.closed_at,
             "labels": labels,
-            "state_reason": issue.state_reason,
         });
+        // gh reports stateReason as "" for open issues; the kind hook governs any
+        // PRESENT value against {completed, not_planned}, so absent is the only
+        // valid encoding for "open / no reason".
+        if let Some(reason) = issue.state_reason.as_deref().filter(|r| !r.is_empty()) {
+            properties["state_reason"] = json!(reason);
+        }
 
         registry
             .dispatch(

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -653,7 +653,15 @@ async fn ingest_prs(
             "number,title,author,createdAt,mergedAt,closedAt,updatedAt,baseRefName,headRefName,mergeCommit,body",
         ],
     )?;
-    let prs: Vec<GhPr> = serde_json::from_str(&raw).context("parsing gh pr list --json")?;
+    let mut prs: Vec<GhPr> = serde_json::from_str(&raw).context("parsing gh pr list --json")?;
+    // `gh pr list` makes no ordering guarantee. The frozen-cursor retry
+    // guarantee below (cursor freezes at the last contiguous success, so a
+    // failed record is retried next pass) only holds if records are walked
+    // in nondecreasing updated_at order; otherwise a newer record ahead of
+    // an older failing one in the raw list would push the cursor past the
+    // failure and it would never be retried. Sort ascending first (stable —
+    // ties keep gh's original relative order).
+    prs.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
 
     // `cursor_stalled` mirrors `ingest_commits`: once one PR fails to create,
     // later PRs in this pass are still attempted (so every failure surfaces
@@ -782,8 +790,13 @@ async fn ingest_issues(
             "number,title,author,createdAt,closedAt,updatedAt,labels,stateReason,body",
         ],
     )?;
-    let issues: Vec<GhIssue> =
+    let mut issues: Vec<GhIssue> =
         serde_json::from_str(&raw).context("parsing gh issue list --json")?;
+    // See `ingest_prs`: the frozen-cursor retry guarantee requires walking
+    // records in nondecreasing updated_at order, which `gh issue list` does
+    // not itself guarantee. Sort ascending first (stable — ties keep gh's
+    // original relative order).
+    issues.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
 
     // `cursor_stalled` mirrors `ingest_commits`/`ingest_prs`: a per-record
     // create failure is aggregated as a warning and later records in this

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -781,7 +781,7 @@ async fn ingest_issues(
         });
         // gh reports stateReason as "" for open issues and UPPERCASE enum values
         // (NOT_PLANNED) for closed ones; the kind hook governs any PRESENT value
-        // against lowercase {completed, not_planned}, so normalize case and encode
+        // against the lowercase GitHub stateReason enum, so normalize case and encode
         // "open / no reason" as absent.
         if let Some(reason) = issue.state_reason.as_deref().filter(|r| !r.is_empty()) {
             properties["state_reason"] = json!(reason.to_ascii_lowercase());

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -779,11 +779,12 @@ async fn ingest_issues(
             "closed_at": issue.closed_at,
             "labels": labels,
         });
-        // gh reports stateReason as "" for open issues; the kind hook governs any
-        // PRESENT value against {completed, not_planned}, so absent is the only
-        // valid encoding for "open / no reason".
+        // gh reports stateReason as "" for open issues and UPPERCASE enum values
+        // (NOT_PLANNED) for closed ones; the kind hook governs any PRESENT value
+        // against lowercase {completed, not_planned}, so normalize case and encode
+        // "open / no reason" as absent.
         if let Some(reason) = issue.state_reason.as_deref().filter(|r| !r.is_empty()) {
-            properties["state_reason"] = json!(reason);
+            properties["state_reason"] = json!(reason.to_ascii_lowercase());
         }
 
         registry

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1,0 +1,813 @@
+//! Batch, cursor-based git-history ingester (ADR-088 §5).
+//!
+//! One-shot: walks local git history plus (optionally) `gh`-fetched issues
+//! and pull requests, and writes `commit` / `issue` / `pull_request` notes
+//! through the standard `create` verb (so `KindHook` validation and
+//! `annotates` edge creation run exactly as they would for any other
+//! caller). Reuses ADR-087's operational pattern (cursor table, secret
+//! masking on ingest, cursor advances only on success) — NOT a daemon loop,
+//! NOT a webhook, NOT a poller: one pass per invocation.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, VerbRegistry};
+use khive_storage::types::{SqlStatement, SqlValue};
+
+/// Options for one ingest pass.
+#[derive(Debug, Clone)]
+pub struct IngestOptions {
+    /// Local path to the git repository to walk.
+    pub repo: PathBuf,
+    /// The repo-anchor `project` entity — full UUID or an 8+ hex prefix.
+    pub project: String,
+}
+
+/// Outcome of one ingest pass. Serializable so CLI callers can emit it as JSON.
+#[derive(Debug, Default, Serialize)]
+pub struct IngestReport {
+    pub commits_ingested: u64,
+    pub commits_skipped_existing: u64,
+    pub issues_ingested: u64,
+    pub issues_skipped_existing: u64,
+    pub prs_ingested: u64,
+    pub prs_skipped_existing: u64,
+    /// `false` when the `gh` CLI was not found on PATH — issues/PRs were
+    /// skipped but commits still ingested (ADR-088 §5 graceful-absence rule).
+    pub gh_available: bool,
+    pub warnings: Vec<String>,
+}
+
+/// Run one ingest pass: issues + PRs first (via `gh`, when available), then
+/// commits (via local `git log`). PRs are ingested before commits so a
+/// commit's `annotates` list can reference an already-created merging-PR
+/// note (the generic `create` verb validates `annotates` targets exist
+/// before it writes — see `khive-runtime::operations::create_note_inner`).
+pub async fn run_ingest(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+    opts: IngestOptions,
+) -> Result<IngestReport> {
+    let mut report = IngestReport::default();
+
+    let project_id = resolve_id(runtime, token, &opts.project)
+        .await?
+        .ok_or_else(|| anyhow!("--project {:?} did not resolve to an entity", opts.project))?;
+
+    let mut merge_sha_to_pr: HashMap<String, Uuid> = HashMap::new();
+    let mut number_to_pr: HashMap<u64, Uuid> = HashMap::new();
+
+    // Graceful degradation covers both "gh is not on PATH" and "gh is present
+    // but this repo has no usable GitHub remote" (e.g. a synthetic/local-only
+    // repo) — either way, issues/PRs are skipped with a warning and commits
+    // still ingest (ADR-088 §5). A hard `gh` failure must never abort the
+    // whole pass.
+    if gh_available(&opts.repo) {
+        report.gh_available = true;
+        match ingest_prs(
+            runtime,
+            token,
+            registry,
+            &opts.repo,
+            project_id,
+            &mut report,
+            &mut merge_sha_to_pr,
+            &mut number_to_pr,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(e) => report
+                .warnings
+                .push(format!("gh pr list failed, skipping pull requests: {e}")),
+        }
+        if let Err(e) = ingest_issues(
+            runtime,
+            token,
+            registry,
+            &opts.repo,
+            project_id,
+            &mut report,
+        )
+        .await
+        {
+            report
+                .warnings
+                .push(format!("gh issue list failed, skipping issues: {e}"));
+        }
+    } else {
+        report.gh_available = false;
+        report.warnings.push(
+            "gh CLI not found on PATH; skipped issues and pull requests — commits still ingest"
+                .to_string(),
+        );
+    }
+
+    ingest_commits(
+        runtime,
+        token,
+        registry,
+        &opts.repo,
+        project_id,
+        &merge_sha_to_pr,
+        &number_to_pr,
+        &mut report,
+    )
+    .await?;
+
+    Ok(report)
+}
+
+/// Resolve a full UUID or an 8+ hex prefix to a full UUID, unfiltered by
+/// namespace (matches the by-ID resolution contract used by `get`/`update`).
+async fn resolve_id(
+    runtime: &KhiveRuntime,
+    _token: &NamespaceToken,
+    raw: &str,
+) -> Result<Option<Uuid>> {
+    if let Ok(u) = Uuid::parse_str(raw) {
+        return Ok(Some(u));
+    }
+    runtime
+        .resolve_prefix_unfiltered(raw)
+        .await
+        .map_err(|e| anyhow!("{e}"))
+}
+
+/// `true` when `gh` is on PATH and can run inside `repo` (a lightweight
+/// `gh --version` probe — cheap and does not require network access).
+fn gh_available(repo: &Path) -> bool {
+    Command::new("gh")
+        .arg("--version")
+        .current_dir(repo)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Look up an existing `commit` note by its `properties.sha` (natural-key
+/// idempotence — dedupe-before-create, matching the precedent used elsewhere
+/// in this codebase for `json_extract`-keyed lookups).
+async fn find_commit_by_sha(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    sha: &str,
+) -> Result<Option<Uuid>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM notes WHERE kind='commit' AND namespace=?1 \
+                  AND deleted_at IS NULL AND json_extract(properties,'$.sha')=?2 LIMIT 1"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(sha.to_string()),
+            ],
+            label: Some("git_ingest_find_commit_by_sha".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(row.and_then(|r| row_uuid(&r)))
+}
+
+/// Look up an existing `issue`/`pull_request` note by its `properties.number`
+/// (natural-key idempotence, scoped by kind + project so numbers from
+/// different repos under the same project never collide).
+async fn find_by_number(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    kind: &str,
+    number: u64,
+) -> Result<Option<Uuid>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 \
+                  AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 LIMIT 1"
+                .into(),
+            params: vec![
+                SqlValue::Text(kind.to_string()),
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Integer(number as i64),
+            ],
+            label: Some("git_ingest_find_by_number".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(row.and_then(|r| row_uuid(&r)))
+}
+
+fn row_uuid(row: &khive_storage::types::SqlRow) -> Option<Uuid> {
+    match row.get("id") {
+        Some(SqlValue::Uuid(u)) => Some(*u),
+        Some(SqlValue::Text(s)) => Uuid::parse_str(s).ok(),
+        _ => None,
+    }
+}
+
+/// Find an existing `document` entity whose `properties.source_uri` or `name`
+/// matches `path` (ADR-086 keying convention). Returns `None` when no match —
+/// v0 never creates documents on the ingester's behalf (skip the edge).
+async fn find_document_for_path(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    path: &str,
+) -> Result<Option<Uuid>> {
+    let file_name = Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(path);
+    let like_pattern = format!("%{path}");
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
+                  AND deleted_at IS NULL \
+                  AND (json_extract(properties,'$.source_uri')=?2 \
+                       OR json_extract(properties,'$.source_uri') LIKE ?3 \
+                       OR name=?4) \
+                  LIMIT 1"
+                .into(),
+            params: vec![
+                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(path.to_string()),
+                SqlValue::Text(like_pattern),
+                SqlValue::Text(file_name.to_string()),
+            ],
+            label: Some("git_ingest_find_document_for_path".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(row.and_then(|r| row_uuid(&r)))
+}
+
+/// Read the last-ingested cursor value for `(project_id, kind)`, if any.
+async fn read_cursor(
+    runtime: &KhiveRuntime,
+    project_id: Uuid,
+    kind: &str,
+) -> Result<Option<String>> {
+    let sql = runtime.sql();
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2"
+                .into(),
+            params: vec![
+                SqlValue::Text(project_id.to_string()),
+                SqlValue::Text(kind.to_string()),
+            ],
+            label: Some("git_ingest_read_cursor".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(row.and_then(|r| match r.get("cursor_value") {
+        Some(SqlValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    }))
+}
+
+/// Advance the `(project_id, kind)` cursor. Called only after the
+/// corresponding batch has been fully written — a mid-batch failure leaves
+/// the cursor at its prior value so the next pass safely re-ingests the
+/// batch (natural-key dedupe makes the re-ingest a no-op for anything that
+/// already landed).
+async fn write_cursor(
+    runtime: &KhiveRuntime,
+    project_id: Uuid,
+    kind: &str,
+    value: &str,
+) -> Result<()> {
+    let sql = runtime.sql();
+    let mut w = sql.writer().await.map_err(|e| anyhow!("{e}"))?;
+    w.execute(SqlStatement {
+        sql: "INSERT INTO git_mirror_cursor(project_id, kind, cursor_value, updated_at) \
+              VALUES(?1, ?2, ?3, ?4) \
+              ON CONFLICT(project_id, kind) DO UPDATE SET \
+                cursor_value=excluded.cursor_value, \
+                updated_at=excluded.updated_at"
+            .into(),
+        params: vec![
+            SqlValue::Text(project_id.to_string()),
+            SqlValue::Text(kind.to_string()),
+            SqlValue::Text(value.to_string()),
+            SqlValue::Integer(Utc::now().timestamp_micros()),
+        ],
+        label: Some("git_ingest_write_cursor".into()),
+    })
+    .await
+    .map_err(|e| anyhow!("{e}"))?;
+    Ok(())
+}
+
+// ── commits ─────────────────────────────────────────────────────────────────
+
+const RECORD_SEP: char = '\u{1e}';
+const FIELD_SEP: char = '\u{1f}';
+
+struct RawCommit {
+    sha: String,
+    short_sha: String,
+    author: String,
+    author_email: String,
+    committed_at: String,
+    parents: Vec<String>,
+    subject: String,
+    body: String,
+}
+
+/// Walk local git history via `git log` with a stable, machine-parseable
+/// format (v0 choice per ADR-088 §5 — `git2`/`gix` are not workspace
+/// dependencies today, so shelling out avoids a new heavy dependency).
+fn walk_commits(repo: &Path, since_sha: Option<&str>) -> Result<Vec<RawCommit>> {
+    // Raw control-byte separators embedded directly in the format string
+    // (not git's `%xHH` escape syntax) — passed as a single argv element
+    // (never through a shell), so the literal bytes survive intact and git's
+    // pretty-format engine emits any non-`%` character verbatim.
+    let format = format!("%H{FIELD_SEP}%h{FIELD_SEP}%an{FIELD_SEP}%ae{FIELD_SEP}%cI{FIELD_SEP}%P{FIELD_SEP}%s{FIELD_SEP}%b{RECORD_SEP}");
+    let mut args = vec![
+        "log".to_string(),
+        "--reverse".to_string(),
+        format!("--pretty=format:{format}"),
+    ];
+    if let Some(sha) = since_sha {
+        args.push(format!("{sha}..HEAD"));
+    }
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(&args)
+        .output()
+        .context("spawning git log")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git log failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut commits = Vec::new();
+    for record in text.split(RECORD_SEP) {
+        let record = record.trim_matches('\n');
+        if record.is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = record.splitn(8, FIELD_SEP).collect();
+        if fields.len() < 8 {
+            continue;
+        }
+        let sha = fields[0].to_string();
+        let short_sha = fields[1].to_string();
+        let author = fields[2].to_string();
+        let author_email = fields[3].to_string();
+        let committed_at = fields[4].to_string();
+        let parents = fields[5]
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let subject = fields[6].to_string();
+        let body = fields[7].trim_end_matches('\n').to_string();
+        commits.push(RawCommit {
+            sha,
+            short_sha,
+            author,
+            author_email,
+            committed_at,
+            parents,
+            subject,
+            body,
+        });
+    }
+    Ok(commits)
+}
+
+/// `sha -> [touched paths]` for every commit in `repo`'s history, via a
+/// separate `--name-only` pass (kept apart from `walk_commits`'s custom
+/// `--pretty=format` — interleaving file-name lines with the metadata format
+/// has no clean, unambiguous delimiter).
+fn touched_files(repo: &Path) -> Result<HashMap<String, Vec<String>>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("log")
+        .arg("--name-only")
+        .arg(format!("--pretty=format:{RECORD_SEP}%H"))
+        .output()
+        .context("spawning git log --name-only")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git log --name-only failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    for block in text.split(RECORD_SEP) {
+        let mut lines = block.lines().filter(|l| !l.trim().is_empty());
+        let Some(sha) = lines.next() else { continue };
+        let files: Vec<String> = lines.map(str::to_string).collect();
+        map.insert(sha.trim().to_string(), files);
+    }
+    Ok(map)
+}
+
+/// Squash-merge subject suffix `"... (#123)"` -> `123`.
+fn squash_merge_pr_number(subject: &str) -> Option<u64> {
+    let trimmed = subject.trim_end();
+    let close = trimmed.strip_suffix(')')?;
+    let open = close.rfind("(#")?;
+    close[open + 2..].parse::<u64>().ok()
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn ingest_commits(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+    repo: &Path,
+    project_id: Uuid,
+    merge_sha_to_pr: &HashMap<String, Uuid>,
+    number_to_pr: &HashMap<u64, Uuid>,
+    report: &mut IngestReport,
+) -> Result<()> {
+    let since = read_cursor(runtime, project_id, "commits").await?;
+    let commits = walk_commits(repo, since.as_deref())?;
+    if commits.is_empty() {
+        return Ok(());
+    }
+    let files_by_sha = touched_files(repo)?;
+
+    let mut last_sha: Option<String> = since;
+    for c in &commits {
+        if find_commit_by_sha(runtime, token, &c.sha).await?.is_some() {
+            report.commits_skipped_existing += 1;
+            last_sha = Some(c.sha.clone());
+            continue;
+        }
+
+        let raw_content = if c.body.trim().is_empty() {
+            c.subject.clone()
+        } else {
+            format!("{}\n\n{}", c.subject, c.body)
+        };
+        let content = secret_gate::mask_secrets(&raw_content).into_owned();
+
+        let mut annotates = vec![project_id.to_string()];
+
+        if let Some(paths) = files_by_sha.get(&c.sha) {
+            for p in paths {
+                if !p.starts_with("docs/adr/") {
+                    continue;
+                }
+                if let Some(doc_id) = find_document_for_path(runtime, token, p).await? {
+                    annotates.push(doc_id.to_string());
+                }
+            }
+        }
+
+        // Merge-commit sha mapping and squash-merge suffix parsing are both
+        // scoped to PRs discovered THIS pass; also fall back to a direct
+        // by-number lookup so a commit can still resolve its merging PR when
+        // that PR was ingested in an earlier pass (its note already exists,
+        // but this run's `number_to_pr` in-memory map starts empty).
+        let pr_id = match merge_sha_to_pr.get(&c.sha).copied() {
+            Some(id) => Some(id),
+            None => match squash_merge_pr_number(&c.subject) {
+                Some(n) => match number_to_pr.get(&n).copied() {
+                    Some(id) => Some(id),
+                    None => find_by_number(runtime, token, "pull_request", n).await?,
+                },
+                None => None,
+            },
+        };
+        if let Some(pr_id) = pr_id {
+            annotates.push(pr_id.to_string());
+        }
+
+        let properties = json!({
+            "sha": c.sha,
+            "short_sha": c.short_sha,
+            "author": c.author,
+            "author_email": c.author_email,
+            "committed_at": c.committed_at,
+            "parents": c.parents,
+        });
+
+        registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "commit",
+                    "content": content,
+                    "properties": properties,
+                    "annotates": annotates,
+                }),
+            )
+            .await
+            .map_err(|e| anyhow!("create commit {}: {e}", c.sha))?;
+
+        report.commits_ingested += 1;
+        last_sha = Some(c.sha.clone());
+    }
+
+    if let Some(sha) = last_sha {
+        write_cursor(runtime, project_id, "commits", &sha).await?;
+    }
+    Ok(())
+}
+
+// ── issues + PRs (gh CLI) ───────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct GhAuthor {
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    author: Option<GhAuthor>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(rename = "closedAt")]
+    closed_at: Option<String>,
+    #[serde(rename = "updatedAt")]
+    updated_at: Option<String>,
+    labels: Option<Vec<GhLabel>>,
+    #[serde(rename = "stateReason")]
+    state_reason: Option<String>,
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhMergeCommit {
+    oid: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPr {
+    number: u64,
+    title: String,
+    author: Option<GhAuthor>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(rename = "mergedAt")]
+    merged_at: Option<String>,
+    #[serde(rename = "closedAt")]
+    closed_at: Option<String>,
+    #[serde(rename = "updatedAt")]
+    updated_at: Option<String>,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: Option<String>,
+    #[serde(rename = "headRefName")]
+    head_ref_name: Option<String>,
+    #[serde(rename = "mergeCommit")]
+    merge_commit: Option<GhMergeCommit>,
+    body: Option<String>,
+}
+
+fn gh_json(repo: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("gh")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .context("spawning gh")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "gh {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn ingest_prs(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+    repo: &Path,
+    project_id: Uuid,
+    report: &mut IngestReport,
+    merge_sha_to_pr: &mut HashMap<String, Uuid>,
+    number_to_pr: &mut HashMap<u64, Uuid>,
+) -> Result<()> {
+    let since = read_cursor(runtime, project_id, "prs").await?;
+    let raw = gh_json(
+        repo,
+        &[
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,author,createdAt,mergedAt,closedAt,updatedAt,baseRefName,headRefName,mergeCommit,body",
+        ],
+    )?;
+    let prs: Vec<GhPr> = serde_json::from_str(&raw).context("parsing gh pr list --json")?;
+
+    let mut max_updated: Option<String> = since.clone();
+    for pr in prs {
+        let is_new = since
+            .as_deref()
+            .zip(pr.updated_at.as_deref())
+            .map(|(cursor, updated)| updated > cursor)
+            .unwrap_or(true);
+
+        if let Some(existing) = find_by_number(runtime, token, "pull_request", pr.number).await? {
+            number_to_pr.insert(pr.number, existing);
+            if let Some(oid) = pr.merge_commit.as_ref().and_then(|m| m.oid.clone()) {
+                merge_sha_to_pr.insert(oid, existing);
+            }
+            report.prs_skipped_existing += 1;
+            if let Some(u) = &pr.updated_at {
+                if max_updated
+                    .as_deref()
+                    .map(|m| u.as_str() > m)
+                    .unwrap_or(true)
+                {
+                    max_updated = Some(u.clone());
+                }
+            }
+            continue;
+        }
+        if !is_new {
+            continue;
+        }
+
+        let raw_body = pr.body.unwrap_or_default();
+        let content = secret_gate::mask_secrets(&raw_body).into_owned();
+        let properties = json!({
+            "number": pr.number,
+            "title": pr.title,
+            "author": pr.author.and_then(|a| a.login),
+            "created_at": pr.created_at,
+            "merged_at": pr.merged_at,
+            "closed_at": pr.closed_at,
+            "base": pr.base_ref_name,
+            "head": pr.head_ref_name,
+        });
+
+        let result = registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "pull_request",
+                    "content": content,
+                    "properties": properties,
+                    "annotates": [project_id.to_string()],
+                }),
+            )
+            .await
+            .map_err(|e| anyhow!("create pull_request #{}: {e}", pr.number))?;
+
+        if let Some(id) = result
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+        {
+            number_to_pr.insert(pr.number, id);
+            if let Some(oid) = pr.merge_commit.and_then(|m| m.oid) {
+                merge_sha_to_pr.insert(oid, id);
+            }
+        }
+        report.prs_ingested += 1;
+        if let Some(u) = &pr.updated_at {
+            if max_updated
+                .as_deref()
+                .map(|m| u.as_str() > m)
+                .unwrap_or(true)
+            {
+                max_updated = Some(u.clone());
+            }
+        }
+    }
+
+    if let Some(cursor) = max_updated {
+        write_cursor(runtime, project_id, "prs", &cursor).await?;
+    }
+    Ok(())
+}
+
+async fn ingest_issues(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    registry: &VerbRegistry,
+    repo: &Path,
+    project_id: Uuid,
+    report: &mut IngestReport,
+) -> Result<()> {
+    let since = read_cursor(runtime, project_id, "issues").await?;
+    let raw = gh_json(
+        repo,
+        &[
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,author,createdAt,closedAt,updatedAt,labels,stateReason,body",
+        ],
+    )?;
+    let issues: Vec<GhIssue> =
+        serde_json::from_str(&raw).context("parsing gh issue list --json")?;
+
+    let mut max_updated: Option<String> = since.clone();
+    for issue in issues {
+        let is_new = since
+            .as_deref()
+            .zip(issue.updated_at.as_deref())
+            .map(|(cursor, updated)| updated > cursor)
+            .unwrap_or(true);
+
+        if find_by_number(runtime, token, "issue", issue.number)
+            .await?
+            .is_some()
+        {
+            report.issues_skipped_existing += 1;
+            if let Some(u) = &issue.updated_at {
+                if max_updated
+                    .as_deref()
+                    .map(|m| u.as_str() > m)
+                    .unwrap_or(true)
+                {
+                    max_updated = Some(u.clone());
+                }
+            }
+            continue;
+        }
+        if !is_new {
+            continue;
+        }
+
+        let raw_body = issue.body.unwrap_or_default();
+        let content = secret_gate::mask_secrets(&raw_body).into_owned();
+        let labels: Vec<String> = issue
+            .labels
+            .unwrap_or_default()
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        let properties = json!({
+            "number": issue.number,
+            "title": issue.title,
+            "author": issue.author.and_then(|a| a.login),
+            "created_at": issue.created_at,
+            "closed_at": issue.closed_at,
+            "labels": labels,
+            "state_reason": issue.state_reason,
+        });
+
+        registry
+            .dispatch(
+                "create",
+                json!({
+                    "kind": "issue",
+                    "content": content,
+                    "properties": properties,
+                    "annotates": [project_id.to_string()],
+                }),
+            )
+            .await
+            .map_err(|e| anyhow!("create issue #{}: {e}", issue.number))?;
+
+        report.issues_ingested += 1;
+        if let Some(u) = &issue.updated_at {
+            if max_updated
+                .as_deref()
+                .map(|m| u.as_str() > m)
+                .unwrap_or(true)
+            {
+                max_updated = Some(u.clone());
+            }
+        }
+    }
+
+    if let Some(cursor) = max_updated {
+        write_cursor(runtime, project_id, "issues", &cursor).await?;
+    }
+    Ok(())
+}

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -180,12 +180,14 @@ async fn find_commit_by_sha(
 }
 
 /// Look up an existing `issue`/`pull_request` note by its `properties.number`
-/// (natural-key idempotence, scoped by kind + project so numbers from
-/// different repos under the same project never collide).
+/// (natural-key idempotence, scoped by kind + namespace + `project_id` —
+/// GitHub issue/PR numbers are repository-scoped, so a bare `kind`+`number`
+/// filter would incorrectly collide two different repos' `#1`).
 async fn find_by_number(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
     kind: &str,
+    project_id: Uuid,
     number: u64,
 ) -> Result<Option<Uuid>> {
     let sql = runtime.sql();
@@ -193,12 +195,14 @@ async fn find_by_number(
     let row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM notes WHERE kind=?1 AND namespace=?2 \
-                  AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 LIMIT 1"
+                  AND deleted_at IS NULL AND json_extract(properties,'$.number')=?3 \
+                  AND json_extract(properties,'$.project_id')=?4 LIMIT 1"
                 .into(),
             params: vec![
                 SqlValue::Text(kind.to_string()),
                 SqlValue::Text(token.namespace().as_str().to_string()),
                 SqlValue::Integer(number as i64),
+                SqlValue::Text(project_id.to_string()),
             ],
             label: Some("git_ingest_find_by_number".into()),
         })
@@ -278,11 +282,13 @@ async fn read_cursor(
     }))
 }
 
-/// Advance the `(project_id, kind)` cursor. Called only after the
-/// corresponding batch has been fully written — a mid-batch failure leaves
-/// the cursor at its prior value so the next pass safely re-ingests the
-/// batch (natural-key dedupe makes the re-ingest a no-op for anything that
-/// already landed).
+/// Advance the `(project_id, kind)` cursor. Called once per section
+/// (commits/prs/issues) after that section's loop finishes, with a value
+/// that stops advancing at the first per-record create failure (see the
+/// `cursor_stalled` handling in each `ingest_*` loop) — so the next pass
+/// re-walks from before the failure and retries it, while records that
+/// already landed (including ones ingested later in a stalled pass) are
+/// no-ops via natural-key dedupe.
 async fn write_cursor(
     runtime: &KhiveRuntime,
     project_id: Uuid,
@@ -448,11 +454,23 @@ async fn ingest_commits(
     }
     let files_by_sha = touched_files(repo)?;
 
+    // `cursor_stalled` freezes `last_sha` at the last contiguous successfully
+    // processed commit: once a record fails to create, later records in this
+    // same pass are still attempted (so a run surfaces every failure it can,
+    // not just the first) but the cursor no longer advances past them. That
+    // guarantees a failed record is retried — and its warning re-surfaced —
+    // on every subsequent pass until it is fixed upstream, rather than being
+    // silently skipped forever because the cursor moved past it. Records that
+    // do succeed after a stall are still written (idempotent via the
+    // sha natural key), so a retried pass never double-creates them.
     let mut last_sha: Option<String> = since;
+    let mut cursor_stalled = false;
     for c in &commits {
         if find_commit_by_sha(runtime, token, &c.sha).await?.is_some() {
             report.commits_skipped_existing += 1;
-            last_sha = Some(c.sha.clone());
+            if !cursor_stalled {
+                last_sha = Some(c.sha.clone());
+            }
             continue;
         }
 
@@ -486,7 +504,7 @@ async fn ingest_commits(
             None => match squash_merge_pr_number(&c.subject) {
                 Some(n) => match number_to_pr.get(&n).copied() {
                     Some(id) => Some(id),
-                    None => find_by_number(runtime, token, "pull_request", n).await?,
+                    None => find_by_number(runtime, token, "pull_request", project_id, n).await?,
                 },
                 None => None,
             },
@@ -504,7 +522,7 @@ async fn ingest_commits(
             "parents": c.parents,
         });
 
-        registry
+        match registry
             .dispatch(
                 "create",
                 json!({
@@ -515,10 +533,20 @@ async fn ingest_commits(
                 }),
             )
             .await
-            .map_err(|e| anyhow!("create commit {}: {e}", c.sha))?;
-
-        report.commits_ingested += 1;
-        last_sha = Some(c.sha.clone());
+        {
+            Ok(_) => {
+                report.commits_ingested += 1;
+                if !cursor_stalled {
+                    last_sha = Some(c.sha.clone());
+                }
+            }
+            Err(e) => {
+                report
+                    .warnings
+                    .push(format!("create commit {}: {e}", c.sha));
+                cursor_stalled = true;
+            }
+        }
     }
 
     if let Some(sha) = last_sha {
@@ -627,7 +655,13 @@ async fn ingest_prs(
     )?;
     let prs: Vec<GhPr> = serde_json::from_str(&raw).context("parsing gh pr list --json")?;
 
+    // `cursor_stalled` mirrors `ingest_commits`: once one PR fails to create,
+    // later PRs in this pass are still attempted (so every failure surfaces
+    // in this pass's warnings), but `max_updated` no longer advances past the
+    // stall point — the next pass re-fetches from before the failure and
+    // retries it, while already-landed PRs are no-ops via the natural key.
     let mut max_updated: Option<String> = since.clone();
+    let mut cursor_stalled = false;
     for pr in prs {
         let is_new = since
             .as_deref()
@@ -635,19 +669,23 @@ async fn ingest_prs(
             .map(|(cursor, updated)| updated > cursor)
             .unwrap_or(true);
 
-        if let Some(existing) = find_by_number(runtime, token, "pull_request", pr.number).await? {
+        if let Some(existing) =
+            find_by_number(runtime, token, "pull_request", project_id, pr.number).await?
+        {
             number_to_pr.insert(pr.number, existing);
             if let Some(oid) = pr.merge_commit.as_ref().and_then(|m| m.oid.clone()) {
                 merge_sha_to_pr.insert(oid, existing);
             }
             report.prs_skipped_existing += 1;
-            if let Some(u) = &pr.updated_at {
-                if max_updated
-                    .as_deref()
-                    .map(|m| u.as_str() > m)
-                    .unwrap_or(true)
-                {
-                    max_updated = Some(u.clone());
+            if !cursor_stalled {
+                if let Some(u) = &pr.updated_at {
+                    if max_updated
+                        .as_deref()
+                        .map(|m| u.as_str() > m)
+                        .unwrap_or(true)
+                    {
+                        max_updated = Some(u.clone());
+                    }
                 }
             }
             continue;
@@ -665,11 +703,12 @@ async fn ingest_prs(
             "created_at": pr.created_at,
             "merged_at": pr.merged_at,
             "closed_at": pr.closed_at,
-            "base": pr.base_ref_name,
-            "head": pr.head_ref_name,
+            "base_ref": pr.base_ref_name,
+            "head_ref": pr.head_ref_name,
+            "project_id": project_id.to_string(),
         });
 
-        let result = registry
+        let result = match registry
             .dispatch(
                 "create",
                 json!({
@@ -680,7 +719,16 @@ async fn ingest_prs(
                 }),
             )
             .await
-            .map_err(|e| anyhow!("create pull_request #{}: {e}", pr.number))?;
+        {
+            Ok(v) => v,
+            Err(e) => {
+                report
+                    .warnings
+                    .push(format!("create pull_request #{}: {e}", pr.number));
+                cursor_stalled = true;
+                continue;
+            }
+        };
 
         if let Some(id) = result
             .get("id")
@@ -693,13 +741,15 @@ async fn ingest_prs(
             }
         }
         report.prs_ingested += 1;
-        if let Some(u) = &pr.updated_at {
-            if max_updated
-                .as_deref()
-                .map(|m| u.as_str() > m)
-                .unwrap_or(true)
-            {
-                max_updated = Some(u.clone());
+        if !cursor_stalled {
+            if let Some(u) = &pr.updated_at {
+                if max_updated
+                    .as_deref()
+                    .map(|m| u.as_str() > m)
+                    .unwrap_or(true)
+                {
+                    max_updated = Some(u.clone());
+                }
             }
         }
     }
@@ -735,7 +785,13 @@ async fn ingest_issues(
     let issues: Vec<GhIssue> =
         serde_json::from_str(&raw).context("parsing gh issue list --json")?;
 
+    // `cursor_stalled` mirrors `ingest_commits`/`ingest_prs`: a per-record
+    // create failure is aggregated as a warning and later records in this
+    // pass are still attempted, but `max_updated` freezes at the stall point
+    // so the next pass retries the failed record instead of skipping it
+    // forever; already-landed records are no-ops via the natural key.
     let mut max_updated: Option<String> = since.clone();
+    let mut cursor_stalled = false;
     for issue in issues {
         let is_new = since
             .as_deref()
@@ -743,18 +799,20 @@ async fn ingest_issues(
             .map(|(cursor, updated)| updated > cursor)
             .unwrap_or(true);
 
-        if find_by_number(runtime, token, "issue", issue.number)
+        if find_by_number(runtime, token, "issue", project_id, issue.number)
             .await?
             .is_some()
         {
             report.issues_skipped_existing += 1;
-            if let Some(u) = &issue.updated_at {
-                if max_updated
-                    .as_deref()
-                    .map(|m| u.as_str() > m)
-                    .unwrap_or(true)
-                {
-                    max_updated = Some(u.clone());
+            if !cursor_stalled {
+                if let Some(u) = &issue.updated_at {
+                    if max_updated
+                        .as_deref()
+                        .map(|m| u.as_str() > m)
+                        .unwrap_or(true)
+                    {
+                        max_updated = Some(u.clone());
+                    }
                 }
             }
             continue;
@@ -778,6 +836,7 @@ async fn ingest_issues(
             "created_at": issue.created_at,
             "closed_at": issue.closed_at,
             "labels": labels,
+            "project_id": project_id.to_string(),
         });
         // gh reports stateReason as "" for open issues and UPPERCASE enum values
         // (NOT_PLANNED) for closed ones; the kind hook governs any PRESENT value
@@ -787,7 +846,7 @@ async fn ingest_issues(
             properties["state_reason"] = json!(reason.to_ascii_lowercase());
         }
 
-        registry
+        if let Err(e) = registry
             .dispatch(
                 "create",
                 json!({
@@ -798,16 +857,24 @@ async fn ingest_issues(
                 }),
             )
             .await
-            .map_err(|e| anyhow!("create issue #{}: {e}", issue.number))?;
+        {
+            report
+                .warnings
+                .push(format!("create issue #{}: {e}", issue.number));
+            cursor_stalled = true;
+            continue;
+        }
 
         report.issues_ingested += 1;
-        if let Some(u) = &issue.updated_at {
-            if max_updated
-                .as_deref()
-                .map(|m| u.as_str() > m)
-                .unwrap_or(true)
-            {
-                max_updated = Some(u.clone());
+        if !cursor_stalled {
+            if let Some(u) = &issue.updated_at {
+                if max_updated
+                    .as_deref()
+                    .map(|m| u.as_str() > m)
+                    .unwrap_or(true)
+                {
+                    max_updated = Some(u.clone());
+                }
             }
         }
     }

--- a/crates/khive-pack-git/src/lib.rs
+++ b/crates/khive-pack-git/src/lib.rs
@@ -1,0 +1,13 @@
+//! `khive-pack-git` — the git-lifecycle pack (ADR-088).
+//!
+//! Contributes three note kinds (`commit`, `issue`, `pull_request`) that make
+//! repository provenance queryable through the KG graph, populated by a
+//! batch, cursor-based ingester (`ingest`) rather than any new agent-facing
+//! verb. See `docs/adr/ADR-088-git-lifecycle-pack.md`.
+
+pub mod hook;
+pub mod ingest;
+mod pack;
+pub(crate) mod vocab;
+
+pub use pack::GitPack;

--- a/crates/khive-pack-git/src/pack.rs
+++ b/crates/khive-pack-git/src/pack.rs
@@ -1,0 +1,126 @@
+//! `GitPack` struct, `Pack` impl, self-registration factory, and `PackRuntime` impl.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{
+    KhiveRuntime, KindHook, NamespaceToken, NoteKindSpec, PackSchemaPlan, RuntimeError, SchemaPlan,
+    VerbRegistry,
+};
+use khive_types::{EdgeEndpointRule, HandlerDef, Pack};
+
+use crate::hook::{CommitHook, IssueLikeHook};
+use crate::vocab::{GIT_NOTE_KIND_SPECS, GIT_SCHEMA_PLAN_STMTS};
+
+/// Git-lifecycle pack (ADR-088) — registers `commit` / `issue` / `pull_request`
+/// note kinds populated by the batch ingester in `src/ingest.rs`. Contributes
+/// no new verbs and no edge endpoint rules: provenance edges use the base
+/// `annotates` contract only.
+pub struct GitPack {
+    #[allow(dead_code)]
+    runtime: KhiveRuntime,
+}
+
+impl Pack for GitPack {
+    const NAME: &'static str = "git";
+    const NOTE_KINDS: &'static [&'static str] = &["commit", "issue", "pull_request"];
+    const ENTITY_KINDS: &'static [&'static str] = &[];
+    const HANDLERS: &'static [HandlerDef] = &[];
+    const REQUIRES: &'static [&'static str] = &["kg"];
+    const NOTE_KIND_SPECS: &'static [NoteKindSpec] = &GIT_NOTE_KIND_SPECS;
+    const SCHEMA_PLAN: Option<PackSchemaPlan> = Some(PackSchemaPlan {
+        pack: "git",
+        statements: &GIT_SCHEMA_PLAN_STMTS,
+    });
+}
+
+impl GitPack {
+    /// Create a new `GitPack` bound to the given runtime.
+    pub fn new(runtime: KhiveRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+// -- inventory self-registration --------------------------------------------
+
+struct GitPackFactory;
+
+impl khive_runtime::PackFactory for GitPackFactory {
+    fn name(&self) -> &'static str {
+        "git"
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        &["kg"]
+    }
+
+    fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
+        Box::new(GitPack::new(runtime))
+    }
+}
+
+inventory::submit! { khive_runtime::PackRegistration(&GitPackFactory) }
+
+#[async_trait]
+impl PackRuntime for GitPack {
+    fn name(&self) -> &str {
+        <GitPack as Pack>::NAME
+    }
+
+    fn note_kinds(&self) -> &'static [&'static str] {
+        <GitPack as Pack>::NOTE_KINDS
+    }
+
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        <GitPack as Pack>::ENTITY_KINDS
+    }
+
+    fn handlers(&self) -> &'static [HandlerDef] {
+        <GitPack as Pack>::HANDLERS
+    }
+
+    fn edge_rules(&self) -> &'static [EdgeEndpointRule] {
+        <GitPack as Pack>::EDGE_RULES
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        <GitPack as Pack>::REQUIRES
+    }
+
+    fn note_kind_specs(&self) -> &'static [NoteKindSpec] {
+        <GitPack as Pack>::NOTE_KIND_SPECS
+    }
+
+    fn schema_plan(&self) -> SchemaPlan {
+        SchemaPlan {
+            pack: "git",
+            statements: &GIT_SCHEMA_PLAN_STMTS,
+        }
+    }
+
+    fn kind_hook(&self, kind: &str) -> Option<Arc<dyn KindHook>> {
+        match kind {
+            "commit" => Some(Arc::new(CommitHook)),
+            "issue" => Some(Arc::new(IssueLikeHook { kind: "issue" })),
+            "pull_request" => Some(Arc::new(IssueLikeHook {
+                kind: "pull_request",
+            })),
+            _ => None,
+        }
+    }
+
+    async fn dispatch(
+        &self,
+        verb: &str,
+        _params: Value,
+        _registry: &VerbRegistry,
+        _token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        Err(RuntimeError::InvalidInput(format!(
+            "git pack does not handle verb {verb:?}"
+        )))
+    }
+}

--- a/crates/khive-pack-git/src/vocab.rs
+++ b/crates/khive-pack-git/src/vocab.rs
@@ -1,0 +1,56 @@
+//! Git pack vocabulary: note kind specs and the pack-auxiliary cursor schema.
+//!
+//! No `HANDLERS` and no `EDGE_RULES` are declared here (unlike gtd): this pack
+//! introduces zero new verbs and relies exclusively on the base `annotates`
+//! contract (note -> any substrate) for provenance edges — no endpoint
+//! extension is needed. See `crates/khive-pack-git/src/pack.rs`.
+
+use khive_runtime::{NoteKindSpec, NoteLifecycleSpec};
+
+/// Lifecycle declaration shared by `issue` and `pull_request` — both track an
+/// open/closed state with the same posture as ADR-088's `finding` precedent:
+/// declared for introspection, not yet enforced by the runtime (Phase 1).
+const GIT_LIFECYCLE: NoteLifecycleSpec = NoteLifecycleSpec {
+    field: "kind_status",
+    initial: "open",
+    terminal: &["closed"],
+    transitions: &[("open", "closed"), ("closed", "open")],
+};
+
+/// Note kind specs for the two lifecycle-bearing kinds this pack contributes.
+///
+/// `commit` deliberately has no entry: commits are immutable and carry no
+/// lifecycle field.
+pub(crate) static GIT_NOTE_KIND_SPECS: [NoteKindSpec; 2] = [
+    NoteKindSpec {
+        kind: "issue",
+        aliases: &[],
+        lifecycle: GIT_LIFECYCLE,
+    },
+    NoteKindSpec {
+        kind: "pull_request",
+        aliases: &[],
+        lifecycle: GIT_LIFECYCLE,
+    },
+];
+
+/// Pack-auxiliary schema: the git-ingest cursor table (ADR-088 §5, ADR-087
+/// operational pattern reused).
+///
+/// Shape is intentionally generic across git record kinds within a project —
+/// `kind` distinguishes `commits` / `issues` / `prs` cursors so a follow-up
+/// pack (e.g. a code-review pack) can reuse this exact table for its own
+/// cursor rows without a schema change, keyed by its own `project_id`/`kind`
+/// pair. Idempotent (`CREATE TABLE IF NOT EXISTS`), applied once at pack
+/// registration time; not part of the core versioned migration chain.
+pub(crate) static GIT_SCHEMA_PLAN_STMTS: [&str; 2] = [
+    "CREATE TABLE IF NOT EXISTS git_mirror_cursor (\
+        project_id   TEXT NOT NULL,\
+        kind         TEXT NOT NULL,\
+        cursor_value TEXT,\
+        updated_at   INTEGER NOT NULL,\
+        PRIMARY KEY (project_id, kind)\
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_git_mirror_cursor_updated \
+        ON git_mirror_cursor(updated_at DESC)",
+];

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -778,3 +778,321 @@ async fn gh_boundary_contract_and_partial_ingest_failure() {
         report2.warnings
     );
 }
+
+// ── unsorted `gh` output must not desync the frozen-cursor retry guarantee
+//    (review round-2 [Medium]) ───────────────────────────────────────────────
+
+/// Reads the git-ingest cursor row directly, mirroring `ingest.rs`'s private
+/// `read_cursor` — the acceptance tests otherwise only observe cursor state
+/// indirectly through `IngestReport` deltas across passes, which is not
+/// precise enough to assert the exact freeze point below.
+async fn read_git_cursor(rt: &KhiveRuntime, project_id: Uuid, kind: &str) -> Option<String> {
+    use khive_storage::types::{SqlStatement, SqlValue};
+    let sql = rt.sql();
+    let mut r = sql.reader().await.expect("sql reader");
+    let row = r
+        .query_row(SqlStatement {
+            sql: "SELECT cursor_value FROM git_mirror_cursor WHERE project_id=?1 AND kind=?2"
+                .into(),
+            params: vec![
+                SqlValue::Text(project_id.to_string()),
+                SqlValue::Text(kind.to_string()),
+            ],
+            label: Some("test_read_git_cursor".into()),
+        })
+        .await
+        .expect("query cursor row");
+    row.and_then(|r| match r.get("cursor_value") {
+        Some(SqlValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+/// `gh issue list` / `gh pr list` make no ordering guarantee (review round-2
+/// [Medium]): the frozen-cursor retry contract only holds if records are
+/// walked in nondecreasing `updatedAt` order, so unsorted `gh` output can let
+/// a later, newer record's timestamp overwrite the freeze point before an
+/// earlier, older record fails — after which the older failure looks
+/// already-covered by the cursor and is skipped forever instead of retried.
+///
+/// This fixture returns three issues out of raw order — `[#10 (newest,
+/// good), #20 (older than #10, BAD: ungoverned stateReason), #5 (oldest,
+/// good)]` — so an unsorted walk would create #10 before #20 fails, wrongly
+/// freezing the cursor at #10's timestamp (newer than #20's). Sorting
+/// ascending first (the fix) walks `#5, #20, #10`, so the freeze lands at
+/// #5's timestamp instead — at/below #20's — and pass 2 (after #20's
+/// `stateReason` is corrected upstream) retries and lands it without
+/// duplicating #5 or #10.
+#[tokio::test]
+async fn issue_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_listing() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-order-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let bad_issue_json = |state_reason: &str| {
+        json!([
+            {"number": 10, "title": "i10-newest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-03T00:00:00Z", "labels": [], "stateReason": "completed", "body": ""},
+            {"number": 20, "title": "i20-older-bad", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "stateReason": state_reason, "body": ""},
+            {"number": 5, "title": "i5-oldest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2025-12-01T00:00:00Z", "labels": [], "stateReason": "", "body": ""}
+        ])
+        .to_string()
+    };
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &bad_issue_json("WONTFIX"));
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+
+    assert_eq!(
+        report.issues_ingested, 2,
+        "#5 and #10 both land, #20 warns-and-skips: {report:?}"
+    );
+    assert_eq!(
+        report
+            .warnings
+            .iter()
+            .filter(|w| w.contains("issue #20"))
+            .count(),
+        1,
+        "exactly one warning names the ungoverned record: {:?}",
+        report.warnings
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, "2025-12-01T00:00:00Z",
+        "cursor must freeze at #5's timestamp (at/below failed #20's \
+         2026-01-01T00:00:00Z), not advance to #10's later 2026-01-03T00:00:00Z \
+         just because #10 appeared earlier in gh's raw (unsorted) output: {cursor_after_pass1:?}"
+    );
+
+    // Upstream correction: #20's stateReason is fixed to a governed value —
+    // pass 2 must retry and land it without duplicating #5 or #10.
+    std::fs::write(
+        log_dir.join("issue_response.json"),
+        bad_issue_json("completed"),
+    )
+    .expect("rewrite issue fixture with corrected stateReason");
+
+    let report2 = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+
+    assert_eq!(
+        report2.issues_ingested, 1,
+        "only #20 (now corrected) is newly created on pass 2: {report2:?}"
+    );
+    assert_eq!(
+        report2.issues_skipped_existing, 2,
+        "#5 and #10 are found by natural key, not duplicated: {report2:?}"
+    );
+    assert!(
+        report2.warnings.iter().all(|w| !w.contains("issue #20")),
+        "#20 must not warn once its stateReason is corrected: {:?}",
+        report2.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 20}))
+        .await
+        .expect("list issues ok");
+    let numbers: Vec<u64> = issues_list
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|i| i["properties"]["number"].as_u64())
+        .collect();
+    assert_eq!(
+        numbers.len(),
+        3,
+        "exactly #5, #10, #20 — no duplicates: {numbers:?}"
+    );
+
+    let cursor_after_pass2 = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(cursor_after_pass2, "2026-01-03T00:00:00Z");
+}
+
+/// PR mirror of `issue_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_listing`.
+/// `pull_request` has no `stateReason` field in `gh pr list --json` (verified
+/// against the live `gh` CLI's field list — only `issue`s carry one), so this
+/// fixture forces the per-record failure a different, equally real way: a
+/// leaked-credential-shaped PR title. `create_note_inner` scans `properties`
+/// (which carries `title`) through `secret_gate::check_json` independently
+/// of `ingest.rs`'s own `mask_secrets` pass over the PR body — a credential
+/// pasted into a title is masked nowhere upstream, so the create is rejected
+/// outright rather than silently landing unmasked.
+#[tokio::test]
+async fn pr_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_listing() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "pr-order-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let leaked_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let bad_pr_json = |title_20: &str| {
+        json!([
+            {"number": 10, "title": "pr10-newest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2026-01-03T00:00:00Z", "baseRefName": "main", "headRefName": "f10", "mergeCommit": null, "body": ""},
+            {"number": 20, "title": title_20, "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2026-01-01T00:00:00Z", "baseRefName": "main", "headRefName": "f20", "mergeCommit": null, "body": ""},
+            {"number": 5, "title": "pr5-oldest-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": "2025-12-01T00:00:00Z", "baseRefName": "main", "headRefName": "f5", "mergeCommit": null, "body": ""}
+        ])
+        .to_string()
+    };
+
+    write_fake_gh(
+        &bin_dir,
+        &log_dir,
+        &bad_pr_json(&format!("pr20-older-bad {leaked_token}")),
+        "[]",
+    );
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+
+    assert_eq!(
+        report.prs_ingested, 2,
+        "#5 and #10 both land, #20 (leaked credential in title) warns-and-skips: {report:?}"
+    );
+    assert_eq!(
+        report
+            .warnings
+            .iter()
+            .filter(|w| w.contains("pull_request #20"))
+            .count(),
+        1,
+        "exactly one warning names the rejected record: {:?}",
+        report.warnings
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "prs")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, "2025-12-01T00:00:00Z",
+        "cursor must freeze at #5's timestamp (at/below failed #20's \
+         2026-01-01T00:00:00Z), not advance to #10's later 2026-01-03T00:00:00Z \
+         just because #10 appeared earlier in gh's raw (unsorted) output: {cursor_after_pass1:?}"
+    );
+
+    // Upstream correction: #20's title no longer carries a credential — pass
+    // 2 must retry and land it without duplicating #5 or #10.
+    std::fs::write(
+        log_dir.join("pr_response.json"),
+        bad_pr_json("pr20-older-fixed"),
+    )
+    .expect("rewrite pr fixture with corrected title");
+
+    let report2 = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+
+    assert_eq!(
+        report2.prs_ingested, 1,
+        "only #20 (now corrected) is newly created on pass 2: {report2:?}"
+    );
+    assert_eq!(
+        report2.prs_skipped_existing, 2,
+        "#5 and #10 are found by natural key, not duplicated: {report2:?}"
+    );
+    assert!(
+        report2
+            .warnings
+            .iter()
+            .all(|w| !w.contains("pull_request #20")),
+        "#20 must not warn once its title no longer carries a credential: {:?}",
+        report2.warnings
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 20}))
+        .await
+        .expect("list prs ok");
+    let numbers: Vec<u64> = prs_list
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|i| i["properties"]["number"].as_u64())
+        .collect();
+    assert_eq!(
+        numbers.len(),
+        3,
+        "exactly #5, #10, #20 — no duplicates: {numbers:?}"
+    );
+
+    let cursor_after_pass2 = read_git_cursor(&rt, project_id, "prs")
+        .await
+        .expect("cursor must be written");
+    assert_eq!(cursor_after_pass2, "2026-01-03T00:00:00Z");
+}

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1,0 +1,333 @@
+//! End-to-end acceptance test for the ADR-088 git-lifecycle pack (v0).
+//!
+//! Builds a synthetic fixture repo with `git` inside a tempdir, runs one
+//! ingest pass against an in-memory runtime, and asserts the provenance
+//! query genre works: traversing/searching from a pre-created `document`
+//! entity via incoming `annotates` edges yields exactly the commits that
+//! touched its path, and a squash-merge commit's PR edge resolves. Also
+//! covers `KindHook` validation and secret-masking on ingested content.
+
+use std::path::Path;
+use std::process::Command;
+
+use khive_pack_git::ingest::{run_ingest, IngestOptions};
+use khive_pack_git::GitPack;
+use khive_pack_kg::KgPack;
+use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, VerbRegistry, VerbRegistryBuilder};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+fn rt() -> KhiveRuntime {
+    KhiveRuntime::memory().expect("memory runtime")
+}
+
+async fn fixture() -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
+    let rt = rt();
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(GitPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry.apply_schema_plans(rt.backend());
+    let token = rt.authorize(Namespace::local()).expect("authorize local");
+    (rt, token, registry)
+}
+
+async fn create(registry: &VerbRegistry, body: Value) -> Uuid {
+    let resp = registry.dispatch("create", body).await.expect("create ok");
+    Uuid::parse_str(resp["id"].as_str().expect("id present")).expect("id is uuid")
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn init_repo(repo: &Path) {
+    git(repo, &["init", "-q", "-b", "main"]);
+    git(repo, &["config", "user.email", "test@example.com"]);
+    git(repo, &["config", "user.name", "Test User"]);
+}
+
+fn write(repo: &Path, rel: &str, contents: &str) {
+    let path = repo.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+fn commit(repo: &Path, rel_paths: &[&str], message: &str) {
+    for p in rel_paths {
+        git(repo, &["add", p]);
+    }
+    git(repo, &["commit", "-q", "-m", message]);
+}
+
+fn head_sha(repo: &Path) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("rev-parse");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Full end-to-end: a fixture repo with three commits (two touching a
+/// tracked ADR path, one unrelated), a pre-ingested PR that a squash-merge
+/// commit references by `(#NNN)` suffix — asserts the provenance query
+/// genre: incoming `annotates` from the document yields exactly the
+/// touching commits, and the squash-merge commit's PR edge resolves.
+#[tokio::test]
+async fn ingest_links_commits_to_document_and_pr_by_provenance_query() {
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "acceptance-repo"}),
+    )
+    .await;
+    let doc_id = create(
+        &registry,
+        json!({
+            "kind": "document",
+            "name": "ADR-045-test.md",
+            "properties": {"source_uri": "docs/adr/ADR-045-test.md"},
+        }),
+    )
+    .await;
+    let pr_id = create(
+        &registry,
+        json!({
+            "kind": "pull_request",
+            "content": "",
+            "properties": {"number": 42, "title": "Add ADR-045"},
+            "annotates": [project_id.to_string()],
+        }),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    write(
+        repo,
+        "docs/adr/ADR-045-test.md",
+        "# ADR-045\n\nInitial draft.\n",
+    );
+    commit(repo, &["docs/adr/ADR-045-test.md"], "Add ADR-045 (#42)");
+    let commit1 = head_sha(repo);
+
+    write(repo, "src/lib.rs", "// unrelated change\n");
+    commit(repo, &["src/lib.rs"], "Unrelated source change");
+
+    write(repo, "docs/adr/ADR-045-test.md", "# ADR-045\n\nRevised.\n");
+    commit(repo, &["docs/adr/ADR-045-test.md"], "Revise ADR-045");
+    let commit3 = head_sha(repo);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.to_path_buf(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.commits_ingested, 3,
+        "all three commits ingest: {report:?}"
+    );
+
+    // Provenance query genre: incoming `annotates` from the document.
+    let doc_neighbors = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": doc_id.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    let hits = doc_neighbors.as_array().expect("array");
+    assert_eq!(
+        hits.len(),
+        2,
+        "exactly the two touching commits annotate the document: {hits:?}"
+    );
+    for h in hits {
+        assert_eq!(h["kind"], "commit");
+    }
+    // `neighbors` returns the note's own UUID, not its `properties.sha` — resolve
+    // each hit through `get` to compare against the real commit shas.
+    let mut hit_shas: Vec<String> = Vec::new();
+    for h in hits {
+        let id = h["id"].as_str().expect("neighbor id");
+        let got = registry
+            .dispatch("get", json!({"id": id}))
+            .await
+            .expect("get ok");
+        hit_shas.push(
+            got["properties"]["sha"]
+                .as_str()
+                .expect("commit note has properties.sha")
+                .to_string(),
+        );
+    }
+    assert!(
+        hit_shas.contains(&commit1),
+        "commit1 {commit1} must be among document neighbors: {hit_shas:?}"
+    );
+    assert!(
+        hit_shas.contains(&commit3),
+        "commit3 {commit3} must be among document neighbors: {hit_shas:?}"
+    );
+
+    // The squash-merge commit's PR edge resolves: pr_id has exactly one
+    // incoming `annotates` from a commit.
+    let pr_neighbors = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": pr_id.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    let pr_hits = pr_neighbors.as_array().expect("array");
+    assert_eq!(
+        pr_hits.len(),
+        1,
+        "exactly one commit annotates the PR: {pr_hits:?}"
+    );
+    assert_eq!(pr_hits[0]["kind"], "commit");
+
+    // The project entity is annotated by all three commits and the PR.
+    let project_neighbors = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": project_id.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    assert_eq!(
+        project_neighbors.as_array().expect("array").len(),
+        4,
+        "3 commits + 1 pull_request annotate the project: {project_neighbors:?}"
+    );
+}
+
+/// Coordinator addendum requirement: a commit message containing a
+/// credential-shaped token must be masked before it is stored.
+#[tokio::test]
+async fn ingest_masks_secrets_in_commit_message() {
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(&registry, json!({"kind": "project", "name": "secret-repo"})).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path();
+    init_repo(repo);
+
+    let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    write(repo, "README.md", "hello\n");
+    commit(
+        repo,
+        &["README.md"],
+        &format!("Rotate deploy key\n\naccidentally committed {fake_token} here"),
+    );
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.to_path_buf(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok");
+    assert_eq!(report.commits_ingested, 1);
+
+    let list = registry
+        .dispatch("list", json!({"kind": "commit", "limit": 10}))
+        .await
+        .expect("list ok");
+    let items = list.as_array().expect("list returns a plain array");
+    assert_eq!(items.len(), 1);
+    let stored_content = items[0]["content"].as_str().expect("content is string");
+    assert!(
+        !stored_content.contains(fake_token),
+        "raw token must not survive into stored content: {stored_content:?}"
+    );
+    assert!(
+        stored_content.contains("***MASKED***") || stored_content.contains("MASKED"),
+        "masked marker must be present: {stored_content:?}"
+    );
+}
+
+// ── KindHook validation unit tests ──────────────────────────────────────────
+
+#[tokio::test]
+async fn commit_hook_rejects_bad_sha() {
+    let (_rt, _token, registry) = fixture().await;
+    let err = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "commit",
+                "content": "bad commit",
+                "properties": {"sha": "not-a-sha"},
+            }),
+        )
+        .await
+        .expect_err("bad sha must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("40-character hex"),
+        "error must name the valid shape: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn issue_hook_rejects_ungoverned_state_reason() {
+    let (_rt, _token, registry) = fixture().await;
+    let err = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "issue",
+                "content": "bad issue",
+                "properties": {"number": 7, "state_reason": "wontfix"},
+            }),
+        )
+        .await
+        .expect_err("ungoverned state_reason must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("completed") && msg.contains("not_planned"),
+        "error must list the governed set: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn commit_hook_requires_properties_sha() {
+    let (_rt, _token, registry) = fixture().await;
+    let err = registry
+        .dispatch(
+            "create",
+            json!({"kind": "commit", "content": "no sha", "properties": {}}),
+        )
+        .await
+        .expect_err("missing sha must be rejected");
+    assert!(format!("{err}").contains("sha"));
+}

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1096,3 +1096,275 @@ async fn pr_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_li
         .expect("cursor must be written");
     assert_eq!(cursor_after_pass2, "2026-01-03T00:00:00Z");
 }
+
+// ── equal-`updated_at` ties must not strand a failed record (review round-3
+//    [Medium]) ─────────────────────────────────────────────────────────────
+
+/// Sorting alone (the round-2 fix) does not cover a TIE: if a successful
+/// record and a failing record share the exact same `updated_at`, the
+/// success still advances the cursor to that shared timestamp, and an
+/// exclusive `updated > cursor` retry check would then see the failed
+/// record's `updated_at == cursor` on the next pass and treat it as
+/// not-new — stranding it forever even with correct sort order. `is_new` is
+/// now inclusive (`updated >= cursor`), so every record AT the cursor
+/// timestamp is re-examined every pass until the cursor moves past it; the
+/// already-landed one is a cheap no-op via the natural-key lookup.
+///
+/// Fixture: #5 (good) and #20 (bad — ungoverned `stateReason`) share the
+/// identical `updatedAt`, #5 first in gh's raw output so it lands before
+/// #20 fails and freezes the cursor at that shared timestamp. Pass 2 (after
+/// #20's `stateReason` is corrected) must retry and land #20 without
+/// duplicating #5.
+#[tokio::test]
+async fn issue_ingest_retries_tie_at_cursor_timestamp() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-tie-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    const TIE_AT: &str = "2026-02-01T00:00:00Z";
+    let issue_json = |state_reason: &str| {
+        json!([
+            {"number": 5, "title": "i5-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": TIE_AT, "labels": [], "stateReason": "", "body": ""},
+            {"number": 20, "title": "i20-bad-tied", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": TIE_AT, "labels": [], "stateReason": state_reason, "body": ""}
+        ])
+        .to_string()
+    };
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json("WONTFIX"));
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "#5 lands, #20 (tied timestamp, ungoverned stateReason) warns-and-skips: {report:?}"
+    );
+    assert_eq!(
+        report
+            .warnings
+            .iter()
+            .filter(|w| w.contains("issue #20"))
+            .count(),
+        1,
+        "exactly one warning names the ungoverned record: {:?}",
+        report.warnings
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, TIE_AT,
+        "cursor freezes at #5's timestamp, which is the SAME as failed #20's — \
+         the exact tie the exclusive `updated > cursor` check used to strand \
+         #20 on: {cursor_after_pass1:?}"
+    );
+
+    // Upstream correction: #20's stateReason is fixed to a governed value —
+    // pass 2 must retry the tied record and land it without duplicating #5.
+    std::fs::write(log_dir.join("issue_response.json"), issue_json("completed"))
+        .expect("rewrite issue fixture with corrected stateReason");
+
+    let report2 = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+
+    assert_eq!(
+        report2.issues_ingested, 1,
+        "only #20 (now corrected) is newly created on pass 2, proving the \
+         tied timestamp did not strand it: {report2:?}"
+    );
+    assert_eq!(
+        report2.issues_skipped_existing, 1,
+        "#5 is found by natural key, not duplicated, even though it is \
+         re-examined every pass at the tied cursor timestamp: {report2:?}"
+    );
+    assert!(
+        report2.warnings.iter().all(|w| !w.contains("issue #20")),
+        "#20 must not warn once its stateReason is corrected: {:?}",
+        report2.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 20}))
+        .await
+        .expect("list issues ok");
+    let numbers: Vec<u64> = issues_list
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|i| i["properties"]["number"].as_u64())
+        .collect();
+    assert_eq!(
+        numbers.len(),
+        2,
+        "exactly #5, #20 — no duplicates: {numbers:?}"
+    );
+}
+
+/// PR mirror of `issue_ingest_retries_tie_at_cursor_timestamp` — see that
+/// test and `ingest_prs`'s sort-rationale comment for the tie hazard. Uses
+/// the leaked-credential-in-title failure mechanism (see
+/// `pr_ingest_sorts_by_updated_at_so_frozen_cursor_survives_out_of_order_listing`)
+/// since `pull_request` has no `stateReason` field.
+#[tokio::test]
+async fn pr_ingest_retries_tie_at_cursor_timestamp() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(&registry, json!({"kind": "project", "name": "pr-tie-repo"})).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    const TIE_AT: &str = "2026-02-01T00:00:00Z";
+    let leaked_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let pr_json = |title_20: &str| {
+        json!([
+            {"number": 5, "title": "pr5-good", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": TIE_AT, "baseRefName": "main", "headRefName": "f5", "mergeCommit": null, "body": ""},
+            {"number": 20, "title": title_20, "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "mergedAt": null, "closedAt": null, "updatedAt": TIE_AT, "baseRefName": "main", "headRefName": "f20", "mergeCommit": null, "body": ""}
+        ])
+        .to_string()
+    };
+
+    write_fake_gh(
+        &bin_dir,
+        &log_dir,
+        &pr_json(&format!("pr20-bad-tied {leaked_token}")),
+        "[]",
+    );
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+
+    assert_eq!(
+        report.prs_ingested, 1,
+        "#5 lands, #20 (tied timestamp, leaked credential in title) warns-and-skips: {report:?}"
+    );
+    assert_eq!(
+        report
+            .warnings
+            .iter()
+            .filter(|w| w.contains("pull_request #20"))
+            .count(),
+        1,
+        "exactly one warning names the rejected record: {:?}",
+        report.warnings
+    );
+
+    let cursor_after_pass1 = read_git_cursor(&rt, project_id, "prs")
+        .await
+        .expect("cursor must be written (#5 landed before the stall)");
+    assert_eq!(
+        cursor_after_pass1, TIE_AT,
+        "cursor freezes at #5's timestamp, which is the SAME as failed #20's — \
+         the exact tie the exclusive `updated > cursor` check used to strand \
+         #20 on: {cursor_after_pass1:?}"
+    );
+
+    // Upstream correction: #20's title no longer carries a credential — pass
+    // 2 must retry the tied record and land it without duplicating #5.
+    std::fs::write(log_dir.join("pr_response.json"), pr_json("pr20-fixed"))
+        .expect("rewrite pr fixture with corrected title");
+
+    let report2 = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+
+    assert_eq!(
+        report2.prs_ingested, 1,
+        "only #20 (now corrected) is newly created on pass 2, proving the \
+         tied timestamp did not strand it: {report2:?}"
+    );
+    assert_eq!(
+        report2.prs_skipped_existing, 1,
+        "#5 is found by natural key, not duplicated, even though it is \
+         re-examined every pass at the tied cursor timestamp: {report2:?}"
+    );
+    assert!(
+        report2
+            .warnings
+            .iter()
+            .all(|w| !w.contains("pull_request #20")),
+        "#20 must not warn once its title no longer carries a credential: {:?}",
+        report2.warnings
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 20}))
+        .await
+        .expect("list prs ok");
+    let numbers: Vec<u64> = prs_list
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|i| i["properties"]["number"].as_u64())
+        .collect();
+    assert_eq!(
+        numbers.len(),
+        2,
+        "exactly #5, #20 — no duplicates: {numbers:?}"
+    );
+}

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -7,8 +7,9 @@
 //! touched its path, and a squash-merge commit's PR edge resolves. Also
 //! covers `KindHook` validation and secret-masking on ingested content.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::LazyLock;
 
 use khive_pack_git::ingest::{run_ingest, IngestOptions};
 use khive_pack_git::GitPack;
@@ -19,6 +20,85 @@ use uuid::Uuid;
 
 fn rt() -> KhiveRuntime {
     KhiveRuntime::memory().expect("memory runtime")
+}
+
+/// `PATH` (and, transitively, which `gh`/`git` binaries `Command::new` resolves
+/// to) is process-global state. Every test that calls `run_ingest` — whether
+/// or not it installs a fake `gh` fixture — must serialize on this mutex, or a
+/// concurrently running fake-`gh` test's `PATH` mutation leaks into it.
+static ENV_MUTEX: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+/// RAII guard: prepends `bin_dir` to `PATH` for the duration of the guard,
+/// restoring the prior `PATH` on drop (even on panic).
+struct PathGuard {
+    prior: Option<String>,
+}
+
+impl PathGuard {
+    fn install(bin_dir: &Path) -> Self {
+        let prior = std::env::var("PATH").ok();
+        let new_path = match &prior {
+            Some(p) => format!("{}:{p}", bin_dir.display()),
+            None => bin_dir.display().to_string(),
+        };
+        std::env::set_var("PATH", new_path);
+        Self { prior }
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+}
+
+/// Write a PATH-shadowing fake `gh` executable into `bin_dir` that logs every
+/// invocation's cwd and argv into `log_dir`, and replies to `pr list` /
+/// `issue list` with the given canned JSON bodies (and to `--version` with a
+/// trivial success, matching `gh_available`'s probe).
+fn write_fake_gh(bin_dir: &Path, log_dir: &Path, pr_json: &str, issue_json: &str) {
+    std::fs::write(log_dir.join("pr_response.json"), pr_json).expect("write pr fixture");
+    std::fs::write(log_dir.join("issue_response.json"), issue_json).expect("write issue fixture");
+
+    let script = format!(
+        r#"#!/bin/sh
+printf '%s\n' "$(pwd)" >> '{cwd_log}'
+printf '%s\n' "$*" >> '{args_log}'
+case "$1" in
+  --version)
+    echo "gh version 2.0.0 (fake)"
+    ;;
+  pr)
+    cat '{pr_json_path}'
+    ;;
+  issue)
+    cat '{issue_json_path}'
+    ;;
+  *)
+    echo "fake gh: unsupported args: $*" 1>&2
+    exit 1
+    ;;
+esac
+"#,
+        cwd_log = log_dir.join("cwd.log").display(),
+        args_log = log_dir.join("args.log").display(),
+        pr_json_path = log_dir.join("pr_response.json").display(),
+        issue_json_path = log_dir.join("issue_response.json").display(),
+    );
+    let script_path = bin_dir.join("gh");
+    std::fs::write(&script_path, script).expect("write fake gh script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("fake gh metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod fake gh");
+    }
 }
 
 async fn fixture() -> (KhiveRuntime, NamespaceToken, VerbRegistry) {
@@ -88,6 +168,7 @@ fn head_sha(repo: &Path) -> String {
 /// touching commits, and the squash-merge commit's PR edge resolves.
 #[tokio::test]
 async fn ingest_links_commits_to_document_and_pr_by_provenance_query() {
+    let _guard = ENV_MUTEX.lock().await;
     let (rt, token, registry) = fixture().await;
 
     let project_id = create(
@@ -109,7 +190,7 @@ async fn ingest_links_commits_to_document_and_pr_by_provenance_query() {
         json!({
             "kind": "pull_request",
             "content": "",
-            "properties": {"number": 42, "title": "Add ADR-045"},
+            "properties": {"number": 42, "title": "Add ADR-045", "project_id": project_id.to_string()},
             "annotates": [project_id.to_string()],
         }),
     )
@@ -229,6 +310,7 @@ async fn ingest_links_commits_to_document_and_pr_by_provenance_query() {
 /// credential-shaped token must be masked before it is stored.
 #[tokio::test]
 async fn ingest_masks_secrets_in_commit_message() {
+    let _guard = ENV_MUTEX.lock().await;
     let (rt, token, registry) = fixture().await;
 
     let project_id = create(&registry, json!({"kind": "project", "name": "secret-repo"})).await;
@@ -301,13 +383,18 @@ async fn commit_hook_rejects_bad_sha() {
 #[tokio::test]
 async fn issue_hook_rejects_ungoverned_state_reason() {
     let (_rt, _token, registry) = fixture().await;
+    let project_id = create(&registry, json!({"kind": "project", "name": "hook-repo"})).await;
     let err = registry
         .dispatch(
             "create",
             json!({
                 "kind": "issue",
                 "content": "bad issue",
-                "properties": {"number": 7, "state_reason": "wontfix"},
+                "properties": {
+                    "number": 7,
+                    "state_reason": "wontfix",
+                    "project_id": project_id.to_string(),
+                },
             }),
         )
         .await
@@ -317,6 +404,23 @@ async fn issue_hook_rejects_ungoverned_state_reason() {
         msg.contains("completed") && msg.contains("not_planned"),
         "error must list the governed set: {msg}"
     );
+}
+
+#[tokio::test]
+async fn issue_hook_requires_properties_project_id() {
+    let (_rt, _token, registry) = fixture().await;
+    let err = registry
+        .dispatch(
+            "create",
+            json!({
+                "kind": "issue",
+                "content": "no project_id",
+                "properties": {"number": 8},
+            }),
+        )
+        .await
+        .expect_err("missing project_id must be rejected");
+    assert!(format!("{err}").contains("project_id"));
 }
 
 #[tokio::test]
@@ -330,4 +434,347 @@ async fn commit_hook_requires_properties_sha() {
         .await
         .expect_err("missing sha must be rejected");
     assert!(format!("{err}").contains("sha"));
+}
+
+// ── project-scoped idempotency (review round-1 [High] #1) ──────────────────
+
+/// GitHub issue/PR numbers are repository-scoped: two different `project`
+/// entities can each have a `#1`. Both a direct `find_by_number` collision
+/// and the commit ingester's squash-merge-suffix PR fallback must resolve
+/// within the ingesting project only, never across projects.
+#[tokio::test]
+async fn issue_and_pr_idempotency_is_scoped_per_project() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_a = create(&registry, json!({"kind": "project", "name": "repo-a"})).await;
+    let project_b = create(&registry, json!({"kind": "project", "name": "repo-b"})).await;
+
+    // Project A already has issue #1 and PR #1 (as if ingested in a prior pass).
+    let pr_a = create(
+        &registry,
+        json!({
+            "kind": "pull_request",
+            "content": "",
+            "properties": {"number": 1, "title": "A#1", "project_id": project_a.to_string()},
+            "annotates": [project_a.to_string()],
+        }),
+    )
+    .await;
+    let issue_a = create(
+        &registry,
+        json!({
+            "kind": "issue",
+            "content": "",
+            "properties": {"number": 1, "title": "issue A#1", "project_id": project_a.to_string()},
+            "annotates": [project_a.to_string()],
+        }),
+    )
+    .await;
+
+    // Project B's fixture repo has its own squash-merge commit suffixed
+    // "(#1)" -- before project B has any PR #1 of its own, the fallback must
+    // NOT resolve to project A's PR #1.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo_b: PathBuf = dir.path().to_path_buf();
+    init_repo(&repo_b);
+    write(&repo_b, "README.md", "b\n");
+    commit(&repo_b, &["README.md"], "Add repo-b feature (#1)");
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo_b.clone(),
+            project: project_b.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+    assert_eq!(report.commits_ingested, 1);
+
+    let pr_a_neighbors = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": pr_a.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    assert_eq!(
+        pr_a_neighbors.as_array().expect("array").len(),
+        0,
+        "project B's commit must never attach to project A's PR #1: {pr_a_neighbors:?}"
+    );
+
+    // Directly create project B's own issue #1 and PR #1 (both numbered the
+    // same as project A's), then ingest a second squash-merge commit -- the
+    // fallback must now resolve within project B.
+    let pr_b = create(
+        &registry,
+        json!({
+            "kind": "pull_request",
+            "content": "",
+            "properties": {"number": 1, "title": "B#1", "project_id": project_b.to_string()},
+            "annotates": [project_b.to_string()],
+        }),
+    )
+    .await;
+    let issue_b = create(
+        &registry,
+        json!({
+            "kind": "issue",
+            "content": "",
+            "properties": {"number": 1, "title": "issue B#1", "project_id": project_b.to_string()},
+            "annotates": [project_b.to_string()],
+        }),
+    )
+    .await;
+    assert_ne!(pr_a, pr_b, "both projects' #1 PRs are distinct records");
+    assert_ne!(
+        issue_a, issue_b,
+        "both projects' #1 issues are distinct records"
+    );
+
+    write(&repo_b, "src/lib.rs", "// b2\n");
+    commit(&repo_b, &["src/lib.rs"], "Add another repo-b feature (#1)");
+
+    run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo_b.clone(),
+            project: project_b.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+
+    let pr_b_neighbors = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": pr_b.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    assert_eq!(
+        pr_b_neighbors.as_array().expect("array").len(),
+        1,
+        "project B's own PR #1 resolves the squash-merge fallback: {pr_b_neighbors:?}"
+    );
+    let pr_a_neighbors_after = registry
+        .dispatch(
+            "neighbors",
+            json!({"id": pr_a.to_string(), "direction": "incoming", "relations": ["annotates"]}),
+        )
+        .await
+        .expect("neighbors ok");
+    assert_eq!(
+        pr_a_neighbors_after.as_array().expect("array").len(),
+        0,
+        "project A's PR #1 remains untouched: {pr_a_neighbors_after:?}"
+    );
+}
+
+// ── gh boundary contract + per-record warning aggregation (review round-1
+//    [High] #2, [Medium] #3, [Medium] #4) ───────────────────────────────────
+
+/// End-to-end over a PATH-shadowing fake `gh`: locks the four demo-found
+/// regression classes ((a) no `-C`, correct cwd; (b) empty `stateReason`
+/// omitted; (c) uppercase enum values lowercased; (d) all four governed
+/// values accepted), asserts `pull_request` properties use `base_ref`/
+/// `head_ref` (not `base`/`head`), and asserts one ungoverned-`state_reason`
+/// issue between two valid ones aborts only its own record (one warning,
+/// both neighbors still land) rather than the whole ingest pass.
+#[tokio::test]
+async fn gh_boundary_contract_and_partial_ingest_failure() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "gh-boundary-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+    let repo_canon = repo.canonicalize().expect("canonicalize repo");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let pr_json = json!([{
+        "number": 99,
+        "title": "Add feature",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "mergedAt": "2026-01-02T00:00:00Z",
+        "closedAt": "2026-01-02T00:00:00Z",
+        "updatedAt": "2026-01-02T00:00:00Z",
+        "baseRefName": "main",
+        "headRefName": "feature/x",
+        "mergeCommit": null,
+        "body": "PR body"
+    }])
+    .to_string();
+
+    // 6 issues, ordered good, good, BAD, good, good, good -- #3's ungoverned
+    // `stateReason` must warn-and-skip without aborting #4/#5/#6, and the two
+    // good records sandwiching it (#2, #4) must both land.
+    let issue_json = json!([
+        {"number": 1, "title": "i1", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": null, "updatedAt": "2026-01-01T00:00:01Z", "labels": [], "stateReason": "", "body": ""},
+        {"number": 2, "title": "i2", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:02Z", "updatedAt": "2026-01-01T00:00:02Z", "labels": [], "stateReason": "NOT_PLANNED", "body": ""},
+        {"number": 3, "title": "i3-bad", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:03Z", "updatedAt": "2026-01-01T00:00:03Z", "labels": [], "stateReason": "WONTFIX", "body": ""},
+        {"number": 4, "title": "i4", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:04Z", "updatedAt": "2026-01-01T00:00:04Z", "labels": [], "stateReason": "COMPLETED", "body": ""},
+        {"number": 5, "title": "i5", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:05Z", "updatedAt": "2026-01-01T00:00:05Z", "labels": [], "stateReason": "REOPENED", "body": ""},
+        {"number": 6, "title": "i6", "author": {"login": "a"}, "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:06Z", "updatedAt": "2026-01-01T00:00:06Z", "labels": [], "stateReason": "DUPLICATE", "body": ""}
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, &pr_json, &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 1)");
+
+    assert!(
+        report.gh_available,
+        "fake gh must be found on PATH: {report:?}"
+    );
+    assert_eq!(report.prs_ingested, 1, "{report:?}");
+    assert_eq!(
+        report.issues_ingested, 5,
+        "5 of 6 issues land, #3 warns-and-skips: {report:?}"
+    );
+    assert_eq!(
+        report
+            .warnings
+            .iter()
+            .filter(|w| w.contains("issue #3"))
+            .count(),
+        1,
+        "exactly one warning names the ungoverned record: {:?}",
+        report.warnings
+    );
+
+    // (a) gh is never invoked with -C, and always runs with the repo as cwd.
+    let args_log = std::fs::read_to_string(log_dir.join("args.log")).expect("read args.log");
+    assert!(
+        !args_log.contains("-C"),
+        "gh must never receive an unsupported -C flag: {args_log}"
+    );
+    let cwd_log = std::fs::read_to_string(log_dir.join("cwd.log")).expect("read cwd.log");
+    let cwd_lines: Vec<&str> = cwd_log.lines().filter(|l| !l.is_empty()).collect();
+    assert!(
+        !cwd_lines.is_empty(),
+        "gh must have been invoked at least once"
+    );
+    for line in &cwd_lines {
+        let logged = Path::new(line)
+            .canonicalize()
+            .expect("canonicalize logged cwd");
+        assert_eq!(
+            logged, repo_canon,
+            "every gh invocation must run with the repo as its current_dir"
+        );
+    }
+
+    // (b)/(c)/(d) + Finding 2: pull_request properties use base_ref/head_ref.
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 20}))
+        .await
+        .expect("list issues ok");
+    let issue_items = issues_list.as_array().expect("array");
+    let issue_by_number = |n: u64| -> &Value {
+        issue_items
+            .iter()
+            .find(|i| i["properties"]["number"].as_u64() == Some(n))
+            .unwrap_or_else(|| panic!("issue #{n} must be stored: {issue_items:?}"))
+    };
+    assert!(
+        issue_by_number(1)["properties"]
+            .get("state_reason")
+            .is_none(),
+        "empty stateReason must be omitted, not stored as \"\""
+    );
+    assert_eq!(
+        issue_by_number(2)["properties"]["state_reason"],
+        "not_planned"
+    );
+    assert_eq!(
+        issue_by_number(4)["properties"]["state_reason"],
+        "completed"
+    );
+    assert_eq!(issue_by_number(5)["properties"]["state_reason"], "reopened");
+    assert_eq!(
+        issue_by_number(6)["properties"]["state_reason"],
+        "duplicate"
+    );
+    assert!(
+        !issue_items
+            .iter()
+            .any(|i| i["properties"]["number"].as_u64() == Some(3)),
+        "the ungoverned record must never land: {issue_items:?}"
+    );
+
+    let prs_list = registry
+        .dispatch("list", json!({"kind": "pull_request", "limit": 10}))
+        .await
+        .expect("list prs ok");
+    let pr_items = prs_list.as_array().expect("array");
+    let pr99 = pr_items
+        .iter()
+        .find(|i| i["properties"]["number"].as_u64() == Some(99))
+        .expect("PR #99 must be stored");
+    assert_eq!(pr99["properties"]["base_ref"], "main");
+    assert_eq!(pr99["properties"]["head_ref"], "feature/x");
+    assert!(
+        pr99["properties"].get("base").is_none() && pr99["properties"].get("head").is_none(),
+        "ADR-088 names these base_ref/head_ref, not base/head: {pr99:?}"
+    );
+
+    // Second pass: the frozen cursor retries #3 (fails again) without
+    // re-creating any already-landed record.
+    let report2 = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: repo.clone(),
+            project: project_id.to_string(),
+        },
+    )
+    .await
+    .expect("ingest ok (pass 2)");
+    assert_eq!(
+        report2.issues_ingested, 0,
+        "already-landed issues are found by natural key, not re-created: {report2:?}"
+    );
+    assert_eq!(
+        report2
+            .warnings
+            .iter()
+            .filter(|w| w.contains("issue #3"))
+            .count(),
+        1,
+        "the frozen cursor retries the failed record every pass, not just once: {:?}",
+        report2.warnings
+    );
 }

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -77,8 +77,8 @@ Over MCP, the same call is issued as a DSL string:
 request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
 ```
 
-`khive-mcp` loads a default set of eight packs — `kg`, `gtd`, `memory`, `brain`,
-`comm`, `schedule`, `knowledge`, `session` — with `kg` always present;
+`khive-mcp` loads a default set of nine packs — `kg`, `gtd`, `memory`, `brain`,
+`comm`, `schedule`, `knowledge`, `session`, `git` — with `kg` always present;
 `KHIVE_PACKS` / `--pack` select a subset.
 
 ## Where this sits

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -88,7 +88,7 @@ All 19 verbs are `Visibility::Verb` (exposed on the agent-facing MCP surface).
 [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg) (a hard `REQUIRES`
 dependency for the underlying `concept`/`document` entity substrate) and
 [`khive-pack-brain`](https://crates.io/crates/khive-pack-brain) (feedback
-target). It is one of the eight packs loaded by default in `khive-mcp`. Governing
+target). It is one of the nine packs loaded by default in `khive-mcp`. Governing
 ADRs:
 [ADR-017 (Pack Standard)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md),
 [ADR-048 (Knowledge Section Profiles)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-048-knowledge-section-profiles.md),

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -306,6 +306,7 @@ impl Default for RuntimeConfig {
                     "schedule",
                     "knowledge",
                     "session",
+                    "git",
                 ]
                 .into_iter()
                 .map(String::from)

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1045,7 +1045,8 @@ mod tests {
         // session loads by default so its background mirror warm-hook runs in
         // production; its handlers are all operator-only subhandlers (0 wire verbs).
         assert!(cfg.packs.contains(&"session".to_string()));
-        assert_eq!(cfg.packs.len(), 8);
+        assert!(cfg.packs.contains(&"git".to_string()));
+        assert_eq!(cfg.packs.len(), 9);
         if let Some(v) = prior {
             // SAFETY: single-threaded test cleanup; restores KHIVE_PACKS to its prior value.
             unsafe {

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -28,6 +28,7 @@ khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
 khive-pack-formal = { version = "0.3.0", path = "../khive-pack-formal" }
 khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
+khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
 khive-request = { version = "0.3.0", path = "../khive-request" }
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -38,7 +38,7 @@ This is the production entrypoint. The deno/npm distribution invokes it:
 # stdio MCP server (default transport) — what MCP clients spawn
 kkernel mcp --db ~/.khive/khive.db
 
-# pick packs explicitly (default loads all 8 production packs)
+# pick packs explicitly (default loads all 9 production packs)
 kkernel mcp --pack kg --pack gtd --pack knowledge
 
 # warm Unix-socket daemon (owns ANN indexes; stdio clients auto-spawn + forward to it)

--- a/crates/kkernel/src/git_ingest.rs
+++ b/crates/kkernel/src/git_ingest.rs
@@ -1,0 +1,111 @@
+//! `kkernel git-ingest` — one-shot batch ingest of commit/issue/PR provenance
+//! notes into the graph (ADR-088). Builds a `VerbRegistry` the same way
+//! `khive-mcp`'s `KhiveMcpServer::with_packs` does (see `server.rs`), then
+//! drives `khive_pack_git::ingest::run_ingest` against it. NOT a daemon loop,
+//! NOT a webhook, NOT a poller — one pass per invocation.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
+use khive_pack_git::ingest::{run_ingest, IngestOptions};
+use khive_runtime::{KhiveRuntime, Namespace, PackRegistry, VerbRegistryBuilder};
+
+/// Arguments for `kkernel git-ingest`.
+#[derive(Parser, Debug)]
+pub struct GitIngestArgs {
+    /// Path to the local git repository to walk.
+    #[arg(long)]
+    pub repo: PathBuf,
+
+    /// The repo-anchor `project` entity commits/issues/PRs annotate — full
+    /// UUID or an 8+ hex prefix.
+    #[arg(long)]
+    pub project: String,
+
+    /// Database path (defaults to `~/.khive/khive.db`).
+    #[arg(long, env = "KHIVE_DB")]
+    pub db: Option<String>,
+
+    /// Namespace to operate in.
+    #[arg(long, default_value = "local")]
+    pub namespace: String,
+
+    /// Print human-readable output instead of JSON.
+    #[arg(long)]
+    pub human: bool,
+}
+
+/// Run one `kkernel git-ingest` pass: resolve config, build a registry with
+/// the configured pack set (which includes `git` by default), and dispatch
+/// the ingester against it.
+pub async fn run_git_ingest(args: GitIngestArgs) -> Result<()> {
+    let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let cfg = resolve_runtime_config(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: None,
+        namespace: ns,
+        namespace_explicit: true,
+        actor_explicit: false,
+        no_embed: false,
+        packs: None,
+        brain_profile: None,
+    })?;
+
+    let runtime = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let resolved_ns = runtime.config().default_namespace.clone();
+    let token = runtime
+        .authorize(resolved_ns)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .context("failed to authorize namespace")?;
+
+    // Mirrors `KhiveMcpServer::with_packs` (khive-mcp/src/server.rs): same
+    // gate/namespace/visibility/actor wiring, built from the SAME
+    // `runtime.config().packs` list a live server would use, so the ingester
+    // observes identical `KindHook`/edge-rule/verb behavior.
+    let mut builder = VerbRegistryBuilder::new();
+    builder.with_gate(runtime.config().gate.clone());
+    builder.with_default_namespace(runtime.config().default_namespace.as_str());
+    builder.with_visible_namespaces(runtime.config().visible_namespaces.clone());
+    builder.with_actor_id(runtime.config().actor_id.clone());
+    PackRegistry::register_packs(
+        &runtime.config().packs.clone(),
+        runtime.clone(),
+        &mut builder,
+    )
+    .map_err(|e| anyhow::anyhow!("pack registration failed: {e:?}"))?;
+    let registry = builder.build().map_err(|e| anyhow::anyhow!("{e}"))?;
+    runtime.install_edge_rules(registry.all_edge_rules());
+
+    let report = run_ingest(
+        &runtime,
+        &token,
+        &registry,
+        IngestOptions {
+            repo: args.repo,
+            project: args.project,
+        },
+    )
+    .await?;
+
+    if args.human {
+        println!(
+            "commits: {} ingested, {} skipped\nissues: {} ingested, {} skipped\nprs: {} ingested, {} skipped\ngh_available: {}",
+            report.commits_ingested,
+            report.commits_skipped_existing,
+            report.issues_ingested,
+            report.issues_skipped_existing,
+            report.prs_ingested,
+            report.prs_skipped_existing,
+            report.gh_available,
+        );
+        for w in &report.warnings {
+            eprintln!("warning: {w}");
+        }
+    } else {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    }
+    Ok(())
+}

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -4,6 +4,7 @@ pub mod coordinator;
 pub mod dbpath;
 pub mod engine;
 pub mod exec;
+pub mod git_ingest;
 pub mod kg;
 pub mod pack_introspect;
 pub mod pending_events;
@@ -27,6 +28,7 @@ mod _pack_links {
     use khive_pack_brain::BrainPack as _;
     use khive_pack_comm::CommPack as _;
     use khive_pack_formal::FormalPack as _;
+    use khive_pack_git::GitPack as _;
     use khive_pack_gtd::GtdPack as _;
     use khive_pack_kg::KgPack as _;
     use khive_pack_knowledge::KnowledgePack as _;

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -15,6 +15,8 @@
 //! - `exec`    — run a verb DSL expression through the pack registry
 //! - `mcp`     — serve the MCP `request` surface (stdio / daemon / transports)
 //! - `backend` — inspect registered backends (`list`, `info <name>`)
+//! - `git-ingest` — one-shot batch ingest of commit/issue/pull_request
+//!   provenance notes from a local git repository (ADR-088)
 //!
 //! All subcommands emit JSON on stdout by default for easy piping/parsing.
 //! Pass `--human` to switch to a readable table where supported.
@@ -28,7 +30,7 @@ use clap::{Parser, Subcommand};
 use khive_runtime::{BackendId, KhiveConfig, KhiveRuntime, RuntimeConfig};
 use kkernel::{
     coordinator::{BackendRegistry, SubstrateCoordinator, SubstrateCoordinatorService},
-    engine, exec, kg, pack_introspect, reindex, sync, vector,
+    engine, exec, git_ingest, kg, pack_introspect, reindex, sync, vector,
 };
 
 #[derive(Parser, Debug)]
@@ -98,6 +100,10 @@ enum Command {
     /// Inspect registered backends.
     #[command(subcommand)]
     Backend(BackendCommand),
+
+    /// One-shot batch ingest of commit/issue/pull_request provenance notes
+    /// from a local git repository (ADR-088).
+    GitIngest(git_ingest::GitIngestArgs),
 }
 
 /// Database schema lifecycle subcommands.
@@ -311,6 +317,7 @@ async fn main() -> Result<()> {
             }
         }
         Command::Backend(b) => cmd_backend(b),
+        Command::GitIngest(a) => git_ingest::run_git_ingest(a).await,
     }
 }
 

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -215,3 +215,47 @@ rejected — see Open Questions.
 - ADR-087 — background ingestion operational pattern reused here
 - `crates/khive-types/src/note.rs` — `Note.content: String` (free body-text storage this
   ADR relies on)
+
+## Amendment (v0 implementation)
+
+The v0 implementation of `khive-pack-git` resolves the three Open Questions above and
+records two shape decisions made during the build that were not fixed in the original
+Decision text.
+
+1. **`pull_request` shipped in v0, not deferred.** Open Question 1 recommended deferral,
+   but the acceptance criterion for this pack — a provenance query that walks from a
+   `project` entity to the commits and pull requests that touch it — cannot be
+   demonstrated without a PR-linked commit in the graph. `pull_request` is therefore a
+   third `NOTE_KINDS` entry alongside `commit` and `issue`, sharing `issue`'s properties
+   shape (`number`, `title`, `author`, `created_at`, `closed_at`, `merged_at`, `base_ref`,
+   `head_ref`) plus a `KindHook` that validates `number` is present but does not enforce a
+   governed `state_reason` enum for PRs — GitHub's PR schema does not document one the way
+   it does for issues (`completed` / `not_planned`), so PR `state_reason`, when present, is
+   only checked for non-emptiness rather than validated against a closed set.
+
+2. **Commit-to-document `annotates` enrichment.** The ingester additionally links a
+   `commit` note to a `document`-kind entity (ADR-086) when the commit's touched-file paths
+   match that document's `properties.source_uri` or filename. This is a best-effort
+   enrichment, not a hard requirement: no match means no edge and no document is
+   auto-created. This narrows, rather than widens, the pack's footprint — it reuses an
+   edge relation and entity kind already licensed elsewhere in the schema.
+
+3. **Cursor table shape (Open Question 2).** `git_mirror_cursor(project_id, kind,
+   cursor_value, updated_at)`, primary key `(project_id, kind)`. `kind` is a generic
+   discriminator (`"commits"`, `"issues"`, `"prs"`), not separate per-kind tables or
+   columns, so a future ingestion pack for another lifecycle domain (for example, a
+   code-review pack) can reuse this table for its own cursor rows without a schema
+   migration.
+
+4. **GitHub API access path (Open Question 3).** The ingester shells the `gh` CLI (already
+   the fleet-standard GitHub client) rather than an installed GitHub App or direct REST
+   calls. When `gh` is unavailable, or fails against a given repository (no linked GitHub
+   remote, no auth), issue and pull-request ingestion are skipped with a warning in the
+   ingest report; commit ingestion — which depends only on local `.git` history — proceeds
+   regardless. This is a one-shot batch pass per invocation, not a poller.
+
+5. **Secret masking is enforced at the generic `create` verb, not re-implemented in the
+   ingester.** The KG pack's `create_note_inner` already hard-rejects content containing
+   unmasked secret patterns. The ingester calls the same masking helper the gate uses
+   before submitting commit-message and issue/PR-body content, so ingested provenance text
+   is redacted rather than rejected outright.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -247,9 +247,9 @@ Decision text.
    code-review pack) can reuse this table for its own cursor rows without a schema
    migration.
 
-4. **GitHub API access path (Open Question 3).** The ingester shells the `gh` CLI (already
-   the fleet-standard GitHub client) rather than an installed GitHub App or direct REST
-   calls. When `gh` is unavailable, or fails against a given repository (no linked GitHub
+4. **GitHub API access path (Open Question 3).** The ingester shells the configured GitHub
+   CLI (`gh`) rather than an installed GitHub App or direct REST calls. When `gh` is
+   unavailable, or fails against a given repository (no linked GitHub
    remote, no auth), issue and pull-request ingestion are skipped with a warning in the
    ingest report; commit ingestion — which depends only on local `.git` history — proceeds
    regardless. This is a one-shot batch pass per invocation, not a poller.

--- a/docs/adr/ADR-088-git-lifecycle-pack.md
+++ b/docs/adr/ADR-088-git-lifecycle-pack.md
@@ -61,7 +61,7 @@ New pack crate `khive-pack-git`, `REQUIRES = ["kg"]`, following `khive-pack-form
    `kind_status`.
 
 3. **`issue` properties**: `number`, `title`, `author`, `created_at`, `closed_at`
-   (optional), `labels` (array), `state_reason` (optional: `completed` / `not_planned`).
+   (optional), `labels` (array), `state_reason` (optional: `completed` / `not_planned` / `reopened` / `duplicate` — the GitHub `stateReason` enum, normalized to lowercase).
    `NoteKindSpec` lifecycle (declared now, enforced when the generic Phase-2 lifecycle
    layer lands — same posture as `finding`'s): `kind_status`, initial `open`, terminal
    `closed`. `pull_request` is explicitly NOT in v1 — see Open Questions.
@@ -230,7 +230,7 @@ Decision text.
    shape (`number`, `title`, `author`, `created_at`, `closed_at`, `merged_at`, `base_ref`,
    `head_ref`) plus a `KindHook` that validates `number` is present but does not enforce a
    governed `state_reason` enum for PRs — GitHub's PR schema does not document one the way
-   it does for issues (`completed` / `not_planned`), so PR `state_reason`, when present, is
+   it does for issues (`completed` / `not_planned` / `reopened` / `duplicate`), so PR `state_reason`, when present, is
    only checked for non-emptiness rather than validated against a closed set.
 
 2. **Commit-to-document `annotates` enrichment.** The ingester additionally links a

--- a/docs/adr/ADR-095-verb-surface-consolidation.md
+++ b/docs/adr/ADR-095-verb-surface-consolidation.md
@@ -7,7 +7,7 @@
 ADR-023 (pack verb surface, visibility, and composition), ADR-083 (session pack T1 verbs),
 ADR-084 (verb-surface
 consistency contract)
-**Scope**: the 74-verb MCP surface across the 8 default packs; the KindHook create-time
+**Scope**: the 74-verb MCP surface across the 9 default packs; the KindHook create-time
 extension seam; per-verb field validation (status enums, memory_type enums, datetime
 checks). Out of scope: brain and knowledge pack-private storage, closed taxonomies.
 
@@ -40,8 +40,8 @@ this repo).
 
 ### The surface as it stands
 
-The 74 user-facing verbs across 8 default packs (kg 17, gtd 5, memory 5, brain 14, comm 6,
-schedule 4, knowledge 19, session 4) are asserted as a tripwire: `tests/smoke_test.py:209`
+The 74 user-facing verbs across 9 default packs (kg 17, gtd 5, memory 5, brain 14, comm 6,
+schedule 4, knowledge 19, session 4, git 0) are asserted as a tripwire: `tests/smoke_test.py:209`
 carries `assert verbs_result["total"] == 74`, with a comment stating the assertion exists to
 catch silent drift. Any change to the count moves this assertion, the AGENTS.md catalog, and
 the `request` tool description in lockstep.

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1,14 +1,14 @@
 # API Reference
 
-khive exposes exactly one MCP tool, `request`. Everything else — 74 verbs across 8
+khive exposes exactly one MCP tool, `request`. Everything else — 74 verbs across 9
 production packs — is dispatched through that single tool via a small request DSL.
 This page documents the DSL grammar, the response envelope, and every verb's full
 parameter contract, so an agent can call khive correctly without reading Rust source.
 
 This page is verified against the live registry (`request(ops="verbs()")`, run
-2026-07-04) and the pack source (`crates/khive-pack-*/src/*.rs` `HandlerDef`/`ParamDef`
+2026-07-07) and the pack source (`crates/khive-pack-*/src/*.rs` `HandlerDef`/`ParamDef`
 struct literals). Verb count: **74**, matching both the live registry `total` field and
-the sum of the 8 pack counts below. If your server reports a different total, your
+the sum of the 9 pack counts below. If your server reports a different total, your
 `KHIVE_PACKS` configuration loads a different pack set than the default — run
 `request(ops="verbs()")` against your own server to get the authoritative list.
 
@@ -29,9 +29,14 @@ An always-machine-readable copy of this page is at
 | `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`  | Yes                 |
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge` | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
+| `git`       | 0     | `KHIVE_PACKS=kg,git`       | Yes                 |
 
-The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 8 packs: 17 + 5 + 5 +
-14 + 6 + 4 + 19 + 4 = **74 verbs**.
+`git` contributes zero verbs — it registers the `commit` / `issue` / `pull_request` note
+kinds and a batch ingester (`crates/khive-pack-git/src/ingest.rs`), consumed outside the
+`request` DSL, not new MCP-callable verbs.
+
+The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 9 packs: 17 + 5 + 5 +
+14 + 6 + 4 + 19 + 4 + 0 = **74 verbs**.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Every other pack
 namespaces its verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 74 verbs across 8 packs, dispatched through a single MCP tool.
+through 74 verbs across 9 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -1,11 +1,14 @@
 # Specialized Packs
 
-khive's default install loads eight production packs
-(`kg, gtd, memory, brain, comm, schedule, knowledge, session`, per
-`RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Beyond
-these, khive ships niche packs that extend the graph for a specific domain
-without adding verbs of their own. This guide covers the formal-math pack,
-the first of these, and how pack loading works in general.
+khive's default install loads nine production packs
+(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git`, per
+`RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Of these,
+`git` already contributes zero verbs of its own — it registers the `commit` /
+`issue` / `pull_request` note kinds and a batch ingester for a git-lifecycle
+provenance graph (see `crates/khive-pack-git/`). Beyond the default set, khive
+also ships niche packs that extend the graph for a specific domain without
+adding verbs of their own. This guide covers the formal-math pack, the first
+of these, and how pack loading works in general.
 
 ## Pack composition model
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 74 verbs across 8 packs.
+exposing one tool — `request` — that dispatches 74 verbs across 9 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 74 verbs, 8 packs, one MCP tool.
+A research knowledge graph runtime — 74 verbs, 9 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -19,7 +19,7 @@ Add to `.mcp.json` (project-level or `~/.claude/mcp.json` for global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-All 8 packs load by default. A background daemon auto-spawns to keep the runtime warm.
+All 9 packs load by default. A background daemon auto-spawns to keep the runtime warm.
 
 ## What you get
 
@@ -33,6 +33,7 @@ All 8 packs load by default. A background daemon auto-spawns to keep the runtime
 | **schedule**  | 4     | Reminders and scheduled verb execution                |
 | **knowledge** | 19    | Atom-based KB with embedding rerank search            |
 | **session**   | 4     | Session record persistence (store/list/resume/export) |
+| **git**       | 0     | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester |
 
 ## Usage
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -196,21 +196,22 @@ def main():
         assert "total" in verbs_result, f"verbs must return 'total' key: {verbs_result}"
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
-        # unset) loads 8 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session), so verbs() returns exactly 74 user-facing
+        # unset) loads 9 production packs (kg, gtd, memory, brain, comm, schedule,
+        # knowledge, session, git), so verbs() returns exactly 74 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
         # Visibility::Verb per ADR-083; brain.register_adapter (#354), context
         # (ADR-089, the 17th kg-substrate bare verb), and comm.health (#606,
-        # verified live 2026-07-04) are included in the count. Update this
-        # number when the pack set or verb surface changes; a silent drift
-        # here is the bug this assertion exists to catch.
+        # verified live 2026-07-04) are included in the count; git contributes
+        # 0 verbs (note kinds + ingester only). Update this number when the
+        # pack set or verb surface changes; a silent drift here is the bug
+        # this assertion exists to catch.
         assert verbs_result["total"] == 74, (
-            f"expected 74 user-facing verbs from the 8 default packs "
+            f"expected 74 user-facing verbs from the 9 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
-            f"comm.health is #606), "
+            f"comm.health is #606; git contributes 0), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]


### PR DESCRIPTION
# feat(pack-git): ADR-088 git-lifecycle pack v0 — commit/issue/PR ingestion with provenance edges

Implements the v0 cut of [ADR-088](docs/adr/ADR-088-git-lifecycle-pack.md): a new
`khive-pack-git` crate providing the `git.ingest` verb plus pack-owned `commit` / `issue` /
`pull_request` note kinds with kind-hook property governance.

## What ships

- **`git.ingest(repo, project_id, ...)`** — cursor-based batch ingester:
  - commits via `git log` walk (local repo, no network),
  - issues and pull requests via the `gh` CLI (JSON output),
  - idempotent by natural key (commit sha; repo + number for issues/PRs) — re-running skips
    existing records, never duplicates,
  - per-record warning aggregation: a malformed record is reported, not fatal to the batch,
  - commit-message content is secret-masked before storage (with tests).
- **Kind hooks** validating each subtype's property schema. `state_reason` is governed
  against the full GitHub `stateReason` enum (`completed`, `not_planned`, `reopened`,
  `duplicate`), normalized to lowercase, and omitted when GitHub reports it empty.
- **Edges** (all `annotates`, no schema change): commit → project, commit → touched
  ADR document (docs/adr path match), commit → merging PR, issue/PR → project.
- **ADR-088 amendment** (separate docs commit) recording the v0 implementation decisions.

## Live acceptance run (this repository's real history)

Full-corpus ingest into a scratch database: **391 commits, 376 pull requests, 314 issues,
zero warnings**. Re-run confirms idempotency (all records skipped as existing).

The ADR-045-genre provenance query from the ADR's acceptance criteria, run live:

> Which commit introduced ADR-099, and which PR brought it to main?

```
neighbors(node_id=<ADR-099 document>, direction="both")
  → commit note: sha b32ad689, author OceanLi
    "docs(adr): ADR-099 cross-op atomicity for bulk apply + ADR-067 Amendment 1 (#671)"
  → that commit annotates: the ADR-099 document, the khive project entity,
    and pull_request note #671
      "docs(adr): ADR-099 cross-op atomicity for bulk apply + ADR-067 Amendment 1"
      base main, merged 2026-07-06T21:50:27Z
```

Answer recovered purely from the graph: **ADR-099 was added in commit `b32ad689`,
introduced to `main` by PR #671.**

## Hardening found by the live run

Four real-world `gh` output shapes surfaced by the full-corpus run, each fixed with a
regression-relevant change:

1. `gh` has no `-C` flag — the ingester targets the repo via `current_dir` (git keeps `-C`).
2. Open issues report `stateReason: ""` — the key is omitted rather than failing validation.
3. `gh` emits UPPERCASE enum values (`NOT_PLANNED`) — normalized to lowercase before the hook.
4. The governed set initially covered only `{completed, not_planned}` — widened to GitHub's
   full enum after live data contained `reopened`.

## Deferred (per ADR-088 v0 scope)

Comments, webhooks/live ingestion, multi-repo, branch lineage, ref resolution.

## Gates

`cargo fmt --check`, `cargo test -p khive-pack-git`, `cargo clippy -p khive-pack-git
--all-targets -- -D warnings` all green; doc build (`-D warnings`) verified.
