### PR TITLE
feat(pack-code): khive-pack-code v0 (ADR-085)

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "khive-pack-comm",
     "khive-pack-schedule",
     "khive-pack-formal",
+    "khive-pack-code",
     "khive-pack-template",
     "khive-pack-knowledge",
     "khive-pack-session",

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "khive-pack-code"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Code ontology pack - typed edge rules and audit findings vocabulary"
+
+[dependencies]
+khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
+khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
+khive-storage = { version = "0.3.0", path = "../khive-storage" }
+inventory = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+khive-pack-kg = { version = "0.3.0", path = "../khive-pack-kg" }
+tokio = { workspace = true, features = ["full"] }

--- a/crates/khive-pack-code/src/error.rs
+++ b/crates/khive-pack-code/src/error.rs
@@ -1,0 +1,46 @@
+//! `CodeIngestError` — fail-closed validation errors for `findings.json` ingest.
+
+use thiserror::Error;
+
+/// Errors returned by [`crate::ingest::ingest_findings_json`].
+///
+/// All variants name the valid values or shapes so callers can fix input
+/// without consulting external documentation.
+#[derive(Debug, Error)]
+pub enum CodeIngestError {
+    #[error("findings.json must be a JSON object with required field findings: array")]
+    InvalidRoot,
+
+    #[error("missing required field {path}")]
+    MissingField { path: &'static str },
+
+    #[error("field {path} must be {expected}")]
+    InvalidType {
+        path: String,
+        expected: &'static str,
+    },
+
+    #[error("invalid {field} {value:?}; valid: {valid}")]
+    InvalidValue {
+        field: &'static str,
+        value: String,
+        valid: &'static str,
+    },
+
+    #[error("finding {id:?} with severity {severity:?} requires non-empty failure_scenario")]
+    MissingFailureScenario { id: String, severity: String },
+
+    #[error(
+        "invalid evidence at findings[{finding_index}].evidence[{evidence_index}]; valid: string or object with path,line,description"
+    )]
+    InvalidEvidence {
+        finding_index: usize,
+        evidence_index: usize,
+    },
+
+    #[error("invalid source_run; provide options.source_run or audit.date and audit.commit")]
+    MissingSourceRun,
+
+    #[error("json parse: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/khive-pack-code/src/hook.rs
+++ b/crates/khive-pack-code/src/hook.rs
@@ -1,0 +1,146 @@
+//! `FindingHook` — validates and defaults the `finding` note kind on the
+//! shared `create(kind="finding", ...)` path.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use khive_runtime::{KhiveRuntime, KindHook, RuntimeError};
+
+use crate::vocab::{is_valid_confidence, is_valid_finding_status, is_valid_severity};
+
+#[derive(Debug, Default)]
+pub(crate) struct FindingHook;
+
+#[async_trait]
+impl KindHook for FindingHook {
+    async fn prepare_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        args: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        let title = args
+            .get("title")
+            .or_else(|| args.get("name"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                RuntimeError::InvalidInput(
+                    "kind=note + note_kind=finding requires 'title' or 'name'".into(),
+                )
+            })?;
+        if title.trim().is_empty() {
+            return Err(RuntimeError::InvalidInput("title must not be empty".into()));
+        }
+
+        let mut props = match args.get("properties") {
+            Some(Value::Object(map)) => Value::Object(map.clone()),
+            Some(Value::Null) | None => json!({}),
+            Some(_) => {
+                return Err(RuntimeError::InvalidInput(
+                    "properties must be an object".into(),
+                ))
+            }
+        };
+        let obj = props
+            .as_object_mut()
+            .expect("props is object by construction");
+
+        for key in [
+            "severity",
+            "confidence",
+            "categories",
+            "source_run",
+            "standard",
+            "evidence",
+            "refs",
+        ] {
+            if let Some(v) = args.get(key) {
+                obj.insert(key.to_string(), v.clone());
+            }
+        }
+
+        if let Some(v) = args.get("kind_status") {
+            obj.insert("kind_status".into(), v.clone());
+        } else if !obj.contains_key("kind_status") {
+            obj.insert("kind_status".into(), json!("open"));
+        }
+
+        let kind_status = obj
+            .get("kind_status")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| RuntimeError::InvalidInput("kind_status must be a string".into()))?;
+        if !is_valid_finding_status(&kind_status) {
+            return Err(RuntimeError::InvalidInput(format!(
+                "invalid kind_status {kind_status:?}; valid: open, resolved, wontfix, invalid"
+            )));
+        }
+
+        if let Some(v) = obj.get("severity") {
+            let s = v
+                .as_str()
+                .ok_or_else(|| RuntimeError::InvalidInput("severity must be a string".into()))?;
+            if !is_valid_severity(s) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "invalid severity {s:?}; valid: critical, high, medium, low, info"
+                )));
+            }
+        }
+
+        if let Some(v) = obj.get("confidence") {
+            let s = v
+                .as_str()
+                .ok_or_else(|| RuntimeError::InvalidInput("confidence must be a string".into()))?;
+            if !is_valid_confidence(s) {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "invalid confidence {s:?}; valid: high, medium, low"
+                )));
+            }
+        }
+
+        if let Some(v) = obj.get("categories") {
+            let arr = v.as_array().ok_or_else(|| {
+                RuntimeError::InvalidInput("categories must be an array of strings".into())
+            })?;
+            for item in arr {
+                if !item.is_string() {
+                    return Err(RuntimeError::InvalidInput(
+                        "categories must be an array of strings".into(),
+                    ));
+                }
+            }
+        }
+
+        if let Some(v) = obj.get("evidence") {
+            if !v.is_array() {
+                return Err(RuntimeError::InvalidInput(
+                    "evidence must be an array".into(),
+                ));
+            }
+        }
+
+        let content = args
+            .get("content")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| title.clone());
+
+        let root = args
+            .as_object_mut()
+            .ok_or_else(|| RuntimeError::Internal("create args must be a JSON object".into()))?;
+        root.insert("name".into(), json!(title));
+        root.insert("content".into(), json!(content));
+        root.insert("properties".into(), props);
+
+        Ok(())
+    }
+
+    async fn after_create(
+        &self,
+        _runtime: &KhiveRuntime,
+        _id: uuid::Uuid,
+        _args: &Value,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}

--- a/crates/khive-pack-code/src/hook.rs
+++ b/crates/khive-pack-code/src/hook.rs
@@ -98,19 +98,6 @@ impl KindHook for FindingHook {
             }
         }
 
-        if let Some(v) = obj.get("categories") {
-            let arr = v.as_array().ok_or_else(|| {
-                RuntimeError::InvalidInput("categories must be an array of strings".into())
-            })?;
-            for item in arr {
-                if !item.is_string() {
-                    return Err(RuntimeError::InvalidInput(
-                        "categories must be an array of strings".into(),
-                    ));
-                }
-            }
-        }
-
         if let Some(v) = obj.get("evidence") {
             if !v.is_array() {
                 return Err(RuntimeError::InvalidInput(

--- a/crates/khive-pack-code/src/ingest.rs
+++ b/crates/khive-pack-code/src/ingest.rs
@@ -2,16 +2,24 @@
 //!
 //! `ingest_findings_json` validates the entire input before constructing any
 //! output record, so a malformed file never yields a partial batch. Record
-//! identity is content-derived (UUIDv5 over JSON tuples), so re-ingesting the
-//! same `findings.json` under the same [`CodeIngestOptions`] reproduces the
-//! same entity, note, and edge IDs.
+//! identity is a content-derived UUIDv5 hash of the validated finding record
+//! (`observed_at` excluded), so re-ingesting the same `findings.json` under
+//! the same [`CodeIngestOptions`] reproduces the same entity, note, and edge
+//! IDs, while a content change (severity, evidence, impact, ...) produces a
+//! new finding id rather than colliding with the prior record.
 //!
-//! Only `severity`, `confidence`, `priority`, and the evidence shape are
-//! governed at ingest time — they reject unknown/malformed values by design
-//! (ADR-085 D4 "fail closed; no silent coercion"). Raw audit `status` has no
-//! agreed mapping to the finding lifecycle (`kind_status`) yet, so it is
-//! preserved verbatim under `properties.audit_status` rather than validated
-//! or coerced.
+//! Only `severity` and `confidence` values, the evidence shape, and
+//! `failure_scenario` presence are governed at ingest time — they reject
+//! unknown/malformed values by design (ADR-085 D4 "fail closed; no silent
+//! coercion"). Every other field (`categories`, `standard`, `refs`,
+//! `priority`, raw audit `status`, `impact`, `recommendation`,
+//! `verification`) is tolerated per ADR-085 Amendment 1 A1: ingest neither
+//! rejects nor coerces them, it preserves whatever JSON value was provided
+//! and omits the key when the field is absent. Raw `status` is preserved
+//! verbatim under `properties.audit_status` — it has no agreed mapping to
+//! the finding lifecycle (`kind_status`) yet.
+
+use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
 use khive_storage::{Edge, Entity, LinkId, Note};
@@ -20,7 +28,7 @@ use serde_json::{json, Map, Value};
 use uuid::Uuid;
 
 use crate::error::CodeIngestError;
-use crate::vocab::{is_valid_confidence, is_valid_priority, is_valid_severity};
+use crate::vocab::{is_valid_confidence, is_valid_severity};
 
 /// UUIDv5 namespace for all code-pack ingest identity, derived from
 /// `Uuid::new_v5(Uuid::NAMESPACE_URL, b"https://github.com/ohdearquant/khive/adr/085/code-pack/v1")`.
@@ -51,6 +59,47 @@ pub struct CodeIngestBatch {
 fn uuid5_tuple<T: serde::Serialize>(parts: &T) -> Result<Uuid, CodeIngestError> {
     let bytes = serde_json::to_vec(parts)?;
     Ok(Uuid::new_v5(&CODE_INGEST_NAMESPACE, &bytes))
+}
+
+/// Recursively sort object keys so two JSON values that differ only in key
+/// order serialize identically. Array element order is content and is left
+/// untouched.
+fn sort_json_keys(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let sorted: BTreeMap<&str, Value> = map
+                .iter()
+                .map(|(k, v)| (k.as_str(), sort_json_keys(v)))
+                .collect();
+            let mut out = Map::with_capacity(sorted.len());
+            for (k, v) in sorted {
+                out.insert(k.to_string(), v);
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(sort_json_keys).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Render a tolerated (ungoverned) field for inclusion in note content text.
+/// Strings pass through verbatim; any other JSON shape renders as its
+/// canonical JSON text; absence renders as empty.
+fn value_to_display(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// A tolerated field is present when the key exists and its value is not
+/// JSON `null` — an explicit `null` is treated the same as absence.
+fn tolerated_field(obj: &Map<String, Value>, key: &str) -> Option<Value> {
+    match obj.get(key) {
+        None | Some(Value::Null) => None,
+        Some(v) => Some(v.clone()),
+    }
 }
 
 fn require_str<'a>(
@@ -143,12 +192,6 @@ fn canonicalize_evidence(
     Ok(out)
 }
 
-fn first_evidence_path(evidence: &[Value]) -> Option<String> {
-    evidence
-        .iter()
-        .find_map(|e| e.get("path").and_then(Value::as_str).map(str::to_string))
-}
-
 struct ValidatedAudit {
     date: String,
     scope: String,
@@ -194,15 +237,15 @@ struct ValidatedFinding {
     normalized_title: String,
     severity: String,
     confidence: String,
-    categories: Vec<String>,
-    standard: String,
+    categories: Option<Value>,
+    standard: Option<Value>,
     evidence: Vec<Value>,
-    impact: String,
-    recommendation: String,
-    verification: String,
+    impact: Option<Value>,
+    recommendation: Option<Value>,
+    verification: Option<Value>,
     failure_scenario: Option<String>,
-    priority: Option<String>,
-    audit_status: Option<String>,
+    priority: Option<Value>,
+    audit_status: Option<Value>,
     refs: Option<Value>,
     raw: Map<String, Value>,
 }
@@ -254,64 +297,23 @@ impl ValidatedFinding {
             });
         }
 
-        let categories = match obj.get("categories") {
-            None => Vec::new(),
-            Some(Value::Array(arr)) => {
-                let mut out = Vec::with_capacity(arr.len());
-                for item in arr {
-                    match item {
-                        Value::String(s) => out.push(s.clone()),
-                        _ => {
-                            return Err(CodeIngestError::InvalidType {
-                                path: "findings[].categories".to_string(),
-                                expected: "array of strings",
-                            });
-                        }
-                    }
-                }
-                out
-            }
-            Some(_) => {
-                return Err(CodeIngestError::InvalidType {
-                    path: "findings[].categories".to_string(),
-                    expected: "array of strings",
-                });
-            }
-        };
-
-        let standard =
-            optional_str(obj, "standard", "findings[].standard")?.unwrap_or_else(String::new);
+        // `categories`, `standard`, `refs`, `priority`, `status`, `impact`,
+        // `recommendation`, and `verification` are tolerated (ADR-085
+        // Amendment 1 A1): ingest neither rejects nor coerces their shape,
+        // it preserves whatever JSON value was provided or omits the key
+        // when absent. Only `evidence` shape and `severity`/`confidence`/
+        // `failure_scenario` presence remain fail-closed.
+        let categories = tolerated_field(obj, "categories");
+        let standard = tolerated_field(obj, "standard");
         let evidence = canonicalize_evidence(obj.get("evidence"), finding_index)?;
-        let impact = optional_str(obj, "impact", "findings[].impact")?.unwrap_or_else(String::new);
-        let recommendation = optional_str(obj, "recommendation", "findings[].recommendation")?
-            .unwrap_or_else(String::new);
-        let verification = optional_str(obj, "verification", "findings[].verification")?
-            .unwrap_or_else(String::new);
+        let impact = tolerated_field(obj, "impact");
+        let recommendation = tolerated_field(obj, "recommendation");
+        let verification = tolerated_field(obj, "verification");
         let failure_scenario =
             optional_str(obj, "failure_scenario", "findings[].failure_scenario")?;
-        let audit_status = optional_str(obj, "status", "findings[].status")?;
-
-        let priority = optional_str(obj, "priority", "findings[].priority")?;
-        if let Some(p) = &priority {
-            if !is_valid_priority(p) {
-                return Err(CodeIngestError::InvalidValue {
-                    field: "priority",
-                    value: p.clone(),
-                    valid: "P0 | P1 | P2 | P3",
-                });
-            }
-        }
-
-        let refs = match obj.get("refs") {
-            None | Some(Value::Null) => None,
-            Some(Value::Object(m)) => Some(Value::Object(m.clone())),
-            Some(_) => {
-                return Err(CodeIngestError::InvalidType {
-                    path: "findings[].refs".to_string(),
-                    expected: "object",
-                });
-            }
-        };
+        let audit_status = tolerated_field(obj, "status");
+        let priority = tolerated_field(obj, "priority");
+        let refs = tolerated_field(obj, "refs");
 
         if matches!(severity.as_str(), "medium" | "high" | "critical") {
             let has_scenario = failure_scenario
@@ -439,50 +441,80 @@ pub fn ingest_findings_json(
     let mut edges = Vec::with_capacity(validated_findings.len());
 
     for finding in &validated_findings {
-        let first_path = first_evidence_path(&finding.evidence);
-        let finding_key = (
-            "code-finding",
-            1u8,
-            options.namespace,
-            source_run.as_str(),
-            audit.scope.as_str(),
-            finding.id.as_str(),
-            finding.normalized_title.as_str(),
-            first_path.as_deref().unwrap_or(""),
-        );
-        let finding_id = uuid5_tuple(&finding_key)?;
-        let finding_external_id = serde_json::to_string(&finding_key)?;
+        // Identity is a canonical content hash of the validated finding,
+        // `observed_at` excluded: same content re-ingested at a different
+        // time reproduces the same id, and any content change (severity,
+        // evidence, impact, ...) produces a different id rather than
+        // silently overwriting the prior record under the old one.
+        let identity_value = sort_json_keys(&json!({
+            "kind": "code-finding",
+            "schema_version": 1,
+            "namespace": options.namespace,
+            "source_run": source_run,
+            "scope": audit.scope,
+            "id": finding.id,
+            "normalized_title": finding.normalized_title,
+            "severity": finding.severity,
+            "confidence": finding.confidence,
+            "categories": finding.categories,
+            "standard": finding.standard,
+            "evidence": finding.evidence,
+            "impact": finding.impact,
+            "recommendation": finding.recommendation,
+            "verification": finding.verification,
+            "failure_scenario": finding.failure_scenario,
+            "priority": finding.priority,
+            "audit_status": finding.audit_status,
+            "refs": finding.refs,
+            "raw": finding.raw,
+        }));
+        let finding_id = uuid5_tuple(&identity_value)?;
+        let finding_external_id = serde_json::to_string(&identity_value)?;
 
         let mut props = Map::new();
         props.insert("external_id".into(), json!(finding_external_id));
         props.insert("finding_id".into(), json!(finding.id));
         props.insert("severity".into(), json!(finding.severity));
         props.insert("confidence".into(), json!(finding.confidence));
-        props.insert("categories".into(), json!(finding.categories));
         props.insert("source_run".into(), json!(source_run));
-        props.insert("standard".into(), json!(finding.standard));
         props.insert("evidence".into(), Value::Array(finding.evidence.clone()));
+        if let Some(categories) = &finding.categories {
+            props.insert("categories".into(), categories.clone());
+        }
+        if let Some(standard) = &finding.standard {
+            props.insert("standard".into(), standard.clone());
+        }
         if let Some(refs) = &finding.refs {
             props.insert("refs".into(), refs.clone());
         }
         if let Some(priority) = &finding.priority {
-            props.insert("priority".into(), json!(priority));
+            props.insert("priority".into(), priority.clone());
         }
         if let Some(status) = &finding.audit_status {
-            props.insert("audit_status".into(), json!(status));
+            props.insert("audit_status".into(), status.clone());
         }
         if let Some(scenario) = &finding.failure_scenario {
             props.insert("failure_scenario".into(), json!(scenario));
         }
-        props.insert("impact".into(), json!(finding.impact));
-        props.insert("recommendation".into(), json!(finding.recommendation));
-        props.insert("verification".into(), json!(finding.verification));
+        if let Some(impact) = &finding.impact {
+            props.insert("impact".into(), impact.clone());
+        }
+        if let Some(recommendation) = &finding.recommendation {
+            props.insert("recommendation".into(), recommendation.clone());
+        }
+        if let Some(verification) = &finding.verification {
+            props.insert("verification".into(), verification.clone());
+        }
         props.insert("kind_status".into(), json!("open"));
         if !finding.raw.is_empty() {
             props.insert("raw".into(), Value::Object(finding.raw.clone()));
         }
 
-        let content = format!("{}: {}", finding.title, finding.impact);
+        let content = format!(
+            "{}: {}",
+            finding.title,
+            value_to_display(finding.impact.as_ref())
+        );
         let mut note = Note::new(options.namespace, "finding", content);
         note.id = finding_id;
         note.name = Some(finding.title.clone());

--- a/crates/khive-pack-code/src/ingest.rs
+++ b/crates/khive-pack-code/src/ingest.rs
@@ -1,0 +1,522 @@
+//! Pure `findings.json -> Vec<Entity>, Vec<Note>, Vec<Edge>` mapper.
+//!
+//! `ingest_findings_json` validates the entire input before constructing any
+//! output record, so a malformed file never yields a partial batch. Record
+//! identity is content-derived (UUIDv5 over JSON tuples), so re-ingesting the
+//! same `findings.json` under the same [`CodeIngestOptions`] reproduces the
+//! same entity, note, and edge IDs.
+//!
+//! Only `severity`, `confidence`, `priority`, and the evidence shape are
+//! governed at ingest time — they reject unknown/malformed values by design
+//! (ADR-085 D4 "fail closed; no silent coercion"). Raw audit `status` has no
+//! agreed mapping to the finding lifecycle (`kind_status`) yet, so it is
+//! preserved verbatim under `properties.audit_status` rather than validated
+//! or coerced.
+
+use chrono::{DateTime, Utc};
+use khive_storage::{Edge, Entity, LinkId, Note};
+use khive_types::EdgeRelation;
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use crate::error::CodeIngestError;
+use crate::vocab::{is_valid_confidence, is_valid_priority, is_valid_severity};
+
+/// UUIDv5 namespace for all code-pack ingest identity, derived from
+/// `Uuid::new_v5(Uuid::NAMESPACE_URL, b"https://github.com/ohdearquant/khive/adr/085/code-pack/v1")`.
+pub const CODE_INGEST_NAMESPACE: Uuid = Uuid::from_u128(0x288fe3dc_ac69_5aef_ab1e_9b170fb07376);
+
+/// Options controlling one `ingest_findings_json` call.
+#[derive(Clone, Debug)]
+pub struct CodeIngestOptions<'a> {
+    /// KG namespace the produced records belong to.
+    pub namespace: &'a str,
+    /// Wall-clock timestamp stamped on produced records. Excluded from every
+    /// identity tuple so re-ingesting the same sweep at a later time still
+    /// reproduces the same IDs.
+    pub observed_at: DateTime<Utc>,
+    /// Stable sweep identity. When absent, derived as `audit.date:audit.commit`.
+    pub source_run: Option<&'a str>,
+}
+
+/// Output of a successful ingest: deterministic entity/note/edge records
+/// ready for the caller to persist through existing storage/runtime paths.
+#[derive(Clone, Debug)]
+pub struct CodeIngestBatch {
+    pub entities: Vec<Entity>,
+    pub notes: Vec<Note>,
+    pub edges: Vec<Edge>,
+}
+
+fn uuid5_tuple<T: serde::Serialize>(parts: &T) -> Result<Uuid, CodeIngestError> {
+    let bytes = serde_json::to_vec(parts)?;
+    Ok(Uuid::new_v5(&CODE_INGEST_NAMESPACE, &bytes))
+}
+
+fn require_str<'a>(
+    obj: &'a Map<String, Value>,
+    key: &'static str,
+    path: &'static str,
+) -> Result<&'a str, CodeIngestError> {
+    match obj.get(key) {
+        None => Err(CodeIngestError::MissingField { path }),
+        Some(Value::String(s)) => Ok(s.as_str()),
+        Some(_) => Err(CodeIngestError::InvalidType {
+            path: path.to_string(),
+            expected: "string",
+        }),
+    }
+}
+
+fn optional_str(
+    obj: &Map<String, Value>,
+    key: &'static str,
+    path: &'static str,
+) -> Result<Option<String>, CodeIngestError> {
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(CodeIngestError::InvalidType {
+            path: path.to_string(),
+            expected: "string",
+        }),
+    }
+}
+
+fn normalize_title(title: &str) -> Result<String, CodeIngestError> {
+    let normalized = title
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err(CodeIngestError::InvalidType {
+            path: "findings[].title".to_string(),
+            expected: "non-empty string",
+        });
+    }
+    Ok(normalized)
+}
+
+/// Canonicalize the tolerated `evidence` shapes (null, string, object, array
+/// of strings/objects) into an array of `{description}`-or-richer objects.
+/// Any other shape is rejected with the finding/evidence index named.
+fn canonicalize_evidence(
+    value: Option<&Value>,
+    finding_index: usize,
+) -> Result<Vec<Value>, CodeIngestError> {
+    let items: Vec<Value> = match value {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::String(s)) => vec![Value::String(s.clone())],
+        Some(Value::Object(m)) => vec![Value::Object(m.clone())],
+        Some(Value::Array(arr)) => arr.clone(),
+        Some(_) => {
+            return Err(CodeIngestError::InvalidEvidence {
+                finding_index,
+                evidence_index: 0,
+            });
+        }
+    };
+
+    let mut out = Vec::with_capacity(items.len());
+    for (evidence_index, item) in items.into_iter().enumerate() {
+        let canonical = match item {
+            Value::String(s) => {
+                if s.trim().is_empty() {
+                    return Err(CodeIngestError::InvalidEvidence {
+                        finding_index,
+                        evidence_index,
+                    });
+                }
+                json!({ "description": s })
+            }
+            Value::Object(m) => Value::Object(m),
+            _ => {
+                return Err(CodeIngestError::InvalidEvidence {
+                    finding_index,
+                    evidence_index,
+                });
+            }
+        };
+        out.push(canonical);
+    }
+    Ok(out)
+}
+
+fn first_evidence_path(evidence: &[Value]) -> Option<String> {
+    evidence
+        .iter()
+        .find_map(|e| e.get("path").and_then(Value::as_str).map(str::to_string))
+}
+
+struct ValidatedAudit {
+    date: String,
+    scope: String,
+    repo: String,
+    branch: String,
+    commit: String,
+    standards_file: String,
+    extra: Map<String, Value>,
+}
+
+const KNOWN_AUDIT_KEYS: &[&str] = &[
+    "date",
+    "scope",
+    "repo",
+    "branch",
+    "commit",
+    "standards_file",
+];
+
+impl ValidatedAudit {
+    fn parse(obj: &Map<String, Value>) -> Result<Self, CodeIngestError> {
+        let mut extra = Map::new();
+        for (k, v) in obj {
+            if !KNOWN_AUDIT_KEYS.contains(&k.as_str()) {
+                extra.insert(k.clone(), v.clone());
+            }
+        }
+        Ok(Self {
+            date: require_str(obj, "date", "audit.date")?.to_string(),
+            scope: require_str(obj, "scope", "audit.scope")?.to_string(),
+            repo: require_str(obj, "repo", "audit.repo")?.to_string(),
+            branch: require_str(obj, "branch", "audit.branch")?.to_string(),
+            commit: require_str(obj, "commit", "audit.commit")?.to_string(),
+            standards_file: require_str(obj, "standards_file", "audit.standards_file")?.to_string(),
+            extra,
+        })
+    }
+}
+
+struct ValidatedFinding {
+    id: String,
+    title: String,
+    normalized_title: String,
+    severity: String,
+    confidence: String,
+    categories: Vec<String>,
+    standard: String,
+    evidence: Vec<Value>,
+    impact: String,
+    recommendation: String,
+    verification: String,
+    failure_scenario: Option<String>,
+    priority: Option<String>,
+    audit_status: Option<String>,
+    refs: Option<Value>,
+    raw: Map<String, Value>,
+}
+
+const KNOWN_FINDING_KEYS: &[&str] = &[
+    "id",
+    "title",
+    "severity",
+    "confidence",
+    "categories",
+    "status",
+    "standard",
+    "evidence",
+    "impact",
+    "recommendation",
+    "verification",
+    "failure_scenario",
+    "priority",
+    "refs",
+];
+
+impl ValidatedFinding {
+    fn parse(obj: &Map<String, Value>, finding_index: usize) -> Result<Self, CodeIngestError> {
+        let id = require_str(obj, "id", "findings[].id")?.to_string();
+        let title = require_str(obj, "title", "findings[].title")?.to_string();
+        if title.trim().is_empty() {
+            return Err(CodeIngestError::InvalidType {
+                path: "findings[].title".to_string(),
+                expected: "non-empty string",
+            });
+        }
+        let normalized_title = normalize_title(&title)?;
+
+        let severity = require_str(obj, "severity", "findings[].severity")?.to_string();
+        if !is_valid_severity(&severity) {
+            return Err(CodeIngestError::InvalidValue {
+                field: "severity",
+                value: severity,
+                valid: "critical | high | medium | low | info",
+            });
+        }
+
+        let confidence = require_str(obj, "confidence", "findings[].confidence")?.to_string();
+        if !is_valid_confidence(&confidence) {
+            return Err(CodeIngestError::InvalidValue {
+                field: "confidence",
+                value: confidence,
+                valid: "high | medium | low",
+            });
+        }
+
+        let categories = match obj.get("categories") {
+            None => Vec::new(),
+            Some(Value::Array(arr)) => {
+                let mut out = Vec::with_capacity(arr.len());
+                for item in arr {
+                    match item {
+                        Value::String(s) => out.push(s.clone()),
+                        _ => {
+                            return Err(CodeIngestError::InvalidType {
+                                path: "findings[].categories".to_string(),
+                                expected: "array of strings",
+                            });
+                        }
+                    }
+                }
+                out
+            }
+            Some(_) => {
+                return Err(CodeIngestError::InvalidType {
+                    path: "findings[].categories".to_string(),
+                    expected: "array of strings",
+                });
+            }
+        };
+
+        let standard =
+            optional_str(obj, "standard", "findings[].standard")?.unwrap_or_else(String::new);
+        let evidence = canonicalize_evidence(obj.get("evidence"), finding_index)?;
+        let impact = optional_str(obj, "impact", "findings[].impact")?.unwrap_or_else(String::new);
+        let recommendation = optional_str(obj, "recommendation", "findings[].recommendation")?
+            .unwrap_or_else(String::new);
+        let verification = optional_str(obj, "verification", "findings[].verification")?
+            .unwrap_or_else(String::new);
+        let failure_scenario =
+            optional_str(obj, "failure_scenario", "findings[].failure_scenario")?;
+        let audit_status = optional_str(obj, "status", "findings[].status")?;
+
+        let priority = optional_str(obj, "priority", "findings[].priority")?;
+        if let Some(p) = &priority {
+            if !is_valid_priority(p) {
+                return Err(CodeIngestError::InvalidValue {
+                    field: "priority",
+                    value: p.clone(),
+                    valid: "P0 | P1 | P2 | P3",
+                });
+            }
+        }
+
+        let refs = match obj.get("refs") {
+            None | Some(Value::Null) => None,
+            Some(Value::Object(m)) => Some(Value::Object(m.clone())),
+            Some(_) => {
+                return Err(CodeIngestError::InvalidType {
+                    path: "findings[].refs".to_string(),
+                    expected: "object",
+                });
+            }
+        };
+
+        if matches!(severity.as_str(), "medium" | "high" | "critical") {
+            let has_scenario = failure_scenario
+                .as_deref()
+                .is_some_and(|s| !s.trim().is_empty());
+            if !has_scenario {
+                return Err(CodeIngestError::MissingFailureScenario {
+                    id: id.clone(),
+                    severity: severity.clone(),
+                });
+            }
+        }
+
+        let mut raw = Map::new();
+        for (k, v) in obj {
+            if !KNOWN_FINDING_KEYS.contains(&k.as_str()) {
+                raw.insert(k.clone(), v.clone());
+            }
+        }
+
+        Ok(Self {
+            id,
+            title,
+            normalized_title,
+            severity,
+            confidence,
+            categories,
+            standard,
+            evidence,
+            impact,
+            recommendation,
+            verification,
+            failure_scenario,
+            priority,
+            audit_status,
+            refs,
+            raw,
+        })
+    }
+}
+
+/// Map a `findings.json` document into deterministic KG records.
+///
+/// Validates the entire document before constructing any output record —
+/// malformed input never produces a partial batch. Output identity is
+/// content-derived (see module docs), so calling this twice with the same
+/// bytes and options reproduces identical entity/note/edge IDs.
+pub fn ingest_findings_json(
+    input: &[u8],
+    options: CodeIngestOptions<'_>,
+) -> Result<CodeIngestBatch, CodeIngestError> {
+    let root: Value = serde_json::from_slice(input)?;
+    let root_obj = root.as_object().ok_or(CodeIngestError::InvalidRoot)?;
+
+    let audit_obj = root_obj
+        .get("audit")
+        .and_then(Value::as_object)
+        .ok_or(CodeIngestError::InvalidRoot)?;
+    let findings_arr = root_obj
+        .get("findings")
+        .and_then(Value::as_array)
+        .ok_or(CodeIngestError::InvalidRoot)?;
+
+    let audit = ValidatedAudit::parse(audit_obj)?;
+
+    let source_run = match options.source_run.filter(|s| !s.trim().is_empty()) {
+        Some(explicit) => explicit.to_string(),
+        None => {
+            if audit.date.trim().is_empty() || audit.commit.trim().is_empty() {
+                return Err(CodeIngestError::MissingSourceRun);
+            }
+            format!("{}:{}", audit.date, audit.commit)
+        }
+    };
+
+    let mut validated_findings = Vec::with_capacity(findings_arr.len());
+    for (finding_index, raw) in findings_arr.iter().enumerate() {
+        let obj = raw
+            .as_object()
+            .ok_or_else(|| CodeIngestError::InvalidType {
+                path: format!("findings[{finding_index}]"),
+                expected: "object",
+            })?;
+        validated_findings.push(ValidatedFinding::parse(obj, finding_index)?);
+    }
+
+    // All validation above must succeed before any record is constructed.
+
+    let project_id = uuid5_tuple(&(
+        "code-project",
+        1u8,
+        options.namespace,
+        audit.repo.as_str(),
+        audit.scope.as_str(),
+    ))?;
+    let project_external_id = serde_json::to_string(&(
+        "code-project",
+        1u8,
+        options.namespace,
+        audit.repo.as_str(),
+        audit.scope.as_str(),
+    ))?;
+
+    let mut project_properties = Map::new();
+    project_properties.insert("repo".into(), json!(audit.repo));
+    project_properties.insert("branch".into(), json!(audit.branch));
+    project_properties.insert("commit".into(), json!(audit.commit));
+    project_properties.insert("date".into(), json!(audit.date));
+    project_properties.insert("standards_file".into(), json!(audit.standards_file));
+    project_properties.insert("source_run".into(), json!(source_run));
+    project_properties.insert("external_id".into(), json!(project_external_id));
+    if !audit.extra.is_empty() {
+        project_properties.insert("audit_extra".into(), Value::Object(audit.extra));
+    }
+
+    let observed_micros = options.observed_at.timestamp_micros();
+
+    let mut project_entity = Entity::new(options.namespace, "project", audit.scope.as_str());
+    project_entity.id = project_id;
+    project_entity.properties = Some(Value::Object(project_properties));
+    project_entity.created_at = observed_micros;
+    project_entity.updated_at = observed_micros;
+
+    let mut notes = Vec::with_capacity(validated_findings.len());
+    let mut edges = Vec::with_capacity(validated_findings.len());
+
+    for finding in &validated_findings {
+        let first_path = first_evidence_path(&finding.evidence);
+        let finding_key = (
+            "code-finding",
+            1u8,
+            options.namespace,
+            source_run.as_str(),
+            audit.scope.as_str(),
+            finding.id.as_str(),
+            finding.normalized_title.as_str(),
+            first_path.as_deref().unwrap_or(""),
+        );
+        let finding_id = uuid5_tuple(&finding_key)?;
+        let finding_external_id = serde_json::to_string(&finding_key)?;
+
+        let mut props = Map::new();
+        props.insert("external_id".into(), json!(finding_external_id));
+        props.insert("finding_id".into(), json!(finding.id));
+        props.insert("severity".into(), json!(finding.severity));
+        props.insert("confidence".into(), json!(finding.confidence));
+        props.insert("categories".into(), json!(finding.categories));
+        props.insert("source_run".into(), json!(source_run));
+        props.insert("standard".into(), json!(finding.standard));
+        props.insert("evidence".into(), Value::Array(finding.evidence.clone()));
+        if let Some(refs) = &finding.refs {
+            props.insert("refs".into(), refs.clone());
+        }
+        if let Some(priority) = &finding.priority {
+            props.insert("priority".into(), json!(priority));
+        }
+        if let Some(status) = &finding.audit_status {
+            props.insert("audit_status".into(), json!(status));
+        }
+        if let Some(scenario) = &finding.failure_scenario {
+            props.insert("failure_scenario".into(), json!(scenario));
+        }
+        props.insert("impact".into(), json!(finding.impact));
+        props.insert("recommendation".into(), json!(finding.recommendation));
+        props.insert("verification".into(), json!(finding.verification));
+        props.insert("kind_status".into(), json!("open"));
+        if !finding.raw.is_empty() {
+            props.insert("raw".into(), Value::Object(finding.raw.clone()));
+        }
+
+        let content = format!("{}: {}", finding.title, finding.impact);
+        let mut note = Note::new(options.namespace, "finding", content);
+        note.id = finding_id;
+        note.name = Some(finding.title.clone());
+        note.properties = Some(Value::Object(props));
+        note.created_at = observed_micros;
+        note.updated_at = observed_micros;
+        notes.push(note);
+
+        let edge_id = uuid5_tuple(&(
+            "code-edge",
+            1u8,
+            options.namespace,
+            finding_id,
+            project_id,
+            EdgeRelation::Annotates.as_str(),
+        ))?;
+        edges.push(Edge {
+            id: LinkId::from(edge_id),
+            namespace: options.namespace.to_string(),
+            source_id: finding_id,
+            target_id: project_id,
+            relation: EdgeRelation::Annotates,
+            weight: 1.0,
+            created_at: options.observed_at,
+            updated_at: options.observed_at,
+            deleted_at: None,
+            metadata: None,
+            target_backend: None,
+        });
+    }
+
+    Ok(CodeIngestBatch {
+        entities: vec![project_entity],
+        notes,
+        edges,
+    })
+}

--- a/crates/khive-pack-code/src/lib.rs
+++ b/crates/khive-pack-code/src/lib.rs
@@ -1,0 +1,18 @@
+//! pack-code — code ontology pack for khive (ADR-085).
+//!
+//! Registers four concept subtypes (`module`, `function`, `datatype`,
+//! `interface`) via `khive-pack-kg`'s entity type registry, additive
+//! `EDGE_RULES` over the closed relation set, and the `finding` audit note
+//! kind. Contributes no verbs; `findings.json` ingest is an internal Rust
+//! API (see [`ingest`]), not an MCP wire surface. Opt-in only — not part of
+//! the default pack set.
+
+mod error;
+mod hook;
+pub mod ingest;
+mod pack;
+pub(crate) mod vocab;
+
+pub use error::CodeIngestError;
+pub use ingest::{ingest_findings_json, CodeIngestBatch, CodeIngestOptions, CODE_INGEST_NAMESPACE};
+pub use pack::CodePack;

--- a/crates/khive-pack-code/src/pack.rs
+++ b/crates/khive-pack-code/src/pack.rs
@@ -1,0 +1,133 @@
+//! `CodePack` struct, `Pack` impl, self-registration factory, and `PackRuntime` impl.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{
+    KhiveRuntime, KindHook, NamespaceToken, NoteKindSpec, RuntimeError, SchemaPlan, VerbRegistry,
+};
+use khive_types::{EdgeEndpointRule, HandlerDef, Pack};
+
+use crate::hook::FindingHook;
+use crate::vocab::{CODE_EDGE_RULES, CODE_NOTE_KIND_SPECS};
+
+/// Code ontology pack — additive edge rules over four concept subtypes plus
+/// the `finding` audit-observation note kind. No verbs (ADR-085 D1).
+pub struct CodePack {
+    #[allow(dead_code)]
+    runtime: KhiveRuntime,
+}
+
+impl Pack for CodePack {
+    const NAME: &'static str = "code";
+    const NOTE_KINDS: &'static [&'static str] = &["finding"];
+    const ENTITY_KINDS: &'static [&'static str] = &[];
+    const HANDLERS: &'static [HandlerDef] = &[];
+    const EDGE_RULES: &'static [EdgeEndpointRule] = &CODE_EDGE_RULES;
+    const REQUIRES: &'static [&'static str] = &["kg"];
+    const NOTE_KIND_SPECS: &'static [NoteKindSpec] = &CODE_NOTE_KIND_SPECS;
+    const SCHEMA_PLAN: Option<khive_runtime::PackSchemaPlan> = None;
+}
+
+impl CodePack {
+    pub fn new(runtime: KhiveRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+// ── inventory self-registration ───────────────────────────────────────────────
+
+struct CodePackFactory;
+
+impl khive_runtime::PackFactory for CodePackFactory {
+    fn name(&self) -> &'static str {
+        "code"
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        &["kg"]
+    }
+
+    fn create(&self, runtime: KhiveRuntime) -> Box<dyn khive_runtime::PackRuntime> {
+        Box::new(CodePack::new(runtime))
+    }
+}
+
+inventory::submit! { khive_runtime::PackRegistration(&CodePackFactory) }
+
+#[async_trait]
+impl PackRuntime for CodePack {
+    fn name(&self) -> &str {
+        <CodePack as Pack>::NAME
+    }
+
+    fn note_kinds(&self) -> &'static [&'static str] {
+        <CodePack as Pack>::NOTE_KINDS
+    }
+
+    fn entity_kinds(&self) -> &'static [&'static str] {
+        <CodePack as Pack>::ENTITY_KINDS
+    }
+
+    fn handlers(&self) -> &'static [HandlerDef] {
+        <CodePack as Pack>::HANDLERS
+    }
+
+    fn edge_rules(&self) -> &'static [EdgeEndpointRule] {
+        <CodePack as Pack>::EDGE_RULES
+    }
+
+    fn requires(&self) -> &'static [&'static str] {
+        <CodePack as Pack>::REQUIRES
+    }
+
+    fn note_kind_specs(&self) -> &'static [NoteKindSpec] {
+        <CodePack as Pack>::NOTE_KIND_SPECS
+    }
+
+    fn schema_plan(&self) -> SchemaPlan {
+        SchemaPlan {
+            pack: "code",
+            statements: &[],
+        }
+    }
+
+    fn kind_hook(&self, kind: &str) -> Option<Arc<dyn KindHook>> {
+        match kind {
+            "finding" => Some(Arc::new(FindingHook)),
+            _ => None,
+        }
+    }
+
+    async fn dispatch(
+        &self,
+        verb: &str,
+        _params: Value,
+        _registry: &VerbRegistry,
+        _token: &NamespaceToken,
+    ) -> Result<Value, RuntimeError> {
+        Err(RuntimeError::InvalidInput(format!(
+            "code pack does not handle verb {verb:?}"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use khive_types::Pack;
+
+    use super::CodePack;
+
+    #[test]
+    fn code_pack_declares_adr085_metadata() {
+        assert_eq!(<CodePack as Pack>::NAME, "code");
+        assert_eq!(<CodePack as Pack>::NOTE_KINDS, &["finding"]);
+        assert!(<CodePack as Pack>::ENTITY_KINDS.is_empty());
+        assert!(<CodePack as Pack>::HANDLERS.is_empty());
+        assert_eq!(<CodePack as Pack>::REQUIRES, &["kg"]);
+        assert!(<CodePack as Pack>::SCHEMA_PLAN.is_none());
+    }
+}

--- a/crates/khive-pack-code/src/vocab.rs
+++ b/crates/khive-pack-code/src/vocab.rs
@@ -1,0 +1,214 @@
+//! Code pack vocabulary: governed value sets, the `finding` note kind spec,
+//! and additive `EDGE_RULES` over the closed relation set.
+
+use khive_runtime::{NoteKindSpec, NoteLifecycleSpec};
+use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind};
+
+pub(crate) const VALID_SEVERITIES: &[&str] = &["critical", "high", "medium", "low", "info"];
+pub(crate) const VALID_CONFIDENCES: &[&str] = &["high", "medium", "low"];
+pub(crate) const VALID_PRIORITIES: &[&str] = &["P0", "P1", "P2", "P3"];
+pub(crate) const VALID_FINDING_STATUSES: &[&str] = &["open", "resolved", "wontfix", "invalid"];
+
+pub(crate) fn is_valid_severity(value: &str) -> bool {
+    VALID_SEVERITIES.contains(&value)
+}
+
+pub(crate) fn is_valid_confidence(value: &str) -> bool {
+    VALID_CONFIDENCES.contains(&value)
+}
+
+pub(crate) fn is_valid_priority(value: &str) -> bool {
+    VALID_PRIORITIES.contains(&value)
+}
+
+pub(crate) fn is_valid_finding_status(value: &str) -> bool {
+    VALID_FINDING_STATUSES.contains(&value)
+}
+
+/// `finding` note kind: an epistemic observation attached to a `project` (or
+/// code-subtype) entity, not an entity itself. ADR-085 D4.
+pub(crate) static CODE_NOTE_KIND_SPECS: [NoteKindSpec; 1] = [NoteKindSpec {
+    kind: "finding",
+    aliases: &["defect"],
+    lifecycle: NoteLifecycleSpec {
+        field: "kind_status",
+        initial: "open",
+        terminal: &["resolved", "wontfix", "invalid"],
+        transitions: &[
+            ("open", "resolved"),
+            ("open", "wontfix"),
+            ("open", "invalid"),
+        ],
+    },
+}];
+
+macro_rules! code_ep {
+    ($entity_type:literal) => {
+        EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type: $entity_type,
+        }
+    };
+}
+
+/// Additive edge endpoint rules for the code ontology (ADR-085 D3).
+///
+/// Every row uses an existing `EdgeRelation` variant; the closed relation
+/// enum is never extended. Rows 1-16 are code-pack-specific; rows 17-22 are
+/// base-covered but declared here for introspection per ADR-085.
+pub(crate) static CODE_EDGE_RULES: [EdgeEndpointRule; 22] = [
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("function"),
+        target: code_ep!("function"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("function"),
+        target: code_ep!("datatype"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("function"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("datatype"),
+        target: code_ep!("datatype"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("datatype"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("interface"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("interface"),
+        target: code_ep!("datatype"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::DependsOn,
+        source: code_ep!("module"),
+        target: code_ep!("module"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("project"),
+        target: code_ep!("module"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("project"),
+        target: code_ep!("function"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("project"),
+        target: code_ep!("datatype"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: EndpointKind::EntityOfKind("project"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Implements,
+        source: code_ep!("datatype"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Implements,
+        source: code_ep!("function"),
+        target: EndpointKind::EntityOfKind("concept"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Implements,
+        source: code_ep!("datatype"),
+        target: EndpointKind::EntityOfKind("concept"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Implements,
+        source: code_ep!("module"),
+        target: EndpointKind::EntityOfKind("concept"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: code_ep!("module"),
+        target: code_ep!("module"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: code_ep!("module"),
+        target: code_ep!("function"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: code_ep!("module"),
+        target: code_ep!("datatype"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Contains,
+        source: code_ep!("module"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Extends,
+        source: code_ep!("interface"),
+        target: code_ep!("interface"),
+    },
+    EdgeEndpointRule {
+        relation: EdgeRelation::Extends,
+        source: code_ep!("datatype"),
+        target: code_ep!("datatype"),
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use khive_types::{EdgeRelation, EndpointKind};
+
+    use super::CODE_EDGE_RULES;
+
+    #[test]
+    fn code_edge_rules_has_22_rows() {
+        assert_eq!(CODE_EDGE_RULES.len(), 22);
+    }
+
+    #[test]
+    fn code_edge_rules_contains_function_depends_on_datatype() {
+        let found = CODE_EDGE_RULES.iter().any(|r| {
+            r.relation == EdgeRelation::DependsOn
+                && r.source
+                    == EndpointKind::EntityOfType {
+                        kind: "concept",
+                        entity_type: "function",
+                    }
+                && r.target
+                    == EndpointKind::EntityOfType {
+                        kind: "concept",
+                        entity_type: "datatype",
+                    }
+        });
+        assert!(found, "must contain function depends_on datatype");
+    }
+
+    #[test]
+    fn code_edge_rules_contains_project_contains_module() {
+        let found = CODE_EDGE_RULES.iter().any(|r| {
+            r.relation == EdgeRelation::Contains
+                && r.source == EndpointKind::EntityOfKind("project")
+                && r.target
+                    == EndpointKind::EntityOfType {
+                        kind: "concept",
+                        entity_type: "module",
+                    }
+        });
+        assert!(found, "must contain project contains module");
+    }
+}

--- a/crates/khive-pack-code/src/vocab.rs
+++ b/crates/khive-pack-code/src/vocab.rs
@@ -6,7 +6,6 @@ use khive_types::{EdgeEndpointRule, EdgeRelation, EndpointKind};
 
 pub(crate) const VALID_SEVERITIES: &[&str] = &["critical", "high", "medium", "low", "info"];
 pub(crate) const VALID_CONFIDENCES: &[&str] = &["high", "medium", "low"];
-pub(crate) const VALID_PRIORITIES: &[&str] = &["P0", "P1", "P2", "P3"];
 pub(crate) const VALID_FINDING_STATUSES: &[&str] = &["open", "resolved", "wontfix", "invalid"];
 
 pub(crate) fn is_valid_severity(value: &str) -> bool {
@@ -15,10 +14,6 @@ pub(crate) fn is_valid_severity(value: &str) -> bool {
 
 pub(crate) fn is_valid_confidence(value: &str) -> bool {
     VALID_CONFIDENCES.contains(&value)
-}
-
-pub(crate) fn is_valid_priority(value: &str) -> bool {
-    VALID_PRIORITIES.contains(&value)
 }
 
 pub(crate) fn is_valid_finding_status(value: &str) -> bool {

--- a/crates/khive-pack-code/tests/integration.rs
+++ b/crates/khive-pack-code/tests/integration.rs
@@ -1,0 +1,637 @@
+//! End-to-end tests for the code pack against an in-memory runtime.
+//!
+//! FILE SIZE JUSTIFICATION: mirrors `khive-pack-gtd/tests/integration.rs` — a
+//! single shared `Fixture` wires `KgPack` + `CodePack` against an in-memory
+//! runtime; splitting would duplicate that setup across files.
+//!
+//! Covers the ADR-085 integration matrix: vocabulary registration, edge
+//! endpoint acceptance and rejection, finding-hook defaulting and validation,
+//! ingest idempotency, and malformed-input rejection.
+
+use chrono::{DateTime, Utc};
+use khive_pack_code::{ingest_findings_json, CodeIngestError, CodeIngestOptions, CodePack};
+use khive_pack_kg::KgPack;
+use khive_runtime::pack::PackRuntime;
+use khive_runtime::{KhiveRuntime, RuntimeError, VerbRegistry, VerbRegistryBuilder};
+use khive_types::{EdgeRelation, EndpointKind};
+use serde_json::{json, Value};
+
+#[allow(dead_code)]
+fn rt() -> KhiveRuntime {
+    KhiveRuntime::memory().expect("memory runtime")
+}
+
+#[allow(dead_code)]
+fn registry(rt: KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(CodePack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+#[allow(dead_code)]
+fn kg_only_registry(rt: KhiveRuntime) -> VerbRegistry {
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let registry = builder.build().expect("registry builds");
+    rt.install_edge_rules(registry.all_edge_rules());
+    registry
+}
+
+#[allow(dead_code)]
+async fn dispatch(registry: &VerbRegistry, verb: &str, args: Value) -> Result<Value, RuntimeError> {
+    registry.dispatch(verb, args).await
+}
+
+#[allow(dead_code)]
+fn sample_findings_json() -> Value {
+    json!({
+        "audit": {
+            "date": "2026-07-07",
+            "scope": "khive-pack-code",
+            "repo": "khive",
+            "branch": "show/khive-sweep-0707/code-pack",
+            "commit": "abc123",
+            "standards_file": "audit-guidelines.md",
+        },
+        "findings": [
+            {
+                "id": "khive-pack-code-001",
+                "title": "  Missing   bounds check  ",
+                "severity": "high",
+                "confidence": "high",
+                "categories": ["security"],
+                "status": "open",
+                "standard": "audit-guidelines.md#security",
+                "evidence": [{"path": "src/ingest.rs", "line": 42, "description": "unchecked index"}],
+                "impact": "panics on malformed input",
+                "recommendation": "validate before indexing",
+                "verification": "add regression test",
+                "failure_scenario": "attacker-controlled index panics the process",
+                "priority": "P1",
+            }
+        ]
+    })
+}
+
+#[allow(dead_code)]
+fn ingest_options(source_run: Option<&str>) -> CodeIngestOptions<'_> {
+    CodeIngestOptions {
+        namespace: "local",
+        observed_at: Utc::now(),
+        source_run,
+    }
+}
+
+#[tokio::test]
+async fn code_pack_declares_adr085_metadata() {
+    let registry = registry(rt());
+    assert!(registry.all_note_kinds().contains(&"finding"));
+}
+
+/// End-to-end (not merely unit-level) proof that the four code concept
+/// subtypes and their aliases registered in `khive-pack-kg`'s `BUILTIN_DEFS`
+/// are reachable through the full `create` verb dispatch path, canonicalizing
+/// aliases to their token before persistence. The registry-level resolution
+/// itself is covered by `khive-pack-kg`'s own
+/// `entity_type_registry_accepts_code_tokens_and_aliases` unit test; this
+/// proves the wiring holds through dispatch, not just the raw registry call.
+#[tokio::test]
+async fn entity_type_registry_accepts_code_tokens_and_aliases() {
+    let reg = registry(rt());
+    for (alias, canonical) in [
+        ("mod", "module"),
+        ("namespace", "module"),
+        ("fn", "function"),
+        ("func", "function"),
+        ("method", "function"),
+        ("enum", "datatype"),
+        ("record", "datatype"),
+        ("type_alias", "datatype"),
+        ("trait", "interface"),
+        ("protocol", "interface"),
+    ] {
+        let created = dispatch(
+            &reg,
+            "create",
+            json!({"kind": "entity", "name": format!("Node-{alias}"), "entity_kind": "concept", "entity_type": alias}),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("alias {alias:?} must be creatable: {e}"));
+        assert_eq!(
+            created["entity_type"], canonical,
+            "alias {alias:?} must canonicalize to {canonical:?}"
+        );
+    }
+}
+
+/// `struct`/`class` must remain owned by formal's `structure` token even when
+/// the code pack is registered — the code pack must not shadow them with
+/// `datatype`. See also `khive-pack-kg`'s unit-level
+/// `entity_type_registry_does_not_claim_struct_or_class_for_code`.
+#[tokio::test]
+async fn entity_type_registry_does_not_claim_struct_or_class_for_code() {
+    let reg = registry(rt());
+    for alias in ["struct", "class"] {
+        let created = dispatch(
+            &reg,
+            "create",
+            json!({"kind": "entity", "name": format!("Node-{alias}"), "entity_kind": "concept", "entity_type": alias}),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("alias {alias:?} must be creatable: {e}"));
+        assert_eq!(
+            created["entity_type"], "structure",
+            "alias {alias:?} must remain owned by formal's structure, not datatype"
+        );
+    }
+}
+
+#[test]
+fn code_edge_rules_match_adr085_triples() {
+    let pack = CodePack::new(rt());
+    let rules = pack.edge_rules();
+    assert_eq!(
+        rules.len(),
+        22,
+        "ADR-085 declares exactly 22 additive edge rules"
+    );
+
+    fn concept(entity_type: &'static str) -> EndpointKind {
+        EndpointKind::EntityOfType {
+            kind: "concept",
+            entity_type,
+        }
+    }
+
+    let expected: Vec<(EdgeRelation, EndpointKind, EndpointKind)> = vec![
+        (
+            EdgeRelation::DependsOn,
+            concept("function"),
+            concept("function"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("function"),
+            concept("datatype"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("function"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("datatype"),
+            concept("datatype"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("datatype"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("interface"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("interface"),
+            concept("datatype"),
+        ),
+        (
+            EdgeRelation::DependsOn,
+            concept("module"),
+            concept("module"),
+        ),
+        (
+            EdgeRelation::Contains,
+            EndpointKind::EntityOfKind("project"),
+            concept("module"),
+        ),
+        (
+            EdgeRelation::Contains,
+            EndpointKind::EntityOfKind("project"),
+            concept("function"),
+        ),
+        (
+            EdgeRelation::Contains,
+            EndpointKind::EntityOfKind("project"),
+            concept("datatype"),
+        ),
+        (
+            EdgeRelation::Contains,
+            EndpointKind::EntityOfKind("project"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::Implements,
+            concept("datatype"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::Implements,
+            concept("function"),
+            EndpointKind::EntityOfKind("concept"),
+        ),
+        (
+            EdgeRelation::Implements,
+            concept("datatype"),
+            EndpointKind::EntityOfKind("concept"),
+        ),
+        (
+            EdgeRelation::Implements,
+            concept("module"),
+            EndpointKind::EntityOfKind("concept"),
+        ),
+        (EdgeRelation::Contains, concept("module"), concept("module")),
+        (
+            EdgeRelation::Contains,
+            concept("module"),
+            concept("function"),
+        ),
+        (
+            EdgeRelation::Contains,
+            concept("module"),
+            concept("datatype"),
+        ),
+        (
+            EdgeRelation::Contains,
+            concept("module"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::Extends,
+            concept("interface"),
+            concept("interface"),
+        ),
+        (
+            EdgeRelation::Extends,
+            concept("datatype"),
+            concept("datatype"),
+        ),
+    ];
+    assert_eq!(
+        expected.len(),
+        22,
+        "expected fixture itself must list all 22 ADR-085 triples"
+    );
+
+    for (relation, source, target) in &expected {
+        assert!(
+            rules
+                .iter()
+                .any(|r| r.relation == *relation && r.source == *source && r.target == *target),
+            "missing ADR-085 rule {relation:?} {source:?} -> {target:?}"
+        );
+    }
+}
+
+async fn create_concept(registry: &VerbRegistry, name: &str, entity_type: &str) -> String {
+    let created = dispatch(
+        registry,
+        "create",
+        json!({"kind": "entity", "name": name, "entity_kind": "concept", "entity_type": entity_type}),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create {entity_type} entity must succeed: {e}"));
+    created["id"]
+        .as_str()
+        .expect("created entity has id")
+        .to_string()
+}
+
+async fn create_project(registry: &VerbRegistry, name: &str) -> String {
+    let created = dispatch(
+        registry,
+        "create",
+        json!({"kind": "entity", "name": name, "entity_kind": "project"}),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create project entity must succeed: {e}"));
+    created["id"]
+        .as_str()
+        .expect("created entity has id")
+        .to_string()
+}
+
+#[tokio::test]
+async fn link_accepts_function_depends_on_datatype_with_code_pack() {
+    let reg = registry(rt());
+    let src = create_concept(&reg, "DoTheThing", "function").await;
+    let tgt = create_concept(&reg, "ThingRecord", "datatype").await;
+    let result = dispatch(
+        &reg,
+        "link",
+        json!({"source_id": src, "target_id": tgt, "relation": "depends_on", "weight": 1.0}),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "function depends_on datatype must be accepted with kg,code registered: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn link_accepts_project_contains_module_with_code_pack() {
+    let reg = registry(rt());
+    let src = create_project(&reg, "khive-pack-code").await;
+    let tgt = create_concept(&reg, "ingest", "module").await;
+    let result = dispatch(
+        &reg,
+        "link",
+        json!({"source_id": src, "target_id": tgt, "relation": "contains", "weight": 1.0}),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "project contains module must be accepted with kg,code registered: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn link_rejects_function_depends_on_datatype_without_code_pack() {
+    let reg = kg_only_registry(rt());
+    let src = create_concept(&reg, "DoTheThing", "function").await;
+    let tgt = create_concept(&reg, "ThingRecord", "datatype").await;
+    let err = dispatch(
+        &reg,
+        "link",
+        json!({"source_id": src, "target_id": tgt, "relation": "depends_on", "weight": 1.0}),
+    )
+    .await
+    .expect_err("function depends_on datatype must be rejected without the code pack");
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn link_rejects_function_depends_on_project_with_code_pack() {
+    let reg = registry(rt());
+    let src = create_concept(&reg, "DoTheThing", "function").await;
+    let tgt = create_project(&reg, "khive-pack-code").await;
+    let err = dispatch(
+        &reg,
+        "link",
+        json!({"source_id": src, "target_id": tgt, "relation": "depends_on", "weight": 1.0}),
+    )
+    .await
+    .expect_err("function depends_on project has no ADR-085 rule and must remain rejected");
+    assert!(
+        matches!(err, RuntimeError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_finding_defaults_kind_status_open() {
+    let reg = registry(rt());
+    let resp = dispatch(
+        &reg,
+        "create",
+        json!({
+            "kind": "finding",
+            "title": "Missing bounds check",
+            "properties": {"severity": "high", "confidence": "high"},
+        }),
+    )
+    .await
+    .expect("create(kind=finding) with valid severity/confidence must succeed");
+    assert_eq!(resp["properties"]["kind_status"], "open");
+}
+
+#[tokio::test]
+async fn create_finding_rejects_invalid_severity_with_valid_values() {
+    let reg = registry(rt());
+    let err = dispatch(
+        &reg,
+        "create",
+        json!({
+            "kind": "finding",
+            "title": "Missing bounds check",
+            "properties": {"severity": "catastrophic", "confidence": "high"},
+        }),
+    )
+    .await
+    .expect_err("invalid severity must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("critical, high, medium, low, info"),
+        "error must name valid severities, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_finding_rejects_invalid_confidence_with_valid_values() {
+    let reg = registry(rt());
+    let err = dispatch(
+        &reg,
+        "create",
+        json!({
+            "kind": "finding",
+            "title": "Missing bounds check",
+            "properties": {"severity": "high", "confidence": "sorta"},
+        }),
+    )
+    .await
+    .expect_err("invalid confidence must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("high, medium, low"),
+        "error must name valid confidences, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_finding_rejects_non_object_properties() {
+    let reg = registry(rt());
+    let err = dispatch(
+        &reg,
+        "create",
+        json!({
+            "kind": "finding",
+            "title": "Missing bounds check",
+            "properties": "high",
+        }),
+    )
+    .await
+    .expect_err("a present non-object properties must be rejected, not coerced");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("properties must be an object"),
+        "error must name the properties-shape requirement, got: {msg}"
+    );
+}
+
+fn valid_findings_bytes() -> Vec<u8> {
+    serde_json::to_vec(&sample_findings_json()).expect("sample findings.json serializes")
+}
+
+#[test]
+fn ingest_findings_json_same_input_same_ids() {
+    let bytes = valid_findings_bytes();
+    let opts_a = ingest_options(Some("fixed-run"));
+    let opts_b = ingest_options(Some("fixed-run"));
+
+    let batch_a = ingest_findings_json(&bytes, opts_a).expect("first ingest must succeed");
+    let batch_b = ingest_findings_json(&bytes, opts_b).expect("second ingest must succeed");
+
+    assert_eq!(batch_a.entities.len(), 1);
+    assert_eq!(batch_b.entities.len(), 1);
+    assert_eq!(batch_a.entities[0].id, batch_b.entities[0].id);
+
+    assert_eq!(batch_a.notes.len(), batch_b.notes.len());
+    for (a, b) in batch_a.notes.iter().zip(batch_b.notes.iter()) {
+        assert_eq!(
+            a.id, b.id,
+            "re-ingesting the same findings.json must reproduce the same note id"
+        );
+    }
+
+    assert_eq!(batch_a.edges.len(), batch_b.edges.len());
+    for (a, b) in batch_a.edges.iter().zip(batch_b.edges.iter()) {
+        assert_eq!(
+            a.id, b.id,
+            "re-ingesting the same findings.json must reproduce the same edge id"
+        );
+    }
+}
+
+#[test]
+fn ingest_findings_json_same_ids_across_different_observed_at() {
+    let bytes = valid_findings_bytes();
+    let early: DateTime<Utc> = "2020-01-01T00:00:00Z".parse().expect("valid rfc3339");
+    let late: DateTime<Utc> = "2030-06-15T12:30:00Z".parse().expect("valid rfc3339");
+
+    let batch_early = ingest_findings_json(
+        &bytes,
+        CodeIngestOptions {
+            namespace: "local",
+            observed_at: early,
+            source_run: Some("fixed-run"),
+        },
+    )
+    .expect("ingest at early timestamp must succeed");
+    let batch_late = ingest_findings_json(
+        &bytes,
+        CodeIngestOptions {
+            namespace: "local",
+            observed_at: late,
+            source_run: Some("fixed-run"),
+        },
+    )
+    .expect("ingest at late timestamp must succeed");
+
+    assert_eq!(
+        batch_early.entities[0].id, batch_late.entities[0].id,
+        "observed_at must be excluded from identity"
+    );
+    assert_eq!(batch_early.notes[0].id, batch_late.notes[0].id);
+    assert_eq!(batch_early.edges[0].id, batch_late.edges[0].id);
+}
+
+#[test]
+fn ingest_rejects_missing_findings_array() {
+    let malformed = json!({
+        "audit": {
+            "date": "2026-07-07",
+            "scope": "khive-pack-code",
+            "repo": "khive",
+            "branch": "show/khive-sweep-0707/code-pack",
+            "commit": "abc123",
+            "standards_file": "audit-guidelines.md",
+        },
+    });
+    let bytes = serde_json::to_vec(&malformed).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("missing findings array must be rejected");
+    assert!(
+        matches!(err, CodeIngestError::InvalidRoot),
+        "expected InvalidRoot, got: {err:?}"
+    );
+}
+
+#[test]
+fn ingest_rejects_invalid_confidence_before_records() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["confidence"] = json!("sorta");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("invalid confidence must be rejected before any record is built");
+    match err {
+        CodeIngestError::InvalidValue { field, valid, .. } => {
+            assert_eq!(field, "confidence");
+            assert_eq!(valid, "high | medium | low");
+        }
+        other => panic!("expected InvalidValue{{field: confidence}}, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_invalid_severity_before_records() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["severity"] = json!("catastrophic");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("invalid severity must be rejected before any record is built");
+    match err {
+        CodeIngestError::InvalidValue { field, valid, .. } => {
+            assert_eq!(field, "severity");
+            assert_eq!(valid, "critical | high | medium | low | info");
+        }
+        other => panic!("expected InvalidValue{{field: severity}}, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_invalid_priority_before_records() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["priority"] = json!("P9");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("invalid priority must be rejected before any record is built");
+    match err {
+        CodeIngestError::InvalidValue { field, valid, .. } => {
+            assert_eq!(field, "priority");
+            assert_eq!(valid, "P0 | P1 | P2 | P3");
+        }
+        other => panic!("expected InvalidValue{{field: priority}}, got: {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_invalid_evidence_shape() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["evidence"] = json!([42]);
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("evidence entries that are neither string nor object must be rejected");
+    assert!(
+        matches!(err, CodeIngestError::InvalidEvidence { .. }),
+        "expected InvalidEvidence, got: {err:?}"
+    );
+}
+
+#[test]
+fn ingest_requires_failure_scenario_for_medium_or_higher() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["severity"] = json!("medium");
+    doc["findings"][0]
+        .as_object_mut()
+        .expect("finding is an object")
+        .remove("failure_scenario");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect_err("medium severity without failure_scenario must be rejected");
+    match err {
+        CodeIngestError::MissingFailureScenario { severity, .. } => {
+            assert_eq!(severity, "medium");
+        }
+        other => panic!("expected MissingFailureScenario, got: {other:?}"),
+    }
+}

--- a/crates/khive-pack-code/tests/integration.rs
+++ b/crates/khive-pack-code/tests/integration.rs
@@ -52,7 +52,7 @@ fn sample_findings_json() -> Value {
             "date": "2026-07-07",
             "scope": "khive-pack-code",
             "repo": "khive",
-            "branch": "show/khive-sweep-0707/code-pack",
+            "branch": "feature/code-pack",
             "commit": "abc123",
             "standards_file": "audit-guidelines.md",
         },
@@ -536,13 +536,42 @@ fn ingest_findings_json_same_ids_across_different_observed_at() {
 }
 
 #[test]
+fn ingest_different_content_produces_different_finding_id() {
+    // Same external id/title/evidence path as `sample_findings_json`, but a
+    // changed content field (severity). The finding id must diverge — a
+    // content change must never collide with the prior record's id.
+    let bytes_a = valid_findings_bytes();
+    let mut doc_b = sample_findings_json();
+    doc_b["findings"][0]["severity"] = json!("critical");
+    let bytes_b = serde_json::to_vec(&doc_b).expect("serializes");
+
+    let batch_a = ingest_findings_json(&bytes_a, ingest_options(Some("fixed-run")))
+        .expect("first ingest must succeed");
+    let batch_b = ingest_findings_json(&bytes_b, ingest_options(Some("fixed-run")))
+        .expect("second ingest must succeed");
+
+    assert_ne!(
+        batch_a.notes[0].id, batch_b.notes[0].id,
+        "changing finding content (severity) must produce a different finding id"
+    );
+    assert_ne!(
+        batch_a.edges[0].id, batch_b.edges[0].id,
+        "the finding's annotate-edge id derives from the finding id and must also diverge"
+    );
+    // The unrelated project entity is scoped by repo/scope only, so it is
+    // unaffected by a finding-level content change — the old record's
+    // entity is left untouched, as the amendment requires.
+    assert_eq!(batch_a.entities[0].id, batch_b.entities[0].id);
+}
+
+#[test]
 fn ingest_rejects_missing_findings_array() {
     let malformed = json!({
         "audit": {
             "date": "2026-07-07",
             "scope": "khive-pack-code",
             "repo": "khive",
-            "branch": "show/khive-sweep-0707/code-pack",
+            "branch": "feature/code-pack",
             "commit": "abc123",
             "standards_file": "audit-guidelines.md",
         },
@@ -589,19 +618,19 @@ fn ingest_rejects_invalid_severity_before_records() {
 }
 
 #[test]
-fn ingest_rejects_invalid_priority_before_records() {
+fn ingest_tolerates_out_of_vocab_priority() {
+    // ADR-085 Amendment 1 A1: `priority` is ungoverned — ingest neither
+    // rejects nor coerces it, it preserves whatever value was provided.
     let mut doc = sample_findings_json();
     doc["findings"][0]["priority"] = json!("P9");
     let bytes = serde_json::to_vec(&doc).expect("serializes");
-    let err = ingest_findings_json(&bytes, ingest_options(Some("run")))
-        .expect_err("invalid priority must be rejected before any record is built");
-    match err {
-        CodeIngestError::InvalidValue { field, valid, .. } => {
-            assert_eq!(field, "priority");
-            assert_eq!(valid, "P0 | P1 | P2 | P3");
-        }
-        other => panic!("expected InvalidValue{{field: priority}}, got: {other:?}"),
-    }
+    let batch = ingest_findings_json(&bytes, ingest_options(Some("run")))
+        .expect("out-of-vocab priority must be tolerated, not rejected");
+    assert_eq!(
+        batch.notes[0].properties.as_ref().expect("has properties")["priority"],
+        json!("P9"),
+        "tolerated priority value must be preserved as-is"
+    );
 }
 
 #[test]

--- a/crates/khive-pack-kg/src/entity_type_registry.rs
+++ b/crates/khive-pack-kg/src/entity_type_registry.rs
@@ -170,6 +170,30 @@ static BUILTIN_DEFS: &[EntityTypeDef] = &[
         type_name: "objective",
         aliases: &["loss"],
     },
+    // ── Code (ADR-085) ──────────────────────────────────────────────────────
+    // "struct" and "class" are not registered as aliases here: formal-math
+    // "structure" already owns them (see above), and ADR-085 requires
+    // ingesters to write the canonical code tokens instead.
+    EntityTypeDef {
+        kind: EntityKind::Concept,
+        type_name: "module",
+        aliases: &["mod", "namespace"],
+    },
+    EntityTypeDef {
+        kind: EntityKind::Concept,
+        type_name: "function",
+        aliases: &["fn", "func", "method"],
+    },
+    EntityTypeDef {
+        kind: EntityKind::Concept,
+        type_name: "datatype",
+        aliases: &["enum", "record", "type_alias"],
+    },
+    EntityTypeDef {
+        kind: EntityKind::Concept,
+        type_name: "interface",
+        aliases: &["trait", "protocol"],
+    },
     // ── Dataset ──────────────────────────────────────────────────────────────
     // benchmark belongs to Dataset, not Concept (it evaluates models, it is not itself a concept).
     EntityTypeDef {
@@ -801,5 +825,58 @@ mod tests {
             .resolve(EntityKind::Document, Some("blog-post"))
             .expect("blog-post must normalise to blog_post");
         assert_eq!(res.entity_type.as_deref(), Some("blog_post"));
+    }
+
+    // ── ADR-085 code subtypes ────────────────────────────────────────────────
+
+    #[test]
+    fn entity_type_registry_accepts_code_tokens_and_aliases() {
+        let r = reg();
+        for (raw, canonical) in [
+            ("module", "module"),
+            ("mod", "module"),
+            ("namespace", "module"),
+            ("function", "function"),
+            ("fn", "function"),
+            ("func", "function"),
+            ("method", "function"),
+            ("datatype", "datatype"),
+            ("enum", "datatype"),
+            ("record", "datatype"),
+            ("type_alias", "datatype"),
+            ("interface", "interface"),
+            ("trait", "interface"),
+            ("protocol", "interface"),
+        ] {
+            let res = r
+                .resolve(EntityKind::Concept, Some(raw))
+                .unwrap_or_else(|e| panic!("{raw:?} must resolve for Concept: {e}"));
+            assert_eq!(
+                res.entity_type.as_deref(),
+                Some(canonical),
+                "{raw:?} must resolve to {canonical:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn entity_type_registry_does_not_claim_struct_or_class_for_code() {
+        let r = reg();
+        let struct_res = r
+            .resolve(EntityKind::Concept, Some("struct"))
+            .expect("struct remains a valid Concept subtype (owned by formal structure)");
+        assert_eq!(
+            struct_res.entity_type.as_deref(),
+            Some("structure"),
+            "struct must still resolve to formal-math structure, not datatype"
+        );
+        let class_res = r
+            .resolve(EntityKind::Concept, Some("class"))
+            .expect("class remains a valid Concept subtype (owned by formal structure)");
+        assert_eq!(
+            class_res.entity_type.as_deref(),
+            Some("structure"),
+            "class must still resolve to formal-math structure, not datatype"
+        );
     }
 }

--- a/crates/khive-pack-schedule/src/handlers.rs
+++ b/crates/khive-pack-schedule/src/handlers.rs
@@ -621,6 +621,30 @@ const ENTITY_TYPE_DEFS_FOR_REPLAY: &[(khive_types::EntityKind, &str, &[&str])] =
     ),
     (khive_types::EntityKind::Concept, "metric", &[]),
     (khive_types::EntityKind::Concept, "objective", &["loss"]),
+    // ── Code (ADR-085) ────────────────────────────────────────────────────
+    // "struct"/"class" stay with formal-math "structure" (see above); the
+    // registry does not alias them to code subtypes and neither does this
+    // mirror.
+    (
+        khive_types::EntityKind::Concept,
+        "module",
+        &["mod", "namespace"],
+    ),
+    (
+        khive_types::EntityKind::Concept,
+        "function",
+        &["fn", "func", "method"],
+    ),
+    (
+        khive_types::EntityKind::Concept,
+        "datatype",
+        &["enum", "record", "type_alias"],
+    ),
+    (
+        khive_types::EntityKind::Concept,
+        "interface",
+        &["trait", "protocol"],
+    ),
     // ── Dataset ───────────────────────────────────────────────────────────
     (khive_types::EntityKind::Dataset, "benchmark", &[]),
     (khive_types::EntityKind::Dataset, "corpus", &[]),

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -26,6 +26,7 @@ khive-pack-brain = { version = "0.3.0", path = "../khive-pack-brain" }
 khive-pack-comm = { version = "0.3.0", path = "../khive-pack-comm" }
 khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
 khive-pack-formal = { version = "0.3.0", path = "../khive-pack-formal" }
+khive-pack-code = { version = "0.3.0", path = "../khive-pack-code" }
 khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
 khive-request = { version = "0.3.0", path = "../khive-request" }

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -26,6 +26,7 @@ pub mod vector;
 #[allow(unused_imports)]
 mod _pack_links {
     use khive_pack_brain::BrainPack as _;
+    use khive_pack_code::CodePack as _;
     use khive_pack_comm::CommPack as _;
     use khive_pack_formal::FormalPack as _;
     use khive_pack_gtd::GtdPack as _;


### PR DESCRIPTION
Implements ADR-085 D4: the `code` pack v0 — audit findings as first-class graph records.

- New opt-in crate `crates/khive-pack-code`: zero-handler `Pack` (`NAME="code"`, `REQUIRES=["kg"]`), self-registered via inventory (mirrors `khive-pack-formal` precedent).
- Vocabulary: 4 concept subtypes (`module`, `function`, `datatype`, `interface`) added additively; `finding` audit-note kind with governed properties via `FindingHook`.
- 22-row additive `EDGE_RULES` reusing existing relations only — the closed `EdgeRelation` enum is untouched.
- Idempotent ingest: pure internal `ingest_findings_json` mapper, content-derived UUIDv5 identity (`observed_at` excluded from key tuples), whole-document validation before any record construction, fail-closed on governed values with valid values named in every error.
- No schema migration; 24 tests (4 lib + 20 integration).

Contract: ADR-085 + **Amendment 1 (PR #693 — merges BEFORE this PR)**: A1 tolerate free-form/ungoverned fields, A2 `kind_status` default-open + raw `audit_status` preserved (governed mapping = v0.1), A3 internal UUIDv5 mapper honoring the no-verbs decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)