### PR TITLE
fix(runtime): multi-backend annotates→edge resolution, tier-3 config anchor, curation merge SQL unification

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1073,11 +1073,16 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
     // When no [[backends]] are declared, fall through to the existing single-backend path
     // to preserve byte-for-byte backward compatibility.
     //
-    // `config.db_path` (already resolved above) anchors tier-3 project-local config
-    // discovery to the database's own directory rather than the process cwd, so this
-    // reload agrees with the one inside `resolve_runtime_config` regardless of cwd.
+    // Deliberately `config_discovery_db_anchor(args.db.as_deref())`, NOT
+    // `config.db_path` — `config.db_path` (already resolved above) materializes
+    // the `$HOME/.khive/khive.db` default when `--db` is unset (#689), which
+    // would re-anchor this reload's tier-3 project-local config discovery to
+    // the home directory instead of the process cwd. This keeps the reload in
+    // agreement with the discovery anchor `resolve_runtime_config` already used
+    // to produce `config` above.
+    let db_path_for_config = config_discovery_db_anchor(args.db.as_deref());
     let khive_cfg =
-        KhiveConfig::load_with_home_fallback(args.config.as_deref(), config.db_path.as_deref())
+        KhiveConfig::load_with_home_fallback(args.config.as_deref(), db_path_for_config.as_deref())
             .map_err(|e| anyhow::anyhow!("config error: {e}"))?
             .unwrap_or_default();
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1344,6 +1344,24 @@ fn expand_tilde(path: &std::path::Path) -> PathBuf {
     }
 }
 
+/// Resolve the `--db`/`KHIVE_DB` value into the anchor used for tier-3
+/// project-local `.khive/config.toml` DISCOVERY — as distinct from
+/// [`khive_runtime::resolve_db_anchor`], which always materializes a concrete
+/// anchor (defaulting to `$HOME/.khive/khive.db`) for the database that is
+/// actually about to be opened.
+///
+/// An explicit `--db`/`KHIVE_DB` still anchors discovery to that path, for the
+/// same config_id-coherence reason `resolve_db_anchor` documents. But when no
+/// db was supplied, this returns `None` instead of the materialized home
+/// default (#689): passing the home-default path into
+/// `KhiveConfig::load_with_home_fallback`'s `db_path` collapses tier 3 onto
+/// `$HOME/.khive/config.toml`, silently skipping the project-local
+/// `<cwd>/.khive/config.toml` that `project_config_anchor_dir` documents as
+/// the `db_path == None` fallback.
+pub fn config_discovery_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
+    db.and_then(|d| khive_runtime::resolve_db_anchor(Some(d)))
+}
+
 /// Inputs for [`resolve_runtime_config`] — the subset of serve-time arguments
 /// that determine the resolved [`RuntimeConfig`]. Callers other than
 /// `kkernel mcp` (e.g. `kkernel reindex`) supply these directly so they resolve
@@ -1408,12 +1426,15 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
         ..RuntimeConfig::default()
     };
 
-    // Captured before `base_config` (which owns `db_path`) is consumed below —
-    // threaded into the config-file resolvers so tier-3 project-local config
+    // Threaded into the config-file resolvers so tier-3 project-local config
     // discovery anchors to the resolved database's directory rather than the
-    // process cwd (kills config_id drift between a client and the daemon
-    // serving the same database at a different working directory).
-    let db_path_for_config = base_config.db_path.clone();
+    // process cwd when an explicit `--db`/`KHIVE_DB` is given (kills config_id
+    // drift between a client and the daemon serving the same database at a
+    // different working directory). Deliberately NOT `base_config.db_path`
+    // (which materializes the `$HOME/.khive/khive.db` default when unset,
+    // #689) — an unset db must fall through to cwd-anchored discovery instead
+    // of silently searching the home directory.
+    let db_path_for_config = config_discovery_db_anchor(inputs.db);
 
     let resolved = if inputs.no_embed {
         let no_embed_base = RuntimeConfig {
@@ -1627,6 +1648,32 @@ mod tests {
     use khive_runtime::Namespace;
     use serial_test::serial;
     use std::io::Write;
+
+    // #689: `config_discovery_db_anchor` is a pure function (no env/cwd
+    // dependency), so its explicit-vs-unset contract is covered here without
+    // the env-mutation isolation the cwd/HOME-dependent tests below require.
+    #[test]
+    fn config_discovery_db_anchor_unset_is_none() {
+        assert_eq!(
+            config_discovery_db_anchor(None),
+            None,
+            "unset --db must not anchor discovery on the materialized home default"
+        );
+    }
+
+    #[test]
+    fn config_discovery_db_anchor_explicit_matches_resolve_db_anchor() {
+        assert_eq!(
+            config_discovery_db_anchor(Some("/tmp/explicit.db")),
+            khive_runtime::resolve_db_anchor(Some("/tmp/explicit.db")),
+            "an explicit --db must anchor discovery identically to resolve_db_anchor"
+        );
+    }
+
+    #[test]
+    fn config_discovery_db_anchor_memory_sentinel_is_none() {
+        assert_eq!(config_discovery_db_anchor(Some(":memory:")), None);
+    }
 
     fn write_config(dir: &std::path::Path, body: &str) -> PathBuf {
         let path = dir.join("khive.toml");
@@ -2058,6 +2105,64 @@ brain_profile = "project-profile"
             resolved.actor_id.as_deref(),
             Some("local"),
             "must not collapse to the literal namespace string"
+        );
+    }
+
+    /// #689 regression: an unset `--db`/`KHIVE_DB` must anchor tier-3
+    /// `.khive/config.toml` discovery on the process cwd, not on
+    /// `resolve_db_anchor(None)`'s materialized `$HOME/.khive/khive.db`
+    /// default. Before the fix, `db_path_for_config` was cloned straight from
+    /// `base_config.db_path`, so an unset db collapsed tier 3 onto
+    /// `$HOME/.khive/config.toml` and silently ignored a real project-local
+    /// config with no error of any kind.
+    ///
+    /// Uses `[runtime].brain_profile` — read from the db-anchored config load
+    /// (`resolve_config`/`runtime_config_from_khive_config`), unlike `[actor]`
+    /// which is resolved through a separate, always-cwd-anchored tier (see
+    /// `seat_shaped_project_actor_resolves_through_full_tier_chain` above) and
+    /// so cannot observe this bug on its own.
+    #[test]
+    #[serial]
+    fn resolve_runtime_config_unset_db_discovers_cwd_config_over_home() {
+        std::env::remove_var("KHIVE_ACTOR");
+
+        let project_dir = tempfile::tempdir().expect("project tempdir");
+        std::fs::create_dir_all(project_dir.path().join(".khive")).expect("mkdir project .khive");
+        std::fs::write(
+            project_dir.path().join(".khive/config.toml"),
+            "[runtime]\nbrain_profile = \"cwd-profile\"\n",
+        )
+        .expect("write project config");
+
+        let seat_env = SeatEnv::enter(project_dir.path());
+
+        // A conflicting $HOME/.khive/config.toml — must NOT win when --db is unset.
+        std::fs::create_dir_all(seat_env._isolated_home.path().join(".khive"))
+            .expect("mkdir home .khive");
+        std::fs::write(
+            seat_env._isolated_home.path().join(".khive/config.toml"),
+            "[runtime]\nbrain_profile = \"home-profile\"\n",
+        )
+        .expect("write home config");
+
+        let resolved = resolve_runtime_config(RuntimeConfigInputs {
+            db: None,
+            config: None,
+            namespace: Namespace::parse("local").expect("ns"),
+            namespace_explicit: false,
+            actor_explicit: false,
+            no_embed: true,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve unset-db config");
+
+        assert_eq!(
+            resolved.brain_profile.as_deref(),
+            Some("cwd-profile"),
+            "unset --db must resolve tier-3 discovery against the project cwd, \
+             not $HOME/.khive/khive.db's directory — got {:?}",
+            resolved.brain_profile
         );
     }
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1108,9 +1108,7 @@ fn merge_entity_sql(
                 let conflict_src = new_src.to_string();
                 let conflict_tgt = new_tgt.to_string();
                 conn.query_row(
-                    "SELECT id FROM graph_edges \
-                     WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
-                     AND relation = ?4 AND id != ?5",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
                     rusqlite::params![
                         &namespace,
                         &conflict_src,
@@ -1128,14 +1126,11 @@ fn merge_entity_sql(
                 // Case (b): a live or soft-deleted row already owns this natural key.
                 // Delete the from-edge and refresh the existing row.
                 conn.execute(
-                    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                     rusqlite::params![&namespace, edge.id.to_string()],
                 )?;
                 conn.execute(
-                    "UPDATE graph_edges SET \
-                     weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                     target_backend = ?3, metadata = ?4 \
-                     WHERE namespace = ?5 AND id = ?6",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
                     rusqlite::params![
                         edge.weight,
                         now_ts,
@@ -1552,9 +1547,7 @@ fn merge_note_sql(
                 let conflict_src = new_src.to_string();
                 let conflict_tgt = new_tgt.to_string();
                 conn.query_row(
-                    "SELECT id FROM graph_edges \
-                     WHERE namespace = ?1 AND source_id = ?2 AND target_id = ?3 \
-                     AND relation = ?4 AND id != ?5",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
                     rusqlite::params![
                         &namespace,
                         &conflict_src,
@@ -1570,14 +1563,11 @@ fn merge_note_sql(
 
             let changed = if let Some(existing_id) = conflict_id {
                 conn.execute(
-                    "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                     rusqlite::params![&namespace, edge.id.to_string()],
                 )?;
                 conn.execute(
-                    "UPDATE graph_edges SET \
-                     weight = ?1, updated_at = ?2, deleted_at = NULL, \
-                     target_backend = ?3, metadata = ?4 \
-                     WHERE namespace = ?5 AND id = ?6",
+                    khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
                     rusqlite::params![
                         edge.weight,
                         now_ts,
@@ -2508,6 +2498,74 @@ mod tests {
         assert!(
             from_store.get_note(from_id).await.unwrap().is_none(),
             "merged-from note should be soft-deleted"
+        );
+    }
+
+    // #690 regression: after routing merge_note's conflict-probe/delete/refresh
+    // arms through the shared khive-db EDGE_SYMMETRIC_*_SQL constants, note merge
+    // must still absorb a conflicting edge natural key exactly as before —
+    // mirrors merge_entity_survives_shared_edge_to_third_party for the note path.
+    #[tokio::test]
+    async fn merge_note_survives_shared_edge_to_third_party() {
+        use khive_storage::EdgeRelation;
+        let rt = rt();
+        let tok = NamespaceToken::local();
+
+        let into = rt
+            .create_note(&tok, "observation", None, "Into", None, None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_note(&tok, "observation", None, "From", None, None, vec![])
+            .await
+            .unwrap();
+        let shared = rt
+            .create_entity(&tok, "concept", None, "Shared", None, None, vec![])
+            .await
+            .unwrap();
+
+        // Both into and from annotate the same shared entity — rewiring from's
+        // edge onto into during merge produces a duplicate (into, shared,
+        // annotates) triple, exercising the conflict-probe/delete/refresh arms.
+        rt.link(&tok, into.id, shared.id, EdgeRelation::Annotates, 1.0, None)
+            .await
+            .unwrap();
+        rt.link(&tok, from.id, shared.id, EdgeRelation::Annotates, 1.0, None)
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_note(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
+            .await
+            .expect("merge must succeed even when both notes annotate the same entity");
+
+        assert_eq!(summary.kept_id, into.id);
+        assert_eq!(summary.removed_id, from.id);
+
+        let into_edges = rt
+            .list_edges(
+                &tok,
+                crate::EdgeListFilter {
+                    source_id: Some(into.id),
+                    target_id: Some(shared.id),
+                    relations: vec![EdgeRelation::Annotates],
+                    ..Default::default()
+                },
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            into_edges.len(),
+            1,
+            "exactly one live into→shared annotates edge must exist after merge; got: {into_edges:?}"
         );
     }
 

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -62,6 +62,13 @@ pub enum ConfigError {
          remove it from the config or wait for a future release that implements it"
     )]
     UnsupportedBackendField { name: String, field: &'static str },
+
+    #[error(
+        "top-level `db = {value:?}` is not a supported config-file key; \
+         use `--db` / `KHIVE_DB` to select a single-file database, or \
+         `[[backends]].path` to declare storage backend topology"
+    )]
+    UnsupportedTopLevelDb { value: String },
 }
 
 // ---- Config structs ----
@@ -235,6 +242,14 @@ pub struct PackConfig {
 /// Unknown keys are silently ignored by serde — forward-compatible.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct KhiveConfig {
+    /// Typed only so a top-level `db` key can be rejected loudly by
+    /// [`KhiveConfig::validate`] instead of being silently ignored as an
+    /// unknown key. Not a supported config-file storage selector: single-file
+    /// database selection is `--db`/`KHIVE_DB`, and storage topology is
+    /// `[[backends]].path`.
+    #[serde(default)]
+    pub db: Option<String>,
+
     /// Embedding engine declarations.
     #[serde(default)]
     pub engines: Vec<EngineConfig>,
@@ -458,6 +473,19 @@ impl KhiveConfig {
     /// Model name validity is checked lazily at runtime (the config loader does
     /// not import `lattice_embed` directly to keep the dep surface minimal).
     pub fn validate(&self) -> Result<(), ConfigError> {
+        // Reject a top-level `db` key loudly (#689) instead of letting serde's
+        // forward-compatible unknown-key tolerance silently swallow it: a config
+        // author who writes `db = "..."` expecting it to select the database
+        // would otherwise get silent divergence from the actual database opened
+        // via `--db`/`KHIVE_DB`.
+        if let Some(value) = self.db.as_deref() {
+            if !value.is_empty() {
+                return Err(ConfigError::UnsupportedTopLevelDb {
+                    value: value.to_string(),
+                });
+            }
+        }
+
         // Validate actor.id when present — an invalid namespace is a startup error,
         // not a silent fallback.
         if let Some(id) = self.actor.id.as_deref() {
@@ -1599,6 +1627,25 @@ journal_mode = "wal"
         assert!(
             matches!(err, ConfigError::UnsupportedBackendField { ref name, field: "journal_mode" } if name == "main"),
             "expected UnsupportedBackendField {{ name: \"main\", field: \"journal_mode\" }}, got {err:?}"
+        );
+    }
+
+    // #689: a top-level `db` key must be rejected loudly at validate() instead
+    // of being silently ignored as an unknown key (serde's forward-compatible
+    // default) — the exact incident class the tier-3 discovery fix closes.
+    #[test]
+    fn test_top_level_db_rejected_at_validate() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_toml(
+            &dir,
+            r#"
+db = "/tmp/scratch/demo.db"
+"#,
+        );
+        let err = KhiveConfig::load(Some(&path)).expect_err("top-level db must be rejected");
+        assert!(
+            matches!(err, ConfigError::UnsupportedTopLevelDb { ref value } if value == "/tmp/scratch/demo.db"),
+            "expected UnsupportedTopLevelDb {{ value: \"/tmp/scratch/demo.db\" }}, got {err:?}"
         );
     }
 }

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -71,7 +71,8 @@ pub use operations::{
     arm_vector_fail, arm_vector_fail_after,
 };
 pub use operations::{
-    merge_entry_metadata, EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved,
+    merge_entry_metadata, EdgeEndpointKind, EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult,
+    Resolved,
 };
 pub use pack::{
     resolve_explicit_namespace, DispatchHook, HandlerDef, KindHook, NoteKindSpec,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -258,6 +258,20 @@ pub enum Resolved {
     },
 }
 
+/// A by-ID edge-endpoint substrate kind, including `Edge` itself.
+///
+/// Unlike [`Resolved`], this carries no record data — it is used where only
+/// the substrate classification is needed (coordinator locate/link parity
+/// with `get`, ADR-002 rule 1: `annotates` target may be entity, note, edge,
+/// or event).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EdgeEndpointKind {
+    Entity,
+    Note,
+    Event,
+    Edge,
+}
+
 /// Map a resolved endpoint to its `(substrate, kind, entity_type)` triple, or
 /// `None` if the substrate is not a valid edge endpoint (events, edges).
 ///
@@ -1540,6 +1554,51 @@ impl KhiveRuntime {
             )));
         }
 
+        Ok(())
+    }
+
+    /// Validate an `annotates` edge relation using pre-located endpoint kinds
+    /// (ADR-029 D3, #674).
+    ///
+    /// Sibling of [`Self::validate_link_endpoints_by_resolved`] for callers that
+    /// only have an [`EdgeEndpointKind`] (entity/note/event/edge) rather than a
+    /// full [`Resolved`] record — the `SubstrateCoordinator`'s cross-backend
+    /// `locate_endpoint` resolves edge-substrate UUIDs too (matching `get`'s
+    /// by-ID resolution order per ADR-002 rule 1), but edges have no `Resolved`
+    /// variant, so `validate_link_endpoints_by_resolved` cannot express them.
+    ///
+    /// `annotates` is the only relation this covers: source must be a note,
+    /// target may be any substrate (entity, note, event, or edge).
+    pub fn validate_annotates_endpoint_kinds(
+        &self,
+        source_id: Uuid,
+        target_id: Uuid,
+        source: Option<EdgeEndpointKind>,
+        target: Option<EdgeEndpointKind>,
+    ) -> RuntimeResult<()> {
+        if source_id == target_id {
+            return Err(RuntimeError::InvalidInput(
+                "self-loop edges are not allowed: source_id and target_id must be different".into(),
+            ));
+        }
+        match source {
+            Some(EdgeEndpointKind::Note) => {}
+            Some(_) => {
+                return Err(RuntimeError::InvalidInput(format!(
+                    "annotates source {source_id} must be a note"
+                )));
+            }
+            None => {
+                return Err(RuntimeError::NotFound(format!(
+                    "link source {source_id} not found"
+                )));
+            }
+        }
+        if target.is_none() {
+            return Err(RuntimeError::NotFound(format!(
+                "link target {target_id} not found"
+            )));
+        }
         Ok(())
     }
 

--- a/crates/kkernel/src/coordinator/dispatch.rs
+++ b/crates/kkernel/src/coordinator/dispatch.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use tokio::task::JoinError;
 use uuid::Uuid;
 
-use khive_runtime::{BackendId, KhiveRuntime, NoteSearchHit, SearchHit};
+use khive_runtime::{
+    BackendId, EdgeEndpointKind, KhiveRuntime, NoteSearchHit, Resolved, SearchHit,
+};
 use khive_score::DeterministicScore;
 use khive_storage::EdgeRelation;
 use khive_types::namespace::Namespace;
@@ -25,6 +27,16 @@ pub struct BackendSearchResult {
     pub hits: Vec<SearchHit>,
     pub note_hits: Vec<NoteSearchHit>,
     pub error: Option<String>,
+}
+
+/// A located edge endpoint: which backend owns it, and its substrate kind.
+///
+/// `kind` lets cross-backend `annotates` validation accept edge-substrate
+/// targets (ADR-002 rule 1) without a second DB round-trip once located.
+#[derive(Clone, Debug)]
+struct LocatedEndpoint {
+    backend_id: BackendId,
+    kind: EdgeEndpointKind,
 }
 
 /// Cross-backend dispatch layer.
@@ -117,11 +129,32 @@ impl SubstrateCoordinator {
     /// is sufficient — the stored namespace is NOT compared to the caller namespace.
     /// The `namespace` parameter is used only for `runtime.authorize()` capability checks.
     ///
-    /// Checks the locator cache first; on a miss, scans all backends concurrently.
-    /// Probes both entity and note substrates.
+    /// Delegates to the private `locate_endpoint`, which resolves in the same
+    /// substrate order as `get` (entity/note/event, then edge — #674), so a
+    /// full-UUID `link` endpoint locates exactly what `get` resolves for the
+    /// same UUID.
     pub async fn locate(&self, id: Uuid, namespace: &Namespace) -> Option<BackendId> {
+        self.locate_endpoint(id, namespace)
+            .await
+            .map(|e| e.backend_id)
+    }
+
+    /// Resolve which backend owns the substrate node identified by `id`,
+    /// together with its endpoint kind (entity, note, event, or edge).
+    ///
+    /// Namespace-agnostic per ADR-007 Rev 3, same contract as [`Self::locate`].
+    /// Checks the locator cache first; on a miss, scans all backends concurrently.
+    /// Resolves in the same substrate order as `get` (ADR-002 rule 1 parity,
+    /// #674): entity/note/event via `resolve_edge_endpoint`, then edge via
+    /// `get_edge`.
+    async fn locate_endpoint(&self, id: Uuid, namespace: &Namespace) -> Option<LocatedEndpoint> {
         if let Some(backend_id) = self.locator.get(id) {
-            return Some(backend_id);
+            let runtime = self
+                .registry
+                .get(&backend_id)
+                .map(|e| Arc::clone(&e.runtime))?;
+            let kind = Self::probe_endpoint_kind(&runtime, namespace, id).await?;
+            return Some(LocatedEndpoint { backend_id, kind });
         }
 
         let entries: Vec<(BackendId, Arc<KhiveRuntime>)> = self
@@ -136,32 +169,12 @@ impl SubstrateCoordinator {
 
         if entries.len() == 1 {
             let (backend_id, runtime) = &entries[0];
-            let token = match runtime.authorize(namespace.clone()) {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!(error = %e, "locate: authorization denied for namespace");
-                    return None;
-                }
-            };
-            // ADR-007 Rev 3: presence on this backend is sufficient.
-            // Do NOT filter by stored record namespace.
-            let entity_owned = match runtime.entities(&token) {
-                Ok(store) => store.get_entity(id).await.ok().flatten().is_some(),
-                Err(_) => false,
-            };
-            if entity_owned {
-                self.locator.insert(id, backend_id.clone());
-                return Some(backend_id.clone());
-            }
-            let note_owned = match runtime.notes(&token) {
-                Ok(store) => store.get_note(id).await.ok().flatten().is_some(),
-                Err(_) => false,
-            };
-            if note_owned {
-                self.locator.insert(id, backend_id.clone());
-                return Some(backend_id.clone());
-            }
-            return None;
+            let kind = Self::probe_endpoint_kind(runtime, namespace, id).await?;
+            self.locator.insert(id, backend_id.clone());
+            return Some(LocatedEndpoint {
+                backend_id: backend_id.clone(),
+                kind,
+            });
         }
 
         let ns_clone = namespace.clone();
@@ -172,40 +185,60 @@ impl SubstrateCoordinator {
             let ns = ns_clone.clone();
             let locator = Arc::clone(&locator);
             let handle = tokio::spawn(async move {
-                let token = match runtime.authorize(ns.clone()) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "locate: authorization denied for namespace");
-                        return None;
-                    }
-                };
-                // ADR-007 Rev 3: presence on this backend is sufficient.
-                // Do NOT filter by stored record namespace.
-                if let Ok(store) = runtime.entities(&token) {
-                    if let Ok(Some(_)) = store.get_entity(id).await {
-                        locator.insert(id, backend_id.clone());
-                        return Some(backend_id);
-                    }
-                }
-                if let Ok(store) = runtime.notes(&token) {
-                    if let Ok(Some(_)) = store.get_note(id).await {
-                        locator.insert(id, backend_id.clone());
-                        return Some(backend_id);
-                    }
-                }
-                None
+                let kind = Self::probe_endpoint_kind(&runtime, &ns, id).await?;
+                locator.insert(id, backend_id.clone());
+                Some(LocatedEndpoint { backend_id, kind })
             });
             handles.push(handle);
         }
 
-        let results: Vec<Result<Option<BackendId>, JoinError>> =
+        let results: Vec<Result<Option<LocatedEndpoint>, JoinError>> =
             futures_util::future::join_all(handles).await;
         for result in results {
-            if let Ok(Some(backend_id)) = result {
-                return Some(backend_id);
+            if let Ok(Some(located)) = result {
+                return Some(located);
             }
         }
         None
+    }
+
+    /// Probe a single backend for `id`'s substrate kind, authorizing for
+    /// `namespace` first.
+    ///
+    /// ADR-007 Rev 3: presence on this backend is sufficient — the stored
+    /// record namespace is NOT compared to the caller namespace. Mirrors the
+    /// by-ID resolution order `get` uses: entity/note/event first
+    /// (`resolve_edge_endpoint`), then edge (`get_edge`).
+    async fn probe_endpoint_kind(
+        runtime: &Arc<KhiveRuntime>,
+        namespace: &Namespace,
+        id: Uuid,
+    ) -> Option<EdgeEndpointKind> {
+        let token = match runtime.authorize(namespace.clone()) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "locate_endpoint: authorization denied for namespace");
+                return None;
+            }
+        };
+        match runtime.resolve_edge_endpoint(&token, id).await {
+            Ok(Some(Resolved::Entity(_))) => return Some(EdgeEndpointKind::Entity),
+            Ok(Some(Resolved::Note(_))) => return Some(EdgeEndpointKind::Note),
+            Ok(Some(Resolved::Event(_))) => return Some(EdgeEndpointKind::Event),
+            Ok(Some(Resolved::PackRecord { .. })) | Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "locate_endpoint: resolve_edge_endpoint failed");
+                return None;
+            }
+        }
+        match runtime.get_edge(&token, id).await {
+            Ok(Some(_)) => Some(EdgeEndpointKind::Edge),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(error = %e, "locate_endpoint: get_edge failed");
+                None
+            }
+        }
     }
 
     /// Prewarm the locator cache after a successful create.
@@ -241,14 +274,17 @@ impl SubstrateCoordinator {
         weight: f64,
         metadata: Option<serde_json::Value>,
     ) -> Result<khive_storage::Edge, String> {
-        let src_backend = self
-            .locate(source_id, namespace)
+        let src_located = self
+            .locate_endpoint(source_id, namespace)
             .await
             .ok_or_else(|| format!("node {source_id} not found on any backend"))?;
-        let tgt_backend = self
-            .locate(target_id, namespace)
+        let tgt_located = self
+            .locate_endpoint(target_id, namespace)
             .await
             .ok_or_else(|| format!("node {target_id} not found on any backend"))?;
+
+        let src_backend = src_located.backend_id.clone();
+        let tgt_backend = tgt_located.backend_id.clone();
 
         let src_runtime = self
             .registry
@@ -268,8 +304,22 @@ impl SubstrateCoordinator {
                 .validate_link_endpoints(&token, source_id, target_id, relation)
                 .await
                 .map_err(|e| e.to_string())?;
+        } else if relation == EdgeRelation::Annotates {
+            // Cross-backend annotates: `locate_endpoint` already resolved each
+            // endpoint's substrate kind using the same by-ID order `get` uses
+            // (ADR-002 rule 1 parity, #674), including edge-substrate targets
+            // that `resolve_primary`/`Resolved` cannot express — no extra
+            // cross-backend DB lookup is needed.
+            src_runtime
+                .validate_annotates_endpoint_kinds(
+                    source_id,
+                    target_id,
+                    Some(src_located.kind),
+                    Some(tgt_located.kind),
+                )
+                .map_err(|e| e.to_string())?;
         } else {
-            // Cross-backend: the target entity lives on a different backend so the source
+            // Cross-backend, non-annotates: the target entity lives on a different backend so the source
             // runtime cannot resolve it via its own DB. Fetch each endpoint from its
             // respective backend and validate the ADR-002 kind-pairing rules using the
             // pre-fetched records (no cross-backend DB lookup required).

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -32,8 +32,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 
 use khive_mcp::serve::{
-    apply_env_output_format, build_server_multi_backend, enforce_strict_actor_mode,
-    resolve_runtime_config, RuntimeConfigInputs,
+    apply_env_output_format, build_server_multi_backend, config_discovery_db_anchor,
+    enforce_strict_actor_mode, resolve_runtime_config, RuntimeConfigInputs,
 };
 #[cfg(unix)]
 use khive_mcp::server::compute_config_id;
@@ -506,8 +506,13 @@ async fn run_exec_inline_with_forward(
     // topology (further below) resolve from the identical TOML file the
     // daemon's own boot path loads (`serve.rs`'s `build_server`:
     // `KhiveConfig::load_with_home_fallback(args.config.as_deref(),
-    // config.db_path.as_deref())` — `kkernel exec` has no `--config` flag, so
-    // the first argument here is always `None`, exactly like there).
+    // config_discovery_db_anchor(args.db.as_deref()).as_deref())` —
+    // `kkernel exec` has no `--config` flag, so the first argument here is
+    // always `None`, exactly like there. The second argument is the raw
+    // `--db`/`KHIVE_DB` discovery anchor (`None` unless `--db` was set) rather
+    // than `cfg.db_path` — `cfg.db_path` materializes the `$HOME/.khive`
+    // default when `--db` is unset (#689), which would incorrectly re-anchor
+    // tier-3 discovery away from the process cwd.
     //
     // Fixes the config_id topology-drift bug: the forward frame below used to
     // always fold `None` here, while the daemon folds `Some(&khive_cfg)`
@@ -517,7 +522,8 @@ async fn run_exec_inline_with_forward(
     // diverged, so a correctly-configured client was rejected as a
     // `ConfigMismatch` and silently fell back to the cold in-process path on
     // every call.
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, cfg.db_path.as_deref())
+    let db_path_for_config = config_discovery_db_anchor(db.as_deref());
+    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
         .unwrap_or_default();
 
@@ -672,7 +678,8 @@ async fn run_exec_ops_file(
     // `[[backends]]` multi-backend topology exactly like the daemon-fallback
     // path — see `build_local_fallback_server`.
     enforce_strict_actor_mode(cfg.actor_id.as_deref(), &cfg.packs)?;
-    let khive_cfg = KhiveConfig::load_with_home_fallback(None, cfg.db_path.as_deref())
+    let db_path_for_config = config_discovery_db_anchor(db.as_deref());
+    let khive_cfg = KhiveConfig::load_with_home_fallback(None, db_path_for_config.as_deref())
         .map_err(|e| anyhow::anyhow!("config error: {e}"))?
         .unwrap_or_default();
 

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -1115,4 +1115,159 @@ mod tests {
             "error must name the canonical anchor path: {msg}"
         );
     }
+
+    // --- #674: coordinator link-target resolution parity with `get` ---
+
+    /// Regression for #674: a full-UUID `link(..., relation="annotates")` whose
+    /// target is an edge-substrate UUID must succeed on the coordinator-attached
+    /// multi-backend boot path, exactly like `get(<edge_uuid>)` does.
+    ///
+    /// Reproduces the production topology from the issue: two backends (`main`
+    /// plus `sessions`), with the `session` pack bound to `sessions` while `kg`
+    /// falls back to `main`. That pack-to-backend split is what engages the
+    /// `SubstrateCoordinator` for `kg` verbs (`build_multi_backend_server_with_coordinator`,
+    /// not the coordinator-less `khive_mcp::serve::build_server_multi_backend`) —
+    /// a single-backend or unsplit config does not reproduce the bug.
+    ///
+    /// Before the fix, the coordinator's node locator only probed entity and
+    /// note substrates, so `link(note, <edge_uuid>, annotates)` failed with
+    /// "node <uuid> not found on any backend" even though `get(<edge_uuid>)`
+    /// resolved the same UUID.
+    #[tokio::test]
+    async fn coordinator_link_annotates_resolves_edge_target_like_get() {
+        use khive_mcp::tools::request::RequestParams;
+        use khive_runtime::PackConfig;
+
+        let khive_cfg = KhiveConfig {
+            backends: vec![
+                khive_runtime::BackendConfig {
+                    name: "main".to_string(),
+                    kind: khive_runtime::BackendKind::Memory,
+                    path: None,
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+                khive_runtime::BackendConfig {
+                    name: "sessions".to_string(),
+                    kind: khive_runtime::BackendKind::Memory,
+                    path: None,
+                    cache_mb: None,
+                    journal_mode: None,
+                    read_only: false,
+                },
+            ],
+            packs: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "session".to_string(),
+                    PackConfig {
+                        backend: "sessions".to_string(),
+                    },
+                );
+                m
+            },
+            ..KhiveConfig::default()
+        };
+
+        let base_cfg = RuntimeConfig {
+            packs: vec!["kg".to_string(), "session".to_string()],
+            ..base_multi_backend_runtime_config()
+        };
+
+        let server = build_multi_backend_server_with_coordinator(base_cfg, &khive_cfg, None)
+            .expect("coordinator-attached multi-backend boot must succeed");
+
+        let dispatch = |ops: String| {
+            let server = &server;
+            async move {
+                // "verbose" presentation: the bug is specifically about
+                // full-UUID `link` endpoints (issue #674) — the default
+                // "agent" presentation truncates ids, which would silently
+                // route around the coordinator's full-UUID-only interception.
+                let resp = server
+                    .dispatch_request_local(RequestParams {
+                        ops,
+                        presentation: Some("verbose".to_string()),
+                        presentation_per_op: None,
+                        save_to: None,
+                        format: None,
+                        format_per_op: None,
+                    })
+                    .await
+                    .expect("dispatch must not error");
+                serde_json::from_str::<serde_json::Value>(&resp).expect("valid JSON")
+            }
+        };
+
+        // Two concepts + a link between them to create an edge.
+        let a = dispatch(r#"create(kind="concept", name="edge-endpoint-a")"#.to_string()).await;
+        let a_id = a["results"][0]["result"]["id"]
+            .as_str()
+            .expect("create must return an id")
+            .to_string();
+        let b = dispatch(r#"create(kind="concept", name="edge-endpoint-b")"#.to_string()).await;
+        let b_id = b["results"][0]["result"]["id"]
+            .as_str()
+            .expect("create must return an id")
+            .to_string();
+        let edge_resp = dispatch(format!(
+            r#"link(source_id="{a_id}", target_id="{b_id}", relation="extends")"#
+        ))
+        .await;
+        assert_eq!(
+            edge_resp["results"][0]["ok"].as_bool(),
+            Some(true),
+            "seed edge creation must succeed: {edge_resp}"
+        );
+        let edge_id = edge_resp["results"][0]["result"]["id"]
+            .as_str()
+            .expect("link must return an edge id")
+            .to_string();
+
+        // A note to use as the annotates source.
+        let note_resp =
+            dispatch(r#"create(kind="observation", content="annotates source")"#.to_string()).await;
+        let note_id = note_resp["results"][0]["result"]["id"]
+            .as_str()
+            .expect("create must return an id")
+            .to_string();
+
+        // Parity check #1: `get` resolves the edge-substrate UUID.
+        let got_edge = dispatch(format!(r#"get(id="{edge_id}")"#)).await;
+        assert_eq!(
+            got_edge["results"][0]["ok"].as_bool(),
+            Some(true),
+            "get(<edge_uuid>) must succeed: {got_edge}"
+        );
+        assert_eq!(
+            got_edge["results"][0]["result"]["kind"].as_str(),
+            Some("edge"),
+            "get must resolve the UUID as an edge: {got_edge}"
+        );
+
+        // Parity check #2 (the regression): note -> edge `annotates` link
+        // through the coordinator-attached multi-backend path must succeed
+        // too, resolving the exact same UUID `get` just resolved above.
+        let annotate_resp = dispatch(format!(
+            r#"link(source_id="{note_id}", target_id="{edge_id}", relation="annotates")"#
+        ))
+        .await;
+        assert_eq!(
+            annotate_resp["results"][0]["ok"].as_bool(),
+            Some(true),
+            "note->edge annotates link must succeed, proving get/link resolution parity \
+             for an edge-substrate UUID under multi-backend pack bindings: {annotate_resp}"
+        );
+
+        // Parity assertion: the `annotates` link's written target_id is
+        // exactly the same UUID `get` resolved as kind=edge above — `get`
+        // and `link` endpoint resolution agree for an edge-substrate UUID.
+        assert_eq!(
+            annotate_resp["results"][0]["result"]["target_id"].as_str(),
+            got_edge["results"][0]["result"]["id"].as_str(),
+            "link's resolved annotates target must be the exact same edge UUID get() resolved: \
+             annotate_resp={annotate_resp} got_edge={got_edge}"
+        );
+    }
 }

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -257,15 +257,17 @@ async fn main() -> Result<()> {
 
             // Check if multi-backend is configured (ADR-028 / ADR-029 Phase 2).
             //
-            // Resolve `db_path` with the SAME precedence as `resolve_runtime_config`
-            // below (`:memory:` -> no file to anchor on; explicit `--db`/`KHIVE_DB`
-            // -> that path; unset -> the default `$HOME/.khive/khive.db`) so this
-            // early multi-backend classification anchors tier-3 project-local config
-            // discovery to the identical directory the per-request `config_id` path
-            // uses. Anchoring only the explicit case and leaving the default case on
-            // the process cwd would let this branch select a different topology than
-            // the config the server actually resolves further down this path.
-            let db_path_hint = khive_runtime::resolve_db_anchor(a.db.as_deref());
+            // Resolve the tier-3 discovery anchor with the SAME
+            // `config_discovery_db_anchor` semantics `resolve_runtime_config`
+            // below uses (explicit `--db`/`KHIVE_DB` -> that path; unset ->
+            // `None`, falling through to cwd-anchored discovery) so this early
+            // multi-backend classification sees the identical config file the
+            // per-request `config_id` path resolves further down (#689: using
+            // `resolve_db_anchor`'s materialized `$HOME/.khive/khive.db`
+            // default here anchored classification to the home directory
+            // instead of the project, silently skipping a project-local
+            // `.khive/config.toml`).
+            let db_path_hint = khive_mcp::serve::config_discovery_db_anchor(a.db.as_deref());
             let khive_cfg =
                 KhiveConfig::load_with_home_fallback(a.config.as_deref(), db_path_hint.as_deref())
                     .unwrap_or_default()

--- a/crates/kkernel/tests/config_discovery_reload_anchor.rs
+++ b/crates/kkernel/tests/config_discovery_reload_anchor.rs
@@ -1,0 +1,153 @@
+//! Regression test for #689 (residual, attempt 2): post-resolution config
+//! reloads must anchor tier-3 discovery to the fixed `config_discovery_db_anchor`
+//! semantics (`None`/cwd for an unset `--db`), never to `$HOME`.
+//!
+//! Play-gate repro shape this test encodes: a cwd `.khive/config.toml` declares
+//! two `[[backends]]` and `--db` is left unset. Before the fix, the
+//! post-resolution reloads at `exec.rs`'s `run_exec_inline_with_forward` /
+//! `run_exec_ops_file` and `serve.rs`'s `build_server` fed the materialized
+//! `$HOME/.khive/khive.db` default back into `KhiveConfig::load_with_home_fallback`,
+//! so tier-3 discovery searched `$HOME/.khive/config.toml` instead of the cwd
+//! project config — the cwd-declared backends were invisible, and the run fell
+//! back to a single, home-anchored default database.
+//!
+//! This test isolates both `HOME` and the process cwd in a dedicated temp dir
+//! each, so it asserts on ACTUAL backend-file creation (not just a resolved,
+//! non-empty `KhiveConfig`): the fixed behavior must create both declared
+//! backend files under the project dir and must NOT create
+//! `$HOME/.khive/khive.db`.
+//!
+//! Lives as its own integration-test binary (rather than inside `exec.rs`'s
+//! `#[cfg(test)] mod tests`) because it mutates the process-wide cwd via
+//! `std::env::set_current_dir` — isolating that mutation to a dedicated test
+//! binary avoids any risk of it leaking into unrelated cwd-sensitive tests
+//! that run concurrently within `kkernel`'s unit-test binary.
+
+use std::path::PathBuf;
+
+use kkernel::exec::{run_exec, ExecArgs};
+use serial_test::serial;
+
+/// Snapshot + restore guard for the ambient process state this test mutates
+/// (`HOME` and cwd). Restoring via `Drop` keeps the host process clean even
+/// if an assertion panics partway through.
+struct EnvGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_cwd: PathBuf,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        // Best-effort: if the original cwd no longer exists for some reason,
+        // there is nothing sane left to restore to.
+        let _ = std::env::set_current_dir(&self.prev_cwd);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn unset_db_with_cwd_multi_backend_config_creates_configured_backends_not_home_default() {
+    let prev_home = std::env::var_os("HOME");
+    let prev_cwd = std::env::current_dir().expect("read current cwd");
+    let guard = EnvGuard {
+        prev_home,
+        prev_cwd,
+    };
+
+    // Ambient env vars that could otherwise influence config/actor/embedding
+    // resolution and mask the bug this test targets.
+    std::env::remove_var("KHIVE_DB");
+    std::env::remove_var("KHIVE_CONFIG");
+    std::env::remove_var("KHIVE_EMBEDDING_MODEL");
+    std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+    std::env::remove_var("KHIVE_ACTOR");
+    std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+    std::env::remove_var("KHIVE_BRAIN_PROFILE");
+    std::env::remove_var("KHIVE_OUTPUT_FORMAT");
+    std::env::remove_var("KHIVE_PACKS");
+    // Force in-process dispatch — no reliance on a warm/absent daemon socket.
+    std::env::set_var("KHIVE_NO_DAEMON", "1");
+
+    // Isolated HOME: must remain untouched by the run (no `.khive` created here).
+    let home_dir = tempfile::tempdir().expect("tempdir for isolated HOME");
+    std::env::set_var("HOME", home_dir.path());
+
+    // Isolated project dir: this becomes the process cwd, and hosts the
+    // multi-backend `.khive/config.toml` the fixed tier-3 discovery must find.
+    let project_dir = tempfile::tempdir().expect("tempdir for isolated project cwd");
+    let khive_dir = project_dir.path().join(".khive");
+    std::fs::create_dir_all(&khive_dir).expect("mkdir project .khive");
+
+    let main_backend_path = khive_dir.join("main.db");
+    let sessions_backend_path = khive_dir.join("sessions.db");
+    std::fs::write(
+        khive_dir.join("config.toml"),
+        format!(
+            r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{}"
+
+[[backends]]
+name = "sessions"
+kind = "sqlite"
+path = "{}"
+"#,
+            main_backend_path.display(),
+            sessions_backend_path.display(),
+        ),
+    )
+    .expect("write multi-backend config.toml");
+
+    std::env::set_current_dir(project_dir.path()).expect("chdir into isolated project dir");
+
+    let args = ExecArgs {
+        ops: Some("stats()".to_string()),
+        pending_events: false,
+        db: None, // the repro shape: --db left unset
+        namespace: "local".to_string(),
+        presentation: Some("agent".to_string()),
+        output_format: None,
+        verbose: false,
+        save_file: None,
+        ops_file: None,
+        dry_run: false,
+        atomic: false,
+        atomic_max_ops: None,
+    };
+
+    let result = run_exec(args).await;
+
+    let home_default_db = home_dir.path().join(".khive").join("khive.db");
+
+    assert!(
+        result.is_ok(),
+        "kkernel exec 'stats()' with an unset --db and a cwd multi-backend config \
+         must succeed (RC=0 equivalent): {result:?}"
+    );
+    assert!(
+        main_backend_path.exists(),
+        "configured `main` backend file must be created at {} — tier-3 config \
+         discovery must have anchored to the cwd project config, not $HOME",
+        main_backend_path.display()
+    );
+    assert!(
+        sessions_backend_path.exists(),
+        "configured `sessions` backend file must be created at {} — tier-3 config \
+         discovery must have anchored to the cwd project config, not $HOME",
+        sessions_backend_path.display()
+    );
+    assert!(
+        !home_default_db.exists(),
+        "the $HOME/.khive/khive.db fallback must NOT be created when a cwd config \
+         declares [[backends]] and --db is unset — found {}",
+        home_default_db.display()
+    );
+
+    drop(guard);
+}


### PR DESCRIPTION
Fixes three storage/config defects:

- **#674**: \`link(note→edge, annotates)\` failed with "node not found on any backend" on multi-backend coordinator topologies (two sqlite backends + pack-bound backend). Edge-substrate targets are now resolved via an endpoint-kind path instead of the node-only resolver; \`get\`/\`link\` resolution parity for edge UUIDs. Regression test builds the coordinator-attached two-backend shape and proves the failure mode.
- **#689**: tier-3 config reload sites anchored discovery to \`$HOME\` instead of the config-discovery anchor (cwd/None), and a top-level \`db =\` key vanished into serde unknown-key tolerance. All reload sites now thread \`config_discovery_db_anchor\`; top-level \`db\` is rejected loudly at validate. Env-isolated integration test asserts actual backend-file creation under the project config with no \`$HOME\` fallback.
- **#690**: curation merge SQL routed through the shared conflict-arm builder (from #683); text-identical SQL, no behavior change, note-merge conflict regression added.

Closes #674, closes #689, closes #690.