### PR TITLE
fix(brain): resolve tier-2 actor+namespace bindings on the feedback path

### DIFF
--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -107,20 +107,29 @@ pub struct ProfileBinding {
     pub created_at: DateTime<Utc>,
 }
 
-/// Resolve the effective profile for a `(namespace, consumer_kind)` pair via
-/// the brain pack's tier-2 binding table. Returns `None` unless `brain.resolve`
-/// reports `matched_binding=true` — the system-default fallback profile it
-/// returns otherwise must not be mistaken for an explicit binding, or each
-/// pack's tier-3 (global tuning prior) would become unreachable.
+/// Resolve the effective profile for an `(actor, namespace, consumer_kind)`
+/// triple via the brain pack's tier-2 binding table. Returns `None` unless
+/// `brain.resolve` reports `matched_binding=true` — the system-default
+/// fallback profile it returns otherwise must not be mistaken for an explicit
+/// binding, or each pack's tier-3 (global tuning prior) would become
+/// unreachable.
+///
+/// `actor` should be the caller's identity (e.g. `NamespaceToken::actor().id`)
+/// so actor-scoped bindings can match; pass `None` only when the call site has
+/// no caller identity to thread through (wildcard `actor="*"` bindings still
+/// match in that case).
 ///
 /// Shared by the memory pack (`ConsumerKind::Recall`) and the knowledge pack
-/// (`ConsumerKind::KnowledgeCompose`) — ADR-058 amendment, #542.
+/// (`ConsumerKind::KnowledgeCompose`) — ADR-058 amendment, #542; actor-aware
+/// resolution added by #697.
 pub async fn resolve_consumer_profile(
     registry: &khive_runtime::VerbRegistry,
+    actor: Option<&str>,
     namespace: &str,
     consumer_kind: ConsumerKind,
 ) -> Option<String> {
     let resolve_params = serde_json::json!({
+        "actor": actor,
         "namespace": namespace,
         "consumer_kind": consumer_kind.as_str(),
     });

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -21,8 +21,8 @@ use khive_brain_core::derive_deterministic_weights;
 #[cfg(feature = "lattice-router")]
 use khive_brain_core::BetaPosterior;
 use khive_brain_core::{
-    FeedbackEventKind, ProfileBinding, ProfileLifecycle, ProfileRecord, SectionPosteriorState,
-    SectionType, DEFAULT_ESS_CAP,
+    ConsumerKind, FeedbackEventKind, ProfileBinding, ProfileLifecycle, ProfileRecord,
+    SectionPosteriorState, SectionType, DEFAULT_ESS_CAP,
 };
 
 // ── Adapter revision sentinel ─────────────────────────────────────────────────
@@ -969,6 +969,36 @@ impl BrainPack {
         .await
     }
 
+    /// Resolve the effective serving profile for feedback attribution
+    /// (ADR-035 tiers 1-2, #697): explicit `served_by_profile_id` wins outright;
+    /// otherwise resolve an actor+namespace-scoped binding via the same
+    /// `resolve_with_match` table `brain.resolve` uses, before falling back to
+    /// the system default. `brain.auto_feedback` forwards into `handle_feedback`
+    /// unresolved so it inherits this without duplicating the logic.
+    ///
+    /// Consumer kind is fixed to `recall`: feedback routed directly through
+    /// `brain.feedback`/`brain.auto_feedback` (as opposed to `memory.feedback`,
+    /// which resolves its own tier and passes an explicit profile) always
+    /// originates from the recall serve loop, so it must resolve against the
+    /// same binding bucket the serve path used.
+    fn resolve_effective_feedback_profile(
+        &self,
+        token: &NamespaceToken,
+        explicit: Option<&str>,
+    ) -> String {
+        if let Some(profile_id) = explicit {
+            return profile_id.to_string();
+        }
+        let actor = token.actor().id.as_str();
+        let namespace = token.namespace().as_str();
+        let state = self.state.lock().unwrap();
+        match state.resolve_with_match(Some(actor), Some(namespace), ConsumerKind::Recall.as_str())
+        {
+            Some((record, _matched_kind, true)) => record.id.clone(),
+            _ => "balanced-recall-v1".to_string(),
+        }
+    }
+
     // ── brain.feedback ────────────────────────────────────────────────────
 
     pub(crate) async fn handle_feedback(
@@ -1046,12 +1076,12 @@ impl BrainPack {
             }
         }
 
-        // Compute the effective serving profile (explicit or default), then validate
-        // that it exists in the registry and is not Archived.
-        let effective_profile = p
-            .served_by_profile_id
-            .as_deref()
-            .unwrap_or("balanced-recall-v1");
+        // Compute the effective serving profile (explicit, else a matching
+        // actor+namespace binding, else the system default — #697), then
+        // validate that it exists in the registry and is not Archived.
+        let effective_profile =
+            self.resolve_effective_feedback_profile(token, p.served_by_profile_id.as_deref());
+        let effective_profile = effective_profile.as_str();
         {
             let state = self.state.lock().unwrap();
             match state.profiles.get(effective_profile) {
@@ -1267,11 +1297,7 @@ impl BrainPack {
             event
         };
 
-        let serving_profile_owned = p
-            .served_by_profile_id
-            .as_deref()
-            .unwrap_or("balanced-recall-v1")
-            .to_string();
+        let serving_profile_owned = effective_profile.to_string();
 
         let brain_signal = interpret(&event);
 

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2136,6 +2136,251 @@ async fn r2_user_profile_feedback_routes_to_profile_state() {
     );
 }
 
+// ── #697: feedback-path tier-2 binding resolution ─────────────────────────
+
+/// Build a runtime whose minted tokens carry a configured actor identity
+/// (rather than `ActorRef::anonymous()`), so actor-scoped bindings can match.
+fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
+    let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+        db_path: None,
+        packs: vec!["kg".to_string()],
+        actor_id: Some(actor_id.to_string()),
+        ..khive_runtime::RuntimeConfig::default()
+    })
+    .expect("in-memory runtime with actor");
+    let pack = BrainPack::new(rt.clone());
+    (pack, rt)
+}
+
+/// #697 (a): feedback without an explicit `served_by_profile_id` but with a
+/// matching actor binding must attribute to the bound profile — not
+/// balanced-recall-v1 — and must leave the default profile's posteriors untouched.
+#[tokio::test]
+async fn feedback_697_unattributed_resolves_via_actor_binding() {
+    let (pack, rt) = make_pack_with_actor("leo");
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    assert_eq!(
+        token.actor().id,
+        "leo",
+        "test setup: token must carry the configured actor"
+    );
+
+    let target = create_test_entity(&rt, &token).await;
+
+    pack.dispatch(
+        "brain.create_profile",
+        json!({"name": "leo-bound-v1", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    pack.dispatch(
+        "brain.activate",
+        json!({"profile_id": "leo-bound-v1"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    // Bind by actor only (namespace left as the "*" wildcard) — a
+    // namespace-only resolution (pre-#697) can never reach this binding.
+    pack.dispatch(
+        "brain.bind",
+        json!({"actor": "leo", "profile_id": "leo-bound-v1", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let default_before = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+
+    // No served_by_profile_id supplied.
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "useful"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let bound_after = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "leo-bound-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        bound_after, 1,
+        "unattributed feedback with a matching actor binding must land on the bound profile"
+    );
+
+    let default_after = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        default_after, default_before,
+        "the default profile's posteriors must be untouched when a binding resolves the event elsewhere"
+    );
+}
+
+/// #697 (b): feedback with neither an explicit profile nor any matching
+/// binding still defaults to balanced-recall-v1 — existing behavior preserved.
+#[tokio::test]
+async fn feedback_697_unattributed_no_binding_falls_back_to_default() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let target = create_test_entity(&rt, &token).await;
+
+    let default_before = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "useful"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let default_after = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        default_after,
+        default_before + 1,
+        "feedback with no binding and no explicit profile must still credit balanced-recall-v1"
+    );
+}
+
+/// #697 (d): an explicit `served_by_profile_id` always wins over a matching
+/// actor binding.
+#[tokio::test]
+async fn feedback_697_explicit_profile_overrides_actor_binding() {
+    let (pack, rt) = make_pack_with_actor("leo");
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let target = create_test_entity(&rt, &token).await;
+
+    pack.dispatch(
+        "brain.create_profile",
+        json!({"name": "leo-bound-v2", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    pack.dispatch(
+        "brain.activate",
+        json!({"profile_id": "leo-bound-v2"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    pack.dispatch(
+        "brain.bind",
+        json!({"actor": "leo", "profile_id": "leo-bound-v2", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    // Explicit param names balanced-recall-v1 even though "leo" has a binding.
+    pack.dispatch(
+        "brain.feedback",
+        json!({
+            "target_id": target,
+            "signal": "useful",
+            "served_by_profile_id": "balanced-recall-v1",
+        }),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let bound_events = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "leo-bound-v2"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        bound_events, 0,
+        "explicit served_by_profile_id must override an actor binding, not merely supplement it"
+    );
+
+    let default_events = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        default_events, 1,
+        "explicit served_by_profile_id must be honored"
+    );
+}
+
 // H4: brain.profile accepts profile_id (canonical) and id (alias).
 #[tokio::test]
 async fn w4_h4_profile_accepts_profile_id_and_id_alias() {

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2141,11 +2141,22 @@ async fn r2_user_profile_feedback_routes_to_profile_state() {
 /// Build a runtime whose minted tokens carry a configured actor identity
 /// (rather than `ActorRef::anonymous()`), so actor-scoped bindings can match.
 fn make_pack_with_actor(actor_id: &str) -> (BrainPack, KhiveRuntime) {
+    // Mirror KhiveRuntime::memory() exactly (in-memory db, NO embedding model)
+    // plus a configured actor. `..RuntimeConfig::default()` is a CI trap: the
+    // Default impl resolves embedding_model to a real on-disk model, which is
+    // absent on CI runners and fails entity creation with ModelInitialization.
     let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
         db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
         packs: vec!["kg".to_string()],
+        backend_id: khive_runtime::BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
         actor_id: Some(actor_id.to_string()),
-        ..khive_runtime::RuntimeConfig::default()
     })
     .expect("in-memory runtime with actor");
     let pack = BrainPack::new(rt.clone());

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -396,9 +396,14 @@ impl KnowledgePack {
         // Use "knowledge_compose" (not "recall") — the knowledge pack's compose-ranking
         // feedback has its own consumer_kind bucket (ADR-058 amendment, #542) so it no
         // longer shares posteriors with the memory pack's recall bucket.
+        //
+        // actor=None: this path does not thread the caller's actor identity through
+        // (unlike the memory pack's recall path, fixed by #697), so actor-scoped
+        // knowledge_compose bindings cannot match here yet — only namespace/wildcard
+        // bindings do. Tracked as a known gap, not fixed by #697 (out of that issue's scope).
         if let Some(ref tid) = target_id_str {
             if let Some(profile_id) =
-                resolve_consumer_profile(registry, &ns, ConsumerKind::KnowledgeCompose).await
+                resolve_consumer_profile(registry, None, &ns, ConsumerKind::KnowledgeCompose).await
             {
                 let brain_params = json!({
                     "namespace": ns,
@@ -457,8 +462,10 @@ impl KnowledgePack {
         }
 
         // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
+        // actor=None: see the identical note in record_feedback above — this read-side
+        // resolution shares the same not-yet-actor-aware seam, tracked as a known gap.
         if let Some(profile_id) =
-            resolve_consumer_profile(registry, &ns, ConsumerKind::KnowledgeCompose).await
+            resolve_consumer_profile(registry, None, &ns, ConsumerKind::KnowledgeCompose).await
         {
             if let Some(weights) = load_profile_type_weights(registry, &profile_id).await {
                 return weights;

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -123,8 +123,8 @@ pub(super) fn parse_fusion_strategy_str(s: &str) -> Result<FusionStrategy, Runti
 }
 
 /// Resolve the serving profile via ADR-035 tiers 1-2 only (explicit config,
-/// then namespace-bound `brain.resolve(consumer_kind="recall")`). Shared by
-/// `memory.feedback` (which falls through to its own tier-3 global-prior
+/// then actor+namespace-bound `brain.resolve(consumer_kind="recall")`). Shared
+/// by `memory.feedback` (which falls through to its own tier-3 global-prior
 /// behavior on `None`) and `memory.recall`'s ADR-081 §5 serve-time stamp
 /// (which simply omits the stamp on `None`) — extracted so the two resolution
 /// paths cannot drift apart.
@@ -137,8 +137,12 @@ pub(super) async fn resolve_serving_profile(
         return Some(profile_id.clone());
     }
     let ns = token.namespace().as_str().to_string();
+    // #697: thread the caller's actor identity through so actor-scoped
+    // bindings match, not just namespace-scoped ones.
+    let actor = token.actor().id.as_str();
     khive_brain_core::resolve_consumer_profile(
         registry,
+        Some(actor),
         &ns,
         khive_brain_core::ConsumerKind::Recall,
     )

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1047,6 +1047,159 @@ mod tests {
         );
     }
 
+    // `#[serial(background_tasks)]`: see the note on
+    // `recall_with_dollar_sign_query_does_not_error` above — this test
+    // directly exercises the same `track_background_task`-driven ledger
+    // append it names, so it shares the process-wide counter.
+    //
+    // #697 (c): the serve-time stamp resolves through an actor-scoped binding,
+    // not just a namespace-scoped one. Before #697, `resolve_serving_profile`
+    // called `resolve_consumer_profile` with no actor, so a binding keyed on
+    // actor (namespace left "*") could never match here.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_stamps_served_by_profile_id_via_actor_binding() {
+        use khive_pack_brain::BrainPack;
+
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-mem-recall-actor-binding-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp dir");
+        let db_path = tmp.path().join("khive.db");
+        std::mem::forget(tmp);
+
+        let rt = khive_runtime::KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            packs: vec!["kg".to_string(), "memory".to_string(), "brain".to_string()],
+            actor_id: Some("leo".to_string()),
+            ..khive_runtime::RuntimeConfig::default()
+        })
+        .expect("runtime");
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+        assert_eq!(
+            token.actor().id,
+            "leo",
+            "test setup: token must carry the configured actor"
+        );
+
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "actor binding recall stamp note",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        // `VerbRegistry` mints its own per-dispatch tokens from its own
+        // construction-baked actor id (independent of `RuntimeConfig::actor_id`,
+        // which only affects tokens minted directly via `rt.authorize`) — bake
+        // the same actor here so `registry.dispatch` calls carry it too.
+        builder.with_actor_id(Some("leo".to_string()));
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "leo-actor-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+        registry
+            .dispatch(
+                "brain.activate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "leo-actor-recall-v1",
+                }),
+            )
+            .await
+            .expect("activate profile");
+        // Bind by actor only — namespace defaults to the "*" wildcard — so a
+        // namespace-only resolution can never reach this binding.
+        registry
+            .dispatch(
+                "brain.bind",
+                serde_json::json!({
+                    "actor": "leo",
+                    "profile_id": "leo-actor-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("bind profile to actor");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "actor binding recall stamp note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("memory.recall");
+
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty(), "must find the seeded note");
+        assert_eq!(
+            hits[0]["served_by_profile_id"],
+            serde_json::json!("leo-actor-recall-v1"),
+            "recall response must stamp the actor-bound profile, not the default"
+        );
+
+        // The ledger append is fired via track_background_task off the response
+        // path — poll briefly rather than assume it has landed by the time recall returns.
+        let target_id = note_id.id.to_string();
+        let mut found = false;
+        for _ in 0..100 {
+            let mut reader = rt.sql().reader().await.expect("reader");
+            let row = reader
+                .query_row(khive_storage::types::SqlStatement {
+                    sql: "SELECT served_by_profile_id FROM brain_serve_ledger \
+                          WHERE target_id = ?1"
+                        .into(),
+                    params: vec![khive_storage::types::SqlValue::Text(target_id.clone())],
+                    label: None,
+                })
+                .await
+                .expect("query row");
+            if let Some(row) = row {
+                assert!(
+                    matches!(
+                        row.get("served_by_profile_id"),
+                        Some(khive_storage::types::SqlValue::Text(s)) if s == "leo-actor-recall-v1"
+                    ),
+                    "serve ledger row must carry the actor-bound profile id"
+                );
+                found = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            found,
+            "serve ledger row for the recalled target must appear within 2s"
+        );
+    }
+
     // `#[serial(background_tasks)]`: non-empty recall — see the note on
     // `recall_with_dollar_sign_query_does_not_error` above.
     #[tokio::test]


### PR DESCRIPTION
Fixes #697.

`brain.feedback` / `brain.auto_feedback` previously computed the effective serving profile as the explicit `served_by_profile_id` else the literal `balanced-recall-v1`, skipping the binding tier entirely. Feedback events without an explicit profile silently trained the default profile's posteriors even when an actor-scoped binding existed. Separately, `resolve_consumer_profile` resolved by namespace only, so actor-scoped bindings could never match on the recall serve path either.

## Changes

- `handle_feedback` resolves through a shared `resolve_effective_feedback_profile`: explicit param → `resolve_with_match(actor, namespace, "recall")` accepting only `matched_binding=true` → default. Computed once and reused at both prior duplicate call sites; `brain.auto_feedback` inherits the fix by forwarding unresolved.
- `resolve_consumer_profile` (khive-brain-core) gains an `actor` parameter, threaded from `NamespaceToken::actor().id` — the same identity source the comm pack uses for `from_actor` stamping — via the memory pack's `resolve_serving_profile`.
- Knowledge-pack call sites compile-updated with `actor=None` plus an inline note: they share the same missing-actor seam but are out of this fix's scope.

## Tests

Four regression tests: unattributed feedback with a matching actor binding attributes to the bound profile (default posteriors untouched); no binding still defaults to `balanced-recall-v1`; explicit param overrides a binding; serve-ledger stamping resolves through an actor binding.

Gates: `cargo fmt --all -- --check`, `cargo clippy -p khive-pack-brain -p khive-brain-core -p khive-pack-memory --all-targets -- -D warnings`, crate test suites (brain-core 50, pack-brain 202+6+4, pack-memory 176+82), MCP brain integration tests — all exit 0.