### PR TITLE
docs: 75-verb counts + comm.probe reference

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1,13 +1,13 @@
 # API Reference
 
-khive exposes exactly one MCP tool, `request`. Everything else — 74 verbs across 9
+khive exposes exactly one MCP tool, `request`. Everything else — 75 verbs across 9
 production packs — is dispatched through that single tool via a small request DSL.
 This page documents the DSL grammar, the response envelope, and every verb's full
 parameter contract, so an agent can call khive correctly without reading Rust source.
 
 This page is verified against the live registry (`request(ops="verbs()")`, run
 2026-07-07) and the pack source (`crates/khive-pack-*/src/*.rs` `HandlerDef`/`ParamDef`
-struct literals). Verb count: **74**, matching both the live registry `total` field and
+struct literals). Verb count: **75**, matching both the live registry `total` field and
 the sum of the 9 pack counts below. If your server reports a different total, your
 `KHIVE_PACKS` configuration loads a different pack set than the default — run
 `request(ops="verbs()")` against your own server to get the authoritative list.
@@ -25,7 +25,7 @@ An always-machine-readable copy of this page is at
 | `gtd`       | 5     | `KHIVE_PACKS=kg,gtd`       | Yes                 |
 | `memory`    | 5     | `KHIVE_PACKS=kg,memory`    | Yes                 |
 | `brain`     | 14    | `KHIVE_PACKS=kg,brain`     | Yes                 |
-| `comm`      | 6     | `KHIVE_PACKS=kg,comm`      | Yes                 |
+| `comm`      | 7     | `KHIVE_PACKS=kg,comm`      | Yes                 |
 | `schedule`  | 4     | `KHIVE_PACKS=kg,schedule`  | Yes                 |
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge` | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
@@ -36,7 +36,7 @@ kinds and a batch ingester (`crates/khive-pack-git/src/ingest.rs`), consumed out
 `request` DSL, not new MCP-callable verbs.
 
 The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 9 packs: 17 + 5 + 5 +
-14 + 6 + 4 + 19 + 4 + 0 = **74 verbs**.
+14 + 7 + 4 + 19 + 4 + 0 = **75 verbs**.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Every other pack
 namespaces its verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,
@@ -841,7 +841,7 @@ request(ops="brain.register_adapter(adapter_id=\"lora-v3\", content_hash=\"<sha2
 
 ---
 
-## `comm` pack — 6 verbs
+## `comm` pack — 7 verbs
 
 Actor-to-actor messaging with threading. Optional; load with `KHIVE_PACKS=kg,comm`.
 
@@ -909,6 +909,24 @@ Retrieve all messages in a conversation thread, ordered chronologically.
 
 ```
 request(ops="comm.thread(id=\"<thread-root-id>\")")
+```
+
+### `comm.probe` — Assertive
+
+Strictly read-only poll for new inbound message metadata and a stale-unread count. No
+read-flag mutation, no writes: designed for monitors polling every ~30 seconds, served by
+a single cheap indexed query. Returns a `cursor_us` high-water mark, a `stale_unread_count`
+of inbound messages unread past the staleness window, and up to 100 new inbound rows
+(id, created_at, from_actor, subject) newer than `since_us`.
+
+| Param           | Type    | Required | Notes                                               |
+| --------------- | ------- | -------- | --------------------------------------------------- |
+| `actor`         | string  | yes      | Actor label whose inbound mail is probed.           |
+| `since_us`      | integer | no       | Microsecond-epoch cursor; only newer rows returned. |
+| `stale_minutes` | integer | no       | Staleness window for the unread count (default 20). |
+
+```
+request(ops="comm.probe(actor=\"lambda:leo\", since_us=1751932800000000)")
 ```
 
 ### `comm.health` — Assertive

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -916,8 +916,8 @@ request(ops="comm.thread(id=\"<thread-root-id>\")")
 Strictly read-only poll for new inbound message metadata and a stale-unread count. No
 read-flag mutation, no writes: designed for monitors polling every ~30 seconds, served by
 a single cheap indexed query. Returns a `cursor_us` high-water mark, a `stale_unread_count`
-of inbound messages unread past the staleness window, and up to 100 new inbound rows
-(id, created_at, from_actor, subject) newer than `since_us`.
+of inbound messages unread past the staleness window, and a `new_messages` array of up to
+100 inbound rows `{id, created_at_us, from_actor, subject?}` newer than `since_us`.
 
 | Param           | Type    | Required | Notes                                               |
 | --------------- | ------- | -------- | --------------------------------------------------- |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 74 verbs across 9 packs, dispatched through a single MCP tool.
+through 75 verbs across 9 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 74 verbs across 9 packs.
+exposing one tool — `request` — that dispatches 75 verbs across 9 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -50,8 +50,8 @@ Once installed, invoke them as `khive:digester`, `khive:polisher`, and so on.
 ## Requirements
 
 The `kg` pack is the base (entities, edges, notes); every other pack builds on it. The default
-server config loads all eight (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
-`session`) — this plugin currently ships pattern skills for the first seven; `session` has no
+server config loads all nine (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
+`session`, `git` — the last contributes note kinds and ingest support, no MCP-callable verbs) — this plugin currently ships pattern skills for the first seven; `session` has no
 skill yet (see the Pattern skills table above).
 See [INSTALL.md](../INSTALL.md) for setup, the actor config, and per-pack smoke tests.
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 74 verbs, 9 packs, one MCP tool.
+A research knowledge graph runtime — 75 verbs, 9 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)

--- a/npm/README.md
+++ b/npm/README.md
@@ -29,7 +29,7 @@ All 9 packs load by default. A background daemon auto-spawns to keep the runtime
 | **gtd**       | 5     | Task lifecycle (inbox → next → active → done)         |
 | **memory**    | 5     | Salience-weighted remember / decay-ranked recall      |
 | **brain**     | 14    | Bayesian user profiles + feedback loop                |
-| **comm**      | 6     | Threaded messaging                                    |
+| **comm**      | 7     | Threaded messaging                                    |
 | **schedule**  | 4     | Reminders and scheduled verb execution                |
 | **knowledge** | 19    | Atom-based KB with embedding rerank search            |
 | **session**   | 4     | Session record persistence (store/list/resume/export) |


### PR DESCRIPTION
Trailing docs update for #698's comm.probe verb: living-doc verb counts 74 -> 75 (getting-started, api-reference, npm and marketplace READMEs), comm pack table 6 -> 7, and a new comm.probe reference section (params verified against ProbeParams in khive-pack-comm; default stale_minutes=20). Historical ADR references to the old count are intentionally untouched.