### PR TITLE
fix(gate): thread caller actor into profile resolution; anonymous actors never match explicit bindings

### DIFF
--- a/crates/khive-brain-core/src/profile.rs
+++ b/crates/khive-brain-core/src/profile.rs
@@ -114,10 +114,12 @@ pub struct ProfileBinding {
 /// binding, or each pack's tier-3 (global tuning prior) would become
 /// unreachable.
 ///
-/// `actor` should be the caller's identity (e.g. `NamespaceToken::actor().id`)
-/// so actor-scoped bindings can match; pass `None` only when the call site has
-/// no caller identity to thread through (wildcard `actor="*"` bindings still
-/// match in that case).
+/// `actor` should be the caller's identity via `NamespaceToken::actor().binding_id()`
+/// so actor-scoped bindings can match; pass `None` for the anonymous caller or
+/// when the call site has no caller identity to thread through (wildcard
+/// `actor="*"` bindings still match in that case). Never pass the anonymous
+/// actor's raw `id` ("local") — it would let an anonymous caller match an
+/// explicit `actor="local"` binding that `None` never can.
 ///
 /// Shared by the memory pack (`ConsumerKind::Recall`) and the knowledge pack
 /// (`ConsumerKind::KnowledgeCompose`) — ADR-058 amendment, #542; actor-aware

--- a/crates/khive-gate/src/actor.rs
+++ b/crates/khive-gate/src/actor.rs
@@ -68,4 +68,25 @@ impl ActorRef {
             id: "local".into(),
         }
     }
+
+    /// Whether this actor is the implicit anonymous caller.
+    pub fn is_anonymous(&self) -> bool {
+        self.kind == "anonymous"
+    }
+
+    /// The identity to use for actor-binding resolution: `None` for the
+    /// anonymous caller, `Some(&self.id)` otherwise.
+    ///
+    /// Invariant: anonymous identity never participates in actor-binding
+    /// resolution. `anonymous()` carries `id: "local"`, which is a valid
+    /// explicit-binding value (e.g. `actor="local"`); resolving on it
+    /// would let an unauthenticated caller match a binding that a
+    /// pre-actor-aware `None` could never match.
+    pub fn binding_id(&self) -> Option<&str> {
+        if self.is_anonymous() {
+            None
+        } else {
+            Some(self.id.as_str())
+        }
+    }
 }

--- a/crates/khive-gate/src/tests.rs
+++ b/crates/khive-gate/src/tests.rs
@@ -39,6 +39,25 @@ fn actor_ref_anonymous() {
 }
 
 #[test]
+fn anonymous_actor_binding_id_is_none() {
+    let a = ActorRef::anonymous();
+    assert!(a.is_anonymous());
+    assert_eq!(
+        a.binding_id(),
+        None,
+        "anonymous actor must never expose a binding_id, even though its \
+         raw id (\"local\") could otherwise match an explicit actor=\"local\" binding"
+    );
+}
+
+#[test]
+fn configured_actor_binding_id_is_its_id() {
+    let a = ActorRef::new("lambda", "leo");
+    assert!(!a.is_anonymous());
+    assert_eq!(a.binding_id(), Some("leo"));
+}
+
+#[test]
 fn decision_helpers() {
     assert!(GateDecision::allow().is_allow());
     assert!(!GateDecision::deny("nope").is_allow());

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -989,11 +989,10 @@ impl BrainPack {
         if let Some(profile_id) = explicit {
             return profile_id.to_string();
         }
-        let actor = token.actor().id.as_str();
+        let actor = token.actor().binding_id();
         let namespace = token.namespace().as_str();
         let state = self.state.lock().unwrap();
-        match state.resolve_with_match(Some(actor), Some(namespace), ConsumerKind::Recall.as_str())
-        {
+        match state.resolve_with_match(actor, Some(namespace), ConsumerKind::Recall.as_str()) {
             Some((record, _matched_kind, true)) => record.id.clone(),
             _ => "balanced-recall-v1".to_string(),
         }

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -2261,6 +2261,94 @@ async fn feedback_697_unattributed_resolves_via_actor_binding() {
     );
 }
 
+/// Systemic-fix regression: an ANONYMOUS caller must not match an explicit
+/// `actor="local"` binding. `ActorRef::anonymous()` carries `id: "local"`
+/// (`khive-gate/src/actor.rs`); before the `binding_id()` fix,
+/// `resolve_effective_feedback_profile` threaded `token.actor().id`
+/// unconditionally, so an anonymous token could match a binding a
+/// pre-actor-aware `None` never could.
+#[tokio::test]
+async fn feedback_anonymous_caller_does_not_match_explicit_actor_local_binding() {
+    // No actor_id configured — `rt.authorize` mints the anonymous actor.
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+    assert!(
+        token.actor().is_anonymous(),
+        "test setup: token must carry the anonymous actor"
+    );
+
+    let target = create_test_entity(&rt, &token).await;
+
+    pack.dispatch(
+        "brain.create_profile",
+        json!({"name": "anon-local-v1", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    pack.dispatch(
+        "brain.activate",
+        json!({"profile_id": "anon-local-v1"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+    // Bind explicitly to actor="local" — the exact id anonymous tokens carry.
+    pack.dispatch(
+        "brain.bind",
+        json!({"actor": "local", "profile_id": "anon-local-v1", "consumer_kind": "recall"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    // No served_by_profile_id supplied.
+    pack.dispatch(
+        "brain.feedback",
+        json!({"target_id": target, "signal": "useful"}),
+        &registry,
+        &token,
+    )
+    .await
+    .unwrap();
+
+    let bound_events = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "anon-local-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        bound_events, 0,
+        "anonymous caller must NOT match the actor=\"local\" binding"
+    );
+
+    let default_events = pack
+        .dispatch(
+            "brain.profile",
+            json!({"profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap()["total_events"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        default_events, 1,
+        "anonymous unattributed feedback must fall through to the default profile"
+    );
+}
+
 /// #697 (b): feedback with neither an explicit profile nor any matching
 /// binding still defaults to balanced-recall-v1 — existing behavior preserved.
 #[tokio::test]

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -396,14 +396,11 @@ impl KnowledgePack {
         // Use "knowledge_compose" (not "recall") — the knowledge pack's compose-ranking
         // feedback has its own consumer_kind bucket (ADR-058 amendment, #542) so it no
         // longer shares posteriors with the memory pack's recall bucket.
-        //
-        // actor=None: this path does not thread the caller's actor identity through
-        // (unlike the memory pack's recall path, fixed by #697), so actor-scoped
-        // knowledge_compose bindings cannot match here yet — only namespace/wildcard
-        // bindings do. Tracked as a known gap, not fixed by #697 (out of that issue's scope).
         if let Some(ref tid) = target_id_str {
+            let actor = token.actor().id.as_str();
             if let Some(profile_id) =
-                resolve_consumer_profile(registry, None, &ns, ConsumerKind::KnowledgeCompose).await
+                resolve_consumer_profile(registry, Some(actor), &ns, ConsumerKind::KnowledgeCompose)
+                    .await
             {
                 let brain_params = json!({
                     "namespace": ns,
@@ -462,10 +459,10 @@ impl KnowledgePack {
         }
 
         // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
-        // actor=None: see the identical note in record_feedback above — this read-side
-        // resolution shares the same not-yet-actor-aware seam, tracked as a known gap.
+        let actor = token.actor().id.as_str();
         if let Some(profile_id) =
-            resolve_consumer_profile(registry, None, &ns, ConsumerKind::KnowledgeCompose).await
+            resolve_consumer_profile(registry, Some(actor), &ns, ConsumerKind::KnowledgeCompose)
+                .await
         {
             if let Some(weights) = load_profile_type_weights(registry, &profile_id).await {
                 return weights;
@@ -773,6 +770,117 @@ mod tests {
             "Tier-2 bound-profile: formalism {formalism_w:.4} must exceed og {og_w:.4}; \
              ordering reflects seed_priors (formalism β(8,1) >> og β(1,8)), \
              not default priors where og α=6,β=1.5 dominates"
+        );
+    }
+
+    /// #700: `resolve_compose_type_weights` must thread the caller's actor identity
+    /// into `resolve_consumer_profile` so an actor-scoped (namespace-wildcard)
+    /// `knowledge_compose` binding resolves at Tier 2 — not just namespace-scoped
+    /// bindings, which the sibling `..._at_tier2` test above already covers.
+    ///
+    /// Binds `compose-tuned-actor-v1` by `actor="leo"` only, leaving namespace as
+    /// the wildcard `"*"`. Before #700 (call sites passed `actor=None`), this
+    /// binding could never match — `resolve_compose_type_weights` would fall
+    /// through to Tier 3 and return the untuned default weights, where
+    /// `operational_guidance` dominates `formalism`. With the caller's actor
+    /// threaded through, Tier 2 must resolve this binding and return the
+    /// seed-tuned weights instead.
+    #[tokio::test]
+    async fn resolve_compose_type_weights_reads_bound_profile_weights_via_actor_binding_at_tier2() {
+        use khive_pack_brain::BrainPack;
+        use khive_pack_kg::KgPack;
+
+        // Mirror `KhiveRuntime::memory()` exactly, plus a configured actor.
+        // `..RuntimeConfig::default()` is a CI trap here: `Default` resolves
+        // `embedding_model` to a real on-disk model, which is absent on CI
+        // runners and fails entity creation with `ModelInitialization`.
+        let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: None,
+            default_namespace: Namespace::local(),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
+            packs: vec!["kg".to_string()],
+            backend_id: khive_runtime::BackendId::main(),
+            brain_profile: None,
+            visible_namespaces: vec![],
+            allowed_outbound_namespaces: vec![],
+            actor_id: Some("leo".to_string()),
+        })
+        .expect("in-memory runtime with actor");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(BrainPack::new(rt.clone()));
+        let registry = builder.build().expect("kg+brain registry builds");
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        assert_eq!(
+            token.actor().id,
+            "leo",
+            "test setup: token must carry the configured actor"
+        );
+
+        // Same inverted seed_priors as the namespace-bound sibling test:
+        //   formalism:            Beta(8, 1) → mean ≈ 0.889
+        //   operational_guidance: Beta(1, 8) → mean ≈ 0.111
+        registry
+            .dispatch(
+                "brain.create_profile",
+                json!({
+                    "name": "compose-tuned-actor-v1",
+                    "consumer_kind": "knowledge_compose",
+                    "seed_priors": {
+                        "section_posteriors": {
+                            "formalism": {"alpha": 8.0, "beta": 1.0},
+                            "operational_guidance": {"alpha": 1.0, "beta": 8.0}
+                        }
+                    }
+                }),
+            )
+            .await
+            .expect("create_profile with skewed seed_priors");
+
+        registry
+            .dispatch(
+                "brain.activate",
+                json!({"profile_id": "compose-tuned-actor-v1"}),
+            )
+            .await
+            .expect("activate compose-tuned-actor-v1");
+
+        // Bind by actor only — namespace left as the "*" wildcard — so a
+        // namespace-only resolution (pre-#700 behavior) can never reach this
+        // binding; only threading the caller's actor through can.
+        registry
+            .dispatch(
+                "brain.bind",
+                json!({
+                    "actor": "leo",
+                    "profile_id": "compose-tuned-actor-v1",
+                    "consumer_kind": "knowledge_compose"
+                }),
+            )
+            .await
+            .expect("bind compose-tuned-actor-v1 for actor=leo");
+
+        // KnowledgePack with brain_profile=None → Tier 1 is skipped.
+        let pack = KnowledgePack::new(rt.clone());
+        let weights = pack.resolve_compose_type_weights(&registry, &token).await;
+
+        let formalism_w = *weights
+            .get("formalism")
+            .expect("formalism weight must be present");
+        let og_w = *weights
+            .get("operational_guidance")
+            .expect("operational_guidance weight must be present");
+
+        assert!(
+            formalism_w > og_w,
+            "Tier-2 actor-bound profile: formalism {formalism_w:.4} must exceed \
+             og {og_w:.4}; ordering reflects seed_priors (formalism β(8,1) >> \
+             og β(1,8)) resolved via the actor-scoped binding, not the default \
+             priors where og α=6,β=1.5 dominates"
         );
     }
 }

--- a/crates/khive-pack-knowledge/src/handlers.rs
+++ b/crates/khive-pack-knowledge/src/handlers.rs
@@ -397,10 +397,9 @@ impl KnowledgePack {
         // feedback has its own consumer_kind bucket (ADR-058 amendment, #542) so it no
         // longer shares posteriors with the memory pack's recall bucket.
         if let Some(ref tid) = target_id_str {
-            let actor = token.actor().id.as_str();
+            let actor = token.actor().binding_id();
             if let Some(profile_id) =
-                resolve_consumer_profile(registry, Some(actor), &ns, ConsumerKind::KnowledgeCompose)
-                    .await
+                resolve_consumer_profile(registry, actor, &ns, ConsumerKind::KnowledgeCompose).await
             {
                 let brain_params = json!({
                     "namespace": ns,
@@ -459,10 +458,9 @@ impl KnowledgePack {
         }
 
         // Tier 2: namespace-bound profile via brain.resolve(consumer_kind="knowledge_compose").
-        let actor = token.actor().id.as_str();
+        let actor = token.actor().binding_id();
         if let Some(profile_id) =
-            resolve_consumer_profile(registry, Some(actor), &ns, ConsumerKind::KnowledgeCompose)
-                .await
+            resolve_consumer_profile(registry, actor, &ns, ConsumerKind::KnowledgeCompose).await
         {
             if let Some(weights) = load_profile_type_weights(registry, &profile_id).await {
                 return weights;
@@ -881,6 +879,98 @@ mod tests {
              og {og_w:.4}; ordering reflects seed_priors (formalism β(8,1) >> \
              og β(1,8)) resolved via the actor-scoped binding, not the default \
              priors where og α=6,β=1.5 dominates"
+        );
+    }
+
+    /// Systemic-fix regression: an ANONYMOUS caller must not match an explicit
+    /// `actor="local"` binding.
+    ///
+    /// `ActorRef::anonymous()` carries `id: "local"` (`khive-gate/src/actor.rs`).
+    /// Before the `binding_id()` fix, `resolve_compose_type_weights` threaded
+    /// `token.actor().id` unconditionally, so an anonymous token's `"local"`
+    /// id could match an explicit `actor="local"` binding that a pre-actor-aware
+    /// `None` could never have matched. This binds `compose-tuned-anon-v1` by
+    /// `actor="local"` and asserts an anonymous-token caller falls through to
+    /// Tier 3 default weights instead (where `operational_guidance` dominates
+    /// `formalism`), not the bound profile's inverted seed_priors.
+    #[tokio::test]
+    async fn resolve_compose_type_weights_anonymous_caller_does_not_match_explicit_actor_local_binding(
+    ) {
+        use khive_pack_brain::BrainPack;
+        use khive_pack_kg::KgPack;
+
+        // Default RuntimeConfig — no actor_id configured — mints an anonymous
+        // token (id="local") via `rt.authorize`, matching an unauthenticated caller.
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(BrainPack::new(rt.clone()));
+        let registry = builder.build().expect("kg+brain registry builds");
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        assert!(
+            token.actor().is_anonymous(),
+            "test setup: token must carry the anonymous actor"
+        );
+        assert_eq!(
+            token.actor().id,
+            "local",
+            "test setup: anonymous actor id must be \"local\" to exercise the collision"
+        );
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                json!({
+                    "name": "compose-tuned-anon-v1",
+                    "consumer_kind": "knowledge_compose",
+                    "seed_priors": {
+                        "section_posteriors": {
+                            "formalism": {"alpha": 8.0, "beta": 1.0},
+                            "operational_guidance": {"alpha": 1.0, "beta": 8.0}
+                        }
+                    }
+                }),
+            )
+            .await
+            .expect("create_profile with skewed seed_priors");
+
+        registry
+            .dispatch(
+                "brain.activate",
+                json!({"profile_id": "compose-tuned-anon-v1"}),
+            )
+            .await
+            .expect("activate compose-tuned-anon-v1");
+
+        // Bind explicitly to actor="local" — the exact id anonymous tokens carry.
+        registry
+            .dispatch(
+                "brain.bind",
+                json!({
+                    "actor": "local",
+                    "profile_id": "compose-tuned-anon-v1",
+                    "consumer_kind": "knowledge_compose"
+                }),
+            )
+            .await
+            .expect("bind compose-tuned-anon-v1 for actor=local");
+
+        let pack = KnowledgePack::new(rt.clone());
+        let weights = pack.resolve_compose_type_weights(&registry, &token).await;
+
+        let formalism_w = *weights
+            .get("formalism")
+            .expect("formalism weight must be present");
+        let og_w = *weights
+            .get("operational_guidance")
+            .expect("operational_guidance weight must be present");
+
+        assert!(
+            og_w > formalism_w,
+            "anonymous caller must NOT match the actor=\"local\" binding: og {og_w:.4} \
+             must exceed formalism {formalism_w:.4} (default-prior ordering, Tier 3), \
+             not the bound profile's inverted seed_priors (formalism β(8,1) >> og β(1,8))"
         );
     }
 }

--- a/crates/khive-pack-knowledge/tests/feedback.rs
+++ b/crates/khive-pack-knowledge/tests/feedback.rs
@@ -30,6 +30,26 @@ fn make_rt(brain_profile: Option<String>, with_brain: bool) -> KhiveRuntime {
     .expect("runtime")
 }
 
+/// Mirrors `make_rt(None, true)` but with a configured actor. Full literal
+/// (no `..RuntimeConfig::default()`) — `Default` resolves `embedding_model`
+/// to a real on-disk model, absent on CI runners.
+fn make_rt_with_actor(actor: &str) -> KhiveRuntime {
+    KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: std::sync::Arc::new(khive_runtime::AllowAllGate),
+        packs: vec!["kg".into(), "knowledge".into(), "brain".into()],
+        backend_id: khive_runtime::BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: Some(actor.to_string()),
+    })
+    .expect("runtime with actor")
+}
+
 /// Create a KG concept entity for use as brain.feedback target_id.
 ///
 /// brain.feedback validates that target_id resolves to a real record in the
@@ -249,6 +269,88 @@ async fn feedback_tier2_namespace_bound_profile_credited() {
         prof["total_events"].as_u64().unwrap_or(0),
         1,
         "ns-bound-compose must receive the feedback event"
+    );
+}
+
+/// Tier-2, actor-bound: `knowledge.feedback`'s own call site must thread the
+/// caller's actor identity, not just `resolve_compose_type_weights` (the read
+/// side). Binds `actor-bound-compose` by `actor="leo"` only, leaving namespace
+/// as the wildcard `"*"` — a namespace-only resolution can never reach it.
+/// Mutation: reverting `handle_feedback`'s call site back to `actor=None`
+/// must make this test fail (fall through to tier-3, `emitted` absent/false).
+#[tokio::test]
+async fn feedback_tier2_actor_bound_profile_credited() {
+    let rt = make_rt_with_actor("leo");
+    let ns = Namespace::parse("local").expect("ns");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    builder.register(KnowledgePack::new(rt.clone()));
+    builder.register(BrainPack::new(rt.clone()));
+    // `VerbRegistry` mints its own per-dispatch tokens from its own
+    // construction-baked actor id (independent of `RuntimeConfig::actor_id`) —
+    // bake the same actor here so `registry.dispatch` calls carry it too.
+    builder.with_actor_id(Some("leo".to_string()));
+    let registry = builder.build().expect("registry");
+    rt.install_edge_rules(registry.all_edge_rules());
+
+    let atom_id = make_entity(&registry, ns.as_str()).await;
+
+    registry
+        .dispatch(
+            "brain.create_profile",
+            json!({"namespace": ns.as_str(), "name": "actor-bound-compose", "consumer_kind": "knowledge_compose"}),
+        )
+        .await
+        .expect("create actor-bound profile");
+    registry
+        .dispatch(
+            "brain.activate",
+            json!({"namespace": ns.as_str(), "profile_id": "actor-bound-compose"}),
+        )
+        .await
+        .expect("activate actor-bound profile");
+    // Bind by actor only — namespace defaults to the "*" wildcard.
+    registry
+        .dispatch(
+            "brain.bind",
+            json!({"actor": "leo", "profile_id": "actor-bound-compose", "consumer_kind": "knowledge_compose"}),
+        )
+        .await
+        .expect("bind actor-bound profile to actor=leo");
+
+    let r = registry
+        .dispatch(
+            "knowledge.feedback",
+            json!({
+                "namespace": ns.as_str(),
+                "target_id": atom_id,
+                "section_signals": {"overview": "useful"},
+            }),
+        )
+        .await
+        .expect("feedback ok");
+    assert_eq!(
+        r["emitted"], true,
+        "tier-2 actor-bound feedback must route to brain pack: {r:?}"
+    );
+    assert_eq!(
+        r.get("brain_profile").and_then(|v| v.as_str()),
+        Some("actor-bound-compose"),
+        "knowledge.feedback must credit the actor-bound profile: {r:?}"
+    );
+
+    let prof = registry
+        .dispatch(
+            "brain.profile",
+            json!({"namespace": ns.as_str(), "profile_id": "actor-bound-compose"}),
+        )
+        .await
+        .expect("brain.profile");
+    assert_eq!(
+        prof["total_events"].as_u64().unwrap_or(0),
+        1,
+        "actor-bound-compose must receive the feedback event"
     );
 }
 

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -139,10 +139,10 @@ pub(super) async fn resolve_serving_profile(
     let ns = token.namespace().as_str().to_string();
     // #697: thread the caller's actor identity through so actor-scoped
     // bindings match, not just namespace-scoped ones.
-    let actor = token.actor().id.as_str();
+    let actor = token.actor().binding_id();
     khive_brain_core::resolve_consumer_profile(
         registry,
-        Some(actor),
+        actor,
         &ns,
         khive_brain_core::ConsumerKind::Recall,
     )

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -1202,6 +1202,139 @@ mod tests {
 
     // `#[serial(background_tasks)]`: non-empty recall — see the note on
     // `recall_with_dollar_sign_query_does_not_error` above.
+    //
+    // Systemic-fix regression: an ANONYMOUS caller must not match an explicit
+    // `actor="local"` binding. `ActorRef::anonymous()` carries `id: "local"`
+    // (`khive-gate/src/actor.rs`); before the `binding_id()` fix,
+    // `resolve_serving_profile` threaded `token.actor().id` unconditionally,
+    // so an anonymous token could match a binding a pre-actor-aware `None`
+    // never could. This binds `anon-local-recall-v1` by `actor="local"` and
+    // asserts an anonymous-token recall omits the serve stamp (falls through
+    // exactly as before actor-threading), rather than crediting the bound profile.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn recall_anonymous_caller_does_not_match_explicit_actor_local_binding() {
+        use khive_pack_brain::BrainPack;
+
+        // No `actor_id` configured — `rt.authorize` mints the anonymous actor
+        // (id="local"), matching an unauthenticated caller.
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("local namespace");
+        let token = rt.authorize(ns.clone()).expect("authorize local");
+        assert!(
+            token.actor().is_anonymous(),
+            "test setup: token must carry the anonymous actor"
+        );
+
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "anonymous actor binding fall-through note",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        // No `with_actor_id` call — registry-minted tokens stay anonymous too.
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "anon-local-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+        registry
+            .dispatch(
+                "brain.activate",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "profile_id": "anon-local-recall-v1",
+                }),
+            )
+            .await
+            .expect("activate profile");
+        // Bind explicitly to actor="local" — the exact id anonymous tokens carry.
+        registry
+            .dispatch(
+                "brain.bind",
+                serde_json::json!({
+                    "actor": "local",
+                    "profile_id": "anon-local-recall-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("bind profile to actor=local");
+
+        let result = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "anonymous actor binding fall-through note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("memory.recall");
+
+        let hits = result.as_array().expect("bare array result");
+        assert!(!hits.is_empty(), "must find the seeded note");
+        assert!(
+            hits[0].get("served_by_profile_id").is_none(),
+            "anonymous caller must NOT match the actor=\"local\" binding: the \
+             serve stamp must be omitted (unresolved profile), not carry \
+             anon-local-recall-v1: {:?}",
+            hits[0]
+        );
+
+        // The target note's id must never appear in the ledger with the
+        // bound profile — poll briefly to catch a delayed async append.
+        let target_id = note_id.id.to_string();
+        for _ in 0..20 {
+            let mut reader = rt.sql().reader().await.expect("reader");
+            let row = reader
+                .query_row(khive_storage::types::SqlStatement {
+                    sql: "SELECT served_by_profile_id FROM brain_serve_ledger \
+                          WHERE target_id = ?1"
+                        .into(),
+                    params: vec![khive_storage::types::SqlValue::Text(target_id.clone())],
+                    label: None,
+                })
+                .await
+                .expect("query row");
+            if let Some(row) = row {
+                assert!(
+                    !matches!(
+                        row.get("served_by_profile_id"),
+                        Some(khive_storage::types::SqlValue::Text(s)) if s == "anon-local-recall-v1"
+                    ),
+                    "serve ledger row must not credit the actor=\"local\" binding \
+                     to an anonymous caller"
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
+    // `#[serial(background_tasks)]`: non-empty recall — see the note on
+    // `recall_with_dollar_sign_query_does_not_error` above.
     #[tokio::test]
     #[serial(background_tasks)]
     async fn recall_without_brain_pack_omits_stamp_and_does_not_error() {


### PR DESCRIPTION
Closes #700.

## What

Two commits:

1. **`9b62674a`** — `knowledge.feedback` and `knowledge.compose` type-weight resolution passed `actor=None` into `resolve_consumer_profile`, so actor-scoped brain bindings never resolved at Tier 2 on the knowledge surfaces (#700). Both call sites now thread the caller's actor identity, mirroring the memory/brain fix that landed in #699.

2. **`ab4f806f`** — fixing a residual the same review class exposed in the already-merged #699 sites: `ActorRef::anonymous()` carries `id: "local"`, so threading the raw actor id let an **anonymous** caller match an explicit `actor="local"` binding that the previous `None` could never match. New seam in `khive-gate`: `ActorRef::is_anonymous()` + `ActorRef::binding_id() -> Option<&str>` (`None` when anonymous — anonymous identity never participates in actor-binding resolution). All four call sites (knowledge feedback + compose read-side, memory recall/feedback, brain feedback) converted from hand-rolled `Some(token.actor().id.as_str())` to `token.actor().binding_id()`.

## Tests

- `knowledge.feedback` actor-bound write-path regression (actor-configured runtime + actor-only bind row → feedback credited to the bound profile).
- Anonymous fall-through regressions on all three surfaces: an explicit `actor="local"` binding exists and an anonymous-token caller must NOT match it (knowledge read-side, memory recall, brain feedback).
- Unit tests on `binding_id()` (anonymous → `None`, configured → `Some`).
- Each regression test was mutation-verified: reverting its call site makes it fail.

## Gates

`cargo fmt --check`, `clippy --all-targets -D warnings`, and full test suites on `khive-gate`, `khive-pack-knowledge`, `khive-pack-memory`, `khive-pack-brain` — all green.