### PR TITLE
fix(mcp): exclude identity-derived visibility from daemon config_id

### DIFF
--- a/crates/khive-mcp/README.md
+++ b/crates/khive-mcp/README.md
@@ -16,8 +16,9 @@ lifetime.
 - **Pluggable transports** — `Transport` trait + `TransportRegistry`; ships `StdioTransport`,
   open for more (e.g. Streamable HTTP) via `TransportRegistry::register`
 - **Daemon-aware dispatch** — `compute_config_id` fingerprints a resolved `RuntimeConfig`
-  (packs, db target, embedders) so a thin client only forwards to a warm daemon
-  (ADR-049) when the fingerprints match; otherwise it falls back to local dispatch
+  (packs, db target, embedders, backend routing, outbound policy) so a thin
+  client only forwards to a warm daemon (ADR-049) when the fingerprints match;
+  otherwise it falls back to local dispatch
 - **Result sinking** — `RequestParams::save_to` writes results as JSONL and returns a
   manifest (`path`, `rows`, `per_column_null_counts`, `schema_fingerprint`, `checksum`)
   instead of inlining a large result set

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1145,17 +1145,22 @@ mod tests {
     use khive_runtime::daemon::run_daemon;
     use serial_test::serial;
 
-    use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
+    use khive_runtime::engine_config::ActorConfig;
+    use khive_runtime::{
+        runtime_config_from_khive_config, KhiveConfig, KhiveRuntime, Namespace, RuntimeConfig,
+    };
+
+    fn memory_runtime_config() -> RuntimeConfig {
+        KhiveRuntime::memory()
+            .expect("memory runtime")
+            .config()
+            .clone()
+    }
 
     fn make_test_server() -> crate::server::KhiveMcpServer {
-        let config = RuntimeConfig {
-            db_path: None,
-            default_namespace: Namespace::parse("test").unwrap(),
-            embedding_model: None,
-            additional_embedding_models: vec![],
-            packs: vec!["kg".to_string(), "gtd".to_string()],
-            ..RuntimeConfig::default()
-        };
+        let mut config = memory_runtime_config();
+        config.default_namespace = Namespace::parse("test").unwrap();
+        config.packs = vec!["kg".to_string(), "gtd".to_string()];
         let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
         crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+gtd")
     }
@@ -1164,14 +1169,9 @@ mod tests {
     /// `Visibility::Subhandler` verbs (`brain.state`, …). Used to exercise the
     /// wire visibility gate through the daemon round-trip.
     fn make_subhandler_test_server() -> crate::server::KhiveMcpServer {
-        let config = RuntimeConfig {
-            db_path: None,
-            default_namespace: Namespace::parse("braintest").unwrap(),
-            embedding_model: None,
-            additional_embedding_models: vec![],
-            packs: vec!["kg".to_string(), "brain".to_string()],
-            ..RuntimeConfig::default()
-        };
+        let mut config = memory_runtime_config();
+        config.default_namespace = Namespace::parse("braintest").unwrap();
+        config.packs = vec!["kg".to_string(), "brain".to_string()];
         let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
         crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+brain")
     }
@@ -1181,17 +1181,25 @@ mod tests {
     /// where `from_actor = token.actor().id`). Used to verify per-request
     /// actor stamping (ADR-096 Fork 1) without a readback/inbox round-trip.
     fn make_comm_test_server(actor_id: Option<&str>) -> crate::server::KhiveMcpServer {
-        let config = RuntimeConfig {
-            db_path: None,
-            default_namespace: Namespace::parse("test").unwrap(),
-            embedding_model: None,
-            additional_embedding_models: vec![],
-            packs: vec!["kg".to_string(), "comm".to_string()],
-            actor_id: actor_id.map(str::to_string),
-            ..RuntimeConfig::default()
-        };
+        let mut config = memory_runtime_config();
+        config.default_namespace = Namespace::parse("test").unwrap();
+        config.packs = vec!["kg".to_string(), "comm".to_string()];
+        config.actor_id = actor_id.map(str::to_string);
         let runtime = KhiveRuntime::new(config).expect("in-memory runtime");
         crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg+comm")
+    }
+
+    fn folded_actor_memory_config(actor: &str) -> RuntimeConfig {
+        runtime_config_from_khive_config(
+            &KhiveConfig {
+                actor: ActorConfig {
+                    id: Some(actor.to_string()),
+                    ..ActorConfig::default()
+                },
+                ..KhiveConfig::default()
+            },
+            memory_runtime_config(),
+        )
     }
 
     fn clear_daemon_env() {
@@ -2007,6 +2015,160 @@ mod tests {
             body_bob["results"][0]["result"]["from"], "bob",
             "write dispatched under bob's frame must stamp actor=bob, NOT cross-\
              contaminated with alice's actor; got: {body_bob}"
+        );
+
+        handle.abort();
+        let _ = handle.await;
+        clear_daemon_env();
+    }
+
+    // ADR-096 Fork 1 completion: actor-derived visible namespaces are request
+    // identity, not daemon engine identity. Two clients with different
+    // configured actors therefore compute the same config_id, but each daemon
+    // frame must still read only through its own visible set.
+    #[tokio::test]
+    #[serial]
+    async fn daemon_config_id_ignores_actor_folded_visibility_but_frame_visibility_isolated() {
+        clear_daemon_env();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("khived.sock");
+        let pid = dir.path().join("khived.pid");
+        std::env::set_var("KHIVE_SOCKET", &sock);
+        std::env::set_var("KHIVE_PID", &pid);
+        std::env::remove_var("KHIVE_NO_DAEMON");
+
+        let actor_a = "lambda:actor-a";
+        let actor_b = "lambda:actor-b";
+        let cfg_a = folded_actor_memory_config(actor_a);
+        let cfg_b = folded_actor_memory_config(actor_b);
+        let ns_a = Namespace::parse(actor_a).expect("actor a namespace");
+        let ns_b = Namespace::parse(actor_b).expect("actor b namespace");
+
+        assert_eq!(cfg_a.actor_id.as_deref(), Some(actor_a));
+        assert_eq!(cfg_b.actor_id.as_deref(), Some(actor_b));
+        assert!(
+            cfg_a.visible_namespaces.contains(&ns_a),
+            "actor.id must fold into client A visible_namespaces"
+        );
+        assert!(
+            cfg_b.visible_namespaces.contains(&ns_b),
+            "actor.id must fold into client B visible_namespaces"
+        );
+        assert_ne!(
+            cfg_a.visible_namespaces, cfg_b.visible_namespaces,
+            "precondition: clients must carry different folded visible sets"
+        );
+
+        let id_a = crate::server::compute_config_id(&cfg_a, None);
+        let id_b = crate::server::compute_config_id(&cfg_b, None);
+        assert_eq!(
+            id_a, id_b,
+            "actor-derived visible_namespaces must not affect daemon config_id"
+        );
+
+        let daemon_server = {
+            let runtime = KhiveRuntime::new(memory_runtime_config()).expect("in-memory runtime");
+            crate::server::KhiveMcpServer::new(runtime).expect("server builds with kg")
+        };
+        assert_eq!(
+            daemon_server.config_id(),
+            id_a,
+            "daemon and both clients must share the same engine-coherence key"
+        );
+        let handle = tokio::spawn(async move {
+            let _ = run_daemon(daemon_server).await;
+        });
+        let _ready = connect_when_ready(&sock).await;
+        drop(_ready);
+
+        let frame = |ops: &str, actor: &str, visible: &[Namespace]| DaemonRequestFrame {
+            ops: ops.to_string(),
+            presentation: Some("verbose".to_string()),
+            presentation_per_op: None,
+            namespace: "local".to_string(),
+            actor_id: Some(actor.to_string()),
+            visible_namespaces: visible.iter().map(|ns| ns.as_str().to_string()).collect(),
+            config_id: id_a.clone(),
+            protocol_version: PROTOCOL_VERSION,
+            probe_only: false,
+            metrics_only: false,
+            format: None,
+            format_per_op: None,
+            from_wire: false,
+        };
+
+        let seed_a = exchange(
+            &sock,
+            &frame(
+                r#"create(kind="concept", name="ActorAVisibleOnly", namespace="lambda:actor-a")"#,
+                actor_a,
+                &cfg_a.visible_namespaces,
+            ),
+        )
+        .await;
+        assert!(seed_a.ok, "seed A must succeed: {:?}", seed_a.error);
+        let seed_b = exchange(
+            &sock,
+            &frame(
+                r#"create(kind="concept", name="ActorBVisibleOnly", namespace="lambda:actor-b")"#,
+                actor_b,
+                &cfg_b.visible_namespaces,
+            ),
+        )
+        .await;
+        assert!(seed_b.ok, "seed B must succeed: {:?}", seed_b.error);
+
+        fn names_from_list_response(resp: &DaemonResponseFrame) -> Vec<String> {
+            assert!(resp.ok, "list response must be ok: {:?}", resp.error);
+            assert!(
+                !resp.config_mismatch,
+                "list response must not reject on config_id"
+            );
+            let body: serde_json::Value =
+                serde_json::from_str(resp.result.as_deref().expect("list result body"))
+                    .expect("decode list result json");
+            let first = &body["results"][0];
+            assert_eq!(
+                first["ok"], true,
+                "list op must succeed inside daemon result: {first}"
+            );
+            let rows = first["result"]
+                .as_array()
+                .or_else(|| first["result"]["items"].as_array())
+                .expect("list result must be an array or object with items");
+            rows.iter()
+                .filter_map(|row| row.get("name").and_then(|v| v.as_str()).map(str::to_string))
+                .collect()
+        }
+
+        let list_a = exchange(
+            &sock,
+            &frame(r#"list(kind="entity")"#, actor_a, &cfg_a.visible_namespaces),
+        )
+        .await;
+        let names_a = names_from_list_response(&list_a);
+        assert!(
+            names_a.iter().any(|name| name == "ActorAVisibleOnly"),
+            "actor A frame must see actor A namespace rows; got {names_a:?}"
+        );
+        assert!(
+            !names_a.iter().any(|name| name == "ActorBVisibleOnly"),
+            "actor A frame must not see actor B namespace rows; got {names_a:?}"
+        );
+
+        let list_b = exchange(
+            &sock,
+            &frame(r#"list(kind="entity")"#, actor_b, &cfg_b.visible_namespaces),
+        )
+        .await;
+        let names_b = names_from_list_response(&list_b);
+        assert!(
+            names_b.iter().any(|name| name == "ActorBVisibleOnly"),
+            "actor B frame must see actor B namespace rows; got {names_b:?}"
+        );
+        assert!(
+            !names_b.iter().any(|name| name == "ActorAVisibleOnly"),
+            "actor B frame must not see actor A namespace rows; got {names_b:?}"
         );
 
         handle.abort();

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2477,9 +2477,9 @@ id = "lambda:project-actor"
     /// `config_id` must stay byte-identical across two connections that share ONE
     /// database but declare DIFFERENT `[actor]` ids via their own project/cwd
     /// config (ADR-096 Fork 2 hard invariant — `actor_id` must never feed
-    /// `compute_config_id`, whether directly or via the `visible_namespaces`
-    /// fold-in). `default_namespace` must also stay `"local"` for both
-    /// (ADR-007 Rev 4 Rule 0), independent of the configured actor.
+    /// `compute_config_id`, and neither may the identity-derived
+    /// `visible_namespaces` fold-in). `default_namespace` must also stay
+    /// `"local"` for both (ADR-007 Rev 4 Rule 0), independent of the configured actor.
     ///
     /// Deliberately does NOT use an explicit `--config` override for the two
     /// connections: an explicit path is tier 1 and would make the db-anchored
@@ -2578,7 +2578,7 @@ id = "lambda:project-actor"
             crate::server::compute_config_id(&cfg_a, None),
             crate::server::compute_config_id(&cfg_b, None),
             "config_id must be byte-identical across connections that differ ONLY \
-             in [actor] id — actor_id must never feed compute_config_id"
+             in [actor] id and folded visibility — identity fields must never feed compute_config_id"
         );
     }
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -33,13 +33,16 @@ use khive_storage::EdgeRelation;
 use crate::coordinator::CoordinatorService;
 use crate::tools::request::RequestParams;
 
-/// Fingerprint the dispatch-affecting parts of a resolved [`RuntimeConfig`].
+/// Fingerprint the engine-coherence parts of a resolved [`RuntimeConfig`].
 ///
-/// Two servers produce the same id iff they would dispatch identically: same
-/// pack set (order-independent), same storage target, and same embedders. The
-/// daemon compares this against each forwarded request's `config_id` and rejects
+/// Two servers produce the same id iff they can safely share one warm engine:
+/// same pack set (order-independent), same storage target, same embedders, same
+/// backend topology/routing, and same construction-baked outbound policy.
+/// Identity fields (`namespace`, `actor_id`, `visible_namespaces`) are carried
+/// per request in the daemon frame and must never enter this key. The daemon
+/// compares this against each forwarded request's `config_id` and rejects
 /// mismatches so a restricted client (e.g. `--pack kg`, `--db :memory:`) cannot
-/// execute through the broader default daemon. Namespace is carried separately.
+/// execute through the broader default daemon.
 ///
 /// When `khive_cfg` is supplied and contains a non-empty `[[backends]]`
 /// declaration, the backend topology (sorted backend list and pack→backend
@@ -70,13 +73,6 @@ pub fn compute_config_id(
         .map(|m| format!("{m:?}"))
         .collect();
     extra.sort();
-    let mut visible: Vec<String> = config
-        .visible_namespaces
-        .iter()
-        .map(|ns| ns.as_str().to_owned())
-        .collect();
-    visible.sort();
-    visible.dedup();
     let mut outbound: Vec<String> = config
         .allowed_outbound_namespaces
         .iter()
@@ -86,13 +82,12 @@ pub fn compute_config_id(
     outbound.dedup();
 
     let base = format!(
-        "packs=[{}];db={};embed={};extra=[{}];backend={:?};visible=[{}];outbound=[{}]",
+        "packs=[{}];db={};embed={};extra=[{}];backend={:?};outbound=[{}]",
         packs.join(","),
         db,
         primary,
         extra.join(","),
         config.backend_id,
-        visible.join(","),
         outbound.join(","),
     );
 

--- a/crates/khive-mcp/tests/integration.rs
+++ b/crates/khive-mcp/tests/integration.rs
@@ -4054,81 +4054,55 @@ async fn test_propose_pipe_withdraw_chain() -> anyhow::Result<()> {
 }
 
 // =============================================================================
-// Finding 1: compute_config_id must include visible_namespaces so two configs
-// with different visible sets produce distinct fingerprints.
+// ADR-096 Fork 1 completion: identity-derived visibility is carried per request,
+// not in the daemon engine-coherence key.
 // =============================================================================
 
 /// Two RuntimeConfigs that are identical except for their `visible_namespaces`
-/// must produce different `compute_config_id` fingerprints.
+/// must produce the same `compute_config_id` fingerprint.
 ///
-/// `visible_namespaces` widens the default multi-record read scope to
-/// `['local'] ∪ visible_namespaces` on the OSS dispatch path (ADR-007 Rev 4
-/// Rule 3b). The fingerprint includes the visible set so configs with different
-/// read scopes are treated as distinct daemon configurations.
+/// `visible_namespaces` is a per-request identity field in the daemon frame.
+/// Keeping it out of the engine-coherence key lets seats with different folded
+/// actor visibility share one warm daemon while still dispatching under their
+/// own frame identity.
 #[test]
-fn compute_config_id_differs_when_visible_namespaces_differ() {
+fn compute_config_id_is_identical_when_only_visible_namespaces_differ() {
     use khive_mcp::server::compute_config_id;
-    use khive_runtime::{Namespace, RuntimeConfig};
 
-    let base = RuntimeConfig {
-        db_path: None,
-        default_namespace: Namespace::parse("vis-a").unwrap(),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        packs: vec!["kg".to_string()],
-        visible_namespaces: vec![],
-        ..RuntimeConfig::default()
-    };
+    let mut base = KhiveRuntime::memory()
+        .expect("memory runtime")
+        .config()
+        .clone();
+    base.default_namespace = Namespace::parse("vis-a").unwrap();
+    base.visible_namespaces = vec![];
+
     let with_visible = RuntimeConfig {
         visible_namespaces: vec![Namespace::parse("vis-b").unwrap()],
         ..base.clone()
     };
-
-    let id_no_vis = compute_config_id(&base, None);
-    let id_with_vis = compute_config_id(&with_visible, None);
-
-    assert_ne!(
-        id_no_vis, id_with_vis,
-        "compute_config_id must differ when visible_namespaces differs; \
-         same id would allow wrong-visibility daemon reuse"
-    );
-    assert!(
-        id_with_vis.contains("vis-b"),
-        "visible namespace 'vis-b' must appear in config_id string; got: {id_with_vis}"
-    );
-}
-
-/// Order of entries in visible_namespaces must not change the fingerprint
-/// (the fingerprint sorts + deduplicates before hashing).
-#[test]
-fn compute_config_id_is_stable_under_visible_namespace_reorder() {
-    use khive_mcp::server::compute_config_id;
-    use khive_runtime::{Namespace, RuntimeConfig};
-
-    let cfg_ab = RuntimeConfig {
-        db_path: None,
-        default_namespace: Namespace::parse("vis-a").unwrap(),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        packs: vec!["kg".to_string()],
-        visible_namespaces: vec![
-            Namespace::parse("vis-b").unwrap(),
-            Namespace::parse("vis-c").unwrap(),
-        ],
-        ..RuntimeConfig::default()
-    };
-    let cfg_ba = RuntimeConfig {
+    let reordered_visible = RuntimeConfig {
         visible_namespaces: vec![
             Namespace::parse("vis-c").unwrap(),
             Namespace::parse("vis-b").unwrap(),
         ],
-        ..cfg_ab.clone()
+        ..base.clone()
     };
 
     assert_eq!(
-        compute_config_id(&cfg_ab, None),
-        compute_config_id(&cfg_ba, None),
-        "compute_config_id must be stable under reordering of visible_namespaces"
+        compute_config_id(&base, None),
+        compute_config_id(&with_visible, None),
+        "compute_config_id must ignore visible_namespaces; visibility travels \
+         per request in the daemon frame"
+    );
+    assert_eq!(
+        compute_config_id(&with_visible, None),
+        compute_config_id(&reordered_visible, None),
+        "visible namespace order must also be inert because visible_namespaces \
+         are excluded from the fingerprint"
+    );
+    assert!(
+        !compute_config_id(&with_visible, None).contains("vis-b"),
+        "visible namespace 'vis-b' must not appear in config_id string"
     );
 }
 
@@ -4149,17 +4123,13 @@ fn compute_config_id_is_stable_under_visible_namespace_reorder() {
 #[test]
 fn compute_config_id_differs_when_allowed_outbound_namespaces_differ() {
     use khive_mcp::server::compute_config_id;
-    use khive_runtime::{Namespace, RuntimeConfig};
 
-    let base = RuntimeConfig {
-        db_path: None,
-        default_namespace: Namespace::parse("out-a").unwrap(),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        packs: vec!["kg".to_string()],
-        allowed_outbound_namespaces: vec![],
-        ..RuntimeConfig::default()
-    };
+    let mut base = KhiveRuntime::memory()
+        .expect("memory runtime")
+        .config()
+        .clone();
+    base.default_namespace = Namespace::parse("out-a").unwrap();
+    base.allowed_outbound_namespaces = vec![];
     let with_outbound = RuntimeConfig {
         allowed_outbound_namespaces: vec![Namespace::parse("lambda:khive").unwrap()],
         ..base.clone()
@@ -4184,20 +4154,16 @@ fn compute_config_id_differs_when_allowed_outbound_namespaces_differ() {
 #[test]
 fn compute_config_id_is_stable_under_allowed_outbound_namespace_reorder() {
     use khive_mcp::server::compute_config_id;
-    use khive_runtime::{Namespace, RuntimeConfig};
 
-    let cfg_ab = RuntimeConfig {
-        db_path: None,
-        default_namespace: Namespace::parse("out-a").unwrap(),
-        embedding_model: None,
-        additional_embedding_models: vec![],
-        packs: vec!["kg".to_string()],
-        allowed_outbound_namespaces: vec![
-            Namespace::parse("lambda:khive").unwrap(),
-            Namespace::parse("lambda:leo").unwrap(),
-        ],
-        ..RuntimeConfig::default()
-    };
+    let mut cfg_ab = KhiveRuntime::memory()
+        .expect("memory runtime")
+        .config()
+        .clone();
+    cfg_ab.default_namespace = Namespace::parse("out-a").unwrap();
+    cfg_ab.allowed_outbound_namespaces = vec![
+        Namespace::parse("lambda:khive").unwrap(),
+        Namespace::parse("lambda:leo").unwrap(),
+    ];
     let cfg_ba = RuntimeConfig {
         allowed_outbound_namespaces: vec![
             Namespace::parse("lambda:leo").unwrap(),

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -412,7 +412,7 @@ pub fn assert_db_anchor_consistent(
 /// directory (commit 10d9c92c, #651) keeps `config_id` coherent between a
 /// short-lived client and a long-running daemon that share one database — that is
 /// correct for the fields that make up `config_id` (packs/db/embed/backend/
-/// visible/outbound). It also relocated discovery of the project-local `[actor]`
+/// outbound policy). It also relocated discovery of the project-local `[actor]`
 /// block, though. When many per-project connections share one database under a
 /// single `HOME` (the daemon-multiplexed fleet case), the shared database-anchored
 /// config carries no `[actor]`, so every connection's write-stamp attribution
@@ -421,10 +421,11 @@ pub fn assert_db_anchor_consistent(
 /// This performs a SEPARATE, cwd-anchored lookup (`db_path: None`, matching the
 /// pre-#651 tier-3 search) and reads only `[actor].id`. It intentionally does not
 /// read or return anything else from the resolved `KhiveConfig` — `config_id`,
-/// `default_namespace`, and `visible_namespaces` remain governed exclusively by
-/// the existing database-anchored load and must not be perturbed by this tier:
-/// `actor_id` is not part of `compute_config_id` (`khive-mcp` `server.rs`), and
-/// ADR-007 Rev 4 Rule 0 already keeps `[actor].id` out of `default_namespace`.
+/// `default_namespace` remain governed exclusively by the existing
+/// database-anchored load and must not be perturbed by this tier: `actor_id`
+/// and identity-derived `visible_namespaces` are not part of
+/// `compute_config_id` (`khive-mcp` `server.rs`), and ADR-007 Rev 4 Rule 0
+/// already keeps `[actor].id` out of `default_namespace`.
 ///
 /// `config_path` is the same explicit `--config` / `KHIVE_CONFIG` override the
 /// caller's database-anchored load receives — tier 1 short-circuits identically

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -203,10 +203,12 @@ pub struct DaemonRequestFrame {
     /// beyond `namespace` itself.
     #[serde(default)]
     pub visible_namespaces: Vec<String>,
-    /// Fingerprint of the client's resolved runtime config (packs, db target,
-    /// embedders). The daemon rejects a request whose `config_id` differs from
-    /// its own so a restricted client (e.g. `--pack kg`, `--db :memory:`) never
-    /// dispatches through the broader default daemon. See ADR-027 / ADR-049.
+    /// Fingerprint of the client's engine-coherence config: packs, db target,
+    /// embedders, backend routing, and construction-baked outbound policy.
+    /// Identity fields are carried separately in this frame. The daemon rejects
+    /// a request whose `config_id` differs from its own so a restricted client
+    /// (e.g. `--pack kg`, `--db :memory:`) never dispatches through the broader
+    /// default daemon. See ADR-027 / ADR-049 / ADR-096.
     #[serde(default)]
     pub config_id: String,
     /// IPC protocol version sent by the client. Pre-versioning clients omit

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -443,8 +443,9 @@ pub async fn run_exec(args: ExecArgs) -> Result<()> {
         // unconditionally). It is also empirically inert for config_id parity:
         // in the embed path (`no_embed: false`, exec's only mode), this flag
         // gates only the actor_id fill-when-None guard in `resolve_runtime_config`
-        // — and `compute_config_id` never reads `actor_id` (namespace is
-        // "carried separately" per its own doc comment). See the
+        // — and `compute_config_id` never reads identity fields (`actor_id` or
+        // `visible_namespaces`; namespace is carried separately per its own doc
+        // comment). See the
         // `namespace_explicit_changes_actor_id_fill_but_not_config_id` and
         // `exec_config_id_matches_serve_config_id_for_project_toml_actor` tests
         // below, which construct both arms and assert this directly rather than
@@ -1053,13 +1054,13 @@ default = true
             "namespace_explicit=false must NOT fill actor_id"
         );
 
-        // ...but `compute_config_id` never reads `actor_id` (namespace is
-        // "carried separately" per its own doc comment), so the two configs —
-        // which differ ONLY in actor_id — must still produce a byte-identical
-        // fingerprint. This is the empirical basis for `run_exec` picking
-        // `namespace_explicit: true`: it is the conservative, behavior-
-        // preserving choice, and it provably does not affect config_id parity
-        // with the daemon either way.
+        // ...but `compute_config_id` never reads identity fields (`actor_id` or
+        // `visible_namespaces`; namespace is carried separately per its own doc
+        // comment), so the two configs — which differ ONLY in actor_id — must
+        // still produce a byte-identical fingerprint. This is the empirical
+        // basis for `run_exec` picking `namespace_explicit: true`: it is the
+        // conservative, behavior-preserving choice, and it provably does not
+        // affect config_id parity with the daemon either way.
         assert_eq!(
             compute_config_id(&with_explicit_true, None),
             compute_config_id(&with_explicit_false, None),

--- a/docs/adr/ADR-096-warm-daemon-per-request-identity.md
+++ b/docs/adr/ADR-096-warm-daemon-per-request-identity.md
@@ -347,13 +347,31 @@ This ADR is accepted with the following binding conditions:
 
 ---
 
+## Amendment: config_id excludes request identity (2026-07-08)
+
+ADR-096 Fork 1 makes the daemon request frame the authority for request identity. Therefore
+`config_id` is an engine-coherence key only: it covers the pack set, database target, primary and
+additional embedding models, backend topology/routing, and construction-baked outbound policy.
+
+Identity-derived fields are excluded from `config_id`: `namespace`, `actor_id`, and
+`visible_namespaces`, including the actor namespace that ADR-007 Rev 4 folds into
+`visible_namespaces` at config load. Those fields travel per request in `DaemonRequestFrame` and
+are consumed when dispatch mints the request token.
+
+`allowed_outbound_namespaces` remains in `config_id` for now because outbound policy is still
+construction-baked and is not carried in `RequestIdentity`. Excluding it before outbound policy is
+threaded per request would allow a client with stricter outbound policy to reuse a daemon built
+with a broader outbound allowlist.
+
+---
+
 ## Scope / Non-goals
 
 - **Does not implement.** This is a design contract; the code change is a separate, gated task.
 - **Does not solve #580 / WAL snapshot lifetime** (ADR-091 owns that). It only establishes
   non-interaction.
-- **Does not change** the `config_id` fingerprint definition, the entity/edge/note taxonomy, or
-  any pack vocabulary.
+- **Does not change** the entity/edge/note taxonomy or any pack vocabulary. The 2026-07-08
+  amendment above defines the `config_id` identity-field exclusion.
 - **Does not add** a socket auth/admin plane, an HTTP listener, or a snapshot-format change —
   ADR-049's other scope boundaries are unchanged. Only the "No multi-namespace daemon" clause
   (lines 108-111) and the request-frame shape are amended.


### PR DESCRIPTION
## Problem

`compute_config_id` fingerprinted `visible_namespaces` alongside engine-coherence fields. Actor identity is folded into `visible_namespaces` at config load, so every identity-bearing client computes a different `config_id` than the daemon it should attach to. The daemon hard-rejects those clients with `config_mismatch`, forcing each into a cold direct-open of the shared SQLite database and defeating the warm-daemon architecture entirely.

Per-request identity (protocol v3) already serves every wire request under the frame's own namespace/actor/visibility, so the construction-baked visible set is dead weight for dispatch — yet it fires the reject first.

## Change

- `compute_config_id` now keys on engine-coherence fields only: packs, db path, embed models, backends, and outbound policy. Identity-derived fields (`namespace`, `actor_id`, `visible_namespaces`) are excluded; identity travels per-request in the frame.
- `allowed_outbound_namespaces` stays in the key: it is construction-baked policy, not part of `RequestIdentity`.
- Old visible-affects-key integration tests replaced with `compute_config_id_is_identical_when_only_visible_namespaces_differ`; outbound-difference test unchanged.
- New regression `daemon_config_id_ignores_actor_folded_visibility_but_frame_visibility_isolated`: two clients with different configured actors compute the same `config_id`, share one daemon dispatcher, and each reads only under its own frame visibility.
- ADR-096 amended (2026-07-08): `config_id` is an engine-coherence key only.

## Verification

`cargo fmt --check`, `clippy -p khive-mcp -p khive-runtime -D warnings`, `cargo test -p khive-mcp -p khive-runtime`, `cargo check --workspace` — all clean. Mutation checks: re-adding `visible_namespaces` to the fingerprint fails the identity test; dropping frame identity at dispatch fails the isolation regression.