### PR TITLE
docs(adr): ADR-101 change-set model + ADR-102 tiered validate-and-merge

### DIFF
--- a/docs/adr/ADR-101-kg-changeset-model.md
+++ b/docs/adr/ADR-101-kg-changeset-model.md
@@ -111,7 +111,8 @@ whole-state NDJSON (ADR-020 §2) — a change-set's ordering is operation order,
 canonical sort, because operation order is semantically load-bearing (a `link` can depend on an
 earlier `create` in the same file) in a way a state snapshot's row order is not. Each line
 carries enough to be applied independently of the file's byte layout: op kind, target kind,
-resolved or newly-minted identifiers, and the op's fields. The concrete field-level shape is
+resolved or newly-minted identifiers, the op's fields, and — for `delete` and `merge` — the
+captured stage-time preimage D1 requires. The concrete field-level shape is
 implementation detail of the `khive-changeset` crate (D5) and is not pinned by this ADR beyond
 the op-kind/identifier/fields shape above; it evolves as an internal format under the crate's
 own versioning, not as a wire contract this ADR freezes.

--- a/docs/adr/ADR-101-kg-changeset-model.md
+++ b/docs/adr/ADR-101-kg-changeset-model.md
@@ -1,0 +1,219 @@
+# ADR-101: KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs
+
+**Status**: Proposed
+**Date**: 2026-07-08
+**Depends on**: ADR-002 (edge ontology), ADR-016 (request DSL — the op shape this format serializes), ADR-017 (pack standard), ADR-020 (git-native KG implementation — `KgArchive` as the import/export envelope this ADR does not replace)
+**Related**: ADR-088 (git-lifecycle pack — the future-work loop below), ADR-100 (store backup and replication — whole-graph snapshots, a different artifact from the change-set this ADR defines)
+
+---
+
+## Context
+
+Writes into a khive knowledge graph arrive from more than one kind of producer: an interactive
+agent issuing MCP `request` ops directly against the live daemon, and periodic batch
+producers — extraction pipelines that scan a corpus on a schedule and emit a block of proposed
+graph changes for later application. The second class needs a durable, inspectable staging
+artifact between "a producer decided what to write" and "the write lands in the live graph,"
+so that the change can be diffed, reviewed, and committed as a unit rather than applied as a
+sequence of independent, unreviewable side effects.
+
+No such artifact exists today. A batch producer's only path into the graph is the same live
+`request` batch surface an interactive agent uses — there is no typed, serializable
+intermediate form a producer can emit, a reviewer can render, and a later stage can apply.
+Three problems follow directly from that gap:
+
+1. **No stable cross-producer identifier.** If a producer references an entity or edge it is
+   about to create later in the same batch (a `link` targeting a `create` earlier in the file),
+   nothing mints that identifier until the write actually lands. A change-set that is staged,
+   reviewed, and applied hours or days apart from when it was produced needs identifiers that
+   are stable from the moment of staging, not assigned at commit time.
+2. **No format a reviewer can render without executing it.** Rendering "what would this batch
+   do" today means running it and inspecting the result, which is exactly the operation review
+   exists to gate before it happens.
+3. **No single artifact shape multiple producers and multiple consumers can agree on.** Without
+   a canonical staged format, each batch producer would grow its own ad hoc output shape, and
+   each downstream tool (validator, diff renderer, review UI) would grow a parser per producer.
+
+This ADR defines that artifact: a producer-agnostic change-set model, its serialization, the
+ingester pattern by which a producer's native output becomes one, and the provenance carried on
+commit. [ADR-102](ADR-102-tiered-validate-and-merge.md) is the companion ADR that defines what
+happens to a change-set once it exists — validation, the tier split, review, and the commit and
+revert mechanics. This ADR is scoped to the artifact itself: what it is, how it is minted, how
+it is serialized, and which crates own that model as durable, UI-agnostic logic.
+
+### Why not extend `KgArchive`
+
+[ADR-020](ADR-020-git-native-kg-implementation.md) already defines `KgArchive` as the
+in-memory import/export representation used by whole-graph export and import. It is tempting to
+reuse it here, since both are "a bag of entities and edges." They solve different problems and
+conflating them would corrupt both:
+
+- `KgArchive` is a **state snapshot** — the full or filtered contents of the graph at a point in
+  time, sorted and diffable as a whole document. It has no notion of an individual operation, no
+  distinction between "this row is new" and "this row already existed," and no place to attach
+  per-op provenance.
+- A change-set is an **op-list** — a sequence of discrete, individually-typed mutations
+  (`create`, `link`, `update`, `delete`) that have not yet been applied. Its unit of meaning is
+  the operation, not the resulting state.
+
+`KgArchive` remains exactly what ADR-020 defines it as: the whole-graph import/export envelope.
+It is explicitly **not** the change-set format, and this ADR introduces no change to its shape
+or its consumers.
+
+---
+
+## Decision
+
+### D1 — Canonical staged artifact: a producer-agnostic typed op-list
+
+The canonical staged artifact is a **typed op-list**: an ordered sequence of operations, each
+one of `create`, `link`, `update`, or `delete`, over the same entity/edge/note vocabulary and
+edge-endpoint contract ADR-001/ADR-002/ADR-013 already define. An op-list is producer-agnostic
+by construction — it names no producer, encodes no producer-specific shape, and carries only
+what any consumer (a rule evaluator, a diff renderer, a live-write applier) needs: the op kind,
+its target substrate, its fields, and — for `create` and `link` — the identifier(s) involved.
+
+**Stage-time stable IDs are a hard requirement, not an optimization.** Every entity or note a
+`create` op introduces is minted a UUID at the moment the op is staged, not at the moment it is
+applied. A `link` op staged later in the same or a different change-set that targets that
+identifier resolves correctly regardless of how much time elapses between staging and
+application, and regardless of whether the two ops are ever applied together. This is what
+makes cross-producer handoff possible: one producer can stage a `create`, and a second producer
+— or a human reviewer — can stage a `link` against it before the first op has been applied,
+because the identifier already exists and is stable. An identifier minted at apply time would
+make that handoff impossible without an intermediate resolution step every consumer would have
+to reimplement.
+
+### D2 — Serialization: NDJSON-delta
+
+A change-set serializes as **NDJSON-delta**: one JSON object per line, one line per operation,
+in stage order. This is a deliberate departure from `KgArchive`'s sorted-by-primary-key,
+whole-state NDJSON (ADR-020 §2) — a change-set's ordering is operation order, not a diffable
+canonical sort, because operation order is semantically load-bearing (a `link` can depend on an
+earlier `create` in the same file) in a way a state snapshot's row order is not. Each line
+carries enough to be applied independently of the file's byte layout: op kind, target kind,
+resolved or newly-minted identifiers, and the op's fields. The concrete field-level shape is
+implementation detail of the `khive-changeset` crate (D5) and is not pinned by this ADR beyond
+the op-kind/identifier/fields shape above; it evolves as an internal format under the crate's
+own versioning, not as a wire contract this ADR freezes.
+
+### D3 — Ingester pattern: producers convert native output into the op-list
+
+A change-set producer does not emit NDJSON-delta directly from its own internal representation.
+It emits its **native output** — whatever shape is natural to how it works — and an **ingester**
+converts that native output into the canonical op-list. This keeps the op-list format
+independent of any one producer's internals and lets a new producer be onboarded by writing one
+ingester, not by reshaping the format to fit it.
+
+The first ingester converts a periodic extraction-pipeline's block output — a batch of proposed
+entities, edges, and notes recovered from scanning a corpus on a schedule — into the canonical
+op-list. This producer's adoption is unblocked by shipping first, and it is treated as exactly
+that: the first of what is expected to be several ingesters (an interactive-agent op recorder,
+a future bulk-import adapter), not a privileged or format-defining one. Nothing in the op-list
+model, the NDJSON-delta serialization, or the crates in D5 encodes anything specific to this
+producer; the ingester is where producer-specific translation lives, and it is the only layer
+that is.
+
+### D4 — Provenance: batch description in the commit message, batch identifier as a commit trailer
+
+When a change-set is committed (per [ADR-102](ADR-102-tiered-validate-and-merge.md)'s tier-2
+flow), the git commit that lands it carries provenance at two levels:
+
+- The **commit message body** carries a human-readable description of the batch — what was
+  produced and why, in the producer's own words.
+- A **producer-assigned batch identifier** rides as a commit trailer (a standard
+  `Key: value` trailer line, in the convention `git interpret-trailers` already recognizes).
+  The identifier is opaque to this ADR — it is whatever token the producer uses internally to
+  track the unit of work that generated the change-set — and its only contract here is that it
+  round-trips: a reader of the commit can extract it verbatim and correlate it back to the
+  producer's own tracking, without this ADR or the graph needing to understand what it means.
+
+This is deliberately generic. The mechanism by which a specific producer generates that
+description or that identifier — its own scheduling, batching, or tasking model — is out of
+scope for a public architectural contract and is not named here.
+
+### D5 — Three UI-agnostic crates, no filesystem access, wasm32-compilable
+
+Graduate exactly three crates from day one, each carrying durable model or logic and none
+carrying a view:
+
+1. **`khive-changeset`** — the op-list type and its NDJSON-delta serialization (D1, D2): the
+   data model this ADR defines, with no knowledge of any producer, ingester, or UI.
+2. **The rule evaluator** — the pure function from a change-set plus a rules definition to a set
+   of pass/fail findings. [ADR-102](ADR-102-tiered-validate-and-merge.md) defines the rules
+   themselves and how they route to tiers; this crate is the engine that runs them, shared
+   identically by a headless CLI and any graphical reviewer.
+3. **Diff computation** — a pure function from two NDJSON states to a structured graph-diff (the
+   set of entity/edge/note-level additions, removals, and field changes between them), used both
+   to render a change-set's effect before it is applied and to render the effect of a commit
+   after the fact.
+
+**Constraint, binding on all three**: no filesystem access and no I/O of any kind inside the
+crate boundary — every function takes its input as an in-memory value and returns an in-memory
+value. Each crate must be **wasm32-compilable**, and CI carries a **wasm-parity check**: the
+same test suite run against the native target and the wasm32 target must produce byte-identical
+results, following the same template already proven for `lattice-embed`'s wasm build.
+
+**Rationale.** A view layer — a CLI renderer, a desktop review UI, a future web frontend — is
+replaceable and, at this stage of the project, is expected to be replaced more than once. The
+op-list model, the rule evaluation logic, and the diff computation are not: they are the
+durable asset a producer, a reviewer, and a future UI all depend on agreeing about. Keeping
+them filesystem-free and wasm-compilable from day one is what keeps that guarantee real rather
+than aspirational — a crate that quietly grows a filesystem read is a crate a future web
+frontend cannot reuse without discovering the dependency the hard way. The CI wasm-parity check
+makes the constraint enforced, not just documented.
+
+---
+
+## Future work (non-binding)
+
+A change-set, once committed, is itself graph-shaped history: a sequence of typed operations,
+each with provenance, applied to a graph. [ADR-088](ADR-088-git-lifecycle-pack.md) already
+defines a git-lifecycle pack that ingests a git repository's own commit and issue history into
+the graph as `commit` and `issue` note kinds. The natural composition — not committed to by this
+ADR, and explicitly out of scope for the implementation this ADR authorizes — is a loop in which
+the git-lifecycle pack ingests the KG's own change-set commits (the artifact this ADR defines)
+back into the same graph, making the graph's own change provenance queryable as graph: which
+producer proposed which operation, when, and under what batch. This would let a query answer
+"what changed this entity and why" as a graph traversal rather than as a manual read of git
+history. It is named here as the direction this design is deliberately compatible with, not as
+a commitment this ADR or its implementation makes.
+
+---
+
+## Consequences
+
+- A batch producer gains a real staging artifact instead of the live write surface as its only
+  option, and gains it without the op-list model knowing anything about that producer
+  specifically — the ingester pattern (D3) is the only producer-specific surface.
+- Cross-producer and cross-time handoff (one producer's `create`, referenced by a `link` staged
+  later, by the same or a different actor) is correct by construction because of stage-time ID
+  minting (D1), at the cost of every ingester having to mint and track identifiers itself rather
+  than deferring that to apply time.
+- Three additional crates (D5) are now durable public surface with a wasm-parity CI obligation;
+  this is a maintenance cost taken on deliberately in exchange for keeping the model, rules, and
+  diff logic reusable by a view layer not yet built.
+- `KgArchive` (ADR-020) is unchanged and remains the whole-graph import/export envelope; this
+  ADR does not touch its shape, its consumers, or the boundary between it and the change-set
+  model defined here.
+- The concrete field-level schema of an NDJSON-delta line is intentionally left to the
+  `khive-changeset` crate rather than pinned in this ADR text; a future amendment is expected
+  once the schema stabilizes under real ingester and reviewer use.
+
+---
+
+## References
+
+- ADR-001 — Entity Kind Taxonomy: the entity vocabulary an op-list's `create`/`link`/`update`
+  ops draw from.
+- ADR-002 — Closed Edge Ontology: the edge-relation vocabulary and endpoint contract a `link` op
+  must satisfy.
+- ADR-013 — Note Kind Taxonomy: the note vocabulary an op-list's note-targeting ops draw from.
+- ADR-016 — Request DSL: the live op shape (`create`/`link`/`update`/`delete` verbs) this
+  format's op kinds mirror.
+- ADR-020 — Git-Native KG Implementation: `KgArchive` as the retained whole-graph import/export
+  envelope this ADR explicitly does not replace or extend.
+- ADR-088 — Git-Lifecycle Pack: the commit/issue ingestion this ADR's future-work section
+  proposes composing with.
+- ADR-102 — Tiered Validate-and-Merge: the companion ADR defining what happens to a change-set
+  once it exists (validation, tiering, review, commit, revert).

--- a/docs/adr/ADR-101-kg-changeset-model.md
+++ b/docs/adr/ADR-101-kg-changeset-model.md
@@ -53,7 +53,7 @@ conflating them would corrupt both:
   distinction between "this row is new" and "this row already existed," and no place to attach
   per-op provenance.
 - A change-set is an **op-list** — a sequence of discrete, individually-typed mutations
-  (`create`, `link`, `update`, `delete`) that have not yet been applied. Its unit of meaning is
+  (`create`, `link`, `update`, `delete`, `merge`) that have not yet been applied. Its unit of meaning is
   the operation, not the resulting state.
 
 `KgArchive` remains exactly what ADR-020 defines it as: the whole-graph import/export envelope.
@@ -67,11 +67,14 @@ or its consumers.
 ### D1 — Canonical staged artifact: a producer-agnostic typed op-list
 
 The canonical staged artifact is a **typed op-list**: an ordered sequence of operations, each
-one of `create`, `link`, `update`, or `delete`, over the same entity/edge/note vocabulary and
-edge-endpoint contract ADR-001/ADR-002/ADR-013 already define. An op-list is producer-agnostic
+one of `create`, `link`, `update`, `delete`, or `merge`, over the same entity/edge/note
+vocabulary and edge-endpoint contract ADR-001/ADR-002/ADR-013 already define — the same
+mutation surface the live request DSL (ADR-016) exposes, so nothing expressible as a live
+write is inexpressible as a staged one. An op-list is producer-agnostic
 by construction — it names no producer, encodes no producer-specific shape, and carries only
 what any consumer (a rule evaluator, a diff renderer, a live-write applier) needs: the op kind,
-its target substrate, its fields, and — for `create` and `link` — the identifier(s) involved.
+its target substrate, its fields, the identifier(s) involved, and — for `delete` and `merge` —
+the stage-time preimage described below.
 
 **Stage-time stable IDs are a hard requirement, not an optimization.** Every entity or note a
 `create` op introduces is minted a UUID at the moment the op is staged, not at the moment it is
@@ -83,6 +86,22 @@ makes cross-producer handoff possible: one producer can stage a `create`, and a 
 because the identifier already exists and is stable. An identifier minted at apply time would
 make that handoff impossible without an intermediate resolution step every consumer would have
 to reimplement.
+
+**Destructive operations capture their preimage at stage time.** A `delete` op records the
+full prior state of the record it removes, and a `merge` op records both prior entities and
+the incident edges the merge will rewire, as part of the staged operation itself. This is what
+makes op-list inversion ([ADR-102](ADR-102-tiered-validate-and-merge.md) D4) well-defined for
+destructive operations: an inverse can only restore what was captured. An operation staged
+without its preimage cannot be surgically reverted, and any revert of it must fall back to the
+coarser mechanisms ADR-102 D4 names.
+
+**Operations are producer-agnostic; the change-set envelope is attributed.** While no
+individual operation names a producer, the change-set as a whole carries a small **envelope
+metadata block**, captured at stage time, recording the producer's identity and its model
+family. The envelope exists for exactly two consumers: reviewer routing (ADR-102 D3's
+cross-family gate takes the producer's model family as its input) and commit provenance (D4
+below). No op-level consumer — rule evaluator, diff renderer, applier — reads it, so the
+op-list itself stays producer-agnostic.
 
 ### D2 — Serialization: NDJSON-delta
 
@@ -152,7 +171,7 @@ carrying a view:
 crate boundary — every function takes its input as an in-memory value and returns an in-memory
 value. Each crate must be **wasm32-compilable**, and CI carries a **wasm-parity check**: the
 same test suite run against the native target and the wasm32 target must produce byte-identical
-results, following the same template already proven for `lattice-embed`'s wasm build.
+results, and the CI job fails on any divergence between the two.
 
 **Rationale.** A view layer — a CLI renderer, a desktop review UI, a future web frontend — is
 replaceable and, at this stage of the project, is expected to be replaced more than once. The
@@ -169,8 +188,8 @@ makes the constraint enforced, not just documented.
 
 A change-set, once committed, is itself graph-shaped history: a sequence of typed operations,
 each with provenance, applied to a graph. [ADR-088](ADR-088-git-lifecycle-pack.md) already
-defines a git-lifecycle pack that ingests a git repository's own commit and issue history into
-the graph as `commit` and `issue` note kinds. The natural composition — not committed to by this
+defines a git-lifecycle pack that ingests a git repository's own commit, issue, and
+pull-request history into the graph as `commit`, `issue`, and `pull_request` note kinds. The natural composition — not committed to by this
 ADR, and explicitly out of scope for the implementation this ADR authorizes — is a loop in which
 the git-lifecycle pack ingests the KG's own change-set commits (the artifact this ADR defines)
 back into the same graph, making the graph's own change provenance queryable as graph: which
@@ -209,7 +228,7 @@ a commitment this ADR or its implementation makes.
 - ADR-002 — Closed Edge Ontology: the edge-relation vocabulary and endpoint contract a `link` op
   must satisfy.
 - ADR-013 — Note Kind Taxonomy: the note vocabulary an op-list's note-targeting ops draw from.
-- ADR-016 — Request DSL: the live op shape (`create`/`link`/`update`/`delete` verbs) this
+- ADR-016 — Request DSL: the live op shape (`create`/`link`/`update`/`delete`/`merge` verbs) this
   format's op kinds mirror.
 - ADR-020 — Git-Native KG Implementation: `KgArchive` as the retained whole-graph import/export
   envelope this ADR explicitly does not replace or extend.

--- a/docs/adr/ADR-102-tiered-validate-and-merge.md
+++ b/docs/adr/ADR-102-tiered-validate-and-merge.md
@@ -1,0 +1,247 @@
+# ADR-102: Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path
+
+**Status**: Proposed
+**Date**: 2026-07-08
+**Amends**: [ADR-020](ADR-020-git-native-kg-implementation.md) (restores the `kg commit` CLI
+primitive to the `kkernel kg` subcommand surface; see "Amendment to ADR-020" below)
+**Depends on**: [ADR-101](ADR-101-kg-changeset-model.md) (the change-set artifact this ADR
+validates, tiers, and merges), ADR-002 (edge ontology — the contract the rule engine
+mechanizes), ADR-010 (KG versioning — the git-native strategic frame), ADR-037 (atomic
+staging-then-rename, reused for the snapshot-commit lane), ADR-055 (epistemic relations —
+`supports`/`refutes` as tier-2 triggers), ADR-067 (single-writer daemon — the write path
+tier-1 rides)
+
+---
+
+## Context
+
+[ADR-101](ADR-101-kg-changeset-model.md) defines the change-set artifact: a producer-agnostic,
+stage-time-ID-stable op-list. That artifact needs a path from "staged" to "landed in the live
+graph," and not every staged operation carries the same risk. Creating a new entity and adding
+a routine link are low-risk, high-volume, and time-sensitive — a batch producer's whole value
+proposition depends on its output becoming searchable within minutes, not after a review queue
+clears. Marking one claim as superseded, refuting another, deleting a row, or merging two
+entities together are comparatively rare, harder to undo cleanly, and materially more expensive
+to get wrong: they change what the graph asserts, not just what it contains.
+
+Applying every staged operation through the same gate is wrong in both directions. Gating
+everything on review starves the high-volume, low-risk case of the latency it needs. Gating
+nothing lets the small number of judgment-bearing operations land unreviewed, which is exactly
+the failure mode a change-set model exists to prevent. This ADR splits the write path in two by
+risk, and defines the rule engine that decides which path a given operation takes.
+
+### What is already shipped and what this ADR builds on
+
+Two relevant surfaces exist in the codebase today, and this ADR extends both rather than
+inventing beside them:
+
+- **`kkernel kg validate`** ([ADR-020](ADR-020-git-native-kg-implementation.md),
+  [ADR-034](ADR-034-kg-validation-pipelines.md)) already runs a configurable, TOML-driven rule
+  pass over KG data, with a severity model (`error` / `warning` / `info`) and five shipped,
+  individually enable/disable/configurable rule classes: **edge-endpoint-types** (validates each
+  edge's source/relation/target kinds against the canonical endpoint contract),
+  **edge-direction-conventions** (flags likely-inverted directional edges against a configurable
+  forward pattern per relation), **dangling-refs** (a configurable counterpart to the always-on
+  referential-integrity check), **naming-conventions** (entity name hygiene with
+  per-entity-kind overrides), and **citation-date-lint** (flags forward-dated citation values).
+  This ADR does not add a sixth rule class or change any of the five; it adds a **tier
+  predicate** that reads a change-set's proposed operations and this same rule pass's findings
+  to decide which write path an operation takes (D2 below).
+- **The `kkernel kg` subcommand tree** ([ADR-020](ADR-020-git-native-kg-implementation.md) §5)
+  specifies eleven verbs, including `kg commit` (export + validate + git add + git commit). Of
+  those, `validate`, `init`, `fetch`/`sync`, `export`, `import`, `status`, and hook management
+  are implemented; `kg commit` is not — it exists today only as an unimplemented, proposed
+  design concept. This ADR restores it as a real CLI primitive, scoped to the tier-2 flow
+  defined below.
+
+---
+
+## Decision
+
+### D1 — Tier split of the write path
+
+Every staged change-set operation resolves, before it is applied, to exactly one of two tiers:
+
+- **Tier-1 (fast path)**: stage-time rule validation, then the **existing live batch write**
+  (the same MCP batch-op surface an interactive agent already uses, preserving today's batch
+  write latency), followed by an **asynchronous snapshot-commit** that records the write into
+  the git-native history after the fact.
+- **Tier-2 (reviewed path)**: the operation stays a **staged NDJSON change-set**, a **rendered
+  diff** is produced against current graph state, an **independent review** gates it, and only
+  on approval does it become a live write plus a synchronous commit.
+
+Tier-1 optimizes for the case ADR-101's context describes: high-volume, low-risk, time-sensitive
+writes that a batch producer needs searchable within minutes. Tier-2 optimizes for correctness
+on the small number of operations whose blast radius justifies a human or cross-model check
+before they land. Neither tier is optional or bypassable per D2; every staged operation is
+classified, not just the ones a caller happens to flag.
+
+### D2 — Rule engine and tier predicate
+
+**Rules run at stage time**, against the change-set as staged, using the same rule pass
+described in Context: **headless** via `kkernel kg validate --rules <path>`, driven by a rules
+file; a graphical reviewer evaluates the identical rules file through the shared rule-evaluator
+crate ([ADR-101](ADR-101-kg-changeset-model.md) D5), so a headless CI run and an interactive
+review session can never disagree about whether a given change-set is clean.
+
+**The tier predicate is configurable in the rules file, not hardcoded.** The predicate is a
+declarative condition over an operation's kind, its edge relation (where applicable), its field
+changes, and the rule pass's own findings for it. The seed predicate, shipped as the default and
+overridable per deployment:
+
+- **Tier-1 eligible**: `create`, a non-judgment `link` (any edge relation other than the ones
+  named tier-2 below), or an `update` to a mutable entity field — **and** the rule pass reports
+  all rules green (no `error`-severity finding) for that operation.
+- **Tier-2 required**: a `link` carrying `supersedes`, `supports`, or `refutes` (ADR-002's
+  derivation category and [ADR-055](ADR-055-epistemic-edge-relations.md)'s epistemic category —
+  the judgment-bearing relations by construction), any `delete`, any `merge`, any change to an
+  existing edge's relation or weight, or a `link`/edge-weight change where the resulting weight
+  falls below `0.7` (ADR-002's own boundary between "strong" and "plausible or weaker"
+  evidential strength). Any operation the rule pass does **not** report fully green is also
+  tier-2, regardless of its kind — a rule violation always escalates, never silently degrades to
+  a warning that still ships tier-1.
+
+Because the predicate lives in the rules file rather than in code, a deployment can widen or
+narrow the tier-1 set (for example, admitting more relation types to tier-1 once a producer has
+an established low-error track record) without an ADR amendment or a binary rebuild, so long as
+the change stays inside the rules-file contract this ADR defines. It cannot, by that same
+contract, remove `supersedes`/`supports`/`refutes`/`delete`/`merge` from tier-2 — those are named
+here as the ADR-002/ADR-055-derived floor, not a default a rules file is free to lower.
+
+### D3 — Review gate: hard routing, not convention
+
+Tier-2's independent review has one binding requirement: **the reviewer's model family must
+differ from the producer's.** This is enforced as a **hard routing gate** — the tier-2 flow
+refuses to present a change-set for approval to a reviewer identity sharing the producer's model
+family, rather than relying on a convention or a reviewer's own judgment to self-recuse. The
+rationale is the same one that motivates cross-family review in code review generally: a
+same-family reviewer is more likely to share the producer's blind spots and less likely to catch
+a systematic error class the producer itself cannot see. Making this a routing gate rather than
+guidance means the property holds even when an operator forgets to configure it deliberately.
+
+### D4 — Revert semantics
+
+**Op-list inversion is the primary revert mechanism.** Because every tier-2 change-set is a
+typed op-list ([ADR-101](ADR-101-kg-changeset-model.md) D1), each operation has a well-defined
+inverse (a `create`'s inverse is a `delete` of the same identifier; a `link`'s inverse removes
+that edge; an `update`'s inverse restores the prior field values captured at stage time), and
+reverting a landed change-set means applying its inverted op-list as a new, independently
+reviewed change-set. This keeps a revert auditable as its own change-set with its own
+provenance, exactly like any other tier-2 write.
+
+**Git revert of the NDJSON commit is the backstop**, used when op-list inversion is unavailable
+or insufficient (for example, a revert requested long after intervening writes have touched the
+same rows, where a straightforward field-level inversion would clobber later legitimate state).
+**Stated plainly, because the two are easy to conflate**: a snapshot-level git revert reverts
+**whole-graph state as committed at that snapshot**, not the surgical effect of one operation. It
+is a coarse instrument — correct for "put the graph back exactly as it was at commit X," wrong
+for "undo just this one edge without touching anything else that has changed since." Op-list
+inversion is the surgical tool; git revert is the blunt one, kept available deliberately for the
+cases the surgical tool cannot reach.
+
+### D5 — Topology: MCP-client-only access to the live graph
+
+Tooling built for this ADR (the headless CLI and any future reviewer surface) accesses the
+**live graph exclusively as an MCP client of the warm daemon** — the same stdio-MCP-client
+topology the daemon already serves other clients through, preserving the single DB handle and
+single-writer discipline [ADR-067](ADR-067-write-owner-daemon.md) establishes. **No tooling in
+this ADR's scope opens a second process handle on the live SQLite file.** Staged change-sets and
+committed snapshots are read as NDJSON files directly from disk — they are not live-graph state
+and carry no daemon-coexistence hazard, so file access to them is unrestricted.
+
+This deliberately diverges from patterns elsewhere in the codebase that link against the graph
+store in-process for a shared KG; the divergence is explicit and normative for this ADR's
+tooling, not an oversight. The same principle extends to the read side of tier-1's
+snapshot-commit: exporting the graph for the periodic snapshot commit reads from a **replica**,
+not the live store — a sustained read against the live database is the same
+WAL-checkpoint-pinning hazard class this topology constraint exists to prevent, and a
+periodically-refreshed replica is current enough for a snapshot cadence measured in hours while
+adding zero live-store contention.
+
+### D6 — Local-only change-set and snapshot repository (binding constraint)
+
+**The repository holding staged change-sets and committed snapshots is local-only.** Exports
+carry live graph content — including notes and memories that may never leave the local host
+without an explicit, separate decision — so this repository **MUST NOT** have a git remote
+added to it, and no lane, tool, or automation defined by this ADR may add one. This is a
+normative constraint, not a default that happens to be unconfigured: a future need for off-host
+replication of this repository's content is a new decision, made explicitly and covered by its
+own ADR, not a configuration change slipped into an existing lane.
+
+Rationale: unlike the source-code repository this design otherwise takes its git-native
+inspiration from ([ADR-010](ADR-010-kg-versioning.md), [ADR-020](ADR-020-git-native-kg-implementation.md)),
+this repository's content is not source code — it is a live export of graph data that may include
+material never intended for any shared or public destination. Treating "local-only" as the
+default-safe posture, and requiring a deliberate future decision to change it, is the same
+data-sensitivity posture the codebase already applies to backup and replication targets
+elsewhere; it is restated here as a binding constraint specifically because a remote is the one
+mistake that would be silent, easy to make by habit, and hard to undo.
+
+### Amendment to ADR-020: restoring `kg commit`
+
+[ADR-020](ADR-020-git-native-kg-implementation.md) §5 specifies `kg commit -m <msg>` — export,
+validate, `git add`, `git commit` — as part of the `kkernel kg` CLI surface. It was never
+implemented; the shipped subcommand tree covers `validate`, `init`, `fetch` (aliased `sync`),
+`export`, `import`, `status`, and hook management, but not `commit`. This ADR restores it, scoped
+specifically to the tier-2 flow this ADR defines: `kkernel kg commit` runs validate against the
+staged change-set's rules file, and on a clean pass performs the git add and commit that lands
+an approved tier-2 change-set, carrying the provenance trailer [ADR-101](ADR-101-kg-changeset-model.md)
+D4 defines. This is additive to ADR-020's CLI surface — no existing verb's behavior changes —
+and the `commit` verb is scoped to this ADR's own local, non-remote repository (D6), not to
+the project-repository-embedded `.khive/kg/` layout ADR-020 §1 otherwise describes.
+
+---
+
+## Consequences
+
+Honest costs, stated rather than assumed away:
+
+- **Two write paths to maintain.** Tier-1 and tier-2 are genuinely different code paths with
+  different latency, different failure modes, and different testing needs. A bug specific to
+  one tier does not automatically surface in the other, and both need their own regression
+  coverage.
+- **Review latency on tier-2.** Any operation routed to tier-2 — including a legitimate,
+  correct `supersedes` edge from a well-behaved producer — waits on the cross-family review gate
+  (D3) before it lands. This is the deliberate trade this ADR makes: correctness on
+  judgment-bearing writes, at the cost of latency those writes did not previously pay when they
+  went through the same live-write path as everything else.
+- **The rules file becomes a contract surface.** Because the tier predicate lives in the rules
+  file (D2) and both the headless CLI and any graphical reviewer evaluate it identically, the
+  rules file is no longer a soft convenience — it is load-bearing configuration that determines
+  which operations get reviewed. A malformed or misconfigured rules file is now a correctness
+  risk (silently widening tier-1 past the ADR-002/ADR-055 floor is explicitly not permitted, per
+  D2, but a bug in an implementation that fails to enforce that floor would be a real regression
+  worth guarding with its own test).
+- **No new edge relations, no new entity or note kinds.** This ADR mechanizes the existing
+  ADR-002 contract — the tier predicate reads relation types and weights ADR-002 and
+  [ADR-055](ADR-055-epistemic-edge-relations.md) already define — and introduces no schema
+  change. Everything in D2's seed predicate is expressible against the closed taxonomies as they
+  stand today.
+- **`kg commit`'s restoration (Amendment to ADR-020) is scoped, not a general revival.** It
+  lands specifically as the tier-2 commit primitive against this ADR's local-only repository
+  (D6); it does not resurrect the whole of ADR-020 §5's original eleven-verb workflow or its
+  project-repository-embedded layout, both of which remain a separate, larger piece of work if
+  ever pursued.
+
+---
+
+## References
+
+- ADR-002 — Closed Edge Ontology: the relation vocabulary and weight scale the tier predicate
+  (D2) reads.
+- ADR-010 — KG Versioning Strategy: the git-native strategic frame this ADR's commit and revert
+  mechanics operate inside.
+- ADR-020 — Git-Native KG Implementation: the `kg commit` primitive this ADR restores (Amendment
+  to ADR-020), and the shipped `kkernel kg validate` rule-pass surface this ADR's tier predicate
+  extends.
+- ADR-034 — KG Validation Pipelines: the five shipped, configurable rule classes this ADR's tier
+  predicate reads findings from.
+- ADR-037 — Remote Entity Resolution and Content-Hash Verification: the atomic
+  staging-then-rename pattern reused for writing the snapshot-commit lane's export before it is
+  committed.
+- ADR-055 — Epistemic Edge Relations: `supports`/`refutes` as two of the relations this ADR's
+  tier predicate routes to tier-2 by construction.
+- ADR-067 — Write-Owner Daemon: the single-writer, single-DB-handle discipline this ADR's
+  topology section (D5) preserves by requiring MCP-client-only access to the live graph.
+- ADR-101 — KG Change-Set Model: the op-list artifact this ADR validates, tiers, reviews, and
+  commits.

--- a/docs/adr/ADR-102-tiered-validate-and-merge.md
+++ b/docs/adr/ADR-102-tiered-validate-and-merge.md
@@ -35,10 +35,11 @@ risk, and defines the rule engine that decides which path a given operation take
 Two relevant surfaces exist in the codebase today, and this ADR extends both rather than
 inventing beside them:
 
-- **`kkernel kg validate`** ([ADR-020](ADR-020-git-native-kg-implementation.md),
-  [ADR-034](ADR-034-kg-validation-pipelines.md)) already runs a configurable, TOML-driven rule
-  pass over KG data, with a severity model (`error` / `warning` / `info`) and five shipped,
-  individually enable/disable/configurable rule classes: **edge-endpoint-types** (validates each
+- **`kkernel kg validate`** already runs a configurable, TOML-driven rule pass over KG data
+  with a severity model (`error` / `warning` / `info`). [ADR-020](ADR-020-git-native-kg-implementation.md)
+  and [ADR-034](ADR-034-kg-validation-pipelines.md) define that validation surface; the shipped
+  implementation has since extended it with five individually
+  enable/disable/configurable rule classes: **edge-endpoint-types** (validates each
   edge's source/relation/target kinds against the canonical endpoint contract),
   **edge-direction-conventions** (flags likely-inverted directional edges against a configurable
   forward pattern per relation), **dangling-refs** (a configurable counterpart to the always-on
@@ -91,15 +92,17 @@ overridable per deployment:
 
 - **Tier-1 eligible**: `create`, a non-judgment `link` (any edge relation other than the ones
   named tier-2 below), or an `update` to a mutable entity field — **and** the rule pass reports
-  all rules green (no `error`-severity finding) for that operation.
+  no `error`-severity finding for that operation. `warning`- and `info`-severity findings do
+  not block tier-1; they are recorded on the change-set so a reviewer or later reader sees
+  them, but they do not gate the fast path.
 - **Tier-2 required**: a `link` carrying `supersedes`, `supports`, or `refutes` (ADR-002's
   derivation category and [ADR-055](ADR-055-epistemic-edge-relations.md)'s epistemic category —
   the judgment-bearing relations by construction), any `delete`, any `merge`, any change to an
   existing edge's relation or weight, or a `link`/edge-weight change where the resulting weight
   falls below `0.7` (ADR-002's own boundary between "strong" and "plausible or weaker"
-  evidential strength). Any operation the rule pass does **not** report fully green is also
-  tier-2, regardless of its kind — a rule violation always escalates, never silently degrades to
-  a warning that still ships tier-1.
+  evidential strength). Any operation carrying an `error`-severity finding is also tier-2,
+  regardless of its kind — an `error` always escalates to review; it is never downgraded to a
+  lower severity, suppressed, or shipped tier-1.
 
 Because the predicate lives in the rules file rather than in code, a deployment can widen or
 narrow the tier-1 set (for example, admitting more relation types to tier-1 once a producer has
@@ -114,6 +117,9 @@ Tier-2's independent review has one binding requirement: **the reviewer's model 
 differ from the producer's.** This is enforced as a **hard routing gate** — the tier-2 flow
 refuses to present a change-set for approval to a reviewer identity sharing the producer's model
 family, rather than relying on a convention or a reviewer's own judgment to self-recuse. The
+gate's input is the producer model family recorded in the change-set's envelope metadata
+([ADR-101](ADR-101-kg-changeset-model.md) D1) — an authoritative, stage-time-captured field,
+not an out-of-band convention an implementer has to invent. The
 rationale is the same one that motivates cross-family review in code review generally: a
 same-family reviewer is more likely to share the producer's blind spots and less likely to catch
 a systematic error class the producer itself cannot see. Making this a routing gate rather than
@@ -123,11 +129,16 @@ guidance means the property holds even when an operator forgets to configure it 
 
 **Op-list inversion is the primary revert mechanism.** Because every tier-2 change-set is a
 typed op-list ([ADR-101](ADR-101-kg-changeset-model.md) D1), each operation has a well-defined
-inverse (a `create`'s inverse is a `delete` of the same identifier; a `link`'s inverse removes
-that edge; an `update`'s inverse restores the prior field values captured at stage time), and
-reverting a landed change-set means applying its inverted op-list as a new, independently
-reviewed change-set. This keeps a revert auditable as its own change-set with its own
-provenance, exactly like any other tier-2 write.
+inverse: a `create`'s inverse is a `delete` of the same identifier; a `link`'s inverse removes
+that edge; an `update`'s inverse restores the prior field values captured at stage time; a
+`delete`'s or `merge`'s inverse is reconstructed from the stage-time preimage ADR-101 D1
+requires destructive operations to capture. Reverting a landed change-set means applying its
+inverted op-list as a new, independently reviewed change-set, which keeps a revert auditable
+with its own provenance, exactly like any other tier-2 write. **Inversion is defined only over
+operations whose preimage was captured**: an operation staged without one, or whose preimage
+has been invalidated by intervening writes to the same rows, cannot be surgically inverted and
+must fall back to a reviewed compensating change-set authored against current state, or to the
+git backstop below.
 
 **Git revert of the NDJSON commit is the backstop**, used when op-list inversion is unavailable
 or insufficient (for example, a revert requested long after intervening writes have touched the
@@ -234,8 +245,8 @@ Honest costs, stated rather than assumed away:
 - ADR-020 — Git-Native KG Implementation: the `kg commit` primitive this ADR restores (Amendment
   to ADR-020), and the shipped `kkernel kg validate` rule-pass surface this ADR's tier predicate
   extends.
-- ADR-034 — KG Validation Pipelines: the five shipped, configurable rule classes this ADR's tier
-  predicate reads findings from.
+- ADR-034 — KG Validation Pipelines: the configurable rule-pass surface whose shipped rule-class
+  extensions this ADR's tier predicate reads findings from.
 - ADR-037 — Remote Entity Resolution and Content-Hash Verification: the atomic
   staging-then-rename pattern reused for writing the snapshot-commit lane's export before it is
   committed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,6 +124,8 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-096](ADR-096-warm-daemon-per-request-identity.md)       | Warm Daemon Per-Request Identity — Serving Many Attribution Identities Over One Shared Backend (Accepted)       |
 | [ADR-099](ADR-099-bulk-apply-atomic-units.md)                | Cross-Op Atomicity for Bulk Apply — Prepared Write Plans over the Single-Writer Seam (Accepted)                 |
 | [ADR-100](ADR-100-store-backup-replication.md)               | Store Backup and Replication — Scheduled Differential Sync with Tiered Recovery Objectives (Proposed)           |
+| [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs (Proposed)                           |
+| [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path (Proposed)                        |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Two new proposed ADRs establishing the staged change-set architecture:

- **ADR-101 — KG Change-Set Model**: producer-agnostic typed op-list (create/link/update/delete/merge) with stage-time stable UUIDs and destructive-op preimage capture, NDJSON-delta serialization, the ingester pattern, envelope metadata for reviewer routing, commit-trailer provenance, and three UI-agnostic wasm32-compilable crates (khive-changeset, rule evaluator, diff computation).
- **ADR-102 — Tiered Validate-and-Merge**: risk-split write path (tier-1 fast path with async snapshot-commit; tier-2 staged/reviewed change-sets), rules-file tier predicate with a non-lowerable tier-2 floor, cross-model-family review as a hard routing gate, op-list-inversion revert with git backstop, MCP-client-only live-graph topology, local-only repository constraint (normative MUST NOT), and a scoped ADR-020 amendment restoring `kg commit`.

Docs-only: the two ADR files plus two README index rows. Both ADRs are Proposed; implementation is gated separately.

## Review

Three-round internal review: round 1 APPROVE-WITH-FIXES (2 High / 2 Medium / 2 Low, all addressed in be2dab61), round 2 caught one residual serialization-contract gap (fixed in 9d86fb3f), round 3 clean APPROVE. Shipped-code claims (five validate rule classes, `kg commit` absent from the shipped subcommand enum) verified against source and the validator integration test.