### PR TITLE
feat(kkernel): kg commit — tier-2 change-set commit primitive

### DIFF
--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -31,6 +31,7 @@ khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
 khive-request = { version = "0.3.0", path = "../khive-request" }
+khive-changeset = { version = "0.3.0", path = "../khive-changeset" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -44,9 +45,9 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 toml = { workspace = true }
 rmcp = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 serial_test = { workspace = true }
 lattice-embed = { workspace = true }

--- a/crates/kkernel/src/kg/commit.rs
+++ b/crates/kkernel/src/kg/commit.rs
@@ -203,8 +203,9 @@ fn project_changeset(changeset: &ChangeSet) -> ProjectedNdjson {
                         // `edge-endpoint-types`, via `collect_kind_map`) and
                         // `description` (generic `[[rules]] require_field`)
                         // are both consulted by `kg validate`'s rule classes,
-                        // not just `id`/`kind`/`name`/`properties`/`tags` —
-                        // see codex round-1 review H1 (khive#kg-commit-tier2).
+                        // not just `id`/`kind`/`name`/`properties`/`tags`.
+                        // Projecting a narrower record than the staged op
+                        // causes false rejections and vacuous rule passes.
                         let rec = serde_json::json!({
                             "id": id_str,
                             "kind": serde_json::to_value(fields.entity_kind)
@@ -223,8 +224,7 @@ fn project_changeset(changeset: &ChangeSet) -> ProjectedNdjson {
                         // Project every `NoteCreateFields` field the rule
                         // pass can read (generic `[[rules]]` can
                         // `require_field`/condition on any top-level field,
-                        // not just `kind`/`properties`/`tags`) — see codex
-                        // round-1 review H1.
+                        // not just `kind`/`properties`/`tags`).
                         let rec = serde_json::json!({
                             "id": id_str,
                             "kind": fields.note_kind,
@@ -299,7 +299,7 @@ fn check_no_duplicate_stage_ids(duplicate_ids: &[String]) -> RuleResult {
 /// "dangling-refs"` filter would also swallow the malformed-config error
 /// result `validate_severity` emits under that same id, and any generic
 /// `[[rules]]` entry a rules author happens to name `"dangling-refs"` — both
-/// of which must still fail the commit (codex round-1 review H2).
+/// of which must still fail the commit.
 fn run_commit_time_rules(changeset: &ChangeSet, rules_path: &Path) -> Result<Vec<RuleResult>> {
     let projected = project_changeset(changeset);
 

--- a/crates/kkernel/src/kg/commit.rs
+++ b/crates/kkernel/src/kg/commit.rs
@@ -198,11 +198,20 @@ fn project_changeset(changeset: &ChangeSet) -> ProjectedNdjson {
                 }
                 match &create.target {
                     CreateTarget::Entity(fields) => {
+                        // Project every `EntityCreateFields` field the rule
+                        // pass can read: `entity_type` (pack `EDGE_RULES` /
+                        // `edge-endpoint-types`, via `collect_kind_map`) and
+                        // `description` (generic `[[rules]] require_field`)
+                        // are both consulted by `kg validate`'s rule classes,
+                        // not just `id`/`kind`/`name`/`properties`/`tags` —
+                        // see codex round-1 review H1 (khive#kg-commit-tier2).
                         let rec = serde_json::json!({
                             "id": id_str,
                             "kind": serde_json::to_value(fields.entity_kind)
                                 .expect("EntityKind serializes"),
+                            "entity_type": fields.entity_type,
                             "name": fields.name,
+                            "description": fields.description,
                             "properties": serde_json::to_value(&fields.properties)
                                 .expect("properties serialize"),
                             "tags": fields.tags,
@@ -211,12 +220,20 @@ fn project_changeset(changeset: &ChangeSet) -> ProjectedNdjson {
                         entities.push('\n');
                     }
                     CreateTarget::Note(fields) => {
+                        // Project every `NoteCreateFields` field the rule
+                        // pass can read (generic `[[rules]]` can
+                        // `require_field`/condition on any top-level field,
+                        // not just `kind`/`properties`/`tags`) — see codex
+                        // round-1 review H1.
                         let rec = serde_json::json!({
                             "id": id_str,
                             "kind": fields.note_kind,
+                            "content": fields.content,
                             "properties": serde_json::to_value(&fields.properties)
                                 .expect("properties serialize"),
                             "tags": fields.tags,
+                            "salience": fields.salience,
+                            "decay_factor": fields.decay_factor,
                         });
                         notes.push_str(&serde_json::to_string(&rec).expect("json line"));
                         notes.push('\n');
@@ -274,11 +291,15 @@ fn check_no_duplicate_stage_ids(duplicate_ids: &[String]) -> RuleResult {
 
 /// Run the commit-time rule subset against `changeset`, using `rules_path`
 /// for the configurable rule classes. See the module doc comment for exactly
-/// which classes run and why `dangling-refs` is filtered out of the
-/// `configurable_rule_checks` result rather than never invoked — invoking it
-/// is a plain NDJSON read (no DB, no topology hazard); its *result* is simply
-/// not meaningful against a partial change-set view, so it is excluded from
-/// the pass/fail decision and never displayed as a real finding.
+/// which classes run and why the built-in `dangling-refs` *finding* is not
+/// meaningful against a partial change-set view. That exclusion is done by
+/// calling `validate::configurable_rule_checks_partial_view`, which never
+/// invokes the built-in dangling-ref evaluator — it is NOT a post-hoc filter
+/// over the returned `RuleResult`s by public id. A post-hoc `id ==
+/// "dangling-refs"` filter would also swallow the malformed-config error
+/// result `validate_severity` emits under that same id, and any generic
+/// `[[rules]]` entry a rules author happens to name `"dangling-refs"` — both
+/// of which must still fail the commit (codex round-1 review H2).
 fn run_commit_time_rules(changeset: &ChangeSet, rules_path: &Path) -> Result<Vec<RuleResult>> {
     let projected = project_changeset(changeset);
 
@@ -299,14 +320,14 @@ fn run_commit_time_rules(changeset: &ChangeSet, rules_path: &Path) -> Result<Vec
     ];
 
     if rules_path.exists() {
-        let configurable = validate::configurable_rule_checks(
+        let configurable = validate::configurable_rule_checks_partial_view(
             &entities_path,
             &edges_path,
             &notes_path,
             rules_path,
         )
         .context("evaluating configurable rules")?;
-        results.extend(configurable.into_iter().filter(|r| r.id != "dangling-refs"));
+        results.extend(configurable);
     }
 
     Ok(results)

--- a/crates/kkernel/src/kg/commit.rs
+++ b/crates/kkernel/src/kg/commit.rs
@@ -1,0 +1,791 @@
+//! `kkernel kg commit` — the tier-2 change-set commit primitive.
+//!
+//! Restores the `kg commit` verb [ADR-020](../../../../docs/adr/ADR-020-git-native-kg-implementation.md)
+//! §5 specified but never shipped, scoped per [ADR-102](../../../../docs/adr/ADR-102-tiered-validate-and-merge.md)'s
+//! "Amendment to ADR-020": this is the commit step for an already-staged
+//! [ADR-101](../../../../docs/adr/ADR-101-kg-changeset-model.md) change-set, run
+//! against ADR-102's own local-only staged-change-set/snapshot repository
+//! (D6) — never the project-repository-embedded `.khive/kg/` layout the other
+//! `kg` verbs operate on.
+//!
+//! # What this command does
+//!
+//! 1. Parse the change-set NDJSON-delta file via `khive_changeset::from_ndjson`
+//!    (fail-loud on any parse/schema error — malformed input never reaches
+//!    step 2).
+//! 2. Project the change-set's `create`/`link` ops into synthetic
+//!    `entities.ndjson` / `notes.ndjson` / `edges.ndjson` content and run a
+//!    **subset** of the same rule pass `kkernel kg validate` uses against
+//!    them (see "Commit-time validation scope" below). Any `error`-severity
+//!    finding refuses the commit.
+//! 3. On a clean pass: `git add` the change-set file into the target repo and
+//!    `git commit`, carrying the ADR-101 D4 provenance trailers. Refuses
+//!    (fail-loud, before touching git) if the target repo has any configured
+//!    remote (ADR-102 D6).
+//!
+//! # Commit-time validation scope
+//!
+//! A change-set is a **partial** view of the graph: most `link` ops target
+//! entities or notes created by an *earlier*, already-committed change-set,
+//! not by this one. Rule classes that assume a complete known-ID universe
+//! (`referential-integrity`, `dangling-refs`) would therefore flag the
+//! overwhelming majority of ordinary edges as broken if run against this
+//! change-set alone — a false-positive storm, not a real finding. Those two
+//! classes are **not evaluated here**; they are deferred to stage time, where
+//! the producer/reviewer has (or can obtain) full graph context, per
+//! ADR-102 D5's own framing of `dangling-refs` as an offline, dataset-scoped
+//! check. `edge-endpoint-types` and `edge-direction-conventions` do not need
+//! this exclusion: both already skip any edge whose endpoint fails to resolve
+//! within the given NDJSON dataset (see `validate::check_edge_endpoint_types`),
+//! so restricting them to this change-set's own `create` ops degrades
+//! gracefully to "check what we can see" rather than false-flagging.
+//!
+//! `update`, `delete`, and `merge` ops are not re-projected into the
+//! synthetic view: they patch or remove records that already exist outside
+//! this change-set, so this command has no fresh kind/name/relation data to
+//! check for them beyond what ADR-102 D2 already routes to tier-2 review by
+//! construction (`delete`, `merge`, and any edge-relation/weight change are
+//! *always* tier-2). Re-validating already-reviewed preimage data offline
+//! here would not catch anything new.
+//!
+//! No SQLite handle is opened anywhere in this module (ADR-102 D5 topology
+//! guard) — `validate::build_taxonomy` builds its registry with `db_path:
+//! None`, exactly as `kg validate` already does, and every NDJSON read below
+//! is a plain file read against the synthetic projection or the change-set
+//! file itself.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use khive_changeset::{ChangeSet, CreateTarget, Op};
+
+use super::types::{CommitArgs, CommitReport, OutputFormat, RuleResult, Violation};
+use super::validate;
+
+pub(super) fn cmd_commit(args: CommitArgs) -> Result<()> {
+    // ── 1. Parse the change-set (fail-loud) ────────────────────────────────
+    let changeset_text = std::fs::read_to_string(&args.changeset)
+        .with_context(|| format!("reading change-set {}", args.changeset.display()))?;
+    let changeset = khive_changeset::from_ndjson(&changeset_text).with_context(|| {
+        format!(
+            "parsing change-set {} as NDJSON-delta",
+            args.changeset.display()
+        )
+    })?;
+
+    if !args.rules.exists() {
+        bail!(
+            "rules file not found: {} — `kg commit` requires an explicit rules \
+             file (ADR-102 D2: the tier predicate and its rule pass live in this \
+             file, not a default)",
+            args.rules.display()
+        );
+    }
+
+    // ── 2. Commit-time validation ───────────────────────────────────────────
+    let rule_results =
+        run_commit_time_rules(&changeset, &args.rules).context("running commit-time rule pass")?;
+
+    let errors: usize = rule_results
+        .iter()
+        .filter(|r| r.severity == "error" && !r.passed)
+        .count();
+    let warnings: usize = rule_results
+        .iter()
+        .filter(|r| r.severity == "warning" && !r.passed)
+        .count();
+    let info: usize = rule_results
+        .iter()
+        .filter(|r| r.severity == "info" && !r.passed)
+        .count();
+    let passed = errors == 0;
+
+    print_report(&args.format, &rule_results, errors, warnings, info, passed);
+
+    if !passed {
+        // Refuse to commit: an error-severity finding on a staged change-set
+        // means either the tier predicate under-tiered it, or a producer bug
+        // slipped past stage-time review. Either way this primitive is the
+        // last gate before the write lands, so it re-checks and refuses
+        // rather than trusting an upstream "already reviewed" claim.
+        std::process::exit(1);
+    }
+
+    // ── 3. Git add + commit ─────────────────────────────────────────────────
+    let repo = args
+        .repo
+        .canonicalize()
+        .with_context(|| format!("resolving repo path {}", args.repo.display()))?;
+    if !repo.join(".git").exists() {
+        bail!(
+            "{} is not a git repository (no .git); run `git init` in the \
+             staged change-set/snapshot repo first",
+            repo.display()
+        );
+    }
+
+    ensure_no_remote(&repo)?;
+
+    let rel_path = stage_changeset_file(&repo, &args.changeset)?;
+
+    run_git_ok(&repo, &["add", "--", &rel_path])?;
+
+    let producer_batch = format!(
+        "{}@{}us",
+        changeset.envelope.producer,
+        changeset.envelope.staged_at.as_micros()
+    );
+    let full_message = format!(
+        "{}\n\nChange-Set-Producer: {}\nChange-Set-Producer-Batch: {}\n",
+        args.message.trim_end(),
+        sanitize_trailer_value(&changeset.envelope.producer),
+        sanitize_trailer_value(&producer_batch),
+    );
+    let message_file =
+        tempfile::NamedTempFile::new().context("creating commit-message temp file")?;
+    std::fs::write(message_file.path(), &full_message).context("writing commit message")?;
+
+    let message_path = message_file
+        .path()
+        .to_str()
+        .context("commit-message temp path is not valid UTF-8")?;
+    run_git_ok(&repo, &["commit", "-F", message_path])?;
+
+    let commit_sha = run_git_ok(&repo, &["rev-parse", "HEAD"])?;
+
+    let report = CommitReport {
+        commit_sha,
+        changeset_path: rel_path,
+        ops: changeset.ops.len(),
+        producer: changeset.envelope.producer.clone(),
+        producer_batch,
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("serialize CommitReport")
+    );
+    Ok(())
+}
+
+// ── Commit-time rule pass ───────────────────────────────────────────────────
+
+/// Synthetic NDJSON projection of a change-set's `create`/`link` ops, in the
+/// same per-substrate file shape `kg validate`'s rule functions read.
+struct ProjectedNdjson {
+    entities: String,
+    notes: String,
+    edges: String,
+    /// Stage-time ids minted more than once by `create` ops in this
+    /// change-set (across both entity and note targets).
+    duplicate_ids: Vec<String>,
+}
+
+fn project_changeset(changeset: &ChangeSet) -> ProjectedNdjson {
+    let mut entities = String::new();
+    let mut notes = String::new();
+    let mut edges = String::new();
+    let mut seen_ids: HashMap<String, ()> = HashMap::new();
+    let mut duplicate_ids = Vec::new();
+
+    for op in &changeset.ops {
+        match op {
+            Op::Create(create) => {
+                let id_str = create.id.to_string();
+                if seen_ids.insert(id_str.clone(), ()).is_some() {
+                    duplicate_ids.push(id_str.clone());
+                }
+                match &create.target {
+                    CreateTarget::Entity(fields) => {
+                        let rec = serde_json::json!({
+                            "id": id_str,
+                            "kind": serde_json::to_value(fields.entity_kind)
+                                .expect("EntityKind serializes"),
+                            "name": fields.name,
+                            "properties": serde_json::to_value(&fields.properties)
+                                .expect("properties serialize"),
+                            "tags": fields.tags,
+                        });
+                        entities.push_str(&serde_json::to_string(&rec).expect("json line"));
+                        entities.push('\n');
+                    }
+                    CreateTarget::Note(fields) => {
+                        let rec = serde_json::json!({
+                            "id": id_str,
+                            "kind": fields.note_kind,
+                            "properties": serde_json::to_value(&fields.properties)
+                                .expect("properties serialize"),
+                            "tags": fields.tags,
+                        });
+                        notes.push_str(&serde_json::to_string(&rec).expect("json line"));
+                        notes.push('\n');
+                    }
+                }
+            }
+            Op::Link(link) => {
+                let rec = serde_json::json!({
+                    "edge_id": link.id.to_string(),
+                    "source_id": link.source.to_string(),
+                    "target_id": link.target.to_string(),
+                    "relation": serde_json::to_value(link.relation)
+                        .expect("EdgeRelation serializes"),
+                    "weight": link.weight,
+                    "properties": serde_json::to_value(&link.properties)
+                        .expect("properties serialize"),
+                });
+                edges.push_str(&serde_json::to_string(&rec).expect("json line"));
+                edges.push('\n');
+            }
+            // `update`/`delete`/`merge` are out of scope for commit-time
+            // re-validation — see the module-level doc comment.
+            Op::Update(_) | Op::Delete(_) | Op::Merge(_) => {}
+        }
+    }
+
+    ProjectedNdjson {
+        entities,
+        notes,
+        edges,
+        duplicate_ids,
+    }
+}
+
+fn check_no_duplicate_stage_ids(duplicate_ids: &[String]) -> RuleResult {
+    let violations: Vec<Violation> = duplicate_ids
+        .iter()
+        .map(|id| Violation {
+            entity_id: Some(id.clone()),
+            entity_name: None,
+            entity_kind: None,
+            rule_id: "no-duplicate-uuids".into(),
+            severity: "error",
+            message: format!("Duplicate stage-time id within change-set: {id}"),
+            fixable: false,
+        })
+        .collect();
+    RuleResult {
+        id: "no-duplicate-uuids".into(),
+        severity: "error",
+        passed: violations.is_empty(),
+        violations,
+    }
+}
+
+/// Run the commit-time rule subset against `changeset`, using `rules_path`
+/// for the configurable rule classes. See the module doc comment for exactly
+/// which classes run and why `dangling-refs` is filtered out of the
+/// `configurable_rule_checks` result rather than never invoked — invoking it
+/// is a plain NDJSON read (no DB, no topology hazard); its *result* is simply
+/// not meaningful against a partial change-set view, so it is excluded from
+/// the pass/fail decision and never displayed as a real finding.
+fn run_commit_time_rules(changeset: &ChangeSet, rules_path: &Path) -> Result<Vec<RuleResult>> {
+    let projected = project_changeset(changeset);
+
+    let tmp = tempfile::TempDir::new().context("creating projection temp dir")?;
+    let entities_path = tmp.path().join("entities.ndjson");
+    let notes_path = tmp.path().join("notes.ndjson");
+    let edges_path = tmp.path().join("edges.ndjson");
+    std::fs::write(&entities_path, &projected.entities).context("writing projected entities")?;
+    std::fs::write(&notes_path, &projected.notes).context("writing projected notes")?;
+    std::fs::write(&edges_path, &projected.edges).context("writing projected edges")?;
+
+    let taxonomy = validate::build_taxonomy().context("building KG taxonomy")?;
+
+    let mut results = vec![
+        check_no_duplicate_stage_ids(&projected.duplicate_ids),
+        validate::check_valid_entity_kinds(&entities_path, &taxonomy.entity_kinds),
+        validate::check_valid_note_kinds(&notes_path, &taxonomy.note_kinds),
+    ];
+
+    if rules_path.exists() {
+        let configurable = validate::configurable_rule_checks(
+            &entities_path,
+            &edges_path,
+            &notes_path,
+            rules_path,
+        )
+        .context("evaluating configurable rules")?;
+        results.extend(configurable.into_iter().filter(|r| r.id != "dangling-refs"));
+    }
+
+    Ok(results)
+}
+
+fn print_report(
+    format: &OutputFormat,
+    rule_results: &[RuleResult],
+    errors: usize,
+    warnings: usize,
+    info: usize,
+    passed: bool,
+) {
+    match format {
+        OutputFormat::Json => {
+            let payload = serde_json::json!({
+                "rules": rule_results,
+                "summary": {
+                    "errors": errors,
+                    "warnings": warnings,
+                    "info": info,
+                    "passed": passed,
+                },
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&payload).expect("serialize commit report")
+            );
+        }
+        OutputFormat::Github => {
+            for r in rule_results {
+                for v in &r.violations {
+                    let level = if r.severity == "error" {
+                        "error"
+                    } else {
+                        "warning"
+                    };
+                    println!("::{level} ::{}", v.message);
+                }
+            }
+        }
+        OutputFormat::Text => {
+            for r in rule_results {
+                let symbol = if r.passed {
+                    "\u{2713}"
+                } else if r.severity == "error" {
+                    "\u{2717}"
+                } else {
+                    "\u{26a0}"
+                };
+                println!("  {symbol} {}: {} violation(s)", r.id, r.violations.len());
+                for v in &r.violations {
+                    println!("    - {}", v.message);
+                }
+            }
+            println!("\nSummary: {errors} error(s), {warnings} warning(s), {info} info");
+            if passed {
+                println!("clean pass — proceeding to commit");
+            } else {
+                println!("refusing to commit: {errors} error-severity finding(s)");
+            }
+        }
+    }
+}
+
+// ── Git ──────────────────────────────────────────────────────────────────────
+
+/// Refuse (ADR-102 D6) if `repo` has any configured git remote.
+fn ensure_no_remote(repo: &Path) -> Result<()> {
+    let stdout = run_git_ok(repo, &["remote"])?;
+    let remotes: Vec<&str> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    if !remotes.is_empty() {
+        bail!(
+            "refusing to commit: {} has configured git remote(s) [{}] — ADR-102 D6 \
+             requires the staged change-set/snapshot repository to be local-only; \
+             remove the remote(s) before running `kg commit`",
+            repo.display(),
+            remotes.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Ensure the change-set file is present inside `repo` and return its path
+/// relative to `repo` (the path `git add`/`git commit` operate on).
+///
+/// If `changeset_src` already lives under `repo`, it is used in place. If
+/// not — the common case for a producer staging into a scratch directory
+/// before commit — it is copied into `<repo>/.khive/kg/changesets/<name>`,
+/// creating that directory if needed, so the committed artifact always has a
+/// stable, auditable home inside the target repository.
+fn stage_changeset_file(repo: &Path, changeset_src: &Path) -> Result<String> {
+    let repo_abs = repo
+        .canonicalize()
+        .with_context(|| format!("resolving repo path {}", repo.display()))?;
+    let src_abs = changeset_src
+        .canonicalize()
+        .with_context(|| format!("resolving change-set path {}", changeset_src.display()))?;
+
+    if let Ok(rel) = src_abs.strip_prefix(&repo_abs) {
+        return Ok(rel.to_string_lossy().into_owned());
+    }
+
+    let file_name = changeset_src
+        .file_name()
+        .context("change-set path has no file name")?;
+    let dest_dir = repo.join(".khive/kg/changesets");
+    std::fs::create_dir_all(&dest_dir)
+        .with_context(|| format!("creating {}", dest_dir.display()))?;
+    let dest = dest_dir.join(file_name);
+    std::fs::copy(&src_abs, &dest).with_context(|| {
+        format!(
+            "copying change-set {} into {}",
+            src_abs.display(),
+            dest.display()
+        )
+    })?;
+
+    let rel: PathBuf = [".khive", "kg", "changesets"]
+        .iter()
+        .collect::<PathBuf>()
+        .join(file_name);
+    Ok(rel.to_string_lossy().into_owned())
+}
+
+fn run_git_ok(repo: &Path, args: &[&str]) -> Result<String> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        // This repo's whole purpose (ADR-102 D6) is committing exported KG
+        // NDJSON — exactly the pattern the machine-wide `check-json-data.sh`
+        // leak guard (`~/.git-hooks`, `core.hooksPath`) exists to catch by
+        // default. `KHIVE_ALLOW_DATA=1` is that hook's own documented,
+        // auditable bypass, not `--no-verify`; the hook's header comment
+        // names this exact commit path ("khive-vcs kg git-sync write path
+        // ... commits .khive/kg/*.ndjson BY DESIGN; it sets
+        // KHIVE_ALLOW_DATA=1 on its own git subprocesses") as the precedent
+        // this follows. A no-op for every non-commit invocation below.
+        .env("KHIVE_ALLOW_DATA", "1")
+        .output()
+        .with_context(|| format!("running git {} in {}", args.join(" "), repo.display()))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        bail!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            repo.display(),
+            stderr.trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Collapse embedded newlines so a value is safe to carry as a one-line
+/// `git interpret-trailers`-shaped `Key: value` trailer.
+fn sanitize_trailer_value(value: &str) -> String {
+    value.replace(['\n', '\r'], " ").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use khive_changeset::{
+        CreateOp, CreateTarget, EntityCreateFields, Envelope, LinkOp, NoteCreateFields,
+    };
+    use khive_types::{EdgeRelation, EntityKind, Id128, Namespace, Timestamp};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        // Hermetic: machine-wide hooks (e.g. leak-guard via core.hooksPath)
+        // must not block commits inside throwaway test repos. Mirrors the
+        // `run_git` test helper in `khive-vcs::sync::tests` / `kg::fetch::tests`.
+        let status = std::process::Command::new("git")
+            .args(["-c", "core.hooksPath=/dev/null"])
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .unwrap_or_else(|e| panic!("git {} failed to spawn: {e}", args.join(" ")));
+        assert!(
+            status.success(),
+            "git {} exited with {}",
+            args.join(" "),
+            status
+        );
+    }
+
+    fn init_repo(dir: &Path) {
+        run_git(dir, &["init", "-b", "main"]);
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        run_git(dir, &["config", "user.name", "Test"]);
+        // Persisted (not just a `-c` override on this call): the global
+        // `check-json-data.sh` leak guard reads `core.hooksPath` from repo
+        // config on every subsequent `git commit`, including the ones issued
+        // by production code under test (`run_git_ok`, which never passes
+        // `-c` itself). Per that hook's own documented guidance: "Fix is
+        // test-side hermeticity ... Never add hook exemptions for test
+        // paths."
+        run_git(dir, &["config", "core.hooksPath", "/dev/null"]);
+        run_git(dir, &["commit", "--allow-empty", "-m", "init"]);
+    }
+
+    fn sample_changeset() -> ChangeSet {
+        let envelope = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let create = Op::Create(CreateOp {
+            id: Id128::from_u128(1),
+            namespace: Namespace::local(),
+            target: CreateTarget::Entity(EntityCreateFields {
+                entity_kind: EntityKind::Concept,
+                entity_type: None,
+                name: "X".into(),
+                description: None,
+                properties: Default::default(),
+                tags: vec![],
+            }),
+        });
+        ChangeSet::new(envelope, vec![create])
+    }
+
+    fn write_changeset(dir: &Path, cs: &ChangeSet) -> PathBuf {
+        let path = dir.join("changeset.ndjson");
+        std::fs::write(&path, khive_changeset::to_ndjson(cs).unwrap()).unwrap();
+        path
+    }
+
+    // ── Projection / commit-time rule pass ─────────────────────────────────
+
+    #[test]
+    fn project_changeset_emits_entity_and_edge_records() {
+        let a = Id128::from_u128(1);
+        let b = Id128::from_u128(2);
+        let envelope = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let ops = vec![
+            Op::Create(CreateOp {
+                id: a,
+                namespace: Namespace::local(),
+                target: CreateTarget::Entity(EntityCreateFields {
+                    entity_kind: EntityKind::Concept,
+                    entity_type: None,
+                    name: "A".into(),
+                    description: None,
+                    properties: Default::default(),
+                    tags: vec![],
+                }),
+            }),
+            Op::Create(CreateOp {
+                id: b,
+                namespace: Namespace::local(),
+                target: CreateTarget::Entity(EntityCreateFields {
+                    entity_kind: EntityKind::Concept,
+                    entity_type: None,
+                    name: "B".into(),
+                    description: None,
+                    properties: Default::default(),
+                    tags: vec![],
+                }),
+            }),
+            Op::Link(LinkOp {
+                id: Id128::from_u128(3),
+                namespace: Namespace::local(),
+                source: a,
+                target: b,
+                relation: EdgeRelation::Extends,
+                weight: 1.0,
+                properties: Default::default(),
+            }),
+        ];
+        let cs = ChangeSet::new(envelope, ops);
+        let projected = project_changeset(&cs);
+        assert_eq!(projected.entities.lines().count(), 2);
+        assert_eq!(projected.edges.lines().count(), 1);
+        assert!(projected.duplicate_ids.is_empty());
+        assert!(projected.edges.contains("extends"));
+    }
+
+    #[test]
+    fn project_changeset_flags_duplicate_stage_ids() {
+        let dup = Id128::from_u128(1);
+        let envelope = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let mk = || {
+            Op::Create(CreateOp {
+                id: dup,
+                namespace: Namespace::local(),
+                target: CreateTarget::Entity(EntityCreateFields {
+                    entity_kind: EntityKind::Concept,
+                    entity_type: None,
+                    name: "dup".into(),
+                    description: None,
+                    properties: Default::default(),
+                    tags: vec![],
+                }),
+            })
+        };
+        let cs = ChangeSet::new(envelope, vec![mk(), mk()]);
+        let projected = project_changeset(&cs);
+        assert_eq!(projected.duplicate_ids.len(), 1);
+    }
+
+    #[test]
+    fn commit_time_rules_reject_invalid_note_kind() {
+        let envelope = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let ops = vec![Op::Create(CreateOp {
+            id: Id128::from_u128(1),
+            namespace: Namespace::local(),
+            target: CreateTarget::Note(NoteCreateFields {
+                note_kind: "not_a_real_kind".into(),
+                content: "hello".into(),
+                properties: Default::default(),
+                tags: vec![],
+                salience: None,
+                decay_factor: None,
+            }),
+        })];
+        let cs = ChangeSet::new(envelope, ops);
+        let tmp = TempDir::new().unwrap();
+        let rules_path = tmp.path().join("rules.toml");
+        std::fs::write(&rules_path, "").unwrap();
+
+        let results = run_commit_time_rules(&cs, &rules_path).unwrap();
+        let note_rule = results
+            .iter()
+            .find(|r| r.id == "valid-note-kinds")
+            .expect("valid-note-kinds must run");
+        assert!(!note_rule.passed);
+    }
+
+    #[test]
+    fn commit_time_rules_exclude_dangling_refs_from_results() {
+        // A link whose endpoints are not part of this change-set (the
+        // ordinary case: they were created by an earlier committed
+        // change-set) must not be reported as a dangling-refs violation.
+        let envelope = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let ops = vec![Op::Link(LinkOp {
+            id: Id128::from_u128(3),
+            namespace: Namespace::local(),
+            source: Id128::from_u128(100),
+            target: Id128::from_u128(200),
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+            properties: Default::default(),
+        })];
+        let cs = ChangeSet::new(envelope, ops);
+        let tmp = TempDir::new().unwrap();
+        let rules_path = tmp.path().join("rules.toml");
+        std::fs::write(
+            &rules_path,
+            "[dangling_refs]\nenabled = true\nseverity = \"error\"\n",
+        )
+        .unwrap();
+
+        let results = run_commit_time_rules(&cs, &rules_path).unwrap();
+        assert!(
+            !results.iter().any(|r| r.id == "dangling-refs"),
+            "dangling-refs must be excluded from commit-time results: {results:?}"
+        );
+    }
+
+    // ── Git flow ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ensure_no_remote_passes_for_remote_free_repo() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        ensure_no_remote(tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn ensure_no_remote_refuses_when_remote_configured() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        run_git(
+            tmp.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.invalid/repo.git",
+            ],
+        );
+        let err = ensure_no_remote(tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("local-only"), "{err}");
+    }
+
+    #[test]
+    fn stage_changeset_file_copies_external_file_into_repo() {
+        let repo_tmp = TempDir::new().unwrap();
+        init_repo(repo_tmp.path());
+        let outside_tmp = TempDir::new().unwrap();
+        let cs = sample_changeset();
+        let src = write_changeset(outside_tmp.path(), &cs);
+
+        let rel = stage_changeset_file(repo_tmp.path(), &src).unwrap();
+        assert_eq!(rel, ".khive/kg/changesets/changeset.ndjson");
+        assert!(repo_tmp.path().join(&rel).exists());
+    }
+
+    #[test]
+    fn stage_changeset_file_uses_in_place_path_when_already_inside_repo() {
+        let repo_tmp = TempDir::new().unwrap();
+        init_repo(repo_tmp.path());
+        let cs = sample_changeset();
+        let src = write_changeset(repo_tmp.path(), &cs);
+
+        let rel = stage_changeset_file(repo_tmp.path(), &src).unwrap();
+        assert_eq!(rel, "changeset.ndjson");
+    }
+
+    #[test]
+    fn sanitize_trailer_value_collapses_newlines() {
+        assert_eq!(sanitize_trailer_value("a\nb\r\nc"), "a b  c");
+    }
+
+    // ── End-to-end `cmd_commit` ─────────────────────────────────────────────
+
+    #[test]
+    fn cmd_commit_lands_clean_changeset_and_carries_trailers() {
+        let repo_tmp = TempDir::new().unwrap();
+        init_repo(repo_tmp.path());
+        let stage_tmp = TempDir::new().unwrap();
+        let cs = sample_changeset();
+        let changeset_path = write_changeset(stage_tmp.path(), &cs);
+        let rules_path = stage_tmp.path().join("rules.toml");
+        std::fs::write(&rules_path, "").unwrap();
+
+        let args = CommitArgs {
+            changeset: changeset_path,
+            rules: rules_path,
+            repo: repo_tmp.path().to_path_buf(),
+            message: "stage batch 1".into(),
+            format: OutputFormat::Json,
+        };
+        cmd_commit(args).expect("clean change-set must commit");
+
+        let log = run_git_ok(repo_tmp.path(), &["log", "-1", "--pretty=%B"]).unwrap();
+        assert!(log.contains("stage batch 1"));
+        assert!(log.contains("Change-Set-Producer: agent:test"));
+        assert!(log.contains("Change-Set-Producer-Batch: agent:test@1000000us"));
+
+        assert!(repo_tmp
+            .path()
+            .join(".khive/kg/changesets/changeset.ndjson")
+            .exists());
+    }
+
+    #[test]
+    fn cmd_commit_refuses_repo_with_remote() {
+        let repo_tmp = TempDir::new().unwrap();
+        init_repo(repo_tmp.path());
+        run_git(
+            repo_tmp.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.invalid/repo.git",
+            ],
+        );
+        let stage_tmp = TempDir::new().unwrap();
+        let cs = sample_changeset();
+        let changeset_path = write_changeset(stage_tmp.path(), &cs);
+        let rules_path = stage_tmp.path().join("rules.toml");
+        std::fs::write(&rules_path, "").unwrap();
+
+        let args = CommitArgs {
+            changeset: changeset_path,
+            rules: rules_path,
+            repo: repo_tmp.path().to_path_buf(),
+            message: "should not land".into(),
+            format: OutputFormat::Json,
+        };
+        let err = cmd_commit(args).unwrap_err();
+        assert!(err.to_string().contains("local-only"), "{err}");
+
+        // No commit landed beyond the init commit.
+        let log = run_git_ok(repo_tmp.path(), &["log", "--oneline"]).unwrap();
+        assert_eq!(log.lines().count(), 1, "only the init commit must exist");
+    }
+}

--- a/crates/kkernel/src/kg/dispatch.rs
+++ b/crates/kkernel/src/kg/dispatch.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 
 use super::archive;
+use super::commit;
 use super::fetch;
 use super::init;
 use super::status;
@@ -19,5 +20,6 @@ pub async fn run_kg(cmd: KgCommand) -> Result<()> {
         KgCommand::Import(args) => archive::cmd_import(args).await,
         KgCommand::Status(args) => status::cmd_status(args).await,
         KgCommand::Hook(h) => init::cmd_hook(h),
+        KgCommand::Commit(args) => commit::cmd_commit(args),
     }
 }

--- a/crates/kkernel/src/kg/mod.rs
+++ b/crates/kkernel/src/kg/mod.rs
@@ -1,6 +1,7 @@
 //! `kkernel kg` — KG validation, init, hook management, fetch, export, import, and status.
 
 mod archive;
+mod commit;
 mod dispatch;
 mod fetch;
 mod init;
@@ -10,7 +11,7 @@ mod validate;
 
 pub use dispatch::run_kg;
 pub use types::{
-    ExportArgs, FetchArgs, HookCommand, HookStatus, ImportArgs, ImportFormat, InitArgs, KgCommand,
-    KgStatusReport, OutputFormat, RuleResult, StatusArgs, ValidateArgs, ValidationReport,
-    ValidationSummary, Violation,
+    CommitArgs, CommitReport, ExportArgs, FetchArgs, HookCommand, HookStatus, ImportArgs,
+    ImportFormat, InitArgs, KgCommand, KgStatusReport, OutputFormat, RuleResult, StatusArgs,
+    ValidateArgs, ValidationReport, ValidationSummary, Violation,
 };

--- a/crates/kkernel/src/kg/types.rs
+++ b/crates/kkernel/src/kg/types.rs
@@ -35,6 +35,9 @@ pub enum KgCommand {
     /// Manage the pre-commit hook for KG validation.
     #[command(subcommand)]
     Hook(HookCommand),
+
+    /// Validate and commit a staged tier-2 change-set (ADR-102 Amendment to ADR-020).
+    Commit(CommitArgs),
 }
 
 /// CLI arguments for `kkernel kg validate`.
@@ -198,6 +201,58 @@ pub struct StatusArgs {
     /// Namespace to compare.
     #[arg(long, default_value = "local")]
     pub namespace: String,
+}
+
+/// CLI arguments for `kkernel kg commit`.
+///
+/// Restores the `kg commit` primitive [ADR-020](../../../docs/adr/ADR-020-git-native-kg-implementation.md)
+/// §5 specified but never shipped, scoped per
+/// [ADR-102](../../../docs/adr/ADR-102-tiered-validate-and-merge.md)'s Amendment
+/// to ADR-020: the tier-2 commit step for an already-reviewed staged
+/// change-set, against this ADR's own local-only change-set/snapshot
+/// repository (D6) — not the project-repository-embedded `.khive/kg/` layout
+/// `validate`/`init`/`export`/`import`/`status` operate on.
+#[derive(clap::Parser, Debug)]
+pub struct CommitArgs {
+    /// Path to the staged change-set NDJSON-delta file (ADR-101 D2).
+    pub changeset: PathBuf,
+
+    /// Path to the rules file (TOML) the change-set is validated against
+    /// before it may be committed. Required — the rules file is load-bearing
+    /// configuration for this primitive, not an optional convenience.
+    #[arg(long)]
+    pub rules: PathBuf,
+
+    /// Target git repository holding staged change-sets and committed
+    /// snapshots. Must have no configured git remote (ADR-102 D6) — this
+    /// repository is local-only by binding constraint.
+    #[arg(long, default_value = ".")]
+    pub repo: PathBuf,
+
+    /// Commit message body: a human-readable description of the batch
+    /// (ADR-101 D4).
+    #[arg(short = 'm', long = "message")]
+    pub message: String,
+
+    /// Output format for the pre-commit validation report.
+    #[arg(long, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+/// Result of a successful `kkernel kg commit` run.
+#[derive(Debug, Serialize)]
+pub struct CommitReport {
+    /// SHA of the git commit that landed the change-set.
+    pub commit_sha: String,
+    /// Path (relative to `repo`) of the committed change-set file.
+    pub changeset_path: String,
+    /// Number of operations in the committed change-set.
+    pub ops: usize,
+    /// `Envelope::producer` — carried as the `Change-Set-Producer` trailer.
+    pub producer: String,
+    /// Value carried as the `Change-Set-Producer-Batch` trailer (see
+    /// `kg::commit` module docs for how it is derived from the envelope).
+    pub producer_batch: String,
 }
 
 /// Subcommands for `kkernel kg hook` — install, remove, and check the pre-commit hook.

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -16,9 +16,13 @@ use super::types::{
 };
 
 /// Taxonomy sets derived from the loaded pack registry.
-struct KgTaxonomy {
-    entity_kinds: HashSet<String>,
-    note_kinds: HashSet<String>,
+///
+/// `pub(super)`: also consumed by `kg::commit` (`kkernel kg commit`, ADR-102)
+/// to reuse the same entity-kind/note-kind vocabulary this module builds for
+/// `kg validate`, rather than re-deriving it.
+pub(super) struct KgTaxonomy {
+    pub(super) entity_kinds: HashSet<String>,
+    pub(super) note_kinds: HashSet<String>,
 }
 
 /// Build the merged entity-kind and note-kind sets from all registered packs.
@@ -39,7 +43,7 @@ struct KgTaxonomy {
 /// operator must be able to run taxonomy validation against a strict-mode
 /// deployment. See `enforce_strict_actor_mode` in
 /// `crates/khive-mcp/src/serve.rs` for the authoritative boundary definition.
-fn build_taxonomy() -> Result<KgTaxonomy> {
+pub(super) fn build_taxonomy() -> Result<KgTaxonomy> {
     let config = RuntimeConfig {
         db_path: None,
         default_namespace: khive_runtime::Namespace::parse("kkernel-validate")
@@ -351,7 +355,12 @@ fn record_prefix(entity_id: Option<&str>, entity_name: Option<&str>) -> String {
     }
 }
 
-fn check_valid_entity_kinds(entities_path: &Path, valid_kinds: &HashSet<String>) -> RuleResult {
+/// `pub(super)`: reused by `kg::commit` (ADR-102) to check `create`-op entity
+/// kinds against the same pack-declared taxonomy `kg validate` enforces.
+pub(super) fn check_valid_entity_kinds(
+    entities_path: &Path,
+    valid_kinds: &HashSet<String>,
+) -> RuleResult {
     let valid_list = {
         let mut v: Vec<&str> = valid_kinds.iter().map(String::as_str).collect();
         v.sort_unstable();
@@ -400,7 +409,14 @@ fn check_valid_entity_kinds(entities_path: &Path, valid_kinds: &HashSet<String>)
     }
 }
 
-fn check_valid_note_kinds(notes_path: &Path, valid_kinds: &HashSet<String>) -> RuleResult {
+/// `pub(super)`: reused by `kg::commit` (ADR-102) to check `create`-op note
+/// kinds against the same pack-declared taxonomy `kg validate` enforces —
+/// meaningful here because `NoteCreateFields::note_kind` is a free-form
+/// string, not a closed Rust enum, so it needs a runtime check.
+pub(super) fn check_valid_note_kinds(
+    notes_path: &Path,
+    valid_kinds: &HashSet<String>,
+) -> RuleResult {
     let valid_list = {
         let mut v: Vec<&str> = valid_kinds.iter().map(String::as_str).collect();
         v.sort_unstable();

--- a/crates/kkernel/src/kg/validate.rs
+++ b/crates/kkernel/src/kg/validate.rs
@@ -986,6 +986,40 @@ pub(super) fn configurable_rule_checks(
     notes_path: &Path,
     rules_path: &Path,
 ) -> Result<Vec<RuleResult>> {
+    configurable_rule_checks_impl(entities_path, edges_path, notes_path, rules_path, false)
+}
+
+/// Same as [`configurable_rule_checks`], but for callers evaluating rules
+/// against a *partial* view of the graph (e.g. `kg commit`'s projection of a
+/// single staged change-set, not the full dataset). The built-in
+/// `dangling-refs` evaluator's *finding* is meaningless over a partial view
+/// (every cross-change-set reference looks "dangling"), so its actual check
+/// is skipped here. Its configuration is still validated: a malformed
+/// `[dangling_refs] severity = "..."` still produces an error-severity
+/// `RuleResult` (same as the full-dataset path), and any generic `[[rules]]`
+/// entry — even one that happens to share the id `"dangling-refs"` — is
+/// still evaluated and returned. Skipping is done by *not invoking* the
+/// built-in evaluator, never by filtering results after the fact by id: a
+/// post-hoc `id == "dangling-refs"` filter would also swallow the malformed-
+/// config error result and any same-id generic rule, silently letting
+/// error-severity findings through (see ADR-102 D2; the commit-time rule
+/// pass must never suppress a real error to make a partial-view check quiet).
+pub(super) fn configurable_rule_checks_partial_view(
+    entities_path: &Path,
+    edges_path: &Path,
+    notes_path: &Path,
+    rules_path: &Path,
+) -> Result<Vec<RuleResult>> {
+    configurable_rule_checks_impl(entities_path, edges_path, notes_path, rules_path, true)
+}
+
+fn configurable_rule_checks_impl(
+    entities_path: &Path,
+    edges_path: &Path,
+    notes_path: &Path,
+    rules_path: &Path,
+    skip_dangling_refs_partial_view_finding: bool,
+) -> Result<Vec<RuleResult>> {
     let ext = rules_path
         .extension()
         .and_then(|e| e.to_str())
@@ -1100,8 +1134,10 @@ pub(super) fn configurable_rule_checks(
     if let Some(cfg) = &rules_file.dangling_refs {
         if cfg.enabled {
             if let Some(err_result) = validate_severity("dangling-refs", &cfg.severity) {
+                // Malformed config is always an error, full-dataset or
+                // partial-view alike — never skipped.
                 results.push(err_result);
-            } else {
+            } else if !skip_dangling_refs_partial_view_finding {
                 results.push(check_dangling_refs(
                     entities_path,
                     notes_path,

--- a/crates/kkernel/tests/kg_commit_tier2.rs
+++ b/crates/kkernel/tests/kg_commit_tier2.rs
@@ -364,7 +364,7 @@ fn kg_commit_fails_loud_on_malformed_changeset() {
     );
 }
 
-// ── Codex round-1 review regressions (H1: projection fidelity) ─────────────
+// ── Projection-fidelity regressions: rules must see the full staged record ─
 
 /// H1(a): a formal typed endpoint (`concept/theorem -[depends_on]->
 /// concept/definition`) is a pack-allowed pairing
@@ -480,7 +480,7 @@ fn kg_commit_lands_changeset_with_description_satisfying_require_field_rule() {
     );
 }
 
-// ── Codex round-1 review regressions (H2: dangling-refs suppression) ───────
+// ── Rule-result suppression regressions: only the built-in partial-view ────
 
 /// H2(a): a malformed `[dangling_refs] severity = "catastrophic"` must still
 /// produce an error-severity config-validation finding and refuse the

--- a/crates/kkernel/tests/kg_commit_tier2.rs
+++ b/crates/kkernel/tests/kg_commit_tier2.rs
@@ -98,6 +98,58 @@ fn invalid_note_kind_op(id: &str) -> String {
     .to_string()
 }
 
+/// A `create` op for a `concept` entity carrying `entity_type` (the field
+/// H1's fix now projects into `entities.ndjson`).
+fn typed_concept_create_op(id: &str, name: &str, entity_type: &str) -> String {
+    serde_json::json!({
+        "op": "create",
+        "id": id,
+        "namespace": "local",
+        "target": {
+            "kind": "entity",
+            "entity_kind": "concept",
+            "entity_type": entity_type,
+            "name": name,
+            "properties": {},
+            "tags": [],
+        },
+    })
+    .to_string()
+}
+
+/// A `create` op for a `concept` entity carrying `description` (the other
+/// field H1's fix now projects into `entities.ndjson`).
+fn described_concept_create_op(id: &str, name: &str, description: &str) -> String {
+    serde_json::json!({
+        "op": "create",
+        "id": id,
+        "namespace": "local",
+        "target": {
+            "kind": "entity",
+            "entity_kind": "concept",
+            "name": name,
+            "description": description,
+            "properties": {},
+            "tags": [],
+        },
+    })
+    .to_string()
+}
+
+fn link_op(id: &str, source: &str, target: &str, relation: &str) -> String {
+    serde_json::json!({
+        "op": "link",
+        "id": id,
+        "namespace": "local",
+        "source": source,
+        "target": target,
+        "relation": relation,
+        "weight": 1.0,
+        "properties": {},
+    })
+    .to_string()
+}
+
 #[test]
 fn kg_commit_lands_a_clean_changeset_with_provenance_trailers() {
     let repo = TempDir::new().expect("repo tmp");
@@ -309,5 +361,253 @@ fn kg_commit_fails_loud_on_malformed_changeset() {
     assert!(
         !output.status.success(),
         "malformed change-set must fail loud"
+    );
+}
+
+// ── Codex round-1 review regressions (H1: projection fidelity) ─────────────
+
+/// H1(a): a formal typed endpoint (`concept/theorem -[depends_on]->
+/// concept/definition`) is a pack-allowed pairing
+/// (`khive-pack-formal::vocab::FORMAL_EDGE_RULES`), but only if
+/// `project_changeset` actually carries `entity_type` into the projected
+/// `entities.ndjson` the `edge-endpoint-types` rule reads. Before the H1 fix
+/// both endpoints projected as plain `concept` with no `entity_type`, so the
+/// pack rule never matched and this change-set was wrongly rejected.
+#[test]
+fn kg_commit_lands_formal_typed_endpoint_with_edge_endpoint_types_enabled() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    let theorem_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let definition_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[
+            typed_concept_create_op(theorem_id, "Pythagorean theorem", "theorem"),
+            typed_concept_create_op(definition_id, "Right triangle", "definition"),
+            link_op(
+                "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                theorem_id,
+                definition_id,
+                "depends_on",
+            ),
+        ],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(
+        &rules,
+        "[edge_endpoint_types]\nenabled = true\nseverity = \"error\"\n",
+    )
+    .expect("write rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "-m",
+            "formal typed endpoint",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        output.status.success(),
+        "theorem -[depends_on]-> definition is a pack-allowed endpoint pairing \
+         and must commit; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// H1(b): a generic `[[rules]] require_field = "description"` rule must see
+/// the `description` a create op actually carries. Before the H1 fix
+/// `project_changeset` dropped `description` entirely, so this rule always
+/// reported it missing.
+#[test]
+fn kg_commit_lands_changeset_with_description_satisfying_require_field_rule() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[described_concept_create_op(
+            "11112222-3333-4444-5555-666677778888",
+            "Gamma",
+            "a concept with a real description",
+        )],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(
+        &rules,
+        "[[rules]]\nid = \"require-description\"\nseverity = \"error\"\nkind = \"entity\"\nrequire_field = \"description\"\nmessage = \"missing description: {id}\"\n",
+    )
+    .expect("write rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "-m",
+            "described concept",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        output.status.success(),
+        "a create op carrying description must satisfy require_field=\"description\"; \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Codex round-1 review regressions (H2: dangling-refs suppression) ───────
+
+/// H2(a): a malformed `[dangling_refs] severity = "catastrophic"` must still
+/// produce an error-severity config-validation finding and refuse the
+/// commit, even though the built-in dangling-ref evaluator itself is never
+/// invoked at commit time. Before the H2 fix, `commit.rs` filtered every
+/// result with `id == "dangling-refs"` out of the pass/fail decision — which
+/// also silently dropped this config-error result — and the commit landed.
+#[test]
+fn kg_commit_refuses_malformed_dangling_refs_severity() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[clean_create_op(
+            "99990000-1111-2222-3333-444455556666",
+            "Delta",
+        )],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(
+        &rules,
+        "[dangling_refs]\nenabled = true\nseverity = \"catastrophic\"\n",
+    )
+    .expect("write rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "-m",
+            "should not land",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        !output.status.success(),
+        "malformed dangling_refs severity must be an error-severity config \
+         finding and refuse the commit; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log_output = Command::new("git")
+        .args(["log", "--oneline"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git log");
+    let log = String::from_utf8_lossy(&log_output.stdout);
+    assert_eq!(
+        log.lines().count(),
+        1,
+        "only the init commit may exist after a refused commit: {log}"
+    );
+}
+
+/// H2(b): a generic `[[rules]]` entry that happens to be named
+/// `id = "dangling-refs"` must still be evaluated and enforced. Before the
+/// H2 fix, `commit.rs`'s post-hoc `id == "dangling-refs"` filter dropped
+/// this result regardless of where it came from, letting an error-severity
+/// `require_field` violation through.
+#[test]
+fn kg_commit_refuses_generic_rule_named_dangling_refs() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    // No `description` field on this create op, so the rule below fails.
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[clean_create_op(
+            "77778888-9999-0000-1111-222233334444",
+            "Epsilon",
+        )],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(
+        &rules,
+        "[[rules]]\nid = \"dangling-refs\"\nseverity = \"error\"\nkind = \"entity\"\nrequire_field = \"description\"\nmessage = \"missing description: {id}\"\n",
+    )
+    .expect("write rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "-m",
+            "should not land",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        !output.status.success(),
+        "a generic rule named \"dangling-refs\" must still be enforced; \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log_output = Command::new("git")
+        .args(["log", "--oneline"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git log");
+    let log = String::from_utf8_lossy(&log_output.stdout);
+    assert_eq!(
+        log.lines().count(),
+        1,
+        "only the init commit may exist after a refused commit: {log}"
     );
 }

--- a/crates/kkernel/tests/kg_commit_tier2.rs
+++ b/crates/kkernel/tests/kg_commit_tier2.rs
@@ -1,0 +1,313 @@
+//! End-to-end integration test for `kkernel kg commit` (ADR-102 Amendment to
+//! ADR-020 — the tier-2 change-set commit primitive).
+//!
+//! Drives the compiled `kkernel` binary rather than calling `cmd_commit` in
+//! process: on an error-severity finding it calls `std::process::exit`
+//! directly (mirroring `cmd_validate`'s documented exit-code contract, see
+//! `kg_validate_builtin_rule_classes.rs`), which would kill the test process
+//! if invoked in-tree. Spawning the binary also exercises the real CLI
+//! argument parsing end-to-end.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn kkernel_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_kkernel")
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|e| panic!("git {} failed to spawn: {e}", args.join(" ")));
+    assert!(
+        status.success(),
+        "git {} exited with {}",
+        args.join(" "),
+        status
+    );
+}
+
+/// Initializes a git repo hermetically. `core.hooksPath` is persisted (not a
+/// transient `-c` flag) so it also applies to the `git commit` the
+/// `kkernel` binary itself runs under test, keeping the machine-wide
+/// `check-json-data.sh` leak guard out of this test's way regardless of
+/// `kg commit`'s own `KHIVE_ALLOW_DATA=1` bypass.
+fn init_repo(dir: &Path) {
+    run_git(dir, &["init", "-b", "main"]);
+    run_git(dir, &["config", "user.email", "test@example.com"]);
+    run_git(dir, &["config", "user.name", "Test"]);
+    run_git(dir, &["config", "core.hooksPath", "/dev/null"]);
+    run_git(dir, &["commit", "--allow-empty", "-m", "init"]);
+}
+
+fn envelope_line() -> String {
+    serde_json::json!({
+        "schema_version": 1,
+        "producer": "pipeline:acceptance-test",
+        "producer_model_family": "family:sonnet",
+        "staged_at": 2_000_000_u64,
+    })
+    .to_string()
+}
+
+fn write_changeset(dir: &Path, name: &str, op_lines: &[String]) -> std::path::PathBuf {
+    let mut content = envelope_line();
+    content.push('\n');
+    for line in op_lines {
+        content.push_str(line);
+        content.push('\n');
+    }
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("write change-set");
+    path
+}
+
+fn clean_create_op(id: &str, name: &str) -> String {
+    serde_json::json!({
+        "op": "create",
+        "id": id,
+        "namespace": "local",
+        "target": {
+            "kind": "entity",
+            "entity_kind": "concept",
+            "name": name,
+            "properties": {},
+            "tags": [],
+        },
+    })
+    .to_string()
+}
+
+fn invalid_note_kind_op(id: &str) -> String {
+    serde_json::json!({
+        "op": "create",
+        "id": id,
+        "namespace": "local",
+        "target": {
+            "kind": "note",
+            "note_kind": "not_a_real_kind",
+            "content": "hello",
+            "properties": {},
+            "tags": [],
+        },
+    })
+    .to_string()
+}
+
+#[test]
+fn kg_commit_lands_a_clean_changeset_with_provenance_trailers() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[clean_create_op(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "Alpha",
+        )],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(&rules, "").expect("write empty rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "-m",
+            "acceptance batch",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        output.status.success(),
+        "clean change-set must commit; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log_output = Command::new("git")
+        .args(["log", "-1", "--pretty=%B"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git log");
+    let message = String::from_utf8_lossy(&log_output.stdout);
+    assert!(message.contains("acceptance batch"), "{message}");
+    assert!(
+        message.contains("Change-Set-Producer: pipeline:acceptance-test"),
+        "{message}"
+    );
+    assert!(
+        message.contains("Change-Set-Producer-Batch: pipeline:acceptance-test@2000000us"),
+        "{message}"
+    );
+
+    assert!(
+        repo.path()
+            .join(".khive/kg/changesets/batch.ndjson")
+            .exists(),
+        "committed change-set file must be staged into the repo"
+    );
+}
+
+#[test]
+fn kg_commit_refuses_repo_with_configured_remote() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    run_git(
+        repo.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ],
+    );
+    let stage = TempDir::new().expect("stage tmp");
+
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[clean_create_op(
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "Beta",
+        )],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(&rules, "").expect("write empty rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "-m",
+            "should not land",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        !output.status.success(),
+        "a repo with a configured remote must refuse (ADR-102 D6)"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("local-only"), "{stderr}");
+
+    let log_output = Command::new("git")
+        .args(["log", "--oneline"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git log");
+    let log = String::from_utf8_lossy(&log_output.stdout);
+    assert_eq!(
+        log.lines().count(),
+        1,
+        "only the init commit may exist after a refused commit: {log}"
+    );
+}
+
+#[test]
+fn kg_commit_refuses_changeset_with_error_severity_finding() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    // `note_kind` is a free-form string in the change-set model — an
+    // unregistered kind trips `valid-note-kinds` (error severity), which
+    // must refuse the commit before any git operation runs.
+    let changeset = write_changeset(
+        stage.path(),
+        "batch.ndjson",
+        &[invalid_note_kind_op("cccccccc-cccc-cccc-cccc-cccccccccccc")],
+    );
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(&rules, "").expect("write empty rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "-m",
+            "should not land",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        !output.status.success(),
+        "an error-severity finding must refuse the commit"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}\n{stdout}"));
+    assert_eq!(report["summary"]["passed"], false);
+    assert!(report["summary"]["errors"].as_u64().unwrap() >= 1);
+
+    let log_output = Command::new("git")
+        .args(["log", "--oneline"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git log");
+    let log = String::from_utf8_lossy(&log_output.stdout);
+    assert_eq!(
+        log.lines().count(),
+        1,
+        "only the init commit may exist after a refused commit: {log}"
+    );
+}
+
+#[test]
+fn kg_commit_fails_loud_on_malformed_changeset() {
+    let repo = TempDir::new().expect("repo tmp");
+    init_repo(repo.path());
+    let stage = TempDir::new().expect("stage tmp");
+
+    let changeset = stage.path().join("garbage.ndjson");
+    std::fs::write(&changeset, "not valid ndjson-delta\n").expect("write garbage");
+    let rules = stage.path().join("rules.toml");
+    std::fs::write(&rules, "").expect("write empty rules.toml");
+
+    let output = Command::new(kkernel_bin())
+        .args([
+            "kg",
+            "commit",
+            changeset.to_str().unwrap(),
+            "--rules",
+            rules.to_str().unwrap(),
+            "--repo",
+            repo.path().to_str().unwrap(),
+            "-m",
+            "should not land",
+        ])
+        .output()
+        .expect("run kkernel kg commit");
+
+    assert!(
+        !output.status.success(),
+        "malformed change-set must fail loud"
+    );
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,6 +29,7 @@ explicitly and describes what the code does.
 | `kg export`                          | no (writes an output file, not the DB) | Dump a namespace's entities+edges to one JSON archive                                   |
 | `kg import`                          | yes (target DB)                        | Load an archive/JSON/NDJSON file into a DB                                              |
 | `kg status`                          | no                                     | Compare DB content hash against tracked NDJSON content hash                             |
+| `kg commit`                          | yes (a separate local-only git repo)   | Validate + git-commit a staged tier-2 change-set (ADR-102 Amendment to ADR-020)         |
 | `db migrate` / `db check`            | `migrate` yes, `check` no              | Apply or report pending schema migrations                                               |
 | `engine list` / `status`             | no                                     | Inspect the `_embedding_models` table                                                   |
 | `engine migrate` / `drift-check`     | n/a                                    | **Not implemented**, always return an error (see §3)                                    |
@@ -295,12 +296,87 @@ fields = ["year", "date", "published_at", "publication_date"]
   printed pass/fail reflects pre-fix state, and it refuses to touch a file containing malformed
   JSON rather than guessing at a fix (fail-closed).
 - **Exit code**: a failing validation calls `std::process::exit(1)` directly
-  (`kg/validate.rs:147-149`); this is the one `kg` subcommand that hard-exits on failure rather
-  than only reporting it in JSON.
+  (`kg/validate.rs:147-149`); `kg commit` (below) shares this hard-exit-on-failure behavior for its
+  own pre-commit report, so between them `kg validate` and `kg commit` are the two `kg`
+  subcommands that hard-exit on a failing report rather than only reporting it in JSON.
 
 `kg init`'s generated pre-commit hook (below) runs exactly `kkernel kg validate` with no extra
 flags whenever staged files touch `entities.ndjson`/`edges.ndjson`; it is bypassed the normal git
 way (`git commit --no-verify`).
+
+### `kg commit`: the tier-2 change-set commit primitive
+
+```bash
+kkernel kg commit <changeset.ndjson> --rules <rules.toml> --repo <path> -m "<message>" [--format text|json|github]
+```
+
+Restores the `kg commit` verb ADR-020 §5 specified (`export + validate + git add + git commit`)
+but never shipped, scoped per [ADR-102](adr/ADR-102-tiered-validate-and-merge.md)'s "Amendment to
+ADR-020" to the tier-2 flow that ADR defines: landing an already-staged, already-reviewed
+[ADR-101](adr/ADR-101-kg-changeset-model.md) NDJSON-delta change-set into ADR-102's own
+**local-only** staged-change-set/snapshot repository (D6) — this is a _different_ repository from
+the project-repository-embedded `.khive/kg/` layout every other `kg` verb above operates on.
+`--repo` here is that separate repository's root, not a project checkout.
+
+**Flow**:
+
+1. Parse `<changeset.ndjson>` via `khive_changeset::from_ndjson` — a malformed file (bad JSON, an
+   unrecognized `schema_version`, an op missing a required field such as a `delete`/`merge`
+   preimage) fails loud before any validation or git operation runs.
+2. Project the change-set's `create` and `link` ops into synthetic `entities.ndjson` /
+   `notes.ndjson` / `edges.ndjson` content and run a **subset** of the same rule pass `kg
+   validate` uses against them: a local duplicate-stage-id check, `valid-entity-kinds`,
+   `valid-note-kinds`, and (if `--rules` enables them) `edge_endpoint_types`,
+   `edge_direction_conventions`, `naming_conventions`, `citation_date_lint`, and any generic
+   `[[rules]]` entries. Any `error`-severity finding refuses the commit — the report is printed
+   (respecting `--format`) and the process hard-exits `1`, exactly like `kg validate`, before any
+   git command runs.
+3. On a clean pass: refuses (fail-loud, before any git mutation) if `--repo` has **any** configured
+   git remote (`git remote` returns a non-empty list) — ADR-102 D6's local-only constraint,
+   enforced in code, not by convention. Otherwise stages the change-set file into the repo (in
+   place if it already lives under `--repo`, or copied to
+   `<repo>/.khive/kg/changesets/<file-name>` if it was staged elsewhere), `git add`s it, and
+   `git commit -F <message-file>` with `-m`'s value as the body plus two trailers: `Change-Set-Producer:
+   <envelope.producer>` and `Change-Set-Producer-Batch: <envelope.producer>@<staged_at
+   microseconds>us` (ADR-101 D4's "producer-assigned batch identifier" trailer — see the crate note
+   below for why it is derived rather than read verbatim from a dedicated field). Prints a JSON
+   `CommitReport` (`commit_sha`, `changeset_path`, `ops`, `producer`, `producer_batch`) on success.
+
+**Why `referential-integrity`/`dangling-refs` are excluded from step 2**: a change-set is a
+_partial_ view of the graph — most `link` ops target entities or notes created by an earlier,
+already-committed change-set, not by this one. Running either of those two rule classes against
+this change-set alone would flag the overwhelming majority of ordinary edges as broken, a
+false-positive storm rather than a real finding, so they are deferred to stage time (where the
+producer/reviewer has, or can obtain, full graph context) instead of re-run here.
+`edge_endpoint_types`/`edge_direction_conventions` need no such exclusion: both already skip any
+edge whose endpoint fails to resolve within the given NDJSON dataset, so restricting them to this
+change-set's own `create` ops degrades gracefully rather than false-flagging.
+
+**Why `update`/`delete`/`merge` ops are not re-projected**: they patch or remove records that
+already exist outside this change-set, so `kg commit` has no fresh kind/name/relation data to
+check for them beyond what ADR-102 D2 already routes to tier-2 review by construction (`delete`,
+`merge`, and any edge-relation/weight change are _always_ tier-2, so a reviewer has already looked
+at them before a change-set reaches this command).
+
+**Batch-identifier trailer, a documented gap**: ADR-101 D4 specifies a commit trailer carrying "a
+producer-assigned batch identifier," read from the change-set envelope. The shipped
+`khive-changeset::Envelope` (schema version 1) carries `producer`, `producer_model_family`, and
+`staged_at`, but no separate batch-identifier field. `kg commit` derives the trailer value as
+`<producer>@<staged_at_micros>us` — unique per staged change-set and round-trippable, matching
+ADR-101 D4's only stated contract for the field — rather than inventing a new envelope field on a
+crate this branch does not modify. A future `khive-changeset` schema revision adding an explicit
+batch-id field would let this trailer read it directly instead.
+
+**Topology**: no SQLite handle is opened anywhere in this command. `valid-entity-kinds`/
+`valid-note-kinds` build their pack-metadata taxonomy the same way `kg validate` does (`db_path:
+None`), and every other check reads only the synthetic NDJSON projection or the change-set file
+itself — matching ADR-102 D5's MCP-client-only / no-second-DB-handle constraint on live-graph
+access.
+
+**Local-repository leak guard**: this repository's entire purpose is committing exported KG
+NDJSON, which trips the machine-wide `check-json-data.sh` pre-commit leak guard
+(`core.hooksPath`) by default. `kg commit`'s own `git commit` invocation sets
+`KHIVE_ALLOW_DATA=1` — that hook's documented, auditable bypass — rather than `--no-verify`.
 
 ### `kg init`: repo scaffolding
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -351,6 +351,16 @@ producer/reviewer has, or can obtain, full graph context) instead of re-run here
 `edge_endpoint_types`/`edge_direction_conventions` need no such exclusion: both already skip any
 edge whose endpoint fails to resolve within the given NDJSON dataset, so restricting them to this
 change-set's own `create` ops degrades gracefully rather than false-flagging.
+`referential-integrity` is always-on and unaffected (it never runs over `link` ops here — only
+`no-duplicate-uuids`/`valid-entity-kinds`/`valid-note-kinds` are always-on at commit time; see
+`run_commit_time_rules`). The `dangling-refs` exclusion is implemented by never invoking the
+built-in dangling-ref evaluator in the first place (`validate::configurable_rule_checks_partial_view`)
+— **not** by filtering the returned findings by id after the fact. A post-hoc `id ==
+"dangling-refs"` filter would also swallow a malformed `[dangling_refs] severity = "..."`
+config-validation error (which is always real, partial-view or not) and any generic `[[rules]]`
+entry a rules author happens to name `"dangling-refs"`, silently letting error-severity findings
+through. Both are checked-in regressions (`kg_commit_refuses_malformed_dangling_refs_severity`,
+`kg_commit_refuses_generic_rule_named_dangling_refs` in `kg_commit_tier2.rs`).
 
 **Why `update`/`delete`/`merge` ops are not re-projected**: they patch or remove records that
 already exist outside this change-set, so `kg commit` has no fresh kind/name/relation data to


### PR DESCRIPTION
## Summary

Restores `kg commit` as the tier-2 change-set commit primitive over the khive-changeset crate (ADR-101/102):

- Parses a change-set via `khive_changeset::from_ndjson`, projects create/link ops into synthetic entities/notes/edges NDJSON, and runs the commit-time subset of the configurable rule classes
- Projection carries the full field surface any rule class can read (entity_type, description, note content/salience/decay_factor) — validating a narrower record than the staged op causes false rejections and vacuous passes
- The built-in dangling-refs evaluator is never invoked for the partial change-set view (`configurable_rule_checks_partial_view`), rather than post-hoc-filtered by public rule id — malformed-config errors and generic rules that happen to share the id still fail the commit
- Refuses on any error-severity finding and on any configured git remote (ADR-102 D6 local-only snapshot repo)
- Commits with `Change-Set-Producer` / `Change-Set-Producer-Batch` trailers; the batch value currently derives from `producer@staged_at_micros`, documented as the fallback pending the ADR-101 envelope `batch_id` amendment (in flight)
- No live DB handle anywhere in the commit path (`build_taxonomy` with `db_path: None`, ADR-102 D5)

## Tests

8 binary-level integration tests including four regression classes: formal typed-endpoint change-sets land, `require_field` on description passes, malformed `[dangling_refs]` severity refuses, and a generic rule named `dangling-refs` refuses. Each regression verified failing against the pre-fix implementation.