### PR TITLE
feat(changeset): envelope batch_id + field-scoped update preimage

### DIFF
--- a/crates/khive-changeset/README.md
+++ b/crates/khive-changeset/README.md
@@ -28,11 +28,12 @@ artifact itself — nothing about how it is validated, tiered, reviewed, or comm
   - `Link` — creates a new edge; `source`/`target` may reference another op's minted id.
   - `Update` — patches an existing entity's, note's, or edge's mutable fields. Carries a
     **required** field-scoped `preimage`: the prior value of exactly the fields the patch
-    touches (sets or explicitly clears to null), and nothing else. `UpdateOp`'s custom
-    deserialize enforces that the preimage's populated field set matches the patch's touched
-    field set exactly — a mismatched pair (a field the patch touches with no captured prior
-    value, or a captured prior value for a field the patch leaves unchanged) cannot be
-    constructed or deserialized.
+    touches (sets or explicitly clears to null), and nothing else. `UpdateOp`'s fields are
+    private; the only ways to build one are the checked `UpdateOp::new` constructor and
+    `Deserialize`, and both enforce that the preimage's populated field set matches the
+    patch's touched field set exactly — a mismatched pair (a field the patch touches with no
+    captured prior value, or a captured prior value for a field the patch leaves unchanged)
+    cannot be constructed or deserialized.
   - `Delete` — removes an entity, note, or edge. Carries the full prior record state as a
     **required** field (`preimage`); a `delete` op without one cannot be constructed or
     deserialized.

--- a/crates/khive-changeset/README.md
+++ b/crates/khive-changeset/README.md
@@ -15,14 +15,24 @@ artifact itself — nothing about how it is validated, tiered, reviewed, or comm
   load-bearing: a `link` op may target the stage-time id an earlier `create` op in the same
   file minted, so order is preserved exactly through serialization.
 - **`Envelope`** — change-set-level metadata captured at stage time: producer identity,
-  producer model family, and a `schema_version`. No individual op reads it; it exists for a
-  cross-family review gate and commit provenance to consume downstream.
+  producer model family, a `schema_version`, and an optional `batch_id`. No individual op
+  reads it; it exists for a cross-family review gate, commit provenance, and (for `batch_id`)
+  the commit trailer to consume downstream. `batch_id` is an opaque, producer-assigned token:
+  when a producer supplies one, a commit landing the change-set uses it verbatim as the
+  provenance trailer; when absent, the committing tool derives a deterministic fallback from
+  `producer` and `staged_at` instead. Absent by default and never serialized (not even as
+  `null`) — round-tripping an envelope without one leaves it unset.
 - **`Op`** — one of five typed operations, over the same entity/edge/note vocabulary and
   edge-endpoint contract the live request DSL already uses:
   - `Create` — mints a stage-time-stable `Id128` for a new entity or note.
   - `Link` — creates a new edge; `source`/`target` may reference another op's minted id.
-  - `Update` — patches an existing entity's, note's, or edge's mutable fields. Carries no
-    preimage (see "Known gap" below).
+  - `Update` — patches an existing entity's, note's, or edge's mutable fields. Carries a
+    **required** field-scoped `preimage`: the prior value of exactly the fields the patch
+    touches (sets or explicitly clears to null), and nothing else. `UpdateOp`'s custom
+    deserialize enforces that the preimage's populated field set matches the patch's touched
+    field set exactly — a mismatched pair (a field the patch touches with no captured prior
+    value, or a captured prior value for a field the patch leaves unchanged) cannot be
+    constructed or deserialized.
   - `Delete` — removes an entity, note, or edge. Carries the full prior record state as a
     **required** field (`preimage`); a `delete` op without one cannot be constructed or
     deserialized.
@@ -50,22 +60,6 @@ row order does not.
 The envelope is a header line rather than a sidecar file: a change-set is meant to move as
 one artifact between a producer, a reviewer, and an applier, and a header line keeps that
 artifact self-contained without a second file that could go missing or drift out of sync.
-
-## Known gap: `Update` has no preimage
-
-The op-list inversion this artifact is meant to support (a later, separate consumer) needs a
-prior-value snapshot for every reversible op. The ADR that defines this model scopes
-mandatory stage-time preimage capture to the two *destructive* operations, `delete` and
-`merge`, and says nothing about `update`. The ADR that defines op-list inversion, by contrast,
-describes an `update`'s inverse as restoring "the prior field values captured at stage time,"
-which presumes an `update` op captures priors — something the first ADR never requires.
-
-This crate follows the model-defining ADR's literal, binding text: `UpdateOp` carries no
-preimage. An `update` op therefore cannot be surgically inverted today; a future revert of one
-falls back to the coarser mechanisms available for any op without a captured preimage. This
-gap is a candidate for a future ADR amendment (adding optional stage-time prior-value capture
-to `update`), not something this crate has resolved by inventing schema the model ADR does
-not specify.
 
 ## Constraints
 

--- a/crates/khive-changeset/src/changeset.rs
+++ b/crates/khive-changeset/src/changeset.rs
@@ -133,6 +133,26 @@ mod tests {
     }
 
     #[test]
+    fn envelope_batch_id_round_trips_through_ndjson() {
+        let mut cs = sample_changeset();
+        cs.envelope = cs.envelope.with_batch_id("batch-xyz");
+        let text = to_ndjson(&cs).unwrap();
+        let decoded = from_ndjson(&text).unwrap();
+        assert_eq!(decoded.envelope.batch_id.as_deref(), Some("batch-xyz"));
+        assert_eq!(decoded.envelope, cs.envelope);
+    }
+
+    #[test]
+    fn envelope_without_batch_id_round_trips_through_ndjson() {
+        let cs = sample_changeset();
+        assert_eq!(cs.envelope.batch_id, None);
+        let text = to_ndjson(&cs).unwrap();
+        let decoded = from_ndjson(&text).unwrap();
+        assert_eq!(decoded.envelope.batch_id, None);
+        assert_eq!(decoded.envelope, cs.envelope);
+    }
+
+    #[test]
     fn empty_input_errors() {
         let result = from_ndjson("");
         assert!(matches!(result, Err(ChangeSetError::Empty)));

--- a/crates/khive-changeset/src/envelope.rs
+++ b/crates/khive-changeset/src/envelope.rs
@@ -19,10 +19,18 @@ pub struct Envelope {
     pub producer_model_family: String,
     /// Wall-clock time the change-set was staged, supplied by the caller.
     pub staged_at: Timestamp,
+    /// Opaque producer-assigned batch identifier. When present, a commit
+    /// landing this change-set uses it verbatim as the provenance trailer;
+    /// when absent, the committing tool derives a deterministic fallback
+    /// from `producer` and `staged_at` instead. Optional because the
+    /// identifier is opaque producer-internal tracking — a producer without
+    /// its own batching model is not forced to invent one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_id: Option<String>,
 }
 
 impl Envelope {
-    /// Construct an envelope stamped with [`CURRENT_SCHEMA_VERSION`].
+    /// Construct an envelope stamped with [`CURRENT_SCHEMA_VERSION`] and no `batch_id`.
     pub fn new(
         producer: impl Into<String>,
         producer_model_family: impl Into<String>,
@@ -33,7 +41,14 @@ impl Envelope {
             producer: producer.into(),
             producer_model_family: producer_model_family.into(),
             staged_at,
+            batch_id: None,
         }
+    }
+
+    /// Attach a producer-assigned batch identifier.
+    pub fn with_batch_id(mut self, batch_id: impl Into<String>) -> Self {
+        self.batch_id = Some(batch_id.into());
+        self
     }
 }
 
@@ -60,5 +75,35 @@ mod tests {
         });
         let result: Result<Envelope, _> = serde_json::from_value(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn batch_id_absent_by_default_and_not_serialized() {
+        let env = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        assert_eq!(env.batch_id, None);
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            !json.contains("batch_id"),
+            "absent batch_id must not appear on the wire at all (not even as null): {json}"
+        );
+    }
+
+    #[test]
+    fn batch_id_round_trips_when_present() {
+        let env = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1))
+            .with_batch_id("batch-123");
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: Envelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, env);
+        assert_eq!(decoded.batch_id.as_deref(), Some("batch-123"));
+    }
+
+    #[test]
+    fn batch_id_round_trips_when_absent() {
+        let env = Envelope::new("agent:test", "family:sonnet", Timestamp::from_secs(1));
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: Envelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, env);
+        assert_eq!(decoded.batch_id, None);
     }
 }

--- a/crates/khive-changeset/src/lib.rs
+++ b/crates/khive-changeset/src/lib.rs
@@ -8,6 +8,7 @@ mod strict;
 pub use changeset::{from_ndjson, to_ndjson, ChangeSet, ChangeSetError};
 pub use envelope::{Envelope, CURRENT_SCHEMA_VERSION};
 pub use op::{
-    CreateOp, CreateTarget, DeleteOp, DeletePreimage, EdgePatch, EntityCreateFields, EntityPatch,
-    LinkOp, MergeOp, MergePreimage, NoteCreateFields, NotePatch, Op, UpdateOp, UpdatePatch,
+    CreateOp, CreateTarget, DeleteOp, DeletePreimage, EdgePatch, EdgePreimage, EntityCreateFields,
+    EntityPatch, EntityPreimage, LinkOp, MergeOp, MergePreimage, NoteCreateFields, NotePatch,
+    NotePreimage, Op, UpdateOp, UpdatePatch, UpdatePreimage,
 };

--- a/crates/khive-changeset/src/op.rs
+++ b/crates/khive-changeset/src/op.rs
@@ -151,13 +151,42 @@ impl<'de> Deserialize<'de> for LinkOp {
 
 // ---- update ---------------------------------------------------------------
 
-/// Patch an existing entity, note, or edge's mutable fields. Carries no
-/// preimage; see `README.md` for why and the known gap that leaves open.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+/// Patch an existing entity, note, or edge's mutable fields, carrying a
+/// stage-time preimage scoped to exactly the fields the patch touches.
+/// `preimage`'s populated fields must equal `patch`'s touched fields —
+/// every field the patch sets or explicitly clears to null, and no field
+/// the patch leaves unchanged — enforced at deserialize time, the same
+/// discipline `DeleteOp` and `MergeOp` apply to their own preimages below.
+/// An `UpdateOp` whose preimage and patch disagree on which fields changed
+/// is unrepresentable.
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UpdateOp {
     pub target_id: Id128,
     pub patch: UpdatePatch,
+    pub preimage: UpdatePreimage,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateOpRaw {
+    target_id: Id128,
+    patch: UpdatePatch,
+    preimage: UpdatePreimage,
+}
+
+impl<'de> Deserialize<'de> for UpdateOp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = UpdateOpRaw::deserialize(deserializer)?;
+        validate_update_congruence(&raw.patch, &raw.preimage).map_err(serde::de::Error::custom)?;
+        Ok(UpdateOp {
+            target_id: raw.target_id,
+            patch: raw.patch,
+            preimage: raw.preimage,
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -278,6 +307,180 @@ mod opt_opt {
     {
         let opt: Option<T> = Option::deserialize(d)?;
         Ok(Some(opt))
+    }
+}
+
+// ---- update preimage -------------------------------------------------------
+
+/// Prior value of exactly the fields an [`UpdateOp`]'s patch touches,
+/// captured at stage time. Mirrors [`EntityPatch`]'s field shape one-to-one:
+/// a populated preimage field means "the patch touches this field, and this
+/// was its value before the patch"; an absent preimage field means "the
+/// patch leaves this field unchanged." [`UpdateOp`]'s custom `Deserialize`
+/// enforces that this field set exactly equals `EntityPatch`'s touched-field
+/// set.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EntityPreimage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "opt_opt")]
+    pub description: Option<Option<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<String, PropertyValue>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+/// Prior value of exactly the fields an [`UpdateOp`]'s patch touches;
+/// mirrors [`NotePatch`] the same way [`EntityPreimage`] mirrors
+/// [`EntityPatch`]. A captured `salience`/`decay_factor` value, when
+/// present, must satisfy the same finite/range invariant
+/// `khive_types::Note::is_valid` enforces on a live note — a prior value
+/// outside that range could never have been real.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NotePreimage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "opt_opt")]
+    pub salience: Option<Option<f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "opt_opt")]
+    pub decay_factor: Option<Option<f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<String, PropertyValue>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+/// Prior value of exactly the fields an [`UpdateOp`]'s patch touches;
+/// mirrors [`EdgePatch`] the same way [`EntityPreimage`] mirrors
+/// [`EntityPatch`]. A captured `weight` value, when present, must satisfy
+/// the same finite/`[0.0, 1.0]` invariant `EdgePatch`/`LinkOp`/
+/// `khive_types::Link` enforce on a live edge weight.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EdgePreimage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relation: Option<EdgeRelation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+}
+
+/// The field-scoped preimage for one [`UpdateOp`], tagged by the same
+/// `target` discriminant [`UpdatePatch`] uses so a preimage's substrate is
+/// self-describing on the wire.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case")]
+pub enum UpdatePreimage {
+    Entity(EntityPreimage),
+    Note(NotePreimage),
+    Edge(EdgePreimage),
+}
+
+/// Enforce [`UpdateOp`]'s hard requirement: `preimage` targets the same
+/// substrate as `patch`, and the set of fields `preimage` populates equals
+/// the set of fields `patch` touches (sets or explicitly clears) exactly —
+/// no field the patch leaves unchanged, no field the patch touches left
+/// uncaptured. Also re-validates the finite/range invariants a captured
+/// prior `salience`, `decay_factor`, or edge `weight` must satisfy, since an
+/// out-of-range prior value could never have been a real previously-live
+/// state.
+fn validate_update_congruence(
+    patch: &UpdatePatch,
+    preimage: &UpdatePreimage,
+) -> Result<(), String> {
+    match (patch, preimage) {
+        (UpdatePatch::Entity(p), UpdatePreimage::Entity(pre)) => {
+            check_touched("name", p.name.is_some(), pre.name.is_some())?;
+            check_touched(
+                "description",
+                p.description.is_some(),
+                pre.description.is_some(),
+            )?;
+            check_touched(
+                "properties",
+                p.properties.is_some(),
+                pre.properties.is_some(),
+            )?;
+            check_touched("tags", p.tags.is_some(), pre.tags.is_some())?;
+            Ok(())
+        }
+        (UpdatePatch::Note(p), UpdatePreimage::Note(pre)) => {
+            check_touched("content", p.content.is_some(), pre.content.is_some())?;
+            check_touched("salience", p.salience.is_some(), pre.salience.is_some())?;
+            check_touched(
+                "decay_factor",
+                p.decay_factor.is_some(),
+                pre.decay_factor.is_some(),
+            )?;
+            check_touched(
+                "properties",
+                p.properties.is_some(),
+                pre.properties.is_some(),
+            )?;
+            check_touched("tags", p.tags.is_some(), pre.tags.is_some())?;
+            if let Some(Some(s)) = pre.salience {
+                if !s.is_finite() || !(0.0..=1.0).contains(&s) {
+                    return Err(format!(
+                        "UpdateOp note preimage salience must be finite and in [0.0, 1.0], got {s}"
+                    ));
+                }
+            }
+            if let Some(Some(d)) = pre.decay_factor {
+                if !d.is_finite() || d < 0.0 {
+                    return Err(format!(
+                        "UpdateOp note preimage decay_factor must be finite and non-negative, got {d}"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        (UpdatePatch::Edge(p), UpdatePreimage::Edge(pre)) => {
+            check_touched("relation", p.relation.is_some(), pre.relation.is_some())?;
+            check_touched("weight", p.weight.is_some(), pre.weight.is_some())?;
+            if let Some(w) = pre.weight {
+                if !w.is_finite() || !(0.0..=1.0).contains(&w) {
+                    return Err(format!(
+                        "UpdateOp edge preimage weight must be finite and in [0.0, 1.0], got {w}"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        _ => Err(format!(
+            "UpdateOp patch target ({}) does not match preimage target ({})",
+            patch_target_name(patch),
+            preimage_target_name(preimage)
+        )),
+    }
+}
+
+fn check_touched(field: &str, patch_touched: bool, preimage_present: bool) -> Result<(), String> {
+    match (patch_touched, preimage_present) {
+        (true, false) => Err(format!(
+            "UpdateOp preimage is missing `{field}`, which the patch sets or clears"
+        )),
+        (false, true) => Err(format!(
+            "UpdateOp preimage carries `{field}`, which the patch leaves unchanged"
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn patch_target_name(patch: &UpdatePatch) -> &'static str {
+    match patch {
+        UpdatePatch::Entity(_) => "entity",
+        UpdatePatch::Note(_) => "note",
+        UpdatePatch::Edge(_) => "edge",
+    }
+}
+
+fn preimage_target_name(preimage: &UpdatePreimage) -> &'static str {
+    match preimage {
+        UpdatePreimage::Entity(_) => "entity",
+        UpdatePreimage::Note(_) => "note",
+        UpdatePreimage::Edge(_) => "edge",
     }
 }
 
@@ -535,6 +738,98 @@ mod tests {
             "from_id": "00000000-0000-0000-0000-000000000002"
         });
         let result: Result<MergeOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_rejects_preimage_missing_touched_field() {
+        // patch sets `name`; preimage omits it.
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "entity", "name": "new-name" },
+            "preimage": { "target": "entity" }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_rejects_preimage_with_extra_untouched_field() {
+        // patch leaves `name` unchanged; preimage carries it anyway.
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "entity", "tags": ["a"] },
+            "preimage": {
+                "target": "entity",
+                "name": "stale-prior-name",
+                "tags": ["prior-a"]
+            }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_rejects_mismatched_target_variant() {
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "entity", "name": "n" },
+            "preimage": { "target": "note", "content": "prior" }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_explicit_null_clear_captures_prior_value() {
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "entity", "description": null },
+            "preimage": { "target": "entity", "description": "was-set" }
+        });
+        let op: UpdateOp = serde_json::from_value(json).unwrap();
+        match op.patch {
+            UpdatePatch::Entity(p) => assert_eq!(p.description, Some(None)),
+            other => panic!("expected entity patch, got {other:?}"),
+        }
+        match op.preimage {
+            UpdatePreimage::Entity(pre) => {
+                assert_eq!(pre.description, Some(Some("was-set".to_string())))
+            }
+            other => panic!("expected entity preimage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_op_accepts_congruent_preimage() {
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "edge", "weight": 0.5 },
+            "preimage": { "target": "edge", "weight": 0.9 }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn update_op_rejects_out_of_range_preimage_weight() {
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "edge", "weight": 0.5 },
+            "preimage": { "target": "edge", "weight": 1.5 }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_rejects_out_of_range_preimage_salience() {
+        let json = serde_json::json!({
+            "target_id": "00000000-0000-0000-0000-000000000001",
+            "patch": { "target": "note", "salience": 0.2 },
+            "preimage": { "target": "note", "salience": 1.9 }
+        });
+        let result: Result<UpdateOp, _> = serde_json::from_value(json);
         assert!(result.is_err());
     }
 }

--- a/crates/khive-changeset/src/op.rs
+++ b/crates/khive-changeset/src/op.rs
@@ -158,12 +158,49 @@ impl<'de> Deserialize<'de> for LinkOp {
 /// the patch leaves unchanged — enforced at deserialize time, the same
 /// discipline `DeleteOp` and `MergeOp` apply to their own preimages below.
 /// An `UpdateOp` whose preimage and patch disagree on which fields changed
-/// is unrepresentable.
+/// is unrepresentable — both the checked constructor and `Deserialize`
+/// enforce the same congruence validation, so there is no construction path
+/// that bypasses it.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UpdateOp {
-    pub target_id: Id128,
-    pub patch: UpdatePatch,
-    pub preimage: UpdatePreimage,
+    target_id: Id128,
+    patch: UpdatePatch,
+    preimage: UpdatePreimage,
+}
+
+impl UpdateOp {
+    /// Construct an `UpdateOp`, enforcing the congruence invariant:
+    /// `preimage` must target the same substrate as `patch` and populate
+    /// exactly the fields `patch` touches. This is the same invariant the
+    /// `Deserialize` impl enforces on the wire, so an incongruent update
+    /// cannot be built through either entry point.
+    pub fn new(
+        target_id: Id128,
+        patch: UpdatePatch,
+        preimage: UpdatePreimage,
+    ) -> Result<Self, String> {
+        validate_update_congruence(&patch, &preimage)?;
+        Ok(UpdateOp {
+            target_id,
+            patch,
+            preimage,
+        })
+    }
+
+    /// The identifier of the record this update targets.
+    pub fn target_id(&self) -> Id128 {
+        self.target_id
+    }
+
+    /// The staged patch.
+    pub fn patch(&self) -> &UpdatePatch {
+        &self.patch
+    }
+
+    /// The field-scoped prior value the patch touches.
+    pub fn preimage(&self) -> &UpdatePreimage {
+        &self.preimage
+    }
 }
 
 #[derive(Deserialize)]
@@ -180,12 +217,7 @@ impl<'de> Deserialize<'de> for UpdateOp {
         D: Deserializer<'de>,
     {
         let raw = UpdateOpRaw::deserialize(deserializer)?;
-        validate_update_congruence(&raw.patch, &raw.preimage).map_err(serde::de::Error::custom)?;
-        Ok(UpdateOp {
-            target_id: raw.target_id,
-            patch: raw.patch,
-            preimage: raw.preimage,
-        })
+        UpdateOp::new(raw.target_id, raw.patch, raw.preimage).map_err(serde::de::Error::custom)
     }
 }
 
@@ -830,6 +862,30 @@ mod tests {
             "preimage": { "target": "note", "salience": 1.9 }
         });
         let result: Result<UpdateOp, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_op_new_rejects_incongruent_construction() {
+        // The public `UpdateOp::new` constructor is the only in-memory way to
+        // build an `UpdateOp` — this proves it enforces the same congruence
+        // invariant `Deserialize` does, so no incongruent op (patch sets
+        // `name`, preimage doesn't capture it) can ever reach `to_ndjson`.
+        let result = UpdateOp::new(
+            Id128::from_u128(1),
+            UpdatePatch::Entity(EntityPatch {
+                name: Some("new-name".to_string()),
+                description: None,
+                properties: None,
+                tags: None,
+            }),
+            UpdatePreimage::Entity(EntityPreimage {
+                name: None,
+                description: None,
+                properties: None,
+                tags: None,
+            }),
+        );
         assert!(result.is_err());
     }
 }

--- a/crates/khive-changeset/tests/roundtrip.rs
+++ b/crates/khive-changeset/tests/roundtrip.rs
@@ -5,9 +5,9 @@
 use std::collections::BTreeMap;
 
 use khive_changeset::{
-    ChangeSet, CreateOp, CreateTarget, DeleteOp, DeletePreimage, EdgePatch, EntityCreateFields,
-    EntityPatch, Envelope, LinkOp, MergeOp, MergePreimage, NoteCreateFields, NotePatch, Op,
-    UpdateOp, UpdatePatch,
+    ChangeSet, CreateOp, CreateTarget, DeleteOp, DeletePreimage, EdgePatch, EdgePreimage,
+    EntityCreateFields, EntityPatch, EntityPreimage, Envelope, LinkOp, MergeOp, MergePreimage,
+    NoteCreateFields, NotePatch, NotePreimage, Op, UpdateOp, UpdatePatch, UpdatePreimage,
 };
 use khive_types::{
     Entity, EntityKind, Header, Id128, Link, Namespace, Note, NoteStatus, Timestamp,
@@ -162,11 +162,19 @@ proptest! {
         name in prop::option::of("[a-zA-Z0-9 ]{1,16}"),
     ) {
         let envelope = Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1));
+        // preimage field presence must exactly mirror the patch's touched fields.
+        let preimage_name = name.is_some().then(|| "prior-name".to_string());
         let op = Op::Update(UpdateOp {
             target_id,
             patch: UpdatePatch::Entity(EntityPatch {
                 name,
                 description: Some(None),
+                properties: None,
+                tags: None,
+            }),
+            preimage: UpdatePreimage::Entity(EntityPreimage {
+                name: preimage_name,
+                description: Some(Some("prior-description".to_string())),
                 properties: None,
                 tags: None,
             }),
@@ -181,11 +189,20 @@ proptest! {
         content in prop::option::of("[a-zA-Z0-9 ]{1,16}"),
     ) {
         let envelope = Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1));
+        // preimage field presence must exactly mirror the patch's touched fields.
+        let preimage_content = content.is_some().then(|| "prior-content".to_string());
         let op = Op::Update(UpdateOp {
             target_id,
             patch: UpdatePatch::Note(NotePatch {
                 content,
                 salience: Some(Some(0.42)),
+                decay_factor: None,
+                properties: None,
+                tags: None,
+            }),
+            preimage: UpdatePreimage::Note(NotePreimage {
+                content: preimage_content,
+                salience: Some(Some(0.1)),
                 decay_factor: None,
                 properties: None,
                 tags: None,
@@ -202,9 +219,15 @@ proptest! {
         weight in prop::option::of(weight_strategy()),
     ) {
         let envelope = Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1));
+        // preimage field presence must exactly mirror the patch's touched fields.
+        let preimage = EdgePreimage {
+            relation: relation.map(|_| khive_types::EdgeRelation::Extends),
+            weight: weight.map(|_| 0.5),
+        };
         let op = Op::Update(UpdateOp {
             target_id,
             patch: UpdatePatch::Edge(EdgePatch { relation, weight }),
+            preimage: UpdatePreimage::Edge(preimage),
         });
         let cs = ChangeSet::new(envelope, vec![op]);
         assert_roundtrips_byte_identical(&cs);

--- a/crates/khive-changeset/tests/roundtrip.rs
+++ b/crates/khive-changeset/tests/roundtrip.rs
@@ -164,21 +164,24 @@ proptest! {
         let envelope = Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1));
         // preimage field presence must exactly mirror the patch's touched fields.
         let preimage_name = name.is_some().then(|| "prior-name".to_string());
-        let op = Op::Update(UpdateOp {
-            target_id,
-            patch: UpdatePatch::Entity(EntityPatch {
-                name,
-                description: Some(None),
-                properties: None,
-                tags: None,
-            }),
-            preimage: UpdatePreimage::Entity(EntityPreimage {
-                name: preimage_name,
-                description: Some(Some("prior-description".to_string())),
-                properties: None,
-                tags: None,
-            }),
-        });
+        let op = Op::Update(
+            UpdateOp::new(
+                target_id,
+                UpdatePatch::Entity(EntityPatch {
+                    name,
+                    description: Some(None),
+                    properties: None,
+                    tags: None,
+                }),
+                UpdatePreimage::Entity(EntityPreimage {
+                    name: preimage_name,
+                    description: Some(Some("prior-description".to_string())),
+                    properties: None,
+                    tags: None,
+                }),
+            )
+            .unwrap(),
+        );
         let cs = ChangeSet::new(envelope, vec![op]);
         assert_roundtrips_byte_identical(&cs);
     }
@@ -191,23 +194,26 @@ proptest! {
         let envelope = Envelope::new("agent:proptest", "family:test", Timestamp::from_secs(1));
         // preimage field presence must exactly mirror the patch's touched fields.
         let preimage_content = content.is_some().then(|| "prior-content".to_string());
-        let op = Op::Update(UpdateOp {
-            target_id,
-            patch: UpdatePatch::Note(NotePatch {
-                content,
-                salience: Some(Some(0.42)),
-                decay_factor: None,
-                properties: None,
-                tags: None,
-            }),
-            preimage: UpdatePreimage::Note(NotePreimage {
-                content: preimage_content,
-                salience: Some(Some(0.1)),
-                decay_factor: None,
-                properties: None,
-                tags: None,
-            }),
-        });
+        let op = Op::Update(
+            UpdateOp::new(
+                target_id,
+                UpdatePatch::Note(NotePatch {
+                    content,
+                    salience: Some(Some(0.42)),
+                    decay_factor: None,
+                    properties: None,
+                    tags: None,
+                }),
+                UpdatePreimage::Note(NotePreimage {
+                    content: preimage_content,
+                    salience: Some(Some(0.1)),
+                    decay_factor: None,
+                    properties: None,
+                    tags: None,
+                }),
+            )
+            .unwrap(),
+        );
         let cs = ChangeSet::new(envelope, vec![op]);
         assert_roundtrips_byte_identical(&cs);
     }
@@ -224,11 +230,14 @@ proptest! {
             relation: relation.map(|_| khive_types::EdgeRelation::Extends),
             weight: weight.map(|_| 0.5),
         };
-        let op = Op::Update(UpdateOp {
-            target_id,
-            patch: UpdatePatch::Edge(EdgePatch { relation, weight }),
-            preimage: UpdatePreimage::Edge(preimage),
-        });
+        let op = Op::Update(
+            UpdateOp::new(
+                target_id,
+                UpdatePatch::Edge(EdgePatch { relation, weight }),
+                UpdatePreimage::Edge(preimage),
+            )
+            .unwrap(),
+        );
         let cs = ChangeSet::new(envelope, vec![op]);
         assert_roundtrips_byte_identical(&cs);
     }
@@ -334,13 +343,19 @@ fn probe_rejects_out_of_range_edge_patch_weight() {
         "patch": {
             "target": "edge",
             "weight": 1.5
+        },
+        "preimage": {
+            "target": "edge",
+            "weight": 0.5
         }
     });
 
     let result: Result<UpdateOp, _> = serde_json::from_value(json);
+    let err = result.expect_err("edge update patches must reject weights outside [0.0, 1.0]");
+    let message = err.to_string();
     assert!(
-        result.is_err(),
-        "edge update patches must reject weights outside [0.0, 1.0]"
+        message.contains("must be in [0.0, 1.0]"),
+        "expected the weight-bound error, got: {message}"
     );
 }
 


### PR DESCRIPTION
## What

Closes out the two merged ADR-101 amendments in the khive-changeset crate, together per the agreed sequencing:

1. **Envelope `batch_id`** (ADR-101 D1 amendment, #722): optional, producer-assigned, opaque. Absent stays absent on the wire (`skip_serializing_if`); `deny_unknown_fields` preserved; NDJSON round-trips both presence and absence.
2. **Field-scoped update preimage** (ADR-101 D1 / makes ADR-102 D4 update-inversion true): `UpdateOp` now carries an `UpdatePreimage` (`EntityPreimage`/`NotePreimage`/`EdgePreimage` mirroring the Patch types). The congruence invariant — preimage populates exactly the fields the patch sets or clears — is enforced at a single point (`validate_update_congruence`) reachable only through `UpdateOp::new` and `Deserialize`, so an incongruent op is unrepresentable through any public path. Explicit-null clears count as touched fields; captured priors get the same range validation as live values (salience, decay_factor, edge weight).

## Testing

- 30 unit + 14 integration/property tests green
- clippy `--all-targets -- -D warnings` clean; doc build with `-D warnings` clean
- `wasm32-unknown-unknown` lib check clean (CI wasm parity job covers native-vs-wasm)
- Regression tests: incongruent construction rejected via both entry points; edge-weight probe asserts the range-bound error text specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)