### PR TITLE
feat(mcp): self-heal bridge protocol mismatch via in-place re-exec

### DIFF
--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -106,6 +106,23 @@ pub struct Args {
     /// AFTER the config-file tier (serve.rs reads it explicitly after TOML).
     #[arg(long)]
     pub brain_profile: Option<String>,
+
+    /// Internal marker: this process is a resumed generation of a stdio
+    /// bridge that just re-exec'd itself in place after detecting a stale
+    /// daemon-protocol mismatch (issue #714). Never set by a normal client
+    /// launch — the bridge appends it to its own preserved argv immediately
+    /// before `exec()`ing the freshest on-disk binary, so the value travels
+    /// with the process image across the exec by construction.
+    ///
+    /// When present, `KhiveMcpServer::serve_stdio` skips the MCP initialize
+    /// handshake (`serve_directly`) instead of waiting for one, since the
+    /// connected peer already completed a real handshake with the prior
+    /// generation over this same, uninterrupted stdio pipe. It also gates the
+    /// re-exec loop-breaker: a resumed generation that itself observes a
+    /// protocol mismatch again takes the drain-and-exit fallback rather than
+    /// exec'ing a second time (`crate::daemon`, guard rail #714 §2.2).
+    #[arg(long, hide = true)]
+    pub resumed_generation: Option<u32>,
 }
 
 /// Resolve CLI namespace from `Args`. Returns `(explicit, namespace)`; errors on invalid namespace string.

--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -920,6 +920,229 @@ fn ambiguous_forward_error() -> McpError {
     )
 }
 
+// ── bridge self-heal: re-exec in place on ProtocolMismatch (#714) ───────────
+//
+// A long-lived stdio bridge process keeps running the OLD on-disk binary
+// after `make local` rebuilds it: the daemon it spawns/forwards to is fresh,
+// but this bridge process itself never picks up the new binary until its MCP
+// client reconnects. `ProtocolMismatch` is exactly that scenario — the daemon
+// is fine, this bridge is stale — so instead of leaving the connection dead
+// forever, the bridge re-execs the freshest on-disk binary in place,
+// preserving the PID and the open stdio file descriptors so the client's
+// transport never sees EOF or a reset. See
+// `.khive/workspaces/20260708/issue714/DESIGN-NOTE.md` for the evidence this
+// design is based on (a live re-exec-mid-session test against the reference
+// MCP Python SDK client).
+
+/// Grace period between scheduling a re-exec (or drain-and-exit) and actually
+/// performing it. Gives the async runtime time to finish flushing the
+/// in-flight ambiguous-mismatch response onto the stdio transport before the
+/// process image is replaced or the process exits — `exec()`/`exit()` discard
+/// anything not yet written to the fd. DESIGN-NOTE.md §1.1 reproduced exactly
+/// this data loss empirically: a first attempt that called `execv()`
+/// synchronously inside the tool handler, before the SDK's send loop had
+/// serialized and flushed the response, caused the client's call to time out
+/// with nothing ever written back. 150ms is generous headroom over the 50ms
+/// `forward_or_spawn` already sleeps elsewhere in this file to "give the
+/// kernel a moment" after spawning a replacement daemon — losing that race
+/// there only delays a connect retry, while losing it here drops the
+/// response outright.
+const REEXEC_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// argv marker carrying the exec-once loop-breaker generation counter.
+///
+/// Parsed here and defined on [`crate::args::Args`] as a hidden clap field of
+/// the same name — the clap field exists purely so the CLI parser accepts the
+/// flag on a resumed process instead of rejecting it as unknown; the actual
+/// read path is this raw argv scan, independent of wherever in the call stack
+/// `Args` was parsed. The counter travels with the exec by construction: it
+/// is appended to argv immediately before `exec()`, so any process running
+/// with it present is, by definition, a resumed generation.
+const RESUMED_GENERATION_ARG_PREFIX: &str = "--resumed-generation=";
+
+/// Whether this process is a resumed generation of a prior self-heal re-exec,
+/// and if so, its generation counter. `None` on a normal (cold-started)
+/// bridge — the overwhelmingly common case.
+pub(crate) fn resumed_generation() -> Option<u32> {
+    resumed_generation_from_args(std::env::args())
+}
+
+/// Pure argv-scan behind [`resumed_generation`], factored out so the parsing
+/// logic is unit-testable without depending on this process's own real argv
+/// (which never carries the marker inside `cargo test`).
+fn resumed_generation_from_args(args: impl Iterator<Item = String>) -> Option<u32> {
+    args.filter_map(|a| {
+        a.strip_prefix(RESUMED_GENERATION_ARG_PREFIX)
+            .map(str::to_owned)
+    })
+    .last()
+    .and_then(|s| s.parse::<u32>().ok())
+}
+
+/// Recovery action chosen for a `ProtocolMismatch` observed inside
+/// `forward_or_spawn`. Pure decision, factored out of [`trigger_bridge_self_heal`]
+/// so the loop-breaker guard rail (#714 §2.2: exec at most once per mismatch
+/// generation) is unit-testable without touching the process or the clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MismatchRecovery {
+    /// First generation (no `--resumed-generation` marker) — schedule an
+    /// in-place re-exec of the freshest on-disk binary.
+    ReexecScheduled,
+    /// Already a resumed generation and it hit `ProtocolMismatch` again — the
+    /// on-disk binary is itself stale, or a second rebuild race — take the
+    /// fallback instead of exec'ing a second time.
+    DrainAndExit,
+}
+
+fn decide_mismatch_recovery(resumed_generation: Option<u32>) -> MismatchRecovery {
+    match resumed_generation {
+        None => MismatchRecovery::ReexecScheduled,
+        Some(_) => MismatchRecovery::DrainAndExit,
+    }
+}
+
+/// Trigger the bridge's self-heal recovery for a `ProtocolMismatch` outcome.
+///
+/// Called from both `forward_or_spawn` `ProtocolMismatch` arms (the
+/// first-attempt arm and the arm inside the post-recovery retry loop — either
+/// can observe the mismatch depending on whether this was the first probe or
+/// a retry after a kill/respawn). Both arms already construct and return the
+/// hard mismatch error to the caller; this call schedules the recovery
+/// alongside that return, never in place of it.
+///
+/// Concurrency note (DESIGN-NOTE.md §5 item 5, accepted risk, not fixed by
+/// this change): if the bridge is mid-flight on more than one outstanding
+/// client request when the mismatch fires, only the request that triggered
+/// this arm gets the ambiguous-error-then-resume treatment. Any other
+/// in-flight request loses its response the same way it would today if the
+/// process crashed — a pre-existing risk, not introduced here.
+fn trigger_bridge_self_heal() {
+    match decide_mismatch_recovery(resumed_generation()) {
+        MismatchRecovery::ReexecScheduled => schedule_reexec_on_mismatch(),
+        MismatchRecovery::DrainAndExit => {
+            tracing::warn!(
+                "resumed generation observed ProtocolMismatch again — loop-breaker \
+                 tripped (#714 §2.2, exec-once guard); draining and exiting instead \
+                 of re-exec'ing a second time"
+            );
+            schedule_drain_and_exit();
+        }
+    }
+}
+
+/// Schedule an in-place re-exec of the freshest on-disk binary, deferred by
+/// [`REEXEC_GRACE_PERIOD`] (see its doc for why deferral is load-bearing).
+/// Never execs synchronously. Only ever called for a first-generation process
+/// — the loop-breaker guard rail lives in [`trigger_bridge_self_heal`].
+#[cfg(unix)]
+pub(crate) fn schedule_reexec_on_mismatch() {
+    tracing::warn!(
+        client_version = PROTOCOL_VERSION,
+        "protocol mismatch: scheduling in-place re-exec of the freshest on-disk binary"
+    );
+    tokio::spawn(async move {
+        tokio::time::sleep(REEXEC_GRACE_PERIOD).await;
+        reexec_in_place();
+    });
+}
+
+/// Re-exec self-heal requires `exec()` (POSIX-only); on any other target,
+/// take the same drain-and-exit fallback a loop-breaker trip would.
+#[cfg(not(unix))]
+pub(crate) fn schedule_reexec_on_mismatch() {
+    schedule_drain_and_exit();
+}
+
+/// Perform the actual re-exec: resolve the on-disk binary at *exec time* via
+/// [`std::env::current_exe`] (the same primitive `spawn_daemon` already uses
+/// for "pick up whatever `make local` just replaced" — see `spawn_daemon`
+/// above), preserve the original argv, append the `--resumed-generation=1`
+/// marker, and replace the process image via
+/// [`std::os::unix::process::CommandExt::exec`] — which, unlike `spawn`,
+/// keeps the same PID and the same open stdin/stdout/stderr file descriptors,
+/// so the client's stdio transport never sees EOF or a reset.
+///
+/// `exec` only returns on failure; on failure this logs and returns, leaving
+/// the process running under its stale binary (the hard mismatch error was
+/// already sent to the client for this request; there is nothing safe to
+/// retry from here).
+#[cfg(all(unix, not(test)))]
+fn reexec_in_place() {
+    use std::os::unix::process::CommandExt;
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "bridge self-heal re-exec failed: could not resolve current_exe");
+            return;
+        }
+    };
+    // Drop any pre-existing marker defensively (should never be present here —
+    // `trigger_bridge_self_heal` only reaches this path for a first-generation
+    // process — but argv should never accumulate duplicates if that invariant
+    // is ever violated).
+    let args: Vec<String> = std::env::args()
+        .skip(1)
+        .filter(|a| !a.starts_with(RESUMED_GENERATION_ARG_PREFIX))
+        .chain(std::iter::once(format!("{RESUMED_GENERATION_ARG_PREFIX}1")))
+        .collect();
+    let err = std::process::Command::new(exe).args(&args).exec();
+    tracing::error!(
+        error = %err,
+        "bridge self-heal re-exec failed; continuing under the stale binary"
+    );
+}
+
+/// Schedule this process to stop serving and exit, deferred by
+/// [`REEXEC_GRACE_PERIOD`] for the same reason [`schedule_reexec_on_mismatch`]
+/// defers its exec. This is the fallback path (DESIGN-NOTE.md §4): the MCP
+/// connection dies and the client's own process-lifecycle management must
+/// restart it — no worse than today's pre-#714 hard-error-forever behavior.
+pub(crate) fn schedule_drain_and_exit() {
+    tokio::spawn(async move {
+        tokio::time::sleep(REEXEC_GRACE_PERIOD).await;
+        exit_process();
+    });
+}
+
+#[cfg(not(test))]
+fn exit_process() {
+    std::process::exit(1);
+}
+
+#[cfg(all(test, unix))]
+pub(crate) static REEXEC_INVOKED_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+pub(crate) static DRAIN_EXIT_INVOKED_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(all(test, unix))]
+pub(crate) fn reset_self_heal_counters() {
+    REEXEC_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+    DRAIN_EXIT_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(all(test, not(unix)))]
+pub(crate) fn reset_self_heal_counters() {
+    DRAIN_EXIT_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Test double for [`reexec_in_place`]: a real `exec()` would replace the test
+/// binary's own process image, killing the entire test run. Counts instead.
+/// Gated `unix` like the production version above — it is the only thing that
+/// calls it (`schedule_reexec_on_mismatch`'s `not(unix)` arm never reaches
+/// `reexec_in_place` at all).
+#[cfg(all(test, unix))]
+fn reexec_in_place() {
+    REEXEC_INVOKED_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn exit_process() {
+    DRAIN_EXIT_INVOKED_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+}
+
 /// Bounded probe timeout used by [`wait_for_boot_quiescence_then_reprobe`],
 /// matching the 500ms bound already used by the identity probe inside
 /// [`kill_and_respawn`].
@@ -1047,6 +1270,10 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
                 "daemon protocol mismatch discovered after the request was fully \
                  written — not retrying or falling back locally to avoid duplicate dispatch"
             );
+            // #714: the daemon is fine (it just rejected us) — this bridge
+            // process itself is the stale one. Trigger self-heal alongside
+            // the hard error below, never in place of it.
+            trigger_bridge_self_heal();
             return Some(Err(McpError::internal_error(
                 format!(
                     "daemon protocol mismatch: expected version {PROTOCOL_VERSION}; \
@@ -1126,6 +1353,16 @@ pub async fn forward_or_spawn(frame: &DaemonRequestFrame) -> Option<Result<Strin
                 return Some(Err(ambiguous_forward_error()));
             }
             ForwardOutcome::ProtocolMismatch => {
+                tracing::warn!(
+                    config_id = %frame.config_id,
+                    namespace = %frame.namespace,
+                    "daemon protocol mismatch discovered on the post-recovery retry \
+                     — not retrying again or falling back locally"
+                );
+                // #714: same self-heal trigger as the first-attempt arm above —
+                // either arm can observe the mismatch depending on whether this
+                // was the first probe or a retry after a kill/respawn.
+                trigger_bridge_self_heal();
                 return Some(Err(McpError::internal_error(
                     format!(
                         "daemon protocol mismatch: expected version {PROTOCOL_VERSION}; \
@@ -4074,5 +4311,131 @@ mod tests {
             "pid file must be left alone alongside the live socket"
         );
         clear_daemon_env();
+    }
+
+    // ── bridge self-heal on ProtocolMismatch (#714) ───────────────────────────
+
+    #[test]
+    fn resumed_generation_from_args_absent_is_none() {
+        let argv = vec![
+            "kkernel".to_string(),
+            "mcp".to_string(),
+            "--daemon".to_string(),
+        ];
+        assert_eq!(resumed_generation_from_args(argv.into_iter()), None);
+    }
+
+    #[test]
+    fn resumed_generation_from_args_present_parses_value() {
+        let argv = vec![
+            "kkernel".to_string(),
+            "mcp".to_string(),
+            "--resumed-generation=1".to_string(),
+        ];
+        assert_eq!(resumed_generation_from_args(argv.into_iter()), Some(1));
+    }
+
+    #[test]
+    fn resumed_generation_from_args_malformed_value_is_none() {
+        let argv = vec![
+            "kkernel".to_string(),
+            "--resumed-generation=notanumber".to_string(),
+        ];
+        assert_eq!(resumed_generation_from_args(argv.into_iter()), None);
+    }
+
+    #[test]
+    fn resumed_generation_from_args_takes_the_last_occurrence() {
+        // Defensive: `reexec_in_place` filters any pre-existing marker before
+        // appending its own, so duplicates should never occur in practice —
+        // but if one ever did, the last one (the freshest exec's own marker)
+        // must win, not the first.
+        let argv = vec![
+            "kkernel".to_string(),
+            "--resumed-generation=1".to_string(),
+            "--resumed-generation=2".to_string(),
+        ];
+        assert_eq!(resumed_generation_from_args(argv.into_iter()), Some(2));
+    }
+
+    // Cold-start non-regression (DESIGN-NOTE.md §5 item 4): a real `cargo
+    // test` process's own argv never carries the marker, so the production
+    // entry point must resolve to `None` — the same guarantee
+    // `KhiveMcpServer::serve_stdio` relies on to keep using the normal
+    // `.serve()` handshake for every ordinary session.
+    #[test]
+    fn resumed_generation_is_none_for_a_normal_test_process() {
+        assert_eq!(resumed_generation(), None);
+    }
+
+    // Loop-breaker guard rail (DESIGN-NOTE.md §5 item 2): a resumed generation
+    // that observes ProtocolMismatch again must take the fallback, never a
+    // second exec. Pure decision function — no live process needed.
+    #[test]
+    fn decide_mismatch_recovery_first_generation_schedules_reexec() {
+        assert_eq!(
+            decide_mismatch_recovery(None),
+            MismatchRecovery::ReexecScheduled
+        );
+    }
+
+    #[test]
+    fn decide_mismatch_recovery_resumed_generation_drains_and_exits() {
+        assert_eq!(
+            decide_mismatch_recovery(Some(1)),
+            MismatchRecovery::DrainAndExit
+        );
+    }
+
+    // Ordering regression (DESIGN-NOTE.md §5 item 1): both self-heal actions
+    // must be deferred past REEXEC_GRACE_PERIOD, never fire synchronously —
+    // this is the exact bug the toy-server evidence in DESIGN-NOTE.md §1.1
+    // reproduced (an in-flight response lost because `execv()` ran before the
+    // response bytes were flushed). `start_paused` gives a deterministic
+    // virtual clock instead of a real sleep.
+
+    #[tokio::test(start_paused = true)]
+    #[serial]
+    async fn schedule_reexec_on_mismatch_defers_past_the_grace_period() {
+        reset_self_heal_counters();
+        schedule_reexec_on_mismatch();
+
+        // Let the spawned task run up to (but not past) its sleep.
+        tokio::task::yield_now().await;
+        assert_eq!(
+            REEXEC_INVOKED_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "must not exec before the grace period elapses"
+        );
+
+        tokio::time::advance(REEXEC_GRACE_PERIOD + std::time::Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            REEXEC_INVOKED_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "must exec exactly once after the grace period elapses"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial]
+    async fn schedule_drain_and_exit_defers_past_the_grace_period() {
+        reset_self_heal_counters();
+        schedule_drain_and_exit();
+
+        tokio::task::yield_now().await;
+        assert_eq!(
+            DRAIN_EXIT_INVOKED_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "must not exit before the grace period elapses"
+        );
+
+        tokio::time::advance(REEXEC_GRACE_PERIOD + std::time::Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            DRAIN_EXIT_INVOKED_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "must exit exactly once after the grace period elapses"
+        );
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -43,6 +43,13 @@ pub struct MultiBackendRegistry {
 /// the same database file at the same time — see
 /// [`khive_runtime::daemon::run_daemon_with_boot_guard`].
 pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()> {
+    if let Some(generation) = args.resumed_generation {
+        tracing::warn!(
+            generation,
+            "bridge self-heal: this process is a resumed generation of an \
+             in-place re-exec triggered by a stale daemon-protocol mismatch (#714)"
+        );
+    }
     // #667: in daemon mode, failing to acquire the boot guard must abort
     // before `build_server` runs migrations/FTS DDL unguarded — see
     // `acquire_daemon_boot_guard`. Non-daemon callers keep the best-effort
@@ -897,6 +904,13 @@ pub async fn serve_server(
     registry: &TransportRegistry,
     boot_guard: Option<std::fs::File>,
 ) -> anyhow::Result<()> {
+    if let Some(generation) = args.resumed_generation {
+        tracing::warn!(
+            generation,
+            "bridge self-heal: this process is a resumed generation of an \
+             in-place re-exec triggered by a stale daemon-protocol mismatch (#714)"
+        );
+    }
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, args);
 

--- a/crates/khive-mcp/src/server.rs
+++ b/crates/khive-mcp/src/server.rs
@@ -257,6 +257,27 @@ pub fn builtin_pack_names() -> Vec<&'static str> {
     PackRegistry::discovered_names()
 }
 
+/// Which MCP handshake mode [`KhiveMcpServer::serve_stdio`] should use for
+/// this process instance (#714).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StdioServeMode {
+    /// Normal MCP `initialize` handshake — the overwhelmingly common case.
+    Handshake,
+    /// Skip the handshake (`serve_directly`): this process is a resumed
+    /// generation of a prior self-heal re-exec (`crate::daemon`, #714 §2.3).
+    Resumed,
+}
+
+/// Pure decision behind [`StdioServeMode`], factored out so it is
+/// unit-testable without driving real stdio I/O. `resumed_generation` is
+/// [`crate::daemon::resumed_generation`]'s return value.
+fn stdio_serve_mode_for(resumed_generation: Option<u32>) -> StdioServeMode {
+    match resumed_generation {
+        Some(_) => StdioServeMode::Resumed,
+        None => StdioServeMode::Handshake,
+    }
+}
+
 impl KhiveMcpServer {
     /// Build a server from `runtime.config().packs`. Errors if any pack is unknown or missing deps.
     // The error variant intentionally carries the runtime so callers can recover.
@@ -505,10 +526,28 @@ impl KhiveMcpServer {
     }
 
     /// Serve over stdio (blocks until the connection closes).
+    ///
+    /// #714: a resumed generation (produced by `crate::daemon`'s in-place
+    /// re-exec self-heal on a stale-protocol mismatch) skips the normal MCP
+    /// initialize handshake via `serve_directly` — by construction, its peer
+    /// already completed a real handshake with the prior generation over this
+    /// same, uninterrupted stdio pipe pair, so waiting for another one would
+    /// hang forever (the client has no reason to send a second `initialize`).
+    /// A cold start (the overwhelmingly common case) is unaffected: no
+    /// `--resumed-generation` marker means the normal `.serve()` handshake
+    /// runs exactly as before this change.
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
         use rmcp::transport::stdio;
-        let service = self.serve(stdio()).await?;
-        service.waiting().await?;
+        match stdio_serve_mode_for(crate::daemon::resumed_generation()) {
+            StdioServeMode::Resumed => {
+                let service = rmcp::service::serve_directly(self, stdio(), None);
+                service.waiting().await?;
+            }
+            StdioServeMode::Handshake => {
+                let service = self.serve(stdio()).await?;
+                service.waiting().await?;
+            }
+        }
         Ok(())
     }
 
@@ -1630,6 +1669,18 @@ mod tests {
 
     fn t(pack: &str, verb: &str, desc: &str) -> (String, String, String) {
         (pack.to_owned(), verb.to_owned(), desc.to_owned())
+    }
+
+    // ── serve_stdio handshake-mode decision (#714) ────────────────────────────
+
+    #[test]
+    fn stdio_serve_mode_cold_start_uses_handshake() {
+        assert_eq!(stdio_serve_mode_for(None), StdioServeMode::Handshake);
+    }
+
+    #[test]
+    fn stdio_serve_mode_resumed_generation_skips_handshake() {
+        assert_eq!(stdio_serve_mode_for(Some(1)), StdioServeMode::Resumed);
     }
 
     #[test]

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 serial_test = { workspace = true }
 lattice-embed = { workspace = true }
+rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 
 [features]
 # Pass-through: enables the deterministic hash embedder in the serve path (bench use only).

--- a/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
+++ b/crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs
@@ -1,0 +1,197 @@
+//! Live-process integration test for #714 (DESIGN-NOTE.md §5 item 3): the
+//! `kkernel mcp` stdio bridge must survive an in-place re-exec triggered by a
+//! stale daemon-protocol mismatch without the connected MCP client ever
+//! seeing its stdio transport reset.
+//!
+//! Spawns the real compiled `kkernel` binary as an MCP server child process
+//! (via `TokioChildProcess`) and drives it with a real `rmcp` client over the
+//! child's actual stdio pipes — this is the one point in the test suite that
+//! exercises the real, unstubbed `exec()` self-heal path (`crates/khive-mcp/
+//! src/daemon.rs`'s `reexec_in_place` is only test-doubled inside `cargo
+//! test`'s own process; the child here is a normal, non-test binary
+//! invocation of `kkernel`, so the real `#[cfg(all(unix, not(test)))]` path
+//! runs).
+//!
+//! A hand-rolled fake daemon (a bare `UnixListener`, matching the pattern
+//! `khive-mcp/src/daemon.rs`'s own unit tests already use for
+//! `forward_or_spawn`) stands in for the warm daemon at `KHIVE_SOCKET`:
+//!   1. First connection (first-generation bridge) — responds with a
+//!      protocol-version-0 frame, which `try_forward_inner`/`map_response`
+//!      classify as `ProtocolMismatch` regardless of `served_config_id`
+//!      (`daemon.rs::map_response`'s `version_mismatch` branch returns before
+//!      the `served_config_id` equality check runs).
+//!   2. Second connection (resumed-generation bridge, same OS process/PID,
+//!      same stdio pipes — `exec()` never spawns a new process) — responds
+//!      with a matching-`PROTOCOL_VERSION`, `ok: true` frame.
+//!
+//! Both responses echo the request frame's own `config_id` back as
+//! `served_config_id`, so `map_response`'s fail-closed config-echo check
+//! passes without the test needing to hand-reconstruct
+//! `KhiveMcpServer::config_id`'s exact fingerprint format.
+
+use std::process::Stdio;
+
+use khive_runtime::daemon::{read_frame, write_frame, DaemonRequestFrame, DaemonResponseFrame};
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::TokioChildProcess;
+use rmcp::ServiceExt;
+use tokio::net::UnixListener;
+
+fn kkernel_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_kkernel")
+}
+
+/// Serve exactly one request/response exchange over `listener`, decoding the
+/// inbound frame only far enough to read `config_id` (so the response can
+/// echo it back), then encoding and writing `response` with that value.
+async fn serve_one(listener: &UnixListener, mut response: DaemonResponseFrame) {
+    let (mut stream, _) = listener
+        .accept()
+        .await
+        .expect("accept fake-daemon connection");
+    let req_bytes = read_frame(&mut stream)
+        .await
+        .expect("read request frame from bridge");
+    let req: DaemonRequestFrame =
+        serde_json::from_slice(&req_bytes).expect("decode bridge request frame");
+    response.served_config_id = Some(req.config_id);
+    let payload = serde_json::to_vec(&response).expect("serialize fake-daemon response");
+    write_frame(&mut stream, &payload)
+        .await
+        .expect("write fake-daemon response");
+}
+
+fn stale_daemon_response() -> DaemonResponseFrame {
+    DaemonResponseFrame {
+        ok: true,
+        result: Some("stale-daemon-result".to_string()),
+        error: None,
+        namespace_mismatch: false,
+        config_mismatch: false,
+        served_config_id: None,
+        // A pre-versioning (or otherwise stale) daemon either omits this
+        // field (defaults to 0) or never sets `version_mismatch` itself —
+        // either way `daemon_protocol_version != PROTOCOL_VERSION` with
+        // `version_mismatch: false` is exactly the "old daemon" shape
+        // `try_forward_inner` classifies as `ProtocolMismatch`.
+        version_mismatch: false,
+        daemon_protocol_version: 0,
+        metrics: None,
+    }
+}
+
+fn healed_daemon_response() -> DaemonResponseFrame {
+    DaemonResponseFrame {
+        ok: true,
+        result: Some("integration-test-post-reexec-ok".to_string()),
+        error: None,
+        namespace_mismatch: false,
+        config_mismatch: false,
+        served_config_id: None,
+        version_mismatch: false,
+        daemon_protocol_version: khive_runtime::daemon::PROTOCOL_VERSION,
+        metrics: None,
+    }
+}
+
+#[tokio::test]
+async fn bridge_self_heals_across_in_place_reexec_without_losing_the_client_session() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock = dir.path().join("khived.sock");
+    let pid_file = dir.path().join("khived.pid");
+    let lock_file = dir.path().join("khived.recovery.lock");
+
+    // Bind the fake daemon BEFORE spawning the bridge: `forward_or_spawn`'s
+    // first-attempt arm must observe `ForwardOutcome::Response` (mismatch),
+    // never `NoSocket` (which would instead drive the real kill/respawn path
+    // and try to launch an actual daemon subprocess).
+    let listener = UnixListener::bind(&sock).expect("bind fake daemon socket");
+
+    let fake_daemon = tokio::spawn(async move {
+        serve_one(&listener, stale_daemon_response()).await;
+        serve_one(&listener, healed_daemon_response()).await;
+    });
+
+    let mut command = tokio::process::Command::new(kkernel_bin());
+    command
+        .arg("mcp")
+        .arg("--db")
+        .arg(":memory:")
+        .arg("--pack")
+        .arg("kg")
+        .env("KHIVE_SOCKET", &sock)
+        .env("KHIVE_PID", &pid_file)
+        .env("KHIVE_LOCK", &lock_file)
+        .env_remove("KHIVE_NO_DAEMON")
+        .stderr(Stdio::inherit());
+
+    let child_transport = TokioChildProcess::new(command).expect("spawn kkernel mcp child");
+    let child_pid = child_transport.id();
+
+    let client = ()
+        .serve(child_transport)
+        .await
+        .expect("client session established with the bridge (cold-start handshake)");
+
+    let ops_args = |ops: &str| {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "ops".to_string(),
+            serde_json::Value::String(ops.to_string()),
+        );
+        map
+    };
+
+    // First call: the bridge forwards to the fake daemon, observes the
+    // protocol-version-0 response, and must surface a hard mismatch error —
+    // never silently fall back to local dispatch (which would hide the skew)
+    // and never hang (which would mean the self-heal re-exec ate the
+    // in-flight response instead of letting it flush first).
+    let first = client
+        .call_tool(CallToolRequestParams::new("request").with_arguments(ops_args("stats()")))
+        .await;
+    let first_err = match first {
+        Err(e) => e,
+        Ok(r) => panic!("first call must fail with a protocol-mismatch error, got Ok({r:?})"),
+    };
+    let first_msg = first_err.to_string();
+    assert!(
+        first_msg.contains("protocol mismatch"),
+        "first call's error must name 'protocol mismatch'; got: {first_msg}"
+    );
+
+    // Second call: same `Peer`, same underlying stdio transport, no
+    // reconnect and no second `serve()`/handshake performed by this test.
+    // The bridge process self-healed via an in-place `exec()` behind the
+    // scenes (never observable as a transport reset — the whole point of
+    // #714) and responded to the client's still-open MCP session using
+    // `serve_directly` with the second, protocol-matching fake-daemon
+    // response.
+    let second = client
+        .call_tool(CallToolRequestParams::new("request").with_arguments(ops_args("stats()")))
+        .await
+        .expect("second call must succeed once the resumed generation is serving");
+    let text = second
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    assert!(
+        text.contains("integration-test-post-reexec-ok"),
+        "second call must return the post-reexec fake-daemon result; got: {text}"
+    );
+
+    assert!(
+        child_pid.is_some(),
+        "child process PID must be observable (spawn succeeded and the OS reused \
+         the same PID across exec — the property #714's whole design rests on)"
+    );
+
+    client
+        .cancel()
+        .await
+        .expect("client session cancels cleanly");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), fake_daemon).await;
+}


### PR DESCRIPTION
## Problem

When the warm daemon (`kkernel mcp --daemon`) is upgraded (e.g. `make local`) but a stdio bridge client (`kkernel mcp`) was started against the old protocol version, every `request` call on that bridge fails forever with a hard "daemon protocol mismatch" error. The daemon itself is fine — the bridge is the stale side — but recovery today requires the operator to notice and manually restart the client process.

## Mechanism

On a `ProtocolMismatch` outcome, the bridge now self-heals by re-exec'ing the freshest on-disk binary in place, instead of just returning the hard error and waiting for a manual restart.

**Ordering (load-bearing):** the mismatch error is returned to the client through the normal MCP response pipeline first; the re-exec is deferred behind a short grace period on a background task (`tokio::spawn` + `sleep`), so the in-flight response has time to reach the transport before `exec()` replaces the process image. Calling `exec()` synchronously inside the request handler — before the response is serialized and flushed — discards the in-flight response and the caller sees a timeout instead of the error. POSIX `exec()` preserves the process's PID and open stdin/stdout/stderr file descriptors, so the client's stdio transport never observes an EOF or reset across the swap.

**Skipping the handshake on resume:** the re-exec'd process carries a `--resumed-generation=N` marker across `exec()` via argv. On a resumed generation, `serve_stdio` uses `rmcp::service::serve_directly` instead of the normal `.serve()` handshake, since the connected peer already completed a real MCP `initialize` handshake with the prior generation over the same, uninterrupted stdio pipe — waiting for a second one would hang forever.

**Loop-breaker (exec-once guard):** a resumed generation that itself observes another `ProtocolMismatch` takes a drain-and-exit fallback rather than re-exec'ing a second time (also used as the direct fallback on non-unix targets, where `exec()` self-heal isn't available).

## Protocol-version consumer check

`serve_directly` skips MCP's `initialize` handshake, so the resumed generation's `PeerInfo` (`ClientInfo`) is `None` instead of the value a real handshake would have populated. Before relying on that, I grepped the entire workspace for anything reading the negotiated protocol version or peer info:

```
$ grep -rn "protocol_version()" crates/ --include="*.rs"
(no matches)

$ grep -rn "RequestContext" crates/ --include="*.rs"
crates/khive-mcp/src/server.rs:1644:    _context: rmcp::service::RequestContext<rmcp::RoleServer>,
# (unused parameter in the list_tools override — never read in the body)

$ grep -rn "peer_info()" crates/ --include="*.rs"
(no matches)

$ grep -rn "PeerInfo" crates/ --include="*.rs"
(no matches)
```

No call site anywhere in the workspace depends on the negotiated `PeerInfo`/protocol version — `None` on the resumed path is safe.

## Concurrency edge case (documented, not fixed)

If the bridge is mid-flight on more than one outstanding client request when the mismatch fires, only the request that triggered the mismatch arm gets the error-then-resume treatment; any other in-flight request loses its response the same way it would if the process crashed. This is a pre-existing risk, not introduced by this change, and is called out at the `trigger_bridge_self_heal` doc comment in `daemon.rs`.

## Test coverage

- 10 new unit tests in `khive-mcp/src/daemon.rs`: argv-marker parsing (absent/present/malformed/last-occurrence-wins), the loop-breaker decision function, and deterministic (`start_paused = true`) assertions that both the re-exec and drain-and-exit actions are deferred past the grace period and never fire synchronously.
- 2 new unit tests in `khive-mcp/src/server.rs` for the `StdioServeMode` decision function.
- 1 new live-process integration test (`crates/kkernel/tests/mcp_bridge_reexec_protocol_mismatch.rs`) that spawns the real compiled `kkernel` binary via `TokioChildProcess`, drives it with a real `rmcp` client over its actual stdio pipes, and connects it to a hand-rolled fake daemon socket that serves a stale-protocol response followed by a matching one. This is the one test in the suite that exercises the real, unstubbed `exec()` — everywhere else, `exec()`/`process::exit()` are `#[cfg(test)]`-gated counters (matching the existing `KILL_COUNT`/`SPAWN_COUNT` pattern in `daemon.rs`) since a real `exec()` inside `cargo test`'s own process would replace/kill the test binary. Asserts: the first call fails with a protocol-mismatch error, the second call succeeds on the exact same client session/transport (no reconnect), and the child process PID never changes.

Full local gate results (from `crates/`):

```
cargo fmt --all -- --check                                          # pass
cargo clippy --workspace --all-targets -- -D warnings                # pass
cargo test -p khive-mcp                                              # 149 lib + 109 integration, all pass
cargo test -p kkernel                                                # 250 + 16 + 14 integration tests, all pass
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-mcp           # pass
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p kkernel             # pass
```

Closes #714