### PR TITLE
feat(daemon): audit duration_us + phase telemetry + comm.health resource self-report (ADR-103 Stage 1, #723)

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -2926,6 +2926,7 @@ id = "lambda:project-actor"
     /// `multi_backend_boot_paths_share_identical_wiring_surface` test, which
     /// exercises the actual coordinator branch.
     #[test]
+    #[serial]
     fn kkernel_multi_backend_path_wires_pool_for_file_backed_main() {
         let dir = tempfile::tempdir().expect("temp dir");
         let main_path = dir.path().join("main.db");
@@ -2959,6 +2960,7 @@ id = "lambda:project-actor"
     /// exercises `build_server_from_multi_backend_registry` — see the note on the
     /// sibling test above.
     #[test]
+    #[serial]
     fn kkernel_multi_backend_path_leaves_pool_none_for_in_memory_main() {
         let khive_cfg = KhiveConfig {
             backends: vec![BackendConfig {
@@ -2993,6 +2995,7 @@ id = "lambda:project-actor"
     /// Both boot paths now delegate to `build_pack_runtime`, which applies the wiring in
     /// one place and prevents any future path from drifting.
     #[test]
+    #[serial]
     fn secondary_pack_runtime_core_resolves_to_main_after_build_registry() {
         use khive_runtime::PackConfig;
 
@@ -3063,6 +3066,7 @@ id = "lambda:project-actor"
     /// in-memory for this invocation, and the declared sqlite paths must never be
     /// created on disk.
     #[test]
+    #[serial]
     fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file() {
         use khive_runtime::PackConfig;
 
@@ -3129,6 +3133,7 @@ id = "lambda:project-actor"
     /// to?) and must fail loud, pointing at khive.toml as the place to make the
     /// change, rather than silently collapsing distinct backends onto one path.
     #[test]
+    #[serial]
     fn concrete_db_override_with_backends_declared_is_rejected() {
         use khive_runtime::PackConfig;
 
@@ -3297,6 +3302,7 @@ id = "lambda:project-actor"
     /// `"main"`. `build_server_multi_backend` must return an error whose
     /// message mentions `"main"` so operators know what to fix.
     #[test]
+    #[serial]
     fn multi_backend_missing_main_returns_error_mentioning_main() {
         let khive_cfg = KhiveConfig {
             backends: vec![BackendConfig {
@@ -3334,6 +3340,7 @@ id = "lambda:project-actor"
     /// must return an `Err` mentioning the pack, the requested backend, and the
     /// defined backends.
     #[test]
+    #[serial]
     fn multi_backend_registry_rejects_undefined_pack_backend() {
         use khive_runtime::PackConfig;
 
@@ -3391,6 +3398,7 @@ id = "lambda:project-actor"
     /// but through the `build_server_multi_backend` public builder, which has its
     /// own independent per-pack backend resolution loop.
     #[test]
+    #[serial]
     fn multi_backend_server_rejects_undefined_pack_backend() {
         use khive_runtime::PackConfig;
 
@@ -3472,6 +3480,7 @@ id = "lambda:project-actor"
     /// run migrations only once. Verified by using two names that differ only by
     /// `./` prefix while pointing at the same absolute path.
     #[test]
+    #[serial]
     fn duplicate_sqlite_paths_deduplicated_to_single_backend() {
         use khive_runtime::PackConfig;
 
@@ -3536,6 +3545,7 @@ id = "lambda:project-actor"
     /// declared backend in-memory for this invocation, and the declared sqlite
     /// paths must never be created on disk.
     #[test]
+    #[serial]
     fn memory_override_forces_all_backends_in_memory_and_never_creates_sqlite_file_via_build_server_multi_backend(
     ) {
         use khive_runtime::PackConfig;
@@ -3604,6 +3614,7 @@ id = "lambda:project-actor"
     /// path too, pointing at khive.toml as the place to make the change, rather
     /// than silently collapsing distinct backends onto one path.
     #[test]
+    #[serial]
     fn concrete_db_override_with_backends_declared_is_rejected_via_build_server_multi_backend() {
         use khive_runtime::PackConfig;
 

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -1097,6 +1097,21 @@ fn channel_health_to_json(note: &Note) -> Value {
 ///
 /// Never returns a computed `healthy: bool` (design review amendment: "report
 /// timestamps only") — staleness/alerting judgment belongs to the caller.
+///
+/// `resource` (ADR-103 Stage 1, issue #723 ask 2): a process-level self-report
+/// of this process's own cumulative CPU time and RSS (via `getrusage`,
+/// `khive_runtime::process_resource_usage`) plus the names of any background
+/// phases (e.g. `ann_warm`) currently in flight in this process
+/// (`khive_runtime::active_phase_names`). "This process" is, in the common
+/// case, the daemon itself: a client-role stdio session without an in-memory
+/// poll loop of its own still forwards `dispatch` calls to the daemon over
+/// its socket, so this handler body executes inside the daemon process, not
+/// the thin client. `cpu_us`/`rss_bytes` are `null` only if the underlying
+/// `getrusage` read is unavailable on this platform; `active_phases` is
+/// always present and empty when nothing is in flight. Raw observations
+/// only, per the same "no computed healthy bool" rule as the rest of this
+/// verb — attributing severity to a given CPU/RSS number is the caller's
+/// judgment, not this verb's.
 pub(crate) async fn handle_health(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -1146,11 +1161,19 @@ pub(crate) async fn handle_health(
         ("daemon", Some("daemon-heartbeat"))
     };
 
+    let usage = khive_runtime::process_resource_usage();
+    let resource = json!({
+        "cpu_us": usage.map(|u| u.cpu_us),
+        "rss_bytes": usage.map(|u| u.rss_bytes),
+        "active_phases": khive_runtime::active_phase_names(),
+    });
+
     Ok(json!({
         "role": role,
         "source": source,
         "as_of": as_of,
         "channels": channels,
+        "resource": resource,
     }))
 }
 

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -5225,6 +5225,51 @@ async fn health_reports_client_role_when_no_heartbeat_state_exists() {
     );
 }
 
+/// ADR-103 Stage 1 / issue #723 ask 2: `comm.health()` must self-report this
+/// process's own resource usage — `cpu_us`/`rss_bytes` via `getrusage`, plus
+/// the (possibly empty) set of named background phases currently in flight.
+/// No computed `healthy` field, matching the rest of this verb's contract.
+#[tokio::test]
+async fn health_includes_resource_self_report() {
+    let (registry, _rt) = build_registry();
+
+    let result = registry
+        .dispatch("comm.health", serde_json::json!({}))
+        .await
+        .expect("health succeeds");
+
+    let resource = &result["resource"];
+    assert!(
+        resource.is_object(),
+        "resource must be an object, got: {resource:?}"
+    );
+    assert!(
+        resource.get("healthy").is_none(),
+        "resource must never carry a computed healthy bool"
+    );
+    // `getrusage` should succeed on every CI runner this crate builds on
+    // (unix); the field must at least be present (null only on a platform
+    // with no implementation) and non-negative when populated.
+    assert!(
+        resource.get("cpu_us").is_some(),
+        "cpu_us key must be present"
+    );
+    if let Some(cpu_us) = resource["cpu_us"].as_i64() {
+        assert!(cpu_us >= 0);
+    }
+    assert!(
+        resource.get("rss_bytes").is_some(),
+        "rss_bytes key must be present"
+    );
+    let active_phases = resource["active_phases"]
+        .as_array()
+        .expect("active_phases must be an array");
+    assert!(
+        active_phases.is_empty(),
+        "no background phase is in flight during this test"
+    );
+}
+
 /// comm.health() takes no arguments — any caller-supplied args must be rejected
 /// rather than silently ignored (spec: "read-only, NO args").
 #[tokio::test]

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -357,6 +357,17 @@ pub(crate) async fn warm_existing_memory_indexes(rt: &KhiveRuntime, ann: &Shared
 }
 
 /// Lazy warm-load for the global index for `model`: snapshot restore or rebuild with double-fingerprint check.
+///
+/// ADR-103 Stage 1 / issue #723 ask 1: brackets the whole attempt (snapshot
+/// load and/or rebuild-from-scratch) as one `ann_warm` phase span, so an
+/// operator can attribute a cold-start or on-demand-warm CPU window after
+/// the fact from the `PhaseStarted`/`PhaseCompleted`/`PhaseCancelled` event
+/// trio. This is the single call site both `warm_existing_memory_indexes`
+/// (daemon-startup cold warm) and `ensure_ann_background` (fire-once
+/// recall/remember-triggered warm) route through, so instrumenting here
+/// covers both callers. Emission is best-effort and a no-op when this
+/// `KhiveRuntime` has no `EventStore` configured, matching ADR-094's
+/// existing lifecycle-event emission contract exactly.
 pub(crate) async fn ensure_ann_for_model(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -366,6 +377,128 @@ pub(crate) async fn ensure_ann_for_model(
     if model.is_empty() {
         return Ok(AnnEnsureStatus::EmptyCorpus);
     }
+
+    let phase_start = std::time::Instant::now();
+    // Held for the lifetime of this call so `comm.health`'s resource
+    // self-report (#723 ask 2) can see `ann_warm` in its active-phases list
+    // while this warm/rebuild is in flight. Dropped (and the gauge
+    // decremented) on every exit path, including an early `?`-propagated
+    // error, since it is a plain RAII guard.
+    let _phase_guard = khive_runtime::register_active_phase("ann_warm");
+    // Best-effort, cheap COUNT(*) — `None` if the query itself fails, which
+    // is fine: `corpus_size` on the Started row is a diagnostic nicety, not
+    // load-bearing for anything downstream.
+    let corpus_size = compute_memory_fingerprint(rt, token, model)
+        .await
+        .map(|fp| fp.vector_count);
+    emit_ann_warm_phase_event(
+        rt,
+        token,
+        model,
+        khive_types::EventKind::PhaseStarted,
+        khive_storage::PhaseStartedPayload {
+            work_class: "warm".into(),
+            phase: "ann_warm".into(),
+            corpus_size,
+        },
+    )
+    .await;
+
+    let result = ensure_ann_for_model_inner(rt, token, ann, model).await;
+
+    let wall_us = phase_start.elapsed().as_micros() as i64;
+    let cpu_us = khive_runtime::process_resource_usage().map(|u| u.cpu_us);
+    match &result {
+        Err(e) if is_benign_shutdown_cancellation(e) => {
+            emit_ann_warm_phase_event(
+                rt,
+                token,
+                model,
+                khive_types::EventKind::PhaseCancelled,
+                khive_storage::PhaseCancelledPayload {
+                    work_class: "warm".into(),
+                    phase: "ann_warm".into(),
+                    wall_us,
+                    cpu_us,
+                },
+            )
+            .await;
+        }
+        _ => {
+            emit_ann_warm_phase_event(
+                rt,
+                token,
+                model,
+                khive_types::EventKind::PhaseCompleted,
+                khive_storage::PhaseCompletedPayload {
+                    work_class: "warm".into(),
+                    phase: "ann_warm".into(),
+                    wall_us,
+                    cpu_us,
+                },
+            )
+            .await;
+        }
+    }
+    result
+}
+
+/// Append one ADR-103 Stage 1 `ann_warm` phase-span event, logging and
+/// swallowing store/serialize failures — the phase-log path must never
+/// interrupt or slow down the warm/rebuild it is observing (same rule as
+/// `khive-db::checkpoint`'s lifecycle-event helper).
+async fn emit_ann_warm_phase_event<P: serde::Serialize>(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+    kind: khive_types::EventKind,
+    payload: P,
+) {
+    // Best-effort exactly like ADR-094's other lifecycle-event emitters: a
+    // backend that cannot resolve an `EventStore` for this token's namespace
+    // is treated as an unconfigured audit sink, not an error to propagate.
+    let Ok(store) = rt.events(token) else {
+        return;
+    };
+    let payload_value = match serde_json::to_value(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                event_kind = %kind.name(),
+                model,
+                "failed to serialize ann_warm phase event payload"
+            );
+            return;
+        }
+    };
+    let event = khive_storage::Event::new(
+        token.namespace().as_str(),
+        "memory.ann_warm",
+        kind,
+        khive_types::SubstrateKind::Event,
+        "daemon:ann_warm",
+    )
+    .with_payload(payload_value);
+    if let Err(err) = store.append_event(event).await {
+        tracing::warn!(
+            error = %err,
+            event_kind = %kind.name(),
+            model,
+            "ann_warm phase event append failed"
+        );
+    }
+}
+
+/// Original `ensure_ann_for_model` body: snapshot restore or rebuild with
+/// double-fingerprint check, split out so [`ensure_ann_for_model`] can
+/// bracket it with ADR-103 Stage 1 phase-span emission above.
+async fn ensure_ann_for_model_inner(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    ann: &SharedAnn,
+    model: &str,
+) -> Result<AnnEnsureStatus, RuntimeError> {
     let ns = "global";
     let key = AnnKey::new(ns, model);
 
@@ -848,6 +981,65 @@ mod tests {
             ann.warming.lock().await.is_empty(),
             "all warming guards must be cleared after invalidation"
         );
+    }
+
+    // ADR-103 Stage 1 / issue #723 ask 1: `ensure_ann_for_model` must bracket
+    // its whole attempt with a `PhaseStarted`/`PhaseCompleted` event pair
+    // whenever an `EventStore` is configured, regardless of which path
+    // inside it runs (here: `EmptyCorpus`, since no vectors are registered
+    // for `model`). `khive_runtime::register_active_phase`'s own guard
+    // release behavior (used here to populate `comm.health`'s
+    // `active_phases`) is covered in isolation by
+    // `khive-runtime`'s own `daemon::tests` — not re-asserted here via the
+    // process-wide gauge, since that gauge is shared across this whole test
+    // binary (any concurrently running `memory.remember`/`memory.recall`
+    // test can trigger its own background `ensure_ann_background` warm) and
+    // asserting its global emptiness here would be inherently racy.
+    #[tokio::test]
+    async fn ensure_ann_for_model_emits_phase_started_and_completed_events() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let ann = new_shared();
+        let model = "ann-warm-phase-event-test-model";
+
+        let status = ensure_ann_for_model(&rt, &token, &ann, model)
+            .await
+            .expect("ensure_ann_for_model must succeed on an empty corpus");
+        assert!(matches!(status, AnnEnsureStatus::EmptyCorpus));
+
+        let store = rt.events(&token).expect("event store for local namespace");
+        let page = store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::types::PageRequest {
+                    limit: 50,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        let started = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseStarted)
+            .count();
+        let completed = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseCompleted)
+            .count();
+        let cancelled = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseCancelled)
+            .count();
+        assert_eq!(started, 1, "exactly one PhaseStarted row, got: {page:?}");
+        assert_eq!(
+            completed, 1,
+            "exactly one PhaseCompleted row, got: {page:?}"
+        );
+        assert_eq!(cancelled, 0, "no PhaseCancelled row on a normal completion");
     }
 
     // internal review PR #583 round-1 Medium (see the rationale comment on

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -48,6 +48,15 @@ pub(crate) struct AnnBridge {
 pub(crate) struct AnnState {
     indexes: RwLock<HashMap<AnnKey, AnnBridge>>,
     warming: Mutex<HashSet<AnnKey>>,
+    /// Review finding (issue #723 fix-round): per-model single-flight lock
+    /// owned by `ensure_ann_for_model` itself, the chokepoint every warm
+    /// path (boot warm, background fire-once warm, recall-miss warm) routes
+    /// through. Distinct from `warming` above, which is `ensure_ann_background`'s
+    /// own fire-once-and-forget guard against re-spawning a background task —
+    /// this map instead lets a second concurrent caller actually wait for the
+    /// in-flight attempt to finish, so only one caller ever emits the
+    /// `PhaseStarted`/`PhaseCompleted` pair for a given model.
+    model_locks: Mutex<HashMap<AnnKey, Arc<tokio::sync::Mutex<()>>>>,
     /// Counts how many times `search_loaded` returned a warm hit. Test-only;
     /// call `reset_warm_route_count()` between operations to isolate counts.
     #[cfg(test)]
@@ -60,9 +69,23 @@ pub(crate) fn new_shared() -> SharedAnn {
     Arc::new(AnnState {
         indexes: RwLock::new(HashMap::new()),
         warming: Mutex::new(HashSet::new()),
+        model_locks: Mutex::new(HashMap::new()),
         #[cfg(test)]
         warm_route_count: AtomicUsize::new(0),
     })
+}
+
+/// Fetch (creating if absent) the per-model warm single-flight lock.
+///
+/// The outer `model_locks` mutex is only held long enough to look up or
+/// insert the per-key `Arc<Mutex<()>>` — never across the warm attempt
+/// itself, so unrelated models never contend on this map.
+async fn model_warm_lock(ann: &SharedAnn, key: &AnnKey) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = ann.model_locks.lock().await;
+    locks
+        .entry(key.clone())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
 }
 
 #[cfg(test)]
@@ -362,12 +385,25 @@ pub(crate) async fn warm_existing_memory_indexes(rt: &KhiveRuntime, ann: &Shared
 /// load and/or rebuild-from-scratch) as one `ann_warm` phase span, so an
 /// operator can attribute a cold-start or on-demand-warm CPU window after
 /// the fact from the `PhaseStarted`/`PhaseCompleted`/`PhaseCancelled` event
-/// trio. This is the single call site both `warm_existing_memory_indexes`
-/// (daemon-startup cold warm) and `ensure_ann_background` (fire-once
-/// recall/remember-triggered warm) route through, so instrumenting here
-/// covers both callers. Emission is best-effort and a no-op when this
-/// `KhiveRuntime` has no `EventStore` configured, matching ADR-094's
-/// existing lifecycle-event emission contract exactly.
+/// trio. This is the chokepoint every warm path converges on —
+/// `warm_existing_memory_indexes` (daemon-startup cold warm),
+/// `ensure_ann_background` (fire-once recall/remember-triggered background
+/// warm), and the recall-miss path in `handlers/common.rs` (synchronous
+/// on-demand warm) all call this function directly or indirectly.
+///
+/// Review finding (issue #723 fix-round): because three independent call
+/// sites can race for the same model (e.g. boot warm still running when a
+/// recall misses), single-flight ownership lives *here*, not in any one
+/// caller — `ensure_ann_background`'s own `warming` guard only dedups its
+/// own fire-once spawns, it says nothing about a concurrent direct caller.
+/// A second caller blocks on the per-model lock below and, once it acquires
+/// it, re-checks `indexes` — if the first caller already warmed the model,
+/// the second returns `AlreadyLoaded` immediately without repeating the
+/// snapshot/rebuild attempt or emitting a second phase-span pair.
+///
+/// Emission is best-effort and a no-op when this `KhiveRuntime` has no
+/// `EventStore` configured, matching ADR-094's existing lifecycle-event
+/// emission contract exactly.
 pub(crate) async fn ensure_ann_for_model(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
@@ -377,8 +413,30 @@ pub(crate) async fn ensure_ann_for_model(
     if model.is_empty() {
         return Ok(AnnEnsureStatus::EmptyCorpus);
     }
+    let key = AnnKey::from_token(token, model);
+
+    // Fast path: no lock needed if already warm.
+    if ann.indexes.read().await.contains_key(&key) {
+        return Ok(AnnEnsureStatus::AlreadyLoaded);
+    }
+
+    let lock = model_warm_lock(ann, &key).await;
+    let _single_flight_guard = lock.lock().await;
+
+    // Re-check after acquiring the lock: a concurrent caller may have
+    // finished warming this model while we were waiting for the guard.
+    if ann.indexes.read().await.contains_key(&key) {
+        return Ok(AnnEnsureStatus::AlreadyLoaded);
+    }
 
     let phase_start = std::time::Instant::now();
+    // Review finding (issue #723 fix-round): `process_resource_usage()`
+    // returns cumulative process CPU since start, so a single post-warm read
+    // is unusable for per-phase attribution on a long-lived daemon (a warm
+    // that runs after the process has already burned minutes of CPU would
+    // report that whole cumulative total as the phase's cost). Snapshot at
+    // entry too and report end-minus-start below.
+    let cpu_start = khive_runtime::process_resource_usage();
     // Held for the lifetime of this call so `comm.health`'s resource
     // self-report (#723 ask 2) can see `ann_warm` in its active-phases list
     // while this warm/rebuild is in flight. Dropped (and the gauge
@@ -407,7 +465,7 @@ pub(crate) async fn ensure_ann_for_model(
     let result = ensure_ann_for_model_inner(rt, token, ann, model).await;
 
     let wall_us = phase_start.elapsed().as_micros() as i64;
-    let cpu_us = khive_runtime::process_resource_usage().map(|u| u.cpu_us);
+    let cpu_us = khive_runtime::cpu_delta_us(cpu_start, khive_runtime::process_resource_usage());
     match &result {
         Err(e) if is_benign_shutdown_cancellation(e) => {
             emit_ann_warm_phase_event(
@@ -1040,6 +1098,176 @@ mod tests {
             "exactly one PhaseCompleted row, got: {page:?}"
         );
         assert_eq!(cancelled, 0, "no PhaseCancelled row on a normal completion");
+    }
+
+    // Review finding (issue #723 fix-round): two concurrent callers warming
+    // the same model (mirroring boot warm racing a recall-miss warm) must
+    // not both run the snapshot/rebuild attempt and emit their own
+    // PhaseStarted/PhaseCompleted pair. Seeds real vector rows (via a
+    // deterministic hash-based embedder, same pattern as
+    // `pack.rs::ann_route_tests`) so the first caller's build actually
+    // populates `ann.indexes` — a prerequisite for the second caller's
+    // post-lock re-check to observe it and short-circuit.
+    //
+    // Fail-on-revert proof: reverting the per-model single-flight lock in
+    // `ensure_ann_for_model` back to "just call `ensure_ann_for_model_inner`
+    // unconditionally" makes both concurrent calls run the full
+    // snapshot/rebuild attempt and each emit their own PhaseStarted row,
+    // failing the `started == 1` assertion below.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn ensure_ann_for_model_concurrent_callers_emit_one_phase_pair() {
+        use async_trait::async_trait;
+        use khive_runtime::{EmbedderProvider, RuntimeConfig};
+        use lattice_embed::{EmbedError, EmbeddingModel, EmbeddingService};
+
+        struct HashVecService {
+            dims: usize,
+        }
+
+        fn fnv_to_vec(text: &str, dims: usize) -> Vec<f32> {
+            let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+            for b in text.bytes() {
+                h ^= b as u64;
+                h = h.wrapping_mul(0x0000_0001_0000_01b3);
+            }
+            let mut v = Vec::with_capacity(dims);
+            let mut s = h;
+            for _ in 0..dims {
+                s = s
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                v.push(((s >> 33) as f32) / (0x7fff_ffff_u32 as f32) - 1.0);
+            }
+            v
+        }
+
+        #[async_trait]
+        impl EmbeddingService for HashVecService {
+            async fn embed(
+                &self,
+                texts: &[String],
+                _model: EmbeddingModel,
+            ) -> Result<Vec<Vec<f32>>, EmbedError> {
+                Ok(texts.iter().map(|t| fnv_to_vec(t, self.dims)).collect())
+            }
+
+            fn supports_model(&self, _model: EmbeddingModel) -> bool {
+                true
+            }
+
+            fn name(&self) -> &'static str {
+                "hash-vec"
+            }
+        }
+
+        struct HashVecProvider {
+            model_name: String,
+            dims: usize,
+        }
+
+        #[async_trait]
+        impl EmbedderProvider for HashVecProvider {
+            fn name(&self) -> &str {
+                &self.model_name
+            }
+
+            fn dimensions(&self) -> usize {
+                self.dims
+            }
+
+            async fn build(&self) -> Result<Arc<dyn EmbeddingService>, RuntimeError> {
+                Ok(Arc::new(HashVecService { dims: self.dims }))
+            }
+        }
+
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-memory-ann-single-flight-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp db dir");
+        let db_path = tmp.path().join("khive-graph.db");
+
+        const MODEL: &str = "ann-warm-single-flight-test-model";
+        const DIMS: usize = 16;
+
+        let rt = KhiveRuntime::new(RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        for i in 0..16u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("ann single-flight note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+        }
+
+        let ann = new_shared();
+
+        // Two concurrent callers warming the same model, mirroring boot warm
+        // racing a recall-miss warm for the same key.
+        let (r1, r2) = tokio::join!(
+            ensure_ann_for_model(&rt, &token, &ann, MODEL),
+            ensure_ann_for_model(&rt, &token, &ann, MODEL)
+        );
+        r1.expect("first caller must succeed");
+        r2.expect("second caller must succeed");
+
+        assert!(
+            ann.indexes
+                .read()
+                .await
+                .contains_key(&AnnKey::from_token(&token, MODEL)),
+            "the model must end up warm regardless of which caller built it"
+        );
+
+        let store = rt.events(&token).expect("event store for local namespace");
+        let page = store
+            .query_events(
+                khive_storage::EventFilter::default(),
+                khive_storage::types::PageRequest {
+                    limit: 50,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query_events");
+
+        let started = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseStarted)
+            .count();
+        let completed = page
+            .items
+            .iter()
+            .filter(|e| e.kind == khive_types::EventKind::PhaseCompleted)
+            .count();
+        assert_eq!(
+            started, 1,
+            "exactly one caller must emit PhaseStarted for the same model, got: {page:?}"
+        );
+        assert_eq!(
+            completed, 1,
+            "exactly one caller must emit PhaseCompleted for the same model, got: {page:?}"
+        );
     }
 
     // internal review PR #583 round-1 Medium (see the rationale comment on

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -524,6 +524,72 @@ pub fn background_task_count() -> usize {
     background_tasks().load(std::sync::atomic::Ordering::Relaxed)
 }
 
+// ── active background phase names (ADR-103 Stage 1 / issue #723 ask 2) ────────
+//
+// A lightweight, best-effort process-wide gauge of which named background
+// phases (e.g. `ann_warm`) are in flight right now, read by `comm.health`'s
+// resource self-report so a caller can see "what is the daemon doing" at a
+// glance without correlating timestamps across the event log itself. Counted
+// per name rather than boolean, since more than one occurrence of the same
+// named phase can legitimately overlap (e.g. two embedding models warming
+// concurrently) — the name only drops out of the reported set once every
+// concurrent occurrence has ended.
+static ACTIVE_PHASES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, usize>>,
+> = std::sync::OnceLock::new();
+
+fn active_phases() -> &'static std::sync::Mutex<std::collections::HashMap<String, usize>> {
+    ACTIVE_PHASES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// RAII guard for one occurrence of a named background phase. Increments the
+/// phase's count on creation (see [`register_active_phase`]); decrements on
+/// `Drop`, so the count comes back down whether the guarded work returns
+/// normally, panics, or is cancelled — the same rationale as
+/// `BackgroundTaskGuard` above.
+pub struct PhaseGuard {
+    name: String,
+}
+
+impl Drop for PhaseGuard {
+    fn drop(&mut self) {
+        let mut map = active_phases()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(count) = map.get_mut(&self.name) {
+            *count -= 1;
+            if *count == 0 {
+                map.remove(&self.name);
+            }
+        }
+    }
+}
+
+/// Register one occurrence of a named background phase as currently active.
+/// Returns a guard: drop it (or let it fall out of scope) when the phase
+/// ends. Best-effort process-wide gauge only, read by `comm.health` — never
+/// load-bearing for correctness.
+pub fn register_active_phase(name: &str) -> PhaseGuard {
+    let mut map = active_phases()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *map.entry(name.to_string()).or_insert(0) += 1;
+    PhaseGuard {
+        name: name.to_string(),
+    }
+}
+
+/// Currently active background-phase names, sorted for deterministic output.
+/// Empty when no tracked phase is in flight.
+pub fn active_phase_names() -> Vec<String> {
+    let map = active_phases()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut names: Vec<String> = map.keys().cloned().collect();
+    names.sort();
+    names
+}
+
 // ── server ────────────────────────────────────────────────────────────────────
 
 /// Build a point-in-time [`MetricsSnapshot`] of this process's server-side
@@ -1359,6 +1425,51 @@ mod tests {
             background_task_count(),
             before,
             "background task counter must return to baseline after the tracked future panics"
+        );
+    }
+
+    // ── active background phase names (ADR-103 Stage 1 / issue #723 ask 2) ──
+
+    // `#[serial(active_phases)]`: these tests read/assert on the process-wide
+    // `ACTIVE_PHASES` static. No other test in this crate touches it today,
+    // but the group mirrors the `background_tasks` precedent above so a
+    // future addition does not silently reintroduce the same interleaving
+    // hazard (internal review PR #583 round-3 Medium) that motivated it there.
+    #[test]
+    #[serial(active_phases)]
+    fn register_active_phase_appears_and_disappears_with_the_guard() {
+        assert!(
+            !active_phase_names().contains(&"adr103_test_phase".to_string()),
+            "must start absent (leaked from a prior failed run would poison this test)"
+        );
+
+        let guard = register_active_phase("adr103_test_phase");
+        assert!(active_phase_names().contains(&"adr103_test_phase".to_string()));
+
+        drop(guard);
+        assert!(
+            !active_phase_names().contains(&"adr103_test_phase".to_string()),
+            "the phase name must drop out of the gauge once its guard is dropped"
+        );
+    }
+
+    #[test]
+    #[serial(active_phases)]
+    fn register_active_phase_counts_concurrent_occurrences_of_the_same_name() {
+        let first = register_active_phase("adr103_concurrent_phase");
+        let second = register_active_phase("adr103_concurrent_phase");
+        assert!(active_phase_names().contains(&"adr103_concurrent_phase".to_string()));
+
+        drop(first);
+        assert!(
+            active_phase_names().contains(&"adr103_concurrent_phase".to_string()),
+            "one of two concurrent occurrences ending must not remove the name early"
+        );
+
+        drop(second);
+        assert!(
+            !active_phase_names().contains(&"adr103_concurrent_phase".to_string()),
+            "the name must be removed only once every concurrent occurrence has ended"
         );
     }
 

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -91,7 +91,7 @@ pub use presentation::{
     apply_redundancy_drop, micros_to_iso, present, render_format, OutputFormat, PresentationMode,
 };
 pub use registry::{ObjectiveRegistry, RegisteredObjective};
-pub use resource::{process_resource_usage, ProcessResourceUsage};
+pub use resource::{cpu_delta_us, process_resource_usage, ProcessResourceUsage};
 pub use retrieval::{SearchHit, SearchSource};
 pub use runtime::{
     assert_db_anchor_consistent, parse_pack_list, resolve_db_anchor, resolve_project_actor_id,

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub mod pack;
 pub mod portability;
 pub mod presentation;
 pub mod registry;
+pub mod resource;
 pub mod retrieval;
 pub mod runtime;
 pub mod secret_gate;
@@ -42,8 +43,9 @@ pub use curation::{
 #[cfg(unix)]
 pub use daemon::acquire_recovery_lock;
 pub use daemon::{
-    background_task_count, pid_path, run_daemon, socket_path, track_background_task,
-    DaemonDispatch, DaemonRequestFrame, DaemonResponseFrame, PROTOCOL_VERSION,
+    active_phase_names, background_task_count, pid_path, register_active_phase, run_daemon,
+    socket_path, track_background_task, DaemonDispatch, DaemonRequestFrame, DaemonResponseFrame,
+    PhaseGuard, PROTOCOL_VERSION,
 };
 pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderProvider};
 pub use engine_config::{
@@ -89,6 +91,7 @@ pub use presentation::{
     apply_redundancy_drop, micros_to_iso, present, render_format, OutputFormat, PresentationMode,
 };
 pub use registry::{ObjectiveRegistry, RegisteredObjective};
+pub use resource::{process_resource_usage, ProcessResourceUsage};
 pub use retrieval::{SearchHit, SearchSource};
 pub use runtime::{
     assert_db_anchor_consistent, parse_pack_list, resolve_db_anchor, resolve_project_actor_id,

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1012,7 +1012,7 @@ impl VerbRegistry {
         // - Ok(Allow) → proceed to pack dispatch (tracing + optional EventStore).
         // - Ok(Deny) → emit audit, persist if store configured, return PermissionDenied.
         // - Err(_) → warn via tracing, fail-open (no audit persisted).
-        let (gate_blocked, mut deferred_link_audit) = match self.gate.check(&gate_req) {
+        let (gate_blocked, mut deferred_audit) = match self.gate.check(&gate_req) {
             Ok(decision) => {
                 let is_deny = matches!(decision, GateDecision::Deny { .. });
 
@@ -1051,24 +1051,23 @@ impl VerbRegistry {
                     }
                 }
 
-                // #676: a singleton `link` call (Allow decision, no `links`
-                // bulk array) defers its audit row until pack dispatch returns
-                // the created/resolved edge, so the row can carry
-                // edge_id/relation/weight instead of the generic v1 shape.
-                // Denied calls and bulk `links` have no post-dispatch edge to
-                // enrich with, so they keep the immediate v1 append below.
-                let defer_link_audit =
-                    !is_deny && verb == "link" && gate_req.args.get("links").is_none();
+                // ADR-103 Stage 1 / #676: every Allow-outcome audit row defers
+                // its append until pack dispatch returns, so the row can carry
+                // the measured dispatch time in `duration_us` (previously the
+                // row was persisted before dispatch ran, so the persisted
+                // `duration_us` was always the `Event::new` default of 0 — see
+                // ADR-103 Stage 1). A singleton `link` call (no `links` bulk
+                // array) additionally enriches the deferred row with the
+                // created/resolved edge fields (schema v2) once dispatch
+                // resolves. Denied calls have no dispatch to wait for and keep
+                // the immediate v1 append below.
+                let defer_audit = !is_deny;
 
-                // Persist to EventStore when configured.
-                if !defer_link_audit {
+                // Persist to EventStore immediately only for denied calls.
+                if !defer_audit {
                     if let Some(store) = &self.event_store {
-                        let outcome = if is_deny {
-                            EventOutcome::Denied
-                        } else {
-                            EventOutcome::Success
-                        };
-                        let storage_event = build_audit_storage_event(&gate_req, &audit, outcome);
+                        let storage_event =
+                            build_audit_storage_event(&gate_req, &audit, EventOutcome::Denied);
                         append_audit_event_best_effort(store, storage_event, verb).await;
                     }
                 }
@@ -1082,7 +1081,7 @@ impl VerbRegistry {
                 } else {
                     None
                 };
-                let deferred = if defer_link_audit { Some(audit) } else { None };
+                let deferred = if defer_audit { Some(audit) } else { None };
                 (reason, deferred)
             }
             Err(err) => {
@@ -1181,15 +1180,21 @@ impl VerbRegistry {
                 let result = pack.dispatch(verb, params, self, &token).await;
                 let dispatch_us = dispatch_start.elapsed().as_micros() as i64;
 
-                // #676: append the deferred singleton `link` audit row now that
-                // dispatch has resolved. Success enriches the row with the
-                // created/resolved edge (schema v2); anything that cannot be
-                // enriched falls back to the v1 audit shape so no audit row is
-                // ever dropped for the deferred path.
-                if let Some(audit) = deferred_link_audit.take() {
+                // ADR-103 Stage 1 / #676: append the deferred Allow-outcome
+                // audit row now that dispatch has resolved, so `duration_us`
+                // carries the measured `dispatch_us` instead of the
+                // `Event::new` default of 0. A successful singleton `link`
+                // call enriches the row with the created/resolved edge
+                // (schema v2); anything that cannot be enriched, or is not a
+                // singleton `link` call, falls back to the generic v1 audit
+                // shape so no audit row is ever dropped for the deferred
+                // path.
+                if let Some(audit) = deferred_audit.take() {
                     if let Some(store) = &self.event_store {
+                        let is_link_singleton =
+                            verb == "link" && gate_req.args.get("links").is_none();
                         match &result {
-                            Ok(ok_val) => {
+                            Ok(ok_val) if is_link_singleton => {
                                 match link_audit_success_from_result(audit.clone(), ok_val) {
                                     Some((edge_id, payload)) => {
                                         let storage_event = Event::new(
@@ -1205,7 +1210,8 @@ impl VerbRegistry {
                                         .with_outcome(EventOutcome::Success)
                                         .with_target(edge_id)
                                         .with_payload(payload)
-                                        .with_payload_schema_version(2);
+                                        .with_payload_schema_version(2)
+                                        .with_duration_us(dispatch_us);
                                         append_audit_event_best_effort(store, storage_event, verb)
                                             .await;
                                     }
@@ -1219,18 +1225,20 @@ impl VerbRegistry {
                                             &gate_req,
                                             &audit,
                                             EventOutcome::Success,
-                                        );
+                                        )
+                                        .with_duration_us(dispatch_us);
                                         append_audit_event_best_effort(store, storage_event, verb)
                                             .await;
                                     }
                                 }
                             }
-                            Err(_) => {
+                            _ => {
                                 let storage_event = build_audit_storage_event(
                                     &gate_req,
                                     &audit,
                                     EventOutcome::Success,
-                                );
+                                )
+                                .with_duration_us(dispatch_us);
                                 append_audit_event_best_effort(store, storage_event, verb).await;
                             }
                         }
@@ -1277,6 +1285,20 @@ impl VerbRegistry {
                 return result;
             }
         }
+
+        // No pack owns this verb: the gate allowed it, but no dispatch runs.
+        // Persist the deferred audit row now (duration stays at the
+        // `Event::new` default of 0 — no dispatch occurred to measure) so an
+        // allowed-but-unknown verb is never silently dropped from the audit
+        // trail (matches the "no audit row is ever dropped" contract above).
+        if let Some(audit) = deferred_audit.take() {
+            if let Some(store) = &self.event_store {
+                let storage_event =
+                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Success);
+                append_audit_event_best_effort(store, storage_event, verb).await;
+            }
+        }
+
         // Verb-visibility handler names, precomputed at build() time (internal
         // subhandlers are excluded so they are not advertised in the
         // unknown-verb error — ue-help-introspection C1 / internal review High).
@@ -2079,6 +2101,50 @@ mod tests {
             _token: &NamespaceToken,
         ) -> Result<Value, RuntimeError> {
             Ok(serde_json::json!({ "pack": "alpha", "verb": verb }))
+        }
+    }
+
+    /// A pack whose `dispatch` sleeps for a fixed, generous duration so
+    /// `duration_us` regression tests (ADR-103 Stage 1) have a reliably
+    /// nonzero, non-flaky measured dispatch time to assert against.
+    struct SleepingPack;
+
+    impl Pack for SleepingPack {
+        const NAME: &'static str = "sleeping";
+        const NOTE_KINDS: &'static [&'static str] = &[];
+        const ENTITY_KINDS: &'static [&'static str] = &[];
+        const HANDLERS: &'static [HandlerDef] = &[HandlerDef {
+            name: "slow_op",
+            description: "sleeps before returning",
+            visibility: Visibility::Verb,
+            category: VerbCategory::Assertive,
+            params: &[],
+        }];
+    }
+
+    #[async_trait]
+    impl PackRuntime for SleepingPack {
+        fn name(&self) -> &str {
+            SleepingPack::NAME
+        }
+        fn note_kinds(&self) -> &'static [&'static str] {
+            SleepingPack::NOTE_KINDS
+        }
+        fn entity_kinds(&self) -> &'static [&'static str] {
+            SleepingPack::ENTITY_KINDS
+        }
+        fn handlers(&self) -> &'static [HandlerDef] {
+            SleepingPack::HANDLERS
+        }
+        async fn dispatch(
+            &self,
+            verb: &str,
+            _params: Value,
+            _registry: &VerbRegistry,
+            _token: &NamespaceToken,
+        ) -> Result<Value, RuntimeError> {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            Ok(serde_json::json!({ "pack": "sleeping", "verb": verb }))
         }
     }
 
@@ -3321,6 +3387,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn audit_event_duration_us_reflects_measured_dispatch_time() {
+        // ADR-103 Stage 1: the persisted audit row's `duration_us` must carry
+        // the measured pack-dispatch time, not the `Event::new` default of 0
+        // (the bug this stage fixes — the row used to be persisted before
+        // dispatch ran at all). `SleepingPack` sleeps 20ms so the assertion
+        // has a wide, non-flaky margin over scheduling jitter.
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(SleepingPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        reg.dispatch("slow_op", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        let ev = &page.items[0];
+        assert!(
+            ev.duration_us >= 10_000,
+            "duration_us must reflect the ~20ms measured dispatch time, got {}",
+            ev.duration_us
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_verb_allowed_by_gate_still_persists_audit_row() {
+        // ADR-103 Stage 1: generalizing audit-row deferral to every
+        // Allow-outcome verb (not just singleton `link`) must not silently
+        // drop the audit row for a verb the gate allows but no pack owns.
+        // `duration_us` stays at the `Event::new` default of 0 here since no
+        // dispatch ever ran to measure.
+        let store = Arc::new(MemoryEventStore::default());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(AlphaPack);
+        builder.with_event_store(store.clone());
+        let reg = builder.build().expect("registry builds");
+
+        let result = reg.dispatch("no_such_verb", serde_json::json!({})).await;
+        assert!(result.is_err(), "unknown verb must still return an error");
+
+        let count = store.count_events(EventFilter::default()).await.unwrap();
+        assert_eq!(
+            count, 1,
+            "an allowed-but-unknown verb must still persist one audit row"
+        );
+        let page = store
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items[0].duration_us, 0);
+    }
+
+    #[tokio::test]
     async fn audit_event_persists_to_event_store_on_deny() {
         #[derive(Debug)]
         struct AlwaysDenyGate;
@@ -4188,7 +4324,9 @@ mod tests {
         let count = store.count_events(EventFilter::default()).await.unwrap();
         assert_eq!(
             count, 1,
-            "bulk `links` gets exactly one immediate v1 audit row, not deferred"
+            "bulk `links` gets exactly one v1 audit row (deferred until dispatch \
+             resolves like every other Allow-outcome row since ADR-103 Stage 1, \
+             but never v2-enriched — enrichment is singleton-`link`-only)"
         );
         let page = store
             .query_events(

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -1061,6 +1061,13 @@ impl VerbRegistry {
                 // created/resolved edge fields (schema v2) once dispatch
                 // resolves. Denied calls have no dispatch to wait for and keep
                 // the immediate v1 append below.
+                //
+                // Accepted trade-off: a crash between this Allow decision and
+                // the deferred append below (post-dispatch, further down this
+                // function) loses that dispatch's audit row entirely. This is
+                // deliberate, not an oversight — see ADR-103, "Stage 1
+                // clarification: audit-row write timing" for the rationale
+                // and the recorded upgrade path.
                 let defer_audit = !is_deny;
 
                 // Persist to EventStore immediately only for denied calls.
@@ -1233,12 +1240,20 @@ impl VerbRegistry {
                                 }
                             }
                             _ => {
-                                let storage_event = build_audit_storage_event(
-                                    &gate_req,
-                                    &audit,
-                                    EventOutcome::Success,
-                                )
-                                .with_duration_us(dispatch_us);
+                                // Review finding (issue #723 fix-round): the
+                                // persisted audit outcome must reflect the
+                                // dispatch result, not be hardcoded to
+                                // Success — otherwise a failed dispatch is
+                                // recorded as successful work and disappears
+                                // from `outcome=error` queries.
+                                let outcome = if result.is_ok() {
+                                    EventOutcome::Success
+                                } else {
+                                    EventOutcome::Error
+                                };
+                                let storage_event =
+                                    build_audit_storage_event(&gate_req, &audit, outcome)
+                                        .with_duration_us(dispatch_us);
                                 append_audit_event_best_effort(store, storage_event, verb).await;
                             }
                         }
@@ -1293,8 +1308,11 @@ impl VerbRegistry {
         // trail (matches the "no audit row is ever dropped" contract above).
         if let Some(audit) = deferred_audit.take() {
             if let Some(store) = &self.event_store {
+                // Review finding (issue #723 fix-round): dispatch is about to
+                // return `InvalidInput` below (no pack owns this verb), so
+                // the persisted outcome must be `Error`, not `Success`.
                 let storage_event =
-                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Success);
+                    build_audit_storage_event(&gate_req, &audit, EventOutcome::Error);
                 append_audit_event_best_effort(store, storage_event, verb).await;
             }
         }
@@ -3454,6 +3472,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page.items[0].duration_us, 0);
+        // Review finding (issue #723 fix-round): dispatch returns
+        // InvalidInput for an unknown verb, so the persisted outcome must be
+        // Error, not the previously-hardcoded Success.
+        assert_eq!(page.items[0].outcome, EventOutcome::Error);
     }
 
     #[tokio::test]
@@ -4235,10 +4257,18 @@ mod tests {
             ev.payload_schema_version, 1,
             "failed link keeps the v1 audit shape"
         );
+        // Review finding (issue #723 fix-round): the persisted outcome must
+        // reflect the dispatch result (Err → Error), not be hardcoded to
+        // Success from the gate's Allow decision.
         assert_eq!(
             ev.outcome,
-            EventOutcome::Success,
-            "outcome reflects the gate decision (Allow), not the dispatch result"
+            EventOutcome::Error,
+            "outcome reflects the dispatch result (Err), not the gate decision (Allow)"
+        );
+        assert!(
+            ev.duration_us >= 0,
+            "duration_us must still be populated (measured, not the Event::new \
+             default sentinel) on a failed dispatch"
         );
         assert!(
             ev.target_id.is_none(),

--- a/crates/khive-runtime/src/resource.rs
+++ b/crates/khive-runtime/src/resource.rs
@@ -56,6 +56,28 @@ pub fn process_resource_usage() -> Option<ProcessResourceUsage> {
     None
 }
 
+/// CPU time consumed strictly between two [`ProcessResourceUsage`] snapshots,
+/// in microseconds.
+///
+/// Review finding (issue #723 fix-round): `cpu_us` on a snapshot is
+/// cumulative process CPU time since process start, not CPU consumed by any
+/// one phase. Callers that want a per-phase attribution must capture a
+/// snapshot at phase entry and another at phase exit and take the delta —
+/// this helper does that subtraction and floors at zero (via `saturating_sub`
+/// followed by `.max(0)`, since a plain `i64::saturating_sub` only guards
+/// against integer overflow/underflow, not against a negative *result* — a
+/// spurious (should-never-happen) decrease in cumulative CPU between two
+/// reads must never surface as a negative delta).
+pub fn cpu_delta_us(
+    start: Option<ProcessResourceUsage>,
+    end: Option<ProcessResourceUsage>,
+) -> Option<i64> {
+    match (start, end) {
+        (Some(start), Some(end)) => Some(end.cpu_us.saturating_sub(start.cpu_us).max(0)),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +98,58 @@ mod tests {
             usage.rss_bytes > 0,
             "rss_bytes must be positive for a live process"
         );
+    }
+
+    // Review finding (issue #723 fix-round): `cpu_delta_us` must report the
+    // difference between two snapshots, not either snapshot's raw
+    // (cumulative-since-process-start) value. This test uses synthetic
+    // snapshots rather than real `getrusage` reads so it fails deterministically
+    // if someone reverts the caller to reporting `end.cpu_us` directly —
+    // a huge cumulative value in `end` alone would otherwise pass a merely
+    // "non-negative" check.
+    #[test]
+    fn cpu_delta_us_reports_the_difference_not_the_cumulative_end_value() {
+        let start = ProcessResourceUsage {
+            cpu_us: 500 * 60 * 1_000_000, // 500 CPU-minutes already burned
+            rss_bytes: 1_000_000,
+        };
+        let end = ProcessResourceUsage {
+            cpu_us: 500 * 60 * 1_000_000 + 1_500, // +1.5ms of CPU during the phase
+            rss_bytes: 1_100_000,
+        };
+
+        let delta = cpu_delta_us(Some(start), Some(end)).expect("both snapshots present");
+        assert_eq!(
+            delta, 1_500,
+            "delta must be end-minus-start, not the cumulative end value"
+        );
+        assert!(
+            delta < start.cpu_us,
+            "a correct delta must be far smaller than the pre-existing cumulative total"
+        );
+    }
+
+    #[test]
+    fn cpu_delta_us_saturates_instead_of_underflowing_on_a_spurious_decrease() {
+        let start = ProcessResourceUsage {
+            cpu_us: 1_000,
+            rss_bytes: 0,
+        };
+        let end = ProcessResourceUsage {
+            cpu_us: 500,
+            rss_bytes: 0,
+        };
+        assert_eq!(cpu_delta_us(Some(start), Some(end)), Some(0));
+    }
+
+    #[test]
+    fn cpu_delta_us_is_none_when_either_snapshot_is_unavailable() {
+        let snap = ProcessResourceUsage {
+            cpu_us: 10,
+            rss_bytes: 0,
+        };
+        assert_eq!(cpu_delta_us(None, Some(snap)), None);
+        assert_eq!(cpu_delta_us(Some(snap), None), None);
+        assert_eq!(cpu_delta_us(None, None), None);
     }
 }

--- a/crates/khive-runtime/src/resource.rs
+++ b/crates/khive-runtime/src/resource.rs
@@ -1,0 +1,80 @@
+//! Process-level resource reads (ADR-103 Stage 1).
+//!
+//! Cumulative CPU time and RSS via `getrusage(2)`, used by the daemon's
+//! phase-span logging (background-task start/completion/cancellation) and
+//! the `comm.health` resource self-report. `libc` is already a workspace
+//! dependency (used elsewhere in this crate for `flock`/`kill`), so this
+//! reuses it rather than adding a new one, per ADR-103 Stage 1's preference
+//! for a small std/libc-based read over a dedicated sysinfo-style crate.
+
+/// A point-in-time snapshot of this process's cumulative resource usage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessResourceUsage {
+    /// Cumulative user+system CPU time consumed by this process since start,
+    /// in microseconds.
+    pub cpu_us: i64,
+    /// Resident set size, in bytes.
+    pub rss_bytes: i64,
+}
+
+/// Read this process's cumulative CPU time and RSS via `getrusage(RUSAGE_SELF)`.
+///
+/// Returns `None` if the underlying syscall fails (never expected in
+/// practice on a supported platform) or on a non-Unix target, where no
+/// portable equivalent is wired up. Callers treat this as a best-effort
+/// diagnostic read, never load-bearing.
+#[cfg(unix)]
+pub fn process_resource_usage() -> Option<ProcessResourceUsage> {
+    // SAFETY: `getrusage` is a POSIX syscall with no memory side effects
+    // beyond writing into the `rusage` out-param, which is a plain
+    // `#[repr(C)]` struct zero-initialized immediately before the call.
+    let usage: libc::rusage = unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, &mut usage) != 0 {
+            return None;
+        }
+        usage
+    };
+    let user_us = usage.ru_utime.tv_sec * 1_000_000 + i64::from(usage.ru_utime.tv_usec as i32);
+    let sys_us = usage.ru_stime.tv_sec * 1_000_000 + i64::from(usage.ru_stime.tv_usec as i32);
+    // `ru_maxrss` is bytes on macOS/Darwin and KiB on Linux — the two
+    // platforms this fleet actually ships on (see CLAUDE.md toolchain rules).
+    let rss_bytes: i64 = if cfg!(target_os = "macos") {
+        usage.ru_maxrss as i64
+    } else {
+        usage.ru_maxrss as i64 * 1024
+    };
+    Some(ProcessResourceUsage {
+        cpu_us: user_us + sys_us,
+        rss_bytes,
+    })
+}
+
+/// Non-Unix fallback: no portable `getrusage` equivalent is wired up.
+#[cfg(not(unix))]
+pub fn process_resource_usage() -> Option<ProcessResourceUsage> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_resource_usage_returns_positive_values() {
+        // Do a small amount of work first so ru_utime/ru_maxrss are
+        // guaranteed non-zero on every platform this runs on.
+        let mut acc: u64 = 0;
+        for i in 0..1_000_000u64 {
+            acc = acc.wrapping_add(i);
+        }
+        std::hint::black_box(acc);
+
+        let usage = process_resource_usage().expect("getrusage must succeed on unix CI runners");
+        assert!(usage.cpu_us >= 0, "cpu_us must be non-negative");
+        assert!(
+            usage.rss_bytes > 0,
+            "rss_bytes must be positive for a live process"
+        );
+    }
+}

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -28,7 +28,8 @@ pub use sql::{AtomicUnitOp, BoxFuture, SqlAccess, SqlReader, SqlWriter};
 pub use telemetry::{
     ChannelBackoffArmedPayload, ChannelBackoffResetPayload, ChannelHeartbeatPersistFailedPayload,
     ChannelPollFailedPayload, ChannelPollStartedPayload, ChannelPollSucceededPayload,
-    CheckpointOutcomeRecordedPayload, ConfigLockedPayload, LifecycleEvent,
+    CheckpointOutcomeRecordedPayload, ConfigLockedPayload, LifecycleEvent, PhaseCancelledPayload,
+    PhaseCompletedPayload, PhaseStartedPayload,
 };
 pub use text::TextSearch;
 pub use types::StorageResult;

--- a/crates/khive-storage/src/telemetry.rs
+++ b/crates/khive-storage/src/telemetry.rs
@@ -7,8 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Mirrors the eight ADR-094 lifecycle `EventKind` variants. Not itself
-/// persisted — see the module docs.
+/// Mirrors the eight ADR-094 lifecycle `EventKind` variants plus the three
+/// ADR-103 Stage 1 phase-span variants. Not itself persisted — see the
+/// module docs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LifecycleEvent {
@@ -20,6 +21,9 @@ pub enum LifecycleEvent {
     ChannelHeartbeatPersistFailed,
     ConfigLocked,
     CheckpointOutcomeRecorded,
+    PhaseStarted,
+    PhaseCompleted,
+    PhaseCancelled,
 }
 
 /// Payload for [`khive_types::EventKind::ChannelPollStarted`].
@@ -93,6 +97,45 @@ pub struct CheckpointOutcomeRecordedPayload {
     pub above_truncate_high_water: bool,
 }
 
+/// Payload for [`khive_types::EventKind::PhaseStarted`] (ADR-103 Stage 1).
+///
+/// `work_class` is the closed ADR-103 enum (`interactive` | `warm` |
+/// `maintenance` | `inference`), carried as a plain string here since the
+/// enum itself is defined in a downstream crate; producers are responsible
+/// for using the closed set of values. `corpus_size` is populated only when
+/// it is cheaply known at phase start (e.g. a corpus count already on hand);
+/// `None` when unknown at this point.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseStartedPayload {
+    pub work_class: String,
+    pub phase: String,
+    pub corpus_size: Option<u64>,
+}
+
+/// Payload for [`khive_types::EventKind::PhaseCompleted`] (ADR-103 Stage 1).
+///
+/// `cpu_us` is a process-level `getrusage` delta across the phase (see
+/// `khive_runtime::resource`), not a per-thread measurement — `None` when
+/// the underlying read is unavailable on this platform.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseCompletedPayload {
+    pub work_class: String,
+    pub phase: String,
+    pub wall_us: i64,
+    pub cpu_us: Option<i64>,
+}
+
+/// Payload for [`khive_types::EventKind::PhaseCancelled`] (ADR-103 Stage 1).
+/// Same shape as [`PhaseCompletedPayload`] — the phase ran for `wall_us`
+/// before being cut short rather than returning a result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseCancelledPayload {
+    pub work_class: String,
+    pub phase: String,
+    pub wall_us: i64,
+    pub cpu_us: Option<i64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,6 +151,9 @@ mod tests {
             LifecycleEvent::ChannelHeartbeatPersistFailed,
             LifecycleEvent::ConfigLocked,
             LifecycleEvent::CheckpointOutcomeRecorded,
+            LifecycleEvent::PhaseStarted,
+            LifecycleEvent::PhaseCompleted,
+            LifecycleEvent::PhaseCancelled,
         ] {
             let json = serde_json::to_string(&kind).expect("serialize");
             let parsed: LifecycleEvent = serde_json::from_str(&json).expect("deserialize");
@@ -129,6 +175,44 @@ mod tests {
         let json = serde_json::to_value(&payload).expect("serialize");
         let parsed: CheckpointOutcomeRecordedPayload =
             serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn phase_started_payload_roundtrips() {
+        let payload = PhaseStartedPayload {
+            work_class: "warm".into(),
+            phase: "ann_warm".into(),
+            corpus_size: Some(553_000),
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        let parsed: PhaseStartedPayload = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn phase_completed_payload_roundtrips_with_absent_cpu_us() {
+        let payload = PhaseCompletedPayload {
+            work_class: "warm".into(),
+            phase: "ann_warm".into(),
+            wall_us: 41_000_000,
+            cpu_us: None,
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        let parsed: PhaseCompletedPayload = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn phase_cancelled_payload_roundtrips() {
+        let payload = PhaseCancelledPayload {
+            work_class: "warm".into(),
+            phase: "ann_warm".into(),
+            wall_us: 12_000,
+            cpu_us: Some(9_500),
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        let parsed: PhaseCancelledPayload = serde_json::from_value(json).expect("deserialize");
         assert_eq!(parsed, payload);
     }
 }

--- a/crates/khive-types/src/event.rs
+++ b/crates/khive-types/src/event.rs
@@ -62,9 +62,9 @@ impl fmt::Display for EventOutcome {
     }
 }
 
-/// Discriminant for the 34 typed event variants produced by the verb dispatch path
+/// Discriminant for the 37 typed event variants produced by the verb dispatch path
 /// and by lifecycle telemetry producers (channel polling/backoff, config-lock,
-/// checkpoint outcome).
+/// checkpoint outcome, background phase spans).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -137,11 +137,17 @@ pub enum EventKind {
     ConfigLocked,
     /// A WAL checkpoint tick's outcome was recorded (ADR-091 elevated/drain edge).
     CheckpointOutcomeRecorded,
+    /// A background phase (ANN warm, index rebuild/backfill, ...) started (ADR-103 Stage 1).
+    PhaseStarted,
+    /// A background phase completed (ADR-103 Stage 1).
+    PhaseCompleted,
+    /// A background phase was cancelled before completion (ADR-103 Stage 1).
+    PhaseCancelled,
 }
 
 impl EventKind {
-    /// All 34 event kind variants in declaration order.
-    pub const ALL: [Self; 34] = [
+    /// All 37 event kind variants in declaration order.
+    pub const ALL: [Self; 37] = [
         Self::Audit,
         Self::RecallExecuted,
         Self::RerankExecuted,
@@ -176,6 +182,9 @@ impl EventKind {
         Self::ChannelHeartbeatPersistFailed,
         Self::ConfigLocked,
         Self::CheckpointOutcomeRecorded,
+        Self::PhaseStarted,
+        Self::PhaseCompleted,
+        Self::PhaseCancelled,
     ];
 
     /// Return the canonical snake_case string for this event kind.
@@ -215,6 +224,9 @@ impl EventKind {
             Self::ChannelHeartbeatPersistFailed => "channel_heartbeat_persist_failed",
             Self::ConfigLocked => "config_locked",
             Self::CheckpointOutcomeRecorded => "checkpoint_outcome_recorded",
+            Self::PhaseStarted => "phase_started",
+            Self::PhaseCompleted => "phase_completed",
+            Self::PhaseCancelled => "phase_cancelled",
         }
     }
 }
@@ -260,6 +272,9 @@ const EVENT_KIND_VALID: &[&str] = &[
     "channel_heartbeat_persist_failed",
     "config_locked",
     "checkpoint_outcome_recorded",
+    "phase_started",
+    "phase_completed",
+    "phase_cancelled",
 ];
 
 impl core::str::FromStr for EventKind {
@@ -301,6 +316,9 @@ impl core::str::FromStr for EventKind {
             "channel_heartbeat_persist_failed" => Ok(Self::ChannelHeartbeatPersistFailed),
             "config_locked" => Ok(Self::ConfigLocked),
             "checkpoint_outcome_recorded" => Ok(Self::CheckpointOutcomeRecorded),
+            "phase_started" => Ok(Self::PhaseStarted),
+            "phase_completed" => Ok(Self::PhaseCompleted),
+            "phase_cancelled" => Ok(Self::PhaseCancelled),
             other => Err(crate::error::UnknownVariant::new(
                 "event_kind",
                 other,

--- a/docs/adr/ADR-103-resource-attribution-model.md
+++ b/docs/adr/ADR-103-resource-attribution-model.md
@@ -307,6 +307,34 @@ self-report) and #724 Ask A (windowed event counts). #723 ask 3 (QoS for warm-pa
 lands in Stage 2, and #724 Ask B (section co-usage aggregates) is a knowledge-pack read
 surface outside this ADR's scope, tracked on that issue independently.
 
+### Stage 1 clarification: audit-row write timing
+
+Populating `duration_us` on the existing audit row (above) requires knowing how long dispatch
+took, which is only known after dispatch returns. The implementation therefore defers the
+Allow-outcome audit row's durable append until after `pack.dispatch` resolves, so the row can
+carry the measured `duration_us` and an outcome derived from the actual dispatch result
+(`Success` for `Ok`, `Error` for `Err`) instead of a value fixed before the result is known.
+
+The consequence: if the process crashes, panics, or is killed mid-dispatch — after the gate
+allows the call but before the deferred row is appended — that one dispatch's audit row is
+lost entirely, not merely incomplete. This widens a pre-existing narrow-case trade-off (the
+prior implementation deferred only around a single verb shape) to every Allow-outcome verb.
+
+This is accepted, not an oversight. The alternative — appending a row before dispatch runs, so
+a crash cannot drop it — means every Allow-outcome row starts life recording an outcome that
+has not actually happened yet (`Success`, before the handler has returned) and a `duration_us`
+of 0. That row is not more complete; it is a preserved misattribution that a crash prevents
+from ever being corrected. The event log is the attribution and cost-accounting plane this ADR
+specifies — it is not the crash-forensics surface; the daemon's own process log is, and it is
+unaffected by this trade-off.
+
+**Upgrade path (not built in Stage 1).** If audit completeness across a crash ever becomes a
+hard requirement (for example, a compliance obligation), the design moves to a durable
+pre-dispatch append plus a narrow finalize/update seam on the event store that sets the final
+`duration_us` and outcome once dispatch resolves — two rows' worth of state collapsed onto one
+row's identity, rather than one row written twice. That seam does not exist today; this
+paragraph records the fork so it is findable if the requirement arrives.
+
 **Stage 2 — scheduling and QoS (sub-ADR).** The per-work-class bounded-concurrency
 semaphore and lowered thread priority for the `warm` and `maintenance` classes (#723 ask
 3); the voluntary quiet-request verb and TTL-bounded deferral at background yield points;


### PR DESCRIPTION
Stage 1, PR-1 of ADR-103 (resource attribution): daemon observability groundwork. Covers issue #723 asks 1 and 2 only; ask 3 (QoS/niceness) and issue #724 are separate follow-ups.

## What

1. **Measured `duration_us` on persisted audit rows.** Generalizes the existing deferred-audit mechanism (previously singleton `link` only, #676) so every Allow-outcome dispatch persists its audit row after dispatch completes, carrying the real measured dispatch time. Denied calls keep the immediate append with `duration_us=0` (no dispatch runs). The unknown-verb fallthrough now explicitly flushes a deferred row so no audit row is dropped. Regression tests for both paths.

   Semantic note: Allow-outcome rows are now written post-dispatch, so a process crash mid-dispatch loses that row (previously a pre-dispatch row with `duration_us=0` would survive). Denied rows are unaffected. This trade is deliberate: the row's value is attribution, and an unattributable zero-duration row is what ADR-103 Stage 1 exists to eliminate.

2. **Phase-span telemetry (#723 ask 1).** Additive `EventKind::PhaseStarted/PhaseCompleted/PhaseCancelled` variants with typed payloads; ANN warm (`ensure_ann_for_model`, the chokepoint for cold-start and on-demand warm) now emits start (corpus size), completion (wall + CPU time), and cancellation markers at INFO.

3. **`comm.health` resource self-report (#723 ask 2).** New `resource: {cpu_us, rss_bytes, active_phases}` object in the health snapshot, read via `getrusage(RUSAGE_SELF)` (no new dependency). Preserves the existing contract: raw observations only, never a computed health judgment.

Out of scope, flagged for follow-up: the full ADR-103 `resource` payload enrichment (`work_class`, `cost_unit`), and `khive-pack-knowledge`'s own ANN warm path (`warm_known_snapshots`), which is structurally similar but not instrumented here.

## Gates

fmt, clippy `-D warnings`, per-crate tests (khive-types, khive-storage, khive-runtime, khive-pack-memory, khive-pack-comm), full workspace test run, doc build with warnings denied — all green.
