### PR TITLE
fix(make): local target spares stdio bridges so #714 self-heal can run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,13 @@ local:
 	SRC_HASH=$$(md5 -q "$$SRC"); \
 	SRC_SIZE=$$(stat -f '%z' "$$SRC"); \
 	echo "==> Source:  $$SRC ($$SRC_HASH, $$SRC_SIZE bytes)"; \
-	echo "==> Killing running kkernel daemon (bridges self-heal via re-exec on next request)..."; \
+	echo "==> Staging + codesigning $$DEST.new..."; \
+	cp "$$SRC" "$$DEST.new"; \
+	codesign -s - -f "$$DEST.new" 2>/dev/null || true; \
+	STAGED_HASH=$$(md5 -q "$$DEST.new"); \
+	echo "==> Atomically moving into place..."; \
+	mv "$$DEST.new" "$$DEST"; \
+	echo "==> Killing running kkernel daemon (bridges respawn the NEW binary and self-heal via re-exec)..."; \
 	pkill -f 'kkernel mcp --daemon' 2>/dev/null || true; \
 	for i in 1 2 3 4 5; do \
 	  if pgrep -f 'kkernel mcp --daemon' >/dev/null 2>&1; then sleep 1; else break; fi; \
@@ -72,12 +78,6 @@ local:
 	  pkill -9 -f 'kkernel mcp --daemon' 2>/dev/null || true; \
 	  sleep 1; \
 	fi; \
-	echo "==> Staging + codesigning $$DEST.new..."; \
-	cp "$$SRC" "$$DEST.new"; \
-	codesign -s - -f "$$DEST.new" 2>/dev/null || true; \
-	STAGED_HASH=$$(md5 -q "$$DEST.new"); \
-	echo "==> Atomically moving into place..."; \
-	mv "$$DEST.new" "$$DEST"; \
 	DEST_HASH=$$(md5 -q "$$DEST"); \
 	DEST_SIZE=$$(stat -f '%z' "$$DEST"); \
 	DEST_MTIME=$$(stat -f '%Sm' "$$DEST"); \

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ local:
 	SRC_HASH=$$(md5 -q "$$SRC"); \
 	SRC_SIZE=$$(stat -f '%z' "$$SRC"); \
 	echo "==> Source:  $$SRC ($$SRC_HASH, $$SRC_SIZE bytes)"; \
-	echo "==> Killing running kkernel processes..."; \
-	pkill -f 'kkernel' 2>/dev/null || true; \
+	echo "==> Killing running kkernel daemon (bridges self-heal via re-exec on next request)..."; \
+	pkill -f 'kkernel mcp --daemon' 2>/dev/null || true; \
 	for i in 1 2 3 4 5; do \
-	  if pgrep -f 'kkernel' >/dev/null 2>&1; then sleep 1; else break; fi; \
+	  if pgrep -f 'kkernel mcp --daemon' >/dev/null 2>&1; then sleep 1; else break; fi; \
 	done; \
-	if pgrep -f 'kkernel' >/dev/null 2>&1; then \
-	  echo "==> WARNING: still running after 5s — SIGKILL"; \
-	  pkill -9 -f 'kkernel' 2>/dev/null || true; \
+	if pgrep -f 'kkernel mcp --daemon' >/dev/null 2>&1; then \
+	  echo "==> WARNING: daemon still running after 5s — SIGKILL"; \
+	  pkill -9 -f 'kkernel mcp --daemon' 2>/dev/null || true; \
 	  sleep 1; \
 	fi; \
 	echo "==> Staging + codesigning $$DEST.new..."; \


### PR DESCRIPTION
Follow-up to #731. The local target's broad kkernel process kill terminated live stdio bridges along with the daemon — which means the #714 self-heal re-exec path was dead on arrival at every rebuild: a bridge cannot survive its own SIGTERM. Tonight's rebuild proved it (bridge killed, harness-level reconnect needed; SelfHealOnFlushTransport never fired).

This narrows the kill set to the daemon process only. Bridges stay alive, hit the generation mismatch on their next request, and re-exec into the new binary in place — the designed #714 acceptance scenario. Transient CLI exec invocations are also no longer killed mid-flight as a side effect.

Risk note: the broad kill guarded against stale processes holding SQLite WAL. Bridges are daemon clients post fail-loud dispatch (#663) and do not hold the DB; the daemon — the process that does — is still killed and waited on exactly as before.

Acceptance: the NEXT rebuild after this merges is the live #714 item-6 test — bridge sessions should continue with zero /mcp or harness reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)