### PR TITLE
feat(brain): windowed event-counts read verb brain.event_counts (ADR-103 Stage 1, #724 Ask A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ khive gives your agent:
 9. **Brain** — Bayesian profile tuning from feedback signals
 10. **Session** — persist and resume agent-session records
 
-All 9 packs load by default. **75 public verbs** across the packs — the `git` pack
+All 9 packs load by default. **76 public verbs** across the packs — the `git` pack
 (commit/issue/pull_request provenance notes, populated by a batch ingester, not agent-facing
 verbs) contributes no new verb (regenerate via `request(ops="verbs()")` before editing this
 line).
@@ -120,16 +120,17 @@ Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 | `brain.bindings`         | List binding rows                                                 | Audit profile routing                                      |
 | `brain.register_adapter` | Register an adapter integrity record                              | Gate adapter composition to the active base-model revision |
 
-### Comm pack — 6 verbs (`comm.` prefix)
+### Comm pack — 7 verbs (`comm.` prefix)
 
-| Verb          | What it does                           | When to use                              |
-| ------------- | -------------------------------------- | ---------------------------------------- |
-| `comm.send`   | Send a message (optionally threaded)   | Inter-agent or inter-namespace messaging |
-| `comm.inbox`  | List inbound messages                  | Check what's waiting                     |
-| `comm.read`   | Mark an **inbound** message as read    | Acknowledge receipt (recipient action)   |
-| `comm.reply`  | Reply to a message (threading linkage) | Respond in-thread                        |
-| `comm.thread` | Retrieve full conversation thread      | Read the whole conversation              |
-| `comm.health` | Per-channel health snapshot (no args)  | Check daemon channel-poll state          |
+| Verb          | What it does                                                           | When to use                                   |
+| ------------- | ---------------------------------------------------------------------- | --------------------------------------------- |
+| `comm.send`   | Send a message (optionally threaded)                                   | Inter-agent or inter-namespace messaging      |
+| `comm.inbox`  | List inbound messages                                                  | Check what's waiting                          |
+| `comm.read`   | Mark an **inbound** message as read                                    | Acknowledge receipt (recipient action)        |
+| `comm.reply`  | Reply to a message (threading linkage)                                 | Respond in-thread                             |
+| `comm.thread` | Retrieve full conversation thread                                      | Read the whole conversation                   |
+| `comm.health` | Per-channel health snapshot (no args)                                  | Check daemon channel-poll state               |
+| `comm.probe`  | Read-only poll for new inbound message metadata and stale unread count | Cheap wake-up check without a full inbox scan |
 
 **Inbox shape (ADR-057).** `comm.inbox` is scannable: each entry carries top-level `from`, `to`,
 `subject`, `read`, `direction`, and a derived `preview` (whitespace-collapsed, truncated to 80

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ khive gives your agent:
 9. **Brain** — Bayesian profile tuning from feedback signals
 10. **Session** — persist and resume agent-session records
 
-All 9 packs load by default. **74 public verbs** across the packs — the `git` pack
+All 9 packs load by default. **75 public verbs** across the packs — the `git` pack
 (commit/issue/pull_request provenance notes, populated by a batch ingester, not agent-facing
 verbs) contributes no new verb (regenerate via `request(ops="verbs()")` before editing this
 line).
@@ -100,24 +100,25 @@ false, id, full_id, from, to, note: "already in target status"}` — the task fi
 `memory.recall` supports `tags` and `tag_mode` ("any"|"all") for tag-based post-filtering.
 Composite scores are always in [0,1]. Typical production floor: 0.3-0.7.
 
-### Brain pack — 14 verbs (`brain.` prefix)
+### Brain pack — 15 verbs (`brain.` prefix)
 
-| Verb                     | What it does                                         | When to use                                                |
-| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------- |
-| `brain.profiles`         | List profiles (optionally filtered by lifecycle)     | See what profiles exist                                    |
-| `brain.profile`          | Full detail: metadata, snapshot, state summary       | Inspect a specific profile                                 |
-| `brain.create_profile`   | Create a new profile with optional seed priors       | Custom tuning for a new consumer                           |
-| `brain.resolve`          | Which profile serves a given consumer context?       | Before recall — check active tuning                        |
-| `brain.activate`         | Start live update loop for a profile                 | Enable feedback-driven tuning                              |
-| `brain.deactivate`       | Stop live updates, retain state                      | Pause tuning without losing progress                       |
-| `brain.archive`          | Read-only, audit-retained                            | Retire a profile permanently                               |
-| `brain.reset`            | Reset posteriors to priors (preserves event history) | Start tuning fresh                                         |
-| `brain.feedback`         | Emit explicit feedback event                         | Rate a recall result as useful/not_useful/wrong            |
-| `brain.auto_feedback`    | Emit implicit feedback for recall results            | Convenience: agents call after memory.recall               |
-| `brain.bind`             | Bind a profile to an actor + consumer                | Route a specific caller to a specific profile              |
-| `brain.unbind`           | Remove a binding                                     | Stop routing                                               |
-| `brain.bindings`         | List binding rows                                    | Audit profile routing                                      |
-| `brain.register_adapter` | Register an adapter integrity record                 | Gate adapter composition to the active base-model revision |
+| Verb                     | What it does                                                      | When to use                                                |
+| ------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| `brain.event_counts`     | Windowed event counts by kind/actor (+ feedback by_profile split) | Flywheel metrics, feedback-coverage reporting              |
+| `brain.profiles`         | List profiles (optionally filtered by lifecycle)                  | See what profiles exist                                    |
+| `brain.profile`          | Full detail: metadata, snapshot, state summary                    | Inspect a specific profile                                 |
+| `brain.create_profile`   | Create a new profile with optional seed priors                    | Custom tuning for a new consumer                           |
+| `brain.resolve`          | Which profile serves a given consumer context?                    | Before recall — check active tuning                        |
+| `brain.activate`         | Start live update loop for a profile                              | Enable feedback-driven tuning                              |
+| `brain.deactivate`       | Stop live updates, retain state                                   | Pause tuning without losing progress                       |
+| `brain.archive`          | Read-only, audit-retained                                         | Retire a profile permanently                               |
+| `brain.reset`            | Reset posteriors to priors (preserves event history)              | Start tuning fresh                                         |
+| `brain.feedback`         | Emit explicit feedback event                                      | Rate a recall result as useful/not_useful/wrong            |
+| `brain.auto_feedback`    | Emit implicit feedback for recall results                         | Convenience: agents call after memory.recall               |
+| `brain.bind`             | Bind a profile to an actor + consumer                             | Route a specific caller to a specific profile              |
+| `brain.unbind`           | Remove a binding                                                  | Stop routing                                               |
+| `brain.bindings`         | List binding rows                                                 | Audit profile routing                                      |
+| `brain.register_adapter` | Register an adapter integrity record                              | Gate adapter composition to the active base-model revision |
 
 ### Comm pack — 6 verbs (`comm.` prefix)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,9 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
 loads all 9 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git
-(75 verbs total — git contributes commit/issue/pull_request note kinds and a batch ingester,
-no new verbs; comm.probe (#644) added 2026-07-07; regenerate via
-`request(ops="verbs()")` before editing this line).
+(76 verbs total — git contributes commit/issue/pull_request note kinds and a batch ingester,
+no new verbs; comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
+Ask A) added 2026-07-08; regenerate via `request(ops="verbs()")` before editing this line).
 
 ### KG pack verbs (17 — ADR-017, ADR-046, ADR-089)
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -72,7 +72,11 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
         name: "brain.event_counts",
         description: "Windowed event counts grouped by kind and actor over the event plane \
             (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
-            served_by_profile_id.",
+            served_by_profile_id; events carrying a work_class (today: phase_started / \
+            phase_completed / phase_cancelled payloads, checked before any future \
+            payload.resource.work_class) split by counts_by_work_class. cost_unit is not \
+            surfaced: it does not exist on any event payload yet (ADR-103 Stage 0 design-only) \
+            and will be added once a resource payload carries it.",
         visibility: khive_types::Visibility::Verb,
         category: khive_types::VerbCategory::Assertive,
         params: &[
@@ -664,7 +668,25 @@ impl BrainPack {
     // ── brain.event_counts ──────────────────────────────────────────────────
     //
     // ADR-103 Stage 1 (#724 Ask A): a windowed, per-actor, per-kind read verb
-    // over the event plane. Named `brain.event_counts` rather than the literal
+    // over the event plane, additionally surfacing `work_class`
+    // (ADR-103-resource-attribution-model.md:303) via `counts_by_work_class`.
+    // `work_class` is read from `payload.work_class` first — the shape the
+    // three Phase* events (`PhaseStarted`/`PhaseCompleted`/`PhaseCancelled`,
+    // `khive_storage::telemetry`) use today — falling back to
+    // `payload.resource.work_class` for the not-yet-emitted future shape
+    // where a generic audit row carries a `resource` sub-object (ADR-103
+    // Stage 1's "resource payload enrichment", still open). Events with
+    // neither path present are simply not counted in the split.
+    // `cost_unit` is NOT surfaced: as of this PR no event payload carries it
+    // anywhere in the codebase (ADR-103 Stage 0 defines it; Stage 1's
+    // resource-payload work has not landed a `cost_unit` field on any
+    // producer yet). Surfacing a field that no event can ever populate today
+    // would be a documentation lie dressed as a response key; once a
+    // producer emits `cost_unit` (under `payload.resource.cost_unit`, by the
+    // same convention as `work_class`), this verb should sum it the same way
+    // `counts_by_work_class` groups `work_class`.
+    //
+    // Named `brain.event_counts` rather than the literal
     // `brain.events(...)` shape sketched on the issue — that name is already
     // taken by the `Visibility::Subhandler` debug-listing verb above, which an
     // MCP-boundary test (`subhandler_verbs_are_blocked_at_mcp_boundary`)
@@ -695,13 +717,23 @@ impl BrainPack {
         struct EventCountsParams {
             actor: Option<String>,
             kind: Option<String>,
-            since: String,
+            // `Option`, not a required `String`: a bare-missing `since` must go through
+            // the same named-field-plus-example-format error as a malformed one, not
+            // serde's generic "missing field `since`" message.
+            since: Option<String>,
             until: Option<String>,
         }
         let p: EventCountsParams = serde_json::from_value(params)
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
 
-        let since_us = parse_rfc3339_micros("since", &p.since)?;
+        let since_raw = p.since.as_deref().ok_or_else(|| {
+            RuntimeError::InvalidInput(
+                "missing `since`: required ISO-8601/RFC-3339 datetime; expected e.g. \
+                 \"2026-07-01T00:00:00Z\""
+                    .to_string(),
+            )
+        })?;
+        let since_us = parse_rfc3339_micros("since", since_raw)?;
         let until_us = match p.until.as_deref() {
             Some(u) => parse_rfc3339_micros("until", u)?,
             None => Utc::now().timestamp_micros(),
@@ -748,6 +780,8 @@ impl BrainPack {
             std::collections::BTreeMap::new();
         let mut by_profile: std::collections::BTreeMap<String, u64> =
             std::collections::BTreeMap::new();
+        let mut counts_by_work_class: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
 
         for event in &page.items {
             *counts_by_kind
@@ -762,6 +796,11 @@ impl BrainPack {
                     .unwrap_or("unspecified")
                     .to_string();
                 *by_profile.entry(profile).or_insert(0) += 1;
+            }
+            if let Some(work_class) = event_work_class(&event.payload) {
+                *counts_by_work_class
+                    .entry(work_class.to_string())
+                    .or_insert(0) += 1;
             }
         }
 
@@ -778,6 +817,9 @@ impl BrainPack {
         });
         if !by_profile.is_empty() {
             result["by_profile"] = json!(by_profile);
+        }
+        if !counts_by_work_class.is_empty() {
+            result["counts_by_work_class"] = json!(counts_by_work_class);
         }
         Ok(result)
     }
@@ -2213,6 +2255,31 @@ fn parse_rfc3339_micros(field: &'static str, value: &str) -> Result<i64, Runtime
                 "invalid `{field}`: {value:?} is not a valid ISO-8601/RFC-3339 datetime ({e}); \
                  expected e.g. \"2026-07-01T00:00:00Z\""
             ))
+        })
+}
+
+/// Extract `work_class` from an event payload for `brain.event_counts`'
+/// `counts_by_work_class` split (ADR-103 Stage 1, ADR-103-resource-attribution-model.md:303).
+///
+/// Checks two paths, phase-payload first:
+/// 1. `payload.work_class` — the shape `PhaseStarted`/`PhaseCompleted`/`PhaseCancelled`
+///    events use today (`khive_storage::telemetry::{PhaseStartedPayload, ...}`).
+/// 2. `payload.resource.work_class` — the not-yet-emitted shape a generic audit row would
+///    use once ADR-103 Stage 1's "resource payload enrichment" lands `work_class` on
+///    non-phase events too. No producer writes this today; the fallback exists so this
+///    verb does not need a second change when one starts.
+///
+/// Returns `None` (silently excluded from the split, not an error) when neither path is
+/// present — the overwhelming majority of event kinds today.
+fn event_work_class(payload: &Value) -> Option<&str> {
+    payload
+        .get("work_class")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            payload
+                .get("resource")
+                .and_then(|resource| resource.get("work_class"))
+                .and_then(Value::as_str)
         })
 }
 

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -69,6 +69,40 @@ pub(crate) static BRAIN_HANDLERS: &[HandlerDef] = &[
         }],
     },
     HandlerDef {
+        name: "brain.event_counts",
+        description: "Windowed event counts grouped by kind and actor over the event plane \
+            (ADR-103 Stage 1, #724 Ask A); feedback_explicit events additionally split by \
+            served_by_profile_id.",
+        visibility: khive_types::Visibility::Verb,
+        category: khive_types::VerbCategory::Assertive,
+        params: &[
+            khive_types::ParamDef {
+                name: "since",
+                param_type: "string",
+                required: true,
+                description: "Window start, ISO-8601/RFC-3339 datetime (e.g. \"2026-07-01T00:00:00Z\"). Inclusive.",
+            },
+            khive_types::ParamDef {
+                name: "until",
+                param_type: "string",
+                required: false,
+                description: "Window end, ISO-8601/RFC-3339 datetime. Exclusive. Defaults to now.",
+            },
+            khive_types::ParamDef {
+                name: "actor",
+                param_type: "string",
+                required: false,
+                description: "Filter to a single actor (e.g. \"lambda:khive\"). Omit for all actors.",
+            },
+            khive_types::ParamDef {
+                name: "kind",
+                param_type: "string",
+                required: false,
+                description: "Filter to a single EventKind (e.g. \"recall_executed\", \"feedback_explicit\"). Omit for all kinds.",
+            },
+        ],
+    },
+    HandlerDef {
         name: "brain.profiles",
         description: "List profiles, optionally filtered by lifecycle",
         visibility: khive_types::Visibility::Verb,
@@ -625,6 +659,127 @@ impl BrainPack {
             "count": events.len(),
             "events": events,
         }))
+    }
+
+    // ── brain.event_counts ──────────────────────────────────────────────────
+    //
+    // ADR-103 Stage 1 (#724 Ask A): a windowed, per-actor, per-kind read verb
+    // over the event plane. Named `brain.event_counts` rather than the literal
+    // `brain.events(...)` shape sketched on the issue — that name is already
+    // taken by the `Visibility::Subhandler` debug-listing verb above, which an
+    // MCP-boundary test (`subhandler_verbs_are_blocked_at_mcp_boundary`)
+    // requires to stay internal-only, and which several existing tests depend
+    // on for its `{count, events}` shape. Reusing the name would either break
+    // that invariant or overload one verb with two incompatible response
+    // shapes; a second, public verb name keeps both surfaces intact.
+
+    /// Cap on events aggregated by a single `brain.event_counts` window query.
+    /// `EventStore` has no SQL-side grouped-count primitive today (`count_events`
+    /// returns one scalar per filter, not a GROUP BY), so this verb fetches a
+    /// bounded page via `query_events` and aggregates by kind/actor/profile in
+    /// the handler. A window wider than this cap still returns counts up to the
+    /// cap and sets `truncated: true` plus the true `window_event_total` rather
+    /// than silently reporting a partial total as complete. At current event
+    /// volumes this bound is not expected to bind in practice; widening the
+    /// storage trait with a grouped-count method was intentionally deferred
+    /// rather than contorting `EventStore` for a case that is not yet load-bearing.
+    const MAX_WINDOW_EVENTS: u32 = 50_000;
+
+    pub(crate) async fn handle_event_counts(
+        &self,
+        token: &NamespaceToken,
+        params: Value,
+    ) -> Result<Value, RuntimeError> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct EventCountsParams {
+            actor: Option<String>,
+            kind: Option<String>,
+            since: String,
+            until: Option<String>,
+        }
+        let p: EventCountsParams = serde_json::from_value(params)
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        let since_us = parse_rfc3339_micros("since", &p.since)?;
+        let until_us = match p.until.as_deref() {
+            Some(u) => parse_rfc3339_micros("until", u)?,
+            None => Utc::now().timestamp_micros(),
+        };
+
+        let kind_filter = match p.kind.as_deref() {
+            Some(k) => Some(
+                k.parse::<khive_types::EventKind>()
+                    .map_err(|e| RuntimeError::InvalidInput(format!("invalid `kind`: {e}")))?,
+            ),
+            None => None,
+        };
+
+        let store = self.runtime.events(token)?;
+        let filter = EventFilter {
+            actors: p.actor.iter().cloned().collect(),
+            kinds: kind_filter.into_iter().collect(),
+            // Half-open window [since, until): `EventFilter.after` is a strict
+            // `created_at > after`, so subtracting one microsecond from `since`
+            // makes the boundary itself inclusive; `before` is already a strict
+            // `created_at < before`, which is exactly the exclusive `until` we want.
+            after: Some(since_us - 1),
+            before: Some(until_us),
+            ..EventFilter::default()
+        };
+
+        let page = store
+            .query_events(
+                filter,
+                PageRequest {
+                    offset: 0,
+                    limit: Self::MAX_WINDOW_EVENTS,
+                },
+            )
+            .await
+            .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?;
+
+        let window_event_total = page.total.unwrap_or(page.items.len() as u64);
+        let truncated = window_event_total > page.items.len() as u64;
+
+        let mut counts_by_kind: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+        let mut counts_by_actor: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+        let mut by_profile: std::collections::BTreeMap<String, u64> =
+            std::collections::BTreeMap::new();
+
+        for event in &page.items {
+            *counts_by_kind
+                .entry(event.kind.name().to_string())
+                .or_insert(0) += 1;
+            *counts_by_actor.entry(event.actor.clone()).or_insert(0) += 1;
+            if event.kind == khive_types::EventKind::FeedbackExplicit {
+                let profile = event
+                    .payload
+                    .get("served_by_profile_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unspecified")
+                    .to_string();
+                *by_profile.entry(profile).or_insert(0) += 1;
+            }
+        }
+
+        let mut result = json!({
+            "since": micros_to_iso(since_us),
+            "until": micros_to_iso(until_us),
+            "actor": p.actor,
+            "kind": p.kind,
+            "total": page.items.len() as u64,
+            "counts_by_kind": counts_by_kind,
+            "counts_by_actor": counts_by_actor,
+            "truncated": truncated,
+            "window_event_total": window_event_total,
+        });
+        if !by_profile.is_empty() {
+            result["by_profile"] = json!(by_profile);
+        }
+        Ok(result)
     }
 
     // ── brain.profiles ────────────────────────────────────────────────────
@@ -2047,6 +2202,20 @@ impl BrainPack {
     }
 }
 
+/// Parse an ISO-8601/RFC-3339 datetime string into a microsecond epoch,
+/// naming the offending field/value in the error rather than a bare parse
+/// failure (`brain.event_counts`, ADR-103 Stage 1).
+fn parse_rfc3339_micros(field: &'static str, value: &str) -> Result<i64, RuntimeError> {
+    chrono::DateTime::parse_from_rfc3339(value.trim())
+        .map(|dt| dt.with_timezone(&Utc).timestamp_micros())
+        .map_err(|e| {
+            RuntimeError::InvalidInput(format!(
+                "invalid `{field}`: {value:?} is not a valid ISO-8601/RFC-3339 datetime ({e}); \
+                 expected e.g. \"2026-07-01T00:00:00Z\""
+            ))
+        })
+}
+
 // ── lattice-router seam (#345 M1 / #352 M2) ──────────────────────────────────
 
 /// Context-vector dimension for the lattice-fann router seam.
@@ -2253,6 +2422,7 @@ impl khive_runtime::pack::PackRuntime for BrainPack {
             "brain.state" => self.handle_state(params).await,
             "brain.config" => self.handle_config(params).await,
             "brain.events" => self.handle_events(token, params).await,
+            "brain.event_counts" => self.handle_event_counts(token, params).await,
             "brain.profiles" => self.handle_profiles(params).await,
             "brain.profile" => self.handle_profile(params).await,
             "brain.resolve" => self.handle_resolve(params).await,

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -5740,3 +5740,409 @@ mod durable_write_tests {
         );
     }
 }
+
+// ── brain.event_counts (ADR-103 Stage 1, #724 Ask A) ────────────────────────
+
+#[cfg(test)]
+mod event_counts_tests {
+    use super::*;
+    use khive_runtime::micros_to_iso;
+    use khive_storage::event::{Event, EventFilter};
+    use khive_storage::types::PageRequest;
+    use khive_types::{EventKind, SubstrateKind};
+    use serde_json::Value;
+
+    /// Append a synthetic event directly through the `EventStore`, bypassing
+    /// verb dispatch, so the window boundary tests control `created_at` and
+    /// payload precisely instead of relying on wall-clock timing.
+    async fn seed_event(
+        rt: &KhiveRuntime,
+        token: &NamespaceToken,
+        verb: &str,
+        kind: EventKind,
+        actor: &str,
+        created_at: i64,
+        payload: Value,
+    ) {
+        let mut event = Event::new(
+            token.namespace().as_str(),
+            verb,
+            kind,
+            SubstrateKind::Note,
+            actor,
+        );
+        event.created_at = created_at;
+        event.payload = payload;
+        rt.events(token)
+            .expect("event store")
+            .append_event(event)
+            .await
+            .expect("seed event append");
+    }
+
+    /// Sanity check that the seeding helper and window semantics agree with
+    /// the underlying `EventFilter` used by other event-store tests: appending
+    /// a handful of rows and reading them back via `query_events` with an
+    /// explicit filter must see exactly what was seeded.
+    async fn seeded_count(rt: &KhiveRuntime, token: &NamespaceToken) -> usize {
+        rt.events(token)
+            .expect("event store")
+            .query_events(
+                EventFilter::default(),
+                PageRequest {
+                    offset: 0,
+                    limit: 1000,
+                },
+            )
+            .await
+            .expect("query_events")
+            .items
+            .len()
+    }
+
+    #[tokio::test]
+    async fn window_boundaries_include_since_exclude_until() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let since = 1_000_000_i64;
+        let until = 2_000_000_i64;
+
+        // Exactly at `since` — must be INCLUDED.
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            since,
+            json!({}),
+        )
+        .await;
+        // Inside the window.
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_500_000,
+            json!({}),
+        )
+        .await;
+        // Exactly at `until` — must be EXCLUDED (half-open window).
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            until,
+            json!({}),
+        )
+        .await;
+        // Before `since` — must be EXCLUDED.
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            500_000,
+            json!({}),
+        )
+        .await;
+
+        assert_eq!(seeded_count(&rt, &token).await, 4);
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": micros_to_iso(since),
+                    "until": micros_to_iso(until),
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(
+            result["total"],
+            json!(2),
+            "window must include the `since` boundary and exclude the `until` boundary: {result}"
+        );
+        assert_eq!(result["counts_by_kind"]["search_executed"], json!(2));
+    }
+
+    #[tokio::test]
+    async fn empty_window_returns_zero_counts_not_error() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": "2020-01-01T00:00:00Z",
+                    "until": "2020-01-02T00:00:00Z",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("empty window must not error");
+
+        assert_eq!(result["total"], json!(0));
+        assert_eq!(result["counts_by_kind"], json!({}));
+        assert_eq!(result["counts_by_actor"], json!({}));
+        assert!(
+            result.get("by_profile").is_none(),
+            "by_profile must be omitted when no feedback events are in the window: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn kind_filter_scopes_counts() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "recall",
+            EventKind::RecallExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": micros_to_iso(0),
+                    "kind": "recall_executed",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(1));
+        assert_eq!(result["counts_by_kind"]["recall_executed"], json!(1));
+        assert!(result["counts_by_kind"].get("search_executed").is_none());
+    }
+
+    #[tokio::test]
+    async fn actor_filter_scopes_counts() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:b",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({
+                    "since": micros_to_iso(0),
+                    "actor": "lambda:b",
+                }),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(1));
+        assert_eq!(result["counts_by_actor"]["lambda:b"], json!(1));
+        assert!(result["counts_by_actor"].get("lambda:a").is_none());
+    }
+
+    #[tokio::test]
+    async fn feedback_events_split_by_served_by_profile_id() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "balanced-recall-v1", "signal": "useful"}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"served_by_profile_id": "balanced-recall-v1", "signal": "wrong"}),
+        )
+        .await;
+        // Missing served_by_profile_id — must fall into the "unspecified" bucket
+        // rather than being dropped from the split.
+        seed_event(
+            &rt,
+            &token,
+            "brain.feedback",
+            EventKind::FeedbackExplicit,
+            "lambda:a",
+            1_000_000,
+            json!({"signal": "useful"}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(3));
+        assert_eq!(
+            result["by_profile"]["balanced-recall-v1"],
+            json!(2),
+            "got: {result}"
+        );
+        assert_eq!(
+            result["by_profile"]["unspecified"],
+            json!(1),
+            "got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_kind_lists_valid_values() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let err = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0), "kind": "not_a_real_kind"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect_err("unknown kind must be rejected");
+
+        match &err {
+            RuntimeError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("not_a_real_kind"),
+                    "error must name the rejected value: {msg}"
+                );
+                assert!(
+                    msg.contains("recall_executed") || msg.contains("Valid:"),
+                    "error must list valid EventKind values: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_since_datetime_names_the_field() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let err = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": "not-a-date"}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect_err("malformed since must be rejected");
+
+        match &err {
+            RuntimeError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("since") && msg.contains("not-a-date"),
+                    "error must name the field and offending value: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_since_is_rejected() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let err = pack
+            .dispatch("brain.event_counts", json!({}), &registry, &token)
+            .await
+            .expect_err("since is required");
+
+        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn handler_is_public_verb_with_required_since() {
+        let h = crate::handlers::BRAIN_HANDLERS
+            .iter()
+            .find(|h| h.name == "brain.event_counts")
+            .expect("brain.event_counts must be registered");
+        assert_eq!(h.visibility, khive_types::Visibility::Verb);
+        assert!(
+            h.params.iter().any(|p| p.name == "since" && p.required),
+            "since must be documented as required"
+        );
+        assert!(
+            h.params.iter().any(|p| p.name == "until" && !p.required),
+            "until must be documented as optional"
+        );
+    }
+}

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -6126,7 +6126,217 @@ mod event_counts_tests {
             .await
             .expect_err("since is required");
 
-        assert!(matches!(err, RuntimeError::InvalidInput(_)));
+        match &err {
+            RuntimeError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("since"),
+                    "error must name the missing field: {msg}"
+                );
+                assert!(
+                    msg.to_ascii_lowercase().contains("iso-8601")
+                        || msg.to_ascii_lowercase().contains("rfc-3339")
+                        || msg.to_ascii_lowercase().contains("rfc3339"),
+                    "error must name the expected format: {msg}"
+                );
+                assert!(
+                    msg.contains("2026-07-01T00:00:00Z") || msg.contains("T00:00:00Z"),
+                    "error must include an example datetime: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn work_class_split_reads_phase_payload_not_resource_fallback() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        // Today's real shape: work_class lives directly on the Phase* payload
+        // (khive_storage::telemetry::PhaseStartedPayload / PhaseCompletedPayload).
+        seed_event(
+            &rt,
+            &token,
+            "ann_warm",
+            EventKind::PhaseStarted,
+            "lambda:khive",
+            1_000_000,
+            json!({"work_class": "warm", "phase": "ann_warm", "corpus_size": 553_000}),
+        )
+        .await;
+        seed_event(
+            &rt,
+            &token,
+            "ann_warm",
+            EventKind::PhaseCompleted,
+            "lambda:khive",
+            1_000_000,
+            json!({"work_class": "warm", "phase": "ann_warm", "wall_us": 41_000_000, "cpu_us": null}),
+        )
+        .await;
+        // A different work_class, distinct kind, so the split can't be faked by
+        // just echoing counts_by_kind.
+        seed_event(
+            &rt,
+            &token,
+            "ann_warm",
+            EventKind::PhaseStarted,
+            "lambda:khive",
+            1_000_000,
+            json!({"work_class": "maintenance", "phase": "index_rebuild"}),
+        )
+        .await;
+        // A non-phase event with no work_class anywhere — must not appear in the split.
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:khive",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+        // Future shape: work_class nested under `resource`, no top-level `work_class`.
+        // Must be picked up via the fallback path, not just the phase path.
+        seed_event(
+            &rt,
+            &token,
+            "recall",
+            EventKind::RecallExecuted,
+            "lambda:khive",
+            1_000_000,
+            json!({"resource": {"work_class": "interactive"}}),
+        )
+        .await;
+        // Both paths present: phase path must win (checked first).
+        seed_event(
+            &rt,
+            &token,
+            "ann_warm",
+            EventKind::PhaseStarted,
+            "lambda:khive",
+            1_000_000,
+            json!({"work_class": "warm", "resource": {"work_class": "maintenance"}}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert_eq!(result["total"], json!(6), "got: {result}");
+        assert_eq!(
+            result["counts_by_work_class"]["warm"],
+            json!(3),
+            "phase-path warm rows (2 pure + 1 dual-path, phase wins) must all count as warm: {result}"
+        );
+        assert_eq!(
+            result["counts_by_work_class"]["maintenance"],
+            json!(1),
+            "the dual-path row must count under warm (phase path), not maintenance \
+             (resource fallback) — phase path must be checked first: {result}"
+        );
+        assert_eq!(
+            result["counts_by_work_class"]["interactive"],
+            json!(1),
+            "resource.work_class fallback must be read when no top-level work_class exists: {result}"
+        );
+        // search_executed carried no work_class anywhere -> excluded from the split,
+        // not zero-filled, so the split total (5) is less than the overall total (6).
+        let split_total: u64 = result["counts_by_work_class"]
+            .as_object()
+            .expect("counts_by_work_class must be an object")
+            .values()
+            .map(|v| v.as_u64().unwrap())
+            .sum();
+        assert_eq!(
+            split_total, 5,
+            "events with neither work_class path present must be excluded, not counted: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn work_class_split_absent_when_no_event_carries_it() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "search",
+            EventKind::SearchExecuted,
+            "lambda:a",
+            1_000_000,
+            json!({}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert!(
+            result.get("counts_by_work_class").is_none(),
+            "counts_by_work_class must be omitted, not an empty object, when no event in \
+             the window carries a work_class: {result}"
+        );
+    }
+
+    /// `cost_unit` does not exist on any event payload in the codebase today (ADR-103
+    /// Stage 0 defines it; no Stage 1 producer emits it yet). This verb must not invent
+    /// a `cost_unit` key — asserts its literal absence from the response shape so a
+    /// future producer landing the field is a deliberate response-shape change, not a
+    /// silent no-op this test would miss.
+    #[tokio::test]
+    async fn cost_unit_is_not_present_in_the_response() {
+        let (pack, rt) = make_pack();
+        let registry = empty_registry();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        seed_event(
+            &rt,
+            &token,
+            "ann_warm",
+            EventKind::PhaseCompleted,
+            "lambda:khive",
+            1_000_000,
+            json!({"work_class": "warm", "phase": "ann_warm", "wall_us": 1, "cpu_us": null}),
+        )
+        .await;
+
+        let result = pack
+            .dispatch(
+                "brain.event_counts",
+                json!({"since": micros_to_iso(0)}),
+                &registry,
+                &token,
+            )
+            .await
+            .expect("brain.event_counts must succeed");
+
+        assert!(
+            result.get("cost_unit").is_none(),
+            "cost_unit must not appear anywhere at the top level: {result}"
+        );
+        assert!(
+            result.get("counts_by_cost_unit").is_none(),
+            "no cost_unit split must be surfaced until a producer emits the field: {result}"
+        );
     }
 
     #[test]

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -197,22 +197,24 @@ def main():
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
         # unset) loads 9 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session, git), so verbs() returns exactly 75 user-facing
+        # knowledge, session, git), so verbs() returns exactly 76 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
         # Visibility::Verb per ADR-083; brain.register_adapter (#354), context
-        # (ADR-089, the 17th kg-substrate bare verb), and comm.health (#606,
-        # verified live 2026-07-04), and comm.probe (#644 read-only inbound
-        # poll) are included in the count; git contributes
+        # (ADR-089, the 17th kg-substrate bare verb), comm.health (#606,
+        # verified live 2026-07-04), comm.probe (#644 read-only inbound
+        # poll), and brain.event_counts (#724, ADR-103 Stage 1 windowed event
+        # read) are included in the count; git contributes
         # 0 verbs (note kinds + ingester only). Update this number when the
         # pack set or verb surface changes; a silent drift here is the bug
         # this assertion exists to catch.
-        assert verbs_result["total"] == 75, (
-            f"expected 75 user-facing verbs from the 9 default packs "
+        assert verbs_result["total"] == 76, (
+            f"expected 76 user-facing verbs from the 9 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
-            f"comm.health is #606; comm.probe is #644; git contributes 0), "
+            f"comm.health is #606; comm.probe is #644; brain.event_counts is "
+            f"#724/ADR-103; git contributes 0), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]


### PR DESCRIPTION
ADR-103 Stage 1 PR-2: the windowed, per-actor, per-kind read verb over the event plane (#724 Ask A).

**Surface**: `brain.event_counts(since, until?, actor?, kind?)` — public read-only Assertive verb returning `total`, `counts_by_kind`, `counts_by_actor`, an optional `by_profile` split for explicit-feedback events (keyed on `served_by_profile_id`, missing values bucketed as "unspecified"), and `truncated`/`window_event_total` when the window exceeds the 50,000-row aggregation cap. Window is half-open `[since, until)`; `until` defaults to now.

**Naming**: the issue sketches `brain.events(...)`, but that name is an existing internal `Visibility::Subhandler` debug verb that MCP-boundary tests require to stay blocked from the public surface. Shipped as `brain.event_counts`; the subhandler is untouched.

**work_class/cost_unit** (ADR-103 mentions surfacing them): `cost_unit` does not exist in code yet; `work_class` exists only inside the three Phase* payloads, not as a cross-kind queryable dimension — so no grouping axis for them in this PR; they join when the fields land generally (later Stage 1/2 scope).

**Storage**: no EventStore trait changes — filters push to SQL via the existing `EventFilter`, aggregation is in-handler over a bounded page. Tradeoff documented in code.

**Tests**: 9 handler-level tests (window boundaries, filters, by_profile split, invalid kind/datetime errors, empty window = zero counts). Gates green: fmt, clippy -D warnings, scoped tests (khive-pack-brain/storage/types), doc -D warnings; MCP-boundary invariant tests re-run and pass.

Docs: verb totals updated in AGENTS.md and CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)