### PR TITLE
feat(memory): ADR-104 Stage B — bounded per-entity posterior term in recall scoring

### DIFF
--- a/crates/khive-pack-memory/src/config.rs
+++ b/crates/khive-pack-memory/src/config.rs
@@ -530,8 +530,13 @@ pub struct ScoreBreakdown {
     /// ADR-104 §3: the serving profile's per-entity Beta posterior mean for
     /// this hit's UUID. `None` when no profile served the request, or the
     /// profile holds no posterior for this UUID beyond the uninformative
-    /// prior. Reported only — Stage A does not let this affect ranking
-    /// (the per-entity multiplicative term is component 2, Stage B).
+    /// prior. As of Stage B (§2), this value is not just reported: it is
+    /// the input to the bounded per-entity term
+    /// `clamp(1 + 0.3 * (entity_posterior_mean - 0.5), 0.85, 1.15)` that
+    /// multiplies the response's `rank_score` — so a value here other than
+    /// the neutral case (`None`, or a mean of exactly 0.5) means this hit's
+    /// `rank_score` was moved by up to +/-15% relative to the same
+    /// candidate under a profile with no posterior for it.
     pub entity_posterior_mean: Option<f64>,
 }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -483,17 +483,27 @@ impl MemoryPack {
             // already fetched once per recall (see the profile-resolution
             // block above) — never a second profile-state read, and never
             // gated behind `is_verbose` like `profile_component`, because
-            // (unlike that diagnostic ratio) it actually feeds `rank_score`
+            // (unlike that diagnostic ratio) it actually feeds the score
             // below and so must run for every request, breakdown or not.
+            //
+            // Applied to `final_score` (below), not to the local
+            // `rank_score` here — `final_score` is whichever composite score
+            // actually reaches ranking (either `rank_score` on the default
+            // path, or `weighted_rerank(...)`'s output when a caller sets
+            // `reranker_weights`). Applying the multiplier to `rank_score`
+            // alone would leave it dead code on the weighted-rerank path:
+            // `weighted_rerank` recomposes its own score from raw features
+            // and never reads `rank_score`, so the entity term must be the
+            // *last* step, applied exactly once regardless of which path
+            // produced the pre-entity-term composite.
             let entity_posterior_mean: Option<f64> = profile_state
                 .as_ref()
                 .and_then(|s| s.entity_posteriors.get(&id))
                 .map(khive_brain_core::BetaPosterior::mean);
-            let rank_score = rank_score
-                * crate::scoring::entity_posterior_term(
-                    entity_posterior_mean,
-                    crate::scoring::ENTITY_POSTERIOR_WEIGHT,
-                );
+            let entity_term = crate::scoring::entity_posterior_term(
+                entity_posterior_mean,
+                crate::scoring::ENTITY_POSTERIOR_WEIGHT,
+            );
 
             let age_days_f64 =
                 ((now_micros - note.created_at).max(0) as f64) / (1_000_000.0 * 86_400.0);
@@ -509,7 +519,7 @@ impl MemoryPack {
             breakdown.entity_posterior_mean = entity_posterior_mean;
 
             let source = source_by_id.get(&id).copied().unwrap_or(SearchSource::Text);
-            let final_score = if !cfg.reranker_weights.is_empty() {
+            let pre_entity_term_score = if !cfg.reranker_weights.is_empty() {
                 let features = RerankFeatures {
                     relevance: norm_relevance as f64,
                     salience: breakdown.salience_decayed,
@@ -521,6 +531,7 @@ impl MemoryPack {
             } else {
                 rank_score
             };
+            let final_score = pre_entity_term_score * entity_term;
 
             let raw_score_opt = raw_vec_scores.get(&id).copied();
             let absolute_relevance = raw_score_opt.unwrap_or(final_score).clamp(0.0, 1.0);
@@ -2867,6 +2878,277 @@ mod tests {
         assert!(
             implied_entity_term >= crate::scoring::ENTITY_POSTERIOR_CLAMP_MIN as f64 - 1e-6,
             "entity term must never fall below the -15% clamp bound: implied={implied_entity_term}"
+        );
+    }
+
+    /// Isolation (row-B gate, internal review PR round-1 Medium): the earlier
+    /// feedback-lift and clamp tests above give one profile strictly more
+    /// feedback than another, which also perturbs that profile's *global*
+    /// salience posterior (component 1, ADR-104 §1) — `on_explicit_feedback`
+    /// updates `state.salience` on every signal regardless of `target_id`
+    /// (see `recall_feedback.rs`). So a passing feedback-lift test alone does
+    /// not prove component 2 (the entity term) did the lifting; it could be
+    /// entirely a Stage A weight-projection effect.
+    ///
+    /// This test controls for that: two profiles each receive exactly ONE
+    /// `useful` signal — identical global salience posterior state — but
+    /// aimed at *different* targets (`target_x` for profile X, `target_y`
+    /// for profile Y). Recalling `target_x`'s note under both profiles must
+    /// therefore show identical `profile_component` (component 1 is
+    /// target-independent), while `entity_posterior_mean` for `target_x` is
+    /// present only under profile X. The measured `rank_score` ratio between
+    /// the two must equal `entity_posterior_term(mean, ENTITY_POSTERIOR_WEIGHT)`
+    /// exactly — the only degree of freedom left once component 1 is held
+    /// constant — proving the multiplier is live end-to-end, not just
+    /// present in the pure function.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_b_entity_term_isolated_via_matched_global_feedback_count() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+
+        let target_x_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr104b isolation target x note",
+                Some(0.6),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note x")
+            .id;
+        let target_y_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr104b isolation target y note",
+                Some(0.6),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note y")
+            .id;
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        for name in ["adr104b-iso-x-v1", "adr104b-iso-y-v1"] {
+            registry
+                .dispatch(
+                    "brain.create_profile",
+                    serde_json::json!({
+                        "namespace": ns.as_str(),
+                        "name": name,
+                        "consumer_kind": "recall",
+                    }),
+                )
+                .await
+                .expect("create profile");
+        }
+
+        // Exactly one signal per profile — same weight, same count — but
+        // profile X's signal targets target_x and profile Y's targets
+        // target_y. Global salience posterior state ends up identical;
+        // per-entity posterior state does not.
+        adr104_skew_salience(&registry, "adr104b-iso-x-v1", target_x_id, 1).await;
+        adr104_skew_salience(&registry, "adr104b-iso-y-v1", target_y_id, 1).await;
+
+        // Both notes share most of their vocabulary ("adr104b isolation ...
+        // note"), so an FTS query naming only `target_x_id`'s note can still
+        // surface `target_y_id`'s note as a secondary hit — locate
+        // `target_x_id` by id within the returned hits rather than assuming
+        // a single-hit result.
+        async fn recall_target_x(
+            registry: &khive_runtime::VerbRegistry,
+            ns: &Namespace,
+            profile_id: &str,
+            target_x_id: Uuid,
+        ) -> (f64, f64, Option<f64>) {
+            let result = registry
+                .dispatch(
+                    "memory.recall",
+                    serde_json::json!({
+                        "namespace": ns.as_str(),
+                        "query": "adr104b isolation target x note",
+                        "profile_id": profile_id,
+                        "include_breakdown": true,
+                        "limit": 10
+                    }),
+                )
+                .await
+                .expect("recall");
+            let hits = result.as_array().expect("bare array result");
+            let pos = adr104_position(hits, target_x_id);
+            let rank_score = hits[pos]["rank_score"].as_f64().expect("rank_score");
+            let profile_component = hits[pos]["breakdown"]["profile_component"]
+                .as_f64()
+                .expect("profile_component present");
+            let entity_posterior_mean = hits[pos]["breakdown"]["entity_posterior_mean"].as_f64();
+            (rank_score, profile_component, entity_posterior_mean)
+        }
+
+        let (score_under_x, component_under_x, ent_mean_under_x) =
+            recall_target_x(&registry, &ns, "adr104b-iso-x-v1", target_x_id).await;
+        let (score_under_y, component_under_y, ent_mean_under_y) =
+            recall_target_x(&registry, &ns, "adr104b-iso-y-v1", target_x_id).await;
+
+        assert!(
+            (component_under_x - component_under_y).abs() < 1e-9,
+            "component 1 (profile_component) must be identical under both \
+             profiles — they received the same global feedback count, just \
+             on different targets: under_x={component_under_x} under_y={component_under_y}"
+        );
+        assert!(
+            ent_mean_under_x.is_some(),
+            "profile X received feedback directly on target_x => entity_posterior_mean must be present"
+        );
+        assert!(
+            ent_mean_under_y.is_none(),
+            "profile Y's signal targeted target_y, not target_x => target_x must have no \
+             posterior under profile Y: got {ent_mean_under_y:?}"
+        );
+
+        let expected_term = crate::scoring::entity_posterior_term(
+            ent_mean_under_x,
+            crate::scoring::ENTITY_POSTERIOR_WEIGHT,
+        ) as f64;
+        let observed_ratio = score_under_x / score_under_y;
+        assert!(
+            (observed_ratio - expected_term).abs() < 1e-4,
+            "with component 1 held constant, the rank_score ratio between the \
+             two profiles must equal the entity term exactly: observed={observed_ratio} \
+             expected={expected_term} (ent_mean_under_x={ent_mean_under_x:?})"
+        );
+    }
+
+    /// Regression (row-B gate, internal review PR round-1 High): the entity
+    /// term must apply on the weighted-rerank path too, not only the
+    /// default `rank_score` path. `weighted_rerank` recomposes its score
+    /// from raw relevance/salience/temporal features and never reads
+    /// `rank_score`, so a naive "multiply `rank_score`" fix is dead code
+    /// whenever a caller sets non-empty `reranker_weights`. This drives a
+    /// single-note corpus through the reranker path before and after one
+    /// `useful` signal and asserts the score moves by exactly the entity
+    /// term, proving the multiplier is applied to whichever composite score
+    /// actually reaches ranking.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_b_entity_term_applies_under_weighted_reranker() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr104b reranker path probe note",
+                Some(0.6),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note")
+            .id;
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "adr104b-rerank-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+
+        let params = serde_json::json!({
+            "namespace": ns.as_str(),
+            "query": "adr104b reranker path probe note",
+            "profile_id": "adr104b-rerank-v1",
+            "include_breakdown": true,
+            "config": {
+                "reranker_weights": {
+                    "relevance": 0.6,
+                    "salience": 0.3,
+                    "temporal": 0.1
+                }
+            },
+            "limit": 10
+        });
+
+        let before = registry
+            .dispatch("memory.recall", params.clone())
+            .await
+            .expect("recall before feedback");
+        let before_hits = before.as_array().expect("array");
+        let score_before = before_hits[0]["rank_score"].as_f64().expect("rank_score");
+        assert!(
+            before_hits[0]["breakdown"]["entity_posterior_mean"].is_null(),
+            "no feedback yet => entity_posterior_mean must be absent"
+        );
+
+        registry
+            .dispatch(
+                "brain.feedback",
+                serde_json::json!({
+                    "target_id": note_id.to_string(),
+                    "signal": "useful",
+                    "served_by_profile_id": "adr104b-rerank-v1",
+                }),
+            )
+            .await
+            .expect("one explicit useful signal");
+
+        let after = registry
+            .dispatch("memory.recall", params)
+            .await
+            .expect("recall after feedback");
+        let after_hits = after.as_array().expect("array");
+        let score_after = after_hits[0]["rank_score"].as_f64().expect("rank_score");
+        let ent_mean_after = after_hits[0]["breakdown"]["entity_posterior_mean"]
+            .as_f64()
+            .expect("entity_posterior_mean present after feedback");
+
+        assert!(
+            score_after > score_before,
+            "the entity term must lift rank_score on the weighted-rerank path too: \
+             before={score_before} after={score_after}"
+        );
+
+        let expected_ratio = crate::scoring::entity_posterior_term(
+            Some(ent_mean_after),
+            crate::scoring::ENTITY_POSTERIOR_WEIGHT,
+        ) as f64;
+        let observed_ratio = score_after / score_before;
+        assert!(
+            (observed_ratio - expected_ratio).abs() < 1e-4,
+            "reranker-path score ratio must equal the entity term exactly \
+             (weighted_rerank's inputs are unaffected by the one signal, so \
+             the entire delta must be the Stage B multiplier): \
+             observed={observed_ratio} expected={expected_ratio}"
         );
     }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -456,11 +456,12 @@ impl MemoryPack {
             // scored under configured-default weights — computed only for
             // verbose responses, since it costs a second `calculate_score`
             // call per candidate. Neutral (1.0) when no profile served the
-            // request (component 1 never ran). `entity_posterior_mean` is
-            // read-only: it must never feed `scoring_cfg` (that's component
-            // 2, Stage B).
-            let (profile_component, entity_posterior_mean) = if is_verbose {
-                let component = match &profile_state {
+            // request (component 1 never ran). It is computed against the
+            // pre-entity-term `rank_score` so it stays a pure read on
+            // component 1 (weight projection) — component 2 (the entity
+            // term, applied below) is orthogonal to the weight ratio.
+            let profile_component = if is_verbose {
+                match &profile_state {
                     Some(_) => {
                         let mut default_cfg = scoring_cfg.clone();
                         default_cfg.weights = default_weights.clone();
@@ -472,15 +473,27 @@ impl MemoryPack {
                         }
                     }
                     None => 1.0,
-                };
-                let ent_mean = profile_state
-                    .as_ref()
-                    .and_then(|s| s.entity_posteriors.get(&id))
-                    .map(khive_brain_core::BetaPosterior::mean);
-                (component, ent_mean)
+                }
             } else {
-                (1.0, None)
+                1.0
             };
+
+            // ADR-104 §2 (Stage B): bounded per-entity posterior term. This
+            // is a single `HashMap::get` against the profile state Stage A
+            // already fetched once per recall (see the profile-resolution
+            // block above) — never a second profile-state read, and never
+            // gated behind `is_verbose` like `profile_component`, because
+            // (unlike that diagnostic ratio) it actually feeds `rank_score`
+            // below and so must run for every request, breakdown or not.
+            let entity_posterior_mean: Option<f64> = profile_state
+                .as_ref()
+                .and_then(|s| s.entity_posteriors.get(&id))
+                .map(khive_brain_core::BetaPosterior::mean);
+            let rank_score = rank_score
+                * crate::scoring::entity_posterior_term(
+                    entity_posterior_mean,
+                    crate::scoring::ENTITY_POSTERIOR_WEIGHT,
+                );
 
             let age_days_f64 =
                 ((now_micros - note.created_at).max(0) as f64) / (1_000_000.0 * 86_400.0);
@@ -2338,9 +2351,15 @@ mod tests {
     /// Breakdown fields (ADR-104 §3): `profile_component` is neutral (1.0)
     /// with no profile and != 1.0 once a differentiating profile serves the
     /// request; `entity_posterior_mean` is absent for a target with no
-    /// feedback and present+correct for one with a seeded posterior — and
-    /// Stage A ranking is driven by component 1 alone: the seeded entity
-    /// posterior on `H` must not move it back above `L`.
+    /// feedback and present+correct for one with a seeded posterior. With
+    /// Stage B (§2) live, the entity term on `H` is also in effect here —
+    /// bounded to at most +15% — but the salience-projection margin that
+    /// puts `L` ahead (component 1, driven by 30 signals against the global
+    /// salience posterior) is wide enough that the entity term alone does
+    /// not overturn it. Component 2's isolated, order-flipping effect is
+    /// covered by the feedback-lift and neutrality tests below (ADR-104
+    /// Stage B gate), which hold the corpus fixed and vary only the entity
+    /// posterior.
     #[tokio::test]
     #[serial(background_tasks)]
     async fn recall_breakdown_reports_profile_component_and_entity_posterior_mean() {
@@ -2429,10 +2448,10 @@ mod tests {
         let l_pos = adr104_position(hits, l_id);
         assert!(
             l_pos < h_pos,
-            "Stage A ranking must still be driven by component 1 alone (matching \
-             the profile-differentiated ranking test) — the entity posterior term \
-             (component 2, Stage B) must not move it even though H has a seeded \
-             posterior: {hits:?}"
+            "the component-1 salience-projection margin (matching the \
+             profile-differentiated ranking test) is wide enough that H's \
+             bounded (<=+15%) component-2 entity term does not overturn it: \
+             {hits:?}"
         );
 
         let h_component = hits[h_pos]["breakdown"]["profile_component"]
@@ -2528,6 +2547,326 @@ mod tests {
             first_scores, second_scores,
             "identical store/query/profile-state must produce byte-identical \
              rank_score values"
+        );
+    }
+
+    // ── ADR-104 Stage B: bounded per-entity posterior term (row-B gate) ────
+
+    /// Neutrality (row-B gate): a candidate with no per-entity posterior must
+    /// score identically whether or not a profile serves the request, as
+    /// long as that profile's *global* weights also equal defaults (a fresh
+    /// profile with untouched Beta priors projects to exactly
+    /// `RecallConfig::default()` — see `tunable.rs`'s
+    /// `project_config_with_default_priors_matches_expected_defaults`). This
+    /// isolates component 2 (the entity term) from component 1 (weight
+    /// projection): with no posterior for this UUID, component 2 must be
+    /// the identity multiplier, so profile-served and default-served scores
+    /// coincide exactly.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_b_no_posterior_candidate_scores_identically_with_fresh_profile() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+        rt.create_note(
+            &token,
+            "memory",
+            None,
+            "adr104b neutrality probe note",
+            Some(0.6),
+            None,
+            vec![],
+        )
+        .await
+        .expect("create note");
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "adr104b-neutral-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+
+        let with_profile = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "adr104b neutrality probe note",
+                    "profile_id": "adr104b-neutral-v1",
+                    "include_breakdown": true,
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall with fresh profile");
+        let without_profile = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "adr104b neutrality probe note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("recall with defaults");
+
+        let with_hits = with_profile.as_array().expect("bare array result");
+        let without_hits = without_profile.as_array().expect("bare array result");
+        assert_eq!(with_hits.len(), 1);
+        assert_eq!(without_hits.len(), 1);
+
+        assert!(
+            with_hits[0]["breakdown"]["entity_posterior_mean"].is_null(),
+            "fresh profile holds no posterior for this UUID => entity_posterior_mean absent"
+        );
+
+        let score_with = with_hits[0]["rank_score"].as_f64().expect("rank_score");
+        let score_without = without_hits[0]["rank_score"].as_f64().expect("rank_score");
+        assert!(
+            (score_with - score_without).abs() < 1e-9,
+            "no-posterior candidate must score identically served vs unserved: \
+             with_profile={score_with} without_profile={score_without}"
+        );
+    }
+
+    /// Feedback-lift (row-B gate, the ADR's headline test): one explicit
+    /// `useful` signal on a recalled memory changes that memory's rank_score
+    /// on the next equivalent query — under the profile the signal targeted
+    /// — and does NOT change it under a different profile or under defaults.
+    /// Both non-targeted arms start numerically identical to the pre-signal
+    /// baseline (a fresh profile projects to default weights, per the
+    /// neutrality test above), so any post-signal divergence is attributable
+    /// to the signal.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_b_one_signal_lifts_rank_only_under_the_served_profile() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr104b feedback lift probe note",
+                Some(0.6),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note")
+            .id;
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        for name in ["adr104b-lift-a-v1", "adr104b-lift-b-v1"] {
+            registry
+                .dispatch(
+                    "brain.create_profile",
+                    serde_json::json!({
+                        "namespace": ns.as_str(),
+                        "name": name,
+                        "consumer_kind": "recall",
+                    }),
+                )
+                .await
+                .expect("create profile");
+        }
+
+        async fn recall_score(
+            registry: &khive_runtime::VerbRegistry,
+            ns: &Namespace,
+            profile_id: Option<&str>,
+        ) -> f64 {
+            let mut params = serde_json::json!({
+                "namespace": ns.as_str(),
+                "query": "adr104b feedback lift probe note",
+                "limit": 10
+            });
+            if let Some(pid) = profile_id {
+                params["profile_id"] = serde_json::json!(pid);
+            }
+            let result = registry
+                .dispatch("memory.recall", params)
+                .await
+                .expect("recall");
+            let hits = result.as_array().expect("bare array result");
+            assert_eq!(hits.len(), 1);
+            hits[0]["rank_score"].as_f64().expect("rank_score")
+        }
+
+        let a_before = recall_score(&registry, &ns, Some("adr104b-lift-a-v1")).await;
+        let b_before = recall_score(&registry, &ns, Some("adr104b-lift-b-v1")).await;
+        let default_before = recall_score(&registry, &ns, None).await;
+        assert!(
+            (a_before - default_before).abs() < 1e-9 && (b_before - default_before).abs() < 1e-9,
+            "both fresh profiles must start identical to defaults: a={a_before} \
+             b={b_before} default={default_before}"
+        );
+
+        registry
+            .dispatch(
+                "brain.feedback",
+                serde_json::json!({
+                    "target_id": note_id.to_string(),
+                    "signal": "useful",
+                    "served_by_profile_id": "adr104b-lift-a-v1",
+                }),
+            )
+            .await
+            .expect("one explicit useful signal under profile A");
+
+        let a_after = recall_score(&registry, &ns, Some("adr104b-lift-a-v1")).await;
+        let b_after = recall_score(&registry, &ns, Some("adr104b-lift-b-v1")).await;
+        let default_after = recall_score(&registry, &ns, None).await;
+
+        assert!(
+            a_after > a_before,
+            "one useful signal under profile A must lift the score under \
+             profile A: before={a_before} after={a_after}"
+        );
+        assert!(
+            (b_after - b_before).abs() < 1e-9,
+            "profile B never received the signal => its score must be \
+             unchanged: before={b_before} after={b_after}"
+        );
+        assert!(
+            (default_after - default_before).abs() < 1e-9,
+            "defaults (no profile) must be unchanged by feedback given under \
+             an explicit profile: before={default_before} after={default_after}"
+        );
+    }
+
+    /// Clamp (row-B gate) at the pipeline level: driving a profile's
+    /// per-entity posterior to its practical ceiling (repeated `useful`
+    /// signals push the Beta posterior mean arbitrarily close to 1.0, never
+    /// reaching it exactly) must never lift `rank_score` by more than the
+    /// documented +15% bound relative to the same candidate's score under a
+    /// fresh, untouched profile. The exact-boundary case
+    /// (`entity_posterior_term`'s clamp at mean=0.0/1.0 precisely) is
+    /// covered at the unit level in `scoring.rs`; this test proves the bound
+    /// holds end-to-end through the handler, not just in the pure function.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn adr104_stage_b_saturated_posterior_never_exceeds_clamp_bound_end_to_end() {
+        use khive_pack_brain::BrainPack;
+
+        let rt = build_full_rt_with_brain();
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns.clone()).expect("token");
+        let note_id = rt
+            .create_note(
+                &token,
+                "memory",
+                None,
+                "adr104b clamp probe note",
+                Some(0.6),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create note")
+            .id;
+
+        let brain = BrainPack::new(rt.clone());
+        let mut builder = VerbRegistryBuilder::new();
+        builder.register(KgPack::new(rt.clone()));
+        builder.register(MemoryPack::new(rt.clone()));
+        builder.register(brain);
+        let registry = builder.build().expect("registry");
+
+        registry
+            .dispatch(
+                "brain.create_profile",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "name": "adr104b-clamp-v1",
+                    "consumer_kind": "recall",
+                }),
+            )
+            .await
+            .expect("create profile");
+
+        let baseline = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "adr104b clamp probe note",
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("baseline recall");
+        let baseline_score = baseline.as_array().expect("array")[0]["rank_score"]
+            .as_f64()
+            .expect("rank_score");
+
+        adr104_skew_salience(&registry, "adr104b-clamp-v1", note_id, 200).await;
+
+        let saturated = registry
+            .dispatch(
+                "memory.recall",
+                serde_json::json!({
+                    "namespace": ns.as_str(),
+                    "query": "adr104b clamp probe note",
+                    "profile_id": "adr104b-clamp-v1",
+                    "include_breakdown": true,
+                    "limit": 10
+                }),
+            )
+            .await
+            .expect("saturated-profile recall");
+        let hits = saturated.as_array().expect("array");
+        let saturated_score = hits[0]["rank_score"].as_f64().expect("rank_score");
+        let ent_mean = hits[0]["breakdown"]["entity_posterior_mean"]
+            .as_f64()
+            .expect("entity_posterior_mean present after 200 signals");
+        assert!(
+            ent_mean > 0.95,
+            "expected a near-saturated mean, got {ent_mean}"
+        );
+
+        // 200 "useful" signals also drive the global salience posterior
+        // (component 1) far from its prior, so `saturated_score` reflects
+        // both components, not component 2 alone. Bound the *entity term's*
+        // contribution directly instead of the composite ratio: divide out
+        // the component-1 (profile_component) ratio the response already
+        // reports, leaving only component 2's multiplier for the assertion.
+        let profile_component = hits[0]["breakdown"]["profile_component"]
+            .as_f64()
+            .expect("profile_component present");
+        let implied_entity_term = (saturated_score / baseline_score) / profile_component;
+        assert!(
+            implied_entity_term <= crate::scoring::ENTITY_POSTERIOR_CLAMP_MAX as f64 + 1e-6,
+            "entity term must never exceed the +15% clamp bound: implied={implied_entity_term}"
+        );
+        assert!(
+            implied_entity_term >= crate::scoring::ENTITY_POSTERIOR_CLAMP_MIN as f64 - 1e-6,
+            "entity term must never fall below the -15% clamp bound: implied={implied_entity_term}"
         );
     }
 

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -185,13 +185,13 @@ static MEMORY_HANDLERS: [HandlerDef; 10] = [
                 name: "min_score",
                 param_type: "number",
                 required: false,
-                description: "Minimum composite score to include (default 0.0). Composite scores are always in [0,1]: relevance is normalized to [0,1] per strategy (RRF rank-1 → 1.0; Weighted scores are [0,1] natively), and all three weighted contributions sum to at most 1.0. Typical production floor: 0.3–0.7.",
+                description: "Minimum rank_score to include (default 0.0). This filters `rank_score`, not `score`: `score` (absolute/raw relevance in each result) stays in [0,1] regardless of fusion strategy, but `rank_score` (the composite used for ranking and this filter) is the weighted relevance/salience/temporal composite — nominally [0,1] — further adjusted by ADR-104 posterior terms whenever a brain profile serves the request: a weight-reprojection component, and a per-entity term bounded to clamp(1 + 0.3 * (entity_posterior_mean - 0.5), 0.85, 1.15). So a served, positively-reinforced memory's rank_score can exceed 1.0 by up to 15%. Typical production floor: 0.3–0.7.",
             },
             ParamDef {
                 name: "score_floor",
                 param_type: "number",
                 required: false,
-                description: "Alias for min_score. Filter out hits below this composite score. Scores are always in [0,1] regardless of fusion strategy.",
+                description: "Alias for min_score. Filters by `rank_score`, not `score` — see min_score for the [0,1]-plus-up-to-15%-under-ADR-104 range of rank_score when a profile serves the request. `score` (absolute/raw relevance) stays in [0,1] regardless of fusion strategy or served profile.",
             },
             ParamDef {
                 name: "min_salience",

--- a/crates/khive-pack-memory/src/scoring.rs
+++ b/crates/khive-pack-memory/src/scoring.rs
@@ -742,6 +742,35 @@ pub fn calculate_score(input: &ScoreInput<'_>, config: &ScoringConfig) -> f32 {
     score.clamp(0.0, 1.0)
 }
 
+// ── ADR-104 §2 (Stage B): bounded per-entity posterior term ───────────────────
+
+/// Default weight for the per-entity posterior term. Chosen so the clamp
+/// bounds below are exactly reachable at posterior means of 0.0 and 1.0
+/// (`1 + 0.3 * (0.0 - 0.5) = 0.85`, `1 + 0.3 * (1.0 - 0.5) = 1.15`).
+pub const ENTITY_POSTERIOR_WEIGHT: f32 = 0.3;
+
+/// Lower bound of the per-entity posterior multiplier — the term can never
+/// move a score down by more than 15%.
+pub const ENTITY_POSTERIOR_CLAMP_MIN: f32 = 0.85;
+
+/// Upper bound of the per-entity posterior multiplier — the term can never
+/// move a score up by more than 15%.
+pub const ENTITY_POSTERIOR_CLAMP_MAX: f32 = 1.15;
+
+/// `clamp(1 + w_ent * (entity_posterior_mean - 0.5), 0.85, 1.15)`.
+///
+/// `None` (no posterior for this candidate beyond the uninformative prior)
+/// is neutral: exactly `1.0`, not the midpoint of the clamp band. Untouched
+/// memories must be unaffected — the neutral value has to be an identity
+/// multiplier, not a value that happens to fall inside the bounds.
+pub fn entity_posterior_term(entity_posterior_mean: Option<f64>, w_ent: f32) -> f32 {
+    match entity_posterior_mean {
+        Some(mean) => (1.0 + w_ent * (mean as f32 - 0.5))
+            .clamp(ENTITY_POSTERIOR_CLAMP_MIN, ENTITY_POSTERIOR_CLAMP_MAX),
+        None => 1.0,
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1196,5 +1225,58 @@ mod tests {
             AdjustmentCondition::EntityMatch.matches(&ctx),
             "boundary anchoring must not break matching the actual word"
         );
+    }
+
+    // ── ADR-104 §2 (Stage B): entity_posterior_term ────────────────────────────
+
+    #[test]
+    fn entity_posterior_term_neutral_when_no_posterior() {
+        assert_eq!(entity_posterior_term(None, ENTITY_POSTERIOR_WEIGHT), 1.0);
+    }
+
+    #[test]
+    fn entity_posterior_term_neutral_at_uninformative_prior_mean() {
+        // Beta(1,1) mean = 0.5 — the uninformative prior itself, distinct
+        // from `None`, must also be an identity multiplier.
+        let term = entity_posterior_term(Some(0.5), ENTITY_POSTERIOR_WEIGHT);
+        assert!((term - 1.0).abs() < 1e-6, "got {term}");
+    }
+
+    #[test]
+    fn entity_posterior_term_reaches_low_clamp_bound_at_mean_zero() {
+        let term = entity_posterior_term(Some(0.0), ENTITY_POSTERIOR_WEIGHT);
+        assert!(
+            (term - ENTITY_POSTERIOR_CLAMP_MIN).abs() < 1e-6,
+            "w_ent=0.3 at mean=0.0 must land exactly on the 0.85 clamp bound, got {term}"
+        );
+    }
+
+    #[test]
+    fn entity_posterior_term_reaches_high_clamp_bound_at_mean_one() {
+        let term = entity_posterior_term(Some(1.0), ENTITY_POSTERIOR_WEIGHT);
+        assert!(
+            (term - ENTITY_POSTERIOR_CLAMP_MAX).abs() < 1e-6,
+            "w_ent=0.3 at mean=1.0 must land exactly on the 1.15 clamp bound, got {term}"
+        );
+    }
+
+    #[test]
+    fn entity_posterior_term_never_exceeds_clamp_bounds_for_out_of_range_input() {
+        // A Beta posterior mean is mathematically bounded to [0, 1], but the
+        // clamp must hold defensively regardless — the term is never allowed
+        // to move a score by more than +-15% no matter what value reaches it.
+        let low = entity_posterior_term(Some(-5.0), ENTITY_POSTERIOR_WEIGHT);
+        let high = entity_posterior_term(Some(5.0), ENTITY_POSTERIOR_WEIGHT);
+        assert_eq!(low, ENTITY_POSTERIOR_CLAMP_MIN);
+        assert_eq!(high, ENTITY_POSTERIOR_CLAMP_MAX);
+    }
+
+    #[test]
+    fn entity_posterior_term_moves_monotonically_with_mean() {
+        let low = entity_posterior_term(Some(0.2), ENTITY_POSTERIOR_WEIGHT);
+        let mid = entity_posterior_term(Some(0.5), ENTITY_POSTERIOR_WEIGHT);
+        let high = entity_posterior_term(Some(0.8), ENTITY_POSTERIOR_WEIGHT);
+        assert!(low < mid, "low={low} mid={mid}");
+        assert!(mid < high, "mid={mid} high={high}");
     }
 }


### PR DESCRIPTION
Implements ADR-104 §2 (Stage B of the staged landing): one multiplicative term after rank_score computation, `clamp(1 + 0.3*(entity_posterior_mean - 0.5), 0.85, 1.15)`.

- Neutral (exactly 1.0) when the serving profile holds no posterior for the candidate — and at the uninformative prior mean itself. No minimum-evidence floor, per the resolved ADR open question.
- No profile serving the request → identity term for every hit → ranking unchanged vs pre-B.
- Single `HashMap::get` per candidate against the profile state Stage A already fetches once per recall — no second profile-state read (preserves the Stage A R2 overhead envelope: +83µs median).
- `entity_posterior_mean` breakdown field now populates with the value used; absent when no posterior.
- New pure-function unit tests (neutrality, clamp bounds, monotonicity) + row-B gate integration tests: feedback-lift (one `useful` signal changes next-query rank under that profile only), neutrality isolation, end-to-end clamp saturation.

Gates: fmt clean; clippy -D warnings clean (khive-pack-memory, khive-brain-core); tests 213 lib + 82 integration + 50 brain-core, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)