### PR TITLE
docs(adr): ADR-085 Amendment 2 — code.ingest verb, tiers, identity, acceptance; flip to Accepted

### DIFF
--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -1,6 +1,6 @@
 # ADR-085: Code Pack — Source-Code Ontology and Audit-Finding Vocabulary
 
-**Status**: Proposed\
+**Status**: Accepted\
 **Date**: 2026-07-03\
 **Authors**: khive maintainers
 **Depends on**: ADR-001 (Entity Kind Taxonomy — `entity_type` subtype registration), ADR-002
@@ -497,3 +497,138 @@ Whole-document validation runs before any record construction (all-or-nothing).
 The `findings.json` schema and producer contract are to be committed in-repo so the
 ingest consumer and its input contract live in one place. Producer tooling itself
 is out of scope for this repository.
+
+## Amendment 2 (2026-07-09): code.ingest verb + acceptance
+
+The base text left the Scanner/Extractor pipeline over the D2-D3 vocabulary as
+"separate ADR-069-layer work" and explicitly out of scope. That pipeline now has a
+design. This amendment specifies it as a single new verb, `code.ingest`, and closes
+the ADR to Accepted.
+
+### B1: One new verb, `code.ingest(path, db?, languages?)`
+
+The pack gains exactly one verb, following the precedent set by the git pack's
+single `git.digest` verb for a comparable bulk-intake surface. Signature:
+`code.ingest(path, db?, languages?=auto)`.
+
+- `path` is a folder, not necessarily a repository root. Monorepo subtree ingest
+  (a single crate, a single package directory) is first-class, not a special case
+  of whole-repo ingest.
+- `languages` defaults to automatic detection from manifest files
+  (`Cargo.toml`, `pyproject.toml`, `package.json`, Lean project files) and file
+  extensions under `path`; callers may pass an explicit language list to skip
+  detection or restrict scope.
+- `db` targets the destination database (see B7); it defaults to a workspace map
+  database, not the shared production graph.
+
+### B2: Pipeline shape
+
+The pipeline follows the Scanner/Extractor split from ADR-069: one Scanner per
+source language performs syntax-level parsing only, and a single Extractor,
+shared across all languages, maps Scanner output into this ADR's D2 subtypes and
+D3 edge rules. The Extractor is ontology-driven and source-blind: it has no
+per-language branching, only per-Scanner-output-shape adapters feeding one
+mapping table.
+
+Scanners are syntax-only in v1: no type-checking and no compilation. A
+declaration's doc comment is transcribed verbatim into its `description`
+property when present (ADR-069 D5, "transcribe, do not invent"); nothing is
+synthesized. Scanner sequencing, in delivery order: Rust (`syn`), Python
+(`rustpython-parser`), TypeScript (`oxc`), then Lean. The Lean scanner performs
+statement-text structural parsing; `structure`-level `extends` relationships
+require environment metadata that a syntax-only parse does not have, so that
+edge kind is an explicit boundary deferred past v1, consistent with this ADR's
+D3 finding that some relations need more than AST structure to resolve.
+
+### B3: Tiers
+
+Ingest proceeds in three tiers of increasing cost and completeness, each usable
+independently of the ones after it:
+
+- **L1 (manifest edges).** Pure manifest parsing (`Cargo.toml`, `pyproject.toml`,
+  `package.json`) yields `project depends_on project` edges with
+  `dependency_kind`, using the base endpoint contract's already-legal triple.
+  Requires no Scanner and covers every language with a package manifest.
+- **L1.5 (import-scan edges).** A regex-based import scan produces
+  module-to-module and project-to-project `depends_on` edges. This is the
+  coverage floor for a language that has no Scanner yet, and doubles as the
+  signal for which language to build a Scanner for next.
+- **L2 (symbol tier).** The full Scanner/Extractor pipeline (B2) over the D2
+  subtypes and D3 edge rules, at declaration granularity.
+
+### B4: Identity and idempotency
+
+Symbol identity is `uuid5` over `(source_project, module_path, name, kind)`,
+where `kind` is one of the four canonical D2 tokens (never an alias). A
+secondary `content_hash` property (a hash of the declaration body) detects
+changed-versus-unchanged content independently of identity. Because identity is
+derived from these fields rather than assigned per call, re-ingesting the same
+path is idempotent: the same declarations produce the same entity and edge
+identities, and repeated ingests do not accumulate duplicate rows. Ingesters
+write the canonical D2 tokens only; the alias-capture hazard documented in D2
+applies identically here.
+
+### B5: Staleness
+
+Ingest performs no automatic deletion. An entity absent from the most recent
+sweep of its source path receives a `properties.last_seen_at` stamp; whether a
+query surfaces it is a view-layer filtering decision, not a data-layer one
+(khive's data-versus-view principle: showing only current state is always a
+query concern, never a reason to delete, mutate, or transfer stored data).
+
+### B6: Cross-repo resolution
+
+An import specifier that names a project not yet ingested (a dependency on a
+crate or package that has not itself been scanned) does not fail the ingest.
+The specifier is recorded on the source entity as an unresolved reference, and
+within-source-project edges land normally. Resolution runs as a re-resolve pass:
+after any repository is ingested, previously recorded unresolved specifiers
+across the target database are replayed against the now-known symbol keys. This
+is the v1 mechanism; a deferred-edge queue that replays only the pending
+references relevant to a specific just-ingested project is a documented, more
+scalable v2 alternative once the number of interlinked repositories grows large
+enough that repeated full-database replay becomes costly.
+
+Once materialized, a cross-repository edge is an ordinary edge: repository
+provenance is carried as a `properties.source` value on the entity, not as a
+namespace distinction, so cross-repository and within-repository edges share
+the same relation semantics and query surface.
+
+### B7: Target database posture
+
+This amendment restates and does not relax the D6.1 granularity fence.
+Exhaustive, whole-repository symbol and call graphs are large by construction
+(comparable in scale to other Subject-scale ingests this codebase already
+supports) and target dedicated map databases via the existing direct-build
+path, not the shared production graph. Promoting a curated slice, such as the
+symbols and modules an agent's work has actually referenced, into the shared
+production database remains a separate, explicit, human-directed act. Ingest
+itself never performs that promotion automatically. `code.ingest`'s `db`
+parameter defaults to a workspace map database for this reason; pointing it at
+the production database is an explicit caller choice, not a default path.
+
+### B8: Acceptance
+
+An implementation of this amendment is acceptance-tested against two
+properties, both expressible as ordinary queries against the shared query
+surface (`neighbors` / `traverse` / `query`) with no additional tooling:
+
+1. **Codeflow parity**, per ingested repository:
+   - blast radius: a reverse, depth-bounded `depends_on` traversal from a named
+     symbol returns its callers;
+   - circular dependencies: a depth-bounded, self-returning `depends_on`
+     pattern at module level is detectable;
+   - dead symbols: the set of functions, datatypes, and interfaces with zero
+     incoming `depends_on` edges is listable (scoped to callers present in the
+     ingested set).
+2. **Cross-repository order independence**: ingesting two related repositories
+   in either order converges to the identical final edge set once both ingests
+   and any pending re-resolve pass have completed.
+
+### Explicitly deferred (unchanged from the base text's posture)
+
+Rename detection, the deferred-edge queue (B6's v2 alternative), Lean
+`structure`-level `extends` resolution, additional D2 subtypes beyond the four
+shipped, commit/PR entities, and any type-checked or semantic (as opposed to
+syntactic) extraction remain out of scope for this amendment, consistent with
+D6 and the base text's Alternatives Considered.

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -568,62 +568,90 @@ identities, and repeated ingests do not accumulate duplicate rows. Ingesters
 write the canonical D2 tokens only; the alias-capture hazard documented in D2
 applies identically here.
 
+Canonicalization of the two identity inputs is fixed, not left to per-caller
+convention:
+
+- `source_project` is the package name declared by the nearest governing
+  manifest at or above the ingested path (`Cargo.toml` `[package].name`,
+  `pyproject.toml` `[project].name`, `package.json` `name`, the Lean project
+  name for a Lean project file). When no such manifest is found above the
+  ingested path, `source_project` falls back to the basename of the ingested
+  folder.
+- `module_path` is the language's own canonical module path, relative to the
+  `source_project` root determined above: a Rust crate-relative `::` path, a
+  Python dotted module path, a TypeScript path relative to the package root
+  with the file extension stripped, and a Lean namespace path.
+- The `uuid5` namespace seed is a fixed, pack-level constant, following the
+  same pattern already used by the pack's existing findings-ingest identity
+  namespace.
+
 ### B5: Staleness
 
-Ingest performs no automatic deletion. An entity absent from the most recent
-sweep of its source path receives a `properties.last_seen_at` stamp; whether a
-query surfaces it is a view-layer filtering decision, not a data-layer one
-(khive's data-versus-view principle: showing only current state is always a
-query concern, never a reason to delete, mutate, or transfer stored data).
+Ingest performs no automatic deletion. Every entity present in a sweep has its
+`properties.last_seen_at` stamped to that sweep's time, recording when it was
+last observed. An entity absent from a sweep is left untouched: its
+`last_seen_at` keeps the value from its last observed sweep. Staleness
+filtering compares an entity's `last_seen_at` against the latest sweep time for
+its source; whether a query surfaces an entity below that threshold is a
+view-layer filtering decision, not a data-layer one (khive's data-versus-view
+principle: showing only current state is always a query concern, never a
+reason to delete, mutate, or transfer stored data).
 
 ### B6: Cross-repo resolution
 
 An import specifier that names a project not yet ingested (a dependency on a
 crate or package that has not itself been scanned) does not fail the ingest.
 The specifier is recorded on the source entity as an unresolved reference, and
-within-source-project edges land normally. Resolution runs as a re-resolve pass:
-after any repository is ingested, previously recorded unresolved specifiers
-across the target database are replayed against the now-known symbol keys. This
-is the v1 mechanism; a deferred-edge queue that replays only the pending
-references relevant to a specific just-ingested project is a documented, more
-scalable v2 alternative once the number of interlinked repositories grows large
-enough that repeated full-database replay becomes costly.
+within-`source_project` edges land normally. Resolution runs as a re-resolve
+pass: after any `source_project` is ingested, previously recorded unresolved
+specifiers across the target database are replayed against the now-known
+symbol keys. In v1 this pass runs synchronously as part of the same
+`code.ingest` call and completes before a successful return; there is no
+pending-resolution state exposed to callers in v1. A deferred-edge queue that
+replays only the pending references relevant to a specific just-ingested
+`source_project` is a documented, more scalable v2 alternative once the number
+of interlinked projects grows large enough that repeated full-database replay
+becomes costly.
 
-Once materialized, a cross-repository edge is an ordinary edge: repository
-provenance is carried as a `properties.source` value on the entity, not as a
-namespace distinction, so cross-repository and within-repository edges share
-the same relation semantics and query surface.
+Once materialized, a cross-project edge is an ordinary edge: source provenance
+is carried as a `properties.source` value on the entity, not as a namespace
+distinction, so cross-project and within-project edges share the same relation
+semantics and query surface.
 
 ### B7: Target database posture
 
 This amendment restates and does not relax the D6.1 granularity fence.
-Exhaustive, whole-repository symbol and call graphs are large by construction
-(comparable in scale to other Subject-scale ingests this codebase already
-supports) and target dedicated map databases via the existing direct-build
-path, not the shared production graph. Promoting a curated slice, such as the
+`code.ingest`'s `db` parameter selects among dedicated map databases only; the
+verb rejects the shared production database as a target for an exhaustive L2
+ingest. Exhaustive, whole-project symbol and call graphs are large by
+construction (comparable in scale to other Subject-scale ingests this codebase
+already supports) and target dedicated map databases via the existing
+direct-build path, never the shared production graph, with no override
+available on the ingest verb itself. Promoting a curated slice, such as the
 symbols and modules an agent's work has actually referenced, into the shared
-production database remains a separate, explicit, human-directed act. Ingest
-itself never performs that promotion automatically. `code.ingest`'s `db`
-parameter defaults to a workspace map database for this reason; pointing it at
-the production database is an explicit caller choice, not a default path.
+production database is a separate, explicit curation or import path, distinct
+from and never performed by `code.ingest`.
 
 ### B8: Acceptance
 
 An implementation of this amendment is acceptance-tested against two
 properties, both expressible as ordinary queries against the shared query
-surface (`neighbors` / `traverse` / `query`) with no additional tooling:
+surface (`neighbors` / `traverse` / `query`) with no additional tooling. The
+acceptance fixture supplies the traversal bound (`max_depth`) and the expected
+result for that bound; `max_depth=3` is the reference value used unless a
+fixture states otherwise.
 
-1. **Codeflow parity**, per ingested repository:
-   - blast radius: a reverse, depth-bounded `depends_on` traversal from a named
-     symbol returns its callers;
-   - circular dependencies: a depth-bounded, self-returning `depends_on`
-     pattern at module level is detectable;
+1. **Codeflow parity**, per ingested `source_project`:
+   - blast radius: a reverse `depends_on` traversal from a named symbol,
+     bounded by the fixture's `max_depth`, returns its callers;
+   - circular dependencies: a self-returning `depends_on` pattern at module
+     level, bounded by the fixture's `max_depth`, is detectable;
    - dead symbols: the set of functions, datatypes, and interfaces with zero
      incoming `depends_on` edges is listable (scoped to callers present in the
      ingested set).
-2. **Cross-repository order independence**: ingesting two related repositories
-   in either order converges to the identical final edge set once both ingests
-   and any pending re-resolve pass have completed.
+2. **Cross-project order independence**: ingesting two related
+   `source_project`s in either order converges to the identical final edge set
+   once both ingests and their synchronous re-resolve passes have completed.
 
 ### Explicitly deferred (unchanged from the base text's posture)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,7 +110,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-082](ADR-082-retrieval-quality-measurement-loop.md)     | Retrieval Quality Measurement Loop (Proposed)                                                                   |
 | [ADR-083](ADR-083-session-pack-t1-verbs.md)                  | Session Pack T1 Verb Surface (Accepted)                                                                         |
 | [ADR-084](ADR-084-verb-surface-consistency.md)               | Verb-Surface Consistency Contract and Live Ontology Introspection (Proposed)                                    |
-| [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary (Proposed)                                        |
+| [ADR-085](ADR-085-code-pack.md)                              | Code Pack — Source-Code Ontology and Audit-Finding Vocabulary (Accepted)                                        |
 | [ADR-086](ADR-086-doc-file-pack.md)                          | Document/File Modeling — Content on the Existing `document` Entity Kind (Proposed)                              |
 | [ADR-087](ADR-087-workspace-mirror.md)                       | Workspace Mirror — Folding `.khive/` Into the Graph Substrate (Proposed)                                        |
 | [ADR-088](ADR-088-git-lifecycle-pack.md)                     | Git-Lifecycle Pack — Commit and Issue Note Kinds (Proposed)                                                     |


### PR DESCRIPTION
Docs-only. Adds Amendment 2 to ADR-085 specifying the code.ingest pipeline the base text left as separate ADR-069-layer work, and flips the ADR status to Accepted (v0 shipped; this ratifies).

Amendment contents:
- B1: one new verb `code.ingest(path, db?, languages?=auto)` — folder-path input, monorepo subtree first-class (git.digest single-verb precedent)
- B2: Scanner/Extractor split per ADR-069; syntax-only Scanners (Rust/Python/TS/Lean order), one ontology-driven Extractor; Lean structure-extends deferred (needs environment metadata)
- B3: three tiers — L1 manifest edges, L1.5 regex import-scan floor, L2 full AST symbol tier
- B4: uuid5(source_project, module_path, name, kind) identity + content_hash; idempotent re-ingest; canonical tokens only
- B5: no auto-delete; last_seen_at staleness, view-layer filtering
- B6: cross-repo re-resolve pass (v1), deferred-edge queue documented as v2; provenance as properties.source, edges ordinary
- B7: D6.1 fence restated — map DB default, promotion to prod explicit and never automatic
- B8: acceptance — parity queries (blast radius, circular deps, dead symbols) + cross-repo ingest-order convergence tested in both orders

docs/adr/README.md index row updated to Accepted. deno fmt clean.