### PR TITLE
feat(runtime): daemon-resident schedule drain tick with missed-event policy

### DIFF
--- a/crates/khive-mcp/src/lib.rs
+++ b/crates/khive-mcp/src/lib.rs
@@ -8,6 +8,7 @@ pub mod coordinator;
 #[cfg(unix)]
 pub mod daemon;
 pub mod pack;
+pub mod pending_events;
 pub mod save_sink;
 pub mod serve;
 pub mod server;

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -288,7 +288,7 @@ pub async fn run_pending_events_on(
             let (sql, params): (String, Vec<SqlValue>) = match &cursor {
                 //
                 // The due-ness predicate compares via SQLite's `datetime()`,
-                // not a raw string `<=` (Ocean review, High finding): stored
+                // not a raw string `<=` (PR #782 review round 3, High finding): stored
                 // `trigger_at` values are NOT normalized to UTC —
                 // `khive-pack-schedule`'s `handle_remind`/`handle_schedule`
                 // deliberately round-trip the caller's original string
@@ -1047,7 +1047,7 @@ async fn discover_pending_namespaces(rt: &KhiveRuntime, now: DateTime<Utc>) -> R
     // candidate scan below, not the final due-ness decision — but a
     // namespace excluded HERE never reaches that scan at all, so it must be
     // held to the same correctness bar as the candidate-page queries
-    // (`datetime(...)` normalization, Ocean review High finding): comparing
+    // (`datetime(...)` normalization, PR #782 review round 3 High finding): comparing
     // `trigger_at` against `now` as raw TEXT is only chronologically correct
     // when every stored string happens to share `now`'s UTC offset.
     // `khive-pack-schedule` round-trips the caller's original `trigger_at`
@@ -1407,7 +1407,7 @@ mod tests {
     }
 
     /// A due event whose `trigger_at` carries a POSITIVE offset must still
-    /// fire (Ocean review, High finding).
+    /// fire (PR #782 review round 3, High finding).
     ///
     /// `khive-pack-schedule` round-trips the caller's original `trigger_at`
     /// string verbatim, offset included (H5) — it is never normalized to
@@ -1471,7 +1471,7 @@ mod tests {
     /// `datetime(...)` normalization correctly excludes it from the
     /// candidate page; even if it were fetched, the retained Rust-side
     /// `trigger_at > now` re-check is the belt-and-suspenders backstop that
-    /// already made this direction benign before the SQL fix (Ocean review:
+    /// already made this direction benign before the SQL fix (PR #782 review round 3:
     /// "Negative-offset strings produce false POSITIVES, which the retained
     /// Rust re-check filters — benign").
     #[tokio::test]

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -21,8 +21,9 @@
 //!   [`run_pending_events`] directly. Suitable for `* * * * * kkernel exec
 //!   --pending-events` to achieve minute-granularity delivery.
 //! - **Daemon-resident tick** (ADR-106): [`schedule_tick_loop`] calls
-//!   [`run_pending_events`] on a fixed interval for the lifetime of the warm
-//!   `khived` daemon process. Spawned only by the daemon role (mirrors the
+//!   [`run_pending_events_on`] against the daemon's own resolved `KhiveRuntime`
+//!   handle on a fixed interval for the lifetime of the warm `khived` daemon
+//!   process. Spawned only by the daemon role (mirrors the
 //!   `is_daemon_role` gate `khive-mcp::serve` already uses for the email
 //!   channel loops), never by a short-lived stdio client. Running both an
 //!   external cron entry and the daemon tick at once is safe: the drain's
@@ -169,6 +170,30 @@ pub async fn run_pending_events(
 
     let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     enforce_strict_actor_mode(rt.config().actor_id.as_deref(), &rt.config().packs)?;
+    run_pending_events_on(&rt, verbose).await
+}
+
+/// One-shot drain against an already-constructed [`KhiveRuntime`] (ADR-106
+/// fix-round: codex PR #782 review, High finding).
+///
+/// [`run_pending_events`] is the CLI-facing entry point (`kkernel exec
+/// --pending-events`): it resolves its own throwaway `RuntimeConfig` from raw
+/// `db`/`namespace` args, one fresh runtime per invocation, which is correct
+/// for a short-lived cron-invoked process.
+///
+/// The daemon-resident tick ([`schedule_tick_loop`]) must NOT do that: the
+/// daemon boot path (`khive-mcp::serve::build_server` /
+/// `build_registry_for_multi_backend`) already resolves `--config`,
+/// `[[backends]]`, actor identity, and `--pack` selection once at startup.
+/// Reconstructing a second, independent `RuntimeConfig::default()` inside the
+/// tick silently discards all of that: it can drain `$HOME/.khive/khive.db`
+/// instead of the configured schedule backend, trip strict-actor-mode
+/// failures the live server never has, and dispatch stored actions through a
+/// pack set the daemon never loaded. This function takes the daemon's own
+/// resolved, already-validated `&KhiveRuntime` by reference instead, so the
+/// tick's storage target, actor identity, and pack set are always identical
+/// to the server it is ticking for.
+pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<DrainSummary> {
     let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let now = Utc::now();
@@ -182,7 +207,7 @@ pub async fn run_pending_events(
     let stale_before = now
         .timestamp_micros()
         .saturating_sub(STALE_FIRING_TIMEOUT_MICROS);
-    summary.reclaimed = reclaim_stale_firing_events(&rt, stale_before).await?;
+    summary.reclaimed = reclaim_stale_firing_events(rt, stale_before).await?;
     if verbose && summary.reclaimed > 0 {
         eprintln!(
             "[pending-events] reclaimed {} stale \"firing\" row(s) back to \"pending\"",
@@ -191,7 +216,7 @@ pub async fn run_pending_events(
     }
 
     // ── Step 1: discover all distinct namespaces with pending scheduled_event notes ──
-    let namespaces = discover_pending_namespaces(&rt, now).await?;
+    let namespaces = discover_pending_namespaces(rt, now).await?;
 
     if verbose {
         eprintln!(
@@ -231,7 +256,20 @@ pub async fn run_pending_events(
             }
         };
 
-        // Page through all pending scheduled_event notes in this namespace.
+        // Snapshot every pending scheduled_event note in this namespace BEFORE
+        // any mutation (codex PR #782 review, Medium finding #2).
+        //
+        // The previous version paged `status="pending"` with LIMIT/OFFSET
+        // *while* processing each page mutated matching rows out of that same
+        // predicate (claim -> "firing" -> "fired"/"missed"/re-armed
+        // "pending"). Once page 1's 200 rows left the "pending" set, the
+        // page-2 query at `OFFSET 200` was evaluated against a result set
+        // that had already shrunk by 200 — row 201 (and beyond) was silently
+        // skipped for the entire pass. Reading the full candidate set into
+        // memory first, before any write touches this namespace's rows, means
+        // pagination happens only over a stable, unmutated snapshot; the
+        // mutation loop below then iterates the fixed-size `Vec` directly and
+        // never re-queries by offset.
         let filter = NoteFilter {
             kind: Some("scheduled_event".to_string()),
             property_filters: vec![PropertyFilter {
@@ -244,25 +282,36 @@ pub async fn run_pending_events(
         };
 
         const PAGE_SIZE: u32 = 200;
-        let mut offset: u64 = 0;
+        let mut candidates = Vec::new();
+        {
+            let mut offset: u64 = 0;
+            loop {
+                let page = store
+                    .query_notes_filtered(
+                        ns_str,
+                        &filter,
+                        PageRequest {
+                            limit: PAGE_SIZE,
+                            offset,
+                        },
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("pending-events: query_notes_filtered failed for ns={ns_str}")
+                    })?;
+                let page_len = page.items.len() as u32;
+                candidates.extend(page.items);
+                if page_len < PAGE_SIZE {
+                    break;
+                }
+                offset = offset
+                    .checked_add(u64::from(PAGE_SIZE))
+                    .ok_or_else(|| anyhow::anyhow!("pending-events: pagination offset overflow"))?;
+            }
+        }
 
-        loop {
-            let page = store
-                .query_notes_filtered(
-                    ns_str,
-                    &filter,
-                    PageRequest {
-                        limit: PAGE_SIZE,
-                        offset,
-                    },
-                )
-                .await
-                .with_context(|| {
-                    format!("pending-events: query_notes_filtered failed for ns={ns_str}")
-                })?;
-            let page_len = page.items.len() as u32;
-
-            for mut note in page.items {
+        {
+            for mut note in candidates {
                 summary.scanned += 1;
 
                 // Parse and check trigger_at.
@@ -345,7 +394,7 @@ pub async fn run_pending_events(
                 // guards the missed path: a missed event still needs
                 // exclusive ownership before it can be marked "missed" or
                 // re-armed to a future occurrence.
-                let claimed_firing_at = match claim_pending_event(&rt, ns_str, note.id).await {
+                let claimed_firing_at = match claim_pending_event(rt, ns_str, note.id).await {
                     Ok(c) => c,
                     Err(e) => {
                         if verbose {
@@ -399,7 +448,7 @@ pub async fn run_pending_events(
                     let updated_at = Utc::now().timestamp_micros();
 
                     match finalize_fired_event(
-                        &rt,
+                        rt,
                         ns_str,
                         note.id,
                         &props,
@@ -478,7 +527,7 @@ pub async fn run_pending_events(
                 // but defensively) raced in after the claim.
                 let final_props = note.properties.clone().unwrap_or_else(|| json!({}));
                 match finalize_fired_event(
-                    &rt,
+                    rt,
                     ns_str,
                     note.id,
                     &final_props,
@@ -521,13 +570,6 @@ pub async fn run_pending_events(
                     }
                 }
             }
-
-            if page_len < PAGE_SIZE {
-                break;
-            }
-            offset = offset
-                .checked_add(u64::from(PAGE_SIZE))
-                .ok_or_else(|| anyhow::anyhow!("pending-events: pagination offset overflow"))?;
         }
     }
 
@@ -954,35 +996,47 @@ pub fn tick_interval_from_env() -> std::time::Duration {
 
 /// Daemon-resident periodic drain loop (ADR-106).
 ///
-/// Runs [`run_pending_events`] on a fixed interval for as long as the daemon
-/// process lives. Only the daemon role spawns this loop (mirrors the
+/// Runs [`run_pending_events_on`] on a fixed interval for as long as the
+/// daemon process lives. Only the daemon role spawns this loop (mirrors the
 /// `is_daemon_role` gate `khive-mcp::serve` already applies to the email
 /// channel loops, #602) — a short-lived `kkernel exec`/stdio client process
 /// never calls this, so there is exactly one tick loop per live daemon.
 ///
-/// Each tick opens its own short-lived `KhiveRuntime` against `db`/
-/// `namespace` — the same construction `kkernel exec --pending-events` uses
-/// — rather than threading the daemon's own warm runtime through. This is a
-/// deliberate simplification: `khive-mcp::server::KhiveMcpServer` does not
-/// retain a single top-level `KhiveRuntime` handle (each pack holds its own),
-/// so reusing the daemon's live runtime here would need new plumbing through
-/// `DaemonDispatch`. Running the documented cron invocation in-process
-/// instead costs a connection-pool warm-up every tick but never a
-/// correctness risk: the drain's `pending -> firing` claim/finalize CAS
-/// already makes concurrent or overlapping invocations harmless by
-/// construction (see the module-level docs), exactly as it does for the
-/// still-supported external-cron redundancy.
+/// `rt` is the daemon's own resolved runtime handle for the `"schedule"` pack
+/// — for a single-backend boot, the one `KhiveRuntime` the whole daemon
+/// shares; for a multi-backend boot (ADR-028 `[[backends]]`), the specific
+/// per-pack runtime `schedule` was wired to. `khive-mcp::serve::build_server`
+/// resolves this once at daemon boot (the same `--config`/`[[backends]]`/
+/// actor-identity/`--pack` resolution the live server itself uses) and passes
+/// it through here, so every tick drains the SAME storage target under the
+/// SAME actor identity and pack set as the daemon it belongs to — never a
+/// silently-reconstructed `RuntimeConfig::default()` (codex PR #782 review,
+/// High finding: a config-backed daemon's tick could otherwise drain
+/// `$HOME/.khive/khive.db` instead of the configured backend, trip
+/// strict-actor-mode failures the live server never has, or dispatch stored
+/// actions through packs the daemon never loaded). `rt.clone()` is cheap
+/// (`KhiveRuntime` is `Arc`-wrapped internally) — every tick reuses the same
+/// warm connection pool rather than opening a fresh one.
+///
+/// Ticks on a fixed `tokio::time::interval` with
+/// [`tokio::time::MissedTickBehavior::Skip`] rather than sleeping `interval`
+/// AFTER each drain: a sleep-after-drain loop's effective cadence is
+/// `interval + drain_duration`, which drifts further behind on every pass
+/// that finds a nontrivial backlog (codex PR #782 review, Medium finding
+/// "tick cadence deviates from the accepted interval contract" — ADR-106
+/// specifies a fixed interval). The first tick fires after one full
+/// `interval` has elapsed (via `interval_at(now + interval, interval)`),
+/// matching the original sleep-based boot behavior instead of draining
+/// immediately at daemon start.
 ///
 /// A per-tick failure (e.g. a transient SQL error) is logged and does not
 /// stop the loop — the next tick simply tries again.
-pub async fn schedule_tick_loop(
-    db: Option<String>,
-    namespace: String,
-    interval: std::time::Duration,
-) {
+pub async fn schedule_tick_loop(rt: KhiveRuntime, interval: std::time::Duration) {
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
-        tokio::time::sleep(interval).await;
-        match run_pending_events(db.as_deref(), &namespace, false).await {
+        ticker.tick().await;
+        match run_pending_events_on(&rt, false).await {
             Ok(summary) => {
                 if summary.fired > 0
                     || summary.advanced > 0
@@ -1954,21 +2008,35 @@ mod tests {
     /// The headline regression: 9 non-repeating events overdue well beyond
     /// the default grace window (300s) must ALL be marked `"missed"` and
     /// NONE dispatched. This is the first-boot-against-a-large-backlog
-    /// scenario the ADR-106 amendment calls out explicitly. The action DSL
-    /// is deliberately a verb (`create`) that would leave an observable
-    /// trace if dispatched, so a regression that accidentally fires the
-    /// missed path would be caught by `summary.fired`/`summary.advanced`
-    /// being non-zero, not just by inspecting note status.
+    /// scenario the ADR-106 amendment calls out explicitly. The action DSL is
+    /// deliberately a genuinely side-effecting verb (`create`, writing a
+    /// distinctively-tagged `observation` note) rather than the read-only
+    /// `stats()`, and the test asserts that note is ABSENT after the drain —
+    /// not just that `summary.fired`/`summary.advanced` read zero. A
+    /// regression that accidentally fires the missed path would otherwise be
+    /// caught only by the summary counters, which is weaker evidence than
+    /// confirming the action's own write never landed (codex PR #782 review,
+    /// Low finding: the previous fixture used `stats()`, contradicting this
+    /// comment's claim of a side-effecting action).
     #[tokio::test]
     async fn nine_overdue_events_beyond_grace_are_missed_with_zero_dispatch() {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
         let past = "2000-01-01T00:00:00Z";
+        let marker = "nine-overdue-zero-dispatch-marker";
+        let action_dsl = format!("create(kind=\"observation\", content=\"{marker}\")");
         let mut ids = Vec::new();
         for _ in 0..9 {
-            let id =
-                create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            let id = create_scheduled_event(
+                &rt,
+                "local",
+                past,
+                Some(action_dsl.as_str()),
+                None,
+                "schedule",
+            )
+            .await;
             ids.push(id);
         }
 
@@ -2011,6 +2079,29 @@ mod tests {
                 "note {id} must never have fired_at set (never dispatched), got {props:?}"
             );
         }
+
+        // Strongest evidence: the side-effecting action's own output record
+        // must be entirely absent — not merely "summary says zero fired".
+        let ns = Namespace::parse("local").unwrap();
+        let token = rt.authorize(ns).expect("authorize");
+        let store = rt.notes(&token).expect("notes");
+        let page = store
+            .query_notes(
+                "local",
+                Some("observation"),
+                PageRequest {
+                    limit: 50,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query observation notes");
+        let marker_hits: Vec<_> = page.items.iter().filter(|n| n.content == marker).collect();
+        assert!(
+            marker_hits.is_empty(),
+            "the missed action must never dispatch: found {} marker note(s): {marker_hits:?}",
+            marker_hits.len()
+        );
     }
 
     /// An event overdue by less than the grace window must still fire
@@ -2115,5 +2206,112 @@ mod tests {
             "re-armed trigger_at must be the very next occurrence, not skip further \
              (no catch-up burst), got {new_trigger} (now={now})"
         );
+    }
+
+    /// A backlog larger than the drain's internal page size (200) must be
+    /// fully processed in ONE drain pass, not silently truncated at the page
+    /// boundary (codex PR #782 review, Medium finding: the previous
+    /// implementation paged `status="pending"` with `LIMIT/OFFSET` while
+    /// simultaneously mutating rows out of that predicate, so once the first
+    /// page's 200 rows left `"pending"`, the page-2 query at `OFFSET 200`
+    /// undercounted and silently skipped every row beyond the first page).
+    /// 201 rows — one more than `PAGE_SIZE` — reproduces the exact boundary
+    /// codex identified.
+    #[tokio::test]
+    async fn backlog_larger_than_page_size_is_fully_drained_in_one_pass() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        const OVERDUE_ROW_COUNT: usize = 201; // PAGE_SIZE (200) + 1
+        let past = "2000-01-01T00:00:00Z"; // far beyond the missed-event grace window
+        let mut ids = Vec::with_capacity(OVERDUE_ROW_COUNT);
+        for _ in 0..OVERDUE_ROW_COUNT {
+            let id =
+                create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            ids.push(id);
+        }
+
+        let summary = run_pending_events(Some(&db_path), "local", false)
+            .await
+            .expect("drain");
+
+        assert_eq!(
+            summary.scanned, OVERDUE_ROW_COUNT as u64,
+            "every overdue row across both pages must be scanned in one pass, got \
+             summary={summary:?}"
+        );
+        assert_eq!(
+            summary.missed.len(),
+            OVERDUE_ROW_COUNT,
+            "every overdue row across both pages must be marked missed in one pass \
+             (the page-boundary row must not be skipped), got summary={summary:?}"
+        );
+        for id in &ids {
+            assert!(
+                summary.missed.contains(id),
+                "missed list must name every row, including ones beyond the first page"
+            );
+        }
+        for id in ids {
+            let props = get_note_props(&rt, id).await;
+            assert_eq!(
+                props["status"].as_str(),
+                Some("missed"),
+                "note {id} must end in status=missed (not left pending past the page \
+                 boundary), got {props:?}"
+            );
+        }
+    }
+
+    /// Two concurrent drain passes over the same store must never double-fire
+    /// a row: the `pending -> firing` CAS claim (`claim_pending_event`) makes
+    /// exactly one of the two concurrent callers win each row (codex PR #782
+    /// review, Medium finding: Amendment B claims Acceptance Criterion 2 is
+    /// met, but no regression exercised concurrent drains until now).
+    #[tokio::test]
+    async fn concurrent_drains_fire_each_row_exactly_once() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        const ROW_COUNT: usize = 20;
+        let past = due_rfc3339(); // in-grace: exercises the normal fire path, not missed
+        let mut ids = Vec::with_capacity(ROW_COUNT);
+        for _ in 0..ROW_COUNT {
+            let id = create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule")
+                .await;
+            ids.push(id);
+        }
+
+        let db_path_a = db_path.clone();
+        let db_path_b = db_path.clone();
+        let (summary_a, summary_b) = tokio::join!(
+            async move { run_pending_events(Some(&db_path_a), "local", false).await },
+            async move { run_pending_events(Some(&db_path_b), "local", false).await },
+        );
+        let summary_a = summary_a.expect("drain A");
+        let summary_b = summary_b.expect("drain B");
+
+        let total_dispatched =
+            summary_a.fired + summary_a.advanced + summary_b.fired + summary_b.advanced;
+        assert_eq!(
+            total_dispatched, ROW_COUNT as u64,
+            "every row must be dispatched exactly once across both concurrent drains, \
+             got a={summary_a:?} b={summary_b:?}"
+        );
+        assert_eq!(
+            summary_a.failed + summary_b.failed,
+            0,
+            "the CAS claim must make the losing drain skip cleanly (skipped_race), \
+             never fail: a={summary_a:?} b={summary_b:?}"
+        );
+
+        for id in ids {
+            let props = get_note_props(&rt, id).await;
+            assert_eq!(
+                props["status"].as_str(),
+                Some("fired"),
+                "note {id} must end fired exactly once, got {props:?}"
+            );
+        }
     }
 }

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -215,7 +215,7 @@ pub async fn run_pending_events(
 ///
 /// [`run_pending_events`] is the CLI-facing entry point (`kkernel exec
 /// --pending-events`); it now resolves both `rt` and `server` via
-/// `khive-mcp::serve::build_server`, the same multi-backend-aware
+/// `khive-mcp::serve::build_server_with_explicit_namespace`, the same multi-backend-aware
 /// construction the daemon boot path uses, one fresh pair per invocation —
 /// correct for a short-lived cron-invoked process.
 ///

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -1,13 +1,34 @@
-//! `kkernel exec --pending-events` — one-shot scheduled event drain.
+//! Scheduled event drain — `kkernel exec --pending-events` (one-shot) and the
+//! daemon-resident tick (ADR-106, [`schedule_tick_loop`]).
 //!
 //! Scans all `scheduled_event` notes with `status="pending"` whose `trigger_at`
 //! is at or before now, fires their stored action through the registry in the
 //! event's own namespace, marks each as `"fired"`, and advances repeating events
-//! to their next occurrence.
+//! to their next occurrence. Events overdue by more than the configured grace
+//! window are never dispatched — see "Missed-event policy" below.
 //!
-//! This is a cron-friendly one-shot drain. It is NOT a long-running daemon.
-//! Run it from cron (e.g. `* * * * * kkernel exec --pending-events`) to achieve
-//! minute-granularity delivery.
+//! This module lives in `khive-mcp` (not `kkernel`, where it originated)
+//! because the daemon tick loop needs to call it in-process from
+//! `khive-mcp::serve`, and `khive-runtime` (where the daemon's socket/accept
+//! loop lives) cannot depend back on `khive-mcp` (`khive-mcp` already depends
+//! on `khive-runtime` — a dependency the other way would cycle). `kkernel`
+//! already depends on `khive-mcp`, so its `exec --pending-events` entry point
+//! simply calls [`run_pending_events`] here instead of a local module.
+//!
+//! ## Invocation modes
+//!
+//! - **One-shot** (`kkernel exec --pending-events`, cron-friendly): call
+//!   [`run_pending_events`] directly. Suitable for `* * * * * kkernel exec
+//!   --pending-events` to achieve minute-granularity delivery.
+//! - **Daemon-resident tick** (ADR-106): [`schedule_tick_loop`] calls
+//!   [`run_pending_events`] on a fixed interval for the lifetime of the warm
+//!   `khived` daemon process. Spawned only by the daemon role (mirrors the
+//!   `is_daemon_role` gate `khive-mcp::serve` already uses for the email
+//!   channel loops), never by a short-lived stdio client. Running both an
+//!   external cron entry and the daemon tick at once is safe: the drain's
+//!   `pending -> firing` CAS claim (`claim_pending_event`) makes concurrent or
+//!   overlapping invocations harmless by construction — at most one caller
+//!   ever wins a given row.
 //!
 //! ## Namespace isolation
 //!
@@ -28,19 +49,48 @@
 //! machine-readable next-fire semantics exist for cron form). Events with a cron
 //! `repeat` are fired and then marked `"fired"` (one-shot). See issue #14 for the
 //! tracking note.
+//!
+//! ## Missed-event policy (ADR-106 amendment)
+//!
+//! An event is "missed" when it is discovered overdue by more than
+//! `KHIVE_FIRE_GRACE_SECS` (default 300s / 5 minutes). A missed event is
+//! **never dispatched** — it is marked `status="missed"` with `missed_at`
+//! stamped (epoch µs) and `fired_at` left null. A missed *repeating* event is
+//! skipped for this occurrence and re-armed at the next occurrence strictly
+//! after now (looping past every accumulated occurrence) — it never fires a
+//! catch-up burst. This means a daemon that was offline for a long stretch
+//! (or a first boot against a store with a large stale backlog) marks the
+//! entire overdue backlog missed on its first tick and dispatches zero of
+//! them. See the ADR-106 amendment for the full rationale and the prior-art
+//! comparison.
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Months, Utc};
 use serde_json::{json, Value};
 
-use khive_mcp::serve::enforce_strict_actor_mode;
-use khive_mcp::server::KhiveMcpServer;
-use khive_mcp::tools::request::RequestParams;
+use crate::serve::enforce_strict_actor_mode;
+use crate::server::KhiveMcpServer;
+use crate::tools::request::RequestParams;
 use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
 use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter, SortDir};
 use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 
-use crate::dbpath::resolve_db_override;
+/// Resolve the `--db`/`KHIVE_DB` value into a `db_path` override, mirroring
+/// `kkernel mcp`: an explicit `:memory:` means the ephemeral in-memory db
+/// (`None`), not a file literally named ":memory:" (which SQLite treats as a
+/// per-connection file → empty schema). `None` leaves the default in place.
+///
+/// Intentionally duplicated from `kkernel::dbpath::resolve_db_override`
+/// rather than shared: `kkernel` depends on `khive-mcp`, so the reverse
+/// dependency this module would need to reuse that copy is unavailable, and
+/// the function is an 8-line pure mapping — not worth a new shared crate.
+fn resolve_db_override(db: Option<&str>) -> Option<Option<std::path::PathBuf>> {
+    match db {
+        Some(":memory:") => Some(None),
+        Some(path) => Some(Some(std::path::PathBuf::from(path))),
+        None => None,
+    }
+}
 
 /// A `scheduled_event` row stuck in `status="firing"` for longer than this is
 /// considered abandoned by a drain process that crashed or was killed between
@@ -56,6 +106,23 @@ use crate::dbpath::resolve_db_override;
 /// still-in-flight claim is never mistaken for an abandoned one.
 const STALE_FIRING_TIMEOUT_MICROS: i64 = 5 * 60 * 1_000_000;
 
+/// Default grace window (seconds): an event discovered overdue by more than
+/// this is "missed" rather than fired late. Overridable via
+/// `KHIVE_FIRE_GRACE_SECS`. See the module-level "Missed-event policy" docs.
+const DEFAULT_FIRE_GRACE_SECS: i64 = 300;
+
+/// Resolve the missed-event grace window from `KHIVE_FIRE_GRACE_SECS`,
+/// falling back to [`DEFAULT_FIRE_GRACE_SECS`] when unset or unparseable as a
+/// non-negative integer.
+fn fire_grace_from_env() -> Duration {
+    let secs = std::env::var("KHIVE_FIRE_GRACE_SECS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|&s| s >= 0)
+        .unwrap_or(DEFAULT_FIRE_GRACE_SECS);
+    Duration::seconds(secs)
+}
+
 /// Summary of a single drain run.
 #[derive(Debug, Default)]
 pub struct DrainSummary {
@@ -66,6 +133,10 @@ pub struct DrainSummary {
     pub skipped_not_due: u64,
     pub skipped_race: u64,
     pub reclaimed: u64,
+    /// IDs of `scheduled_event` notes marked `"missed"` (or re-armed past a
+    /// missed occurrence) this pass — never dispatched. See the module-level
+    /// "Missed-event policy" docs.
+    pub missed: Vec<uuid::Uuid>,
 }
 
 /// One-shot drain: fire all pending, due scheduled events.
@@ -101,6 +172,7 @@ pub async fn run_pending_events(
     let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let now = Utc::now();
+    let grace = fire_grace_from_env();
     let mut summary = DrainSummary::default();
 
     // ── Step 0: reclaim rows abandoned mid-fire by a crashed/killed drain ──
@@ -219,6 +291,15 @@ pub async fn run_pending_events(
                     continue;
                 }
 
+                // ── Missed-event grace policy (ADR-106 amendment) ─────────
+                // An event overdue by more than `grace` is never dispatched:
+                // agent-facing side effects (outbound mail, spawned actions)
+                // must not fire late en masse after a daemon outage or a
+                // first boot against a large stale backlog. See the
+                // module-level "Missed-event policy" docs.
+                let overdue = now.signed_duration_since(trigger_at);
+                let is_missed = overdue > grace;
+
                 // ── Determine what to dispatch ───────────────────────────
                 let event_type = note
                     .properties
@@ -227,7 +308,7 @@ pub async fn run_pending_events(
                     .and_then(Value::as_str)
                     .unwrap_or("remind");
 
-                let action_dsl: Option<String> = if event_type == "schedule" {
+                let action_dsl: Option<String> = if event_type == "schedule" && !is_missed {
                     note.properties
                         .as_ref()
                         .and_then(|p| p.get("payload"))
@@ -237,8 +318,20 @@ pub async fn run_pending_events(
                     // remind events: no DSL action to dispatch. We mark as fired
                     // to acknowledge the trigger. The notification channel (comm,
                     // channel transport, etc.) is out of scope for this drain.
+                    // Missed `schedule` events take this branch too: the whole
+                    // point of the missed policy is that the action is never
+                    // dispatched.
                     None
                 };
+
+                // ── Determine repeat (read before claim; only informs which
+                // finalize branch runs below, never mutates the snapshot) ──
+                let repeat = note
+                    .properties
+                    .as_ref()
+                    .and_then(|p| p.get("repeat"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
 
                 // ── Claim the row before dispatch (issue #462, fire side) ──
                 // `note` is a snapshot read by the page query above; a
@@ -248,7 +341,10 @@ pub async fn run_pending_events(
                 // matches status='pending') fails once we've claimed it, and
                 // (b) if cancel already won the race, our claim fails and we
                 // skip — the drain can no longer clobber a cancel that
-                // landed between the read and this point.
+                // landed between the read and this point. The same claim
+                // guards the missed path: a missed event still needs
+                // exclusive ownership before it can be marked "missed" or
+                // re-armed to a future occurrence.
                 let claimed_firing_at = match claim_pending_event(&rt, ns_str, note.id).await {
                     Ok(c) => c,
                     Err(e) => {
@@ -271,6 +367,70 @@ pub async fn run_pending_events(
                     continue;
                 };
 
+                if is_missed {
+                    // ── Missed path: never dispatch. Mark terminally
+                    // "missed", or (for a repeat) re-arm past every
+                    // accumulated occurrence to the next future one — no
+                    // catch-up bursts. ─────────────────────────────────────
+                    if verbose {
+                        eprintln!(
+                            "[pending-events] note {} overdue by {}s (grace {}s): marking \
+                             missed, not dispatching",
+                            note.id,
+                            overdue.num_seconds(),
+                            grace.num_seconds()
+                        );
+                    }
+                    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+                    props["missed_at"] = json!(now.timestamp_micros());
+                    match advance_repeat_past_missed(&repeat, trigger_at, now) {
+                        Some(next_at) => {
+                            // Repeating event: skip this occurrence, re-arm
+                            // pending at the next future one.
+                            props["trigger_at"] = json!(next_at.to_rfc3339());
+                            props["status"] = json!("pending");
+                        }
+                        None => {
+                            // Non-repeating (or non-advancing cron): terminal
+                            // "missed". `fired_at` stays null/untouched.
+                            props["status"] = json!("missed");
+                        }
+                    }
+                    let updated_at = Utc::now().timestamp_micros();
+
+                    match finalize_fired_event(
+                        &rt,
+                        ns_str,
+                        note.id,
+                        &props,
+                        updated_at,
+                        claimed_firing_at,
+                    )
+                    .await
+                    {
+                        Ok(true) => {
+                            summary.missed.push(note.id);
+                        }
+                        Ok(false) => {
+                            if verbose {
+                                eprintln!(
+                                    "[pending-events] finalize no-op for {}: row no longer in \
+                                     \"firing\" state",
+                                    note.id
+                                );
+                            }
+                            summary.failed += 1;
+                        }
+                        Err(e) => {
+                            if verbose {
+                                eprintln!("[pending-events] finalize failed for {}: {e}", note.id);
+                            }
+                            summary.failed += 1;
+                        }
+                    }
+                    continue;
+                }
+
                 // ── Dispatch the action ──────────────────────────────────
                 if let Some(dsl) = &action_dsl {
                     let dispatch_result = dispatch_action(dsl, ns_str, &server, verbose).await;
@@ -287,14 +447,6 @@ pub async fn run_pending_events(
                         // field to distinguish clean fires from error fires.)
                     }
                 }
-
-                // ── Determine repeat ─────────────────────────────────────
-                let repeat = note
-                    .properties
-                    .as_ref()
-                    .and_then(|p| p.get("repeat"))
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
 
                 let fired_at_rfc = Utc::now().to_rfc3339();
                 let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
@@ -584,6 +736,36 @@ fn is_five_field_cron(expr: &str) -> bool {
     expr.split_whitespace().count() == 5
 }
 
+/// Advance a missed repeating event's `trigger_at` past every occurrence at
+/// or before `now`, landing on the first occurrence strictly after `now`
+/// (ADR-106 missed-event amendment). This is what makes a missed repeat
+/// re-arm without ever firing a catch-up burst: a daily reminder that was
+/// due 10 times while the daemon was down skips straight to tomorrow's
+/// occurrence instead of firing 10 times in a row.
+///
+/// Returns `None` when the event does not advance at all (no `repeat`, or an
+/// unsupported cron form per [`next_trigger_at`]) — the caller then marks the
+/// event terminally `"missed"` instead of re-arming it.
+///
+/// Terminates because [`next_trigger_at`]'s named-alias arms are always
+/// strictly increasing (`current + positive duration`), so each loop
+/// iteration moves `current` forward; `now` is fixed, so the loop reaches
+/// `next > now` in a bounded number of steps.
+fn advance_repeat_past_missed(
+    repeat: &Option<String>,
+    current: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    let mut current = current;
+    loop {
+        let next = next_trigger_at(repeat, current)?;
+        if next > now {
+            return Some(next);
+        }
+        current = next;
+    }
+}
+
 /// Dispatch a DSL action string in the given namespace.
 ///
 /// The action is wrapped as a JSON-form batch with `namespace` injected into
@@ -738,6 +920,8 @@ pub fn print_summary(summary: &DrainSummary) {
         "skipped_not_due": summary.skipped_not_due,
         "skipped_race": summary.skipped_race,
         "reclaimed": summary.reclaimed,
+        "missed_count": summary.missed.len(),
+        "missed_ids": summary.missed.iter().map(uuid::Uuid::to_string).collect::<Vec<_>>(),
     });
     println!(
         "{}",
@@ -750,6 +934,79 @@ pub fn print_summary(summary: &DrainSummary) {
 // KhiveRuntime exposes `sql()` as an accessor to the SqlAccess trait object.
 // We use it here for the namespace-discovery query.
 
+/// Default interval between daemon-resident schedule ticks, in seconds.
+/// Matches the cadence the module doc already documents for the external-cron
+/// invocation (`* * * * * kkernel exec --pending-events` is minute-grain;
+/// 60s is the same order of magnitude for the in-daemon tick).
+const DEFAULT_TICK_INTERVAL_SECS: u64 = 60;
+
+/// Resolve the daemon tick interval from `KHIVE_SCHEDULE_TICK_SECS`, falling
+/// back to `DEFAULT_TICK_INTERVAL_SECS` (60s) when unset or not a positive
+/// integer.
+pub fn tick_interval_from_env() -> std::time::Duration {
+    let secs = std::env::var("KHIVE_SCHEDULE_TICK_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(DEFAULT_TICK_INTERVAL_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Daemon-resident periodic drain loop (ADR-106).
+///
+/// Runs [`run_pending_events`] on a fixed interval for as long as the daemon
+/// process lives. Only the daemon role spawns this loop (mirrors the
+/// `is_daemon_role` gate `khive-mcp::serve` already applies to the email
+/// channel loops, #602) — a short-lived `kkernel exec`/stdio client process
+/// never calls this, so there is exactly one tick loop per live daemon.
+///
+/// Each tick opens its own short-lived `KhiveRuntime` against `db`/
+/// `namespace` — the same construction `kkernel exec --pending-events` uses
+/// — rather than threading the daemon's own warm runtime through. This is a
+/// deliberate simplification: `khive-mcp::server::KhiveMcpServer` does not
+/// retain a single top-level `KhiveRuntime` handle (each pack holds its own),
+/// so reusing the daemon's live runtime here would need new plumbing through
+/// `DaemonDispatch`. Running the documented cron invocation in-process
+/// instead costs a connection-pool warm-up every tick but never a
+/// correctness risk: the drain's `pending -> firing` claim/finalize CAS
+/// already makes concurrent or overlapping invocations harmless by
+/// construction (see the module-level docs), exactly as it does for the
+/// still-supported external-cron redundancy.
+///
+/// A per-tick failure (e.g. a transient SQL error) is logged and does not
+/// stop the loop — the next tick simply tries again.
+pub async fn schedule_tick_loop(
+    db: Option<String>,
+    namespace: String,
+    interval: std::time::Duration,
+) {
+    loop {
+        tokio::time::sleep(interval).await;
+        match run_pending_events(db.as_deref(), &namespace, false).await {
+            Ok(summary) => {
+                if summary.fired > 0
+                    || summary.advanced > 0
+                    || summary.failed > 0
+                    || !summary.missed.is_empty()
+                {
+                    tracing::info!(
+                        scanned = summary.scanned,
+                        fired = summary.fired,
+                        advanced = summary.advanced,
+                        missed = summary.missed.len(),
+                        failed = summary.failed,
+                        reclaimed = summary.reclaimed,
+                        "schedule tick: drain pass complete"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "schedule tick: drain pass failed");
+            }
+        }
+    }
+}
+
 // ── tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -761,6 +1018,15 @@ mod tests {
         let f = NamedTempFile::new().expect("tempfile");
         let path = f.path().to_str().expect("utf8 path").to_string();
         (f, path)
+    }
+
+    /// An RFC 3339 timestamp a few seconds in the past — due, but comfortably
+    /// inside the default 300s missed-event grace window (ADR-106 amendment),
+    /// so tests exercising the normal fire/advance path aren't swept into the
+    /// missed path by a fixed year-2000 sentinel. Tests exercising the missed
+    /// path itself use their own far-past or `now`-relative timestamps.
+    fn due_rfc3339() -> String {
+        (Utc::now() - Duration::seconds(5)).to_rfc3339()
     }
 
     async fn make_rt(db_path: &str) -> KhiveRuntime {
@@ -837,10 +1103,12 @@ mod tests {
 
         // Create a past-due schedule event. Use stats() as the action since it's
         // a valid, registered verb that has no side-effects that need a
-        // namespace argument check.
-        let past = "2000-01-01T00:00:00Z";
+        // namespace argument check. `due_rfc3339` is only a few seconds
+        // overdue — inside the missed-event grace window — so this exercises
+        // the normal fire path, not the ADR-106 missed path.
+        let past = due_rfc3339();
         let id =
-            create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule").await;
 
         let summary = run_pending_events(Some(&db_path), "local", false)
             .await
@@ -893,9 +1161,9 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        let past = "2000-01-01T00:00:00Z";
+        let past = due_rfc3339();
         let id =
-            create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule").await;
 
         // First drain — fires the event.
         let s1 = run_pending_events(Some(&db_path), "local", false)
@@ -931,12 +1199,12 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        // Use a past trigger_at with daily repeat.
-        let past = "2000-06-01T09:00:00Z";
+        // Use a past (but in-grace) trigger_at with daily repeat.
+        let past = due_rfc3339();
         let id = create_scheduled_event(
             &rt,
             "local",
-            past,
+            &past,
             Some("stats()"),
             Some("daily"),
             "schedule",
@@ -981,9 +1249,10 @@ mod tests {
         // in ns-a without touching the ns-b namespace counts.
         let ns_a = "ns-a";
         let ns_b = "ns-b";
-        let past = "2000-01-01T00:00:00Z";
+        let past = due_rfc3339();
 
-        let id_a = create_scheduled_event(&rt, ns_a, past, Some("stats()"), None, "schedule").await;
+        let id_a =
+            create_scheduled_event(&rt, ns_a, &past, Some("stats()"), None, "schedule").await;
 
         // Create a future event in ns-b that must not be fired.
         let _id_b = create_scheduled_event(
@@ -1025,12 +1294,13 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        // Create a past-due event with an invalid action DSL (verb not registered).
-        let past = "2000-01-01T00:00:00Z";
+        // Create a past-due (but in-grace) event with an invalid action DSL
+        // (verb not registered).
+        let past = due_rfc3339();
         let _id_bad = create_scheduled_event(
             &rt,
             "local",
-            past,
+            &past,
             Some("stats()"), // valid — but let's add a second event with a broken action
             None,
             "schedule",
@@ -1040,7 +1310,7 @@ mod tests {
         let id_bad2 = create_scheduled_event(
             &rt,
             "local",
-            past,
+            &past,
             Some("this_verb_does_not_exist(foo=\"bar\")"),
             None,
             "schedule",
@@ -1115,11 +1385,11 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        let past = "2000-01-01T00:00:00Z";
+        let past = due_rfc3339();
         let id = create_scheduled_event(
             &rt,
             "local",
-            past,
+            &past,
             Some("schedule.remind(content=\"ping\", at=\"2099-01-01T00:00:00Z\")"),
             None,
             "schedule",
@@ -1177,11 +1447,11 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        let past = "2000-01-01T00:00:00Z";
+        let past = due_rfc3339();
         let _id = create_scheduled_event(
             &rt,
             "local",
-            past,
+            &past,
             Some("stats() | get(id=$prev.id)"),
             None,
             "schedule",
@@ -1318,9 +1588,9 @@ mod tests {
         let (_tmp, db_path) = tmp_db();
         let rt = make_rt(&db_path).await;
 
-        let past = "2000-01-01T00:00:00Z";
+        let past = due_rfc3339();
         let id =
-            create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule").await;
 
         // Simulate a drain claiming the row, then crashing before finalize:
         // status="firing" with a firing_at well past the stale timeout.
@@ -1647,5 +1917,203 @@ mod tests {
         let base: DateTime<Utc> = "2026-06-01T09:00:00Z".parse().unwrap();
         // 5-field cron: not supported → returns None (one-shot fire)
         assert!(next_trigger_at(&Some("0 9 * * 1".to_string()), base).is_none());
+    }
+
+    // ── ADR-106 missed-event policy ─────────────────────────────────────────
+
+    /// Deterministic unit test for `advance_repeat_past_missed`: 14 daily
+    /// occurrences accumulated while an event was undrained must be skipped
+    /// in a single advance to the first occurrence strictly after `now` —
+    /// never a multi-fire catch-up burst.
+    #[test]
+    fn advance_repeat_past_missed_skips_all_accumulated_occurrences() {
+        let now: DateTime<Utc> = "2026-06-15T09:00:00Z".parse().unwrap();
+        let original: DateTime<Utc> = "2026-06-01T09:00:00Z".parse().unwrap();
+        let next = advance_repeat_past_missed(&Some("daily".to_string()), original, now).unwrap();
+        assert!(next > now, "advanced occurrence must be strictly future");
+        assert!(
+            next <= now + Duration::days(1),
+            "must land on the very next occurrence, not skip further than one interval past now"
+        );
+        assert_eq!(
+            next,
+            original + Duration::days(15),
+            "must be exactly the first daily occurrence after now (single advance, no burst)"
+        );
+    }
+
+    /// No `repeat` (or an unsupported cron form) never advances — the caller
+    /// must fall back to marking the event terminally `"missed"`.
+    #[test]
+    fn advance_repeat_past_missed_no_repeat_returns_none() {
+        let now: DateTime<Utc> = "2026-06-15T09:00:00Z".parse().unwrap();
+        let original: DateTime<Utc> = "2026-06-01T09:00:00Z".parse().unwrap();
+        assert!(advance_repeat_past_missed(&None, original, now).is_none());
+    }
+
+    /// The headline regression: 9 non-repeating events overdue well beyond
+    /// the default grace window (300s) must ALL be marked `"missed"` and
+    /// NONE dispatched. This is the first-boot-against-a-large-backlog
+    /// scenario the ADR-106 amendment calls out explicitly. The action DSL
+    /// is deliberately a verb (`create`) that would leave an observable
+    /// trace if dispatched, so a regression that accidentally fires the
+    /// missed path would be caught by `summary.fired`/`summary.advanced`
+    /// being non-zero, not just by inspecting note status.
+    #[tokio::test]
+    async fn nine_overdue_events_beyond_grace_are_missed_with_zero_dispatch() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        let past = "2000-01-01T00:00:00Z";
+        let mut ids = Vec::new();
+        for _ in 0..9 {
+            let id =
+                create_scheduled_event(&rt, "local", past, Some("stats()"), None, "schedule").await;
+            ids.push(id);
+        }
+
+        let summary = run_pending_events(Some(&db_path), "local", false)
+            .await
+            .expect("drain");
+
+        assert_eq!(summary.scanned, 9, "all 9 overdue rows must be scanned");
+        assert_eq!(summary.fired, 0, "zero dispatches: nothing may be fired");
+        assert_eq!(
+            summary.advanced, 0,
+            "zero dispatches: nothing may be advanced"
+        );
+        assert_eq!(summary.failed, 0, "the missed path is not a failure");
+        assert_eq!(
+            summary.missed.len(),
+            9,
+            "all 9 overdue rows must be marked missed, got summary={summary:?}"
+        );
+        for id in &ids {
+            assert!(
+                summary.missed.contains(id),
+                "missed list must name every overdue id"
+            );
+        }
+
+        for id in ids {
+            let props = get_note_props(&rt, id).await;
+            assert_eq!(
+                props["status"].as_str(),
+                Some("missed"),
+                "note {id} must end in status=missed, got {props:?}"
+            );
+            assert!(
+                props["missed_at"].as_i64().is_some(),
+                "note {id} must have missed_at stamped, got {props:?}"
+            );
+            assert!(
+                props["fired_at"].is_null(),
+                "note {id} must never have fired_at set (never dispatched), got {props:?}"
+            );
+        }
+    }
+
+    /// An event overdue by less than the grace window must still fire
+    /// normally — the missed policy only applies beyond the grace threshold.
+    #[tokio::test]
+    async fn overdue_within_grace_still_fires() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        // 60s overdue is comfortably inside the 300s default grace window.
+        let trigger_at = (Utc::now() - Duration::seconds(60)).to_rfc3339();
+        let id =
+            create_scheduled_event(&rt, "local", &trigger_at, Some("stats()"), None, "schedule")
+                .await;
+
+        let summary = run_pending_events(Some(&db_path), "local", false)
+            .await
+            .expect("drain");
+
+        assert!(
+            summary.missed.is_empty(),
+            "an event within grace must never be marked missed, got summary={summary:?}"
+        );
+        assert!(
+            summary.fired >= 1 || summary.advanced >= 1,
+            "an event within grace must be dispatched normally, got summary={summary:?}"
+        );
+
+        let props = get_note_props(&rt, id).await;
+        assert_eq!(
+            props["status"].as_str(),
+            Some("fired"),
+            "non-repeating in-grace event must end fired, got {props:?}"
+        );
+        assert!(
+            props["fired_at"].as_str().is_some(),
+            "in-grace event must have fired_at set, got {props:?}"
+        );
+    }
+
+    /// End-to-end (drain-level) confirmation that a missed *repeating* event
+    /// is re-armed at a future occurrence instead of ending terminally
+    /// missed — complements the deterministic
+    /// `advance_repeat_past_missed_skips_all_accumulated_occurrences` unit
+    /// test above with the full claim/finalize wiring.
+    #[tokio::test]
+    async fn missed_repeat_is_rearmed_at_next_future_occurrence() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        // 10 days overdue with a daily repeat: 10 accumulated occurrences,
+        // all missed, must collapse into exactly one future re-arm.
+        let original_trigger: DateTime<Utc> = Utc::now() - Duration::days(10);
+        let id = create_scheduled_event(
+            &rt,
+            "local",
+            &original_trigger.to_rfc3339(),
+            Some("stats()"),
+            Some("daily"),
+            "schedule",
+        )
+        .await;
+
+        let summary = run_pending_events(Some(&db_path), "local", false)
+            .await
+            .expect("drain");
+
+        assert_eq!(summary.fired, 0, "a missed repeat must not fire");
+        assert_eq!(
+            summary.advanced, 0,
+            "a missed repeat's re-arm is counted as missed, not advanced"
+        );
+        assert_eq!(
+            summary.missed.len(),
+            1,
+            "exactly one missed occurrence recorded"
+        );
+        assert!(summary.missed.contains(&id));
+
+        let props = get_note_props(&rt, id).await;
+        assert_eq!(
+            props["status"].as_str(),
+            Some("pending"),
+            "a missed repeat must be re-armed to pending, not left terminal, got {props:?}"
+        );
+        assert!(
+            props["missed_at"].as_i64().is_some(),
+            "missed_at must be stamped even though the row is re-armed, got {props:?}"
+        );
+        let new_trigger: DateTime<Utc> = props["trigger_at"]
+            .as_str()
+            .expect("trigger_at must be set")
+            .parse()
+            .expect("parseable trigger_at");
+        let now = Utc::now();
+        assert!(
+            new_trigger > now,
+            "re-armed trigger_at must be strictly in the future, got {new_trigger} (now={now})"
+        );
+        assert!(
+            new_trigger <= now + Duration::days(1),
+            "re-armed trigger_at must be the very next occurrence, not skip further \
+             (no catch-up burst), got {new_trigger} (now={now})"
+        );
     }
 }

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -69,29 +69,10 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Months, Utc};
 use serde_json::{json, Value};
 
-use crate::serve::enforce_strict_actor_mode;
 use crate::server::KhiveMcpServer;
 use crate::tools::request::RequestParams;
-use khive_runtime::{KhiveRuntime, Namespace, RuntimeConfig};
-use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter, SortDir};
-use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
-
-/// Resolve the `--db`/`KHIVE_DB` value into a `db_path` override, mirroring
-/// `kkernel mcp`: an explicit `:memory:` means the ephemeral in-memory db
-/// (`None`), not a file literally named ":memory:" (which SQLite treats as a
-/// per-connection file → empty schema). `None` leaves the default in place.
-///
-/// Intentionally duplicated from `kkernel::dbpath::resolve_db_override`
-/// rather than shared: `kkernel` depends on `khive-mcp`, so the reverse
-/// dependency this module would need to reuse that copy is unavailable, and
-/// the function is an 8-line pure mapping — not worth a new shared crate.
-fn resolve_db_override(db: Option<&str>) -> Option<Option<std::path::PathBuf>> {
-    match db {
-        Some(":memory:") => Some(None),
-        Some(path) => Some(Some(std::path::PathBuf::from(path))),
-        None => None,
-    }
-}
+use khive_runtime::{KhiveRuntime, Namespace};
+use khive_storage::types::{SqlStatement, SqlValue};
 
 /// A `scheduled_event` row stuck in `status="firing"` for longer than this is
 /// considered abandoned by a drain process that crashed or was killed between
@@ -158,44 +139,84 @@ pub async fn run_pending_events(
     namespace: &str,
     verbose: bool,
 ) -> Result<DrainSummary> {
-    let mut cfg = RuntimeConfig::default();
-    if let Some(db_path) = resolve_db_override(db) {
-        cfg.db_path = db_path;
-    }
-    // The drain operates across all namespaces found in the database.
-    // `namespace` from the CLI arg is used as the "home" namespace for
-    // authorizing the initial SQL reader, but event dispatch uses each event's
-    // own namespace.
-    cfg.default_namespace = Namespace::parse(namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    let rt = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
-    enforce_strict_actor_mode(rt.config().actor_id.as_deref(), &rt.config().packs)?;
-    run_pending_events_on(&rt, verbose).await
+    // Resolve through the SAME multi-backend-aware construction the daemon
+    // boot path uses (`khive-mcp::serve::build_server`), rather than a
+    // throwaway `RuntimeConfig::default()` (codex PR #782 review round 2,
+    // High finding continuation): `RuntimeConfig::default()` is env-only —
+    // it never consulted `khive.toml` (`[[backends]]`, `[actor] id`,
+    // `[packs.*].backend`) at all, so a project with a declared multi-backend
+    // config or a tier-3 config-file actor identity was silently invisible
+    // to this one-shot CLI path even though `kkernel mcp --daemon` (and, for
+    // ordinary ops, `kkernel exec`'s own `resolve_runtime_config` call) both
+    // resolve it. `build_server` also returns the fully-wired
+    // `KhiveMcpServer` for the resolved pack set (single- or multi-backend),
+    // so replayed actions route through the correct per-pack backend exactly
+    // like the daemon tick now does — not a single runtime standing in for
+    // every pack (the same High finding this fix-round closes for the
+    // daemon-resident tick). `kkernel exec` has no `--config` flag today
+    // (see `kkernel::exec::run_exec`'s own `resolve_runtime_config` call),
+    // so this mirrors that: `config: None` still triggers `khive.toml`'s
+    // standard cwd/home search order inside `build_server`.
+    let args = crate::args::Args {
+        db: db.map(str::to_string),
+        actor: None,
+        namespace: Some(namespace.to_string()),
+        no_embed: false,
+        pack: Vec::new(),
+        config: None,
+        daemon: false,
+        transport: None,
+        bind: None,
+        brain_profile: None,
+        resumed_generation: None,
+    };
+    let (server, schedule_rt) = crate::serve::build_server(&args)
+        .map_err(|e| anyhow::anyhow!("pending-events: build server: {e}"))?;
+    let rt = schedule_rt.ok_or_else(|| {
+        anyhow::anyhow!(
+            "pending-events: resolved pack set does not include \"schedule\"; nothing to drain"
+        )
+    })?;
+    run_pending_events_on(&rt, &server, verbose).await
 }
 
-/// One-shot drain against an already-constructed [`KhiveRuntime`] (ADR-106
-/// fix-round: codex PR #782 review, High finding).
+/// One-shot drain against an already-constructed [`KhiveRuntime`] +
+/// [`KhiveMcpServer`] pair (ADR-106 fix-round: codex PR #782 review).
 ///
 /// [`run_pending_events`] is the CLI-facing entry point (`kkernel exec
-/// --pending-events`): it resolves its own throwaway `RuntimeConfig` from raw
-/// `db`/`namespace` args, one fresh runtime per invocation, which is correct
-/// for a short-lived cron-invoked process.
+/// --pending-events`); it now resolves both `rt` and `server` via
+/// `khive-mcp::serve::build_server`, the same multi-backend-aware
+/// construction the daemon boot path uses, one fresh pair per invocation —
+/// correct for a short-lived cron-invoked process.
 ///
-/// The daemon-resident tick ([`schedule_tick_loop`]) must NOT do that: the
-/// daemon boot path (`khive-mcp::serve::build_server` /
+/// The daemon-resident tick ([`schedule_tick_loop`]) must NOT build its own
+/// pair: the daemon boot path (`khive-mcp::serve::build_server` /
 /// `build_registry_for_multi_backend`) already resolves `--config`,
 /// `[[backends]]`, actor identity, and `--pack` selection once at startup.
-/// Reconstructing a second, independent `RuntimeConfig::default()` inside the
-/// tick silently discards all of that: it can drain `$HOME/.khive/khive.db`
-/// instead of the configured schedule backend, trip strict-actor-mode
-/// failures the live server never has, and dispatch stored actions through a
-/// pack set the daemon never loaded. This function takes the daemon's own
-/// resolved, already-validated `&KhiveRuntime` by reference instead, so the
-/// tick's storage target, actor identity, and pack set are always identical
-/// to the server it is ticking for.
-pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<DrainSummary> {
-    let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
-
+/// This function therefore takes both by reference — the caller supplies the
+/// already-resolved, already-validated pair so its storage target, actor
+/// identity, and pack set are always identical to the server it is ticking
+/// for (or, for the one-shot path, to what `build_server` just resolved).
+///
+/// `rt` and `server` serve two different roles that must NOT be collapsed
+/// into one (round 1 of this fix-round did exactly that, and codex's round-2
+/// review caught it): `rt` is the **schedule pack's own runtime** — the scan/
+/// claim/finalize SQL below reads and CAS-writes `scheduled_event` notes
+/// directly through it, so it must point at whichever backend the `schedule`
+/// pack is wired to. `server` is the **daemon's live, fully-wired
+/// `KhiveMcpServer`** — every pack registered against its own backend per
+/// `[[backends]]`/`[packs.*].backend` — used only for `dispatch_action`
+/// (replaying a stored action's DSL). Building a second `KhiveMcpServer` from
+/// `rt` alone (`KhiveMcpServer::new(rt.clone())`) would register EVERY pack
+/// against the schedule backend, so a replayed `comm.send` (or any other
+/// pack's action) would silently dispatch into the schedule backend instead
+/// of that pack's configured one in a multi-backend deployment — passing the
+/// real `server` in is what keeps replay routing identical to a live request.
+pub async fn run_pending_events_on(
+    rt: &KhiveRuntime,
+    server: &KhiveMcpServer,
+    verbose: bool,
+) -> Result<DrainSummary> {
     let now = Utc::now();
     let grace = fire_grace_from_env();
     let mut summary = DrainSummary::default();
@@ -228,95 +249,167 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
 
     // ── Step 2: per-namespace drain ──────────────────────────────────────────
     for ns_str in &namespaces {
-        let ns = match Namespace::parse(ns_str) {
-            Ok(n) => n,
-            Err(e) => {
-                if verbose {
-                    eprintln!("[pending-events] skip invalid namespace {ns_str:?}: {e}");
-                }
-                continue;
+        if let Err(e) = Namespace::parse(ns_str) {
+            if verbose {
+                eprintln!("[pending-events] skip invalid namespace {ns_str:?}: {e}");
             }
-        };
-        let token = match rt.authorize(ns.clone()) {
-            Ok(t) => t,
-            Err(e) => {
-                if verbose {
-                    eprintln!("[pending-events] authorize({ns_str}) failed: {e}");
-                }
-                continue;
-            }
-        };
-        let store = match rt.notes(&token) {
-            Ok(s) => s,
-            Err(e) => {
-                if verbose {
-                    eprintln!("[pending-events] notes({ns_str}) failed: {e}");
-                }
-                continue;
-            }
-        };
-
-        // Snapshot every pending scheduled_event note in this namespace BEFORE
-        // any mutation (codex PR #782 review, Medium finding #2).
-        //
-        // The previous version paged `status="pending"` with LIMIT/OFFSET
-        // *while* processing each page mutated matching rows out of that same
-        // predicate (claim -> "firing" -> "fired"/"missed"/re-armed
-        // "pending"). Once page 1's 200 rows left the "pending" set, the
-        // page-2 query at `OFFSET 200` was evaluated against a result set
-        // that had already shrunk by 200 — row 201 (and beyond) was silently
-        // skipped for the entire pass. Reading the full candidate set into
-        // memory first, before any write touches this namespace's rows, means
-        // pagination happens only over a stable, unmutated snapshot; the
-        // mutation loop below then iterates the fixed-size `Vec` directly and
-        // never re-queries by offset.
-        let filter = NoteFilter {
-            kind: Some("scheduled_event".to_string()),
-            property_filters: vec![PropertyFilter {
-                json_path: "$.status".to_string(),
-                op: FilterOp::Eq,
-                value: SqlValue::Text("pending".to_string()),
-            }],
-            order_by: Some(("$.trigger_at".to_string(), SortDir::Asc)),
-            ..Default::default()
-        };
-
-        const PAGE_SIZE: u32 = 200;
-        let mut candidates = Vec::new();
-        {
-            let mut offset: u64 = 0;
-            loop {
-                let page = store
-                    .query_notes_filtered(
-                        ns_str,
-                        &filter,
-                        PageRequest {
-                            limit: PAGE_SIZE,
-                            offset,
-                        },
-                    )
-                    .await
-                    .with_context(|| {
-                        format!("pending-events: query_notes_filtered failed for ns={ns_str}")
-                    })?;
-                let page_len = page.items.len() as u32;
-                candidates.extend(page.items);
-                if page_len < PAGE_SIZE {
-                    break;
-                }
-                offset = offset
-                    .checked_add(u64::from(PAGE_SIZE))
-                    .ok_or_else(|| anyhow::anyhow!("pending-events: pagination offset overflow"))?;
-            }
+            continue;
         }
 
-        {
-            for mut note in candidates {
+        // Bounded, mutation-immune keyset pagination (codex PR #782 review
+        // round 2, Medium finding #2 — a continuation of round 1's fix).
+        //
+        // Round 1 snapshotted every `status="pending"` row for the namespace
+        // into one `Vec` before any mutation, which fixed the LIMIT/OFFSET
+        // skip bug (mutating a row out of the `status="pending"` predicate
+        // mid-page shifted every subsequent page) but introduced a new
+        // failure mode: the snapshot filter checked only `status`, not
+        // `trigger_at`, so a namespace with one due event buried in a large
+        // FUTURE schedule pulled the entire future backlog into memory every
+        // tick. This version instead:
+        //   1. pushes the due-ness predicate (`trigger_at <= now`) into the
+        //      SQL `WHERE` clause directly, via a raw statement (bypassing
+        //      `NoteFilter`, whose `order_by`/property-filter surface can
+        //      only express JSON-path predicates, not compare a JSON path
+        //      against a bind parameter with `<=`) — future events are never
+        //      fetched at all, so the working set is bounded by the due
+        //      backlog, not the namespace's total schedule size;
+        //   2. pages via a `(created_at, id)` keyset cursor instead of
+        //      `LIMIT/OFFSET`. Both columns are immutable — this drain never
+        //      rewrites `created_at` or `id` — so a row's claim/dispatch/
+        //      finalize mutation between pages can never shift a later
+        //      page's boundary (the round-1 bug class), and at most
+        //      `PAGE_SIZE` rows are held in memory at once (never the whole
+        //      namespace).
+        const PAGE_SIZE: u32 = 200;
+        let now_rfc = now.to_rfc3339();
+        let mut cursor: Option<(i64, String)> = None;
+        loop {
+            let (sql, params): (String, Vec<SqlValue>) = match &cursor {
+                None => (
+                    "SELECT id, properties, created_at FROM notes \
+                     WHERE namespace = ?1 AND kind = 'scheduled_event' \
+                       AND deleted_at IS NULL \
+                       AND json_extract(properties, '$.status') = 'pending' \
+                       AND json_extract(properties, '$.trigger_at') <= ?2 \
+                     ORDER BY created_at ASC, id ASC LIMIT ?3"
+                        .to_string(),
+                    vec![
+                        SqlValue::Text(ns_str.clone()),
+                        SqlValue::Text(now_rfc.clone()),
+                        SqlValue::Integer(i64::from(PAGE_SIZE)),
+                    ],
+                ),
+                Some((c_created_at, c_id)) => (
+                    "SELECT id, properties, created_at FROM notes \
+                     WHERE namespace = ?1 AND kind = 'scheduled_event' \
+                       AND deleted_at IS NULL \
+                       AND json_extract(properties, '$.status') = 'pending' \
+                       AND json_extract(properties, '$.trigger_at') <= ?2 \
+                       AND (created_at > ?3 OR (created_at = ?3 AND id > ?4)) \
+                     ORDER BY created_at ASC, id ASC LIMIT ?5"
+                        .to_string(),
+                    vec![
+                        SqlValue::Text(ns_str.clone()),
+                        SqlValue::Text(now_rfc.clone()),
+                        SqlValue::Integer(*c_created_at),
+                        SqlValue::Text(c_id.clone()),
+                        SqlValue::Integer(i64::from(PAGE_SIZE)),
+                    ],
+                ),
+            };
+
+            let rows = {
+                let mut reader = rt
+                    .sql()
+                    .reader()
+                    .await
+                    .context("pending-events: open SQL reader for candidate page")?;
+                reader
+                    .query_all(SqlStatement {
+                        sql,
+                        params,
+                        label: Some("pending_events_candidate_page".into()),
+                    })
+                    .await
+                    .with_context(|| {
+                        format!("pending-events: candidate page query failed for ns={ns_str}")
+                    })?
+            };
+
+            let page_len = rows.len();
+            if page_len == 0 {
+                break;
+            }
+
+            for row in &rows {
+                let id_str = match row.get("id") {
+                    Some(SqlValue::Text(s)) => s.clone(),
+                    other => {
+                        if verbose {
+                            eprintln!(
+                                "[pending-events] skip row with unexpected id column {other:?}"
+                            );
+                        }
+                        continue;
+                    }
+                };
+                let row_created_at = match row.get("created_at") {
+                    Some(SqlValue::Integer(v)) => *v,
+                    other => {
+                        if verbose {
+                            eprintln!(
+                                "[pending-events] skip row {id_str}: unexpected created_at \
+                                 column {other:?}"
+                            );
+                        }
+                        continue;
+                    }
+                };
+                // Advance the cursor even when this row fails downstream
+                // parsing/processing below: the cursor is a pure positional
+                // marker over `(created_at, id)`, not a per-row success
+                // marker, so a single malformed row can never wedge the pass
+                // by being re-fetched on every subsequent page query.
+                cursor = Some((row_created_at, id_str.clone()));
+
+                let id = match uuid::Uuid::parse_str(&id_str) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        if verbose {
+                            eprintln!("[pending-events] skip row: unparseable id {id_str:?}: {e}");
+                        }
+                        continue;
+                    }
+                };
+                let mut properties: Option<Value> = match row.get("properties") {
+                    Some(SqlValue::Text(s)) => match serde_json::from_str(s) {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            if verbose {
+                                eprintln!(
+                                    "[pending-events] skip note {id}: unparseable properties: {e}"
+                                );
+                            }
+                            continue;
+                        }
+                    },
+                    Some(SqlValue::Null) | None => None,
+                    other => {
+                        if verbose {
+                            eprintln!(
+                                "[pending-events] skip note {id}: unexpected properties column \
+                                 {other:?}"
+                            );
+                        }
+                        continue;
+                    }
+                };
+
                 summary.scanned += 1;
 
                 // Parse and check trigger_at.
-                let trigger_at_str = note
-                    .properties
+                let trigger_at_str = properties
                     .as_ref()
                     .and_then(|p| p.get("trigger_at"))
                     .and_then(Value::as_str)
@@ -326,8 +419,7 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     Err(_) => {
                         if verbose {
                             eprintln!(
-                                "[pending-events] skip note {}: unparseable trigger_at {:?}",
-                                note.id, trigger_at_str
+                                "[pending-events] skip note {id}: unparseable trigger_at {trigger_at_str:?}"
                             );
                         }
                         summary.skipped_not_due += 1;
@@ -350,15 +442,14 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 let is_missed = overdue > grace;
 
                 // ── Determine what to dispatch ───────────────────────────
-                let event_type = note
-                    .properties
+                let event_type = properties
                     .as_ref()
                     .and_then(|p| p.get("event_type"))
                     .and_then(Value::as_str)
                     .unwrap_or("remind");
 
                 let action_dsl: Option<String> = if event_type == "schedule" && !is_missed {
-                    note.properties
+                    properties
                         .as_ref()
                         .and_then(|p| p.get("payload"))
                         .and_then(Value::as_str)
@@ -374,19 +465,18 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 };
 
                 // ── Determine repeat (read before claim; only informs which
-                // finalize branch runs below, never mutates the snapshot) ──
-                let repeat = note
-                    .properties
+                // finalize branch runs below, never mutates the row read) ──
+                let repeat = properties
                     .as_ref()
                     .and_then(|p| p.get("repeat"))
                     .and_then(Value::as_str)
                     .map(str::to_string);
 
                 // ── Claim the row before dispatch (issue #462, fire side) ──
-                // `note` is a snapshot read by the page query above; a
-                // concurrent `schedule.cancel` could have transitioned the
-                // row to "cancelled" since then. CAS-claim pending -> firing
-                // now so that: (a) a concurrent cancel's own CAS (which only
+                // `properties` above is a page-query snapshot; a concurrent
+                // `schedule.cancel` could have transitioned the row to
+                // "cancelled" since then. CAS-claim pending -> firing now so
+                // that: (a) a concurrent cancel's own CAS (which only
                 // matches status='pending') fails once we've claimed it, and
                 // (b) if cancel already won the race, our claim fails and we
                 // skip — the drain can no longer clobber a cancel that
@@ -394,11 +484,11 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 // guards the missed path: a missed event still needs
                 // exclusive ownership before it can be marked "missed" or
                 // re-armed to a future occurrence.
-                let claimed_firing_at = match claim_pending_event(rt, ns_str, note.id).await {
+                let claimed_firing_at = match claim_pending_event(rt, ns_str, id).await {
                     Ok(c) => c,
                     Err(e) => {
                         if verbose {
-                            eprintln!("[pending-events] claim failed for note {}: {e}", note.id);
+                            eprintln!("[pending-events] claim failed for note {id}: {e}");
                         }
                         summary.failed += 1;
                         continue;
@@ -407,9 +497,8 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 let Some(claimed_firing_at) = claimed_firing_at else {
                     if verbose {
                         eprintln!(
-                            "[pending-events] skip note {}: no longer pending (concurrent \
-                             cancel or claim)",
-                            note.id
+                            "[pending-events] skip note {id}: no longer pending (concurrent \
+                             cancel or claim)"
                         );
                     }
                     summary.skipped_race += 1;
@@ -423,14 +512,13 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     // catch-up bursts. ─────────────────────────────────────
                     if verbose {
                         eprintln!(
-                            "[pending-events] note {} overdue by {}s (grace {}s): marking \
+                            "[pending-events] note {id} overdue by {}s (grace {}s): marking \
                              missed, not dispatching",
-                            note.id,
                             overdue.num_seconds(),
                             grace.num_seconds()
                         );
                     }
-                    let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+                    let mut props = properties.clone().unwrap_or_else(|| json!({}));
                     props["missed_at"] = json!(now.timestamp_micros());
                     match advance_repeat_past_missed(&repeat, trigger_at, now) {
                         Some(next_at) => {
@@ -450,7 +538,7 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     match finalize_fired_event(
                         rt,
                         ns_str,
-                        note.id,
+                        id,
                         &props,
                         updated_at,
                         claimed_firing_at,
@@ -458,21 +546,20 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     .await
                     {
                         Ok(true) => {
-                            summary.missed.push(note.id);
+                            summary.missed.push(id);
                         }
                         Ok(false) => {
                             if verbose {
                                 eprintln!(
-                                    "[pending-events] finalize no-op for {}: row no longer in \
-                                     \"firing\" state",
-                                    note.id
+                                    "[pending-events] finalize no-op for {id}: row no longer in \
+                                     \"firing\" state"
                                 );
                             }
                             summary.failed += 1;
                         }
                         Err(e) => {
                             if verbose {
-                                eprintln!("[pending-events] finalize failed for {}: {e}", note.id);
+                                eprintln!("[pending-events] finalize failed for {id}: {e}");
                             }
                             summary.failed += 1;
                         }
@@ -482,10 +569,10 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
 
                 // ── Dispatch the action ──────────────────────────────────
                 if let Some(dsl) = &action_dsl {
-                    let dispatch_result = dispatch_action(dsl, ns_str, &server, verbose).await;
+                    let dispatch_result = dispatch_action(dsl, ns_str, server, verbose).await;
                     if let Err(e) = dispatch_result {
                         if verbose {
-                            eprintln!("[pending-events] dispatch failed for note {}: {e}", note.id);
+                            eprintln!("[pending-events] dispatch failed for note {id}: {e}");
                         }
                         summary.failed += 1;
                         // Per-event failure does NOT abort the drain. Continue.
@@ -498,7 +585,8 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 }
 
                 let fired_at_rfc = Utc::now().to_rfc3339();
-                let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
+                let mut props = properties.clone().unwrap_or_else(|| json!({}));
+                let updated_at;
 
                 match next_trigger_at(&repeat, trigger_at) {
                     Some(next_at) => {
@@ -506,16 +594,16 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                         props["trigger_at"] = json!(next_at.to_rfc3339());
                         props["status"] = json!("pending");
                         props["fired_at"] = json!(fired_at_rfc);
-                        note.properties = Some(props);
-                        note.updated_at = Utc::now().timestamp_micros();
+                        properties = Some(props);
+                        updated_at = Utc::now().timestamp_micros();
                         summary.advanced += 1;
                     }
                     None => {
                         // Non-repeating (or cron — deferred): mark as fired.
                         props["status"] = json!("fired");
                         props["fired_at"] = json!(fired_at_rfc);
-                        note.properties = Some(props);
-                        note.updated_at = Utc::now().timestamp_micros();
+                        properties = Some(props);
+                        updated_at = Utc::now().timestamp_micros();
                         summary.fired += 1;
                     }
                 }
@@ -525,13 +613,13 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                 // instead of a full-row `upsert_note`, so this write can never
                 // clobber a cancel that (impossibly, given the claim above,
                 // but defensively) raced in after the claim.
-                let final_props = note.properties.clone().unwrap_or_else(|| json!({}));
+                let final_props = properties.clone().unwrap_or_else(|| json!({}));
                 match finalize_fired_event(
                     rt,
                     ns_str,
-                    note.id,
+                    id,
                     &final_props,
-                    note.updated_at,
+                    updated_at,
                     claimed_firing_at,
                 )
                 .await
@@ -540,9 +628,8 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     Ok(false) => {
                         if verbose {
                             eprintln!(
-                                "[pending-events] finalize no-op for {}: row no longer in \
-                                 \"firing\" state",
-                                note.id
+                                "[pending-events] finalize no-op for {id}: row no longer in \
+                                 \"firing\" state"
                             );
                         }
                         summary.failed += 1;
@@ -555,7 +642,7 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                     }
                     Err(e) => {
                         if verbose {
-                            eprintln!("[pending-events] finalize failed for {}: {e}", note.id);
+                            eprintln!("[pending-events] finalize failed for {id}: {e}");
                         }
                         // Count as failed; drain continues.
                         summary.failed += 1;
@@ -569,6 +656,10 @@ pub async fn run_pending_events_on(rt: &KhiveRuntime, verbose: bool) -> Result<D
                         }
                     }
                 }
+            }
+
+            if page_len < PAGE_SIZE as usize {
+                break;
             }
         }
     }
@@ -1029,14 +1120,33 @@ pub fn tick_interval_from_env() -> std::time::Duration {
 /// matching the original sleep-based boot behavior instead of draining
 /// immediately at daemon start.
 ///
+/// `server` is the daemon's own live [`KhiveMcpServer`] (cloned — cheap,
+/// `Arc`-wrapped internally), used ONLY for replaying a fired event's stored
+/// action DSL (`dispatch_action`, inside [`run_pending_events_on`]). This is
+/// a SEPARATE handle from `rt` on purpose (codex PR #782 review round 2, High
+/// finding): round 1 of this fix-round built a fresh `KhiveMcpServer::new(rt
+/// .clone())` from the schedule runtime alone, which registered EVERY pack
+/// against the schedule backend — correct for scanning `scheduled_event`
+/// rows (which do live on the schedule backend), but wrong for dispatch: a
+/// replayed `comm.send` (or any other pack's action) would then have run
+/// against the schedule backend instead of that pack's own configured
+/// backend in a multi-backend deployment. Passing the daemon's actual,
+/// already-multi-backend-wired `server` through here — the SAME one
+/// `build_server` handed back alongside `rt` at boot — keeps replayed-action
+/// routing identical to a live request against this daemon.
+///
 /// A per-tick failure (e.g. a transient SQL error) is logged and does not
 /// stop the loop — the next tick simply tries again.
-pub async fn schedule_tick_loop(rt: KhiveRuntime, interval: std::time::Duration) {
+pub async fn schedule_tick_loop(
+    rt: KhiveRuntime,
+    server: KhiveMcpServer,
+    interval: std::time::Duration,
+) {
     let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         ticker.tick().await;
-        match run_pending_events_on(&rt, false).await {
+        match run_pending_events_on(&rt, &server, false).await {
             Ok(summary) => {
                 if summary.fired > 0
                     || summary.advanced > 0
@@ -1066,6 +1176,8 @@ pub async fn schedule_tick_loop(rt: KhiveRuntime, interval: std::time::Duration)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use khive_runtime::RuntimeConfig;
+    use khive_storage::types::PageRequest;
     use tempfile::NamedTempFile;
 
     fn tmp_db() -> (NamedTempFile, String) {
@@ -1092,6 +1204,32 @@ mod tests {
             ..Default::default()
         };
         KhiveRuntime::new(cfg).expect("runtime")
+    }
+
+    /// Drive one drain pass directly through [`run_pending_events_on`] against
+    /// a fresh `make_rt`-built runtime, bypassing [`run_pending_events`] (the
+    /// CLI-facing one-shot entrypoint this test module used to call directly).
+    ///
+    /// `run_pending_events` now resolves through `khive-mcp::serve::build_server`
+    /// (codex PR #782 review round 2, High finding continuation), which is
+    /// TOML-aware (`KhiveConfig::load_with_home_fallback`) so that `kkernel
+    /// exec --pending-events` honors a project's `[[backends]]`/`[actor]`
+    /// config exactly like the daemon does. That makes it depend on process
+    /// `HOME`/cwd, which the tests in this module don't isolate (unlike
+    /// `serve.rs`'s own `SeatEnv`-guarded `build_server` tests) — on a
+    /// developer machine with a real `~/.khive/config.toml` declaring
+    /// `[[backends]]`, calling `run_pending_events` with a scratch `--db` path
+    /// would hit "cannot be combined with [[backends]]" instead of exercising
+    /// the drain logic these tests actually target. These tests are about
+    /// drain semantics (claim/dispatch/finalize/pagination/cadence), not CLI
+    /// config resolution, so they build their own runtime + server directly —
+    /// exactly what `run_pending_events_on` itself required even before this
+    /// fix-round, and what `run_pending_events` did internally, unconditionally,
+    /// prior to this fix-round's config-resolution fix.
+    async fn drain_for_test(db_path: &str) -> Result<DrainSummary> {
+        let rt = make_rt(db_path).await;
+        let server = KhiveMcpServer::new(rt.clone()).map_err(|e| anyhow::anyhow!("{e}"))?;
+        run_pending_events_on(&rt, &server, false).await
     }
 
     /// Create a scheduled_event note directly via runtime.create_note, replicating
@@ -1164,9 +1302,7 @@ mod tests {
         let id =
             create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule").await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert!(summary.scanned >= 1, "must have scanned the due event");
         assert!(
@@ -1191,9 +1327,7 @@ mod tests {
         let id =
             create_scheduled_event(&rt, "local", future, Some("stats()"), None, "schedule").await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         // The future event must not be fired. The drain may skip it via the SQL
         // pre-filter (scanned=0, skipped_not_due=0) or via the Rust timestamp
@@ -1220,15 +1354,11 @@ mod tests {
             create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule").await;
 
         // First drain — fires the event.
-        let s1 = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain 1");
+        let s1 = drain_for_test(&db_path).await.expect("drain 1");
         assert!(s1.scanned >= 1);
 
         // Second drain — event is now status="fired", not "pending"; must not re-fire.
-        let s2 = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain 2");
+        let s2 = drain_for_test(&db_path).await.expect("drain 2");
         assert_eq!(s2.scanned, 0, "no pending events on second drain");
         assert_eq!(s2.fired, 0, "no new fires on second drain");
 
@@ -1265,9 +1395,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert!(
             summary.advanced >= 1,
@@ -1319,9 +1447,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         // Only the ns-a event should have been processed.
         assert!(summary.scanned >= 1);
@@ -1371,7 +1497,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
+        let summary = drain_for_test(&db_path)
             .await
             .expect("drain must not abort");
 
@@ -1450,9 +1576,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert_eq!(
             summary.failed, 0,
@@ -1512,7 +1636,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
+        let summary = drain_for_test(&db_path)
             .await
             .expect("drain must not abort or panic on a legacy $prev row");
 
@@ -1665,9 +1789,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert!(
             summary.reclaimed >= 1,
@@ -1705,9 +1827,7 @@ mod tests {
             .expect("claim query")
             .expect("claim must succeed on a fresh pending row");
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert_eq!(
             summary.reclaimed, 0,
@@ -2040,9 +2160,7 @@ mod tests {
             ids.push(id);
         }
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert_eq!(summary.scanned, 9, "all 9 overdue rows must be scanned");
         assert_eq!(summary.fired, 0, "zero dispatches: nothing may be fired");
@@ -2117,9 +2235,7 @@ mod tests {
             create_scheduled_event(&rt, "local", &trigger_at, Some("stats()"), None, "schedule")
                 .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert!(
             summary.missed.is_empty(),
@@ -2165,9 +2281,7 @@ mod tests {
         )
         .await;
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert_eq!(summary.fired, 0, "a missed repeat must not fire");
         assert_eq!(
@@ -2231,9 +2345,7 @@ mod tests {
             ids.push(id);
         }
 
-        let summary = run_pending_events(Some(&db_path), "local", false)
-            .await
-            .expect("drain");
+        let summary = drain_for_test(&db_path).await.expect("drain");
 
         assert_eq!(
             summary.scanned, OVERDUE_ROW_COUNT as u64,
@@ -2266,8 +2378,20 @@ mod tests {
     /// Two concurrent drain passes over the same store must never double-fire
     /// a row: the `pending -> firing` CAS claim (`claim_pending_event`) makes
     /// exactly one of the two concurrent callers win each row (codex PR #782
-    /// review, Medium finding: Amendment B claims Acceptance Criterion 2 is
-    /// met, but no regression exercised concurrent drains until now).
+    /// review round 1, Medium finding: Amendment B claims Acceptance
+    /// Criterion 2 is met, but no regression exercised concurrent drains
+    /// until now).
+    ///
+    /// Each row's action is a genuinely side-effecting `create` writing a
+    /// row-distinct marker `observation` note, rather than the read-only
+    /// `stats()` the round-1 version of this test used (codex PR #782 review
+    /// round 2, Medium finding: a read-only action makes the summary
+    /// counters the ONLY signal, which cannot distinguish "claimed once,
+    /// dispatched once" from "claimed once, dispatched TWICE, only one
+    /// finalize succeeded" — the exact double-dispatch-one-finalize
+    /// regression this test exists to catch). After both drains, the test
+    /// asserts exactly ONE marker note per scheduled event exists — not just
+    /// that the summary counters sum to `ROW_COUNT`.
     #[tokio::test]
     async fn concurrent_drains_fire_each_row_exactly_once() {
         let (_tmp, db_path) = tmp_db();
@@ -2276,17 +2400,28 @@ mod tests {
         const ROW_COUNT: usize = 20;
         let past = due_rfc3339(); // in-grace: exercises the normal fire path, not missed
         let mut ids = Vec::with_capacity(ROW_COUNT);
-        for _ in 0..ROW_COUNT {
-            let id = create_scheduled_event(&rt, "local", &past, Some("stats()"), None, "schedule")
-                .await;
+        let mut markers = Vec::with_capacity(ROW_COUNT);
+        for i in 0..ROW_COUNT {
+            let marker = format!("concurrent-drain-marker-{i}");
+            let action_dsl = format!("create(kind=\"observation\", content=\"{marker}\")");
+            let id = create_scheduled_event(
+                &rt,
+                "local",
+                &past,
+                Some(action_dsl.as_str()),
+                None,
+                "schedule",
+            )
+            .await;
             ids.push(id);
+            markers.push(marker);
         }
 
         let db_path_a = db_path.clone();
         let db_path_b = db_path.clone();
         let (summary_a, summary_b) = tokio::join!(
-            async move { run_pending_events(Some(&db_path_a), "local", false).await },
-            async move { run_pending_events(Some(&db_path_b), "local", false).await },
+            async move { drain_for_test(&db_path_a).await },
+            async move { drain_for_test(&db_path_b).await },
         );
         let summary_a = summary_a.expect("drain A");
         let summary_b = summary_b.expect("drain B");
@@ -2305,12 +2440,42 @@ mod tests {
              never fail: a={summary_a:?} b={summary_b:?}"
         );
 
-        for id in ids {
-            let props = get_note_props(&rt, id).await;
+        for id in &ids {
+            let props = get_note_props(&rt, *id).await;
             assert_eq!(
                 props["status"].as_str(),
                 Some("fired"),
                 "note {id} must end fired exactly once, got {props:?}"
+            );
+        }
+
+        // Strongest evidence: exactly one marker note per row. A
+        // double-dispatch-one-finalize bug would leave the CAS-tracked
+        // `status`/summary counters looking clean while still writing the
+        // action's side effect twice for the row that raced — this is the
+        // only assertion that would catch it.
+        let ns = Namespace::parse("local").unwrap();
+        let token = rt.authorize(ns).expect("authorize");
+        let store = rt.notes(&token).expect("notes");
+        let page = store
+            .query_notes(
+                "local",
+                Some("observation"),
+                PageRequest {
+                    limit: (ROW_COUNT as u32) + 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .expect("query observation notes");
+        for marker in &markers {
+            let hits: Vec<_> = page.items.iter().filter(|n| &n.content == marker).collect();
+            assert_eq!(
+                hits.len(),
+                1,
+                "marker {marker:?} must appear exactly once (double-dispatch check), \
+                 found {}: {hits:?}",
+                hits.len()
             );
         }
     }

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -286,12 +286,44 @@ pub async fn run_pending_events_on(
         let mut cursor: Option<(i64, String)> = None;
         loop {
             let (sql, params): (String, Vec<SqlValue>) = match &cursor {
+                //
+                // The due-ness predicate compares via SQLite's `datetime()`,
+                // not a raw string `<=` (Ocean review, High finding): stored
+                // `trigger_at` values are NOT normalized to UTC —
+                // `khive-pack-schedule`'s `handle_remind`/`handle_schedule`
+                // deliberately round-trip the caller's original string
+                // (offset included, H5), and `validate_at` accepts any RFC
+                // 3339 offset. A raw lexicographic `<=` against a UTC
+                // `now`-string therefore mis-ranks any non-UTC-offset
+                // `trigger_at`: e.g. `"2026-07-10T02:00:00+04:00"`
+                // (chronologically `2026-07-09T22:00:00Z`, overdue) sorts
+                // AFTER a UTC `now` string like
+                // `"2026-07-10T00:47:00.123+00:00"` as raw text, so it would
+                // never be fetched — never fire, never get marked missed,
+                // forever. `datetime(...)` normalizes both sides to UTC
+                // before comparing, so the predicate is chronological
+                // regardless of the stored string's offset. Storage itself
+                // is unchanged — only this fetch-bound comparison is
+                // normalized; the original string still round-trips
+                // faithfully (H5).
+                //
+                // `datetime()` returns NULL for a value it cannot parse, and
+                // NULL <= anything is NULL (never true) — the OR clause below
+                // keeps an unparseable `trigger_at` row in the candidate set
+                // instead of silently dropping it, so the existing Rust-side
+                // unparseable-`trigger_at` branch (which logs and advances
+                // the cursor past it) still sees it. `validate_at` rejects
+                // unparseable `trigger_at` at write time, so this only
+                // matters for a hand-written or pre-validation row.
                 None => (
                     "SELECT id, properties, created_at FROM notes \
                      WHERE namespace = ?1 AND kind = 'scheduled_event' \
                        AND deleted_at IS NULL \
                        AND json_extract(properties, '$.status') = 'pending' \
-                       AND json_extract(properties, '$.trigger_at') <= ?2 \
+                       AND ( \
+                         datetime(json_extract(properties, '$.trigger_at')) <= datetime(?2) \
+                         OR datetime(json_extract(properties, '$.trigger_at')) IS NULL \
+                       ) \
                      ORDER BY created_at ASC, id ASC LIMIT ?3"
                         .to_string(),
                     vec![
@@ -305,7 +337,10 @@ pub async fn run_pending_events_on(
                      WHERE namespace = ?1 AND kind = 'scheduled_event' \
                        AND deleted_at IS NULL \
                        AND json_extract(properties, '$.status') = 'pending' \
-                       AND json_extract(properties, '$.trigger_at') <= ?2 \
+                       AND ( \
+                         datetime(json_extract(properties, '$.trigger_at')) <= datetime(?2) \
+                         OR datetime(json_extract(properties, '$.trigger_at')) IS NULL \
+                       ) \
                        AND (created_at > ?3 OR (created_at = ?3 AND id > ?4)) \
                      ORDER BY created_at ASC, id ASC LIMIT ?5"
                         .to_string(),
@@ -1008,9 +1043,21 @@ async fn discover_pending_namespaces(rt: &KhiveRuntime, now: DateTime<Utc>) -> R
 
     // Select distinct namespaces with at least one potentially-due event.
     // We do a broad filter on `status` here; the Rust layer applies the
-    // parsed-timestamp check. Using `<=` string comparison on trigger_at works
-    // for UTC-normalised timestamps but is a best-effort pre-filter for the
-    // SQL layer only.
+    // parsed-timestamp check. This is a pre-filter gate for the per-namespace
+    // candidate scan below, not the final due-ness decision — but a
+    // namespace excluded HERE never reaches that scan at all, so it must be
+    // held to the same correctness bar as the candidate-page queries
+    // (`datetime(...)` normalization, Ocean review High finding): comparing
+    // `trigger_at` against `now` as raw TEXT is only chronologically correct
+    // when every stored string happens to share `now`'s UTC offset.
+    // `khive-pack-schedule` round-trips the caller's original `trigger_at`
+    // string verbatim (offset included, H5), so a non-UTC-offset value can
+    // sort on the wrong side of a raw-text comparison and silently exclude
+    // its entire namespace from every future pass — not just skip one row.
+    // `datetime(...)` normalizes both sides to UTC before comparing; the `OR
+    // ... IS NULL` clause keeps a namespace with an unparseable `trigger_at`
+    // visible rather than silently dropped, matching the candidate-page
+    // queries' same NULL-safety rider.
     let now_rfc = now.to_rfc3339();
     let rows = reader
         .query_all(SqlStatement {
@@ -1019,8 +1066,11 @@ async fn discover_pending_namespaces(rt: &KhiveRuntime, now: DateTime<Utc>) -> R
                   WHERE kind = 'scheduled_event' \
                     AND deleted_at IS NULL \
                     AND json_extract(properties, '$.status') = 'pending' \
-                    AND json_extract(properties, '$.trigger_at') <= ?1"
-                .into(),
+                    AND ( \
+                      datetime(json_extract(properties, '$.trigger_at')) <= datetime(?1) \
+                      OR datetime(json_extract(properties, '$.trigger_at')) IS NULL \
+                    )"
+            .into(),
             params: vec![SqlValue::Text(now_rfc)],
             label: Some("pending_events_namespaces".into()),
         })
@@ -1176,6 +1226,7 @@ pub async fn schedule_tick_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::FixedOffset;
     use khive_runtime::RuntimeConfig;
     use khive_storage::types::PageRequest;
     use tempfile::NamedTempFile;
@@ -1193,6 +1244,17 @@ mod tests {
     /// path itself use their own far-past or `now`-relative timestamps.
     fn due_rfc3339() -> String {
         (Utc::now() - Duration::seconds(5)).to_rfc3339()
+    }
+
+    /// A UTC "now" RFC 3339 string, formatted the same way the candidate-page
+    /// query's bind parameter is (`now.to_rfc3339()` on a `DateTime<Utc>`).
+    /// Used only by the offset-sorting regressions below to assert their own
+    /// test fixtures actually exercise the raw-text lexicographic-ordering
+    /// bug class they're named for, independent of the real query's own
+    /// `now` capture (a few milliseconds of drift between the two calls is
+    /// irrelevant next to the multi-hour offset margins those tests use).
+    fn now_rfc3339_for_ordering_check() -> String {
+        Utc::now().to_rfc3339()
     }
 
     async fn make_rt(db_path: &str) -> KhiveRuntime {
@@ -1335,6 +1397,114 @@ mod tests {
         // invariant is that fired=0, advanced=0.
         assert_eq!(summary.fired, 0, "future event must not be fired");
         assert_eq!(summary.advanced, 0, "future event must not be advanced");
+
+        let props = get_note_props(&rt, id).await;
+        assert_eq!(
+            props["status"].as_str(),
+            Some("pending"),
+            "future event must remain pending"
+        );
+    }
+
+    /// A due event whose `trigger_at` carries a POSITIVE offset must still
+    /// fire (Ocean review, High finding).
+    ///
+    /// `khive-pack-schedule` round-trips the caller's original `trigger_at`
+    /// string verbatim, offset included (H5) — it is never normalized to
+    /// UTC in storage. The candidate-page SQL predicate used to compare
+    /// `trigger_at` against `now` as raw TEXT (`<=`), which is only
+    /// chronologically correct when every stored string happens to share the
+    /// same offset as the bind parameter. This event is chronologically due
+    /// (10s ago, well inside the default grace window) but stored at a
+    /// `+04:00` wall-clock offset, whose string sorts LEXICOGRAPHICALLY
+    /// AFTER a UTC `now` string (a later-looking hour digit) even though it
+    /// is chronologically earlier — under the pre-fix raw-text predicate
+    /// this row would never be fetched by the candidate query at all, so it
+    /// would never fire, never even reach the Rust-side missed check: it
+    /// would sit `pending` forever. The fix wraps both sides of the SQL
+    /// predicate in `datetime(...)`, which normalizes to UTC before
+    /// comparing, making the fetch chronologically correct regardless of the
+    /// stored string's offset.
+    #[tokio::test]
+    async fn due_event_with_positive_offset_trigger_at_fires() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        // Chronologically 10s overdue (well inside the default 300s grace
+        // window), but formatted at +04:00 wall time so the RFC 3339 string
+        // sorts AFTER a UTC `now` string as raw text.
+        let trigger_instant = Utc::now() - Duration::seconds(10);
+        let plus_four = FixedOffset::east_opt(4 * 3600).expect("valid offset");
+        let trigger_at = trigger_instant.with_timezone(&plus_four).to_rfc3339();
+        assert!(
+            trigger_at.as_str() > now_rfc3339_for_ordering_check().as_str(),
+            "test setup: {trigger_at:?} must sort AFTER a UTC now-string as raw text \
+             for this to exercise the lexicographic-ordering bug"
+        );
+
+        let id =
+            create_scheduled_event(&rt, "local", &trigger_at, Some("stats()"), None, "schedule")
+                .await;
+
+        let summary = drain_for_test(&db_path).await.expect("drain");
+
+        assert!(
+            summary.fired >= 1 || summary.advanced >= 1,
+            "a due event stored with a positive offset must still fire, got {summary:?}"
+        );
+
+        let props = get_note_props(&rt, id).await;
+        let status = props["status"].as_str().unwrap_or("");
+        assert!(
+            status == "fired" || status == "pending",
+            "status must be fired or pending (repeat), got {status:?}"
+        );
+    }
+
+    /// A FUTURE event whose `trigger_at` carries a NEGATIVE offset — whose
+    /// RFC 3339 string sorts BEFORE a UTC `now` string as raw text, a false
+    /// POSITIVE under the pre-fix raw-text predicate — must NOT fire.
+    ///
+    /// This exercises the other direction of the same lexicographic-ordering
+    /// bug class: a negative-offset string can make a genuinely FUTURE event
+    /// look due to a raw-text `<=` comparison. The SQL predicate's
+    /// `datetime(...)` normalization correctly excludes it from the
+    /// candidate page; even if it were fetched, the retained Rust-side
+    /// `trigger_at > now` re-check is the belt-and-suspenders backstop that
+    /// already made this direction benign before the SQL fix (Ocean review:
+    /// "Negative-offset strings produce false POSITIVES, which the retained
+    /// Rust re-check filters — benign").
+    #[tokio::test]
+    async fn future_event_with_negative_offset_trigger_at_is_not_fired() {
+        let (_tmp, db_path) = tmp_db();
+        let rt = make_rt(&db_path).await;
+
+        // Chronologically 2h in the future, but formatted at -08:00 wall
+        // time so the RFC 3339 string sorts BEFORE a UTC `now` string as raw
+        // text (a false positive under naive lexicographic comparison).
+        let trigger_instant = Utc::now() + Duration::hours(2);
+        let minus_eight = FixedOffset::west_opt(8 * 3600).expect("valid offset");
+        let trigger_at = trigger_instant.with_timezone(&minus_eight).to_rfc3339();
+        assert!(
+            trigger_at.as_str() < now_rfc3339_for_ordering_check().as_str(),
+            "test setup: {trigger_at:?} must sort BEFORE a UTC now-string as raw text \
+             for this to exercise the false-positive path"
+        );
+
+        let id =
+            create_scheduled_event(&rt, "local", &trigger_at, Some("stats()"), None, "schedule")
+                .await;
+
+        let summary = drain_for_test(&db_path).await.expect("drain");
+
+        assert_eq!(
+            summary.fired, 0,
+            "a chronologically future event must not be fired, got {summary:?}"
+        );
+        assert_eq!(
+            summary.advanced, 0,
+            "a chronologically future event must not be advanced, got {summary:?}"
+        );
 
         let props = get_note_props(&rt, id).await;
         assert_eq!(

--- a/crates/khive-mcp/src/pending_events.rs
+++ b/crates/khive-mcp/src/pending_events.rs
@@ -140,27 +140,56 @@ pub async fn run_pending_events(
     verbose: bool,
 ) -> Result<DrainSummary> {
     // Resolve through the SAME multi-backend-aware construction the daemon
-    // boot path uses (`khive-mcp::serve::build_server`), rather than a
-    // throwaway `RuntimeConfig::default()` (codex PR #782 review round 2,
-    // High finding continuation): `RuntimeConfig::default()` is env-only —
-    // it never consulted `khive.toml` (`[[backends]]`, `[actor] id`,
-    // `[packs.*].backend`) at all, so a project with a declared multi-backend
-    // config or a tier-3 config-file actor identity was silently invisible
-    // to this one-shot CLI path even though `kkernel mcp --daemon` (and, for
-    // ordinary ops, `kkernel exec`'s own `resolve_runtime_config` call) both
-    // resolve it. `build_server` also returns the fully-wired
-    // `KhiveMcpServer` for the resolved pack set (single- or multi-backend),
-    // so replayed actions route through the correct per-pack backend exactly
-    // like the daemon tick now does — not a single runtime standing in for
-    // every pack (the same High finding this fix-round closes for the
-    // daemon-resident tick). `kkernel exec` has no `--config` flag today
-    // (see `kkernel::exec::run_exec`'s own `resolve_runtime_config` call),
-    // so this mirrors that: `config: None` still triggers `khive.toml`'s
-    // standard cwd/home search order inside `build_server`.
+    // boot path uses (`khive-mcp::serve::build_server_with_explicit_namespace`),
+    // rather than a throwaway `RuntimeConfig::default()` (codex PR #782
+    // review round 2, High finding continuation): `RuntimeConfig::default()`
+    // is env-only — it never consulted `khive.toml` (`[[backends]]`,
+    // `[actor] id`, `[packs.*].backend`) at all, so a project with a
+    // declared multi-backend config or a tier-3 config-file actor identity
+    // was silently invisible to this one-shot CLI path even though
+    // `kkernel mcp --daemon` (and, for ordinary ops, `kkernel exec`'s own
+    // `resolve_runtime_config` call) both resolve it. The wrapper also
+    // returns the fully-wired `KhiveMcpServer` for the resolved pack set
+    // (single- or multi-backend), so replayed actions route through the
+    // correct per-pack backend exactly like the daemon tick now does — not a
+    // single runtime standing in for every pack (the same High finding this
+    // fix-round closes for the daemon-resident tick). `kkernel exec` has no
+    // `--config` flag today (see `kkernel::exec::run_exec`'s own
+    // `resolve_runtime_config` call), so this mirrors that: `config: None`
+    // still triggers `khive.toml`'s standard cwd/home search order inside
+    // `resolve_runtime_config`.
+    //
+    // This does NOT call `crate::serve::build_server` directly (PR #782
+    // review round 4, High finding): `build_server` derives BOTH
+    // `namespace_explicit` and `actor_explicit` from `resolve_cli_namespace`,
+    // which treats "a namespace value is present" and "the operator typed
+    // `--actor`/`--namespace`" as the same fact — true for a real CLI parse,
+    // where there is no other way a namespace value could appear. This
+    // wrapper's `namespace` argument is not a CLI flag the operator typed;
+    // it is a plain default this function was called with (`"local"` unless
+    // the caller passed something else), and `resolve_runtime_config`
+    // (`serve.rs`) treats a genuine explicit actor override as authoritative
+    // — it clears any configured `[actor] id` for the resolved-to-"local"
+    // case rather than falling through to it. Routing this default namespace
+    // through `build_server` therefore silently discarded a project's
+    // configured `[actor] id`, contradicting Amendment B's claim that this
+    // CLI path honors it, and — under strict actor mode with the comm pack —
+    // could make server construction itself fail despite a valid config.
+    // `build_server_with_explicit_namespace` is the seam that lets this
+    // caller assert the narrower, correct semantic instead: the namespace
+    // *is* a real default (`namespace_explicit: true`, so it still becomes
+    // `default_namespace` and fills `actor_id` when non-"local"), but it is
+    // NOT an actor override (`actor_explicit: false`), so a `"local"`
+    // resolution keeps falling through to the project/db/env actor tiers —
+    // exactly the shape `kkernel exec`/`kkernel reindex` already use via
+    // their own direct `resolve_runtime_config` calls (see
+    // `RuntimeConfigInputs::actor_explicit`'s field doc).
+    let ns = Namespace::parse(namespace)
+        .map_err(|e| anyhow::anyhow!("pending-events: invalid namespace {namespace:?}: {e}"))?;
     let args = crate::args::Args {
         db: db.map(str::to_string),
         actor: None,
-        namespace: Some(namespace.to_string()),
+        namespace: None,
         no_embed: false,
         pack: Vec::new(),
         config: None,
@@ -170,8 +199,9 @@ pub async fn run_pending_events(
         brain_profile: None,
         resumed_generation: None,
     };
-    let (server, schedule_rt) = crate::serve::build_server(&args)
-        .map_err(|e| anyhow::anyhow!("pending-events: build server: {e}"))?;
+    let (server, schedule_rt) =
+        crate::serve::build_server_with_explicit_namespace(&args, ns, true, false)
+            .map_err(|e| anyhow::anyhow!("pending-events: build server: {e}"))?;
     let rt = schedule_rt.ok_or_else(|| {
         anyhow::anyhow!(
             "pending-events: resolved pack set does not include \"schedule\"; nothing to drain"
@@ -1023,15 +1053,19 @@ async fn dispatch_action(
 /// `scheduled_event` note (i.e. `status="pending"` AND `trigger_at <= now`).
 ///
 /// Uses a direct SQL query for efficiency — avoids fetching all pending notes
-/// across all namespaces up front. The `trigger_at` comparison is a string
-/// comparison, which is correct for UTC RFC 3339 timestamps (lexicographic
-/// order matches chronological order for `Z` / `+00:00` forms).
-///
-/// RFC 3339 timestamps with non-zero offsets are NOT reliably comparable as
-/// strings — the schedule pack normalises all `trigger_at` values to whatever
-/// the caller supplies. In practice, `validate_at` in `handlers.rs` accepts
-/// any RFC 3339 string that `chrono` parses (including offset forms). We
-/// therefore fetch by namespace and re-check in Rust with parsed `DateTime<Utc>`.
+/// across all namespaces up front. The `trigger_at` comparison is done via
+/// SQLite's `datetime(...)`, not a raw string comparison (PR #782 review
+/// round 3, High finding): `khive-pack-schedule` round-trips the caller's
+/// original `trigger_at` string verbatim, offset included (H5), and
+/// `validate_at` in `handlers.rs` accepts any RFC 3339 offset — a raw-text
+/// `<=` only matches chronological order when every stored string happens to
+/// share `now`'s UTC offset, which is not guaranteed. `datetime(...)`
+/// normalizes both sides to UTC before comparing, making the comparison
+/// chronological regardless of offset; storage still round-trips the
+/// caller's original string unchanged (H5 unaffected). The Rust layer
+/// downstream still re-parses and re-checks each candidate row with
+/// `DateTime<Utc>` as the final authority — this SQL predicate is a fetch
+/// bound, not the last word.
 async fn discover_pending_namespaces(rt: &KhiveRuntime, now: DateTime<Utc>) -> Result<Vec<String>> {
     use khive_storage::types::{SqlStatement, SqlValue};
 
@@ -2648,5 +2682,195 @@ mod tests {
                 hits.len()
             );
         }
+    }
+
+    // ── PR #782 review round 4, High finding: `run_pending_events`'s wrapper
+    //    seam must not misread a default namespace as an explicit actor
+    //    override ──────────────────────────────────────────────────────────
+    //
+    // These tests exercise the REAL config-discovery path (process cwd /
+    // `HOME`), exactly like `serve.rs`'s own ADR-096 Fork 2 regressions —
+    // that module's `SeatEnv`/`write_config` helpers are private to its own
+    // `#[cfg(test)]` module, so this module carries its own copies rather
+    // than exporting test-only scaffolding across a crate boundary that
+    // doesn't otherwise exist between these two files.
+
+    /// RAII guard: temporarily redirects process cwd to `project_root` and
+    /// `HOME` to an isolated, empty tempdir (so tier 4 — `~/.khive/config.toml`
+    /// — never reaches whatever the real machine running this suite happens
+    /// to have configured globally). Restores both on drop, even on
+    /// panic/unwind. Mirrors `serve.rs`'s own `SeatEnv`.
+    struct SeatEnv {
+        original_cwd: std::path::PathBuf,
+        original_home: Option<std::ffi::OsString>,
+        _isolated_home: tempfile::TempDir,
+    }
+
+    impl SeatEnv {
+        fn enter(project_root: &std::path::Path) -> Self {
+            let original_cwd = std::env::current_dir().expect("read cwd");
+            let original_home = std::env::var_os("HOME");
+            let isolated_home = tempfile::tempdir().expect("isolated HOME tempdir");
+            std::env::set_current_dir(project_root).expect("chdir into seat project root");
+            std::env::set_var("HOME", isolated_home.path());
+            Self {
+                original_cwd,
+                original_home,
+                _isolated_home: isolated_home,
+            }
+        }
+    }
+
+    impl Drop for SeatEnv {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original_cwd);
+            match &self.original_home {
+                Some(h) => std::env::set_var("HOME", h),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    /// Write a project-local `.khive/config.toml` declaring `[actor] id`.
+    fn write_project_actor_config(project_root: &std::path::Path, actor_id: &str) {
+        std::fs::create_dir_all(project_root.join(".khive")).expect("mkdir .khive");
+        std::fs::write(
+            project_root.join(".khive/config.toml"),
+            format!("[actor]\nid = \"{actor_id}\"\n"),
+        )
+        .expect("write project actor config");
+    }
+
+    /// The wrapper seam (`build_server_with_explicit_namespace`, called by
+    /// `run_pending_events` with `namespace_explicit: true, actor_explicit:
+    /// false`) must let a `"local"`-resolved default namespace fall through
+    /// to the project-configured actor — never clear it the way a genuine
+    /// `--actor`/`--namespace` CLI override would (`build_server`'s own,
+    /// correctly-narrower semantic). Regression for PR #782 review round 4's
+    /// High finding: before this fix, `run_pending_events` called
+    /// `build_server` directly with a synthesized `namespace: Some("local")`,
+    /// which `resolve_cli_namespace` reported as `explicit = true` and
+    /// `build_server` then fed into BOTH `namespace_explicit` AND
+    /// `actor_explicit`, tripping the "genuinely explicit actor tier
+    /// requesting anonymous" branch in `resolve_runtime_config` and silently
+    /// discarding the configured `[actor] id`.
+    #[test]
+    #[serial_test::serial]
+    fn wrapper_seam_falls_through_to_project_actor_instead_of_clearing_it() {
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        write_project_actor_config(seat_dir.path(), "lambda:pending-events-tenant");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+
+        let args = crate::args::Args {
+            db: Some(":memory:".to_string()),
+            actor: None,
+            namespace: None,
+            no_embed: false,
+            pack: Vec::new(),
+            config: None,
+            daemon: false,
+            transport: None,
+            bind: None,
+            brain_profile: None,
+            resumed_generation: None,
+        };
+        let ns = Namespace::parse("local").expect("local namespace");
+
+        // The seam `run_pending_events` actually calls: namespace is a real
+        // default (`namespace_explicit: true`) but NOT an actor override
+        // (`actor_explicit: false`).
+        let (_server, schedule_rt) =
+            crate::serve::build_server_with_explicit_namespace(&args, ns, true, false)
+                .expect("build_server_with_explicit_namespace must succeed");
+        let rt = schedule_rt.expect("\"schedule\" pack is in the default pack set");
+        assert_eq!(
+            rt.config().actor_id.as_deref(),
+            Some("lambda:pending-events-tenant"),
+            "a default namespace resolving to \"local\" must fall through to the \
+             project-configured [actor] id, not clear it as if it were an explicit \
+             --actor/--namespace override"
+        );
+    }
+
+    /// Positive control for the failure mode the fix above closes: routing
+    /// the same inputs through `build_server` (the genuine CLI-flag seam,
+    /// unchanged by this fix-round) DOES clear the actor, because there a
+    /// present namespace value really does mean "the operator typed
+    /// --namespace". This documents why `run_pending_events` must not reuse
+    /// that entry point for a synthesized, non-CLI-parsed namespace default.
+    #[test]
+    #[serial_test::serial]
+    fn build_server_cli_seam_clears_actor_for_explicit_local_namespace() {
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        write_project_actor_config(seat_dir.path(), "lambda:pending-events-tenant");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+
+        let args = crate::args::Args {
+            db: Some(":memory:".to_string()),
+            actor: None,
+            namespace: Some("local".to_string()),
+            no_embed: false,
+            pack: Vec::new(),
+            config: None,
+            daemon: false,
+            transport: None,
+            bind: None,
+            brain_profile: None,
+            resumed_generation: None,
+        };
+
+        let (_server, schedule_rt) =
+            crate::serve::build_server(&args).expect("build_server must succeed");
+        let rt = schedule_rt.expect("\"schedule\" pack is in the default pack set");
+        assert_eq!(
+            rt.config().actor_id,
+            None,
+            "build_server's genuine CLI-flag seam must still treat a present --namespace \
+             value as an explicit actor override and clear the actor for \"local\" — this \
+             is correct CLI behavior, unaffected by the wrapper-seam fix"
+        );
+    }
+
+    /// `run_pending_events` (the actual `kkernel exec --pending-events`
+    /// entry point, not the lower-level `drain_for_test` helper) must
+    /// succeed under strict actor mode when a project `[actor] id` is
+    /// configured — proving the wrapper's server construction no longer
+    /// spuriously trips `enforce_strict_actor_mode` the way routing through
+    /// `build_server`'s actor-clearing path would have.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn wrapper_succeeds_under_strict_actor_mode_with_configured_project_actor() {
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_PACKS");
+        let prev_strict = std::env::var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR").ok();
+        std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", "1");
+
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        write_project_actor_config(seat_dir.path(), "lambda:pending-events-tenant");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+
+        let result = run_pending_events(Some(":memory:"), "local", false).await;
+
+        match prev_strict {
+            Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
+            None => std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR"),
+        }
+
+        result.expect(
+            "run_pending_events must succeed under strict actor mode when a project \
+             [actor] id is configured — the same config a live `kkernel mcp --daemon` \
+             boot in this project would resolve",
+        );
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -60,11 +60,11 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
     } else {
         khive_runtime::daemon::acquire_recovery_lock()
     };
-    let server = build_server(&args)?;
+    let (server, schedule_rt) = build_server(&args)?;
 
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, &args);
-    spawn_schedule_tick_loop_if_daemon(&args);
+    spawn_schedule_tick_loop_if_daemon(&args, schedule_rt);
 
     #[cfg(unix)]
     if args.daemon {
@@ -138,30 +138,41 @@ fn spawn_email_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
 /// this is not behind a Cargo feature — the schedule pack is always linked,
 /// so the tick loop is always available.
 ///
+/// `schedule_rt` is the daemon's own resolved `"schedule"`-pack runtime
+/// handle, as returned by [`build_server`] (or threaded through
+/// [`serve_server`] by `kkernel`'s coordinator-attached multi-backend boot
+/// path). Passing the ALREADY-RESOLVED runtime, rather than deriving a fresh
+/// `RuntimeConfig` from raw `args.db`/an inferred namespace inside the tick,
+/// is the fix for codex PR #782 review's High finding: the daemon resolves
+/// `--config`/`[[backends]]`/actor identity/`--pack` selection once at boot,
+/// and a second independent resolution inside the tick could silently target
+/// a different database, actor identity, or pack set. `None` means either
+/// this isn't the daemon role, or the resolved pack set does not include
+/// `"schedule"` (nothing to drain) — either way the tick loop is skipped.
+///
 /// If no daemon is running, scheduled events are simply not drained by this
 /// mechanism — the documented external-cron invocation
 /// (`kkernel exec --pending-events`) still works independently and safely
 /// races the tick loop when both are present (see the module docs on
 /// [`crate::pending_events`]).
-fn spawn_schedule_tick_loop_if_daemon(args: &Args) {
-    if args.daemon {
-        let db = args.db.clone();
-        let namespace = args
-            .namespace
-            .clone()
-            .or_else(|| args.actor.clone())
-            .unwrap_or_else(|| "local".to_string());
-        let interval = crate::pending_events::tick_interval_from_env();
-        tracing::info!(
-            interval_secs = interval.as_secs(),
-            "schedule tick loop: spawning (daemon role)"
-        );
-        tokio::spawn(crate::pending_events::schedule_tick_loop(
-            db, namespace, interval,
-        ));
-    } else {
+fn spawn_schedule_tick_loop_if_daemon(args: &Args, schedule_rt: Option<KhiveRuntime>) {
+    if !args.daemon {
         tracing::info!("schedule tick loop: skipped (client role; daemon owns the tick)");
+        return;
     }
+    let Some(rt) = schedule_rt else {
+        tracing::info!(
+            "schedule tick loop: skipped (\"schedule\" pack is not in this daemon's \
+             resolved pack set)"
+        );
+        return;
+    };
+    let interval = crate::pending_events::tick_interval_from_env();
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        "schedule tick loop: spawning (daemon role)"
+    );
+    tokio::spawn(crate::pending_events::schedule_tick_loop(rt, interval));
 }
 
 /// Spawn the email channel polling + outbox loops if the `channel-email`
@@ -933,11 +944,19 @@ async fn channel_outbox_loop(
 /// migrations and applies pack schema plans, so the same
 /// acquire-before-construct/hold-through-bind pattern used in [`run`] applies
 /// here. Pass `None` only if the caller could not acquire the lock.
+///
+/// `schedule_rt` is the caller's resolved `"schedule"`-pack runtime handle
+/// (ADR-106) — see `spawn_schedule_tick_loop_if_daemon`. `kkernel`'s
+/// coordinator-attached multi-backend boot path resolves this from the same
+/// `MultiBackendRegistry.per_pack_runtimes` map it uses to build `server`
+/// itself, so the tick drains the identical backend/actor/pack configuration
+/// the live server serves.
 pub async fn serve_server(
     server: KhiveMcpServer,
     args: &Args,
     registry: &TransportRegistry,
     boot_guard: Option<std::fs::File>,
+    schedule_rt: Option<KhiveRuntime>,
 ) -> anyhow::Result<()> {
     if let Some(generation) = args.resumed_generation {
         tracing::warn!(
@@ -948,7 +967,7 @@ pub async fn serve_server(
     }
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, args);
-    spawn_schedule_tick_loop_if_daemon(args);
+    spawn_schedule_tick_loop_if_daemon(args, schedule_rt);
 
     #[cfg(unix)]
     if args.daemon {
@@ -1275,7 +1294,20 @@ pub fn enforce_strict_actor_mode(
 }
 
 /// Build a fully-configured server from parsed args (without serving).
-pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
+///
+/// Returns, alongside the server, the resolved [`KhiveRuntime`] handle the
+/// `"schedule"` pack is bound to — `None` when the resolved pack set does not
+/// include `"schedule"` — for `spawn_schedule_tick_loop_if_daemon` to drain
+/// against (ADR-106). This is the SAME runtime the server itself dispatches
+/// through: a single-backend boot shares one `KhiveRuntime` across every
+/// pack, and a multi-backend boot (ADR-028 `[[backends]]`) returns the
+/// specific per-pack runtime `"schedule"` was wired to. Threading this
+/// through — rather than having the tick loop re-resolve its own
+/// `RuntimeConfig` from raw `--db`/namespace args — is the fix for codex PR
+/// #782 review's High finding: a second, independently-resolved config could
+/// silently target a different database, actor identity, or pack set than
+/// the daemon it claims to serve.
+pub fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<KhiveRuntime>)> {
     let (cli_namespace_explicit, cli_namespace) =
         resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -1340,14 +1372,27 @@ pub fn build_server(args: &Args) -> anyhow::Result<KhiveMcpServer> {
                  Set KHIVE_ACTOR or --actor to this lambda's id."
             );
         }
+        let schedule_rt = runtime
+            .config()
+            .packs
+            .iter()
+            .any(|p| p == "schedule")
+            .then(|| runtime.clone());
         let fmt = apply_env_output_format(khive_cfg.runtime.default_output_format);
-        return KhiveMcpServer::new(runtime)
+        let server = KhiveMcpServer::new(runtime)
             .map(|s| s.with_default_output_format(fmt))
-            .map_err(|e| anyhow::anyhow!("{e}"));
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        return Ok((server, schedule_rt));
     }
 
     // Multi-backend path (ADR-028).
-    build_server_multi_backend(config, &khive_cfg, args.db.as_deref())
+    let multi = build_registry_for_multi_backend(config, &khive_cfg, args.db.as_deref())?;
+    let schedule_rt = multi
+        .per_pack_runtimes
+        .get("schedule")
+        .map(|rt| (**rt).clone());
+    let server = build_server_from_multi_backend_registry(multi, &khive_cfg, None);
+    Ok((server, schedule_rt))
 }
 
 /// Canonicalize a SQLite backend path for deduplication (ADR-028 §8).
@@ -4453,6 +4498,271 @@ id = "lambda:project-actor"
             result.is_ok(),
             "enforce_strict_actor_mode must return Ok when comm pack is not loaded \
              (no party-line risk even without actor)"
+        );
+    }
+
+    // --- build_server's returned schedule-tick runtime (ADR-106 fix-round,
+    // codex PR #782 review, High finding) ---
+    //
+    // Before this fix-round, the daemon-resident tick (`schedule_tick_loop`)
+    // reconstructed its OWN `RuntimeConfig::default()` from raw `args.db` and
+    // an inferred namespace, discarding everything `build_server` resolves
+    // from `--config`/`[[backends]]`/`--actor`/`--pack`. These regressions
+    // exercise `build_server` itself (the exact function `run()` calls) and
+    // assert the runtime it hands back for the tick to drain against carries
+    // the SAME resolved db path, actor identity, and pack set the live
+    // server itself was built with — not a silently different one.
+    //
+    // All use `SeatEnv` (defined above, ADR-096 Fork 2 section) to isolate
+    // cwd/HOME so no ambient developer-machine `~/.khive/config.toml` or
+    // project `.khive/config.toml` can leak into the resolution, and clear
+    // every `KHIVE_*` env var these tests care about so a shell-level export
+    // in the test-runner's environment cannot silently change the resolved
+    // config out from under the assertion.
+
+    #[test]
+    #[serial]
+    fn build_server_schedule_tick_uses_the_configured_backend_not_the_home_default() {
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let configured_db = seat_dir.path().join("configured-schedule-backend.db");
+
+        use clap::Parser;
+        let args = Args::parse_from(["mcp", "--db", configured_db.to_str().expect("utf8 path")]);
+
+        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let rt = schedule_rt
+            .expect("the default pack set includes \"schedule\" — a runtime must be returned");
+
+        assert_eq!(
+            rt.config().db_path.as_deref(),
+            Some(configured_db.as_path()),
+            "the tick's runtime must target the exact --db this daemon was configured with, \
+             not RuntimeConfig::default()'s $HOME/.khive/khive.db fallback"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn build_server_schedule_tick_uses_the_configured_actor_identity() {
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        use clap::Parser;
+        let args = Args::parse_from([
+            "mcp",
+            "--db",
+            ":memory:",
+            "--actor",
+            "lambda:adr106-tick-actor",
+        ]);
+
+        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let rt = schedule_rt.expect("schedule pack is loaded by default");
+
+        assert_eq!(
+            rt.config().actor_id.as_deref(),
+            Some("lambda:adr106-tick-actor"),
+            "the tick's runtime must carry the daemon's own resolved --actor identity, \
+             not RuntimeConfig::default()'s unattributed actor_id=None"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn build_server_schedule_tick_is_none_when_schedule_pack_is_not_in_the_restricted_pack_set() {
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        use clap::Parser;
+        // Restrict to a pack set that deliberately excludes "schedule".
+        let args = Args::parse_from(["mcp", "--db", ":memory:", "--pack", "kg"]);
+
+        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        assert!(
+            schedule_rt.is_none(),
+            "when the operator restricts --pack to exclude \"schedule\", the tick must have \
+             nothing to drain against — never silently falling back to a runtime that can \
+             dispatch through a pack the daemon was not configured to load"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn build_server_schedule_tick_runtime_satisfies_strict_actor_mode_like_the_live_server() {
+        // Regression for the exact "strict actor mode can make every tick
+        // fail" scenario codex's High finding named: before this fix, the
+        // tick's separately-reconstructed `RuntimeConfig::default()` carried
+        // NO actor regardless of what `--actor` the daemon itself was given,
+        // so a strict-mode daemon's tick would trip `enforce_strict_actor_mode`
+        // on every single pass even though the live server's own actor was
+        // configured correctly. `build_server` must both (a) succeed under
+        // strict mode when an actor IS configured, and (b) hand back a
+        // schedule-tick runtime carrying that SAME actor — proving the tick
+        // no longer performs its own, separately-failing resolution.
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        let prev_strict = std::env::var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR").ok();
+        std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", "1");
+
+        use clap::Parser;
+        let args = Args::parse_from([
+            "mcp",
+            "--db",
+            ":memory:",
+            "--actor",
+            "lambda:strict-mode-tenant",
+            "--pack",
+            "kg",
+            "--pack",
+            "comm",
+            "--pack",
+            "schedule",
+        ]);
+
+        let result = build_server(&args);
+
+        match prev_strict {
+            Some(v) => std::env::set_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR", v),
+            None => std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR"),
+        }
+
+        let (_server, schedule_rt) = result.expect(
+            "build_server must succeed under strict mode when --actor is properly configured",
+        );
+        let rt = schedule_rt.expect("\"schedule\" pack was explicitly requested");
+        assert_eq!(
+            rt.config().actor_id.as_deref(),
+            Some("lambda:strict-mode-tenant"),
+            "the tick's runtime must carry the same actor identity that satisfied strict \
+             mode at daemon boot, not a separately-resolved, unattributed default"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn build_server_schedule_tick_uses_the_declared_multi_backend_not_main() {
+        // Multi-backend (ADR-028 [[backends]]) config-backed targeting: the
+        // "schedule" pack is explicitly routed to its OWN backend, distinct
+        // from "main". `build_server`'s returned schedule-tick runtime must
+        // WRITE INTO that declared backend's file, not main's — proving the
+        // High-finding fix threads the correct per-pack runtime through for
+        // multi-backend boots too, not only the single-backend common case.
+        // (`RuntimeConfig.db_path` is not itself a reliable signal here —
+        // per-pack multi-backend runtimes only override `backend_id`, not
+        // `db_path` — so this test verifies the actual bound storage file by
+        // writing a marker row and re-opening both declared backend files
+        // independently.)
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let main_db = seat_dir.path().join("main.db");
+        let schedule_db = seat_dir.path().join("schedule-backend.db");
+        let config_path = write_config(
+            seat_dir.path(),
+            &format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{main}"
+
+[[backends]]
+name = "schedule-backend"
+kind = "sqlite"
+path = "{schedule}"
+
+[packs.schedule]
+backend = "schedule-backend"
+"#,
+                main = main_db.display(),
+                schedule = schedule_db.display(),
+            ),
+        );
+
+        use clap::Parser;
+        let args = Args::parse_from(["mcp", "--config", config_path.to_str().expect("utf8 path")]);
+
+        let (_server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        let rt = schedule_rt.expect("schedule pack is loaded by default and declared here");
+
+        let marker_content = "adr106-multi-backend-schedule-marker";
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize schedule runtime");
+        let store = rt.notes(&token).expect("notes store");
+        store
+            .upsert_note(khive_storage::note::Note::new(
+                "local",
+                "observation",
+                marker_content,
+            ))
+            .await
+            .expect("write marker note through the tick's runtime");
+
+        // Re-open each declared backend file independently (the original
+        // `_server`/`rt` are dropped-in-scope-still-alive but this is a
+        // sequential, not concurrent, re-open) and confirm the marker landed
+        // in "schedule-backend.db" only.
+        let count_marker_notes = |path: std::path::PathBuf| async move {
+            let cfg = RuntimeConfig {
+                db_path: Some(path),
+                default_namespace: Namespace::parse("local").unwrap(),
+                embedding_model: None,
+                additional_embedding_models: vec![],
+                ..RuntimeConfig::default()
+            };
+            let probe_rt = KhiveRuntime::new(cfg).expect("reopen backend file");
+            let ns = Namespace::parse("local").unwrap();
+            let token = probe_rt.authorize(ns).expect("authorize probe");
+            let store = probe_rt.notes(&token).expect("notes store");
+            let page = store
+                .query_notes(
+                    "local",
+                    Some("observation"),
+                    khive_storage::types::PageRequest {
+                        limit: 10,
+                        offset: 0,
+                    },
+                )
+                .await
+                .expect("query observation notes");
+            page.items
+                .into_iter()
+                .filter(|n| n.content == marker_content)
+                .count()
+        };
+
+        assert_eq!(
+            count_marker_notes(schedule_db.clone()).await,
+            1,
+            "the marker written through the tick's runtime must be present in the declared \
+             \"schedule-backend\" backend file"
+        );
+        assert_eq!(
+            count_marker_notes(main_db.clone()).await,
+            0,
+            "the marker must be ABSENT from \"main\" — the tick's runtime must not have \
+             silently written into the main backend instead of the declared schedule backend"
         );
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -64,6 +64,7 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, &args);
+    spawn_schedule_tick_loop_if_daemon(&args);
 
     #[cfg(unix)]
     if args.daemon {
@@ -126,6 +127,40 @@ fn spawn_email_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
         spawn_email_channel_loops(server);
     } else {
         tracing::info!("email channel loops: skipped (client role; daemon owns channel loops)");
+    }
+}
+
+/// Spawn the daemon-resident schedule-event tick loop (ADR-106) if — and
+/// only if — `args` indicates this process is the daemon. Mirrors
+/// [`spawn_email_channel_loops_if_daemon`]'s `args.daemon` role gate (#602):
+/// a short-lived `kkernel exec`/stdio client process never spawns this, only
+/// the daemon does, exactly once per live process. Unlike the email loops,
+/// this is not behind a Cargo feature — the schedule pack is always linked,
+/// so the tick loop is always available.
+///
+/// If no daemon is running, scheduled events are simply not drained by this
+/// mechanism — the documented external-cron invocation
+/// (`kkernel exec --pending-events`) still works independently and safely
+/// races the tick loop when both are present (see the module docs on
+/// [`crate::pending_events`]).
+fn spawn_schedule_tick_loop_if_daemon(args: &Args) {
+    if args.daemon {
+        let db = args.db.clone();
+        let namespace = args
+            .namespace
+            .clone()
+            .or_else(|| args.actor.clone())
+            .unwrap_or_else(|| "local".to_string());
+        let interval = crate::pending_events::tick_interval_from_env();
+        tracing::info!(
+            interval_secs = interval.as_secs(),
+            "schedule tick loop: spawning (daemon role)"
+        );
+        tokio::spawn(crate::pending_events::schedule_tick_loop(
+            db, namespace, interval,
+        ));
+    } else {
+        tracing::info!("schedule tick loop: skipped (client role; daemon owns the tick)");
     }
 }
 
@@ -913,6 +948,7 @@ pub async fn serve_server(
     }
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, args);
+    spawn_schedule_tick_loop_if_daemon(args);
 
     #[cfg(unix)]
     if args.daemon {

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -64,7 +64,7 @@ pub async fn run(args: Args, registry: &TransportRegistry) -> anyhow::Result<()>
 
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, &args);
-    spawn_schedule_tick_loop_if_daemon(&args, schedule_rt);
+    spawn_schedule_tick_loop_if_daemon(&args, &server, schedule_rt);
 
     #[cfg(unix)]
     if args.daemon {
@@ -150,12 +150,30 @@ fn spawn_email_channel_loops_if_daemon(server: &KhiveMcpServer, args: &Args) {
 /// this isn't the daemon role, or the resolved pack set does not include
 /// `"schedule"` (nothing to drain) — either way the tick loop is skipped.
 ///
+/// `server` is the daemon's own live, fully-wired `KhiveMcpServer` — the
+/// SAME one [`build_server`] returned alongside `schedule_rt` and that this
+/// process is about to serve. It is cloned (cheap — `Arc`-wrapped
+/// internally) and handed to the tick loop for action-dispatch only (round 2
+/// of codex PR #782 review's High finding, a continuation of the
+/// `schedule_rt`-only fix above): `schedule_rt` alone is correct for
+/// *scanning* `scheduled_event` rows (they live on the schedule pack's own
+/// backend), but building a throwaway `KhiveMcpServer` from `schedule_rt`
+/// alone for *dispatch* would register every pack against the schedule
+/// backend, so a replayed action belonging to another pack (e.g.
+/// `comm.send`) would route to the wrong backend in a multi-backend
+/// deployment. Passing the daemon's real `server` keeps replay routing
+/// identical to a live request.
+///
 /// If no daemon is running, scheduled events are simply not drained by this
 /// mechanism — the documented external-cron invocation
 /// (`kkernel exec --pending-events`) still works independently and safely
 /// races the tick loop when both are present (see the module docs on
 /// [`crate::pending_events`]).
-fn spawn_schedule_tick_loop_if_daemon(args: &Args, schedule_rt: Option<KhiveRuntime>) {
+fn spawn_schedule_tick_loop_if_daemon(
+    args: &Args,
+    server: &KhiveMcpServer,
+    schedule_rt: Option<KhiveRuntime>,
+) {
     if !args.daemon {
         tracing::info!("schedule tick loop: skipped (client role; daemon owns the tick)");
         return;
@@ -172,7 +190,11 @@ fn spawn_schedule_tick_loop_if_daemon(args: &Args, schedule_rt: Option<KhiveRunt
         interval_secs = interval.as_secs(),
         "schedule tick loop: spawning (daemon role)"
     );
-    tokio::spawn(crate::pending_events::schedule_tick_loop(rt, interval));
+    tokio::spawn(crate::pending_events::schedule_tick_loop(
+        rt,
+        server.clone(),
+        interval,
+    ));
 }
 
 /// Spawn the email channel polling + outbox loops if the `channel-email`
@@ -967,7 +989,7 @@ pub async fn serve_server(
     }
     #[cfg(feature = "channel-email")]
     spawn_email_channel_loops_if_daemon(&server, args);
-    spawn_schedule_tick_loop_if_daemon(args, schedule_rt);
+    spawn_schedule_tick_loop_if_daemon(args, &server, schedule_rt);
 
     #[cfg(unix)]
     if args.daemon {
@@ -4763,6 +4785,149 @@ backend = "schedule-backend"
             0,
             "the marker must be ABSENT from \"main\" — the tick's runtime must not have \
              silently written into the main backend instead of the declared schedule backend"
+        );
+    }
+
+    /// Multi-backend ACTION-DISPATCH routing (codex PR #782 review round 2,
+    /// High finding): `schedule` defaults to "main" (no `[packs.schedule]`
+    /// entry declared), while `kg` — the pack whose `create` verb the stored
+    /// action below replays — is routed to a SEPARATE declared backend. A due
+    /// scheduled event whose action writes through `kg` must land its side
+    /// effect in `kg`'s OWN declared backend, never "main".
+    ///
+    /// This is the regression the round-1 fix-round was missing: round 1
+    /// fixed SCANNING (`scheduled_event` rows now correctly read from
+    /// `schedule`'s own backend, proven by
+    /// `build_server_schedule_tick_uses_the_declared_multi_backend_not_main`
+    /// above) but not DISPATCH — the drain replayed every stored action
+    /// through a throwaway `KhiveMcpServer::new(schedule_rt.clone())`, which
+    /// registers EVERY pack against the schedule backend alone. This test
+    /// drives the drain through `run_pending_events_on(&rt, &server, ..)`
+    /// with the daemon's REAL, fully-wired `server` (as
+    /// `spawn_schedule_tick_loop_if_daemon` now passes it) and asserts the
+    /// replayed action's own write shows up only in `kg`'s declared backend.
+    #[tokio::test]
+    #[serial]
+    async fn build_server_schedule_tick_dispatches_actions_through_the_declared_multi_backend_not_schedule(
+    ) {
+        let seat_dir = tempfile::tempdir().expect("seat tempdir");
+        let _seat_env = SeatEnv::enter(seat_dir.path());
+        std::env::remove_var("KHIVE_DB");
+        std::env::remove_var("KHIVE_ACTOR");
+        std::env::remove_var("KHIVE_PACKS");
+        std::env::remove_var("KHIVE_REQUIRE_ATTRIBUTED_ACTOR");
+
+        let main_db = seat_dir.path().join("main.db");
+        let kg_db = seat_dir.path().join("kg-backend.db");
+        let config_path = write_config(
+            seat_dir.path(),
+            &format!(
+                r#"
+[[backends]]
+name = "main"
+kind = "sqlite"
+path = "{main}"
+
+[[backends]]
+name = "kg-backend"
+kind = "sqlite"
+path = "{kg}"
+
+[packs.kg]
+backend = "kg-backend"
+"#,
+                main = main_db.display(),
+                kg = kg_db.display(),
+            ),
+        );
+
+        use clap::Parser;
+        let args = Args::parse_from(["mcp", "--config", config_path.to_str().expect("utf8 path")]);
+
+        let (server, schedule_rt) = build_server(&args).expect("build_server must succeed");
+        // No `[packs.schedule]` entry above, so it defaults to "main".
+        let rt = schedule_rt.expect("schedule pack is loaded by default");
+
+        let marker = "adr106-multi-backend-dispatch-marker";
+        let action_dsl = format!("create(kind=\"observation\", content=\"{marker}\")");
+        let past = (chrono::Utc::now() - chrono::Duration::seconds(5)).to_rfc3339();
+        let repeat: Option<&str> = None;
+        let fired_at: Option<&str> = None;
+        let cancelled_at: Option<&str> = None;
+        let props = serde_json::json!({
+            "trigger_at": past,
+            "repeat": repeat,
+            "status": "pending",
+            "event_type": "schedule",
+            "payload": action_dsl,
+            "fired_at": fired_at,
+            "cancelled_at": cancelled_at,
+        });
+        let ns = Namespace::parse("local").expect("ns");
+        let token = rt.authorize(ns).expect("authorize schedule runtime");
+        rt.create_note(
+            &token,
+            "scheduled_event",
+            None,
+            &action_dsl,
+            None,
+            Some(props),
+            vec![],
+        )
+        .await
+        .expect("create scheduled_event through the schedule runtime");
+
+        let summary = crate::pending_events::run_pending_events_on(&rt, &server, false)
+            .await
+            .expect("drain");
+        assert_eq!(
+            summary.fired + summary.advanced,
+            1,
+            "the due event must be dispatched, got summary={summary:?}"
+        );
+        assert_eq!(summary.failed, 0, "dispatch must not fail: {summary:?}");
+
+        let count_marker_notes = |path: std::path::PathBuf| async move {
+            let cfg = RuntimeConfig {
+                db_path: Some(path),
+                default_namespace: Namespace::parse("local").unwrap(),
+                embedding_model: None,
+                additional_embedding_models: vec![],
+                ..RuntimeConfig::default()
+            };
+            let probe_rt = KhiveRuntime::new(cfg).expect("reopen backend file");
+            let ns = Namespace::parse("local").unwrap();
+            let token = probe_rt.authorize(ns).expect("authorize probe");
+            let store = probe_rt.notes(&token).expect("notes store");
+            let page = store
+                .query_notes(
+                    "local",
+                    Some("observation"),
+                    khive_storage::types::PageRequest {
+                        limit: 10,
+                        offset: 0,
+                    },
+                )
+                .await
+                .expect("query observation notes");
+            page.items
+                .into_iter()
+                .filter(|n| n.content == marker)
+                .count()
+        };
+
+        assert_eq!(
+            count_marker_notes(kg_db.clone()).await,
+            1,
+            "the replayed create(kind=\"observation\") action must land in the kg pack's OWN \
+             declared backend (\"kg-backend\"), not the schedule backend"
+        );
+        assert_eq!(
+            count_marker_notes(main_db.clone()).await,
+            0,
+            "the marker must be ABSENT from \"main\" (the schedule backend) — dispatching \
+             through a throwaway single-runtime server built from the schedule runtime alone \
+             would have written it here instead"
         );
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1289,8 +1289,8 @@ pub(crate) fn is_strict_actor_mode() -> bool {
 /// - `build_server` and `build_server_multi_backend` in this file (the `kkernel mcp` paths)
 /// - `build_registry_for_multi_backend` in this file (the ADR-029 coordinator path)
 /// - `kkernel exec` (`crates/kkernel/src/exec.rs`) — dispatches arbitrary ops
-/// - `kkernel pending_events` (`crates/kkernel/src/pending_events.rs`) — drains
-///   and dispatches scheduled events
+/// - `khive_mcp::pending_events::run_pending_events` — drains and dispatches
+///   scheduled events
 ///
 /// **Pure-introspection registry construction is intentionally EXEMPT** because it
 /// never dispatches verbs or reads comm/tenant data, so it carries no

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1329,16 +1329,57 @@ pub fn enforce_strict_actor_mode(
 /// #782 review's High finding: a second, independently-resolved config could
 /// silently target a different database, actor identity, or pack set than
 /// the daemon it claims to serve.
+///
+/// Thin wrapper over [`build_server_with_explicit_namespace`]: derives the
+/// `(namespace, namespace_explicit)` pair from a real CLI parse via
+/// [`resolve_cli_namespace`], and — because this is the genuine `--actor`
+/// / `--namespace` CLI flag path — also treats that explicitness as a real
+/// actor override (`actor_explicit` mirrors `namespace_explicit` here; see
+/// `RuntimeConfigInputs::actor_explicit`'s field doc for why only this call
+/// site is allowed to do that).
 pub fn build_server(args: &Args) -> anyhow::Result<(KhiveMcpServer, Option<KhiveRuntime>)> {
     let (cli_namespace_explicit, cli_namespace) =
         resolve_cli_namespace(args).map_err(|e| anyhow::anyhow!("{e}"))?;
+    build_server_with_explicit_namespace(
+        args,
+        cli_namespace,
+        cli_namespace_explicit,
+        cli_namespace_explicit,
+    )
+}
 
+/// Build a fully-configured server from parsed args plus an independently
+/// resolved `(namespace, namespace_explicit, actor_explicit)` triple.
+///
+/// Extracted from [`build_server`] (PR #782 review round 4, High finding) so
+/// that non-interactive-CLI callers — e.g. the `--pending-events` one-shot
+/// drain wrapper in `pending_events.rs` — can supply a namespace default
+/// without it being misread as a genuine `--actor` override. `build_server`
+/// derives its namespace from a real CLI parse (`resolve_cli_namespace`),
+/// where "a namespace value is present" and "the operator explicitly
+/// overrode the actor identity" are the same fact by construction — there is
+/// no way to type `--namespace foo` without meaning it. A caller that
+/// synthesizes an `Args` value programmatically (no real flag parse behind
+/// it) does not get to make that same inference: passing a default
+/// namespace through `namespace_explicit: true` while asserting the actor
+/// identity was never touched (`actor_explicit: false`) is exactly the
+/// `kkernel exec` / `kkernel reindex` shape (see their own
+/// `resolve_runtime_config` call sites and the field doc on
+/// `RuntimeConfigInputs::actor_explicit`), and this function is the seam
+/// that lets any caller opt into that same, narrower semantic instead of
+/// `build_server`'s CLI-only one.
+pub fn build_server_with_explicit_namespace(
+    args: &Args,
+    namespace: khive_runtime::Namespace,
+    namespace_explicit: bool,
+    actor_explicit: bool,
+) -> anyhow::Result<(KhiveMcpServer, Option<KhiveRuntime>)> {
     let config = resolve_runtime_config(RuntimeConfigInputs {
         db: args.db.as_deref(),
         config: args.config.as_deref(),
-        namespace: cli_namespace,
-        namespace_explicit: cli_namespace_explicit,
-        actor_explicit: cli_namespace_explicit,
+        namespace,
+        namespace_explicit,
+        actor_explicit,
         no_embed: args.no_embed,
         packs: if args.pack.is_empty() {
             None

--- a/crates/kkernel/src/exec.rs
+++ b/crates/kkernel/src/exec.rs
@@ -68,7 +68,10 @@ fn forward_or_spawn_boxed(frame: &DaemonRequestFrame) -> ForwardFuture<'_> {
     Box::pin(khive_mcp::daemon::forward_or_spawn(frame))
 }
 
-use crate::pending_events;
+// The scheduled-event drain now lives in `khive-mcp` (ADR-106: the
+// daemon-resident tick needs to call it from `khive-mcp::serve`, which
+// cannot depend back on `kkernel`).
+use khive_mcp::pending_events;
 
 // ── guarded local construction (cold-boot FTS race, #667/#645) ─────────────
 //

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -8,10 +8,15 @@ pub mod exec;
 pub mod git_ingest;
 pub mod kg;
 pub mod pack_introspect;
-pub mod pending_events;
 pub mod reindex;
 pub mod sync;
 pub mod vector;
+
+// `pending_events` (the scheduled-event drain) now lives in `khive-mcp`
+// (`khive_mcp::pending_events`), not here — the daemon-resident tick (ADR-106)
+// needs to call it from `khive-mcp::serve`, which cannot depend back on
+// `kkernel`. `kkernel exec --pending-events` (`exec.rs`) calls the moved
+// module directly.
 
 // Force the pack crates into the binary so their `inventory::submit!` blocks
 // run at startup. Cargo deps alone are not enough — the linker drops

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -327,13 +327,20 @@ async fn main() -> Result<()> {
                 #[cfg(not(unix))]
                 let boot_guard: Option<std::fs::File> = None;
 
-                let server = build_multi_backend_server_with_coordinator(
+                let (server, schedule_rt) = build_multi_backend_server_with_coordinator(
                     base_cfg,
                     &khive_cfg,
                     a.db.as_deref(),
                 )?;
 
-                khive_mcp::serve::serve_server(server, &a, &transport_registry, boot_guard).await
+                khive_mcp::serve::serve_server(
+                    server,
+                    &a,
+                    &transport_registry,
+                    boot_guard,
+                    schedule_rt,
+                )
+                .await
             }
         }
         Command::Backend(b) => cmd_backend(b),
@@ -415,13 +422,27 @@ fn resolve_command(exec: Option<String>, command: Option<Command>) -> Command {
 /// Extraction also makes this branch directly comparable, in a test, against
 /// `khive_mcp::serve::build_server_multi_backend` (the sibling boot path) —
 /// see `multi_backend_boot_paths_share_identical_wiring_surface` below.
+///
+/// Also returns the resolved `"schedule"`-pack runtime (ADR-106), read out of
+/// the same `multi.per_pack_runtimes` map used to build the coordinator's
+/// `BackendRegistry` below — `None` when the resolved pack set does not
+/// include `"schedule"`. The caller threads this through
+/// `khive_mcp::serve::serve_server` so the daemon-resident tick loop
+/// (`spawn_schedule_tick_loop_if_daemon`) drains the exact backend this
+/// coordinator-attached boot resolved, never a re-derived config (codex PR
+/// #782 review, High finding).
 fn build_multi_backend_server_with_coordinator(
     base_cfg: RuntimeConfig,
     khive_cfg: &KhiveConfig,
     cli_db_override: Option<&str>,
-) -> Result<khive_mcp::server::KhiveMcpServer> {
+) -> Result<(khive_mcp::server::KhiveMcpServer, Option<KhiveRuntime>)> {
     let multi =
         khive_mcp::serve::build_registry_for_multi_backend(base_cfg, khive_cfg, cli_db_override)?;
+
+    let schedule_rt = multi
+        .per_pack_runtimes
+        .get("schedule")
+        .map(|rt| (**rt).clone());
 
     // Build BackendRegistry: one entry per unique backend (deduplicated
     // by backend_name so packs sharing a backend share one runtime).
@@ -447,11 +468,12 @@ fn build_multi_backend_server_with_coordinator(
     let coord =
         SubstrateCoordinatorService::new(SubstrateCoordinator::new(backend_reg), note_kinds);
 
-    Ok(khive_mcp::serve::build_server_from_multi_backend_registry(
+    let server = khive_mcp::serve::build_server_from_multi_backend_registry(
         multi,
         khive_cfg,
         Some(Arc::new(coord) as Arc<dyn khive_mcp::coordinator::CoordinatorService>),
-    ))
+    );
+    Ok((server, schedule_rt))
 }
 
 async fn cmd_db(cmd: DbCommand) -> Result<()> {
@@ -963,7 +985,7 @@ mod tests {
         )
         .expect("plain multi-backend boot must succeed");
 
-        let coordinator_server = build_multi_backend_server_with_coordinator(
+        let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
             base_multi_backend_runtime_config(),
             &khive_cfg,
             None,
@@ -997,7 +1019,7 @@ mod tests {
         )
         .expect("plain multi-backend boot must succeed");
 
-        let coordinator_server = build_multi_backend_server_with_coordinator(
+        let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
             base_multi_backend_runtime_config(),
             &khive_cfg,
             None,
@@ -1074,7 +1096,7 @@ mod tests {
         )
         .expect("plain multi-backend boot must succeed");
 
-        let coordinator_server = build_multi_backend_server_with_coordinator(
+        let (coordinator_server, _schedule_rt) = build_multi_backend_server_with_coordinator(
             base_multi_backend_runtime_config(),
             &khive_cfg,
             None,
@@ -1202,8 +1224,9 @@ mod tests {
             ..base_multi_backend_runtime_config()
         };
 
-        let server = build_multi_backend_server_with_coordinator(base_cfg, &khive_cfg, None)
-            .expect("coordinator-attached multi-backend boot must succeed");
+        let (server, _schedule_rt) =
+            build_multi_backend_server_with_coordinator(base_cfg, &khive_cfg, None)
+                .expect("coordinator-attached multi-backend boot must succeed");
 
         let dispatch = |ops: String| {
             let server = &server;

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -1,7 +1,8 @@
 # ADR-106: Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-09
+**Amended**: 2026-07-09 (missed-event grace policy, Amendment A; implementation note, Amendment B)
 **Depends on**: [ADR-040](ADR-040-communication-and-schedule-packs.md) (schedule pack
 verbs and `scheduled_event` note kind), [ADR-049](ADR-049-khived-daemon.md) (warm daemon
 process model), [ADR-016](ADR-016-request-dsl.md) (request DSL, replayed at fire time)
@@ -442,3 +443,163 @@ daemon-resident tick:
   the drain already has.
 - A new environment-configurable interval knob is introduced for the schedule tick,
   following the same override pattern already used for the checkpoint task's interval.
+
+## Amendment A: Missed-event grace policy (2026-07-09)
+
+The drain, as originally specified above, fires any `scheduled_event` row it finds
+`pending` with `trigger_at <= now`, regardless of how overdue it is. Decision point 7
+calls this out as a feature, not an oversight: "a daemon that was down for an hour
+simply fires everything overdue on its first tick after restart." That behavior is
+correct for a short outage. It is the wrong behavior for a long one, or for a fresh
+deployment's first tick against a database that already carries an accumulated backlog
+of undrained rows: every one of those rows would fire in a single pass, including rows
+whose action has an externally visible, agent-facing side effect (an outbound
+`comm.send`, a spawned action, and similar). Firing a large stale backlog all at once is
+a mass-notification / mass-side-effect incident waiting to happen, not a recovery.
+
+### Policy
+
+An event is **missed** when the drain discovers it `pending` and overdue by more than a
+configurable grace window, `KHIVE_FIRE_GRACE_SECS` (default `300`, five minutes).
+
+- A missed event is **never dispatched**. Its stored action is not replayed, regardless
+  of `event_type`.
+- A missed, **non-repeating** event is marked terminal: `status` transitions to
+  `"missed"`, `missed_at` is stamped (epoch microseconds, the same unit `firing_at` and
+  the drain's other internal timestamps already use), and `fired_at` is left `null` —
+  the row was never fired, so `fired_at` must not claim otherwise.
+- A missed **repeating** event is not left terminal: the drain advances its
+  `trigger_at` past every occurrence at or before `now` in one step, landing on the
+  first occurrence strictly after `now`, and re-arms the row to `status = "pending"` at
+  that new `trigger_at`. `missed_at` is still stamped, recording that at least one
+  occurrence was skipped. The event never fires a catch-up burst — a daily reminder
+  that accumulated ten missed occurrences advances directly to tomorrow's, not through
+  ten sequential fires.
+- A row overdue by less than the grace window is unaffected: it fires (or advances,
+  for a repeat) exactly as specified in the base ADR, with no behavior change.
+
+The practical consequence for a first daemon boot against a store carrying a large
+stale backlog (every row overdue well past the grace window): every such row is marked
+`"missed"` (or re-armed, for repeats) on the first tick, and zero of them are
+dispatched. This is the intended migration behavior, not a bug — it is exactly the
+scenario the policy exists to guard against.
+
+### Why skip-and-mark, not catch-up-once or fire-everything
+
+Prior art disagrees on missed-fire handling, and the disagreement tracks what kind of
+side effect a missed action typically has:
+
+- **systemd** (`Persistent=true` on a timer unit) catches up **once**: if the system was
+  off past a timer's scheduled run, the unit fires a single time on the next boot,
+  collapsing any number of missed occurrences into one. This is close to khive's
+  repeat-rearm behavior in spirit (no burst), but systemd's model still fires the
+  action — it assumes the missed unit's side effect is idempotent-ish or safe to run
+  late (a backup job, a log rotation). khive's action space is a replayed `VerbRegistry`
+  call, and nothing in the schedule pack constrains that call to be side-effect-free or
+  idempotent; a `comm.send` dispatched hours or days late is not equivalent to on-time
+  delivery, it is a surprise.
+- **Quartz** exposes per-trigger misfire instructions (`fire now`, `do nothing`, `reset
+  to next fire time`), pushing the decision to the scheduling caller on a per-schedule
+  basis. This is a real, more flexible design point khive does not adopt for v1: it
+  would require a new field on `scheduled_event` (a per-row misfire policy) and a
+  corresponding write-time API surface on `schedule.schedule`/`schedule.remind`,
+  neither of which exists today. A single global grace window is the smaller, additive
+  change; a per-row override is a natural extension if a real use case demands it,
+  tracked as follow-on work rather than blocking this ADR.
+- **Sidekiq** (the general background-job-queue precedent, not schedule-specific) fires
+  everything it finds due, in full, with no missed-fire concept at all — the job queue
+  model assumes catching up on a backlog of independent jobs is exactly the desired
+  behavior. That assumption is correct for typical queued work (each job is
+  independent, idempotent-by-convention, and "eventually processed" is the contract)
+  and wrong for khive's schedule pack, where a `scheduled_event` models a specific
+  point in time the caller cared about (a reminder due today, a briefing due at 9am),
+  not a work item that is equally valid whenever it happens to run.
+
+khive chooses **skip-and-mark** over both: never replay a stale action (ruling out
+Sidekiq's fire-everything and softening systemd's fire-once), but never lose the
+schedule either (a repeat re-arms to its next real occurrence rather than being
+abandoned, and a non-repeat's miss is visibly recorded via `status = "missed"` +
+`missed_at` rather than silently vanishing). The deciding factor is that khive's action
+space is closed but unconstrained in side-effect shape (Decision point 3 of the base
+ADR: "replay a validated khive verb DSL string," which can be a `comm.send`, a
+`create`, or any other registered verb) — the drain cannot assume any given action is
+safe to fire late, so the only universally safe choice is to never fire late at all, and
+instead make the miss observable and, for repeats, self-healing at the next real
+occurrence.
+
+### Interaction with the rest of this ADR
+
+The missed-event check runs inside the existing claim/finalize CAS
+(`claim_pending_event` / `finalize_fired_event`), not as a separate pass: a row is
+still claimed `pending -> firing` before its missed-vs-fire disposition is decided, so
+the same race protection against a concurrent `schedule.cancel` (Decision point 5's CAS
+argument) and the same redundant-external-cron safety apply identically to the missed
+path. No new claim mechanism was introduced. The `DrainSummary` type gains one new
+field, `missed: Vec<Uuid>` (the IDs marked missed or re-armed this pass), alongside the
+seven fields already specified in Decision point 2.
+
+## Amendment B: Implementation note — the wiring seam actually shipped (2026-07-09)
+
+Decision points 1-3 above specify a fairly involved target design for the tick's home
+and lifecycle: a `DaemonDispatch::drain_pending_events` trait method with `DrainSummary`
+/ `DrainError` types owned by `khive-runtime`, `schedule_tick_loop` spawned from
+`run_daemon_with_boot_guard` in `khive-runtime/src/daemon.rs`, and an explicit
+`tokio::sync::watch`-channel shutdown signal integrated with the daemon's existing
+`track_background_task` bounded-drain shutdown sequence.
+
+The implementation landing alongside this amendment takes a smaller step toward that
+target rather than the full design in one PR, to keep the missed-event policy (Amendment
+A, the change with the more immediate safety payoff) decoupled from a `DaemonDispatch`
+trait-signature change that every implementor of that trait would need to absorb in the
+same PR:
+
+- The drain's internal functions (`claim_pending_event`, `dispatch_action`,
+  `finalize_fired_event`, `reclaim_stale_firing_events`, `discover_pending_namespaces`,
+  and the `run_pending_events` orchestration) moved from `crates/kkernel` into
+  `crates/khive-mcp` (`khive_mcp::pending_events`), matching Decision point 2's target
+  home for the drain logic itself. `kkernel exec --pending-events` now calls
+  `khive_mcp::pending_events::run_pending_events` directly rather than a `kkernel`-local
+  copy — this part of Decision point 2 is delivered as specified.
+- `schedule_tick_loop` is spawned from `khive-mcp/src/serve.rs`
+  (`spawn_schedule_tick_loop_if_daemon`), gated on `args.daemon` exactly the way
+  `spawn_email_channel_loops_if_daemon` already gates the email-channel loops (Decision
+  point 4's `is_daemon_role` gating is delivered as specified; only the _file_ differs
+  from Decision point 1's `daemon.rs` target).
+- The tick does **not** go through a `DaemonDispatch::drain_pending_events` trait
+  method. `khive-runtime` gains no new trait method and no new `DrainSummary`/
+  `DrainError` types; those remain owned by `khive-mcp` (as `DrainSummary` already was
+  before this ADR). Each tick instead constructs its own short-lived `KhiveRuntime`
+  against the daemon's configured `db`/`namespace`, the same construction
+  `kkernel exec --pending-events` uses, rather than sharing the live daemon's warm
+  runtime. This is the "Why the drain cannot be ticked as-is" problem the base ADR
+  identifies, deliberately left unsolved here: the cost is a connection-pool warm-up
+  every tick, not a correctness risk, because the drain's claim/finalize CAS already
+  makes redundant invocations safe by construction (Decision point 5) — the same
+  property that makes running external cron alongside the tick safe makes a per-tick
+  fresh runtime safe too, just at a higher resource cost than the shared-runtime design
+  would have.
+- Shutdown is a bare `tokio::spawn` with no `track_background_task` registration and no
+  watch-channel signal, matching how the checkpoint task and the email-channel loops are
+  already spawned in the current codebase (neither uses `track_background_task` today
+  either). A tick in flight at process shutdown is simply dropped, not drained; the next
+  daemon start (or a redundant external cron invocation) picks up any row left
+  mid-claim via the existing `reclaim_stale_firing_events` sweep, the same recovery
+  path Acceptance Criterion 5 relies on for the target design's bounded-drain case.
+- The interval env var is `KHIVE_SCHEDULE_TICK_SECS` (seconds, default `60`), not
+  `KHIVE_SCHEDULE_TICK_INTERVAL_MS` (milliseconds, default `60000`) as specified in
+  Decision point 6. The resolved default cadence is identical (60 seconds); only the
+  variable name and unit differ from the original decision.
+
+None of this changes Acceptance Criteria 1, 2, 4, or 6, which describe externally
+observable behavior (a due row fires within one tick interval; concurrent cron and tick
+invocations race safely to exactly one fire; the interval is configurable with a 60s
+default; the CLI wrapper is unchanged) — all four hold under the shipped
+implementation. Acceptance Criteria 3, 5, and 7 describe the specific trait-based
+mechanism (the `is_daemon_role` test shape, the watch-channel shutdown regression, and
+`khive-runtime`'s dependency graph): 3 holds as stated (the gate is on `args.daemon`
+regardless of which file spawns the loop); 5 and 7 are **not** met by the shipped
+implementation, since there is no watch-channel shutdown to test and `DrainSummary`
+never moved into `khive-runtime`. Closing that gap — moving to the full
+`DaemonDispatch::drain_pending_events` trait seam with tracked, graceful shutdown and a
+shared warm runtime per tick — remains open follow-on work, tracked separately from the
+missed-event policy this amendment's primary content (Amendment A) delivers.

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -734,6 +734,17 @@ multi-backend deployments, plus two narrower regression/resource issues:
 - The PR description was updated to match this shipped state (shared resolved runtime
   for scan, the daemon's real live server for dispatch, Criteria 5-7 unmet) rather than
   the pre-fix-round "fresh per-tick runtime" / "Criterion 6 met" text it still carried.
+- **Fix-round 3 addendum (2026-07-09):** the round-2 keyset page queries and
+  `discover_pending_namespaces` compared `trigger_at` as raw RFC3339 text, which sorts
+  lexicographically rather than chronologically for values carrying a non-UTC offset
+  (`handlers.rs` deliberately round-trips the caller's original offset, so this was
+  reachable in production, not just theoretically). Fixed by wrapping both sides of the
+  due-ness predicate in SQLite's `datetime(...)` (plus an `OR ... IS NULL` clause so
+  unparseable `trigger_at` values stay visible to the existing Rust-side skip/log path
+  instead of being silently excluded) in all three affected queries: both keyset page
+  branches and `discover_pending_namespaces`. The comparison is now chronological via
+  SQLite `datetime()`; storage still round-trips the caller's original string — H5
+  unchanged.
 
 None of this changes the Criteria 1-7 status table above — the High finding this round
 closed was scoped entirely to dispatch routing, which Criterion 2 (fire-exactly-once)

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -363,8 +363,11 @@ unaffected by this ADR.
 3. No MCP client process (a stdio `kkernel mcp` session without `--daemon`) spawns a
    schedule tick, verified the same way the existing `is_daemon_role_false_for_client_args`
    /`is_daemon_role_true_for_daemon_args` tests verify the email-channel gate.
-4. The tick interval is overridable via `KHIVE_SCHEDULE_TICK_INTERVAL_MS` and defaults
-   to 60000 (60 seconds) when unset, unparseable, or zero.
+4. The tick interval is overridable via `KHIVE_SCHEDULE_TICK_SECS` (seconds) and defaults
+   to 60 seconds when unset, unparseable, or zero. (Amended 2026-07-09, codex PR #782
+   review fix-round: the shipped implementation uses this name and unit — see Amendment
+   B — and this criterion is restated to name the accepted contract rather than the
+   originally-proposed `KHIVE_SCHEDULE_TICK_INTERVAL_MS`/milliseconds form.)
 5. A production-shaped shutdown regression, built against `KhiveMcpServer` (the real
    dispatcher, not a mock), demonstrates that stopping the daemon signals the watch
    channel, the tick loop's `select!` observes the signal while idle and exits
@@ -568,16 +571,7 @@ same PR:
 - The tick does **not** go through a `DaemonDispatch::drain_pending_events` trait
   method. `khive-runtime` gains no new trait method and no new `DrainSummary`/
   `DrainError` types; those remain owned by `khive-mcp` (as `DrainSummary` already was
-  before this ADR). Each tick instead constructs its own short-lived `KhiveRuntime`
-  against the daemon's configured `db`/`namespace`, the same construction
-  `kkernel exec --pending-events` uses, rather than sharing the live daemon's warm
-  runtime. This is the "Why the drain cannot be ticked as-is" problem the base ADR
-  identifies, deliberately left unsolved here: the cost is a connection-pool warm-up
-  every tick, not a correctness risk, because the drain's claim/finalize CAS already
-  makes redundant invocations safe by construction (Decision point 5) — the same
-  property that makes running external cron alongside the tick safe makes a per-tick
-  fresh runtime safe too, just at a higher resource cost than the shared-runtime design
-  would have.
+  before this ADR).
 - Shutdown is a bare `tokio::spawn` with no `track_background_task` registration and no
   watch-channel signal, matching how the checkpoint task and the email-channel loops are
   already spawned in the current codebase (neither uses `track_background_task` today
@@ -588,18 +582,97 @@ same PR:
 - The interval env var is `KHIVE_SCHEDULE_TICK_SECS` (seconds, default `60`), not
   `KHIVE_SCHEDULE_TICK_INTERVAL_MS` (milliseconds, default `60000`) as specified in
   Decision point 6. The resolved default cadence is identical (60 seconds); only the
-  variable name and unit differ from the original decision.
+  variable name and unit differ from the original decision — Acceptance Criterion 4
+  above is amended to name this shipped contract directly.
 
-None of this changes Acceptance Criteria 1, 2, 4, or 6, which describe externally
-observable behavior (a due row fires within one tick interval; concurrent cron and tick
-invocations race safely to exactly one fire; the interval is configurable with a 60s
-default; the CLI wrapper is unchanged) — all four hold under the shipped
-implementation. Acceptance Criteria 3, 5, and 7 describe the specific trait-based
-mechanism (the `is_daemon_role` test shape, the watch-channel shutdown regression, and
-`khive-runtime`'s dependency graph): 3 holds as stated (the gate is on `args.daemon`
-regardless of which file spawns the loop); 5 and 7 are **not** met by the shipped
-implementation, since there is no watch-channel shutdown to test and `DrainSummary`
-never moved into `khive-runtime`. Closing that gap — moving to the full
-`DaemonDispatch::drain_pending_events` trait seam with tracked, graceful shutdown and a
-shared warm runtime per tick — remains open follow-on work, tracked separately from the
-missed-event policy this amendment's primary content (Amendment A) delivers.
+### Fix-round update (2026-07-09, codex PR #782 review)
+
+The initial cut of this amendment (above) additionally claimed the tick "constructs its
+own short-lived `KhiveRuntime` against the daemon's configured `db`/`namespace`... rather
+than sharing the live daemon's warm runtime," and framed that as a resource-cost-only
+deviation. Codex's review of the PR carrying this ADR (#782) identified that claim as
+incorrect: a tick that independently re-resolves `RuntimeConfig::default()` from raw
+`--db` and an inferred namespace does not merely reconstruct the _same_ configuration at
+extra cost — it silently **discards** everything the daemon's own boot path
+(`khive-mcp::serve::build_server` / `build_registry_for_multi_backend`) resolves from
+`--config`/`[[backends]]`/actor identity/`--pack` selection. A config-backed daemon's
+tick could therefore drain `$HOME/.khive/khive.db` instead of the configured schedule
+backend, trip strict-actor-mode failures the live server never has, or dispatch stored
+actions through packs the daemon never loaded. This was filed as the review's High
+finding and fixed in the same PR, before merge:
+
+- `build_server` now returns, alongside the server, the resolved `"schedule"`-pack
+  `KhiveRuntime` handle it already constructed while building the server itself
+  (`Option<KhiveRuntime>` — `None` when the resolved pack set excludes `"schedule"`).
+  For a single-backend boot this is the one runtime the whole daemon shares; for a
+  multi-backend boot (ADR-028 `[[backends]]`) it is the specific per-pack runtime
+  `"schedule"` was wired to, read out of `MultiBackendRegistry.per_pack_runtimes`. The
+  coordinator-attached multi-backend path (`kkernel`'s `Command::Mcp` branch) resolves
+  and threads the same handle through `serve_server`.
+- `schedule_tick_loop` takes that runtime by value (`KhiveRuntime::clone()` is a cheap
+  `Arc`-wrapped clone) instead of `db: Option<String>, namespace: String`, and every tick
+  drains through it via a new `run_pending_events_on(rt: &KhiveRuntime, ...)` entry point.
+  `run_pending_events` (the CLI one-shot path, `kkernel exec --pending-events`) is
+  unchanged — it still resolves its own throwaway config per invocation, which remains
+  correct for a short-lived cron-invoked process — and now delegates to
+  `run_pending_events_on` internally.
+- This also resolves the resource-cost concern the original text raised (a fresh
+  connection-pool warm-up every tick): the tick now reuses the daemon's already-warm
+  runtime and connection pool rather than constructing a new one per pass.
+- Tick cadence was also corrected in the same fix-round (a separate, Medium-severity
+  finding in the same review): `schedule_tick_loop` now ticks on
+  `tokio::time::interval_at(now + interval, interval)` with
+  `MissedTickBehavior::Skip`, matching Decision point 6's fixed-interval specification,
+  rather than sleeping `interval` after each drain (which had produced an effective
+  cadence of `interval + drain_duration`, drifting further behind on every pass that
+  found a nontrivial backlog).
+- The drain's own pagination was independently found to skip rows once an overdue
+  backlog exceeded one page (`PAGE_SIZE = 200`): paging `status="pending"` with
+  `LIMIT/OFFSET` while the same loop mutates rows out of that predicate desynchronizes
+  the offset from the shrinking result set. Fixed by snapshotting every candidate row for
+  a namespace before any mutation begins, then processing the fixed-size snapshot with no
+  further paginated queries. A regression with 201 overdue rows (`PAGE_SIZE + 1`) covers
+  this.
+- A new concurrent-drain regression (two `run_pending_events` calls racing over the same
+  store, asserting exactly one fire per row across both) was added alongside the existing
+  CAS-race unit tests, closing the exact gap Acceptance Criterion 2 names.
+
+None of this changes Acceptance Criteria 1, 3, 4, or 6's _scope_ — but their status
+against the shipped implementation is restated here precisely, since the original
+"None of this changes Acceptance Criteria 1, 2, 4, or 6... all four hold" claim below
+(now superseded) conflated "unchanged in scope" with "met," which was not accurate for
+Criterion 6:
+
+- **Criterion 1** (a due row fires within one tick interval): **met**. Unaffected by this
+  fix-round beyond the cadence and runtime-targeting corrections above, which strengthen
+  rather than weaken it.
+- **Criterion 2** (concurrent cron + tick invocations race to exactly one fire): **met**,
+  now backed by the concurrent-drain regression added in this fix-round (previously
+  claimed met on the strength of the CAS design alone, with no regression exercising
+  concurrency — codex's Medium finding on this amendment).
+- **Criterion 3** (no stdio client spawns a tick): **met**, unchanged — the gate is on
+  `args.daemon` regardless of which file spawns the loop.
+- **Criterion 4** (interval configurable, 60s default): **met**, under the shipped
+  `KHIVE_SCHEDULE_TICK_SECS` contract the criterion text above was amended to name.
+- **Criterion 5** (production-shaped watch-channel shutdown regression): **not met**.
+  There is no watch-channel shutdown to test; a tick in flight at process shutdown is
+  still simply dropped, recovered by the next `reclaim_stale_firing_events` sweep.
+- **Criterion 6** (`kkernel exec --pending-events` implemented as a thin wrapper over
+  `DaemonDispatch::drain_pending_events`): **not met**. The CLI path calls
+  `khive_mcp::pending_events::run_pending_events` directly, not a `DaemonDispatch` trait
+  method — no such trait method exists. This criterion was incorrectly listed as met in
+  the original cut of this amendment; that was a direct contradiction of this same
+  amendment's own bullet stating "the tick does **not** go through a
+  `DaemonDispatch::drain_pending_events` trait method," caught in the codex PR #782
+  review (Medium finding).
+- **Criterion 7** (`khive-runtime` gains no new dependency after `DaemonDispatch` gains
+  `drain_pending_events`): **not met** — vacuously, since no such trait method was added.
+  `cargo tree -p khive-runtime` showing no edge to `khive-mcp`/`khive-request`/`kkernel`
+  remains true today, but for a different reason than the criterion describes (nothing
+  was added to `khive-runtime` at all, rather than something being added safely).
+
+Closing the Criterion 5/6/7 gap — moving to the full `DaemonDispatch::drain_pending_events`
+trait seam with tracked, graceful shutdown and `DrainSummary`/`DrainError` owned by
+`khive-runtime` — remains open follow-on work, tracked separately from the missed-event
+policy (Amendment A) and the runtime-targeting/cadence/pagination fixes (this fix-round)
+this ADR has delivered so far.

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -570,8 +570,10 @@ same PR:
   from Decision point 1's `daemon.rs` target).
 - The tick does **not** go through a `DaemonDispatch::drain_pending_events` trait
   method. `khive-runtime` gains no new trait method and no new `DrainSummary`/
-  `DrainError` types; those remain owned by `khive-mcp` (as `DrainSummary` already was
-  before this ADR).
+  `DrainError` types; `DrainSummary` is owned by `khive-mcp` — it moved there from
+  `crates/kkernel` as part of the same relocation described above, not something
+  `khive-mcp` already owned before this ADR — and no separate `DrainError` type exists
+  at all (per-event failures accumulate in `DrainSummary.failed` instead).
 - Shutdown is a bare `tokio::spawn` with no `track_background_task` registration and no
   watch-channel signal, matching how the checkpoint task and the email-channel loops are
   already spawned in the current codebase (neither uses `track_background_task` today
@@ -745,6 +747,24 @@ multi-backend deployments, plus two narrower regression/resource issues:
   branches and `discover_pending_namespaces`. The comparison is now chronological via
   SQLite `datetime()`; storage still round-trips the caller's original string — H5
   unchanged.
+- **Fix-round 4 addendum (2026-07-09):** the one-shot CLI path (`run_pending_events`)
+  synthesized an `Args` value with `namespace: Some("local")` and called `build_server`
+  directly — the same entry point real `--actor`/`--namespace` CLI flags go through.
+  `build_server` derives both `namespace_explicit` and `actor_explicit` from a single
+  `resolve_cli_namespace` check, which is correct for a genuine CLI parse (there is no
+  way to type `--namespace` without meaning an explicit actor override) but wrong for a
+  synthesized default: it made a default-resolved `"local"` namespace clear any
+  project-configured `[actor] id` exactly as if the operator had typed `--actor local`,
+  contradicting this section's own claim that the CLI path honors `[actor] id`, and
+  could fail server construction outright under strict actor mode despite a valid
+  config. Fixed by extracting `build_server`'s body (after CLI-namespace resolution)
+  into a new `build_server_with_explicit_namespace(args, namespace, namespace_explicit,
+  actor_explicit)` seam; `build_server` itself is unchanged (still derives both flags
+  from `resolve_cli_namespace`), while `run_pending_events` now calls the new seam
+  directly with `namespace_explicit: true, actor_explicit: false` — the same shape
+  `kkernel exec`/`kkernel reindex` already use via their own `resolve_runtime_config`
+  calls, so a `"local"`-resolved default namespace falls through to the project/db/env
+  actor tiers instead of being treated as an explicit override.
 
 None of this changes the Criteria 1-7 status table above — the High finding this round
 closed was scoped entirely to dispatch routing, which Criterion 2 (fire-exactly-once)

--- a/docs/adr/ADR-106-schedule-pack-executor.md
+++ b/docs/adr/ADR-106-schedule-pack-executor.md
@@ -632,10 +632,13 @@ finding and fixed in the same PR, before merge:
   the offset from the shrinking result set. Fixed by snapshotting every candidate row for
   a namespace before any mutation begins, then processing the fixed-size snapshot with no
   further paginated queries. A regression with 201 overdue rows (`PAGE_SIZE + 1`) covers
-  this.
+  this. **Superseded in round 2 below** — the full-namespace snapshot this round
+  introduced turned out to have its own unbounded-memory failure mode.
 - A new concurrent-drain regression (two `run_pending_events` calls racing over the same
   store, asserting exactly one fire per row across both) was added alongside the existing
-  CAS-race unit tests, closing the exact gap Acceptance Criterion 2 names.
+  CAS-race unit tests, closing the exact gap Acceptance Criterion 2 names. **Strengthened
+  in round 2 below** — this version dispatched a read-only `stats()` action, which cannot
+  distinguish a clean single fire from a double-dispatch-one-finalize race.
 
 None of this changes Acceptance Criteria 1, 3, 4, or 6's _scope_ — but their status
 against the shipped implementation is restated here precisely, since the original
@@ -649,7 +652,8 @@ Criterion 6:
 - **Criterion 2** (concurrent cron + tick invocations race to exactly one fire): **met**,
   now backed by the concurrent-drain regression added in this fix-round (previously
   claimed met on the strength of the CAS design alone, with no regression exercising
-  concurrency — codex's Medium finding on this amendment).
+  concurrency — codex's Medium finding on this amendment), and strengthened in round 2
+  below to assert on the action's own side effect, not just the CAS-tracked counters.
 - **Criterion 3** (no stdio client spawns a tick): **met**, unchanged — the gate is on
   `args.daemon` regardless of which file spawns the loop.
 - **Criterion 4** (interval configurable, 60s default): **met**, under the shipped
@@ -670,6 +674,70 @@ Criterion 6:
   `cargo tree -p khive-runtime` showing no edge to `khive-mcp`/`khive-request`/`kkernel`
   remains true today, but for a different reason than the criterion describes (nothing
   was added to `khive-runtime` at all, rather than something being added safely).
+
+### Fix-round 2 update (2026-07-09, codex PR #782 review round 2)
+
+Codex's round-2 pass on this PR verified the round-1 fixes above were all present and
+gates green, but found the High runtime-policy fix (`build_server` threading the
+resolved `"schedule"`-pack runtime through to the tick) was still **incomplete** for
+multi-backend deployments, plus two narrower regression/resource issues:
+
+- **Dispatch still used the wrong runtime for multi-backend actions.** Round 1 fixed
+  _scanning_ — `run_pending_events_on` now reads `scheduled_event` rows from the
+  daemon's own resolved `"schedule"`-pack runtime, correct for multi-backend boots
+  where `schedule` is wired to its own declared backend. But the same function then
+  built its action-dispatch server from that runtime alone
+  (`KhiveMcpServer::new(rt.clone())`), which registers **every** pack against the
+  schedule backend. A replayed action belonging to another pack — `comm.send`, or any
+  `kg` verb — therefore dispatched into the schedule backend instead of that pack's
+  own configured one in a multi-backend deployment: scanning was correct, dispatch was
+  not. Fixed by threading the daemon's actual, already-multi-backend-wired
+  `KhiveMcpServer` through to the tick as a second parameter, alongside the schedule
+  runtime: `schedule_tick_loop(rt, server, interval)` and
+  `run_pending_events_on(rt, server, verbose)` now take both — `rt` for the
+  scan/claim/finalize SQL (schedule's own backend), `server` (cloned — cheap,
+  `Arc`-wrapped internally) for `dispatch_action` only (the daemon's live, fully-wired
+  registry). `spawn_schedule_tick_loop_if_daemon` clones the same `server` it is about
+  to hand to the transport/daemon bind, so replayed-action routing is identical to a
+  live request against this daemon. `run_pending_events` (the CLI one-shot path) now
+  also resolves both through `khive-mcp::serve::build_server` rather than a throwaway
+  `RuntimeConfig::default()` — a further honesty fix, since the CLI path previously
+  never consulted `khive.toml` at all (`[[backends]]`, `[actor] id`) despite
+  `kkernel mcp --daemon` and `kkernel exec`'s own ordinary-ops path both doing so. A new
+  regression (`build_server_schedule_tick_dispatches_actions_through_the_declared_multi_backend_not_schedule`)
+  declares `schedule` on `"main"` and `kg` on a separate backend, schedules a due event
+  whose action is `create(kind="observation", ...)` (a `kg` verb), drains via
+  `run_pending_events_on(&rt, &server, false)`, and asserts the resulting note lands
+  only in `kg`'s declared backend file, never `main`.
+- **The round-1 pagination fix introduced its own unbounded-memory failure mode.**
+  Snapshotting every `status="pending"` row for a namespace before mutation (round 1's
+  fix, above) correctly closed the offset-skip bug, but the snapshot filter checked
+  only `status`, not `trigger_at` — a namespace with one due event sitting in a large
+  FUTURE schedule pulled the entire future backlog into memory on every tick. Fixed by
+  replacing the `NoteFilter`/`query_notes_filtered` snapshot with a raw SQL statement
+  that (a) pushes `trigger_at <= now` into the `WHERE` clause directly, so future events
+  are never fetched at all, and (b) pages via a `(created_at, id)` keyset cursor instead
+  of `LIMIT/OFFSET` — both columns are immutable (this drain never rewrites either), so
+  a row's claim/dispatch/finalize mutation between pages can never shift a later page's
+  boundary (the original round-1 bug class), and at most `PAGE_SIZE` rows are held in
+  memory at once, never the whole namespace. The existing 201-row backlog regression
+  continues to cover the keyset-pagination-under-mutation property.
+- **The concurrent-drain regression's `stats()` action was too weak to catch its own
+  target bug.** A read-only action makes the CAS-tracked `status`/summary counters the
+  only signal, which cannot distinguish "claimed once, dispatched once" from "claimed
+  once, dispatched TWICE, only one finalize succeeded." Fixed by giving each of the 20
+  rows a row-distinct `create(kind="observation", content="concurrent-drain-marker-{i}")`
+  action and asserting, after both drains, that exactly one marker note exists per row —
+  the double-dispatch-one-finalize regression this test exists to catch would show up as
+  a marker count of 2 for the row that raced, which the counter-only version could not
+  detect.
+- The PR description was updated to match this shipped state (shared resolved runtime
+  for scan, the daemon's real live server for dispatch, Criteria 5-7 unmet) rather than
+  the pre-fix-round "fresh per-tick runtime" / "Criterion 6 met" text it still carried.
+
+None of this changes the Criteria 1-7 status table above — the High finding this round
+closed was scoped entirely to dispatch routing, which Criterion 2 (fire-exactly-once)
+already covers; no new criterion becomes met or unmet as a result.
 
 Closing the Criterion 5/6/7 gap — moving to the full `DaemonDispatch::drain_pending_events`
 trait seam with tracked, graceful shutdown and `DrainSummary`/`DrainError` owned by

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,7 +127,7 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-100](ADR-100-store-backup-replication.md)               | Store Backup and Replication — Scheduled Differential Sync with Tiered Recovery Objectives (Proposed)           |
 | [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs (Proposed)                           |
 | [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path (Proposed)                        |
-| [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain (Proposed)                            |
+| [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain (Accepted)                            |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Implements ADR-106: a daemon-resident tick for the schedule pack's pending-event
drain, plus a grace-window "missed event" policy the ADR did not originally specify
(added here as ADR-106 Amendment A).

The executor itself (`kkernel exec --pending-events`, the CAS claim/dispatch/finalize
state machine) already existed and was already well tested — this PR does not rebuild
it. It adds only:

1. **Daemon tick.** `spawn_schedule_tick_loop_if_daemon` in `khive-mcp/src/serve.rs`
   spawns a background task, gated on `args.daemon` exactly like the existing
   email-channel-loop gate (#602), that periodically re-invokes the drain for the
   lifetime of the daemon process. Interval: `KHIVE_SCHEDULE_TICK_SECS`, default 60s,
   ticking on `tokio::time::interval_at(now + interval, interval)` with
   `MissedTickBehavior::Skip` (fixed cadence, no sleep-after-drain drift).
2. **Missed-event grace policy.** An event discovered `pending` and overdue by more
   than `KHIVE_FIRE_GRACE_SECS` (default 300s) is never dispatched. Non-repeating
   events are marked `status=missed` with `missed_at` stamped; repeating events skip
   directly to the next future occurrence (no catch-up bursts). A first boot against a
   store carrying a large stale backlog therefore marks the whole backlog missed and
   dispatches zero of them — the intended migration behavior.
3. **Module relocation.** The drain's internals moved from `crates/kkernel` into
   `crates/khive-mcp` (`khive_mcp::pending_events`), because the daemon tick must call
   it in-process from `khive-mcp::serve`, and `khive-runtime` (where the daemon's
   accept loop lives) cannot depend back on `khive-mcp`. `kkernel exec
   --pending-events` now calls the moved module directly.
4. **Runtime + dispatch wiring (both threaded from the daemon's real boot state, not
   reconstructed inside the tick).** `khive-mcp::serve::build_server` now returns,
   alongside the server, the resolved `"schedule"`-pack `KhiveRuntime` handle it
   already built while constructing the server (`Option<KhiveRuntime>`). The tick
   takes BOTH that runtime and the daemon's own live, fully-wired `KhiveMcpServer`
   (cloned — cheap, `Arc`-wrapped): the runtime is used to scan/claim/finalize
   `scheduled_event` rows against whichever backend the `schedule` pack is wired to
   (single-backend: the one shared runtime; multi-backend/ADR-028 `[[backends]]`: the
   specific per-pack runtime); the server is used only to replay a fired event's
   stored action DSL, so a multi-backend deployment's `comm.send`/`kg`/other-pack
   actions dispatch through THAT pack's own configured backend, not the schedule
   backend. `run_pending_events` (the CLI one-shot path, `kkernel exec
   --pending-events`) resolves both the same way, through `build_server`, rather than
   a throwaway `RuntimeConfig::default()` that never consulted `khive.toml` at all.
5. **ADR-106 amended in place**, status flipped Proposed → Accepted:
   - **Amendment A** states the missed/grace policy normatively, with a
     systemd/Quartz/Sidekiq prior-art comparison explaining why khive chooses
     skip-and-mark over catch-up-once or fire-everything.
   - **Amendment B** documents that the shipped wiring is a smaller step than the
     ADR's original Decision points 1-3 (a `DaemonDispatch::drain_pending_events`
     trait seam in `khive-runtime` with `tokio::sync::watch`-channel graceful
     shutdown): this PR spawns from `khive-mcp::serve` with a bare `tokio::spawn`
     and the daemon's own shared runtime + server (see point 4 above), not a
     `DaemonDispatch` trait method. Two codex review rounds on this PR corrected
     the amendment's initial (inaccurate) claims about what shipped — see the
     amendment's "Fix-round update" and "Fix-round 2 update" subsections for the
     detailed history. Current status: Acceptance Criteria 1, 2, 3, 4 are **met**;
     5, 6, 7 (the `DaemonDispatch` trait seam, graceful shutdown, and
     `khive-runtime`-owned types) are **not met** and remain open follow-on work.

Refs #779: `crates/khive-pack-schedule`'s own tests were audited and already use
`KhiveRuntime::memory()` (fully isolated, in-memory) — the test-isolation fix that
issue requests appears to already be in place in this tree. The issue's other ask
(soft-deleting 8 pre-existing fixture rows reportedly sitting in a live
`~/.khive/khive.db`) was **not** touched by this PR, per the standing prohibition on
writing to any live store from an agent session; that curation needs a human with
direct access to the live database.

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy -p khive-mcp -p kkernel --all-targets -- -D warnings` — pass, zero warnings
- [x] `cargo test -p khive-mcp -p kkernel` — all pass (183 khive-mcp lib + other khive-mcp
      binaries; 232 kkernel lib + 16 main-bin + integration test binaries)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p khive-mcp -p kkernel` — pass
- [x] New regression tests, all on throwaway temp-file/in-memory stores (never touch `~/.khive/khive.db`):
  - `nine_overdue_events_beyond_grace_are_missed_with_zero_dispatch` — 9 events overdue past grace drain to `status=missed`, zero dispatches, verified via a genuinely side-effecting `create` action whose output note is confirmed ABSENT (not just zero fired/advanced counters)
  - `overdue_within_grace_still_fires` — an event overdue by less than the grace window still fires normally
  - `missed_repeat_is_rearmed_at_next_future_occurrence` (end-to-end) + `advance_repeat_past_missed_skips_all_accumulated_occurrences` (deterministic unit test) — a missed daily repeat re-arms to the next future occurrence in a single advance, never a catch-up burst
  - `backlog_larger_than_page_size_is_fully_drained_in_one_pass` — 201 far-overdue rows (one page over `PAGE_SIZE=200`) all drain in a single pass; proves the keyset-pagination fix doesn't skip rows under mutation
  - `concurrent_drains_fire_each_row_exactly_once` — two concurrent drains over the same store, each of 20 rows carrying a row-distinct side-effecting marker action; asserts exactly one marker note lands per row (catches double-dispatch-one-finalize, not just CAS-race counters)
  - `build_server_schedule_tick_uses_the_configured_backend_not_the_home_default`,
    `..._uses_the_configured_actor_identity`,
    `..._is_none_when_schedule_pack_is_not_in_the_restricted_pack_set`,
    `..._runtime_satisfies_strict_actor_mode_like_the_live_server`,
    `..._uses_the_declared_multi_backend_not_main` — `build_server`'s returned
    schedule-tick runtime targets the configured backend/actor/pack-set, single- and
    multi-backend
  - `build_server_schedule_tick_dispatches_actions_through_the_declared_multi_backend_not_schedule` —
    `schedule` and `kg` routed to separate declared backends; a due event's
    `kg`-pack action lands its side effect only in `kg`'s backend, never `schedule`'s
  - All pre-existing drain tests (claim/finalize CAS, stale-firing reclaim, namespace isolation, repeat advance, idempotency, dispatch-failure handling) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
