### PR TITLE
fix(channel-email): persist IMAP UID cursor progress

### DIFF
--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -1768,6 +1768,101 @@ mod tests {
         );
     }
 
+    /// khive #449 High follow-up (Medium-2): the connector-level
+    /// `one_poison_uid_does_not_starve_51_later_valid_uids_and_cursor_passes_it`
+    /// test in `imap.rs` only proves `process_selected_page` assigns the
+    /// poison UID a `SelectedMessage::Malformed` disposition -- it never
+    /// proves that disposition survives into the actual `ChannelEnvelope`
+    /// `EmailChannel::poll_page` hands to `comm.ingest`. Drives a
+    /// `SelectedMessage::Malformed` entry (as the IMAP connector would
+    /// return it for an unparseable UID) through `poll_page`'s public
+    /// pipeline and asserts the resulting envelope carries the stable
+    /// `imap:{host}:{uidvalidity}:{uid}` external ID plus durable quarantine
+    /// metadata -- exactly what the daemon's ingest/query layer needs to
+    /// prove a durable quarantine record, not just an intermediate value.
+    #[tokio::test]
+    async fn poll_page_malformed_uid_produces_a_stable_external_id_and_quarantine_metadata() {
+        let since = Utc::now();
+        let config = make_config("maintainer@example.com");
+        let smtp = SmtpSender::with_connector(RecordingSmtp {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+
+        struct PoisonUidImap {
+            good: RawEmail,
+        }
+        #[async_trait]
+        impl ImapConnector for PoisonUidImap {
+            async fn fetch_page(
+                &self,
+                _since: DateTime<Utc>,
+                _limit: usize,
+                _progress: ImapProgress,
+            ) -> Result<ImapFetchPage, ChannelError> {
+                Ok(ImapFetchPage {
+                    emails: vec![
+                        SelectedMessage::Malformed {
+                            uid: 1,
+                            imap_external_id: "imap:imap.example.com:4:1".to_string(),
+                            reason: MalformedReason::MissingBody,
+                        },
+                        SelectedMessage::Email(Box::new(self.good.clone())),
+                    ],
+                    next_progress: ImapProgress {
+                        uid_validity: NonZeroU32::new(4),
+                        last_seen_uid: NonZeroU32::new(2),
+                    },
+                })
+            }
+        }
+
+        let mut good = make_email("sender@example.com", "imap:imap.example.com:4:2");
+        good.uid = 2;
+        let imap = ImapFetcher::with_connector(PoisonUidImap { good });
+        let ch = EmailChannel::with_connectors(config, smtp, imap);
+
+        let page = ch.poll_page(since, None).await.unwrap();
+        assert_eq!(
+            page.envelopes.len(),
+            2,
+            "the poison UID must still produce a durable quarantine envelope \
+             alongside the valid message, not a dropped/short page"
+        );
+
+        let quarantined = page
+            .envelopes
+            .iter()
+            .find(|e| e.external_id.as_deref() == Some("imap:imap.example.com:4:1"))
+            .expect(
+                "the malformed UID's stable external_id must be present on the \
+                 envelope actually handed to comm.ingest",
+            );
+        assert_eq!(
+            quarantined.from, "email:quarantine",
+            "a malformed UID must be attributed to the fixed quarantine marker"
+        );
+        assert_eq!(
+            quarantined.metadata.get("quarantined").map(String::as_str),
+            Some("true"),
+            "the envelope must carry durable quarantine metadata for comm.ingest \
+             to persist"
+        );
+        assert_eq!(
+            quarantined
+                .metadata
+                .get("quarantine_reason")
+                .map(String::as_str),
+            Some("missing-body"),
+            "the quarantine reason must be preserved onto the persisted envelope"
+        );
+
+        assert_eq!(
+            page.next_checkpoint.unwrap().high_water,
+            Some(2),
+            "the checkpoint candidate must advance past the poison UID"
+        );
+    }
+
     #[tokio::test]
     async fn poll_drains_75_same_day_backlog_across_repeated_calls_via_production_entrypoint() {
         // Drives the actual production entrypoint (`EmailChannel::poll`, the

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -1,18 +1,30 @@
 //! `EmailChannel` — implements the `Channel` trait for email transport.
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use khive_channel::{Channel, ChannelEnvelope, ChannelError};
+use khive_channel::{
+    Channel, ChannelCheckpoint, ChannelEnvelope, ChannelError, ChannelPollPage,
+    StoredChannelCheckpoint,
+};
 use tracing::{debug, warn};
 
 use crate::auth_results;
 use crate::config::{EmailAuth, EmailChannelConfig};
-use crate::connector::imap::ImapFetcher;
+use crate::connector::imap::{ImapFetcher, ImapProgress};
 use crate::connector::smtp::SmtpSender;
 use crate::connector::{MailAddress, RawEmail};
 use crate::oauth::TokenProvider;
+
+/// Literal IMAP folder this connector selects. Not the configured mailbox
+/// address (which identifies the account/credential, not the folder).
+const IMAP_FOLDER: &str = "INBOX";
+
+/// Page size for both the legacy `poll` path and the checkpointed
+/// `poll_page` path.
+const IMAP_PAGE_LIMIT: usize = 50;
 
 /// Reason a message failed the attribution gate (ADR-056 Amendment
 /// 2026-07-02) and was quarantined instead of attributed to the maintainer.
@@ -255,6 +267,111 @@ impl EmailChannel {
         env
     }
 
+    /// This channel's stable, non-secret checkpoint identity.
+    ///
+    /// Compared verbatim (never parsed) against a stored checkpoint's
+    /// `source` to detect a host/port/mailbox/folder configuration change —
+    /// in which case the stored generation/high-water must not be applied to
+    /// the current (different) source.
+    fn checkpoint_source(&self) -> String {
+        format!(
+            "imap+tls:{}:{}:{}:{}",
+            self.config.imap_host.to_lowercase(),
+            self.config.imap_port,
+            self.config.mailbox,
+            IMAP_FOLDER
+        )
+    }
+
+    /// Decode a stored checkpoint into the connector-level [`ImapProgress`],
+    /// plus the `committed_at` recovery floor (only when the source matches).
+    ///
+    /// A source mismatch or absent checkpoint yields default (empty)
+    /// progress and no recovery floor — a different account's high-water or
+    /// timestamp must never apply to this one. A persisted value that does
+    /// not fit a nonzero `u32` fails closed with `ChannelError::Config`
+    /// rather than silently resetting.
+    fn decode_progress(
+        &self,
+        checkpoint: Option<&StoredChannelCheckpoint>,
+    ) -> Result<(ImapProgress, Option<DateTime<Utc>>), ChannelError> {
+        let Some(stored) = checkpoint else {
+            return Ok((ImapProgress::default(), None));
+        };
+        if stored.checkpoint.source != self.checkpoint_source() {
+            return Ok((ImapProgress::default(), None));
+        }
+
+        let uid_validity = u32::try_from(stored.checkpoint.generation)
+            .ok()
+            .and_then(NonZeroU32::new)
+            .ok_or_else(|| {
+                ChannelError::Config(format!(
+                    "persisted IMAP checkpoint generation {} is not a valid nonzero u32",
+                    stored.checkpoint.generation
+                ))
+            })?;
+        let last_seen_uid =
+            match stored.checkpoint.high_water {
+                None => None,
+                Some(h) => Some(u32::try_from(h).ok().and_then(NonZeroU32::new).ok_or_else(
+                    || {
+                        ChannelError::Config(format!(
+                            "persisted IMAP checkpoint high_water {h} is not a valid nonzero u32"
+                        ))
+                    },
+                )?),
+            };
+
+        Ok((
+            ImapProgress {
+                uid_validity: Some(uid_validity),
+                last_seen_uid,
+            },
+            Some(stored.committed_at),
+        ))
+    }
+
+    /// Encode connector-level progress into the transport-neutral checkpoint
+    /// the poll coordinator persists.
+    fn encode_checkpoint(&self, progress: ImapProgress) -> ChannelCheckpoint {
+        ChannelCheckpoint {
+            source: self.checkpoint_source(),
+            generation: progress
+                .uid_validity
+                .map(|v| u64::from(v.get()))
+                .unwrap_or(0),
+            high_water: progress.last_seen_uid.map(|v| u64::from(v.get())),
+        }
+    }
+
+    /// Run the gate/quarantine disposition loop over a fetched batch,
+    /// producing the envelopes ready for `comm.ingest`. Extracted from `poll`
+    /// so `poll_page` shares the exact same per-message logic.
+    fn disposition(&self, raw: Vec<RawEmail>) -> Vec<ChannelEnvelope> {
+        let mut envelopes = Vec::new();
+        for email in raw {
+            let uid = email.uid;
+            match self.gate(&email) {
+                Ok(()) => envelopes.push(self.to_envelope(email)),
+                Err(reason) => {
+                    if self.config.quarantine_store {
+                        envelopes.push(self.quarantine_envelope(&email, reason));
+                    } else {
+                        // Address-free: only the IMAP UID and the quarantine reason
+                        // are logged, never the (possibly forged) From address.
+                        warn!(
+                            uid,
+                            reason = %reason,
+                            "quarantine-store disabled: dropping unattributed message"
+                        );
+                    }
+                }
+            }
+        }
+        envelopes
+    }
+
     /// Convert a `RawEmail` that has already passed `gate` into a `ChannelEnvelope`.
     fn to_envelope(&self, email: RawEmail) -> ChannelEnvelope {
         // Safe: gate() verified exactly one From entry before this is called.
@@ -333,28 +450,41 @@ impl Channel for EmailChannel {
     }
 
     async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError> {
-        let raw = self.imap.fetch_since(since, 50).await?;
-        let mut envelopes = Vec::new();
-        for email in raw {
-            let uid = email.uid;
-            match self.gate(&email) {
-                Ok(()) => envelopes.push(self.to_envelope(email)),
-                Err(reason) => {
-                    if self.config.quarantine_store {
-                        envelopes.push(self.quarantine_envelope(&email, reason));
-                    } else {
-                        // Address-free: only the IMAP UID and the quarantine reason
-                        // are logged, never the (possibly forged) From address.
-                        warn!(
-                            uid,
-                            reason = %reason,
-                            "quarantine-store disabled: dropping unattributed message"
-                        );
-                    }
-                }
-            }
-        }
-        Ok(envelopes)
+        let raw = self.imap.fetch_since(since, IMAP_PAGE_LIMIT).await?;
+        Ok(self.disposition(raw))
+    }
+
+    /// Checkpointed poll (issue #449): resolves the durable IMAP
+    /// UIDVALIDITY/high-water progress from `checkpoint`, fetches strictly
+    /// above it (or bootstraps by date on no/mismatched/reset progress), and
+    /// returns a checkpoint candidate for the poll coordinator to persist
+    /// only after every envelope is durably ingested.
+    async fn poll_page(
+        &self,
+        since: DateTime<Utc>,
+        checkpoint: Option<&StoredChannelCheckpoint>,
+    ) -> Result<ChannelPollPage, ChannelError> {
+        let (progress, committed_at) = self.decode_progress(checkpoint)?;
+        let recovery_since = match committed_at {
+            Some(committed_at) => since.min(committed_at),
+            None => since,
+        };
+
+        let page = self
+            .imap
+            .fetch_page(recovery_since, IMAP_PAGE_LIMIT, progress)
+            .await?;
+        let envelopes = self.disposition(page.emails);
+        let next_checkpoint = if page.next_progress == progress {
+            None
+        } else {
+            Some(self.encode_checkpoint(page.next_progress))
+        };
+
+        Ok(ChannelPollPage {
+            envelopes,
+            next_checkpoint,
+        })
     }
 }
 
@@ -368,7 +498,9 @@ fn strip_kind_prefix<'a>(addr: &'a str, kind: &str) -> &'a str {
 mod tests {
     use super::*;
     use crate::config::{EmailAuth, TrustAnchor};
-    use crate::connector::imap::{parse_raw_bytes, ImapConnector, ImapFetcher};
+    use crate::connector::imap::{
+        parse_raw_bytes, ImapConnector, ImapFetchPage, ImapFetcher, ImapProgress,
+    };
     use crate::connector::smtp::{SmtpConnector, SmtpSender};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -432,12 +564,16 @@ mod tests {
 
     #[async_trait]
     impl ImapConnector for FixedImap {
-        async fn fetch_since(
+        async fn fetch_page(
             &self,
             _since: DateTime<Utc>,
             _limit: usize,
-        ) -> Result<Vec<RawEmail>, ChannelError> {
-            Ok(self.emails.clone())
+            _progress: crate::connector::imap::ImapProgress,
+        ) -> Result<ImapFetchPage, ChannelError> {
+            Ok(ImapFetchPage {
+                emails: self.emails.clone(),
+                next_progress: crate::connector::imap::ImapProgress::default(),
+            })
         }
     }
 
@@ -1232,6 +1368,76 @@ mod tests {
         );
     }
 
+    // --- checkpoint decode (issue #449) ---
+
+    #[test]
+    fn source_mismatch_drops_stored_progress() {
+        let ch = build_channel_from(make_config("maintainer@example.com"), vec![]);
+        let stored = StoredChannelCheckpoint {
+            checkpoint: ChannelCheckpoint {
+                source: "imap+tls:other.example.com:993:other@example.com:INBOX".to_string(),
+                generation: 42,
+                high_water: Some(10),
+            },
+            committed_at: Utc::now(),
+        };
+        let (progress, committed_at) = ch.decode_progress(Some(&stored)).unwrap();
+        assert_eq!(
+            progress,
+            ImapProgress::default(),
+            "a source mismatch (different host/port/mailbox) must drop stored progress"
+        );
+        assert!(
+            committed_at.is_none(),
+            "a source mismatch must not surface the other source's recovery floor either"
+        );
+    }
+
+    #[test]
+    fn invalid_persisted_imap_width_or_zero_fails_closed() {
+        let ch = build_channel_from(make_config("maintainer@example.com"), vec![]);
+        let source = ch.checkpoint_source();
+
+        let overflowing_generation = StoredChannelCheckpoint {
+            checkpoint: ChannelCheckpoint {
+                source: source.clone(),
+                generation: u64::from(u32::MAX) + 1,
+                high_water: None,
+            },
+            committed_at: Utc::now(),
+        };
+        assert!(
+            ch.decode_progress(Some(&overflowing_generation)).is_err(),
+            "a generation wider than u32 must fail closed, not truncate"
+        );
+
+        let zero_generation = StoredChannelCheckpoint {
+            checkpoint: ChannelCheckpoint {
+                source: source.clone(),
+                generation: 0,
+                high_water: None,
+            },
+            committed_at: Utc::now(),
+        };
+        assert!(
+            ch.decode_progress(Some(&zero_generation)).is_err(),
+            "a zero generation must fail closed, not silently reset to empty progress"
+        );
+
+        let overflowing_high_water = StoredChannelCheckpoint {
+            checkpoint: ChannelCheckpoint {
+                source,
+                generation: 1,
+                high_water: Some(u64::from(u32::MAX) + 1),
+            },
+            committed_at: Utc::now(),
+        };
+        assert!(
+            ch.decode_progress(Some(&overflowing_high_water)).is_err(),
+            "a high_water wider than u32 must fail closed"
+        );
+    }
+
     #[test]
     fn strip_kind_prefix_removes_prefix() {
         assert_eq!(
@@ -1241,6 +1447,287 @@ mod tests {
         assert_eq!(
             strip_kind_prefix("user@example.com", "email"),
             "user@example.com"
+        );
+    }
+
+    // --- poll_page / poll integration (issue #449) ---
+    //
+    // `select_uid_page`/`next_progress` are module-private to `connector::imap`
+    // and covered directly by that module's own tests. The mock below
+    // replicates the same sort/dedup/high-water-filter/truncate contract
+    // inline so these tests can drive the actual `EmailChannel::poll_page`/
+    // `poll` orchestration (disposition, checkpoint encode/decode, source
+    // binding), not just the connector-level helpers in isolation.
+
+    struct KeysetMockImap {
+        validity: NonZeroU32,
+        all_uids: Vec<u32>,
+    }
+
+    impl KeysetMockImap {
+        fn select(&self, limit: usize, progress: ImapProgress) -> Vec<NonZeroU32> {
+            let mut uids = self.all_uids.clone();
+            uids.sort_unstable();
+            uids.dedup();
+            if progress.uid_validity == Some(self.validity) {
+                if let Some(high_water) = progress.last_seen_uid {
+                    uids.retain(|&u| u > high_water.get());
+                }
+            }
+            uids.truncate(limit);
+            uids.into_iter()
+                .map(|u| NonZeroU32::new(u).unwrap())
+                .collect()
+        }
+
+        fn email_for(&self, uid: NonZeroU32) -> RawEmail {
+            let mut email = make_email(
+                "sender@example.com",
+                &format!(
+                    "imap:mail.example.com:{}:{}",
+                    self.validity.get(),
+                    uid.get()
+                ),
+            );
+            email.uid = uid.get();
+            email
+        }
+    }
+
+    #[async_trait]
+    impl ImapConnector for KeysetMockImap {
+        async fn fetch_page(
+            &self,
+            _since: DateTime<Utc>,
+            limit: usize,
+            progress: ImapProgress,
+        ) -> Result<ImapFetchPage, ChannelError> {
+            let selected = self.select(limit, progress);
+            let emails: Vec<RawEmail> = selected.iter().map(|&u| self.email_for(u)).collect();
+            let next_progress = match selected.iter().map(|u| u.get()).max() {
+                Some(max) => ImapProgress {
+                    uid_validity: Some(self.validity),
+                    last_seen_uid: NonZeroU32::new(max),
+                },
+                None if progress.uid_validity == Some(self.validity) => progress,
+                None => ImapProgress {
+                    uid_validity: Some(self.validity),
+                    last_seen_uid: None,
+                },
+            };
+            Ok(ImapFetchPage {
+                emails,
+                next_progress,
+            })
+        }
+    }
+
+    fn build_keyset_channel(mailbox: &str, validity: u32, all_uids: Vec<u32>) -> EmailChannel {
+        let mut config = make_config("maintainer@example.com");
+        config.mailbox = mailbox.to_string();
+        config.username = mailbox.to_string();
+        let smtp = SmtpSender::with_connector(RecordingSmtp {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let imap = ImapFetcher::with_connector(KeysetMockImap {
+            validity: NonZeroU32::new(validity).unwrap(),
+            all_uids,
+        });
+        EmailChannel::with_connectors(config, smtp, imap)
+    }
+
+    #[tokio::test]
+    async fn poll_page_resumes_from_persisted_checkpoint_across_restart() {
+        let since = Utc::now();
+
+        // First "process": drains the initial backlog 1..=5 and produces a
+        // checkpoint candidate.
+        let first = build_keyset_channel("a@example.com", 7, vec![1, 2, 3, 4, 5]);
+        let page1 = first.poll_page(since, None).await.unwrap();
+        assert_eq!(page1.envelopes.len(), 5);
+        let checkpoint = page1
+            .next_checkpoint
+            .expect("non-empty page must checkpoint");
+        let stored = StoredChannelCheckpoint {
+            checkpoint,
+            committed_at: Utc::now(),
+        };
+
+        // A brand-new `EmailChannel` instance (simulating a process restart:
+        // no shared in-memory state) sees the same 1..=5 backlog plus one
+        // newly-arrived UID 6.
+        let restarted = build_keyset_channel("a@example.com", 7, vec![1, 2, 3, 4, 5, 6]);
+        let page2 = restarted.poll_page(since, Some(&stored)).await.unwrap();
+        assert_eq!(
+            page2.envelopes.len(),
+            1,
+            "a fresh instance given the persisted checkpoint must fetch zero \
+             already-seen messages"
+        );
+        assert_eq!(
+            page2.envelopes[0].external_id.as_deref(),
+            Some("imap:mail.example.com:7:6"),
+            "the fresh instance must correctly pick up the newly-arrived UID"
+        );
+        assert_eq!(
+            page2.next_checkpoint.unwrap().high_water,
+            Some(6),
+            "checkpoint must advance to the newly-arrived UID"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_page_two_mailboxes_have_independent_cursors() {
+        let since = Utc::now();
+        let mailbox_a_checkpoint = StoredChannelCheckpoint {
+            checkpoint: ChannelCheckpoint {
+                source: "imap+tls:imap.example.com:993:a@example.com:INBOX".to_string(),
+                generation: 99,
+                high_water: Some(50),
+            },
+            committed_at: Utc::now(),
+        };
+
+        // Mailbox B has its own small, low-numbered backlog untouched by A's
+        // checkpoint.
+        let mailbox_b = build_keyset_channel("b@example.com", 5, vec![1, 2, 3]);
+        let page = mailbox_b
+            .poll_page(since, Some(&mailbox_a_checkpoint))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            page.envelopes.len(),
+            3,
+            "mailbox A's checkpoint must be rejected by B's source check, leaving \
+             B's own backlog untouched"
+        );
+        assert_eq!(page.next_checkpoint.unwrap().generation, 5);
+    }
+
+    #[tokio::test]
+    async fn poll_page_retried_call_with_uncommitted_checkpoint_is_idempotent() {
+        let since = Utc::now();
+        let ch = build_keyset_channel("a@example.com", 9, vec![1, 2, 3]);
+
+        let first = ch.poll_page(since, None).await.unwrap();
+        // Simulate a retry after a crash between fetch and cursor commit: the
+        // coordinator calls poll_page again with the same (uncommitted) `None`.
+        let retry = ch.poll_page(since, None).await.unwrap();
+
+        let ids = |p: &ChannelPollPage| {
+            p.envelopes
+                .iter()
+                .map(|e| e.external_id.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ids(&first),
+            ids(&retry),
+            "retrying with the same uncommitted checkpoint must return \
+             byte-identical envelopes"
+        );
+        assert_eq!(
+            first.next_checkpoint.unwrap(),
+            retry.next_checkpoint.unwrap(),
+            "retrying with the same uncommitted checkpoint must return an \
+             identical checkpoint candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_page_quarantine_disabled_drop_still_advances_checkpoint() {
+        let since = Utc::now();
+        let mut config = make_config("maintainer@example.com");
+        config.quarantine_store = false;
+        let smtp = SmtpSender::with_connector(RecordingSmtp {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+
+        // A message with no Authentication-Results header fails the gate
+        // (AuthAbsent) and, with quarantine_store disabled, is dropped rather
+        // than emitted as an envelope.
+        let mut gate_failing = make_email("forged@example.com", "imap:mail.example.com:3:1");
+        gate_failing.authentication_results.clear();
+        gate_failing.uid = 1;
+
+        struct SingleGateFailingImap {
+            email: RawEmail,
+        }
+        #[async_trait]
+        impl ImapConnector for SingleGateFailingImap {
+            async fn fetch_page(
+                &self,
+                _since: DateTime<Utc>,
+                _limit: usize,
+                _progress: ImapProgress,
+            ) -> Result<ImapFetchPage, ChannelError> {
+                Ok(ImapFetchPage {
+                    emails: vec![self.email.clone()],
+                    next_progress: ImapProgress {
+                        uid_validity: NonZeroU32::new(3),
+                        last_seen_uid: NonZeroU32::new(self.email.uid),
+                    },
+                })
+            }
+        }
+        let imap = ImapFetcher::with_connector(SingleGateFailingImap {
+            email: gate_failing,
+        });
+        let ch = EmailChannel::with_connectors(config, smtp, imap);
+
+        let page = ch.poll_page(since, None).await.unwrap();
+        assert!(
+            page.envelopes.is_empty(),
+            "a gate-failing message with quarantine_store disabled must be dropped, \
+             not emitted"
+        );
+        assert_eq!(
+            page.next_checkpoint.unwrap().high_water,
+            Some(1),
+            "the checkpoint must still advance past the dropped message's UID -- \
+             checkpoint advancement is bound to the selected UID page, not to \
+             which envelopes disposition actually emits"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_drains_75_same_day_backlog_across_repeated_calls_via_production_entrypoint() {
+        // Drives the actual production entrypoint (`EmailChannel::poll`, the
+        // literal call `serve.rs` makes) with the issue's own numbers: 75
+        // same-day UIDs, page limit 50, shuffled input mirroring HashSet
+        // iteration-order noise.
+        let mut all_uids: Vec<u32> = (1..=75).rev().collect();
+        all_uids.extend(1..=10); // duplicates
+        let ch = build_keyset_channel("a@example.com", 42, all_uids);
+
+        let since = Utc::now();
+        let page1 = ch.poll(since).await.unwrap();
+        assert_eq!(page1.len(), 50, "first poll must return exactly 50");
+        let page2 = ch.poll(since).await.unwrap();
+        assert_eq!(
+            page2.len(),
+            25,
+            "second poll must return the remaining 25, not a repeat of the first 50"
+        );
+        let page3 = ch.poll(since).await.unwrap();
+        assert!(
+            page3.is_empty(),
+            "third poll must be empty; backlog fully drained"
+        );
+
+        let mut all_ids: Vec<String> = page1
+            .iter()
+            .chain(page2.iter())
+            .map(|e| e.external_id.clone().unwrap())
+            .collect();
+        all_ids.sort();
+        all_ids.dedup();
+        assert_eq!(
+            all_ids.len(),
+            75,
+            "all 75 external IDs must be distinct across both calls -- none skipped, \
+             none repeated"
         );
     }
 }

--- a/crates/khive-channel-email/src/channel.rs
+++ b/crates/khive-channel-email/src/channel.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 
 use crate::auth_results;
 use crate::config::{EmailAuth, EmailChannelConfig};
-use crate::connector::imap::{ImapFetcher, ImapProgress};
+use crate::connector::imap::{ImapFetcher, ImapProgress, MalformedReason, SelectedMessage};
 use crate::connector::smtp::SmtpSender;
 use crate::connector::{MailAddress, RawEmail};
 use crate::oauth::TokenProvider;
@@ -39,6 +39,12 @@ enum QuarantineReason {
     Unaligned,
     /// Domain authentication passed, but the sender is not on the maintainer allowlist.
     OffAllowlist,
+    /// The `UID FETCH` response carried no RFC822 body for this UID (khive
+    /// #449 High fix: a durable terminal disposition, never a silent drop).
+    MissingBody,
+    /// An RFC822 body was present but could not be parsed (khive #449 High
+    /// fix: a durable terminal disposition, never a silent drop).
+    ParseFailure,
 }
 
 impl std::fmt::Display for QuarantineReason {
@@ -48,7 +54,18 @@ impl std::fmt::Display for QuarantineReason {
             QuarantineReason::DmarcFail => "dmarc-fail",
             QuarantineReason::Unaligned => "unaligned",
             QuarantineReason::OffAllowlist => "off-allowlist",
+            QuarantineReason::MissingBody => "missing-body",
+            QuarantineReason::ParseFailure => "parse-failure",
         })
+    }
+}
+
+impl From<MalformedReason> for QuarantineReason {
+    fn from(reason: MalformedReason) -> Self {
+        match reason {
+            MalformedReason::MissingBody => QuarantineReason::MissingBody,
+            MalformedReason::ParseFailure => QuarantineReason::ParseFailure,
+        }
     }
 }
 
@@ -267,6 +284,31 @@ impl EmailChannel {
         env
     }
 
+    /// Build the envelope recorded for a selected UID that could not be
+    /// durably parsed into a message (khive #449 High fix: a missing RFC822
+    /// body or an unparseable one). Unlike [`Self::quarantine_envelope`],
+    /// this is never gated by `quarantine_store` -- a data-integrity failure
+    /// must always leave a queryable record, never a silent drop, since
+    /// dropping it here is the only way this UID's disposition could be lost
+    /// before the cursor advances past it.
+    fn malformed_quarantine_envelope(
+        &self,
+        uid: u32,
+        imap_external_id: &str,
+        reason: QuarantineReason,
+    ) -> ChannelEnvelope {
+        let to = format!("email:{}", self.maintainer_address());
+        let body =
+            format!("(khive: IMAP message UID {uid} could not be parsed and was quarantined)");
+        let mut env = ChannelEnvelope::new("email:quarantine", to, body);
+        env = env.with_external_id(imap_external_id);
+        env.metadata
+            .insert("quarantined".to_string(), "true".to_string());
+        env.metadata
+            .insert("quarantine_reason".to_string(), reason.to_string());
+        env
+    }
+
     /// This channel's stable, non-secret checkpoint identity.
     ///
     /// Compared verbatim (never parsed) against a stored checkpoint's
@@ -348,24 +390,51 @@ impl EmailChannel {
     /// Run the gate/quarantine disposition loop over a fetched batch,
     /// producing the envelopes ready for `comm.ingest`. Extracted from `poll`
     /// so `poll_page` shares the exact same per-message logic.
-    fn disposition(&self, raw: Vec<RawEmail>) -> Vec<ChannelEnvelope> {
+    ///
+    /// Every [`SelectedMessage`] produces exactly one disposition here (khive
+    /// #449 High fix): a parsed email is gated as before, and a
+    /// [`SelectedMessage::Malformed`] entry always becomes a quarantine
+    /// envelope, regardless of `quarantine_store` -- see
+    /// [`Self::malformed_quarantine_envelope`].
+    fn disposition(&self, raw: Vec<SelectedMessage>) -> Vec<ChannelEnvelope> {
         let mut envelopes = Vec::new();
-        for email in raw {
-            let uid = email.uid;
-            match self.gate(&email) {
-                Ok(()) => envelopes.push(self.to_envelope(email)),
-                Err(reason) => {
-                    if self.config.quarantine_store {
-                        envelopes.push(self.quarantine_envelope(&email, reason));
-                    } else {
-                        // Address-free: only the IMAP UID and the quarantine reason
-                        // are logged, never the (possibly forged) From address.
-                        warn!(
-                            uid,
-                            reason = %reason,
-                            "quarantine-store disabled: dropping unattributed message"
-                        );
+        for message in raw {
+            match message {
+                SelectedMessage::Email(email) => {
+                    let uid = email.uid;
+                    match self.gate(&email) {
+                        Ok(()) => envelopes.push(self.to_envelope(*email)),
+                        Err(reason) => {
+                            if self.config.quarantine_store {
+                                envelopes.push(self.quarantine_envelope(&email, reason));
+                            } else {
+                                // Address-free: only the IMAP UID and the quarantine reason
+                                // are logged, never the (possibly forged) From address.
+                                warn!(
+                                    uid,
+                                    reason = %reason,
+                                    "quarantine-store disabled: dropping unattributed message"
+                                );
+                            }
+                        }
                     }
+                }
+                SelectedMessage::Malformed {
+                    uid,
+                    imap_external_id,
+                    reason,
+                } => {
+                    let reason: QuarantineReason = reason.into();
+                    warn!(
+                        uid,
+                        reason = %reason,
+                        "quarantining permanently unparseable IMAP message"
+                    );
+                    envelopes.push(self.malformed_quarantine_envelope(
+                        uid,
+                        &imap_external_id,
+                        reason,
+                    ));
                 }
             }
         }
@@ -571,7 +640,12 @@ mod tests {
             _progress: crate::connector::imap::ImapProgress,
         ) -> Result<ImapFetchPage, ChannelError> {
             Ok(ImapFetchPage {
-                emails: self.emails.clone(),
+                emails: self
+                    .emails
+                    .clone()
+                    .into_iter()
+                    .map(|e| SelectedMessage::Email(Box::new(e)))
+                    .collect(),
                 next_progress: crate::connector::imap::ImapProgress::default(),
             })
         }
@@ -1503,7 +1577,10 @@ mod tests {
             progress: ImapProgress,
         ) -> Result<ImapFetchPage, ChannelError> {
             let selected = self.select(limit, progress);
-            let emails: Vec<RawEmail> = selected.iter().map(|&u| self.email_for(u)).collect();
+            let emails: Vec<SelectedMessage> = selected
+                .iter()
+                .map(|&u| SelectedMessage::Email(Box::new(self.email_for(u))))
+                .collect();
             let next_progress = match selected.iter().map(|u| u.get()).max() {
                 Some(max) => ImapProgress {
                     uid_validity: Some(self.validity),
@@ -1663,7 +1740,7 @@ mod tests {
                 _progress: ImapProgress,
             ) -> Result<ImapFetchPage, ChannelError> {
                 Ok(ImapFetchPage {
-                    emails: vec![self.email.clone()],
+                    emails: vec![SelectedMessage::Email(Box::new(self.email.clone()))],
                     next_progress: ImapProgress {
                         uid_validity: NonZeroU32::new(3),
                         last_seen_uid: NonZeroU32::new(self.email.uid),

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -5,6 +5,7 @@
 //! at construction time from environment variables.
 
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,16 +27,41 @@ type ImapSession = async_imap::Session<
     async_native_tls::TlsStream<tokio_util::compat::Compat<tokio::net::TcpStream>>,
 >;
 
+/// Durable IMAP poll progress: the mailbox's `UIDVALIDITY` epoch plus the
+/// greatest UID durably handled within that epoch (issue #449).
+///
+/// `NonZeroU32` mirrors the wire invariant: IMAP's own `UIDVALIDITY` and
+/// `UID` values are never zero (see [`validate_uid_validity`] and
+/// [`select_uid_page`]'s zero-UID rejection).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ImapProgress {
+    pub(crate) uid_validity: Option<NonZeroU32>,
+    pub(crate) last_seen_uid: Option<NonZeroU32>,
+}
+
+/// One page of IMAP fetch results plus the progress the caller should adopt
+/// once the page is durably handled.
+pub(crate) struct ImapFetchPage {
+    pub(crate) emails: Vec<RawEmail>,
+    pub(crate) next_progress: ImapProgress,
+}
+
 /// Internal trait for IMAP fetch operations.
 ///
 /// Allows unit tests to substitute a mock without a live IMAP server.
 #[async_trait]
 pub(crate) trait ImapConnector: Send + Sync + 'static {
-    async fn fetch_since(
+    /// Fetch a sorted, deduplicated, progress-bound page of messages.
+    ///
+    /// `progress` is the caller's last-known `(UIDVALIDITY, high-water)`
+    /// pair; the connector never advances past an incompletely-handled page
+    /// (see [`process_selected_page`]).
+    async fn fetch_page(
         &self,
         since: DateTime<Utc>,
         limit: usize,
-    ) -> Result<Vec<RawEmail>, ChannelError>;
+        progress: ImapProgress,
+    ) -> Result<ImapFetchPage, ChannelError>;
 }
 
 /// IMAP authentication configuration (basic or OAuth2 XOAUTH2).
@@ -192,11 +218,12 @@ impl LiveImap {
 #[async_trait]
 impl ImapConnector for LiveImap {
     #[instrument(skip(self), fields(imap_host = %self.host))]
-    async fn fetch_since(
+    async fn fetch_page(
         &self,
         since: DateTime<Utc>,
         limit: usize,
-    ) -> Result<Vec<RawEmail>, ChannelError> {
+        progress: ImapProgress,
+    ) -> Result<ImapFetchPage, ChannelError> {
         // Single-flight (#605): hold this credential's one permit for the
         // full connect-through-logout lifecycle below, so a second concurrent
         // call (e.g. a future caller widening the poll loop's concurrency)
@@ -211,33 +238,46 @@ impl ImapConnector for LiveImap {
             .select("INBOX")
             .await
             .map_err(|e| ChannelError::Transport(format!("IMAP SELECT INBOX failed: {e}")))?;
-        let uid_validity = mailbox.uid_validity;
+        let uid_validity = validate_uid_validity(mailbox.uid_validity)?;
 
-        // Search for messages since the given date.
-        let since_str = since.format("%d-%b-%Y").to_string();
-        let uid_set = session
-            .uid_search(format!("SINCE {since_str}"))
-            .await
-            .map_err(|e| ChannelError::Transport(format!("IMAP UID SEARCH SINCE failed: {e}")))?;
-
-        let mut uid_list: Vec<u32> = uid_set.into_iter().collect();
-        uid_list.truncate(limit);
-
-        if uid_list.is_empty() {
+        let Some(query) = uid_search_query(since, uid_validity, progress) else {
+            // Current epoch's high-water is already at u32::MAX: nothing more
+            // to search, and the epoch/high-water are unchanged.
             let _ = session.logout().await;
-            return Ok(vec![]);
+            return Ok(ImapFetchPage {
+                emails: vec![],
+                next_progress: progress,
+            });
+        };
+
+        let uid_set = session
+            .uid_search(query)
+            .await
+            .map_err(|e| ChannelError::Transport(format!("IMAP UID SEARCH failed: {e}")))?;
+
+        let selected =
+            select_uid_page(uid_set.into_iter().collect(), limit, uid_validity, progress)?;
+
+        if selected.is_empty() {
+            let _ = session.logout().await;
+            let next = next_progress(uid_validity, progress, &selected);
+            return Ok(ImapFetchPage {
+                emails: vec![],
+                next_progress: next,
+            });
         }
 
-        let uid_str = uid_list
+        let uid_str = selected
             .iter()
-            .map(|u| u.to_string())
+            .map(|u| u.get().to_string())
             .collect::<Vec<_>>()
             .join(",");
 
         // Collect the fetch stream into owned bytes before releasing the session borrow.
-        // Each entry carries the raw UID as returned by the server (Option<u32>); zero
-        // and absent UIDs are validated inside process_mailbox_fetch.
-        let fetched_raw: Vec<(Option<u32>, Vec<u8>)> = {
+        // Every fetch entry is kept, including a `None` body: filtering bodyless
+        // entries here would hide an incomplete selected page from
+        // `process_selected_page`, which must see (and reject) that gap.
+        let fetched_raw: Vec<(Option<u32>, Option<Vec<u8>>)> = {
             let mut stream = session
                 .uid_fetch(&uid_str, "RFC822")
                 .await
@@ -249,64 +289,172 @@ impl ImapConnector for LiveImap {
                 .await
                 .map_err(|e| ChannelError::Transport(format!("IMAP fetch stream error: {e}")))?
             {
-                if let Some(body) = msg.body() {
-                    collected.push((msg.uid, body.to_vec()));
-                }
+                collected.push((msg.uid, msg.body().map(|b| b.to_vec())));
             }
             collected
         };
 
         let _ = session.logout().await;
 
-        process_mailbox_fetch(uid_validity, fetched_raw, &self.host)
+        let emails = process_selected_page(uid_validity, &selected, fetched_raw, &self.host)?;
+        let next = next_progress(uid_validity, progress, &selected);
+        Ok(ImapFetchPage {
+            emails,
+            next_progress: next,
+        })
     }
 }
 
-/// Validate UIDVALIDITY + per-message UIDs and build the `RawEmail` list.
+/// Reject a missing or zero `UIDVALIDITY` before any search/fetch is issued.
 ///
-/// `uid_validity` must be `Some(non-zero)`.  When it is `None` or `Some(0)` the
-/// whole batch is rejected as a transport error: UIDVALIDITY is required to form
-/// the stable `imap:{host}:{uidvalidity}:{uid}` dedup key, and without it we
-/// cannot safely identify or deduplicate messages.
+/// UIDVALIDITY is required to form the stable `imap:{host}:{uidvalidity}:{uid}`
+/// dedup key and to bind durable high-water progress to the correct epoch;
+/// without it we cannot safely identify, deduplicate, or page messages.
+fn validate_uid_validity(uid_validity: Option<u32>) -> Result<NonZeroU32, ChannelError> {
+    uid_validity.and_then(NonZeroU32::new).ok_or_else(|| {
+        ChannelError::Transport(
+            "IMAP SELECT did not return a valid UIDVALIDITY; \
+             cannot safely deduplicate messages — poll aborted"
+                .to_string(),
+        )
+    })
+}
+
+/// Build the `UID SEARCH` criteria string for the current epoch and progress.
 ///
-/// Per-message UIDs that are `None` or `0` are skipped with a `warn!` log rather
-/// than failing the batch: one missing UID is a server quirk, not a reason to
-/// discard all other messages in the poll.
+/// Returns `None` when the current epoch matches stored progress and the
+/// high-water is already `u32::MAX` (the epoch is exhausted; no search is
+/// issued). Otherwise: same epoch with a known high-water searches strictly
+/// above it (`UID {h+1}:*`); a new/changed epoch, or a same epoch with no
+/// high-water yet, searches by date (`SINCE <since>`), ignoring any high-water
+/// from a different epoch.
+fn uid_search_query(
+    since: DateTime<Utc>,
+    current_uid_validity: NonZeroU32,
+    progress: ImapProgress,
+) -> Option<String> {
+    if progress.uid_validity == Some(current_uid_validity) {
+        match progress.last_seen_uid {
+            Some(h) if h.get() == u32::MAX => None,
+            Some(h) => Some(format!("UID {}:*", h.get().saturating_add(1))),
+            None => Some(format!("SINCE {}", since.format("%d-%b-%Y"))),
+        }
+    } else {
+        Some(format!("SINCE {}", since.format("%d-%b-%Y")))
+    }
+}
+
+/// Normalize a raw `UID SEARCH` result into a bounded, deterministic page.
 ///
-/// This function is extracted from `LiveImap::fetch_since` so the validation
-/// logic can be exercised without a live IMAP server.
-pub(crate) fn process_mailbox_fetch(
-    uid_validity: Option<u32>,
-    fetched_raw: Vec<(Option<u32>, Vec<u8>)>,
+/// Order: reject any zero UID (protocol-invalid); sort ascending; deduplicate;
+/// when the epoch matches stored progress, retain only UIDs strictly above the
+/// high-water as a defensive re-check; then truncate to `limit`.
+fn select_uid_page(
+    mut uids: Vec<u32>,
+    limit: usize,
+    current_uid_validity: NonZeroU32,
+    progress: ImapProgress,
+) -> Result<Vec<NonZeroU32>, ChannelError> {
+    if uids.contains(&0) {
+        return Err(ChannelError::Transport(
+            "IMAP UID SEARCH returned a zero UID, which is protocol-invalid".to_string(),
+        ));
+    }
+    uids.sort_unstable();
+    uids.dedup();
+
+    if progress.uid_validity == Some(current_uid_validity) {
+        if let Some(high_water) = progress.last_seen_uid {
+            uids.retain(|&u| u > high_water.get());
+        }
+    }
+
+    uids.truncate(limit);
+
+    Ok(uids
+        .into_iter()
+        .map(|u| NonZeroU32::new(u).expect("zero UIDs already rejected above"))
+        .collect())
+}
+
+/// Compute the checkpoint candidate after selecting (not yet validating) a page.
+///
+/// A non-empty selection advances to `(current epoch, max selected UID)`. An
+/// empty selection under an unchanged epoch leaves `prior` untouched (nothing
+/// to commit — avoids a write every poll). An empty selection under a new or
+/// changed epoch still replaces the obsolete epoch, with `high_water: None`,
+/// so a stale epoch's high-water is never silently reused.
+fn next_progress(
+    current_uid_validity: NonZeroU32,
+    prior: ImapProgress,
+    selected: &[NonZeroU32],
+) -> ImapProgress {
+    match selected.iter().map(|u| u.get()).max() {
+        Some(max) => ImapProgress {
+            uid_validity: Some(current_uid_validity),
+            last_seen_uid: NonZeroU32::new(max),
+        },
+        None if prior.uid_validity == Some(current_uid_validity) => prior,
+        None => ImapProgress {
+            uid_validity: Some(current_uid_validity),
+            last_seen_uid: None,
+        },
+    }
+}
+
+/// Validate a fully-fetched selected page and build the `RawEmail` list, in
+/// `selected_uids` order.
+///
+/// Every UID in `selected_uids` must appear exactly once in `fetched_raw` with
+/// a non-`None` body that parses successfully; any gap, duplicate, missing
+/// body, or parse failure fails the whole page (no partial advancement — the
+/// poll coordinator must not commit a candidate high-water for an incompletely
+/// materialized page). A fetch response for a UID outside `selected_uids` is
+/// unrequested (e.g. a stray server response) and is ignored with a `warn!`;
+/// it can never affect page validity or the candidate high-water.
+pub(crate) fn process_selected_page(
+    uid_validity: NonZeroU32,
+    selected_uids: &[NonZeroU32],
+    fetched_raw: Vec<(Option<u32>, Option<Vec<u8>>)>,
     host: &str,
 ) -> Result<Vec<RawEmail>, ChannelError> {
-    let uidvalidity = match uid_validity {
-        Some(v) if v != 0 => v,
-        _ => {
-            return Err(ChannelError::Transport(
-                "IMAP SELECT did not return a valid UIDVALIDITY; \
-                 cannot safely deduplicate messages — poll aborted"
-                    .to_string(),
-            ));
-        }
-    };
-
-    let mut result = Vec::new();
-    for (uid_opt, raw_bytes) in fetched_raw {
-        let uid = match uid_opt {
-            Some(u) if u != 0 => u,
-            _ => {
-                tracing::warn!(
-                    host = %host,
-                    uidvalidity = %uidvalidity,
-                    "skipping message with missing or zero UID; cannot form a stable dedup key"
-                );
-                continue;
-            }
+    let mut by_uid: HashMap<u32, Vec<u8>> = HashMap::new();
+    for (uid_opt, body_opt) in fetched_raw {
+        let Some(uid) = uid_opt.filter(|&u| u != 0) else {
+            continue;
         };
-        if let Some(email) = parse_raw_bytes(uid, &raw_bytes, host, uidvalidity) {
-            result.push(email);
+        if !selected_uids.iter().any(|s| s.get() == uid) {
+            tracing::warn!(host = %host, uid, "ignoring unrequested IMAP fetch response");
+            continue;
         }
+        let Some(body) = body_opt else {
+            return Err(ChannelError::Transport(format!(
+                "IMAP UID FETCH returned no RFC822 body for selected UID {uid}; \
+                 page rejected, not partially advanced"
+            )));
+        };
+        if by_uid.insert(uid, body).is_some() {
+            return Err(ChannelError::Transport(format!(
+                "IMAP UID FETCH returned duplicate responses for selected UID {uid}"
+            )));
+        }
+    }
+
+    let mut result = Vec::with_capacity(selected_uids.len());
+    for &uid in selected_uids {
+        let uid = uid.get();
+        let raw = by_uid.remove(&uid).ok_or_else(|| {
+            ChannelError::Transport(format!(
+                "IMAP UID FETCH did not return a response for selected UID {uid}; \
+                 page rejected, not partially advanced"
+            ))
+        })?;
+        let email = parse_raw_bytes(uid, &raw, host, uid_validity.get()).ok_or_else(|| {
+            ChannelError::Transport(format!(
+                "failed to parse RFC822 bytes for selected UID {uid}"
+            ))
+        })?;
+        result.push(email);
     }
     Ok(result)
 }
@@ -439,6 +587,12 @@ pub(crate) fn parse_raw_bytes(
 /// IMAP fetcher wrapping an `ImapConnector`.
 pub struct ImapFetcher {
     pub(crate) inner: Arc<dyn ImapConnector>,
+    /// In-memory compatibility cursor for [`Self::fetch_since`] callers (e.g.
+    /// direct library use outside the daemon poll loop, and this crate's own
+    /// tests). Progress-based within one process, but never persisted — the
+    /// daemon's durable checkpoint path goes through [`Self::fetch_page`]
+    /// with an explicit [`ImapProgress`] loaded from storage instead.
+    legacy_progress: tokio::sync::Mutex<ImapProgress>,
 }
 
 impl ImapFetcher {
@@ -446,6 +600,7 @@ impl ImapFetcher {
     pub fn new(host: impl Into<String>, port: u16, username: &str, password: &str) -> Self {
         Self {
             inner: Arc::new(LiveImap::new(host, port, username, password)),
+            legacy_progress: tokio::sync::Mutex::new(ImapProgress::default()),
         }
     }
 
@@ -458,6 +613,7 @@ impl ImapFetcher {
     ) -> Self {
         Self {
             inner: Arc::new(LiveImap::new_oauth(host, port, mailbox, token_provider)),
+            legacy_progress: tokio::sync::Mutex::new(ImapProgress::default()),
         }
     }
 
@@ -466,16 +622,39 @@ impl ImapFetcher {
     pub(crate) fn with_connector(connector: impl ImapConnector) -> Self {
         Self {
             inner: Arc::new(connector),
+            legacy_progress: tokio::sync::Mutex::new(ImapProgress::default()),
         }
     }
 
     /// Fetch messages received since `since`, up to `limit` items.
+    ///
+    /// Maintains an in-memory `(UIDVALIDITY, high-water)` cursor across calls
+    /// on this `ImapFetcher` instance, advancing it only when the underlying
+    /// fetch succeeds. This makes repeated standalone calls progress-based
+    /// within one process without requiring a durable checkpoint; the daemon
+    /// poll loop uses [`Self::fetch_page`] with an explicit stored checkpoint
+    /// instead.
     pub async fn fetch_since(
         &self,
         since: DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<RawEmail>, ChannelError> {
-        self.inner.fetch_since(since, limit).await
+        let mut progress = self.legacy_progress.lock().await;
+        let page = self.inner.fetch_page(since, limit, *progress).await?;
+        *progress = page.next_progress;
+        Ok(page.emails)
+    }
+
+    /// Fetch one explicit-progress page (crate-internal: used by
+    /// `EmailChannel::poll_page` with a durable checkpoint loaded from
+    /// storage, bypassing the in-memory `legacy_progress` cursor entirely).
+    pub(crate) async fn fetch_page(
+        &self,
+        since: DateTime<Utc>,
+        limit: usize,
+        progress: ImapProgress,
+    ) -> Result<ImapFetchPage, ChannelError> {
+        self.inner.fetch_page(since, limit, progress).await
     }
 }
 
@@ -495,12 +674,16 @@ mod tests {
 
     #[async_trait]
     impl ImapConnector for MockImap {
-        async fn fetch_since(
+        async fn fetch_page(
             &self,
             _since: DateTime<Utc>,
             _limit: usize,
-        ) -> Result<Vec<RawEmail>, ChannelError> {
-            Ok(self.emails.clone())
+            _progress: ImapProgress,
+        ) -> Result<ImapFetchPage, ChannelError> {
+            Ok(ImapFetchPage {
+                emails: self.emails.clone(),
+                next_progress: ImapProgress::default(),
+            })
         }
     }
 
@@ -721,80 +904,343 @@ mod tests {
         assert_eq!(email.correlation(), Some("some-uuid"));
     }
 
-    // --- process_mailbox_fetch guard tests ---
+    // --- UID progress/paging pure-helper tests (issue #449) ---
 
     fn minimal_rfc822(from: &str, subject: &str) -> Vec<u8> {
         format!("From: {from}\r\nTo: me@example.com\r\nSubject: {subject}\r\n\r\nbody").into_bytes()
     }
 
     #[test]
-    fn process_mailbox_fetch_missing_uidvalidity_returns_error() {
-        let raw = minimal_rfc822("a@example.com", "test");
-        let result = process_mailbox_fetch(None, vec![(Some(1), raw)], "imap.example.com");
+    fn validate_uid_validity_rejects_missing_and_zero() {
+        assert!(validate_uid_validity(None).is_err());
+        assert!(validate_uid_validity(Some(0)).is_err());
+        assert!(validate_uid_validity(Some(1)).is_ok());
+    }
+
+    #[test]
+    fn uid_page_progress_drains_75_uids_in_50_then_25() {
+        // Reversed with duplicates, mirroring async-imap's unordered HashSet result.
+        let mut uids: Vec<u32> = (1..=75).rev().collect();
+        uids.extend(1..=10);
+        let validity = NonZeroU32::new(99).unwrap();
+        let progress = ImapProgress::default();
+
+        let page1 = select_uid_page(uids.clone(), 50, validity, progress).unwrap();
+        assert_eq!(
+            page1.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            (1u32..=50).collect::<Vec<_>>(),
+            "first page must be exactly 1..=50"
+        );
+
+        let progress2 = next_progress(validity, progress, &page1);
+        assert_eq!(progress2.last_seen_uid, NonZeroU32::new(50));
+
+        let page2 = select_uid_page(uids.clone(), 50, validity, progress2).unwrap();
+        assert_eq!(
+            page2.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            (51u32..=75).collect::<Vec<_>>(),
+            "second page must be exactly 51..=75, no overlap with the first"
+        );
+
+        let progress3 = next_progress(validity, progress2, &page2);
+        let page3 = select_uid_page(uids, 50, validity, progress3).unwrap();
+        assert!(
+            page3.is_empty(),
+            "third page must be empty; the backlog is fully drained"
+        );
+    }
+
+    #[test]
+    fn uid_page_is_independent_of_input_order_and_deduplicates_before_limit() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let progress = ImapProgress::default();
+        let ascending: Vec<u32> = (1..=10).collect();
+        let mut shuffled = ascending.clone();
+        shuffled.reverse();
+        let mut with_dupes = shuffled.clone();
+        with_dupes.extend(shuffled.clone());
+
+        let a = select_uid_page(ascending, 10, validity, progress).unwrap();
+        let b = select_uid_page(shuffled, 10, validity, progress).unwrap();
+        let c = select_uid_page(with_dupes, 10, validity, progress).unwrap();
+        assert_eq!(a, b, "page selection must not depend on input order");
+        assert_eq!(a, c, "duplicate UIDs must not consume extra page slots");
+    }
+
+    #[test]
+    fn uid_page_rejects_zero_uid() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let result = select_uid_page(vec![0, 1, 2], 10, validity, ImapProgress::default());
         assert!(
             result.is_err(),
-            "missing UIDVALIDITY must return a transport error"
+            "a protocol-invalid zero UID must reject the whole selection"
         );
-        let msg = result.unwrap_err().to_string();
+    }
+
+    #[test]
+    fn same_uidvalidity_query_starts_strictly_above_high_water() {
+        let validity = NonZeroU32::new(99).unwrap();
+        let progress = ImapProgress {
+            uid_validity: Some(validity),
+            last_seen_uid: NonZeroU32::new(50),
+        };
+        assert_eq!(
+            uid_search_query(Utc::now(), validity, progress).as_deref(),
+            Some("UID 51:*")
+        );
+    }
+
+    #[test]
+    fn uidvalidity_change_uses_since_and_ignores_old_high_water() {
+        let old_validity = NonZeroU32::new(99).unwrap();
+        let new_validity = NonZeroU32::new(100).unwrap();
+        let progress = ImapProgress {
+            uid_validity: Some(old_validity),
+            last_seen_uid: NonZeroU32::new(50),
+        };
+        let since = DateTime::parse_from_rfc3339("2026-07-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            uid_search_query(since, new_validity, progress).as_deref(),
+            Some("SINCE 01-Jul-2026")
+        );
+
+        // The new epoch's selection must not filter by the old epoch's high-water.
+        let selected = select_uid_page(vec![3, 1, 2], 50, new_validity, progress).unwrap();
+        assert_eq!(
+            selected.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            vec![1, 2, 3],
+            "new epoch selection must retain low UIDs the old epoch's high-water would have excluded"
+        );
+    }
+
+    #[test]
+    fn max_uid_high_water_issues_no_search_for_same_epoch() {
+        let validity = NonZeroU32::new(99).unwrap();
+        let progress = ImapProgress {
+            uid_validity: Some(validity),
+            last_seen_uid: NonZeroU32::new(u32::MAX),
+        };
+        assert_eq!(
+            uid_search_query(Utc::now(), validity, progress),
+            None,
+            "an exhausted epoch (high-water at u32::MAX) must not repeat the search"
+        );
+    }
+
+    #[test]
+    fn next_progress_changed_epoch_empty_selection_resets_high_water_to_none() {
+        let old_validity = NonZeroU32::new(99).unwrap();
+        let new_validity = NonZeroU32::new(100).unwrap();
+        let prior = ImapProgress {
+            uid_validity: Some(old_validity),
+            last_seen_uid: NonZeroU32::new(50),
+        };
+        let next = next_progress(new_validity, prior, &[]);
+        assert_eq!(
+            next,
+            ImapProgress {
+                uid_validity: Some(new_validity),
+                last_seen_uid: None,
+            },
+            "a UIDVALIDITY change with an empty selection must still adopt the new \
+             epoch and reset high-water, not silently keep the old epoch's value"
+        );
+    }
+
+    #[test]
+    fn next_progress_same_epoch_empty_selection_keeps_prior_unchanged() {
+        let validity = NonZeroU32::new(99).unwrap();
+        let prior = ImapProgress {
+            uid_validity: Some(validity),
+            last_seen_uid: NonZeroU32::new(50),
+        };
+        let next = next_progress(validity, prior, &[]);
+        assert_eq!(
+            next, prior,
+            "an empty page under an unchanged epoch must leave the checkpoint \
+             byte-identical, avoiding a wasted commit every poll"
+        );
+    }
+
+    #[test]
+    fn select_uid_page_dedup_happens_before_truncate_so_limit_is_not_wasted_on_duplicates() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let mut uids = vec![1u32; 200];
+        uids.extend(2..=40); // 39 more distinct UIDs -> 40 distinct total.
+        let selected = select_uid_page(uids, 50, validity, ImapProgress::default()).unwrap();
+        assert_eq!(
+            selected.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            (1u32..=40).collect::<Vec<_>>(),
+            "200 duplicate copies of UID 1 must not consume page slots that belong \
+             to the 39 genuinely distinct UIDs"
+        );
+    }
+
+    #[test]
+    fn select_uid_page_repeated_overlapping_search_result_yields_only_new_uids() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let progress = ImapProgress {
+            uid_validity: Some(validity),
+            last_seen_uid: NonZeroU32::new(10),
+        };
+        // A broad re-search (e.g. after a retry) that re-includes already-consumed
+        // UIDs 1..=10 alongside genuinely new UIDs 11..=15.
+        let uids: Vec<u32> = (1..=15).collect();
+        let selected = select_uid_page(uids, 50, validity, progress).unwrap();
+        assert_eq!(
+            selected.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            (11u32..=15).collect::<Vec<_>>(),
+            "a re-searched page that overlaps already-consumed UIDs must yield only \
+             the strictly-new tail"
+        );
+    }
+
+    #[test]
+    fn select_uid_page_out_of_order_uids_with_gaps_selected_in_sorted_order() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let uids = vec![97, 3, 500, 12, 3, 8, 250];
+        let selected = select_uid_page(uids, 50, validity, ImapProgress::default()).unwrap();
+        assert_eq!(
+            selected.iter().map(|u| u.get()).collect::<Vec<_>>(),
+            vec![3, 8, 12, 97, 250, 500],
+            "sparse, unordered, duplicated UIDs must sort and dedupe correctly, not \
+             just over a contiguous range"
+        );
+    }
+
+    #[test]
+    fn strict_page_orders_fetch_responses_by_selected_uid() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected = vec![
+            NonZeroU32::new(1).unwrap(),
+            NonZeroU32::new(2).unwrap(),
+            NonZeroU32::new(3).unwrap(),
+        ];
+        // Fetch stream returns entries in reverse order.
+        let fetched = vec![
+            (Some(3), Some(minimal_rfc822("c@example.com", "three"))),
+            (Some(2), Some(minimal_rfc822("b@example.com", "two"))),
+            (Some(1), Some(minimal_rfc822("a@example.com", "one"))),
+        ];
+        let emails =
+            process_selected_page(validity, &selected, fetched, "imap.example.com").unwrap();
+        assert_eq!(
+            emails.iter().map(|e| e.uid).collect::<Vec<_>>(),
+            vec![1, 2, 3],
+            "output must follow selected_uids order, not fetch response order"
+        );
+    }
+
+    #[test]
+    fn strict_page_missing_body_or_selected_uid_returns_error() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected = vec![NonZeroU32::new(1).unwrap(), NonZeroU32::new(2).unwrap()];
+
+        // UID 2 is present in the response but carries no RFC822 body.
+        let missing_body = vec![
+            (Some(1), Some(minimal_rfc822("a@example.com", "one"))),
+            (Some(2), None),
+        ];
         assert!(
-            msg.contains("UIDVALIDITY"),
-            "error message should mention UIDVALIDITY; got: {msg}"
+            process_selected_page(validity, &selected, missing_body, "h").is_err(),
+            "a selected UID with no body must fail the whole page, not silently omit it"
         );
-    }
 
-    #[test]
-    fn process_mailbox_fetch_zero_uidvalidity_returns_error() {
-        let raw = minimal_rfc822("a@example.com", "test");
-        let result = process_mailbox_fetch(Some(0), vec![(Some(1), raw)], "imap.example.com");
+        // UID 2 never appears in the fetch response at all.
+        let missing_uid = vec![(Some(1), Some(minimal_rfc822("a@example.com", "one")))];
         assert!(
-            result.is_err(),
-            "zero UIDVALIDITY must return a transport error"
+            process_selected_page(validity, &selected, missing_uid, "h").is_err(),
+            "a selected UID absent from the fetch response must fail the whole page"
         );
     }
 
     #[test]
-    fn process_mailbox_fetch_missing_uid_skips_message() {
-        let raw = minimal_rfc822("a@example.com", "test");
-        let result =
-            process_mailbox_fetch(Some(999), vec![(None, raw)], "imap.example.com").unwrap();
+    fn strict_page_parse_failure_returns_error() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected = vec![NonZeroU32::new(1).unwrap()];
+        // Empty body — mail_parser returns None ("if no headers are found
+        // None is returned").
+        let fetched = vec![(Some(1), Some(Vec::new()))];
         assert!(
-            result.is_empty(),
-            "a message with missing UID must be skipped (not an error)"
+            process_selected_page(validity, &selected, fetched, "h").is_err(),
+            "malformed selected RFC822 bytes must fail the page, not silently advance"
         );
     }
 
     #[test]
-    fn process_mailbox_fetch_zero_uid_skips_message() {
-        let raw = minimal_rfc822("a@example.com", "test");
-        let result =
-            process_mailbox_fetch(Some(999), vec![(Some(0), raw)], "imap.example.com").unwrap();
+    fn strict_page_ignores_unrequested_fetch_response() {
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected = vec![NonZeroU32::new(1).unwrap()];
+        let fetched = vec![
+            (Some(1), Some(minimal_rfc822("a@example.com", "one"))),
+            // UID 99 was never selected; a stray response for it must be ignored,
+            // not treated as part of the page.
+            (Some(99), Some(minimal_rfc822("stray@example.com", "stray"))),
+        ];
+        let emails = process_selected_page(validity, &selected, fetched, "h").unwrap();
+        assert_eq!(emails.len(), 1);
+        assert_eq!(emails[0].uid, 1);
+    }
+
+    #[tokio::test]
+    async fn mock_imap_backlog_drains_across_fetch_since_calls() {
+        // Simulates async-imap search always returning the full 75-message
+        // backlog (as it would every 5s until the SINCE window advances) --
+        // ImapFetcher's legacy_progress cursor must still drain it as
+        // 50, then 25, then 0 across repeated standalone calls.
+        struct BacklogMockImap {
+            validity: NonZeroU32,
+            all_uids: Vec<u32>,
+        }
+
+        #[async_trait]
+        impl ImapConnector for BacklogMockImap {
+            async fn fetch_page(
+                &self,
+                _since: DateTime<Utc>,
+                limit: usize,
+                progress: ImapProgress,
+            ) -> Result<ImapFetchPage, ChannelError> {
+                let selected =
+                    select_uid_page(self.all_uids.clone(), limit, self.validity, progress)?;
+                let fetched: Vec<(Option<u32>, Option<Vec<u8>>)> = selected
+                    .iter()
+                    .map(|u| {
+                        (
+                            Some(u.get()),
+                            Some(minimal_rfc822("sender@example.com", "backlog")),
+                        )
+                    })
+                    .collect();
+                let emails =
+                    process_selected_page(self.validity, &selected, fetched, "mail.example.com")?;
+                let next = next_progress(self.validity, progress, &selected);
+                Ok(ImapFetchPage {
+                    emails,
+                    next_progress: next,
+                })
+            }
+        }
+
+        let mut all_uids: Vec<u32> = (1..=75).rev().collect();
+        all_uids.extend(1..=5); // duplicates, mirroring HashSet noise
+
+        let fetcher = ImapFetcher::with_connector(BacklogMockImap {
+            validity: NonZeroU32::new(42).unwrap(),
+            all_uids,
+        });
+
+        let page1 = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
+        assert_eq!(page1.len(), 50);
+        let page2 = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
+        assert_eq!(page2.len(), 25);
+        let page3 = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
         assert!(
-            result.is_empty(),
-            "a message with zero UID must be skipped (not an error)"
+            page3.is_empty(),
+            "backlog must be fully drained after two pages"
         );
-    }
-
-    #[test]
-    fn process_mailbox_fetch_valid_inputs_produce_email() {
-        let raw = minimal_rfc822("alice@example.com", "hello");
-        let result =
-            process_mailbox_fetch(Some(1234), vec![(Some(7), raw)], "mail.example.com").unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].imap_external_id, "imap:mail.example.com:1234:7");
-    }
-
-    #[test]
-    fn process_mailbox_fetch_skips_invalid_uid_continues_valid() {
-        let raw_bad = minimal_rfc822("bad@example.com", "bad");
-        let raw_good = minimal_rfc822("good@example.com", "good");
-        let result = process_mailbox_fetch(
-            Some(555),
-            vec![(Some(0), raw_bad), (Some(3), raw_good)],
-            "imap.example.com",
-        )
-        .unwrap();
-        assert_eq!(result.len(), 1, "only the valid message should be returned");
-        assert_eq!(result[0].imap_external_id, "imap:imap.example.com:555:3");
     }
 
     #[test]

--- a/crates/khive-channel-email/src/connector/imap.rs
+++ b/crates/khive-channel-email/src/connector/imap.rs
@@ -41,9 +41,50 @@ pub(crate) struct ImapProgress {
 
 /// One page of IMAP fetch results plus the progress the caller should adopt
 /// once the page is durably handled.
+///
+/// `emails` carries exactly one [`SelectedMessage`] per selected UID (khive
+/// #449 High fix): every selected UID gets a durable terminal disposition
+/// before `next_progress` is allowed to advance past it, so a single
+/// permanently malformed message can never starve later UIDs.
 pub(crate) struct ImapFetchPage {
-    pub(crate) emails: Vec<RawEmail>,
+    pub(crate) emails: Vec<SelectedMessage>,
     pub(crate) next_progress: ImapProgress,
+}
+
+/// Why a selected UID could not be parsed into a [`RawEmail`] (khive #449
+/// High fix). Distinguishes the two permanent-failure shapes so the
+/// downstream quarantine record carries an accurate reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MalformedReason {
+    /// The `UID FETCH` response carried no RFC822 body for this UID.
+    MissingBody,
+    /// An RFC822 body was present but `mail_parser` could not parse it.
+    ParseFailure,
+}
+
+impl std::fmt::Display for MalformedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            MalformedReason::MissingBody => "missing-body",
+            MalformedReason::ParseFailure => "parse-failure",
+        })
+    }
+}
+
+/// The terminal disposition of one selected UID: either a successfully
+/// parsed message, or a durable quarantine marker for a UID that could not
+/// be parsed (khive #449 High fix). Every selected UID produces exactly one
+/// of these -- never silently dropped, never left without a disposition.
+pub(crate) enum SelectedMessage {
+    Email(Box<RawEmail>),
+    Malformed {
+        uid: u32,
+        /// Stable `imap:{host}:{uidvalidity}:{uid}` dedup key, precomputed
+        /// here since a malformed message has no parsed headers to derive
+        /// it from.
+        imap_external_id: String,
+        reason: MalformedReason,
+    },
 }
 
 /// Internal trait for IMAP fetch operations.
@@ -402,23 +443,29 @@ fn next_progress(
     }
 }
 
-/// Validate a fully-fetched selected page and build the `RawEmail` list, in
-/// `selected_uids` order.
+/// Validate a fully-fetched selected page and build the [`SelectedMessage`]
+/// list, in `selected_uids` order -- exactly one entry per selected UID.
 ///
-/// Every UID in `selected_uids` must appear exactly once in `fetched_raw` with
-/// a non-`None` body that parses successfully; any gap, duplicate, missing
-/// body, or parse failure fails the whole page (no partial advancement — the
-/// poll coordinator must not commit a candidate high-water for an incompletely
-/// materialized page). A fetch response for a UID outside `selected_uids` is
-/// unrequested (e.g. a stray server response) and is ignored with a `warn!`;
-/// it can never affect page validity or the candidate high-water.
+/// Every UID in `selected_uids` must appear exactly once in `fetched_raw`;
+/// a gap (UID absent from the fetch response entirely) or a duplicate
+/// response for the same UID still fails the whole page (no partial
+/// advancement — these are protocol anomalies, not permanent per-message
+/// failures, and a genuinely expunged message will not be re-selected next
+/// poll). A missing RFC822 body or an unparseable body, by contrast, is a
+/// permanent per-UID failure (khive #449 High fix): rather than failing the
+/// whole page and re-selecting the same poison UID forever, that UID gets a
+/// durable [`SelectedMessage::Malformed`] disposition so the caller can
+/// quarantine it and advance past it. A fetch response for a UID outside
+/// `selected_uids` is unrequested (e.g. a stray server response) and is
+/// ignored with a `warn!`; it can never affect page validity or the
+/// candidate high-water.
 pub(crate) fn process_selected_page(
     uid_validity: NonZeroU32,
     selected_uids: &[NonZeroU32],
     fetched_raw: Vec<(Option<u32>, Option<Vec<u8>>)>,
     host: &str,
-) -> Result<Vec<RawEmail>, ChannelError> {
-    let mut by_uid: HashMap<u32, Vec<u8>> = HashMap::new();
+) -> Result<Vec<SelectedMessage>, ChannelError> {
+    let mut by_uid: HashMap<u32, Option<Vec<u8>>> = HashMap::new();
     for (uid_opt, body_opt) in fetched_raw {
         let Some(uid) = uid_opt.filter(|&u| u != 0) else {
             continue;
@@ -427,13 +474,7 @@ pub(crate) fn process_selected_page(
             tracing::warn!(host = %host, uid, "ignoring unrequested IMAP fetch response");
             continue;
         }
-        let Some(body) = body_opt else {
-            return Err(ChannelError::Transport(format!(
-                "IMAP UID FETCH returned no RFC822 body for selected UID {uid}; \
-                 page rejected, not partially advanced"
-            )));
-        };
-        if by_uid.insert(uid, body).is_some() {
+        if by_uid.insert(uid, body_opt).is_some() {
             return Err(ChannelError::Transport(format!(
                 "IMAP UID FETCH returned duplicate responses for selected UID {uid}"
             )));
@@ -443,18 +484,43 @@ pub(crate) fn process_selected_page(
     let mut result = Vec::with_capacity(selected_uids.len());
     for &uid in selected_uids {
         let uid = uid.get();
-        let raw = by_uid.remove(&uid).ok_or_else(|| {
+        let imap_external_id = format!("imap:{host}:{}:{uid}", uid_validity.get());
+        let entry = by_uid.remove(&uid).ok_or_else(|| {
             ChannelError::Transport(format!(
                 "IMAP UID FETCH did not return a response for selected UID {uid}; \
                  page rejected, not partially advanced"
             ))
         })?;
-        let email = parse_raw_bytes(uid, &raw, host, uid_validity.get()).ok_or_else(|| {
-            ChannelError::Transport(format!(
-                "failed to parse RFC822 bytes for selected UID {uid}"
-            ))
-        })?;
-        result.push(email);
+        let message = match entry {
+            None => {
+                tracing::warn!(
+                    host = %host,
+                    uid,
+                    "IMAP UID FETCH returned no RFC822 body for selected UID; quarantining"
+                );
+                SelectedMessage::Malformed {
+                    uid,
+                    imap_external_id,
+                    reason: MalformedReason::MissingBody,
+                }
+            }
+            Some(raw) => match parse_raw_bytes(uid, &raw, host, uid_validity.get()) {
+                Some(email) => SelectedMessage::Email(Box::new(email)),
+                None => {
+                    tracing::warn!(
+                        host = %host,
+                        uid,
+                        "failed to parse RFC822 bytes for selected UID; quarantining"
+                    );
+                    SelectedMessage::Malformed {
+                        uid,
+                        imap_external_id,
+                        reason: MalformedReason::ParseFailure,
+                    }
+                }
+            },
+        };
+        result.push(message);
     }
     Ok(result)
 }
@@ -634,11 +700,11 @@ impl ImapFetcher {
     /// within one process without requiring a durable checkpoint; the daemon
     /// poll loop uses [`Self::fetch_page`] with an explicit stored checkpoint
     /// instead.
-    pub async fn fetch_since(
+    pub(crate) async fn fetch_since(
         &self,
         since: DateTime<Utc>,
         limit: usize,
-    ) -> Result<Vec<RawEmail>, ChannelError> {
+    ) -> Result<Vec<SelectedMessage>, ChannelError> {
         let mut progress = self.legacy_progress.lock().await;
         let page = self.inner.fetch_page(since, limit, *progress).await?;
         *progress = page.next_progress;
@@ -681,7 +747,12 @@ mod tests {
             _progress: ImapProgress,
         ) -> Result<ImapFetchPage, ChannelError> {
             Ok(ImapFetchPage {
-                emails: self.emails.clone(),
+                emails: self
+                    .emails
+                    .clone()
+                    .into_iter()
+                    .map(|e| SelectedMessage::Email(Box::new(e)))
+                    .collect(),
                 next_progress: ImapProgress::default(),
             })
         }
@@ -713,8 +784,11 @@ mod tests {
         let fetcher = ImapFetcher::with_connector(MockImap::with_emails(emails));
         let result = fetcher.fetch_since(Utc::now(), 50).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].imap_external_id, "imap:mail.example.com:12345:1");
-        assert_eq!(result[0].from_addrs, vec!["alice@example.com"]);
+        let SelectedMessage::Email(email) = &result[0] else {
+            panic!("expected a parsed email, got a malformed disposition");
+        };
+        assert_eq!(email.imap_external_id, "imap:mail.example.com:12345:1");
+        assert_eq!(email.from_addrs, vec!["alice@example.com"]);
     }
 
     #[tokio::test]
@@ -1126,29 +1200,59 @@ mod tests {
         ];
         let emails =
             process_selected_page(validity, &selected, fetched, "imap.example.com").unwrap();
+        let uids: Vec<u32> = emails
+            .iter()
+            .map(|m| match m {
+                SelectedMessage::Email(e) => e.uid,
+                SelectedMessage::Malformed { uid, .. } => *uid,
+            })
+            .collect();
         assert_eq!(
-            emails.iter().map(|e| e.uid).collect::<Vec<_>>(),
+            uids,
             vec![1, 2, 3],
             "output must follow selected_uids order, not fetch response order"
         );
     }
 
     #[test]
-    fn strict_page_missing_body_or_selected_uid_returns_error() {
+    fn strict_page_missing_body_quarantines_without_failing_page() {
+        // UID 2 is present in the response but carries no RFC822 body -- must
+        // get a durable Malformed disposition, not fail the whole page
+        // (khive #449 High fix: a permanently bodyless message must not
+        // starve every later UID).
         let validity = NonZeroU32::new(1).unwrap();
         let selected = vec![NonZeroU32::new(1).unwrap(), NonZeroU32::new(2).unwrap()];
-
-        // UID 2 is present in the response but carries no RFC822 body.
         let missing_body = vec![
             (Some(1), Some(minimal_rfc822("a@example.com", "one"))),
             (Some(2), None),
         ];
+        let result = process_selected_page(validity, &selected, missing_body, "h").unwrap();
+        assert_eq!(result.len(), 2, "both selected UIDs must get a disposition");
         assert!(
-            process_selected_page(validity, &selected, missing_body, "h").is_err(),
-            "a selected UID with no body must fail the whole page, not silently omit it"
+            matches!(&result[0], SelectedMessage::Email(e) if e.uid == 1),
+            "UID 1 must parse normally"
         );
+        assert!(
+            matches!(
+                &result[1],
+                SelectedMessage::Malformed {
+                    uid: 2,
+                    reason: MalformedReason::MissingBody,
+                    ..
+                }
+            ),
+            "UID 2 must be quarantined as missing-body, not dropped or erroring"
+        );
+    }
 
-        // UID 2 never appears in the fetch response at all.
+    #[test]
+    fn strict_page_absent_uid_still_errors() {
+        // UID 2 never appears in the fetch response at all -- a genuine
+        // protocol gap (distinct from a malformed body), so the whole page
+        // still fails; a self-healing retry is safe because an expunged
+        // message will not be re-selected next poll.
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected = vec![NonZeroU32::new(1).unwrap(), NonZeroU32::new(2).unwrap()];
         let missing_uid = vec![(Some(1), Some(minimal_rfc822("a@example.com", "one")))];
         assert!(
             process_selected_page(validity, &selected, missing_uid, "h").is_err(),
@@ -1157,15 +1261,25 @@ mod tests {
     }
 
     #[test]
-    fn strict_page_parse_failure_returns_error() {
+    fn strict_page_parse_failure_quarantines_without_failing_page() {
         let validity = NonZeroU32::new(1).unwrap();
         let selected = vec![NonZeroU32::new(1).unwrap()];
         // Empty body — mail_parser returns None ("if no headers are found
         // None is returned").
         let fetched = vec![(Some(1), Some(Vec::new()))];
+        let result = process_selected_page(validity, &selected, fetched, "h").unwrap();
+        assert_eq!(result.len(), 1);
         assert!(
-            process_selected_page(validity, &selected, fetched, "h").is_err(),
-            "malformed selected RFC822 bytes must fail the page, not silently advance"
+            matches!(
+                &result[0],
+                SelectedMessage::Malformed {
+                    uid: 1,
+                    reason: MalformedReason::ParseFailure,
+                    ..
+                }
+            ),
+            "malformed selected RFC822 bytes must quarantine, not fail the whole page \
+             or silently advance without a record"
         );
     }
 
@@ -1181,7 +1295,7 @@ mod tests {
         ];
         let emails = process_selected_page(validity, &selected, fetched, "h").unwrap();
         assert_eq!(emails.len(), 1);
-        assert_eq!(emails[0].uid, 1);
+        assert!(matches!(&emails[0], SelectedMessage::Email(e) if e.uid == 1));
     }
 
     #[tokio::test]
@@ -1240,6 +1354,58 @@ mod tests {
         assert!(
             page3.is_empty(),
             "backlog must be fully drained after two pages"
+        );
+    }
+
+    #[test]
+    fn one_poison_uid_does_not_starve_51_later_valid_uids_and_cursor_passes_it() {
+        // khive #449 High regression: a single permanently malformed UID
+        // (here, UID 1: an empty body mail_parser cannot parse) followed by
+        // 50 valid messages. All 50 valid ones must parse; the poison UID
+        // must get a durable quarantine disposition (not silently dropped,
+        // not failing the page); and the candidate high-water must advance
+        // past the poison UID along with everything else, so the next poll
+        // never re-selects it.
+        let validity = NonZeroU32::new(1).unwrap();
+        let selected: Vec<NonZeroU32> = (1u32..=51).map(|u| NonZeroU32::new(u).unwrap()).collect();
+
+        let mut fetched: Vec<(Option<u32>, Option<Vec<u8>>)> = vec![(Some(1), Some(Vec::new()))];
+        fetched.extend(
+            (2u32..=51).map(|u| (Some(u), Some(minimal_rfc822("sender@example.com", "valid")))),
+        );
+
+        let result = process_selected_page(validity, &selected, fetched, "h").unwrap();
+        assert_eq!(result.len(), 51, "every selected UID gets a disposition");
+
+        assert!(
+            matches!(
+                &result[0],
+                SelectedMessage::Malformed {
+                    uid: 1,
+                    reason: MalformedReason::ParseFailure,
+                    ..
+                }
+            ),
+            "the poison UID must carry a quarantine record, not be dropped"
+        );
+        let valid_uids: Vec<u32> = result[1..]
+            .iter()
+            .map(|m| match m {
+                SelectedMessage::Email(e) => e.uid,
+                SelectedMessage::Malformed { uid, .. } => *uid,
+            })
+            .collect();
+        assert_eq!(
+            valid_uids,
+            (2u32..=51).collect::<Vec<_>>(),
+            "all 50 valid messages after the poison UID must still ingest"
+        );
+
+        let next = next_progress(validity, ImapProgress::default(), &selected);
+        assert_eq!(
+            next.last_seen_uid,
+            NonZeroU32::new(51),
+            "the checkpoint candidate must advance past the poison UID, not stall on it"
         );
     }
 

--- a/crates/khive-channel/src/lib.rs
+++ b/crates/khive-channel/src/lib.rs
@@ -147,6 +147,55 @@ impl ChannelEnvelope {
     }
 }
 
+/// Durable poll progress for a single `(kind, slug)` channel.
+///
+/// Transport-neutral: IMAP maps `generation` to `UIDVALIDITY` and
+/// `high_water` to the greatest durably handled UID, but the type itself
+/// carries no IMAP-specific meaning so other transports can reuse it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelCheckpoint {
+    /// Stable, non-secret identity of the remote source/configuration.
+    pub source: String,
+    /// Remote identity epoch. IMAP maps this to UIDVALIDITY.
+    pub generation: u64,
+    /// Greatest durably handled remote sequence value. IMAP maps this to UID.
+    pub high_water: Option<u64>,
+}
+
+/// A [`ChannelCheckpoint`] as persisted, with the time it was committed.
+///
+/// `committed_at` is used as the recovery `SINCE` floor after an epoch reset,
+/// so a daemon that was down across a UIDVALIDITY change still bounds its
+/// re-scan instead of falling back to the caller's `since` alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredChannelCheckpoint {
+    #[serde(flatten)]
+    pub checkpoint: ChannelCheckpoint,
+    /// Database commit time, used as the recovery SINCE floor after an epoch reset.
+    pub committed_at: DateTime<Utc>,
+}
+
+/// The result of one [`Channel::poll_page`] call: envelopes ready for
+/// `comm.ingest`, plus the checkpoint the poll coordinator should persist
+/// after every envelope has been durably ingested.
+#[derive(Debug, Clone)]
+pub struct ChannelPollPage {
+    pub envelopes: Vec<ChannelEnvelope>,
+    /// `Some` only when durable progress must be inserted or changed.
+    pub next_checkpoint: Option<ChannelCheckpoint>,
+}
+
+impl ChannelPollPage {
+    /// Wrap a plain envelope list with no checkpoint — the default
+    /// [`Channel::poll_page`] behavior for adapters that only implement `poll`.
+    pub fn stateless(envelopes: Vec<ChannelEnvelope>) -> Self {
+        Self {
+            envelopes,
+            next_checkpoint: None,
+        }
+    }
+}
+
 /// Errors produced by channel operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ChannelError {
@@ -216,6 +265,23 @@ pub trait Channel: Send + Sync + 'static {
     /// deduplicate themselves.  Adapters should apply a best-effort server-side
     /// filter on `since` to avoid fetching large backlogs.
     async fn poll(&self, since: DateTime<Utc>) -> Result<Vec<ChannelEnvelope>, ChannelError>;
+
+    /// Poll for new inbound messages, checkpoint-aware.
+    ///
+    /// The default implementation wraps [`Channel::poll`] with a stateless
+    /// [`ChannelPollPage`] (`next_checkpoint: None`), so every existing
+    /// adapter remains source-compatible without change. Adapters that can
+    /// bind progress to a durable per-source high-water mark (e.g. IMAP's
+    /// UIDVALIDITY/UID) should override this instead of relying on `since`
+    /// alone.
+    async fn poll_page(
+        &self,
+        since: DateTime<Utc>,
+        checkpoint: Option<&StoredChannelCheckpoint>,
+    ) -> Result<ChannelPollPage, ChannelError> {
+        let _ = checkpoint;
+        Ok(ChannelPollPage::stateless(self.poll(since).await?))
+    }
 }
 
 /// Registry of named channel adapters.
@@ -479,6 +545,29 @@ mod tests {
         assert!(
             ch.is_configured(),
             "default is_configured() must return true"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_poll_page_wraps_legacy_poll_without_checkpoint() {
+        // #449: an adapter that implements only `poll` (the pre-checkpoint
+        // shape) must still work through `poll_page`, returning the same
+        // envelopes with no checkpoint to persist.
+        let inbound =
+            vec![
+                ChannelEnvelope::new("email:sender@example.com", "email:me@example.com", "body")
+                    .with_external_id("<id1@example.com>"),
+            ];
+        let ch = MockChannel::new(inbound.clone());
+        let page = ch.poll_page(Utc::now(), None).await.expect("poll_page ok");
+        assert_eq!(page.envelopes.len(), 1);
+        assert_eq!(
+            page.envelopes[0].external_id.as_deref(),
+            Some("<id1@example.com>")
+        );
+        assert!(
+            page.next_checkpoint.is_none(),
+            "default poll_page must never produce a checkpoint"
         );
     }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -5167,26 +5167,66 @@ id = "lambda:project-actor"
             }
         }
 
+        /// The ADR-094 lifecycle-event subsequence the sequencing test
+        /// asserts on. The shared `FakeEventStore` also receives every
+        /// dispatch's audit event and each `comm.heartbeat` write, so raw
+        /// `store.events.len()` is not a proxy for "how many lifecycle
+        /// events landed" -- it inflates far faster than the six events
+        /// this test actually cares about, which is why convergence must
+        /// be checked against this filtered view, not the raw count.
+        fn lifecycle_sequence(store: &FakeEventStore) -> Vec<khive_types::EventKind> {
+            store
+                .events
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|e| e.kind)
+                .filter(|k| {
+                    matches!(
+                        k,
+                        khive_types::EventKind::ChannelPollStarted
+                            | khive_types::EventKind::ChannelPollSucceeded
+                            | khive_types::EventKind::ChannelPollFailed
+                            | khive_types::EventKind::ChannelBackoffArmed
+                            | khive_types::EventKind::ChannelBackoffReset
+                    )
+                })
+                .collect()
+        }
+
         /// Drive the paused virtual clock forward in small steps, yielding
         /// after each one, until the fake store has recorded at least
-        /// `target` events. A single big `advance` can outrun a timer the
-        /// polled task hasn't registered yet (the task only arms its next
-        /// `sleep` after cooperative scheduling lets it run back around the
-        /// loop), so this steps forward repeatedly instead of guessing one
-        /// jump that is simultaneously long enough to fire the next timer
-        /// and short enough not to skip past it unregistered.
+        /// `target` lifecycle events (see [`lifecycle_sequence`]). A single
+        /// big `advance` can outrun a timer the polled task hasn't
+        /// registered yet (the task only arms its next `sleep` after
+        /// cooperative scheduling lets it run back around the loop), so
+        /// this steps forward repeatedly instead of guessing one jump that
+        /// is simultaneously long enough to fire the next timer and short
+        /// enough not to skip past it unregistered.
+        ///
+        /// The loop's own `comm.*` dispatches land on `spawn_blocking`
+        /// (`khive-db`'s writer runs on tokio's real OS-thread blocking
+        /// pool), so how many `advance`/`yield_now` rounds this needs to
+        /// converge depends on real thread-pool scheduling latency, not on
+        /// virtual time -- a fixed iteration count is really a proxy for
+        /// real wall-clock patience, and a bigger fixed count doesn't buy
+        /// more of it if the loop itself runs each round near-instantly in
+        /// real time. Bounding on an actual wall-clock deadline instead
+        /// gives the blocking pool as much real time as it needs under
+        /// load, while still failing fast (with a clear message) if the
+        /// condition is genuinely never met.
         async fn advance_until(store: &FakeEventStore, target: usize) {
-            // khive #449: the poll loop now also dispatches comm.cursor_get /
-            // comm.cursor_commit each iteration, and the first cursor_get
-            // bootstraps the comm_channel_cursor schema -- under this test's
-            // paused clock that bootstrap needs several more cooperative
-            // sleep/wake round-trips to settle than a bare heartbeat write
-            // did, so the iteration budget is higher than a single
-            // fail-then-recover episode would otherwise need.
-            for _ in 0..2000 {
-                if store.events.lock().unwrap().len() >= target {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            loop {
+                if lifecycle_sequence(store).len() >= target {
                     return;
                 }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "lifecycle event sequence did not reach {target} events within 60s of \
+                     wall-clock time; got {:?}",
+                    lifecycle_sequence(store)
+                );
                 tokio::time::advance(std::time::Duration::from_millis(250)).await;
                 for _ in 0..10 {
                     tokio::task::yield_now().await;
@@ -5232,21 +5272,7 @@ id = "lambda:project-actor"
 
             task.abort();
 
-            let events = store.events.lock().unwrap();
-            let sequence: Vec<khive_types::EventKind> = events
-                .iter()
-                .map(|e| e.kind)
-                .filter(|k| {
-                    matches!(
-                        k,
-                        khive_types::EventKind::ChannelPollStarted
-                            | khive_types::EventKind::ChannelPollSucceeded
-                            | khive_types::EventKind::ChannelPollFailed
-                            | khive_types::EventKind::ChannelBackoffArmed
-                            | khive_types::EventKind::ChannelBackoffReset
-                    )
-                })
-                .collect();
+            let sequence = lifecycle_sequence(&store);
 
             assert_eq!(
                 sequence,
@@ -5422,8 +5448,25 @@ id = "lambda:project-actor"
             ));
 
             // Two happy-path 5s ticks: the first drives the partial-failure
-            // page, the second drives the retry the fix must produce.
-            for _ in 0..20 {
+            // page, the second drives the retry the fix must produce. Poll
+            // for the retry directly (rather than blindly running a fixed
+            // number of ticks) and bound the wait by a real wall-clock
+            // deadline, not a virtual-time/iteration budget -- the loop's
+            // `comm.*` dispatches land on `spawn_blocking`'s real OS-thread
+            // pool, so how many advance/yield rounds this needs depends on
+            // real thread-pool scheduling latency, which a fixed count
+            // cannot account for under load.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            loop {
+                if observed_checkpoints.lock().unwrap().len() >= 2 {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "the loop must have retried at least once within 60s of wall-clock \
+                     time: {:?}",
+                    observed_checkpoints.lock().unwrap()
+                );
                 tokio::time::advance(std::time::Duration::from_secs(5)).await;
                 for _ in 0..20 {
                     tokio::task::yield_now().await;
@@ -5468,6 +5511,107 @@ id = "lambda:project-actor"
                 1,
                 "the message that succeeded on the failed page must not be \
                  double-stored once the retry re-delivers the whole page: {notes:?}"
+            );
+        }
+
+        /// A channel whose every `poll_page` call returns an empty page with
+        /// a `next_checkpoint` that `comm.cursor_commit` itself rejects
+        /// (`generation: 0` is outside its documented `1..=i64::MAX` range).
+        /// Exercises the daemon's `commit_channel_cursor`-`Err` branch
+        /// (issue #449 Blocker fix): every other test in this module drives
+        /// a `cursor_get` failure or a `comm.ingest` failure, never a
+        /// rejected commit itself, so that branch was otherwise dead from
+        /// this suite's perspective.
+        struct CommitRejectedChannel {
+            call_count: AtomicUsize,
+        }
+
+        #[async_trait]
+        impl Channel for CommitRejectedChannel {
+            fn kind(&self) -> &'static str {
+                "mock_commit_rejected"
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                _since: DateTime<Utc>,
+                _checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                self.call_count.fetch_add(1, Ordering::SeqCst);
+                Ok(ChannelPollPage {
+                    envelopes: vec![],
+                    next_checkpoint: Some(ChannelCheckpoint {
+                        source: SOURCE.to_string(),
+                        generation: 0,
+                        high_water: Some(1),
+                    }),
+                })
+            }
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn rejected_cursor_commit_leaves_no_committed_checkpoint() {
+            let channel = Arc::new(CommitRejectedChannel {
+                call_count: AtomicUsize::new(0),
+            });
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(channel.clone());
+
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            // Wait for at least two poll_page calls (deterministic condition
+            // on the channel's own call counter, not a fixed tick budget):
+            // the second call proves the loop went all the way around after
+            // the first call's rejected commit, giving that commit's async
+            // dispatch chain every chance to finish before asserting on its
+            // durable effect. Bounded on real wall-clock time, not virtual
+            // time, since the underlying `comm.*` dispatches land on
+            // `spawn_blocking`'s real OS-thread pool.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            loop {
+                if channel.call_count.load(Ordering::SeqCst) >= 2 {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "poll_page was not called at least twice within 60s of wall-clock time"
+                );
+                tokio::time::advance(std::time::Duration::from_millis(250)).await;
+                for _ in 0..10 {
+                    tokio::task::yield_now().await;
+                }
+            }
+            task.abort();
+
+            let restored =
+                load_channel_cursor(&registry, "mock_commit_rejected", "mock_commit_rejected")
+                    .await
+                    .expect("cursor_get must succeed");
+            assert!(
+                restored.is_none(),
+                "a rejected cursor_commit must not leave a committed checkpoint: {restored:?}"
             );
         }
 

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -347,6 +347,16 @@ async fn channel_poll_loop(
     let mut last_error_class: HashMap<(String, String), &'static str> = HashMap::new();
     let mut next_interval = HAPPY_PATH_INTERVAL;
     let event_store = registry.event_store();
+    // Captured before the loop's first sleep (issue #449 High follow-up,
+    // codex re-review). A channel's very first bootstrap floor must reflect
+    // when the daemon actually started, not whenever its first tick happens
+    // to fire: `tokio::time::sleep` below runs before any polling, so
+    // computing `now` after it (as the loop used to) can land on the far
+    // side of a calendar-day boundary the daemon started before. Every
+    // vacant `bootstrap_since` entry -- on tick 1 or any later tick a
+    // channel is first seen on -- uses this single startup timestamp
+    // instead of that tick's own `now`.
+    let startup_since = Utc::now();
 
     loop {
         tokio::time::sleep(next_interval).await;
@@ -356,7 +366,9 @@ async fn channel_poll_loop(
 
         for (kind, slug, channel) in channels.iter() {
             let backoff_key = (kind.to_string(), slug.to_string());
-            let since = *bootstrap_since.entry(backoff_key.clone()).or_insert(now);
+            let since = *bootstrap_since
+                .entry(backoff_key.clone())
+                .or_insert(startup_since);
             // Set once this channel's cycle durably completes (a fresh
             // commit, or nothing new to commit); gates whether `since`
             // advances past this tick's `now` for next time.
@@ -5991,6 +6003,67 @@ id = "lambda:project-actor"
                  calendar-day boundary would permanently skip the earlier \
                  day's uncommitted mail",
                 failing_calls[1]
+            );
+        }
+
+        /// First-tick regression (issue #449 High, codex re-review): the
+        /// very first bootstrap floor a channel ever sees must be seeded
+        /// from when the daemon started, not from whenever the loop's
+        /// first sleep happens to finish. Runs on a live (unpaused) clock
+        /// on purpose -- `tokio::time::pause` only fast-forwards the
+        /// virtual timer, not `Utc::now()`, so it cannot observe a
+        /// regression where `since` is captured after the sleep instead of
+        /// before the loop is entered. If the loop ever goes back to
+        /// computing that floor post-sleep, a daemon started just before
+        /// UTC midnight whose first tick lands just after it would seed
+        /// the new day and permanently skip the previous day's mail.
+        #[tokio::test]
+        async fn first_tick_uses_startup_time_not_post_sleep_time() {
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(RecordingChannel {
+                kind: "mock_startup_clock",
+                since_calls: calls.clone(),
+            }));
+
+            let startup = Utc::now();
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            // Real-time wait for the loop's first (~5s) tick to fire.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            loop {
+                if !calls.lock().unwrap().is_empty() {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() <= deadline,
+                    "first poll_page call did not arrive within 15s"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            task.abort();
+
+            let first_since = calls.lock().unwrap()[0];
+            let drift_ms = (first_since - startup).num_milliseconds().abs();
+            assert!(
+                drift_ms < 2_000,
+                "the first poll_page call's `since` ({first_since:?}) must \
+                 reflect the daemon's startup time ({startup:?}), not a \
+                 timestamp captured after the loop's first ~5s sleep -- a \
+                 {drift_ms}ms drift means the floor is still seeded \
+                 post-sleep, which would drop a full day of mail if that \
+                 sleep happened to cross a calendar-day boundary"
             );
         }
     }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -313,7 +313,7 @@ async fn channel_poll_loop(
     ingest_namespace: String,
     default_inbound_actor: String,
 ) {
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
     use khive_channel_email::{is_backoff_eligible, ImapBackoff};
     use serde_json::json;
     use std::collections::HashMap;
@@ -321,7 +321,19 @@ async fn channel_poll_loop(
 
     const HAPPY_PATH_INTERVAL: Duration = Duration::from_secs(5);
 
-    let mut last_poll = Utc::now();
+    // Per-channel bootstrap "since" floor (issue #449 High follow-up). This
+    // only feeds the date-based SINCE search used while a channel has no
+    // committed UID high-water yet (first-ever poll, or a UIDVALIDITY
+    // reset); once a checkpoint has a high-water, polling is UID-ranged and
+    // this floor is unused for that channel. Each entry only advances to the
+    // poll tick's timestamp once that channel's full cycle -- cursor_get,
+    // poll_page, every comm.ingest, and cursor_commit -- succeeds this tick.
+    // Advancing it unconditionally (as a shared `last_poll` timestamp used
+    // to) would drop the earlier floor on any bootstrap-cycle failure, and
+    // if that failure spans a calendar-day boundary the next checkpoint-less
+    // poll's SINCE clause would use the newer date, permanently skipping the
+    // previous day's uncommitted mail.
+    let mut bootstrap_since: HashMap<(String, String), DateTime<Utc>> = HashMap::new();
     // One backoff state per (kind, slug) — i.e. per credential (#606 round-1
     // internal review, High finding). Keying by kind alone would throttle a
     // second same-kind credential (e.g. a second mailbox) whenever the first
@@ -340,11 +352,15 @@ async fn channel_poll_loop(
         tokio::time::sleep(next_interval).await;
         next_interval = HAPPY_PATH_INTERVAL;
 
-        let since = last_poll;
-        last_poll = Utc::now();
+        let now = Utc::now();
 
         for (kind, slug, channel) in channels.iter() {
             let backoff_key = (kind.to_string(), slug.to_string());
+            let since = *bootstrap_since.entry(backoff_key.clone()).or_insert(now);
+            // Set once this channel's cycle durably completes (a fresh
+            // commit, or nothing new to commit); gates whether `since`
+            // advances past this tick's `now` for next time.
+            let mut bootstrap_floor_advances = false;
 
             append_channel_lifecycle_event(
                 event_store.as_ref(),
@@ -454,16 +470,24 @@ async fn channel_poll_loop(
                     }
 
                     if page_fully_ingested {
-                        if let Some(next_checkpoint) = page.next_checkpoint {
-                            if let Err(e) =
-                                commit_channel_cursor(&registry, kind, slug, &next_checkpoint).await
-                            {
-                                tracing::warn!(
-                                    channel = kind,
-                                    "comm.cursor_commit failed; progress not durably \
-                                     advanced, next poll will retry: {e}"
-                                );
+                        match page.next_checkpoint {
+                            Some(next_checkpoint) => {
+                                match commit_channel_cursor(&registry, kind, slug, &next_checkpoint)
+                                    .await
+                                {
+                                    Ok(()) => bootstrap_floor_advances = true,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            channel = kind,
+                                            "comm.cursor_commit failed; progress not durably \
+                                             advanced, next poll will retry: {e}"
+                                        );
+                                    }
+                                }
                             }
+                            // Nothing new to commit this tick is not a
+                            // failure -- safe to advance the bootstrap floor.
+                            None => bootstrap_floor_advances = true,
                         }
                     } else {
                         tracing::warn!(
@@ -533,6 +557,10 @@ async fn channel_poll_loop(
                         tracing::warn!(channel = kind, "channel poll failed: {e}");
                     }
                 }
+            }
+
+            if bootstrap_floor_advances {
+                bootstrap_since.insert((kind.to_string(), slug.to_string()), now);
             }
         }
     }
@@ -5431,6 +5459,158 @@ id = "lambda:project-actor"
             );
         }
 
+        /// A channel whose one and only `poll_page` call returns a single
+        /// quarantine-shaped envelope -- exactly the field shape
+        /// `EmailChannel::disposition` produces for a permanently
+        /// unparseable UID (see
+        /// `khive-channel-email`'s
+        /// `poll_page_malformed_uid_produces_a_stable_external_id_and_quarantine_metadata`) --
+        /// so this test can drive it through the daemon's real
+        /// `comm.ingest` call and query the durably persisted note.
+        struct QuarantineOnceChannel {
+            envelope: Mutex<Option<ChannelEnvelope>>,
+        }
+
+        #[async_trait]
+        impl Channel for QuarantineOnceChannel {
+            fn kind(&self) -> &'static str {
+                "mock_quarantine"
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                _since: DateTime<Utc>,
+                _checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                let Some(envelope) = self.envelope.lock().unwrap().take() else {
+                    return Ok(ChannelPollPage {
+                        envelopes: vec![],
+                        next_checkpoint: None,
+                    });
+                };
+                Ok(ChannelPollPage {
+                    envelopes: vec![envelope],
+                    next_checkpoint: Some(ChannelCheckpoint {
+                        source: SOURCE.to_string(),
+                        generation: 9,
+                        high_water: Some(1),
+                    }),
+                })
+            }
+        }
+
+        /// khive #449 High follow-up (Medium-2): the connector- and
+        /// channel-level poison-UID tests prove a malformed message becomes
+        /// a quarantine-shaped `ChannelEnvelope`, but neither proves the
+        /// daemon actually turns that into a durable, queryable record.
+        /// Drives a quarantine envelope through the real `channel_poll_loop`
+        /// -> `comm.ingest` path and queries the stored note back out,
+        /// asserting its stable external ID and quarantine metadata
+        /// persisted exactly -- and that the cursor committed, since a
+        /// quarantine envelope must durably ingest like any other message.
+        #[tokio::test(start_paused = true)]
+        async fn malformed_message_durably_quarantines_with_stable_external_id_and_metadata() {
+            let mut envelope = ChannelEnvelope::new(
+                "email:quarantine",
+                "email:maintainer@example.com",
+                "(khive: IMAP message UID 1 could not be parsed and was quarantined)",
+            )
+            .with_external_id("imap:h:9:1");
+            envelope
+                .metadata
+                .insert("quarantined".to_string(), "true".to_string());
+            envelope
+                .metadata
+                .insert("quarantine_reason".to_string(), "missing-body".to_string());
+
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(QuarantineOnceChannel {
+                envelope: Mutex::new(Some(envelope)),
+            }));
+
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            for _ in 0..2000 {
+                let restored = load_channel_cursor(&registry, "mock_quarantine", "mock_quarantine")
+                    .await
+                    .expect("cursor_get must succeed");
+                if restored.is_some() {
+                    break;
+                }
+                tokio::time::advance(std::time::Duration::from_millis(250)).await;
+                for _ in 0..10 {
+                    tokio::task::yield_now().await;
+                }
+            }
+            task.abort();
+
+            let restored = load_channel_cursor(&registry, "mock_quarantine", "mock_quarantine")
+                .await
+                .expect("cursor_get must succeed")
+                .expect(
+                    "the cursor must have committed -- a quarantine envelope must ingest \
+                     durably like any other message",
+                );
+            assert_eq!(restored.checkpoint.high_water, Some(1));
+
+            let inbox = registry
+                .dispatch(
+                    "list",
+                    json!({"namespace": "test-ns", "kind": "message", "limit": 50}),
+                )
+                .await
+                .expect("list must succeed");
+            let notes = inbox.as_array().expect("list returns an array").clone();
+            let quarantined = notes
+                .iter()
+                .find(|n| {
+                    n.get("properties")
+                        .and_then(|p| p.get("external_id"))
+                        .and_then(|v| v.as_str())
+                        == Some("imap:h:9:1")
+                })
+                .expect(
+                    "the quarantined message must be durably queryable by its stable \
+                         external_id, not just held as an intermediate value",
+                );
+
+            let props = quarantined
+                .get("properties")
+                .expect("stored note must carry properties");
+            assert_eq!(
+                props.get("quarantined").and_then(|v| v.as_str()),
+                Some("true"),
+                "durable quarantine metadata must survive comm.ingest: {props:?}"
+            );
+            assert_eq!(
+                props.get("quarantine_reason").and_then(|v| v.as_str()),
+                Some("missing-body"),
+                "the quarantine reason must survive comm.ingest: {props:?}"
+            );
+        }
+
         /// Restart-across-a-checkpoint round-trip (issue #449 part b): once a
         /// page fully ingests and the cursor commits, a fresh call to
         /// `comm.cursor_get` (simulating a daemon restart reading the
@@ -5470,6 +5650,348 @@ id = "lambda:project-actor"
             assert_eq!(restored.checkpoint.source, SOURCE);
             assert_eq!(restored.checkpoint.generation, 7);
             assert_eq!(restored.checkpoint.high_water, Some(123));
+        }
+    }
+
+    /// Regression tests for issue #449's High follow-up: a channel's
+    /// bootstrap `since` floor (the date used in the IMAP `SINCE` clause
+    /// while no UID high-water is committed yet) must only advance once
+    /// `cursor_get`, `poll_page`, every `comm.ingest`, and `cursor_commit`
+    /// have all succeeded for that channel's cycle. A cursor_get failure or
+    /// an ingest failure that blocks the first commit must leave the floor
+    /// exactly where it was, so a later successful cycle still searches from
+    /// the original floor rather than a newer date -- otherwise, if the
+    /// failing cycles spanned a calendar-day boundary, mail from the earlier
+    /// day would be permanently skipped.
+    #[cfg(feature = "channel-email")]
+    mod bootstrap_since_floor_tests {
+        use super::*;
+        use async_trait::async_trait;
+        use chrono::{DateTime, Utc};
+        use khive_channel::{
+            Channel, ChannelEnvelope, ChannelError, ChannelPollPage, ChannelRegistry,
+            StoredChannelCheckpoint,
+        };
+        use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+        use khive_storage::types::{SqlStatement, SqlValue};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        /// A channel that just records the `since` it is called with on
+        /// every `poll_page` call and always reports a clean, empty page --
+        /// harmless to call repeatedly, so the test can drive many ticks and
+        /// inspect only the recorded `since` history.
+        struct RecordingChannel {
+            kind: &'static str,
+            since_calls: Arc<Mutex<Vec<DateTime<Utc>>>>,
+        }
+
+        #[async_trait]
+        impl Channel for RecordingChannel {
+            fn kind(&self) -> &'static str {
+                self.kind
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                since: DateTime<Utc>,
+                _checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                self.since_calls.lock().unwrap().push(since);
+                Ok(ChannelPollPage {
+                    envelopes: vec![],
+                    next_checkpoint: None,
+                })
+            }
+        }
+
+        /// A channel whose first `poll_page` call returns one envelope that
+        /// permanently fails `comm.ingest` validation (empty `content`),
+        /// blocking that cycle's first-ever commit; every later call returns
+        /// no envelopes so the cycle cleanly completes. Also records `since`
+        /// on every call.
+        struct IngestFailsOnceChannel {
+            call_count: AtomicUsize,
+            since_calls: Arc<Mutex<Vec<DateTime<Utc>>>>,
+        }
+
+        #[async_trait]
+        impl Channel for IngestFailsOnceChannel {
+            fn kind(&self) -> &'static str {
+                "mock_ingest_fails_once"
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                since: DateTime<Utc>,
+                _checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                self.since_calls.lock().unwrap().push(since);
+                if self.call_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let bad = ChannelEnvelope::new(
+                        "email:sender@example.com",
+                        "email:me@example.com",
+                        "",
+                    );
+                    Ok(ChannelPollPage {
+                        envelopes: vec![bad],
+                        next_checkpoint: None,
+                    })
+                } else {
+                    Ok(ChannelPollPage {
+                        envelopes: vec![],
+                        next_checkpoint: None,
+                    })
+                }
+            }
+        }
+
+        /// Drive the paused virtual clock forward in small steps, yielding
+        /// after each one, until `calls` has recorded at least `target`
+        /// entries (mirrors `cursor_commit_gating_tests`' convergence
+        /// pattern: the loop's `comm.*` dispatches need several cooperative
+        /// sleep/wake round-trips under a paused clock to settle, so a
+        /// single large `advance` can outrun a timer the task has not
+        /// re-armed yet).
+        async fn advance_until_calls(calls: &Mutex<Vec<DateTime<Utc>>>, target: usize) {
+            for _ in 0..2000 {
+                if calls.lock().unwrap().len() >= target {
+                    return;
+                }
+                tokio::time::advance(std::time::Duration::from_millis(250)).await;
+                for _ in 0..10 {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+
+        /// Cross-date regression (issue #449 High, failure shape 1): a
+        /// `comm.cursor_get` failure on a channel's first cycle must not
+        /// lose that channel's bootstrap floor. This corrupts the durable
+        /// cursor row for `mock_broken_cursor_get` directly (an unparseable
+        /// `generation` column) so its very first `cursor_get` fails and the
+        /// channel is skipped for that tick, then repairs the row before the
+        /// next tick. A `mock_control` channel with no corruption is polled
+        /// on every tick as a same-run reference for what the *first* tick's
+        /// floor actually was -- if the fix works, the broken channel's
+        /// first successful `poll_page` call (after recovery) sees the exact
+        /// same `since` as the control channel's very first call, proving
+        /// the floor survived the cursor_get failure instead of jumping
+        /// forward to a later tick's timestamp (which, across a calendar-day
+        /// boundary, would silently drop the previous day's mail from the
+        /// IMAP `SINCE` search).
+        #[tokio::test(start_paused = true)]
+        async fn cursor_get_failure_preserves_the_bootstrap_floor() {
+            const BROKEN_KIND: &str = "mock_broken_cursor_get";
+
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            // Seed a valid row (also bootstraps the pack-owned schema), then
+            // corrupt `generation` in place so cursor_get's column-type match
+            // falls through to its "malformed" error arm.
+            commit_channel_cursor(
+                &registry,
+                BROKEN_KIND,
+                BROKEN_KIND,
+                &khive_channel::ChannelCheckpoint {
+                    source: "seed".to_string(),
+                    generation: 1,
+                    high_water: Some(1),
+                },
+            )
+            .await
+            .expect("seed cursor_commit must succeed");
+
+            let sql = runtime.sql();
+            {
+                let mut w = sql.writer().await.expect("writer");
+                w.execute(SqlStatement {
+                    sql: "UPDATE comm_channel_cursor SET generation = 1.5 \
+                          WHERE channel_kind = ?1 AND channel_slug = ?2"
+                        .into(),
+                    params: vec![
+                        SqlValue::Text(BROKEN_KIND.to_string()),
+                        SqlValue::Text(BROKEN_KIND.to_string()),
+                    ],
+                    label: Some("test_corrupt_generation".into()),
+                })
+                .await
+                .expect("corrupting update must succeed");
+            }
+
+            let control_calls = Arc::new(Mutex::new(Vec::new()));
+            let broken_calls = Arc::new(Mutex::new(Vec::new()));
+
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(RecordingChannel {
+                kind: "mock_control",
+                since_calls: control_calls.clone(),
+            }));
+            ch_registry.register(Arc::new(RecordingChannel {
+                kind: BROKEN_KIND,
+                since_calls: broken_calls.clone(),
+            }));
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            // Tick 1: control succeeds (records the tick's floor); the
+            // broken channel's cursor_get fails on the corrupted row, so it
+            // is skipped and records nothing.
+            advance_until_calls(&control_calls, 1).await;
+            assert_eq!(
+                control_calls.lock().unwrap().len(),
+                1,
+                "control channel must be polled on the first tick"
+            );
+            assert_eq!(
+                broken_calls.lock().unwrap().len(),
+                0,
+                "the broken channel must be skipped while cursor_get fails"
+            );
+
+            // Repair the row so cursor_get succeeds from the next tick on.
+            {
+                let mut w = sql.writer().await.expect("writer");
+                w.execute(SqlStatement {
+                    sql: "UPDATE comm_channel_cursor SET generation = 1 \
+                          WHERE channel_kind = ?1 AND channel_slug = ?2"
+                        .into(),
+                    params: vec![
+                        SqlValue::Text(BROKEN_KIND.to_string()),
+                        SqlValue::Text(BROKEN_KIND.to_string()),
+                    ],
+                    label: Some("test_repair_generation".into()),
+                })
+                .await
+                .expect("repairing update must succeed");
+            }
+
+            // Tick 2: cursor_get now succeeds and the broken channel is
+            // finally polled for the first time.
+            advance_until_calls(&broken_calls, 1).await;
+            task.abort();
+
+            let control_first = control_calls.lock().unwrap()[0];
+            let broken_first = *broken_calls
+                .lock()
+                .unwrap()
+                .first()
+                .expect("the broken channel must have been polled after recovery");
+
+            assert_eq!(
+                broken_first, control_first,
+                "the broken channel's first poll_page call must see the SAME \
+                 bootstrap floor as the control channel's very first call \
+                 ({control_first:?}), not a later tick's timestamp \
+                 ({broken_first:?}) -- the cursor_get failure must not have \
+                 lost the earlier floor"
+            );
+        }
+
+        /// Cross-date regression (issue #449 High, failure shape 2): an
+        /// ingest failure that blocks a channel's first-ever `cursor_commit`
+        /// must not lose that channel's bootstrap floor either. Uses the
+        /// same same-run control-channel comparison as the cursor_get test
+        /// above.
+        #[tokio::test(start_paused = true)]
+        async fn quarantine_ingest_failure_blocking_first_commit_preserves_the_bootstrap_floor() {
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            let control_calls = Arc::new(Mutex::new(Vec::new()));
+            let failing_calls = Arc::new(Mutex::new(Vec::new()));
+
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(RecordingChannel {
+                kind: "mock_control",
+                since_calls: control_calls.clone(),
+            }));
+            ch_registry.register(Arc::new(IngestFailsOnceChannel {
+                call_count: AtomicUsize::new(0),
+                since_calls: failing_calls.clone(),
+            }));
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            // Tick 1: control succeeds; the ingest-failing channel is polled
+            // (records `since`) but its one envelope fails comm.ingest, so
+            // no checkpoint is committed for it this tick.
+            advance_until_calls(&control_calls, 1).await;
+            advance_until_calls(&failing_calls, 1).await;
+            assert_eq!(control_calls.lock().unwrap().len(), 1);
+            assert_eq!(
+                failing_calls.lock().unwrap().len(),
+                1,
+                "poll_page is still called even though ingest will fail"
+            );
+
+            // Tick 2: the channel is polled again (its envelope now ingests
+            // cleanly with no bad message), and its cycle finally succeeds.
+            advance_until_calls(&failing_calls, 2).await;
+            task.abort();
+
+            let control_first = control_calls.lock().unwrap()[0];
+            let failing_calls = failing_calls.lock().unwrap();
+            assert_eq!(
+                failing_calls.len(),
+                2,
+                "the channel must have been polled again on the second tick"
+            );
+
+            assert_eq!(
+                failing_calls[0], control_first,
+                "the first poll_page call's `since` must match the control \
+                 channel's first-tick floor"
+            );
+            assert_eq!(
+                failing_calls[1], control_first,
+                "the SECOND poll_page call's `since` must still match the \
+                 same original floor ({control_first:?}), not a fresh \
+                 timestamp from the tick where the ingest failure blocked \
+                 the first commit ({:?}) -- otherwise a failure spanning a \
+                 calendar-day boundary would permanently skip the earlier \
+                 day's uncommitted mail",
+                failing_calls[1]
+            );
         }
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -357,8 +357,25 @@ async fn channel_poll_loop(
             )
             .await;
 
-            match channel.poll(since).await {
-                Ok(envelopes) => {
+            // Durable checkpoint path (issue #449): cursor_get -> poll_page ->
+            // every comm.ingest -> cursor_commit, committing only when the
+            // whole page durably ingested. A cursor_get failure means we
+            // cannot trust what progress to poll from, so this channel is
+            // skipped for the cycle rather than risk polling from an empty
+            // checkpoint and silently discarding durable state.
+            let checkpoint = match load_channel_cursor(&registry, kind, slug).await {
+                Ok(cp) => cp,
+                Err(e) => {
+                    tracing::warn!(
+                        channel = kind,
+                        "comm.cursor_get failed; skipping this channel's poll this cycle: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            match channel.poll_page(since, checkpoint.as_ref()).await {
+                Ok(page) => {
                     let prior_attempt =
                         backoffs.get(&backoff_key).map(|b| b.attempt()).unwrap_or(0);
                     if let Some(backoff) = backoffs.get_mut(&backoff_key) {
@@ -377,7 +394,7 @@ async fn channel_poll_loop(
                             khive_storage::ChannelPollSucceededPayload {
                                 channel_kind: kind.to_string(),
                                 channel_slug: slug.to_string(),
-                                envelope_count: envelopes.len(),
+                                envelope_count: page.envelopes.len(),
                                 previous_backoff_attempt: prior_attempt,
                             },
                         )
@@ -402,7 +419,16 @@ async fn channel_poll_loop(
                         event_store.as_ref(),
                     )
                     .await;
-                    for env in envelopes {
+
+                    // Every envelope in the page must durably ingest before
+                    // the cursor is allowed to advance past it (issue #449
+                    // Blocker fix): a partial-page ingest failure must leave
+                    // the checkpoint untouched so the next poll re-selects
+                    // the whole page -- comm.ingest's `INSERT OR IGNORE`
+                    // dedup then skips re-storing the messages that already
+                    // succeeded, and only the failed one is retried.
+                    let mut page_fully_ingested = true;
+                    for env in page.envelopes {
                         let params = json!({
                             "namespace": ingest_namespace,
                             "from": env.from,
@@ -423,7 +449,28 @@ async fn channel_poll_loop(
                                 channel = kind,
                                 "comm.ingest failed for inbound message: {e}"
                             );
+                            page_fully_ingested = false;
                         }
+                    }
+
+                    if page_fully_ingested {
+                        if let Some(next_checkpoint) = page.next_checkpoint {
+                            if let Err(e) =
+                                commit_channel_cursor(&registry, kind, slug, &next_checkpoint).await
+                            {
+                                tracing::warn!(
+                                    channel = kind,
+                                    "comm.cursor_commit failed; progress not durably \
+                                     advanced, next poll will retry: {e}"
+                                );
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            channel = kind,
+                            "not committing IMAP cursor: at least one message in this page \
+                             failed comm.ingest; the whole page will be retried next poll"
+                        );
                     }
                 }
                 Err(e) => {
@@ -619,6 +666,70 @@ async fn record_channel_heartbeat(
         )
         .await;
     }
+}
+
+/// Load the durable poll checkpoint for `(channel_kind, channel_slug)` via
+/// `comm.cursor_get` (issue #449). Returns `Ok(None)` on first-run
+/// (`comm.cursor_get` returns JSON `null`). A dispatch failure or a
+/// malformed response is returned as `Err` so the caller skips this
+/// channel's poll for the cycle rather than risk polling with empty
+/// progress and silently discarding durable state.
+#[cfg(feature = "channel-email")]
+async fn load_channel_cursor(
+    registry: &khive_runtime::VerbRegistry,
+    channel_kind: &str,
+    channel_slug: &str,
+) -> Result<Option<khive_channel::StoredChannelCheckpoint>, khive_runtime::RuntimeError> {
+    use serde_json::json;
+
+    let value = registry
+        .dispatch(
+            "comm.cursor_get",
+            json!({
+                "channel_kind": channel_kind,
+                "channel_slug": channel_slug,
+            }),
+        )
+        .await?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value).map(Some).map_err(|e| {
+        khive_runtime::RuntimeError::Internal(format!(
+            "comm.cursor_get returned a malformed checkpoint: {e}"
+        ))
+    })
+}
+
+/// Persist the durable poll checkpoint for `(channel_kind, channel_slug)`
+/// via `comm.cursor_commit` (issue #449).
+///
+/// Callers MUST only call this after every envelope in the page has
+/// returned `Ok` from `comm.ingest` -- see `channel_poll_loop`. Committing
+/// on a partial page would advance the cursor past a message that was never
+/// durably ingested, permanently skipping it.
+#[cfg(feature = "channel-email")]
+async fn commit_channel_cursor(
+    registry: &khive_runtime::VerbRegistry,
+    channel_kind: &str,
+    channel_slug: &str,
+    checkpoint: &khive_channel::ChannelCheckpoint,
+) -> Result<(), khive_runtime::RuntimeError> {
+    use serde_json::json;
+
+    registry
+        .dispatch(
+            "comm.cursor_commit",
+            json!({
+                "channel_kind": channel_kind,
+                "channel_slug": channel_slug,
+                "source": checkpoint.source,
+                "generation": checkpoint.generation,
+                "high_water": checkpoint.high_water,
+            }),
+        )
+        .await?;
+    Ok(())
 }
 
 /// Log a backoff-eligible poll failure at the level ADR-091's `crossing_warn`
@@ -5025,12 +5136,21 @@ id = "lambda:project-actor"
         /// jump that is simultaneously long enough to fire the next timer
         /// and short enough not to skip past it unregistered.
         async fn advance_until(store: &FakeEventStore, target: usize) {
-            for _ in 0..200 {
+            // khive #449: the poll loop now also dispatches comm.cursor_get /
+            // comm.cursor_commit each iteration, and the first cursor_get
+            // bootstraps the comm_channel_cursor schema -- under this test's
+            // paused clock that bootstrap needs several more cooperative
+            // sleep/wake round-trips to settle than a bare heartbeat write
+            // did, so the iteration budget is higher than a single
+            // fail-then-recover episode would otherwise need.
+            for _ in 0..2000 {
                 if store.events.lock().unwrap().len() >= target {
                     return;
                 }
                 tokio::time::advance(std::time::Duration::from_millis(250)).await;
-                tokio::task::yield_now().await;
+                for _ in 0..10 {
+                    tokio::task::yield_now().await;
+                }
             }
         }
 
@@ -5140,6 +5260,216 @@ id = "lambda:project-actor"
             }
 
             task.abort();
+        }
+    }
+
+    /// Regression tests for issue #449's daemon wiring (Blocker fix): the
+    /// poll loop must drive `cursor_get` -> `poll_page` -> every
+    /// `comm.ingest` -> `cursor_commit`, committing the cursor only when
+    /// every envelope in the page durably ingested.
+    #[cfg(feature = "channel-email")]
+    mod cursor_commit_gating_tests {
+        use super::*;
+        use async_trait::async_trait;
+        use chrono::{DateTime, Utc};
+        use khive_channel::{
+            Channel, ChannelCheckpoint, ChannelEnvelope, ChannelError, ChannelPollPage,
+            ChannelRegistry, StoredChannelCheckpoint,
+        };
+        use khive_runtime::{KhiveRuntime, VerbRegistryBuilder};
+        use serde_json::json;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        const SOURCE: &str = "imap+tls:h:993:m:INBOX";
+
+        /// First `poll_page` call returns one message that ingests cleanly
+        /// and one that permanently fails `comm.ingest` validation (empty
+        /// content) -- simulating a partial-page ingest failure. Every
+        /// subsequent call returns only the message that already succeeded,
+        /// mirroring the daemon's next-poll re-delivery of the whole
+        /// unresolved page. Each call's observed checkpoint is recorded
+        /// (rather than asserted inline, since a panic inside a
+        /// `tokio::spawn`ed task is otherwise silently swallowed by
+        /// `task.abort()`) so the test body can assert on it after the loop
+        /// task is done.
+        struct PartialFailureChannel {
+            call_count: AtomicUsize,
+            observed_checkpoints: Arc<Mutex<Vec<Option<StoredChannelCheckpoint>>>>,
+        }
+
+        #[async_trait]
+        impl Channel for PartialFailureChannel {
+            fn kind(&self) -> &'static str {
+                "mock"
+            }
+
+            async fn send(&self, _envelope: ChannelEnvelope) -> Result<(), ChannelError> {
+                Ok(())
+            }
+
+            async fn poll(
+                &self,
+                _since: DateTime<Utc>,
+            ) -> Result<Vec<ChannelEnvelope>, ChannelError> {
+                panic!("the daemon poll loop must call poll_page, not poll");
+            }
+
+            async fn poll_page(
+                &self,
+                _since: DateTime<Utc>,
+                checkpoint: Option<&StoredChannelCheckpoint>,
+            ) -> Result<ChannelPollPage, ChannelError> {
+                let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+                self.observed_checkpoints
+                    .lock()
+                    .unwrap()
+                    .push(checkpoint.cloned());
+                let good = ChannelEnvelope::new(
+                    "email:sender@example.com",
+                    "email:me@example.com",
+                    "good body",
+                )
+                .with_external_id("imap:h:1:1");
+
+                if call == 0 {
+                    let bad = ChannelEnvelope::new(
+                        "email:sender@example.com",
+                        "email:me@example.com",
+                        "",
+                    );
+                    Ok(ChannelPollPage {
+                        envelopes: vec![good, bad],
+                        next_checkpoint: Some(ChannelCheckpoint {
+                            source: SOURCE.to_string(),
+                            generation: 1,
+                            high_water: Some(2),
+                        }),
+                    })
+                } else {
+                    Ok(ChannelPollPage {
+                        envelopes: vec![good],
+                        next_checkpoint: Some(ChannelCheckpoint {
+                            source: SOURCE.to_string(),
+                            generation: 1,
+                            high_water: Some(1),
+                        }),
+                    })
+                }
+            }
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn partial_ingest_failure_does_not_advance_cursor_and_dedup_prevents_double_store() {
+            let observed_checkpoints = Arc::new(Mutex::new(Vec::new()));
+            let mut ch_registry = ChannelRegistry::new();
+            ch_registry.register(Arc::new(PartialFailureChannel {
+                call_count: AtomicUsize::new(0),
+                observed_checkpoints: observed_checkpoints.clone(),
+            }));
+
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            let task = tokio::spawn(channel_poll_loop(
+                Arc::new(ch_registry),
+                registry.clone(),
+                "test-ns".to_string(),
+                "actor:test".to_string(),
+            ));
+
+            // Two happy-path 5s ticks: the first drives the partial-failure
+            // page, the second drives the retry the fix must produce.
+            for _ in 0..20 {
+                tokio::time::advance(std::time::Duration::from_secs(5)).await;
+                for _ in 0..20 {
+                    tokio::task::yield_now().await;
+                }
+            }
+            task.abort();
+
+            let calls = observed_checkpoints.lock().unwrap().clone();
+            assert!(
+                calls.len() >= 2,
+                "the loop must have retried at least once: {calls:?}"
+            );
+            assert!(
+                calls[0].is_none(),
+                "the first poll must see no persisted checkpoint"
+            );
+            assert!(
+                calls[1].is_none(),
+                "the cursor must NOT have advanced past the partially-failed page \
+                 -- the retry must still see no committed checkpoint: {calls:?}"
+            );
+
+            let inbox = registry
+                .dispatch(
+                    "list",
+                    json!({"namespace": "test-ns", "kind": "message", "limit": 50}),
+                )
+                .await
+                .expect("list must succeed");
+            let notes = inbox.as_array().expect("list returns an array").clone();
+            let matching: Vec<_> = notes
+                .iter()
+                .filter(|n| {
+                    n.get("properties")
+                        .and_then(|p| p.get("external_id"))
+                        .and_then(|v| v.as_str())
+                        == Some("imap:h:1:1")
+                })
+                .collect();
+            assert_eq!(
+                matching.len(),
+                1,
+                "the message that succeeded on the failed page must not be \
+                 double-stored once the retry re-delivers the whole page: {notes:?}"
+            );
+        }
+
+        /// Restart-across-a-checkpoint round-trip (issue #449 part b): once a
+        /// page fully ingests and the cursor commits, a fresh call to
+        /// `comm.cursor_get` (simulating a daemon restart reading the
+        /// persisted row) must return the exact checkpoint that was
+        /// committed -- proving the durable path round-trips independent of
+        /// any in-process state.
+        #[tokio::test]
+        async fn committed_cursor_round_trips_across_a_fresh_cursor_get() {
+            let runtime = KhiveRuntime::memory().expect("in-memory runtime");
+            let mut builder = VerbRegistryBuilder::new();
+            builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+            builder.register(khive_pack_comm::CommPack::new(runtime.clone()));
+            let registry = builder.build().expect("registry builds");
+
+            // Simulates a poll that crosses an IMAP UIDVALIDITY/date-window
+            // boundary: commit once, then read it back as a brand-new
+            // process (a new `comm.cursor_get` call, no shared in-memory
+            // cursor) would on restart.
+            commit_channel_cursor(
+                &registry,
+                "mock",
+                "mailbox-a",
+                &ChannelCheckpoint {
+                    source: SOURCE.to_string(),
+                    generation: 7,
+                    high_water: Some(123),
+                },
+            )
+            .await
+            .expect("cursor_commit must succeed");
+
+            let restored = load_channel_cursor(&registry, "mock", "mailbox-a")
+                .await
+                .expect("cursor_get must succeed")
+                .expect("a committed checkpoint must round-trip, not read back as absent");
+
+            assert_eq!(restored.checkpoint.source, SOURCE);
+            assert_eq!(restored.checkpoint.generation, 7);
+            assert_eq!(restored.checkpoint.high_water, Some(123));
         }
     }
 }

--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -5447,24 +5447,41 @@ id = "lambda:project-actor"
                 "actor:test".to_string(),
             ));
 
-            // Two happy-path 5s ticks: the first drives the partial-failure
-            // page, the second drives the retry the fix must produce. Poll
-            // for the retry directly (rather than blindly running a fixed
-            // number of ticks) and bound the wait by a real wall-clock
-            // deadline, not a virtual-time/iteration budget -- the loop's
-            // `comm.*` dispatches land on `spawn_blocking`'s real OS-thread
-            // pool, so how many advance/yield rounds this needs depends on
-            // real thread-pool scheduling latency, which a fixed count
-            // cannot account for under load.
+            // Three happy-path 5s ticks: the first drives the partial-failure
+            // page, the second drives the retry the fix must produce, and the
+            // third observes the checkpoint the retry committed -- proving
+            // the retry's `comm.ingest` (and its dedup) actually completed and
+            // was durably persisted, not merely that a second `poll_page` call
+            // was made while the retry was still in flight. Poll for that
+            // directly (rather than blindly running a fixed number of ticks)
+            // and bound the wait by a real wall-clock deadline, not a
+            // virtual-time/iteration budget -- the loop's `comm.*` dispatches
+            // land on `spawn_blocking`'s real OS-thread pool, so how many
+            // advance/yield rounds this needs depends on real thread-pool
+            // scheduling latency, which a fixed count cannot account for
+            // under load.
+            let expected_committed_checkpoint = ChannelCheckpoint {
+                source: SOURCE.to_string(),
+                generation: 1,
+                high_water: Some(1),
+            };
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
             loop {
-                if observed_checkpoints.lock().unwrap().len() >= 2 {
+                if observed_checkpoints
+                    .lock()
+                    .unwrap()
+                    .get(2)
+                    .is_some_and(|c| {
+                        c.as_ref().map(|stored| &stored.checkpoint)
+                            == Some(&expected_committed_checkpoint)
+                    })
+                {
                     break;
                 }
                 assert!(
                     std::time::Instant::now() < deadline,
-                    "the loop must have retried at least once within 60s of wall-clock \
-                     time: {:?}",
+                    "the retry must have committed its checkpoint (observable on the \
+                     third poll_page call) within 60s of wall-clock time: {:?}",
                     observed_checkpoints.lock().unwrap()
                 );
                 tokio::time::advance(std::time::Duration::from_secs(5)).await;
@@ -5476,8 +5493,9 @@ id = "lambda:project-actor"
 
             let calls = observed_checkpoints.lock().unwrap().clone();
             assert!(
-                calls.len() >= 2,
-                "the loop must have retried at least once: {calls:?}"
+                calls.len() >= 3,
+                "the loop must have retried and then re-polled with the retry's \
+                 committed checkpoint: {calls:?}"
             );
             assert!(
                 calls[0].is_none(),
@@ -5487,6 +5505,13 @@ id = "lambda:project-actor"
                 calls[1].is_none(),
                 "the cursor must NOT have advanced past the partially-failed page \
                  -- the retry must still see no committed checkpoint: {calls:?}"
+            );
+            assert_eq!(
+                calls[2].as_ref().map(|stored| &stored.checkpoint),
+                Some(&expected_committed_checkpoint),
+                "the third poll must observe the checkpoint the retry committed, \
+                 proving the retry's comm.ingest (and its dedup) actually completed: \
+                 {calls:?}"
             );
 
             let inbox = registry

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashSet;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -16,8 +16,8 @@ use khive_storage::types::{PageRequest, SqlValue};
 
 use crate::message::{dual_write_message, note_to_message_json, resolve_id, short_id};
 use crate::params::{
-    deser, HeartbeatParams, InboxParams, IngestParams, ProbeParams, ReadParams, ReplyParams,
-    SendParams, ThreadParams,
+    deser, CursorCommitParams, CursorGetParams, HeartbeatParams, InboxParams, IngestParams,
+    ProbeParams, ReadParams, ReplyParams, SendParams, ThreadParams,
 };
 
 /// Validate an actor label: non-empty, no control characters, ≤255 bytes (ADR-057 Q1 loose).
@@ -1523,6 +1523,181 @@ async fn query_probe(
         new_messages,
         stale_unread_count,
     })
+}
+
+/// `cursor_get` — read the persisted channel poll checkpoint for
+/// `(channel_kind, channel_slug)` (issue #449). Subhandler — only the
+/// daemon's channel poll loop calls this. Returns JSON `null` when no row
+/// exists yet (first-run compatibility mode).
+///
+/// Runs the pack-owned `comm_channel_cursor` schema statement before the
+/// query so an in-memory/test runtime that never applied the boot-time
+/// schema plan still works (matches the repository's lazy pack-schema
+/// bootstrap convention).
+pub(crate) async fn handle_cursor_get(
+    runtime: &KhiveRuntime,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: CursorGetParams = deser(params)?;
+    if p.channel_kind.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_get: `channel_kind` must not be empty".into(),
+        ));
+    }
+    if p.channel_slug.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_get: `channel_slug` must not be empty".into(),
+        ));
+    }
+
+    let sql = runtime.sql();
+    let mut w = sql.writer().await.map_err(RuntimeError::Storage)?;
+    w.execute_script(crate::vocab::COMM_CHANNEL_CURSOR_SCHEMA_STMT.to_string())
+        .await
+        .map_err(RuntimeError::Storage)?;
+
+    let row = w
+        .query_row(khive_storage::types::SqlStatement {
+            sql: "SELECT source, generation, high_water, updated_at FROM comm_channel_cursor \
+                  WHERE channel_kind = ?1 AND channel_slug = ?2"
+                .into(),
+            params: vec![
+                SqlValue::Text(p.channel_kind.clone()),
+                SqlValue::Text(p.channel_slug.clone()),
+            ],
+            label: Some("comm_cursor_get".into()),
+        })
+        .await
+        .map_err(RuntimeError::Storage)?;
+
+    let Some(row) = row else {
+        return Ok(Value::Null);
+    };
+
+    let source = match row.get("source") {
+        Some(SqlValue::Text(s)) => s.clone(),
+        _ => {
+            return Err(RuntimeError::Internal(
+                "cursor_get: malformed `source` column".into(),
+            ));
+        }
+    };
+    let generation = match row.get("generation") {
+        Some(SqlValue::Integer(i)) if *i > 0 => *i as u64,
+        _ => {
+            return Err(RuntimeError::Internal(
+                "cursor_get: malformed `generation` column".into(),
+            ));
+        }
+    };
+    let high_water = match row.get("high_water") {
+        Some(SqlValue::Integer(i)) if *i > 0 => Some(*i as u64),
+        None | Some(SqlValue::Null) => None,
+        _ => {
+            return Err(RuntimeError::Internal(
+                "cursor_get: malformed `high_water` column".into(),
+            ));
+        }
+    };
+    let updated_at_us = match row.get("updated_at") {
+        Some(SqlValue::Integer(i)) => *i,
+        _ => {
+            return Err(RuntimeError::Internal(
+                "cursor_get: malformed `updated_at` column".into(),
+            ));
+        }
+    };
+    let committed_at = DateTime::<Utc>::from_timestamp_micros(updated_at_us).ok_or_else(|| {
+        RuntimeError::Internal("cursor_get: invalid `updated_at` timestamp".into())
+    })?;
+
+    Ok(json!({
+        "source": source,
+        "generation": generation,
+        "high_water": high_water,
+        "committed_at": committed_at.to_rfc3339(),
+    }))
+}
+
+/// `cursor_commit` — persist a channel poll checkpoint for `(channel_kind,
+/// channel_slug)` (issue #449), replacing any prior row for that identity.
+/// Subhandler — only the daemon's channel poll loop calls this, and only
+/// after every envelope in the page has returned `Ok` from `comm.ingest`.
+pub(crate) async fn handle_cursor_commit(
+    runtime: &KhiveRuntime,
+    params: Value,
+) -> Result<Value, RuntimeError> {
+    let p: CursorCommitParams = deser(params)?;
+    if p.channel_kind.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_commit: `channel_kind` must not be empty".into(),
+        ));
+    }
+    if p.channel_slug.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_commit: `channel_slug` must not be empty".into(),
+        ));
+    }
+    if p.source.trim().is_empty() {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_commit: `source` must not be empty".into(),
+        ));
+    }
+    if p.generation == 0 || p.generation > i64::MAX as u64 {
+        return Err(RuntimeError::InvalidInput(
+            "cursor_commit: `generation` must be in 1..=i64::MAX".into(),
+        ));
+    }
+    if let Some(h) = p.high_water {
+        if h == 0 || h > i64::MAX as u64 {
+            return Err(RuntimeError::InvalidInput(
+                "cursor_commit: `high_water` must be in 1..=i64::MAX when present".into(),
+            ));
+        }
+    }
+
+    let now_us = Utc::now().timestamp_micros();
+
+    let sql = runtime.sql();
+    let mut w = sql.writer().await.map_err(RuntimeError::Storage)?;
+    w.execute_script(crate::vocab::COMM_CHANNEL_CURSOR_SCHEMA_STMT.to_string())
+        .await
+        .map_err(RuntimeError::Storage)?;
+
+    w.execute(khive_storage::types::SqlStatement {
+        sql: "INSERT INTO comm_channel_cursor(channel_kind, channel_slug, source, generation, high_water, updated_at) \
+              VALUES(?1, ?2, ?3, ?4, ?5, ?6) \
+              ON CONFLICT(channel_kind, channel_slug) DO UPDATE SET \
+                source=excluded.source, \
+                generation=excluded.generation, \
+                high_water=excluded.high_water, \
+                updated_at=excluded.updated_at"
+            .into(),
+        params: vec![
+            SqlValue::Text(p.channel_kind.clone()),
+            SqlValue::Text(p.channel_slug.clone()),
+            SqlValue::Text(p.source.clone()),
+            SqlValue::Integer(p.generation as i64),
+            match p.high_water {
+                Some(h) => SqlValue::Integer(h as i64),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(now_us),
+        ],
+        label: Some("comm_cursor_commit".into()),
+    })
+    .await
+    .map_err(RuntimeError::Storage)?;
+
+    let committed_at = DateTime::<Utc>::from_timestamp_micros(now_us)
+        .expect("Utc::now().timestamp_micros() always round-trips");
+
+    Ok(json!({
+        "source": p.source,
+        "generation": p.generation,
+        "high_water": p.high_water,
+        "committed_at": committed_at.to_rfc3339(),
+    }))
 }
 
 /// Candidate `$.external_id` values to match an inbound correlation key against.

--- a/crates/khive-pack-comm/src/pack.rs
+++ b/crates/khive-pack-comm/src/pack.rs
@@ -94,6 +94,8 @@ impl PackRuntime for CommPack {
             "comm.heartbeat" => handlers::handle_heartbeat(self.runtime(), token, params).await,
             "comm.health" => handlers::handle_health(self.runtime(), token, params).await,
             "comm.probe" => handlers::handle_probe(self.runtime(), token, params).await,
+            "comm.cursor_get" => handlers::handle_cursor_get(self.runtime(), params).await,
+            "comm.cursor_commit" => handlers::handle_cursor_commit(self.runtime(), params).await,
             _ => Err(RuntimeError::InvalidInput(format!(
                 "comm pack does not handle verb {verb:?}"
             ))),

--- a/crates/khive-pack-comm/src/params.rs
+++ b/crates/khive-pack-comm/src/params.rs
@@ -177,6 +177,30 @@ fn default_stale_minutes() -> i64 {
     20
 }
 
+/// Parameters for `comm.cursor_get` — reads the persisted channel poll
+/// checkpoint for `(channel_kind, channel_slug)`, or `null` if none exists.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CursorGetParams {
+    pub channel_kind: String,
+    pub channel_slug: String,
+}
+
+/// Parameters for `comm.cursor_commit` — persists a channel poll checkpoint
+/// for `(channel_kind, channel_slug)`, replacing any prior row for that
+/// identity. Only the daemon's channel poll loop calls this, after every
+/// envelope in the page has been durably accepted by `comm.ingest`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CursorCommitParams {
+    pub channel_kind: String,
+    pub channel_slug: String,
+    pub source: String,
+    pub generation: u64,
+    #[serde(default)]
+    pub high_water: Option<u64>,
+}
+
 pub(crate) fn deser<T: serde::de::DeserializeOwned>(params: Value) -> Result<T, RuntimeError> {
     serde_json::from_value(params)
         .map_err(|e| RuntimeError::InvalidInput(format!("bad params: {e}")))

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -17,7 +17,7 @@ use khive_types::{HandlerDef, ParamDef, Visibility};
 /// The `idx_comm_message_external_id` UNIQUE index is NOT listed here; it is
 /// created by the V5 schema migration (`005-unique-comm-external-id.sql`), which
 /// is the sole durable authority for that index.
-pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
+pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 4] = [
     "CREATE INDEX IF NOT EXISTS idx_comm_message_direction \
         ON notes(namespace, kind, json_extract(properties, '$.direction'), \
         json_extract(properties, '$.read'), created_at DESC) \
@@ -32,9 +32,33 @@ pub(crate) static COMM_SCHEMA_PLAN_STMTS: [&str; 3] = [
         json_extract(properties, '$.read'), \
         created_at DESC) \
         WHERE deleted_at IS NULL",
+    COMM_CHANNEL_CURSOR_SCHEMA_STMT,
 ];
 
-pub(crate) static COMM_HANDLERS: [HandlerDef; 9] = [
+/// Pack-owned auxiliary cursor table for durable channel poll progress
+/// (issue #449): one row per `(channel_kind, channel_slug)`, holding the
+/// transport-neutral checkpoint fields from `khive_channel::ChannelCheckpoint`.
+/// For IMAP, `generation` is `UIDVALIDITY` and `high_water` is the greatest
+/// durably handled UID. `source` detects a host/port/mailbox/folder change
+/// under the same registry identity, so a stale checkpoint is never applied
+/// to a different configuration.
+///
+/// Idempotent (`CREATE TABLE IF NOT EXISTS`), applied at boot via
+/// `schema_plan` and shared verbatim with `handle_cursor_get`/
+/// `handle_cursor_commit`'s lazy bootstrap for in-memory/test runtimes that
+/// never run the boot-time schema plan.
+pub(crate) const COMM_CHANNEL_CURSOR_SCHEMA_STMT: &str =
+    "CREATE TABLE IF NOT EXISTS comm_channel_cursor (\
+    channel_kind TEXT NOT NULL CHECK (length(trim(channel_kind)) > 0),\
+    channel_slug TEXT NOT NULL CHECK (length(trim(channel_slug)) > 0),\
+    source TEXT NOT NULL CHECK (length(trim(source)) > 0),\
+    generation INTEGER NOT NULL CHECK (generation > 0),\
+    high_water INTEGER CHECK (high_water IS NULL OR high_water > 0),\
+    updated_at INTEGER NOT NULL,\
+    PRIMARY KEY (channel_kind, channel_slug)\
+)";
+
+pub(crate) static COMM_HANDLERS: [HandlerDef; 11] = [
     HandlerDef {
         name: "comm.send",
         description: "Send a message, optionally threaded.",
@@ -360,6 +384,73 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 9] = [
                 param_type: "integer",
                 required: false,
                 description: "Unread age threshold in minutes. Default 20.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "comm.cursor_get",
+        description: "Read the persisted channel poll checkpoint for (channel_kind, channel_slug), \
+                       or null if none exists. Subhandler — not callable on the MCP wire; only the \
+                       daemon's channel poll loop (khive #449) calls this.",
+        visibility: Visibility::Subhandler,
+        category: khive_types::VerbCategory::Assertive,
+        params: &[
+            ParamDef {
+                name: "channel_kind",
+                param_type: "string",
+                required: true,
+                description: "Channel kind identifier (e.g. `email`).",
+            },
+            ParamDef {
+                name: "channel_slug",
+                param_type: "string",
+                required: true,
+                description: "Stable per-credential identifier distinguishing accounts of the same kind.",
+            },
+        ],
+    },
+    HandlerDef {
+        name: "comm.cursor_commit",
+        description: "Persist a channel poll checkpoint for (channel_kind, channel_slug), replacing \
+                       any prior row for that identity. Subhandler — not callable on the MCP wire; \
+                       only the daemon's channel poll loop calls this, and only after every envelope \
+                       in the page has been durably accepted by comm.ingest (khive #449).",
+        visibility: Visibility::Subhandler,
+        category: khive_types::VerbCategory::Declaration,
+        params: &[
+            ParamDef {
+                name: "channel_kind",
+                param_type: "string",
+                required: true,
+                description: "Channel kind identifier (e.g. `email`).",
+            },
+            ParamDef {
+                name: "channel_slug",
+                param_type: "string",
+                required: true,
+                description: "Stable per-credential identifier distinguishing accounts of the same kind.",
+            },
+            ParamDef {
+                name: "source",
+                param_type: "string",
+                required: true,
+                description: "Stable, non-secret identity of the remote source/configuration (e.g. \
+                               `imap+tls:{host}:{port}:{mailbox}:INBOX`). A mismatch against the \
+                               stored row's source is how the caller detects a configuration change.",
+            },
+            ParamDef {
+                name: "generation",
+                param_type: "integer",
+                required: true,
+                description: "Remote identity epoch (e.g. IMAP UIDVALIDITY). Must be a positive integer.",
+            },
+            ParamDef {
+                name: "high_water",
+                param_type: "integer",
+                required: false,
+                description: "Greatest durably handled remote sequence value (e.g. IMAP UID). Omit \
+                               or null to reset progress within the generation (e.g. right after a \
+                               UIDVALIDITY change with no messages selected yet).",
             },
         ],
     },

--- a/crates/khive-pack-comm/tests/integration.rs
+++ b/crates/khive-pack-comm/tests/integration.rs
@@ -43,9 +43,9 @@ fn comm_pack_declares_message_note_kind() {
 fn comm_pack_declares_nine_handlers() {
     assert_eq!(
         CommPack::HANDLERS.len(),
-        9,
-        "comm pack must declare 9 handlers: send, inbox, read, reply, thread, ingest, \
-         heartbeat, health, probe"
+        11,
+        "comm pack must declare 11 handlers: send, inbox, read, reply, thread, ingest, \
+         heartbeat, health, probe, cursor_get, cursor_commit (khive #449)"
     );
     let names: Vec<&str> = CommPack::HANDLERS.iter().map(|h| h.name).collect();
     assert!(names.contains(&"comm.send"));
@@ -67,6 +67,14 @@ fn comm_pack_declares_nine_handlers() {
     assert!(
         names.contains(&"comm.probe"),
         "comm.probe verb must be registered"
+    );
+    assert!(
+        names.contains(&"comm.cursor_get"),
+        "comm.cursor_get verb must be registered (khive #449)"
+    );
+    assert!(
+        names.contains(&"comm.cursor_commit"),
+        "comm.cursor_commit verb must be registered (khive #449)"
     );
     assert!(
         names.contains(&"comm.health"),
@@ -6389,4 +6397,276 @@ async fn t495_send_rejects_unknown_field_alongside_tags() {
         result.is_err(),
         "unknown field alongside tags must still be rejected; got {result:?}"
     );
+}
+
+// --- channel poll checkpoint persistence tests (khive #449) ---
+
+#[tokio::test]
+async fn cursor_get_returns_none_for_new_mailbox() {
+    let (registry, _rt) = build_registry();
+
+    let result = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "acct-1" }),
+        )
+        .await
+        .expect("cursor_get succeeds for a mailbox with no prior checkpoint");
+    assert!(
+        result.is_null(),
+        "an unseeded (channel_kind, channel_slug) must read back null; got {result}"
+    );
+}
+
+#[tokio::test]
+async fn cursor_commit_round_trips_generation_high_water_and_time() {
+    let (registry, _rt) = build_registry();
+
+    let committed = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:mail.example.com:993:inbox@example.com:INBOX",
+                "generation": 17,
+                "high_water": 42,
+            }),
+        )
+        .await
+        .expect("cursor_commit succeeds");
+    assert_eq!(committed["generation"], 17);
+    assert_eq!(committed["high_water"], 42);
+    assert!(
+        committed["committed_at"].as_str().is_some(),
+        "cursor_commit must return an RFC3339 committed_at; got {committed}"
+    );
+
+    let fetched = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "acct-1" }),
+        )
+        .await
+        .expect("cursor_get succeeds");
+    assert_eq!(
+        fetched["source"],
+        "imap+tls:mail.example.com:993:inbox@example.com:INBOX"
+    );
+    assert_eq!(fetched["generation"], 17);
+    assert_eq!(fetched["high_water"], 42);
+    assert!(
+        fetched["committed_at"].as_str().is_some(),
+        "cursor_get must round-trip an RFC3339 committed_at; got {fetched}"
+    );
+}
+
+#[tokio::test]
+async fn cursor_rows_are_isolated_by_kind_and_slug() {
+    let (registry, _rt) = build_registry();
+
+    registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host-a:993:a@example.com:INBOX",
+                "generation": 1,
+                "high_water": 5,
+            }),
+        )
+        .await
+        .expect("commit for acct-1 succeeds");
+    registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-2",
+                "source": "imap+tls:host-b:993:b@example.com:INBOX",
+                "generation": 9,
+                "high_water": 99,
+            }),
+        )
+        .await
+        .expect("commit for acct-2 succeeds");
+
+    let acct_1 = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "acct-1" }),
+        )
+        .await
+        .expect("cursor_get acct-1 succeeds");
+    let acct_2 = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "acct-2" }),
+        )
+        .await
+        .expect("cursor_get acct-2 succeeds");
+
+    assert_eq!(
+        acct_1["high_water"], 5,
+        "acct-1's row must not see acct-2's write"
+    );
+    assert_eq!(
+        acct_2["high_water"], 99,
+        "acct-2's row must not see acct-1's write"
+    );
+}
+
+#[tokio::test]
+async fn cursor_uidvalidity_reset_can_replace_high_water_with_null() {
+    let (registry, _rt) = build_registry();
+
+    registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 1,
+                "high_water": 50,
+            }),
+        )
+        .await
+        .expect("initial commit succeeds");
+
+    // A UIDVALIDITY change resets the epoch; the new generation carries no
+    // high_water yet because nothing has been fetched in the new epoch.
+    registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 2,
+            }),
+        )
+        .await
+        .expect("reset commit succeeds");
+
+    let fetched = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "acct-1" }),
+        )
+        .await
+        .expect("cursor_get succeeds");
+    assert_eq!(fetched["generation"], 2);
+    assert!(
+        fetched["high_water"].is_null(),
+        "an UIDVALIDITY-reset commit must be able to replace a prior high_water with null; got {fetched}"
+    );
+}
+
+#[tokio::test]
+async fn cursor_commit_rejects_empty_identity_zero_or_i64_overflow() {
+    let (registry, _rt) = build_registry();
+
+    let empty_kind = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 1,
+            }),
+        )
+        .await;
+    assert!(empty_kind.is_err(), "empty channel_kind must be rejected");
+
+    let empty_source = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "",
+                "generation": 1,
+            }),
+        )
+        .await;
+    assert!(empty_source.is_err(), "empty source must be rejected");
+
+    let zero_generation = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 0,
+            }),
+        )
+        .await;
+    assert!(zero_generation.is_err(), "generation=0 must be rejected");
+
+    let zero_high_water = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 1,
+                "high_water": 0,
+            }),
+        )
+        .await;
+    assert!(zero_high_water.is_err(), "high_water=0 must be rejected");
+
+    let overflowing_generation = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "acct-1",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": u64::MAX,
+            }),
+        )
+        .await;
+    assert!(
+        overflowing_generation.is_err(),
+        "generation beyond i64::MAX must be rejected, not silently truncated"
+    );
+}
+
+#[tokio::test]
+async fn cursor_schema_lazy_bootstraps_fresh_memory_runtime() {
+    // A fresh in-memory runtime never runs the boot-time schema plan the way
+    // a real daemon startup does; cursor_get/cursor_commit must still work by
+    // lazily applying the idempotent CREATE TABLE IF NOT EXISTS statement
+    // themselves, exactly like the rest of the pack's lazy-bootstrap tests.
+    let (registry, _rt) = build_registry();
+
+    let before = registry
+        .dispatch(
+            "comm.cursor_get",
+            serde_json::json!({ "channel_kind": "email", "channel_slug": "fresh" }),
+        )
+        .await
+        .expect("cursor_get on a never-written table must not error, just return null");
+    assert!(before.is_null());
+
+    let committed = registry
+        .dispatch(
+            "comm.cursor_commit",
+            serde_json::json!({
+                "channel_kind": "email",
+                "channel_slug": "fresh",
+                "source": "imap+tls:host:993:a@example.com:INBOX",
+                "generation": 1,
+                "high_water": 1,
+            }),
+        )
+        .await
+        .expect("cursor_commit on a never-written table must lazily create the schema and succeed");
+    assert_eq!(committed["generation"], 1);
 }

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -411,35 +411,44 @@ core `khive-db` migration -- consistent with ADR-028's pack-scoped-backend curso
 they directly retract the "no new schema, no new table" claim above for the email adapter only;
 Telegram's offset remains in-memory as originally documented.
 
-### Two independent progress mechanisms, only one of which is wired into the daemon today
+### The durable checkpoint path is wired into the daemon
 
-1. **`ImapFetcher::fetch_since`** (unchanged public signature, used by the existing
-   `EmailChannel::poll`, which `khive-mcp/src/serve.rs`'s poll loop calls verbatim): now holds an
-   in-memory `legacy_progress` mutex that applies the same sort/dedup/high-water/truncate
-   discipline across repeated calls on one process. This closes the issue's literal reported
-   failure -- the same 50-of-75 UIDs repeated forever -- for the code path that actually runs in
-   production today. It is **not persisted**; a daemon restart resets it to an empty progress and
-   the connector bootstraps by `SINCE` again, exactly as before this amendment.
+1. **`ImapFetcher::fetch_since`** (unchanged public signature, still used by `EmailChannel::poll`,
+   the non-checkpointed entrypoint) holds an in-memory `legacy_progress` mutex that applies the
+   same sort/dedup/high-water/truncate discipline across repeated calls on one process. This
+   closes the issue's literal reported failure -- the same 50-of-75 UIDs repeated forever -- for
+   any caller that only uses `poll`. It is **not persisted**; on its own, a process restart resets
+   it to an empty progress and the connector bootstraps by `SINCE` again.
 2. **`EmailChannel::poll_page`** (a new override of the `Channel` trait's default) plus
    `comm.cursor_get`/`comm.cursor_commit`: a fully implemented and unit/integration-tested durable
    checkpoint path, keyed by a stable `imap+tls:{host}:{port}:{mailbox}:INBOX` source string so
-   one account's high-water can never suppress another's. **`khive-mcp/src/serve.rs` does not yet
-   call `poll_page`, `cursor_get`, or `cursor_commit`** -- the daemon poll loop, its lazy
-   checkpoint cache, and the commit-only-after-`comm.ingest`-succeeds ordering described in
-   `architect/design_449.md` remain a deferred follow-up. Restart-survivable progress is therefore
-   built and tested at the library level but not yet reachable from the running daemon.
+   one account's high-water can never suppress another's. **`khive-mcp/src/serve.rs`'s
+   `channel_poll_loop` now calls `cursor_get` -> `poll_page` -> every `comm.ingest` -> `cursor_commit`
+   for each configured channel, committing the cursor only after every envelope in the page has
+   durably ingested.** A partial-page `comm.ingest` failure leaves the checkpoint untouched, so the
+   next poll re-selects the whole page; `comm.ingest`'s `INSERT OR IGNORE` dedup then skips
+   re-storing the messages that already succeeded and only the failed one is effectively retried.
+   A `cursor_get` failure skips that channel's poll for the cycle rather than risk polling from an
+   empty checkpoint and silently discarding durable state.
+3. **Poison-UID durability** (issue #449 High): a selected UID whose `UID FETCH` response carries
+   no RFC822 body, or whose body fails to parse, no longer fails the whole page. It gets a durable
+   terminal disposition -- a quarantine envelope carrying the stable `imap:{host}:{uidvalidity}:{uid}`
+   dedup key and a `missing-body`/`parse-failure` reason, always stored regardless of the
+   `quarantine_store` config flag -- so the cursor can advance past it instead of re-selecting the
+   same poison UID on every subsequent poll.
 
 ### Consequences
 
 - The issue's literal 75-message/50-limit backlog-drain scenario is fixed and covered by tests
   exercising the real `EmailChannel::poll` entrypoint, not only the pure helpers.
 - Full restart durability (a daemon crash or redeploy resuming exactly above the last durably
-  ingested UID, per `architect/design_449.md`'s commit-after-ingest ordering) is **not yet
-  delivered end-to-end**; it requires the `khive-mcp/src/serve.rs` wiring and its own poll-loop
-  regression tests (design doc items 21-26), tracked as separate follow-up work.
-- `comm_channel_cursor` and its subhandlers exist and are tested but are inert (uncalled) in
-  production until that follow-up lands; they introduce no new MCP-callable verb and no core
-  schema migration.
+  ingested UID) is delivered end-to-end: `channel_poll_loop` drives `cursor_get`/`poll_page`/
+  `cursor_commit` on every cycle, and the commit-only-after-full-page-ingest ordering is covered by
+  poll-loop regression tests for partial-ingest-failure non-advancement and cross-restart
+  round-tripping.
+- `comm_channel_cursor` and its subhandlers are pack-owned operational bookkeeping, not a new
+  MCP-callable verb and not a core schema migration; they are exercised in production only via the
+  daemon poll loop's internal dispatch calls.
 - Telegram's in-memory offset watermark and its restart-durability rationale (Amendment
   2026-07-05) are unchanged by this amendment.
 

--- a/docs/adr/ADR-056-channel-transport-layer.md
+++ b/docs/adr/ADR-056-channel-transport-layer.md
@@ -2,16 +2,18 @@
 
 **Status**: Accepted (amended 2026-07-02 -- inbound authentication hardening; amended 2026-07-03
 -- Exchange Online no-authserv-id boundary; amended 2026-07-05 -- Telegram adapter
-implementation and two-way chat; see
+implementation and two-way chat; amended 2026-07-09 -- durable IMAP UID cursor; see
 [§Amendment 2026-07-02](#amendment-2026-07-02----inbound-authentication-hardening),
 [§Amendment 2026-07-03](#amendment-2026-07-03----exchange-online-no-authserv-id-boundary),
-[§Amendment 2026-07-05](#amendment-2026-07-05----telegram-adapter-implementation-and-two-way-chat))\
-**Date**: 2026-06-14 (amended 2026-07-02, 2026-07-03, 2026-07-05)\
+[§Amendment 2026-07-05](#amendment-2026-07-05----telegram-adapter-implementation-and-two-way-chat),
+[§Amendment 2026-07-09](#amendment-2026-07-09----durable-imap-uid-cursor))\
+**Date**: 2026-06-14 (amended 2026-07-02, 2026-07-03, 2026-07-05, 2026-07-09)\
 **Authors**: khive maintainers
 **Depends on**: ADR-017 (Pack Standard), ADR-018 (Authorization Gate), ADR-040 (Communication
 and Schedule Packs), ADR-053 (ActorStore / SessionStore -- extends ADR-018's actor model)\
 **Related issues**: #112 (khive-channel umbrella), #113 (Telegram adapter), #114 (email adapter),
-#448 (inbound header spoofing -- resolved by this amendment)
+#448 (inbound header spoofing -- resolved by this amendment), #449 (IMAP UID progress -- resolved
+by the 2026-07-09 amendment)
 
 ## Amendment 2026-07-02 -- Inbound authentication hardening
 
@@ -370,6 +372,76 @@ compiled). `channel-email` and `channel-telegram` can be enabled together; the
 - Multi-recipient / group chats, inline keyboards, media (text only for v1).
 - Webhook inbound (long-poll only until a public-URL deployment exists -- ADR-056 §7).
 - A general `telegram:<slug>` address book beyond the single maintainer slug.
+
+## Amendment 2026-07-09 -- Durable IMAP UID cursor
+
+### Motivation
+
+Issue #449 (`khive-channel-email: IMAP polling can repeatedly fetch the same UID subset and
+miss later messages`, P1/high): a mailbox with more messages in one `SINCE` day-window than the
+50-item fetch limit could have its overflow permanently starved. `LiveImap::fetch_since` searched
+`SINCE <date>`, collected the result into a `Vec` straight from `async-imap`'s `HashSet<Uid>`, and
+truncated to the limit before any progress state existed. With 75 same-day UIDs and a 50-item
+limit, the same arbitrary 50 could be returned forever while UIDs 51-75 were never fetched, and
+once the date window advanced past that day, those UIDs would never match `SINCE` again.
+
+This directly supersedes this ADR's earlier restart-durability claim (Amendment 2026-07-05,
+"Poll offset and restart durability"): _"the email adapter's IMAP cursor is likewise not
+persisted... no new schema, no new table."_ Issue #449 explicitly requires persisted per-mailbox
+`UIDVALIDITY`/high-water progress, because -- unlike Telegram's `getUpdates`, which
+server-side-drops already-acknowledged updates -- IMAP `SINCE` truncation could permanently skip
+messages the dedup index never saw in the first place; the durable dedup index cannot recover
+mail that pagination never fetched. `Last_in_time` governs: this amendment's persistence
+requirement controls where it conflicts with the earlier claim.
+
+### What changed
+
+`crates/khive-channel-email/src/connector/imap.rs` and `channel.rs` replace unordered
+day-level truncation with a `(UIDVALIDITY, last_seen_uid)` progress model (`ImapProgress`):
+UID search results are rejected if they contain a protocol-invalid zero UID, sorted ascending,
+deduplicated, filtered to strictly above the high-water when the epoch is unchanged, then
+truncated to the page limit. A UIDVALIDITY change discards the old high-water. `khive-channel`
+gains transport-neutral `ChannelCheckpoint`/`StoredChannelCheckpoint`/`ChannelPollPage` types and
+a default `Channel::poll_page` method (existing `Channel::poll` and all other implementers are
+unchanged and source-compatible). `khive-pack-comm` gains a pack-owned auxiliary table,
+`comm_channel_cursor` (keyed by `(channel_kind, channel_slug)`, storing `source`, `generation`,
+`high_water`, `updated_at`), plus internal (non-MCP-callable) `comm.cursor_get`/`comm.cursor_commit`
+subhandlers. This table and its handlers are new, pack-owned operational bookkeeping -- not a
+core `khive-db` migration -- consistent with ADR-028's pack-scoped-backend cursor pattern, and
+they directly retract the "no new schema, no new table" claim above for the email adapter only;
+Telegram's offset remains in-memory as originally documented.
+
+### Two independent progress mechanisms, only one of which is wired into the daemon today
+
+1. **`ImapFetcher::fetch_since`** (unchanged public signature, used by the existing
+   `EmailChannel::poll`, which `khive-mcp/src/serve.rs`'s poll loop calls verbatim): now holds an
+   in-memory `legacy_progress` mutex that applies the same sort/dedup/high-water/truncate
+   discipline across repeated calls on one process. This closes the issue's literal reported
+   failure -- the same 50-of-75 UIDs repeated forever -- for the code path that actually runs in
+   production today. It is **not persisted**; a daemon restart resets it to an empty progress and
+   the connector bootstraps by `SINCE` again, exactly as before this amendment.
+2. **`EmailChannel::poll_page`** (a new override of the `Channel` trait's default) plus
+   `comm.cursor_get`/`comm.cursor_commit`: a fully implemented and unit/integration-tested durable
+   checkpoint path, keyed by a stable `imap+tls:{host}:{port}:{mailbox}:INBOX` source string so
+   one account's high-water can never suppress another's. **`khive-mcp/src/serve.rs` does not yet
+   call `poll_page`, `cursor_get`, or `cursor_commit`** -- the daemon poll loop, its lazy
+   checkpoint cache, and the commit-only-after-`comm.ingest`-succeeds ordering described in
+   `architect/design_449.md` remain a deferred follow-up. Restart-survivable progress is therefore
+   built and tested at the library level but not yet reachable from the running daemon.
+
+### Consequences
+
+- The issue's literal 75-message/50-limit backlog-drain scenario is fixed and covered by tests
+  exercising the real `EmailChannel::poll` entrypoint, not only the pure helpers.
+- Full restart durability (a daemon crash or redeploy resuming exactly above the last durably
+  ingested UID, per `architect/design_449.md`'s commit-after-ingest ordering) is **not yet
+  delivered end-to-end**; it requires the `khive-mcp/src/serve.rs` wiring and its own poll-loop
+  regression tests (design doc items 21-26), tracked as separate follow-up work.
+- `comm_channel_cursor` and its subhandlers exist and are tested but are inert (uncalled) in
+  production until that follow-up lands; they introduce no new MCP-callable verb and no core
+  schema migration.
+- Telegram's in-memory offset watermark and its restart-durability rationale (Amendment
+  2026-07-05) are unchanged by this amendment.
 
 ## Context
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,12 +42,16 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
 echo "=== Tests ==="
 cargo test --workspace
 
-echo "=== Channel Lifecycle Tests (channel-email feature) ==="
-# `--workspace` alone never compiles or runs the ADR-094 channel lifecycle
-# sequencing test: it lives behind `#[cfg(feature = "channel-email")]` in
-# khive-mcp, and the all-features clippy pass above only type-checks it.
-# Run it explicitly so a broken lifecycle sequence fails CI.
-cargo test -p khive-mcp --features channel-email channel_lifecycle
+echo "=== Channel-Email Feature Tests (channel-email feature) ==="
+# `--workspace` alone never runs any of the several `#[cfg(feature =
+# "channel-email")]` test modules in khive-mcp (ADR-094 channel lifecycle
+# sequencing, issue #449 cursor_commit gating, bootstrap-floor regressions,
+# etc.) -- the all-features clippy pass above only type-checks them. A prior
+# name filter here (`channel_lifecycle`) ran only one of those modules and
+# silently skipped the rest, including the daemon's durable-cursor
+# regression tests. Run the whole crate under the feature, unfiltered, so
+# every one of those modules fails CI on a regression.
+cargo test -p khive-mcp --features channel-email
 
 echo "=== No-Default-Features Check ==="
 cargo check --workspace --no-default-features


### PR DESCRIPTION
## What

- Add mailbox-scoped IMAP checkpoint contracts (`ChannelCheckpoint`, `StoredChannelCheckpoint`, `ChannelPollPage`) and `comm.cursor_get` / `comm.cursor_commit` storage handlers, with an ADR-056 amendment documenting the persistence model.
- Replace unordered IMAP UID truncation with sorted, deduplicated pages that advance by UIDVALIDITY and high-water progress, so a full mailbox backlog drains instead of repeatedly re-fetching the same page.
- Give every selected IMAP UID a durable terminal disposition: a message with a missing body or a parse failure is now quarantined as a stable, queryable envelope via `comm.ingest` instead of erroring the whole fetched page and permanently blocking every later UID behind it.
- Wire the durable checkpoint path into the daemon's `channel_poll_loop`: each cycle now runs `comm.cursor_get` -> `Channel::poll_page` -> every `comm.ingest` in the page -> `comm.cursor_commit`, committing the cursor only when every envelope in the page durably ingested. A `cursor_get` failure skips that channel's cycle rather than polling from an unchecked default. A partial ingest failure leaves the cursor unadvanced so the next poll re-delivers the whole page; `comm.ingest`'s dedup (`INSERT OR IGNORE` on external ID) prevents the already-ingested messages from being double-stored on retry.
- Track each channel's bootstrap `since` floor (the date used in the IMAP `SINCE` clause while no UID high-water is committed yet) per `(channel_kind, channel_slug)` instead of one shared timestamp, and only advance it once that channel's full cycle -- `cursor_get`, `poll_page`, every `comm.ingest`, and `cursor_commit` -- has succeeded that tick. A `cursor_get` failure or a blocked first commit now leaves the floor exactly where it was, so a later successful cycle still searches from the original floor instead of a newer date; this closes a gap where a failing cycle spanning a calendar-day boundary would permanently skip the earlier day's mail.
- Seed that per-channel floor from a single `startup_since` timestamp captured before the loop's first sleep, not from `Utc::now()` re-read after it, so a daemon started shortly before a calendar-day boundary does not seed a channel's first bootstrap floor on the wrong side of it. Added a regression test covering this.
- Update `scripts/ci.sh` to run the whole `khive-mcp` crate under the `channel-email` feature unfiltered, instead of a name filter that only ran the ADR-094 lifecycle-sequencing module and silently skipped the newer cursor-gating and bootstrap-floor regression tests.
- De-flake two of `serve.rs`'s `channel-email` tests that were intermittently red in CI under `tokio`'s paused clock: both had replaced a real synchronization point with an iteration- or virtual-time-bounded polling loop, which cannot compensate for scheduling latency on the real OS-thread blocking pool the daemon's SQL writer runs on. One of them was also comparing a raw event-store length against a target count, when the same store also receives unrelated audit and heartbeat events, so the raw count could reach the target before the actual lifecycle-event subsequence did. Both now poll the real condition they care about (the filtered lifecycle-event sequence length, and the channel's own call counter) bounded by a wall-clock deadline instead of a tick budget.
- Add a regression test for the daemon's `cursor_commit`-rejected branch (a checkpoint `comm.cursor_commit` itself rejects, e.g. an out-of-range generation), which was otherwise unexercised: every other cursor-gating test in this file drove a `cursor_get` failure or a `comm.ingest` failure, never a rejected commit.

## Why

IMAP search returns an unordered UID set. Truncating that set before recording progress could repeatedly fetch the same messages and permanently starve later ones in the same date window. A single malformed message could also error an entire fetched page, and since progress rolled back to the old cursor on error, that message would be re-selected and re-fail forever, blocking every later UID in the mailbox behind it.

The durable checkpoint APIs existed but were never called from the daemon: `channel_poll_loop` still called the legacy in-memory-progress `Channel::poll` and only logged `comm.ingest` failures, so an ingest failure after a successful fetch silently lost that message's progress. Wiring the checkpoint path through means a partial failure is retried instead of skipped, and a durable restart sees the same checkpoint an in-process failure would have produced.

The bootstrap floor was originally a single shared timestamp advanced unconditionally once per tick, before the cycle it depends on had even run. That meant a `cursor_get` or ingest failure on a channel's first cycle still consumed the tick's floor update, and a daemon that started near UTC midnight could seed a channel's very first floor on the wrong side of that boundary -- either way, mail from the affected date range would be permanently excluded from the IMAP `SINCE` search.

## How tested

From `crates/` with `CARGO_TARGET_DIR=./target`:

- `cargo fmt --all -- --check` (exit 0)
- `cargo clippy -p khive-mcp --all-targets -- -D warnings` (exit 0)
- `cargo test -p khive-mcp --features channel-email` (exit 0, 109 passed, 0 failed)
- Each de-flaked test run 50 times in a loop (`for i in $(seq 50); do cargo test -p khive-mcp --features channel-email <name> || break; done`) with 0 failures; the new `cursor_commit`-rejection regression test run 20 times with 0 failures.

Fixes #449
