### PR TITLE
fix(db): split punctuated identifiers in FTS5 query sanitization

### DIFF
--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -226,12 +226,14 @@ fn micros_to_dt(micros: i64) -> DateTime<Utc> {
 /// Two-pass approach:
 /// 1. **Replace** grouping/separator chars with spaces so adjacent tokens are
 ///    not merged. This prevents `NEAR(smile,5)` from becoming `NEARsmile5`.
-///    Chars replaced with space: `(`, `)`, `,`
+///    It also keeps punctuated identifiers searchable: `khive-pack-memory`
+///    becomes `khive pack memory`, not `khivepackmemory`.
+///    Chars replaced with space: `(`, `)`, `,`, `:`, `-`, `.`
 /// 2. **Remove** remaining FTS5 operator characters (H1: `~`, `!` added;
 ///    issue #388: `$` added — FTS5's MATCH-expression parser treats a bareword
 ///    starting with, containing, or consisting solely of `$` as a syntax
 ///    error regardless of tokenizer, e.g. the DSL-doc query `$prev.id`):
-///    `*`, `"`, `+`, `-`, `:`, `^`, `.`, `~`, `!`, `$`, `\0`, control characters
+///    `*`, `"`, `'`, `+`, `^`, `~`, `!`, `$`, `\0`, control characters
 ///
 /// After character processing, split on whitespace and remove FTS5 keyword
 /// tokens: AND, OR, NOT, NEAR.
@@ -239,12 +241,12 @@ fn micros_to_dt(micros: i64) -> DateTime<Utc> {
 /// For Phrase mode, the caller wraps the result in double quotes.
 fn sanitize_fts5_query(query: &str) -> String {
     // Pass 1: replace grouping/separator chars with spaces to isolate tokens.
-    // Colon is included here (not in Pass 2) so that "tenant:isolation" becomes
-    // "tenant isolation" rather than "tenantisolation".
+    // Colon, hyphen, and dot are included here (not in Pass 2) so punctuated
+    // identifiers become separate terms rather than merged tokens.
     let spaced: String = query
         .chars()
         .map(|c| {
-            if matches!(c, '(' | ')' | ',' | ':') {
+            if matches!(c, '(' | ')' | ',' | ':' | '-' | '.') {
                 ' '
             } else {
                 c
@@ -261,10 +263,7 @@ fn sanitize_fts5_query(query: &str) -> String {
     let sanitized: String = spaced
         .chars()
         .filter(|c| {
-            !matches!(
-                c,
-                '*' | '"' | '\'' | '+' | '-' | '^' | '.' | '~' | '!' | '$' | '\0'
-            ) && !c.is_control()
+            !matches!(c, '*' | '"' | '\'' | '+' | '^' | '~' | '!' | '$' | '\0') && !c.is_control()
         })
         .collect();
 

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -280,6 +280,232 @@ fn sanitize_fts5_query(query: &str) -> String {
         .join(" ")
 }
 
+/// Legacy (pre-#397) sanitization: hyphen and dot are stripped outright
+/// instead of being space-split, so `khive-pack-memory` normalizes to the
+/// single merged bareword `khivepackmemory` rather than three terms.
+///
+/// Used only to build the merged-form OR-alternative in
+/// [`sanitize_fts5_token_group`] — never as the sole sanitized query. Content
+/// indexed before #397, or under a tokenizer whose own token-splitting rules
+/// collapse punctuation differently than the current space-split pass,  may
+/// still carry this merged token; kept as a fallback match term so those
+/// documents stay reachable.
+fn sanitize_fts5_query_legacy_merged(query: &str) -> String {
+    let spaced: String = query
+        .chars()
+        .map(|c| {
+            if matches!(c, '(' | ')' | ',' | ':') {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+
+    let sanitized: String = spaced
+        .chars()
+        .filter(|c| {
+            !matches!(
+                c,
+                '*' | '"' | '\'' | '+' | '-' | '^' | '.' | '~' | '!' | '$' | '\0'
+            ) && !c.is_control()
+        })
+        .collect();
+
+    sanitized
+        .split_whitespace()
+        .filter(|t| {
+            !matches!(
+                t.to_ascii_uppercase().as_str(),
+                "AND" | "OR" | "NOT" | "NEAR"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Strip a raw token down to what is safe inside a double-quoted FTS5 phrase:
+/// the closing delimiter (`"`), the trailing-`*` prefix-query trigger, and
+/// control characters. Everything else — including `-`, `.`, `:`, `$`, `'`,
+/// digits — passes through literally, since FTS5 phrase text is matched
+/// against the column's own tokenization of that literal text (word-exact
+/// under `unicode61`, substring-exact under `trigram`), not re-sanitized.
+///
+/// Returns `None` if nothing survives the filter.
+fn sanitize_fts5_phrase_literal(token: &str) -> Option<String> {
+    let literal: String = token
+        .chars()
+        .filter(|c| !matches!(c, '"' | '*' | '\0') && !c.is_control())
+        .collect();
+    if literal.is_empty() {
+        None
+    } else {
+        Some(literal)
+    }
+}
+
+/// Below this length, FTS5's built-in `trigram` tokenizer (the production
+/// default — `backend.rs::StorageBackend::text()`) produces zero tokens for
+/// a bareword MATCH term. Verified against a live `tokenize='trigram'`
+/// table: a term this short silently drops out of its AND clause instead of
+/// constraining the match, e.g. `2026 07 10` matches any row containing
+/// `2026` regardless of month/day. `sanitize_fts5_token_group` treats any
+/// split segment at or below this length as trigram-unsafe.
+const FTS5_TRIGRAM_MIN_SAFE_LEN: usize = 3;
+
+/// Sanitize a single whitespace-isolated raw token into an FTS5
+/// match-expression fragment.
+///
+/// #397 split punctuated identifiers (`khive-pack-memory` -> three terms
+/// `khive pack memory`, ANDed together) so they are searchable as distinct
+/// words. That is correct against content indexed with word-splitting
+/// tokenizers (`unicode61`, and multi-word `trigram` content where each
+/// word is long enough to trigram on its own), but two more cases need
+/// covering when punctuation actually causes a split:
+///
+/// - a query for content that only ever matched the pre-#397 merged
+///   bareword (`khivepackmemory`) would silently stop matching — kept
+///   reachable via the legacy-merged alternative.
+/// - under the production `trigram` tokenizer, a split segment shorter
+///   than [`FTS5_TRIGRAM_MIN_SAFE_LEN`] (e.g. the `07`/`10` in a
+///   `2026-07-10` date) tokenizes to zero trigrams and silently drops out
+///   of its AND clause, broadening the match to anything sharing the
+///   longer segment (any `2026`, not just that date). Neither the plain
+///   split AND-group nor the merged form avoids this — both were checked
+///   empirically against a live `tokenize='trigram'` table and both either
+///   broaden or simply fail to match. The fix that does work is a literal
+///   phrase-quoted alternative: FTS5 matches it by exact substring under
+///   `trigram` (confirmed: quoting `"2026-07-10"` discriminates the exact
+///   day) and by exact adjacent sub-tokens under word tokenizers. So when
+///   any split segment is trigram-unsafe, the split AND-group is dropped
+///   entirely rather than paired with the merged/phrase alternatives — an
+///   OR would still admit its broadened matches. Retrieval stays correct
+///   (still matches the right content, still discriminates) at the cost of
+///   requiring adjacency for that token, which is the trade-off intended
+///   by the finding this fixes (khive #397 Finding 2): correctness over a
+///   marginally more lenient match.
+///
+/// All emitted readings are additive OR-alternatives otherwise — the result
+/// is never a narrower match than any single (safe) form alone.
+///
+/// Returns `None` if the token sanitizes to nothing.
+fn sanitize_fts5_token_group(token: &str) -> Option<String> {
+    let split = sanitize_fts5_query(token);
+    let split_terms: Vec<&str> = split.split_whitespace().collect();
+    if split_terms.is_empty() {
+        return None;
+    }
+    if split_terms.len() == 1 {
+        return Some(split_terms[0].to_string());
+    }
+
+    let has_trigram_unsafe_segment = split_terms
+        .iter()
+        .any(|t| t.chars().count() < FTS5_TRIGRAM_MIN_SAFE_LEN);
+
+    let mut alternatives = Vec::new();
+    if !has_trigram_unsafe_segment {
+        alternatives.push(format!("({})", split_terms.join(" ")));
+    }
+
+    let merged = sanitize_fts5_query_legacy_merged(token);
+    if !merged.is_empty() && merged != split_terms.join("") {
+        alternatives.push(merged);
+    }
+
+    if let Some(phrase) = sanitize_fts5_phrase_literal(token) {
+        alternatives.push(format!("\"{}\"", phrase));
+    }
+
+    match alternatives.len() {
+        0 => Some(format!("({})", split_terms.join(" "))),
+        1 => alternatives.into_iter().next(),
+        _ => Some(format!("({})", alternatives.join(" OR "))),
+    }
+}
+
+/// Join Plain-mode per-token groups into one MATCH expression.
+///
+/// FTS5's implicit-AND adjacency rule (a bare space between two terms)
+/// applies only between two *plain* terms — verified against a live table:
+/// `GQA KV cache` (all bare) matches, but `GQA AND KV AND cache` does not,
+/// because FTS5's explicit `AND` treats a trigram-unsafe short bareword
+/// (`KV`, 2 chars, zero trigrams) as an unsatisfiable operand, while
+/// implicit adjacency instead lets it drop out harmlessly. So: use a bare
+/// space between two plain (unparenthesized) groups to preserve that
+/// existing leniency, and fall back to explicit `AND` only where at least
+/// one side is a parenthesized OR-group (`sanitize_fts5_token_group`'s
+/// output for punctuated tokens) — adjacency there without the operator is
+/// a MATCH-expression syntax error (`(a OR b) c` fails; `(a OR b) AND c`
+/// does not).
+fn join_plain_groups(groups: &[String]) -> String {
+    let mut expr = String::new();
+    for (i, group) in groups.iter().enumerate() {
+        if i > 0 {
+            let prev_compound = groups[i - 1].starts_with('(');
+            let this_compound = group.starts_with('(');
+            expr.push_str(if prev_compound || this_compound {
+                " AND "
+            } else {
+                " "
+            });
+        }
+        expr.push_str(group);
+    }
+    expr
+}
+
+/// Build the FTS5 MATCH expression for a query string under a given mode.
+///
+/// Centralizes the AnyTerm/Plain/Phrase branching previously duplicated
+/// across `search()`, `search_unranked()`, and `search_rank_within_cap()`.
+///
+/// AnyTerm and Plain both process the query token-by-token (split on
+/// whitespace) through [`sanitize_fts5_token_group`], so a punctuated
+/// identifier anywhere in the query gets its split/merged OR-alternative;
+/// AnyTerm joins the per-token groups with `OR`; Plain joins them via
+/// [`join_plain_groups`] (implicit-AND space where safe, explicit `AND`
+/// where a group is parenthesized). Phrase mode keeps the single-string
+/// literal behavior — a double-quoted FTS5 phrase cannot contain
+/// `OR`/parenthesized groups.
+///
+/// Returns `None` when the sanitized query is empty (caller short-circuits
+/// to an empty result set rather than sending an invalid MATCH expression).
+fn build_match_expr(query: &str, mode: TextQueryMode) -> Option<String> {
+    match mode {
+        TextQueryMode::AnyTerm => {
+            let groups: Vec<String> = query
+                .split_whitespace()
+                .filter_map(sanitize_fts5_token_group)
+                .collect();
+            if groups.is_empty() {
+                None
+            } else {
+                Some(groups.join(" OR "))
+            }
+        }
+        TextQueryMode::Plain => {
+            let groups: Vec<String> = query
+                .split_whitespace()
+                .filter_map(sanitize_fts5_token_group)
+                .collect();
+            if groups.is_empty() {
+                None
+            } else {
+                Some(join_plain_groups(&groups))
+            }
+        }
+        TextQueryMode::Phrase => {
+            let sanitized = sanitize_fts5_query(query);
+            if sanitized.is_empty() {
+                None
+            } else {
+                Some(format!("\"{}\"", sanitized))
+            }
+        }
+    }
+}
+
 /// Build a WHERE clause fragment and params for a `TextFilter`.
 ///
 /// Returns `(clause, params)` where clause is empty if no filters are active.
@@ -636,32 +862,9 @@ impl TextSearch for Fts5TextSearch {
         let table = self.table_name.clone();
 
         self.with_reader("fts_search", move |conn| {
-            let match_expr = match request.mode {
-                TextQueryMode::AnyTerm => {
-                    // Sanitize each token independently so the OR joiner isn't
-                    // stripped by sanitize_fts5_query's keyword filter.
-                    let parts: Vec<String> = request
-                        .query
-                        .split_whitespace()
-                        .map(sanitize_fts5_query)
-                        .filter(|t| !t.is_empty())
-                        .collect();
-                    if parts.is_empty() {
-                        return Ok(Vec::new());
-                    }
-                    parts.join(" OR ")
-                }
-                _ => {
-                    let sanitized = sanitize_fts5_query(&request.query);
-                    if sanitized.is_empty() {
-                        return Ok(Vec::new());
-                    }
-                    match request.mode {
-                        TextQueryMode::Phrase => format!("\"{}\"", sanitized),
-                        TextQueryMode::Plain => sanitized,
-                        TextQueryMode::AnyTerm => unreachable!(),
-                    }
-                }
+            let match_expr = match build_match_expr(&request.query, request.mode) {
+                Some(expr) => expr,
+                None => return Ok(Vec::new()),
             };
 
             // Snippet column index 3 = body in the FTS5 schema.
@@ -948,20 +1151,6 @@ impl Fts5TextSearch {
         ((n - f + 0.5) / (f + 0.5) + 1.0).ln()
     }
 
-    /// Build the OR match expression from a query string (shared logic).
-    fn build_any_term_expr(query: &str) -> Option<String> {
-        let parts: Vec<String> = query
-            .split_whitespace()
-            .map(sanitize_fts5_query)
-            .filter(|t| !t.is_empty())
-            .collect();
-        if parts.is_empty() {
-            None
-        } else {
-            Some(parts.join(" OR "))
-        }
-    }
-
     /// Gather candidates without BM25 ranking; return with uniform score 1.0.
     async fn search_unranked(
         &self,
@@ -970,22 +1159,9 @@ impl Fts5TextSearch {
         let table = self.table_name.clone();
 
         self.with_reader("fts_search_unranked", move |conn| {
-            let match_expr = match request.mode {
-                TextQueryMode::AnyTerm => match Self::build_any_term_expr(&request.query) {
-                    Some(e) => e,
-                    None => return Ok(Vec::new()),
-                },
-                _ => {
-                    let sanitized = sanitize_fts5_query(&request.query);
-                    if sanitized.is_empty() {
-                        return Ok(Vec::new());
-                    }
-                    match request.mode {
-                        TextQueryMode::Phrase => format!("\"{}\"", sanitized),
-                        TextQueryMode::Plain => sanitized,
-                        TextQueryMode::AnyTerm => unreachable!(),
-                    }
-                }
+            let match_expr = match build_match_expr(&request.query, request.mode) {
+                Some(expr) => expr,
+                None => return Ok(Vec::new()),
             };
 
             let (filter_clause, filter_params) = if let Some(ref filter) = request.filter {
@@ -1052,22 +1228,9 @@ impl Fts5TextSearch {
         let table = self.table_name.clone();
 
         self.with_reader("fts_search_rank_within_cap", move |conn| {
-            let match_expr = match request.mode {
-                TextQueryMode::AnyTerm => match Self::build_any_term_expr(&request.query) {
-                    Some(e) => e,
-                    None => return Ok(Vec::new()),
-                },
-                _ => {
-                    let sanitized = sanitize_fts5_query(&request.query);
-                    if sanitized.is_empty() {
-                        return Ok(Vec::new());
-                    }
-                    match request.mode {
-                        TextQueryMode::Phrase => format!("\"{}\"", sanitized),
-                        TextQueryMode::Plain => sanitized,
-                        TextQueryMode::AnyTerm => unreachable!(),
-                    }
-                }
+            let match_expr = match build_match_expr(&request.query, request.mode) {
+                Some(expr) => expr,
+                None => return Ok(Vec::new()),
             };
 
             let (filter_clause, filter_params) = if let Some(ref filter) = request.filter {

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -408,8 +408,23 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
         alternatives.push(format!("({})", split_terms.join(" ")));
     }
 
+    // An operator-bearing token (e.g. `NEAR(alpha-beta,5)`) can make the
+    // legacy merge itself collapse to multiple space-separated terms rather
+    // than one bareword: pass 1 of `sanitize_fts5_query_legacy_merged` spaces
+    // out `(`, `)`, and `,` while pass 2 removes `-`/`.` outright, so
+    // `NEAR(alpha-beta,5)` merges to `"alphabeta 5"`, not one word. Pushed
+    // unguarded, that multi-term fragment carries the same trigram-unsafe
+    // `5` the split-group check above exists to exclude, and under FTS5's
+    // implicit-AND adjacency it silently drops, broadening the OR-alternative
+    // to any row containing `alphabeta`. Apply the same trigram-safety gate
+    // here whenever the merge is multi-term.
     let merged = sanitize_fts5_query_legacy_merged(token);
-    if !merged.is_empty() && merged != split_terms.join("") {
+    let merged_terms: Vec<&str> = merged.split_whitespace().collect();
+    let merged_has_unsafe_segment = merged_terms.len() > 1
+        && merged_terms
+            .iter()
+            .any(|t| t.chars().count() < FTS5_TRIGRAM_MIN_SAFE_LEN);
+    if !merged.is_empty() && merged != split_terms.join("") && !merged_has_unsafe_segment {
         alternatives.push(merged);
     }
 

--- a/crates/khive-db/src/stores/text.rs
+++ b/crates/khive-db/src/stores/text.rs
@@ -365,7 +365,15 @@ const FTS5_TRIGRAM_MIN_SAFE_LEN: usize = 3;
 ///
 /// - a query for content that only ever matched the pre-#397 merged
 ///   bareword (`khivepackmemory`) would silently stop matching — kept
-///   reachable via the legacy-merged alternative.
+///   reachable via the legacy-merged alternative. The merged form is
+///   dropped only when it is a literal duplicate of an alternative already
+///   emitted into the expression (the split AND-group's own space-joined
+///   content, or the quoted literal phrase) — not merely when it equals the
+///   *concatenation* of the split terms, which for an ordinary punctuated
+///   identifier (`khive-pack-memory`) is always true and would suppress the
+///   legacy alternative unconditionally, leaving rows stored under the
+///   pre-#397 merged token (`khivepackmemory`) unreachable under
+///   `unicode61`.
 /// - under the production `trigram` tokenizer, a split segment shorter
 ///   than [`FTS5_TRIGRAM_MIN_SAFE_LEN`] (e.g. the `07`/`10` in a
 ///   `2026-07-10` date) tokenizes to zero trigrams and silently drops out
@@ -424,11 +432,22 @@ fn sanitize_fts5_token_group(token: &str) -> Option<String> {
         && merged_terms
             .iter()
             .any(|t| t.chars().count() < FTS5_TRIGRAM_MIN_SAFE_LEN);
-    if !merged.is_empty() && merged != split_terms.join("") && !merged_has_unsafe_segment {
+    // Compare against the split AND-group's own space-joined content — the
+    // form it actually contributes to the expression — not the bare
+    // concatenation of its terms. For an ordinary punctuated identifier the
+    // concatenation always matches the merged bareword (both simply drop the
+    // separators), which suppressed this alternative unconditionally and cut
+    // off legacy-indexed content; a real duplicate only exists when the
+    // merge itself produced the same space-separated content the split group
+    // already emits (e.g. an operator token whose merge stays multi-term).
+    let phrase = sanitize_fts5_phrase_literal(token);
+    let duplicates_split = merged == split_terms.join(" ");
+    let duplicates_phrase = phrase.as_deref() == Some(merged.as_str());
+    if !merged.is_empty() && !duplicates_split && !duplicates_phrase && !merged_has_unsafe_segment {
         alternatives.push(merged);
     }
 
-    if let Some(phrase) = sanitize_fts5_phrase_literal(token) {
+    if let Some(phrase) = phrase {
         alternatives.push(format!("\"{}\"", phrase));
     }
 

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -638,6 +638,106 @@ async fn test_search_with_hyphenated_and_dotted_queries_matches_literal_tokens()
     }
 }
 
+/// Round-2 codex re-review regression: `sanitize_fts5_token_group` must keep
+/// the legacy-merged bareword alternative reachable for ordinary punctuated
+/// identifiers under `unicode61`. The merged form (`khivepackmemory`,
+/// `previd`) is content indexed before #397's split-terms change, or content
+/// whose own tokenizer collapsed punctuation the same way; a query for the
+/// punctuated spelling must still find it. Assert exact hit-id sets (not
+/// just "contains") so a fix that accidentally broadens the match — e.g. by
+/// dropping the trigram-safety gate on multi-term merges — is caught too.
+#[tokio::test]
+async fn test_search_matches_legacy_merged_and_punctuated_forms_exact_ids() {
+    let store = setup_memory_store("legacy_merged_punctuated");
+
+    let legacy_merged_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            legacy_merged_id,
+            "doc",
+            "khivepackmemory legacy note",
+        ))
+        .await
+        .unwrap();
+
+    let punctuated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            punctuated_id,
+            "doc",
+            "khive-pack-memory crate",
+        ))
+        .await
+        .unwrap();
+
+    let legacy_prev_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            legacy_prev_id,
+            "DSL docs",
+            "chain results with previd token",
+        ))
+        .await
+        .unwrap();
+
+    let punctuated_prev_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            punctuated_prev_id,
+            "DSL docs",
+            "chain results with the $prev.id token",
+        ))
+        .await
+        .unwrap();
+
+    let unrelated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            unrelated_id,
+            "doc",
+            "completely unrelated content about gardening",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        for (query, expected_ids, label) in [
+            (
+                "khive-pack-memory",
+                vec![legacy_merged_id, punctuated_id],
+                "punctuated identifier reaches both legacy-merged and split forms",
+            ),
+            (
+                "$prev.id",
+                vec![legacy_prev_id, punctuated_prev_id],
+                "dollar+dot query reaches both legacy-merged and split forms",
+            ),
+        ] {
+            let hits = store
+                .search(TextSearchRequest {
+                    query: query.to_string(),
+                    mode: mode.clone(),
+                    filter: Some(ns_filter("test_ns")),
+                    top_k: 10,
+                    snippet_chars: 0,
+                })
+                .await
+                .unwrap();
+            let hit_ids: std::collections::HashSet<_> =
+                hits.iter().map(|hit| hit.subject_id).collect();
+            let expected: std::collections::HashSet<_> = expected_ids.into_iter().collect();
+            assert_eq!(
+                hit_ids, expected,
+                "unicode61 {mode:?} query {query:?} ({label}) must match exactly {expected:?}; got {hit_ids:?}"
+            );
+            assert!(
+                !hit_ids.contains(&unrelated_id),
+                "unicode61 {mode:?} query {query:?} ({label}) must not match unrelated doc {unrelated_id}; got {hit_ids:?}"
+            );
+        }
+    }
+}
+
 /// #397 Finding 2 regression: production defaults to the FTS5 `trigram`
 /// tokenizer (`backend.rs`'s `StorageBackend::text()`), and generic search
 /// (`operations.rs::search_notes`) queries it in `Plain` mode — neither of

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -792,6 +792,64 @@ async fn test_search_trigram_date_query_does_not_broaden_to_same_year() {
     }
 }
 
+/// #397 Finding 2 round-3 regression: a punctuated operand of an FTS5
+/// operator expression (`NEAR(alpha-beta,5)`, `NOT(alpha-beta,5)`) makes the
+/// legacy-merged OR-alternative in `sanitize_fts5_token_group` collapse to
+/// multiple space-separated terms (`"alphabeta 5"`) instead of one bareword,
+/// because the operand's comma spaces the trailing short segment off from
+/// the merged word. Pushed unguarded into the OR-group, that fragment's
+/// trigram-unsafe `5` term silently drops out under FTS5's implicit-AND
+/// adjacency (see `join_plain_groups`'s doc comment), broadening the match
+/// to any row containing the bare `alphabeta` merge. Pin under the
+/// production trigram tokenizer that an unrelated row containing only the
+/// merged bareword does not match.
+#[tokio::test]
+async fn test_search_trigram_operator_short_operand_does_not_broaden() {
+    let store = setup_trigram_store("trigram_operator_short_operand");
+
+    let unrelated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            unrelated_id,
+            "doc",
+            "an alphabeta widget completely unrelated to any proximity or negation query",
+        ))
+        .await
+        .unwrap();
+
+    for (query, label) in [
+        (
+            "NEAR(alpha-beta,5)",
+            "NEAR operator with a short numeric operand",
+        ),
+        (
+            "NOT(alpha-beta,5)",
+            "NOT operator with a short numeric operand",
+        ),
+    ] {
+        for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+            let hits = store
+                .search(TextSearchRequest {
+                    query: query.to_string(),
+                    mode: mode.clone(),
+                    filter: Some(ns_filter("test_ns")),
+                    top_k: 10,
+                    snippet_chars: 0,
+                })
+                .await
+                .unwrap();
+            let hit_ids: std::collections::HashSet<_> =
+                hits.iter().map(|hit| hit.subject_id).collect();
+            assert!(
+                !hit_ids.contains(&unrelated_id),
+                "trigram {mode:?} query {query:?} ({label}) must not broaden to match \
+                 {unrelated_id} via the trigram-unsafe multi-term merged alternative; \
+                 got {hit_ids:?}"
+            );
+        }
+    }
+}
+
 /// #570: all FTS5 operator classes must not crash the generic text search surface.
 #[tokio::test]
 async fn test_search_with_fts_operator_matrix_does_not_crash() {

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -16,6 +16,44 @@ fn setup_memory_store(table_key: &str) -> Fts5TextSearch {
     Fts5TextSearch::new(pool, false, table_key.to_string())
 }
 
+/// #397 Finding 2 regression fixture: the FTS5 `trigram` tokenizer, matching
+/// `StorageBackend::text()`'s production default (`backend.rs`) byte-for-byte
+/// (`tokenize = 'trigram'`), rather than the bare `ensure_fts5_schema` helper
+/// above, which omits `tokenize=` and so falls back to SQLite's own default
+/// (`unicode61`). Production generic search (`operations.rs`, Plain mode) and
+/// AnyTerm search both run against trigram-tokenized tables; a regression
+/// covered only under the test helper's `unicode61` default would miss
+/// trigram-specific behavior entirely.
+fn setup_trigram_store(table_key: &str) -> Fts5TextSearch {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+
+    {
+        let writer = pool.writer().unwrap();
+        let table_name = format!("fts_{}", table_key);
+        let ddl = format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS {} USING fts5(\
+             subject_id UNINDEXED, \
+             kind UNINDEXED, \
+             title, \
+             body, \
+             tags UNINDEXED, \
+             namespace UNINDEXED, \
+             metadata UNINDEXED, \
+             updated_at UNINDEXED, \
+             tokenize = 'trigram'\
+             )",
+            table_name
+        );
+        writer.conn().execute_batch(&ddl).unwrap();
+    }
+
+    Fts5TextSearch::new(pool, false, table_key.to_string())
+}
+
 fn make_document(subject_id: Uuid, title: &str, body: &str) -> TextDocument {
     TextDocument {
         subject_id,
@@ -596,6 +634,160 @@ async fn test_search_with_hyphenated_and_dotted_queries_matches_literal_tokens()
         assert!(
             hit_ids.contains(&expected_id),
             "#397 query {query:?} must match {expected_id}; got {hit_ids:?}"
+        );
+    }
+}
+
+/// #397 Finding 2 regression: production defaults to the FTS5 `trigram`
+/// tokenizer (`backend.rs`'s `StorageBackend::text()`), and generic search
+/// (`operations.rs::search_notes`) queries it in `Plain` mode — neither of
+/// which the prior `unicode61`/`AnyTerm`-only coverage exercised. Assert
+/// exact hit-id sets (not just "contains") for punctuated identifiers,
+/// decimals, versions, and legacy-normalized forms, under a real trigram
+/// table, in both `Plain` and `AnyTerm` mode.
+#[tokio::test]
+async fn test_search_trigram_punctuated_and_decimal_queries_matches_exact_ids() {
+    let store = setup_trigram_store("trigram_punctuated");
+
+    let hyphen_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(hyphen_id, "doc", "khive-pack-memory crate"))
+        .await
+        .unwrap();
+
+    let dotted_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            dotted_id,
+            "doc",
+            "the khive.pack.memory module",
+        ))
+        .await
+        .unwrap();
+
+    let decimal_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            decimal_id,
+            "doc",
+            "salience 0.9 vs 0.3 comparison",
+        ))
+        .await
+        .unwrap();
+
+    let version_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(version_id, "doc", "released version 1.2.3"))
+        .await
+        .unwrap();
+
+    // A literal punctuated identifier short enough (`id` = 2 chars) that its
+    // split segments are trigram-unsafe (below FTS5_TRIGRAM_MIN_SAFE_LEN):
+    // only reachable via the exact-substring phrase alternative under
+    // `trigram`, since the doc body embeds the raw "$prev.id" token verbatim
+    // rather than as separately tokenizable words.
+    let legacy_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            legacy_id,
+            "DSL docs",
+            "chain results with the $prev.id token",
+        ))
+        .await
+        .unwrap();
+
+    let unrelated_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            unrelated_id,
+            "doc",
+            "completely unrelated content about gardening",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        for (query, expected_id, label) in [
+            ("khive-pack-memory", hyphen_id, "hyphenated identifier"),
+            ("khive.pack.memory", dotted_id, "dotted identifier"),
+            ("0.9", decimal_id, "decimal"),
+            ("1.2.3", version_id, "version string"),
+            ("$prev.id", legacy_id, "legacy dollar+dot query"),
+        ] {
+            let hits = store
+                .search(TextSearchRequest {
+                    query: query.to_string(),
+                    mode: mode.clone(),
+                    filter: Some(ns_filter("test_ns")),
+                    top_k: 10,
+                    snippet_chars: 0,
+                })
+                .await
+                .unwrap();
+            let hit_ids: std::collections::HashSet<_> =
+                hits.iter().map(|hit| hit.subject_id).collect();
+            assert!(
+                hit_ids.contains(&expected_id),
+                "trigram {mode:?} query {query:?} ({label}) must match {expected_id}; got {hit_ids:?}"
+            );
+            assert!(
+                !hit_ids.contains(&unrelated_id),
+                "trigram {mode:?} query {query:?} ({label}) must not match unrelated doc {unrelated_id}; got {hit_ids:?}"
+            );
+        }
+    }
+}
+
+/// #397 Finding 2 concrete broadening regression: a hyphenated date query
+/// under the trigram tokenizer must not collapse to matching every document
+/// that merely shares the year. `sanitize_fts5_token_group`'s split reading
+/// keeps the year term ("2026", 4 chars) fully discriminating under trigram;
+/// this test pins that neither the split nor the merged OR-alternative
+/// widens the match to a different day in the same year.
+#[tokio::test]
+async fn test_search_trigram_date_query_does_not_broaden_to_same_year() {
+    let store = setup_trigram_store("trigram_date");
+
+    let target_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            target_id,
+            "doc",
+            "changelog entry dated 2026-07-10",
+        ))
+        .await
+        .unwrap();
+
+    let other_day_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(
+            other_day_id,
+            "doc",
+            "changelog entry dated 2026-03-15",
+        ))
+        .await
+        .unwrap();
+
+    for mode in [TextQueryMode::Plain, TextQueryMode::AnyTerm] {
+        let hits = store
+            .search(TextSearchRequest {
+                query: "2026-07-10".to_string(),
+                mode: mode.clone(),
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 0,
+            })
+            .await
+            .unwrap();
+        let hit_ids: std::collections::HashSet<_> = hits.iter().map(|hit| hit.subject_id).collect();
+        assert!(
+            hit_ids.contains(&target_id),
+            "trigram {mode:?} date query must match its own date {target_id}; got {hit_ids:?}"
+        );
+        assert!(
+            !hit_ids.contains(&other_day_id),
+            "trigram {mode:?} date query for 2026-07-10 must not broaden to 2026-03-15 \
+             ({other_day_id}); got {hit_ids:?}"
         );
     }
 }

--- a/crates/khive-db/src/stores/text_tests.rs
+++ b/crates/khive-db/src/stores/text_tests.rs
@@ -399,9 +399,18 @@ async fn test_sanitize_fts5_query() {
     // M-C4: decimal numbers must not produce "syntax error near '.'"
     assert_eq!(
         sanitize_fts5_query("salience 0.9 vs 0.3"),
-        "salience 09 vs 03"
+        "salience 0 9 vs 0 3"
     );
-    assert_eq!(sanitize_fts5_query("version 1.2.3"), "version 123");
+    assert_eq!(sanitize_fts5_query("version 1.2.3"), "version 1 2 3");
+    // #397: hyphenated and dotted identifiers must space-split, not concatenate.
+    assert_eq!(
+        sanitize_fts5_query("khive-pack-memory"),
+        "khive pack memory"
+    );
+    assert_eq!(
+        sanitize_fts5_query("khive.pack.memory"),
+        "khive pack memory"
+    );
     // H1: tilde and comma must be stripped to prevent FTS5 syntax errors
     assert_eq!(sanitize_fts5_query("~hello"), "hello");
     assert_eq!(sanitize_fts5_query("\"+_~!\""), "_");
@@ -441,7 +450,7 @@ async fn test_sanitize_fts5_query() {
     assert_eq!(sanitize_fts5_query("AND OR NOT"), "");
     // #388: dollar sign is an unconditional FTS5 MATCH-parser syntax error
     // ("syntax error near \"$\"") regardless of position in the token or query.
-    assert_eq!(sanitize_fts5_query("$prev.id"), "previd");
+    assert_eq!(sanitize_fts5_query("$prev.id"), "prev id");
     assert_eq!(sanitize_fts5_query("$prev"), "prev");
     assert_eq!(sanitize_fts5_query("foo$bar"), "foobar");
     assert_eq!(sanitize_fts5_query("$"), "");
@@ -513,7 +522,7 @@ async fn test_search_with_decimal_query_does_not_crash() {
         .upsert_document(make_document(
             Uuid::new_v4(),
             "salience thresholds",
-            "salience 09 vs 03 comparison",
+            "salience 0 9 vs 0 3 comparison",
         ))
         .await
         .unwrap();
@@ -549,6 +558,46 @@ async fn test_search_with_decimal_query_does_not_crash() {
         "version-string query must succeed, got error: {:?}",
         result2.err()
     );
+}
+
+/// #397 regression: punctuated identifier queries must not be concatenated into
+/// tokens that cannot occur in the indexed text.
+#[tokio::test]
+async fn test_search_with_hyphenated_and_dotted_queries_matches_literal_tokens() {
+    let store = setup_memory_store("punctuated_query_match");
+
+    let hyphen_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(hyphen_id, "doc", "LEGACY-FLAT-NOTE"))
+        .await
+        .unwrap();
+
+    let dotted_id = Uuid::new_v4();
+    store
+        .upsert_document(make_document(dotted_id, "doc", "khive.pack.memory"))
+        .await
+        .unwrap();
+
+    for (query, expected_id) in [
+        ("LEGACY-FLAT-NOTE", hyphen_id),
+        ("khive.pack.memory", dotted_id),
+    ] {
+        let hits = store
+            .search(TextSearchRequest {
+                query: query.to_string(),
+                mode: TextQueryMode::AnyTerm,
+                filter: Some(ns_filter("test_ns")),
+                top_k: 10,
+                snippet_chars: 64,
+            })
+            .await
+            .unwrap();
+        let hit_ids: Vec<_> = hits.iter().map(|hit| hit.subject_id).collect();
+        assert!(
+            hit_ids.contains(&expected_id),
+            "#397 query {query:?} must match {expected_id}; got {hit_ids:?}"
+        );
+    }
 }
 
 /// #570: all FTS5 operator classes must not crash the generic text search surface.
@@ -614,7 +663,7 @@ async fn test_search_with_dollar_sign_does_not_crash() {
         .upsert_document(make_document(
             Uuid::new_v4(),
             "DSL docs",
-            "chain results with the previd token",
+            "chain results with the prev id token",
         ))
         .await
         .unwrap();
@@ -633,8 +682,7 @@ async fn test_search_with_dollar_sign_does_not_crash() {
         "#388 dollar-sign query must not crash FTS5, got: {:?}",
         result.err()
     );
-    // sanitize_fts5_query("$prev.id") == "previd" (both '$' and '.' stripped, no
-    // space inserted) — it still matches a document containing that literal token,
+    // sanitize_fts5_query("$prev.id") == "prev id" ('$' stripped, '.' space-split),
     // confirming legitimate text search stays intact after sanitization.
     assert_eq!(result.unwrap().len(), 1);
 }


### PR DESCRIPTION
Closes #397

## Problem

FTS5 query sanitization removed punctuation from identifiers such as `khive-pack-memory`, `khive.pack.memory`, and `$prev.id`, merging their segments into barewords that often do not exist in indexed content. Simply splitting punctuation is not sufficient because older or differently tokenized content can still contain the merged form, and the production trigram tokenizer drops terms shorter than three characters in ways that can broaden a match.

## Approach

- Hyphens and periods now follow the existing separator behavior for colons and grouping characters: they are replaced with spaces before operator characters are removed. This produces split terms instead of accidental concatenation. Apostrophes are also removed from bareword expressions as unsafe syntax.
- Plain and AnyTerm queries process each whitespace-delimited token through `sanitize_fts5_token_group`. A punctuated token can contribute a split-term group, the legacy merged bareword, and a quoted literal phrase as deduplicated OR alternatives. The merged fallback keeps pre-change or tokenizer-normalized content searchable.
- `FTS5_TRIGRAM_MIN_SAFE_LEN` guards both split groups and multi-term legacy alternatives. If punctuation creates a segment shorter than three characters, the unsafe group is omitted so it cannot silently broaden a trigram query. The quoted literal remains available for exact adjacent or substring matching.
- `join_plain_groups` preserves implicit adjacency between ordinary Plain-mode terms and inserts explicit `AND` when a parenthesized OR group requires it for valid FTS5 syntax.
- `build_match_expr` centralizes AnyTerm, Plain, and Phrase construction. The same logic now feeds `search`, `search_unranked`, and `search_rank_within_cap`, so every FTS entrypoint handles punctuated input consistently. Phrase mode retains its whole-query quoted behavior, and fully sanitized-away queries still return no results.

## Test coverage

- `test_sanitize_fts5_query` covers split hyphen, dot, decimal, version, and `$prev.id` normalization.
- `test_search_with_hyphenated_and_dotted_queries_matches_literal_tokens` covers literal punctuated identifiers.
- `test_search_matches_legacy_merged_and_punctuated_forms_exact_ids` verifies both legacy-merged and punctuated forms under `unicode61` without unrelated matches.
- `test_search_trigram_punctuated_and_decimal_queries_matches_exact_ids` exercises Plain and AnyTerm behavior against a production-equivalent trigram table.
- `test_search_trigram_date_query_does_not_broaden_to_same_year` verifies that short date segments do not widen an exact date query.
- `test_search_trigram_operator_short_operand_does_not_broaden` covers short operands inside sanitized operator expressions.
- Existing decimal and dollar-sign no-crash regressions were updated for the new split normalization.
