### PR TITLE
fix(runtime): add RuntimeConfig::no_embeddings() opt-out constructor

### DIFF
--- a/crates/khive-mcp/src/serve.rs
+++ b/crates/khive-mcp/src/serve.rs
@@ -1760,31 +1760,30 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
     // we exclude brain_profile from the default spread and set it to None (CLI-only).
     let cli_brain_profile = inputs.brain_profile.filter(|s| !s.trim().is_empty());
 
-    let base_config = RuntimeConfig {
-        db_path,
-        default_namespace: inputs.namespace,
-        packs,
-        // Explicit CLI flag only at this tier — env and config-file tiers are applied
-        // below in resolve_config / resolve_actor_from_config and apply_env_brain_profile.
-        brain_profile: cli_brain_profile,
-        ..RuntimeConfig::default()
-    };
-
     // Threaded into the config-file resolvers so tier-3 project-local config
     // discovery anchors to the resolved database's directory rather than the
     // process cwd when an explicit `--db`/`KHIVE_DB` is given (kills config_id
     // drift between a client and the daemon serving the same database at a
-    // different working directory). Deliberately NOT `base_config.db_path`
-    // (which materializes the `$HOME/.khive/khive.db` default when unset,
-    // #689) — an unset db must fall through to cwd-anchored discovery instead
-    // of silently searching the home directory.
+    // different working directory). Deliberately NOT the base config's own
+    // `db_path` (which materializes the `$HOME/.khive/khive.db` default when
+    // unset, #689) — an unset db must fall through to cwd-anchored discovery
+    // instead of silently searching the home directory.
     let db_path_for_config = config_discovery_db_anchor(inputs.db);
 
     let resolved = if inputs.no_embed {
+        // `RuntimeConfig::no_embeddings()` is the canonical "zero embedders"
+        // constructor (issue #396) — it clears `embedding_model` and
+        // `additional_embedding_models` together, unlike a manual two-field
+        // override which can leave `additional_embedding_models` populated
+        // from `KHIVE_ADDITIONAL_EMBEDDING_MODELS`.
         let no_embed_base = RuntimeConfig {
-            embedding_model: None,
-            additional_embedding_models: vec![],
-            ..base_config
+            db_path,
+            default_namespace: inputs.namespace,
+            packs,
+            // Explicit CLI flag only at this tier — env and config-file tiers are applied
+            // below in resolve_actor_from_config and apply_env_brain_profile.
+            brain_profile: cli_brain_profile,
+            ..RuntimeConfig::no_embeddings()
         };
         resolve_actor_from_config(
             inputs.config,
@@ -1793,6 +1792,15 @@ pub fn resolve_runtime_config(inputs: RuntimeConfigInputs<'_>) -> anyhow::Result
             db_path_for_config.as_deref(),
         )?
     } else {
+        let base_config = RuntimeConfig {
+            db_path,
+            default_namespace: inputs.namespace,
+            packs,
+            // Explicit CLI flag only at this tier — env and config-file tiers are applied
+            // below in resolve_config and apply_env_brain_profile.
+            brain_profile: cli_brain_profile,
+            ..RuntimeConfig::default()
+        };
         resolve_config(inputs.config, base_config, db_path_for_config.as_deref())?
     };
 

--- a/crates/khive-pack-memory/tests/integration.rs
+++ b/crates/khive-pack-memory/tests/integration.rs
@@ -28,6 +28,46 @@ fn make_registry(rt: KhiveRuntime) -> khive_runtime::VerbRegistry {
     builder.build().expect("registry builds")
 }
 
+/// Issue #396 regression: `memory.remember` dispatched through the real KG+memory
+/// verb registry must succeed when the runtime is built with
+/// `RuntimeConfig::no_embeddings()` — zero embedders registered, no lattice model
+/// load attempted. Mirrors `khive-runtime`'s unit-level regression
+/// (`no_embeddings_config_registers_zero_embedders` /
+/// `no_embeddings_runtime_create_note_succeeds_without_model_fanout`) but drives
+/// the actual `MemoryPack::handle_remember` handler through pack registration and
+/// verb dispatch, not `create_note` directly.
+#[tokio::test]
+async fn test_remember_dispatch_succeeds_with_no_embeddings_runtime() {
+    let rt = KhiveRuntime::new(RuntimeConfig {
+        db_path: None,
+        packs: vec!["kg".to_string()],
+        ..RuntimeConfig::no_embeddings()
+    })
+    .expect("no_embeddings runtime");
+
+    assert!(
+        rt.registered_embedding_model_names().is_empty(),
+        "no_embeddings() runtime must register zero embedders"
+    );
+
+    let registry = make_registry(rt);
+
+    let result = registry
+        .dispatch(
+            "memory.remember",
+            json!({
+                "content": "issue-396 regression: memory.remember via real dispatch with zero embedders",
+                "memory_type": "semantic",
+                "salience": 0.7
+            }),
+        )
+        .await
+        .expect("memory.remember must succeed with zero registered embedders");
+
+    let note_id = result["id"].as_str().expect("has note_id");
+    assert!(!note_id.is_empty());
+}
+
 #[tokio::test]
 async fn test_remember_recall_smoke() {
     let rt = make_runtime();

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -334,6 +334,38 @@ impl Default for RuntimeConfig {
     }
 }
 
+impl RuntimeConfig {
+    /// Build a `RuntimeConfig` with embedding disabled entirely (issue #396).
+    ///
+    /// `embedding_model` and `additional_embedding_models` are computed
+    /// *independently* inside [`Default::default`] (see above): the former from
+    /// `KHIVE_EMBEDDING_MODEL`, the latter from `KHIVE_ADDITIONAL_EMBEDDING_MODELS`
+    /// (falling back to seeding `ParaphraseMultilingualMiniLmL12V2` when that var
+    /// is unset). Writing `RuntimeConfig { embedding_model: None,
+    /// ..RuntimeConfig::default() }` therefore does *not* produce a model-less
+    /// runtime: `additional_embedding_models` still carries the env-driven
+    /// fallback seed, `configured_embedding_models` still reports it, and the
+    /// note-write path fans out embedding to every *registered* model regardless
+    /// of `embedding_model` — so the first `memory.remember` on a machine without
+    /// local model files hard-fails instead of degrading to FTS-only.
+    ///
+    /// This constructor clears both fields together and is the one ergonomic,
+    /// correct spelling for "no embed runtime". Model-less machines (CI runners,
+    /// fresh installs without local model files) should use it instead of the
+    /// two-field struct-update form above.
+    ///
+    /// Deliberately ignores `KHIVE_ADDITIONAL_EMBEDDING_MODELS`: a caller
+    /// reaching for `no_embeddings()` wants zero embedders unconditionally, not
+    /// "zero unless the environment happens to disagree".
+    pub fn no_embeddings() -> Self {
+        Self {
+            embedding_model: None,
+            additional_embedding_models: Vec::new(),
+            ..Self::default()
+        }
+    }
+}
+
 /// Resolve the `--db`/`KHIVE_DB` value into the db path used to ANCHOR tier-3
 /// project-local `.khive/config.toml` discovery (`KhiveConfig::load_with_home_fallback`'s
 /// `db_path` parameter), mirroring the precedence `kkernel mcp`'s and `kkernel exec`'s
@@ -811,6 +843,65 @@ mod resolve_project_actor_id_tests {
             resolve_project_actor_id(Some(&path)).expect("no error"),
             None,
             "a config file with no [actor] section must resolve to None"
+        );
+    }
+}
+
+#[cfg(test)]
+mod no_embeddings_tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn no_embeddings_clears_both_fields() {
+        let config = RuntimeConfig::no_embeddings();
+        assert_eq!(config.embedding_model, None);
+        assert!(config.additional_embedding_models.is_empty());
+        assert!(
+            configured_embedding_models(&config).is_empty(),
+            "no_embeddings() must yield zero configured embedders"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn no_embeddings_ignores_additional_env_override() {
+        // no_embeddings() is an unconditional opt-out: even if the caller's
+        // environment sets KHIVE_ADDITIONAL_EMBEDDING_MODELS, the resulting
+        // config must still report zero embedders.
+        std::env::set_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS", "paraphrase");
+        let config = RuntimeConfig::no_embeddings();
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+
+        assert!(config.additional_embedding_models.is_empty());
+        assert!(configured_embedding_models(&config).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn default_still_seeds_additional_models_when_env_unset() {
+        // Regression guard for issue #396's root cause: `Default` must keep
+        // computing `embedding_model` and `additional_embedding_models`
+        // independently. `no_embeddings()` is a new opt-out constructor, not a
+        // change to `Default`'s existing (env-driven) seeding behavior.
+        std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
+        let config = RuntimeConfig::default();
+
+        assert_eq!(
+            config.additional_embedding_models,
+            vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2]
+        );
+
+        // The bug shape from #396: overriding only `embedding_model` via
+        // struct-update syntax does not clear `additional_embedding_models`.
+        let buggy_form = RuntimeConfig {
+            embedding_model: None,
+            ..RuntimeConfig::default()
+        };
+        assert!(
+            !buggy_form.additional_embedding_models.is_empty(),
+            "Default's independent-field seeding must remain unchanged; \
+             no_embeddings() is the fix, not a change to Default"
         );
     }
 }

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -202,8 +202,14 @@ pub struct RuntimeConfig {
     pub db_path: Option<std::path::PathBuf>,
     /// Namespace used when no explicit namespace is provided.
     pub default_namespace: Namespace,
-    /// Local embedding model. `None` disables embedding and hybrid vector search;
-    /// `hybrid_search` then falls back to text-only.
+    /// Local embedding model. `None` alone does not disable embedding: setting
+    /// only this field to `None` while `additional_embedding_models` is
+    /// non-empty still registers those models. Both `embedding_model` and
+    /// `additional_embedding_models` must be empty to disable built-in
+    /// embedding model registration, at which point `hybrid_search` falls back
+    /// to text-only. Use [`RuntimeConfig::no_embeddings`] to clear both fields
+    /// together — it is the canonical constructor for this. Custom embedder
+    /// providers registered later by packs are not affected by this field.
     ///
     /// Deprecated: embedding engines move to a per-pack `EmbedderRegistry`.
     /// This field persists for backward compatibility until the embedder registry

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -4891,6 +4891,60 @@ mod tests {
         );
     }
 
+    // ── Issue #396 regression ────────────────────────────────────────────────
+    // `RuntimeConfig::no_embeddings()` must register zero embedders, so
+    // `create_note` never attempts to lazily build a lattice embedding model —
+    // this is what lets `memory.remember` succeed on a machine with no local
+    // model files present (the exact failure mode reported in #396).
+
+    #[tokio::test]
+    async fn no_embeddings_config_registers_zero_embedders() {
+        let config = crate::config::RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            ..crate::config::RuntimeConfig::no_embeddings()
+        };
+        let rt = KhiveRuntime::new(config).expect("runtime construction must succeed");
+
+        assert!(rt.config().embedding_model.is_none());
+        assert!(
+            rt.registered_embedding_model_names().is_empty(),
+            "no_embeddings() runtime must register zero embedders"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_embeddings_runtime_create_note_succeeds_without_model_fanout() {
+        let config = crate::config::RuntimeConfig {
+            db_path: None,
+            packs: vec!["kg".to_string()],
+            ..crate::config::RuntimeConfig::no_embeddings()
+        };
+        let rt = KhiveRuntime::new(config).expect("runtime construction must succeed");
+        let tok = NamespaceToken::local();
+
+        // With zero registered embedders, create_note's embed fan-out list is
+        // empty and no lattice model build is ever attempted -- the write must
+        // succeed (degrading to FTS-only) exactly as #396 requires.
+        let note = rt
+            .create_note(
+                &tok,
+                "memory",
+                None,
+                "issue-396 regression: model-less remember must succeed",
+                Some(0.7),
+                None,
+                vec![],
+            )
+            .await
+            .expect("create_note must succeed with zero registered embedders");
+
+        assert_eq!(
+            note.content,
+            "issue-396 regression: model-less remember must succeed"
+        );
+    }
+
     #[tokio::test]
     async fn update_edge_changes_weight() {
         let rt = rt();

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -6,7 +6,9 @@
 use std::sync::{Arc, RwLock};
 
 use khive_db::StorageBackend;
-use khive_gate::{AllowAllGate, GateRequest};
+#[cfg(test)]
+use khive_gate::AllowAllGate;
+use khive_gate::GateRequest;
 use khive_storage::{EntityStore, EventStore, GraphStore, NoteStore, SqlAccess};
 use khive_types::{EdgeEndpointRule, Namespace};
 use lattice_embed::{EmbeddingModel, EmbeddingService};
@@ -269,16 +271,10 @@ impl KhiveRuntime {
     pub fn memory() -> RuntimeResult<Self> {
         Self::new(RuntimeConfig {
             db_path: None,
-            default_namespace: Namespace::local(),
-            embedding_model: None,
-            additional_embedding_models: vec![],
-            gate: Arc::new(AllowAllGate),
             packs: vec!["kg".to_string()],
-            backend_id: BackendId::main(),
             brain_profile: None,
-            visible_namespaces: vec![],
-            allowed_outbound_namespaces: vec![],
             actor_id: None,
+            ..RuntimeConfig::no_embeddings()
         })
     }
 

--- a/docs/adr/ADR-011-embedding-and-inference.md
+++ b/docs/adr/ADR-011-embedding-and-inference.md
@@ -88,9 +88,13 @@ pub struct RuntimeConfig {
 }
 ```
 
-`None` disables embedding. Vector and hybrid search return `Unconfigured("embedding_model")`.
-Text-only search and graph traversal still work. This is the "KG without semantic search"
-deployment.
+Setting `embedding_model` to `None` alone does not disable embedding: `additional_embedding_models`
+is populated independently and those models are still registered. Both `embedding_model` and
+`additional_embedding_models` must be empty to disable built-in embedding model registration —
+use `RuntimeConfig::no_embeddings()`, the canonical constructor for this. With both cleared,
+vector and hybrid search return `Unconfigured("embedding_model")` and text-only search / graph
+traversal still work. This is the "KG without semantic search" deployment. Custom embedder
+providers registered later by packs are not affected by this setting.
 
 Model overrides at the call site are not currently supported — the runtime is configured
 with one active model. Multi-model serving (different models for different namespaces or

--- a/docs/adr/ADR-011-embedding-and-inference.md
+++ b/docs/adr/ADR-011-embedding-and-inference.md
@@ -92,8 +92,8 @@ Setting `embedding_model` to `None` alone does not disable embedding: `additiona
 is populated independently and those models are still registered. Both `embedding_model` and
 `additional_embedding_models` must be empty to disable built-in embedding model registration —
 use `RuntimeConfig::no_embeddings()`, the canonical constructor for this. With both cleared,
-vector and hybrid search return `Unconfigured("embedding_model")` and text-only search / graph
-traversal still work. This is the "KG without semantic search" deployment. Custom embedder
+direct vector search returns `Unconfigured("embedding_model")`, hybrid search skips the vector
+leg and falls back to text-only results, and text-only search / graph traversal still work. This is the "KG without semantic search" deployment. Custom embedder
 providers registered later by packs are not affected by this setting.
 
 Model overrides at the call site are not currently supported — the runtime is configured


### PR DESCRIPTION
## Summary

- `RuntimeConfig::default()` computes `embedding_model` and `additional_embedding_models` independently, so writing `RuntimeConfig { embedding_model: None, ..RuntimeConfig::default() }` does not actually disable embedding: `additional_embedding_models` still carries the env-driven fallback seed (`ParaphraseMultilingualMiniLmL12V2` when `KHIVE_ADDITIONAL_EMBEDDING_MODELS` is unset).
- The note-write path fans out embedding to every *registered* model regardless of `embedding_model`, so the first `memory.remember` on a machine without local model files hard-fails instead of degrading to FTS-only.
- Adds `RuntimeConfig::no_embeddings()`, which clears both fields together — the one ergonomic, correct spelling for a model-less runtime. `Default::default()`'s existing behavior is unchanged (no existing caller is affected).
- Design decision: `no_embeddings()` deliberately ignores `KHIVE_ADDITIONAL_EMBEDDING_MODELS` — a caller reaching for it wants zero embedders unconditionally, not "zero unless the environment disagrees".

## Test plan

- [x] `config::no_embeddings_tests::no_embeddings_clears_both_fields` — direct verification of the fix
- [x] `config::no_embeddings_tests::no_embeddings_ignores_additional_env_override` — confirms the env-override design decision
- [x] `config::no_embeddings_tests::default_still_seeds_additional_models_when_env_unset` — regression guard that `Default`'s existing behavior, including the pre-fix bug shape, is unchanged
- [x] `operations::tests::no_embeddings_config_registers_zero_embedders` — runtime-level: zero embedders registered
- [x] `operations::tests::no_embeddings_runtime_create_note_succeeds_without_model_fanout` — `create_note` succeeds with zero registered embedders (no lattice model build attempted)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p khive-runtime --all-targets -- -D warnings`
- [x] `cargo test -p khive-runtime` (736 unit + 2 + 59 integration tests, all green)

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)