### PR TITLE
fix(query): warn on GQL result truncation at the 500-row cap

### DIFF
--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -87,6 +87,23 @@ pub struct CompiledQuery {
     pub params: Vec<QueryValue>,
     pub return_vars: Vec<ReturnItem>,
     pub warnings: Vec<String>,
+    /// Present when the server-side `max_limit` cap is the binding
+    /// constraint on this query (no explicit `LIMIT`, or an explicit
+    /// `LIMIT` above the cap). The emitted SQL fetches `max_limit + 1`
+    /// rows (a sentinel row) so the execution site can detect whether the
+    /// true match count exceeded the cap and warn accordingly, instead of
+    /// inferring truncation from the requested `LIMIT` alone (issue #777).
+    pub truncation_check: Option<TruncationCheck>,
+}
+
+/// See [`CompiledQuery::truncation_check`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TruncationCheck {
+    /// The server-side row cap; the execution site truncates to this many
+    /// rows after stripping the sentinel.
+    pub max_limit: usize,
+    /// The caller's explicit `LIMIT`, if any, for warning-message purposes.
+    pub requested_limit: Option<usize>,
 }
 
 /// Runtime options injected by the caller to scope and cap query execution.
@@ -106,20 +123,31 @@ impl Default for CompileOptions {
     }
 }
 
-/// Build a truncation warning when the caller's requested limit (or the
-/// implicit default of `max_limit` when no `LIMIT` clause is present)
-/// exceeds the server-side safety cap (issue #777). Returns `None` when the
-/// effective limit is at or below the cap — a query that never asked for
-/// more than `max_limit` rows was not truncated by the clamp.
-fn truncation_warning(requested_limit: Option<usize>, max_limit: usize) -> Option<String> {
-    let effective = requested_limit.unwrap_or(max_limit);
-    if effective > max_limit {
-        Some(format!(
-            "result set capped at {max_limit} rows; requested limit {effective} exceeds the \
-             cap — use LIMIT/OFFSET to page through the remaining results"
-        ))
-    } else {
-        None
+/// Compute the SQL `LIMIT` to emit and whether the execution site must
+/// perform a cap-sentinel check (issue #777).
+///
+/// When the caller's own `LIMIT` is at or below `max_limit`, the cap never
+/// binds: we fetch exactly what was requested and no truncation is
+/// possible. When there is no explicit `LIMIT`, or the explicit `LIMIT`
+/// exceeds `max_limit`, the cap is the binding constraint — we fetch one
+/// extra row (`max_limit + 1`) so the caller can tell, from the actual
+/// result set, whether there were more matches than the cap allows. This
+/// replaces inferring truncation from the requested `LIMIT` alone, which is
+/// both a false positive (`LIMIT 1000` matching only 20 rows) and a false
+/// negative (no `LIMIT`, 501+ rows actually match).
+fn effective_limit(
+    requested_limit: Option<usize>,
+    max_limit: usize,
+) -> (usize, Option<TruncationCheck>) {
+    match requested_limit {
+        Some(limit) if limit <= max_limit => (limit, None),
+        requested => (
+            max_limit.saturating_add(1),
+            Some(TruncationCheck {
+                max_limit,
+                requested_limit: requested,
+            }),
+        ),
     }
 }
 
@@ -138,9 +166,6 @@ pub fn compile(query: &GqlQuery, opts: &CompileOptions) -> Result<CompiledQuery,
     } else {
         compile_fixed_length(&query, opts)?
     };
-    // compile_fixed_length/compile_variable_length may already have pushed a
-    // truncation warning (clamp sites) onto `compiled.warnings` — extend,
-    // don't overwrite, so both sources of warnings survive.
     compiled.warnings.extend(warnings);
 
     // Defense-in-depth: assert the emitted SQL is SELECT-only.
@@ -579,8 +604,7 @@ fn compile_fixed_length(
         }
     }
 
-    let limit_warning = truncation_warning(query.limit, opts.max_limit);
-    let limit = query.limit.unwrap_or(opts.max_limit).min(opts.max_limit);
+    let (limit, truncation_check) = effective_limit(query.limit, opts.max_limit);
     let limit_i64 = i64::try_from(limit)
         .map_err(|_| QueryError::InvalidInput("limit exceeds i64::MAX".into()))?;
     params.push(QueryValue::Integer(limit_i64));
@@ -598,7 +622,8 @@ fn compile_fixed_length(
         sql,
         params,
         return_vars: query.return_items.clone(),
-        warnings: limit_warning.into_iter().collect(),
+        warnings: Vec::new(),
+        truncation_check,
     })
 }
 
@@ -1157,8 +1182,7 @@ fn compile_variable_length(
         end_conditions.push(format!("t.depth >= ?{}", params.len()));
     }
 
-    let limit_warning = truncation_warning(query.limit, opts.max_limit);
-    let limit = query.limit.unwrap_or(opts.max_limit).min(opts.max_limit);
+    let (limit, truncation_check) = effective_limit(query.limit, opts.max_limit);
     let limit_i64 = i64::try_from(limit)
         .map_err(|_| QueryError::InvalidInput("limit exceeds i64::MAX".into()))?;
     params.push(QueryValue::Integer(limit_i64));
@@ -1331,7 +1355,8 @@ fn compile_variable_length(
         sql,
         params,
         return_vars: query.return_items.clone(),
-        warnings: limit_warning.into_iter().collect(),
+        warnings: Vec::new(),
+        truncation_check,
     })
 }
 
@@ -1540,85 +1565,100 @@ mod tests {
 
     #[test]
     fn limit_capped_by_max_limit() {
-        // Query requests 1000, max_limit is 500 — result should be 500
+        // Query requests 1000, max_limit is 500 — the compiler now emits a
+        // sentinel LIMIT of 501 so the execution site can detect and warn on
+        // real truncation (issue #777); the returned rows are still capped
+        // at 500 once the sentinel is stripped at the execution site.
         let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 1000").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
         let limit_param = compiled.params.last().unwrap();
         assert!(
-            matches!(limit_param, QueryValue::Integer(500)),
-            "expected Integer(500), got {limit_param:?}"
+            matches!(limit_param, QueryValue::Integer(501)),
+            "expected Integer(501), got {limit_param:?}"
         );
     }
 
     #[test]
-    fn limit_over_cap_emits_truncation_warning() {
-        // LIMIT 1000 against the default max_limit=500 — the clamp applies AND
-        // the caller must be told the result set was truncated (issue #777).
+    fn limit_over_cap_requests_sentinel_row() {
+        // LIMIT 1000 against the default max_limit=500 — the cap is binding,
+        // so the compiler must fetch a max_limit+1 sentinel row rather than
+        // inferring truncation from the requested LIMIT alone (issue #777).
         let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 1000").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
         assert_eq!(
-            compiled.warnings.len(),
-            1,
-            "warnings: {:?}",
-            compiled.warnings
+            compiled.truncation_check,
+            Some(TruncationCheck {
+                max_limit: 500,
+                requested_limit: Some(1000),
+            })
         );
-        let warning = &compiled.warnings[0];
-        assert!(warning.contains("500"), "warning: {warning}");
-        assert!(warning.contains("1000"), "warning: {warning}");
+        let limit_param = compiled.params.last().unwrap();
+        assert!(
+            matches!(limit_param, QueryValue::Integer(501)),
+            "expected sentinel LIMIT 501, got {limit_param:?}"
+        );
     }
 
     #[test]
-    fn limit_exactly_at_cap_emits_no_truncation_warning() {
-        // LIMIT 500 == max_limit exactly — nothing was dropped, no warning.
+    fn limit_exactly_at_cap_no_sentinel() {
+        // LIMIT 500 == max_limit exactly — the cap never binds, fetch exactly
+        // what was requested and no sentinel check is needed.
         let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 500").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
-        assert!(
-            compiled.warnings.is_empty(),
-            "warnings: {:?}",
-            compiled.warnings
-        );
+        assert_eq!(compiled.truncation_check, None);
+        let limit_param = compiled.params.last().unwrap();
+        assert!(matches!(limit_param, QueryValue::Integer(500)));
     }
 
     #[test]
-    fn limit_below_cap_emits_no_truncation_warning() {
-        // Explicit LIMIT 100, well under the 500 cap — not truncated.
+    fn limit_below_cap_no_sentinel() {
+        // Explicit LIMIT 100, well under the 500 cap — not truncated, no sentinel.
         let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 100").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
-        assert!(
-            compiled.warnings.is_empty(),
-            "warnings: {:?}",
-            compiled.warnings
-        );
+        assert_eq!(compiled.truncation_check, None);
+        let limit_param = compiled.params.last().unwrap();
+        assert!(matches!(limit_param, QueryValue::Integer(100)));
     }
 
     #[test]
-    fn no_explicit_limit_defaults_to_cap_with_no_warning() {
-        // No LIMIT clause at all defaults to max_limit exactly — the compiler
-        // cannot know the true match count, so it does not warn (compile-time
-        // signal only; see issue #777 design note).
+    fn no_explicit_limit_requests_sentinel_row() {
+        // No LIMIT clause at all — the cap is the only bound, and the true
+        // match count is unknown at compile time, so the compiler must fetch
+        // a sentinel row to let the execution site detect real truncation
+        // (this is issue #777's original silent-truncation case).
         let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
+        assert_eq!(
+            compiled.truncation_check,
+            Some(TruncationCheck {
+                max_limit: 500,
+                requested_limit: None,
+            })
+        );
+        let limit_param = compiled.params.last().unwrap();
         assert!(
-            compiled.warnings.is_empty(),
-            "warnings: {:?}",
-            compiled.warnings
+            matches!(limit_param, QueryValue::Integer(501)),
+            "expected sentinel LIMIT 501, got {limit_param:?}"
         );
     }
 
     #[test]
-    fn variable_length_limit_over_cap_emits_truncation_warning() {
-        // Same clamp-site coverage for the variable-length/traversal compile path.
+    fn variable_length_limit_over_cap_requests_sentinel_row() {
+        // Same sentinel-row coverage for the variable-length/traversal compile path.
         let q = gql::parse("MATCH (a)-[:extends*1..3]->(b) RETURN b LIMIT 5000").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
         assert_eq!(
-            compiled.warnings.len(),
-            1,
-            "warnings: {:?}",
-            compiled.warnings
+            compiled.truncation_check,
+            Some(TruncationCheck {
+                max_limit: 500,
+                requested_limit: Some(5000),
+            })
         );
-        let warning = &compiled.warnings[0];
-        assert!(warning.contains("500"), "warning: {warning}");
-        assert!(warning.contains("5000"), "warning: {warning}");
+        let limit_param = compiled.params.last().unwrap();
+        assert!(
+            matches!(limit_param, QueryValue::Integer(501)),
+            "expected sentinel LIMIT 501, got {limit_param:?}"
+        );
     }
 
     #[test]
@@ -2214,7 +2254,9 @@ mod tests {
         }
     }
 
-    /// max_limit=0 with no query limit: query limit defaults to 0, no crash.
+    /// max_limit=0 with no query limit: the cap is binding (0 rows allowed),
+    /// so the compiler fetches a single sentinel row (max_limit+1 = 1) to
+    /// detect whether any row exists at all, no crash.
     #[test]
     fn max_limit_zero_compiles() {
         let q = gql::parse("MATCH (a)-[:extends]->(b) RETURN a").unwrap();
@@ -2223,10 +2265,17 @@ mod tests {
             max_limit: 0,
         };
         let compiled = compile(&q, &opts).unwrap();
+        assert_eq!(
+            compiled.truncation_check,
+            Some(TruncationCheck {
+                max_limit: 0,
+                requested_limit: None,
+            })
+        );
         let limit_param = compiled.params.last().unwrap();
         assert!(
-            matches!(limit_param, QueryValue::Integer(0)),
-            "max_limit=0 should produce LIMIT 0; got {limit_param:?}"
+            matches!(limit_param, QueryValue::Integer(1)),
+            "max_limit=0 should produce sentinel LIMIT 1; got {limit_param:?}"
         );
     }
 

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -106,6 +106,23 @@ impl Default for CompileOptions {
     }
 }
 
+/// Build a truncation warning when the caller's requested limit (or the
+/// implicit default of `max_limit` when no `LIMIT` clause is present)
+/// exceeds the server-side safety cap (issue #777). Returns `None` when the
+/// effective limit is at or below the cap — a query that never asked for
+/// more than `max_limit` rows was not truncated by the clamp.
+fn truncation_warning(requested_limit: Option<usize>, max_limit: usize) -> Option<String> {
+    let effective = requested_limit.unwrap_or(max_limit);
+    if effective > max_limit {
+        Some(format!(
+            "result set capped at {max_limit} rows; requested limit {effective} exceeds the \
+             cap — use LIMIT/OFFSET to page through the remaining results"
+        ))
+    } else {
+        None
+    }
+}
+
 /// Compile a `GqlQuery` AST to a parameterized SQL string and bound parameters.
 pub fn compile(query: &GqlQuery, opts: &CompileOptions) -> Result<CompiledQuery, QueryError> {
     if query.pattern.elements.is_empty() {
@@ -121,7 +138,10 @@ pub fn compile(query: &GqlQuery, opts: &CompileOptions) -> Result<CompiledQuery,
     } else {
         compile_fixed_length(&query, opts)?
     };
-    compiled.warnings = warnings;
+    // compile_fixed_length/compile_variable_length may already have pushed a
+    // truncation warning (clamp sites) onto `compiled.warnings` — extend,
+    // don't overwrite, so both sources of warnings survive.
+    compiled.warnings.extend(warnings);
 
     // Defense-in-depth: assert the emitted SQL is SELECT-only.
     // The parsers already reject write-shaped input; this guard ensures a future
@@ -559,6 +579,7 @@ fn compile_fixed_length(
         }
     }
 
+    let limit_warning = truncation_warning(query.limit, opts.max_limit);
     let limit = query.limit.unwrap_or(opts.max_limit).min(opts.max_limit);
     let limit_i64 = i64::try_from(limit)
         .map_err(|_| QueryError::InvalidInput("limit exceeds i64::MAX".into()))?;
@@ -577,7 +598,7 @@ fn compile_fixed_length(
         sql,
         params,
         return_vars: query.return_items.clone(),
-        warnings: Vec::new(),
+        warnings: limit_warning.into_iter().collect(),
     })
 }
 
@@ -1136,6 +1157,7 @@ fn compile_variable_length(
         end_conditions.push(format!("t.depth >= ?{}", params.len()));
     }
 
+    let limit_warning = truncation_warning(query.limit, opts.max_limit);
     let limit = query.limit.unwrap_or(opts.max_limit).min(opts.max_limit);
     let limit_i64 = i64::try_from(limit)
         .map_err(|_| QueryError::InvalidInput("limit exceeds i64::MAX".into()))?;
@@ -1309,7 +1331,7 @@ fn compile_variable_length(
         sql,
         params,
         return_vars: query.return_items.clone(),
-        warnings: Vec::new(),
+        warnings: limit_warning.into_iter().collect(),
     })
 }
 
@@ -1526,6 +1548,77 @@ mod tests {
             matches!(limit_param, QueryValue::Integer(500)),
             "expected Integer(500), got {limit_param:?}"
         );
+    }
+
+    #[test]
+    fn limit_over_cap_emits_truncation_warning() {
+        // LIMIT 1000 against the default max_limit=500 — the clamp applies AND
+        // the caller must be told the result set was truncated (issue #777).
+        let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 1000").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert_eq!(
+            compiled.warnings.len(),
+            1,
+            "warnings: {:?}",
+            compiled.warnings
+        );
+        let warning = &compiled.warnings[0];
+        assert!(warning.contains("500"), "warning: {warning}");
+        assert!(warning.contains("1000"), "warning: {warning}");
+    }
+
+    #[test]
+    fn limit_exactly_at_cap_emits_no_truncation_warning() {
+        // LIMIT 500 == max_limit exactly — nothing was dropped, no warning.
+        let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 500").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.warnings.is_empty(),
+            "warnings: {:?}",
+            compiled.warnings
+        );
+    }
+
+    #[test]
+    fn limit_below_cap_emits_no_truncation_warning() {
+        // Explicit LIMIT 100, well under the 500 cap — not truncated.
+        let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a LIMIT 100").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.warnings.is_empty(),
+            "warnings: {:?}",
+            compiled.warnings
+        );
+    }
+
+    #[test]
+    fn no_explicit_limit_defaults_to_cap_with_no_warning() {
+        // No LIMIT clause at all defaults to max_limit exactly — the compiler
+        // cannot know the true match count, so it does not warn (compile-time
+        // signal only; see issue #777 design note).
+        let q = gql::parse("MATCH (a:concept)-[e]->(b) RETURN a").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.warnings.is_empty(),
+            "warnings: {:?}",
+            compiled.warnings
+        );
+    }
+
+    #[test]
+    fn variable_length_limit_over_cap_emits_truncation_warning() {
+        // Same clamp-site coverage for the variable-length/traversal compile path.
+        let q = gql::parse("MATCH (a)-[:extends*1..3]->(b) RETURN b LIMIT 5000").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert_eq!(
+            compiled.warnings.len(),
+            1,
+            "warnings: {:?}",
+            compiled.warnings
+        );
+        let warning = &compiled.warnings[0];
+        assert!(warning.contains("500"), "warning: {warning}");
+        assert!(warning.contains("5000"), "warning: {warning}");
     }
 
     #[test]

--- a/crates/khive-query/src/lib.rs
+++ b/crates/khive-query/src/lib.rs
@@ -8,7 +8,7 @@ pub mod parsers;
 pub mod validate;
 
 pub use ast::{GqlQuery, QueryValue, ReturnItem, WhereExpr};
-pub use compilers::sql::{compile, CompileOptions, CompiledQuery};
+pub use compilers::sql::{compile, CompileOptions, CompiledQuery, TruncationCheck};
 pub use error::QueryError;
 pub use language::{parse, parse_auto, QueryLanguage};
 pub use validate::{validate, validate_pattern_shape, validate_with_warnings, MAX_DEPTH};

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -3608,7 +3608,8 @@ impl KhiveRuntime {
             .map(|ns| ns.as_str().to_string())
             .collect();
         let compiled = khive_query::compile(&ast, &opts)?;
-        let warnings = compiled.warnings;
+        let mut warnings = compiled.warnings;
+        let truncation_check = compiled.truncation_check;
 
         // Convert QueryValue params (query-layer type) to SqlValue (storage-layer type)
         // at the query–storage boundary.
@@ -3630,7 +3631,31 @@ impl KhiveRuntime {
             params,
             label: None,
         };
-        let rows = reader.query_all(stmt).await?;
+        let mut rows = reader.query_all(stmt).await?;
+
+        // When the server-side cap was the binding constraint, the compiled
+        // SQL asked for one extra (sentinel) row. Its presence in the actual
+        // result set — not the requested LIMIT — is the truncation signal
+        // (issue #777): a `LIMIT 1000` that only matches 20 rows must not
+        // warn, and a query with no `LIMIT` that matches 501+ rows must.
+        if let Some(check) = truncation_check {
+            if rows.len() > check.max_limit {
+                rows.truncate(check.max_limit);
+                warnings.push(match check.requested_limit {
+                    Some(requested) => format!(
+                        "result set capped at {} rows; requested limit {requested} exceeds the \
+                         cap — use LIMIT/OFFSET to page through the remaining results",
+                        check.max_limit
+                    ),
+                    None => format!(
+                        "result set capped at {} rows; more than {} rows matched with no LIMIT \
+                         clause — use LIMIT/OFFSET to page through the remaining results",
+                        check.max_limit, check.max_limit
+                    ),
+                });
+            }
+        }
+
         Ok(QueryResult { rows, warnings })
     }
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -345,6 +345,174 @@ async fn query_via_gql() {
 }
 
 // =============================================================================
+// GQL query truncation warning (issue #777)
+//
+// The compiler cannot infer truncation from the requested LIMIT alone — it
+// must observe whether a real (max_limit + 1)-th match exists. These tests
+// exercise the full compile -> execute -> strip-sentinel -> warn pipeline
+// against real result sets straddling the default 500-row cap.
+// =============================================================================
+
+/// Seed `n` concept entities into a fresh namespace and return the token.
+async fn seed_concepts(rt: &KhiveRuntime, ns: &str, n: usize) -> khive_runtime::NamespaceToken {
+    let tok = rt.authorize(Namespace::parse(ns).unwrap()).unwrap();
+    for i in 0..n {
+        rt.create_entity(
+            &tok,
+            "concept",
+            None,
+            &format!("seed-{i}"),
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+    }
+    tok
+}
+
+#[tokio::test]
+async fn no_explicit_limit_under_and_at_cap_emits_no_warning() {
+    let rt = rt();
+
+    // 499 matches, no explicit LIMIT: below the cap, all rows returned, no warning.
+    let tok_499 = seed_concepts(&rt, "trunc-499", 499).await;
+    let result_499 = rt
+        .query_with_metadata(
+            &tok_499,
+            "MATCH (a:concept) RETURN a",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result_499.rows.len(), 499);
+    assert!(
+        result_499.warnings.is_empty(),
+        "499 matches under the cap must not warn: {:?}",
+        result_499.warnings
+    );
+
+    // Exactly 500 matches, no explicit LIMIT: right at the cap, no truncation, no warning.
+    let tok_500 = seed_concepts(&rt, "trunc-500", 500).await;
+    let result_500 = rt
+        .query_with_metadata(
+            &tok_500,
+            "MATCH (a:concept) RETURN a",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result_500.rows.len(), 500);
+    assert!(
+        result_500.warnings.is_empty(),
+        "exactly 500 matches must not warn (nothing was dropped): {:?}",
+        result_500.warnings
+    );
+}
+
+#[tokio::test]
+async fn no_explicit_limit_over_cap_warns_and_strips_sentinel() {
+    let rt = rt();
+
+    // 501 matches, no explicit LIMIT — this is issue #777's original silent-
+    // truncation case: the cap is the only bound, and the compiler cannot know
+    // ahead of time that a 501st row exists.
+    let tok = seed_concepts(&rt, "trunc-501", 501).await;
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept) RETURN a",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.rows.len(),
+        500,
+        "sentinel row must be stripped; exactly max_limit rows must be returned"
+    );
+    assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
+    assert!(result.warnings[0].contains("500"), "{}", result.warnings[0]);
+
+    // The sentinel row must not leak into the returned set: every row must be
+    // a distinct seeded entity.
+    let names: std::collections::HashSet<_> = result
+        .rows
+        .iter()
+        .filter_map(|r| match r.get("a_name") {
+            Some(khive_storage::types::SqlValue::Text(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names.len(), 500, "sentinel row must not leak into results");
+}
+
+#[tokio::test]
+async fn explicit_limit_variants_against_501_matches() {
+    let rt = rt();
+    let tok = seed_concepts(&rt, "trunc-501-limits", 501).await;
+
+    // LIMIT above the cap: the cap still binds, warning fires, sentinel stripped.
+    let above_cap = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept) RETURN a LIMIT 600",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(above_cap.rows.len(), 500);
+    assert_eq!(
+        above_cap.warnings.len(),
+        1,
+        "LIMIT above cap with 501 real matches must warn: {:?}",
+        above_cap.warnings
+    );
+    assert!(above_cap.warnings[0].contains("600"));
+    assert!(above_cap.warnings[0].contains("500"));
+
+    // LIMIT exactly at the cap: the cap never binds (requested <= max_limit),
+    // so no sentinel is fetched and no warning fires, even though 501 rows
+    // actually match — the caller asked for exactly 500 and got exactly 500.
+    let at_cap = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept) RETURN a LIMIT 500",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(at_cap.rows.len(), 500);
+    assert!(
+        at_cap.warnings.is_empty(),
+        "LIMIT == cap must not warn: {:?}",
+        at_cap.warnings
+    );
+
+    // LIMIT below the cap: this is the reviewer's false-positive regression
+    // case (LIMIT above the requested value but under real matches would have
+    // wrongly warned under the old requested-limit-only inference). Here the
+    // requested LIMIT is under the cap, so it must never warn regardless of
+    // how many rows actually match.
+    let below_cap = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept) RETURN a LIMIT 100",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(below_cap.rows.len(), 100);
+    assert!(
+        below_cap.warnings.is_empty(),
+        "LIMIT below cap must not warn: {:?}",
+        below_cap.warnings
+    );
+}
+
+// =============================================================================
 // Namespace isolation
 // =============================================================================
 

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -512,6 +512,33 @@ async fn explicit_limit_variants_against_501_matches() {
     );
 }
 
+#[tokio::test]
+async fn explicit_limit_over_cap_with_few_real_matches_emits_no_warning() {
+    let rt = rt();
+
+    // Only 20 real matches, but the explicit LIMIT (600) exceeds the cap
+    // (500). This is the false-positive regression case: the old
+    // warn-whenever-LIMIT-exceeds-cap inference would have fired here even
+    // though nothing was actually truncated. All 20 rows must come back and
+    // no warning must fire.
+    let tok = seed_concepts(&rt, "trunc-20-limit-over-cap", 20).await;
+    let result = rt
+        .query_with_metadata(
+            &tok,
+            "MATCH (a:concept) RETURN a LIMIT 600",
+            khive_query::CompileOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 20);
+    assert!(
+        result.warnings.is_empty(),
+        "LIMIT above cap with fewer real matches than the cap must not warn: {:?}",
+        result.warnings
+    );
+}
+
 // =============================================================================
 // Namespace isolation
 // =============================================================================


### PR DESCRIPTION
## Summary

GQL execution caps results at `max_limit`, which defaults to 500 rows. Previously, callers could not distinguish an exact 500-row result from a larger result set truncated to 500. Inferring truncation from the requested limit would also be incorrect because `LIMIT 600` may match only a few rows, while a query with no explicit limit may match more than the cap.

## Implementation

- The compiler now uses `effective_limit` for both fixed-length and variable-length queries. An explicit limit at or below `max_limit` is emitted unchanged. When no limit is specified or the explicit limit exceeds the cap, the SQL requests `max_limit + 1` rows so the extra row acts as a truncation sentinel.
- `CompiledQuery` adds the public `truncation_check: Option<TruncationCheck>` field, and `TruncationCheck` is exported from `khive-query`. It carries the applied `max_limit` and the optional explicit requested limit to the execution layer.
- `KhiveRuntime::query_with_metadata` executes the sentinel query and checks the actual row count. If more than `max_limit` rows were returned, it trims the sentinel row, returns exactly the capped number of rows, and appends a pagination warning. The warning distinguishes an explicit over-cap request from a query with no `LIMIT` clause.
- No warning is emitted when the sentinel is absent or when the query returns no sentinel row. This avoids false positives for explicit limits above the cap with few real matches. An explicit limit equal to or below the cap remains caller-selected behavior and does not trigger truncation detection.
- Compiler warnings are extended rather than replaced, preserving existing validation warnings alongside any runtime truncation warning in the existing `QueryResult.warnings` response path.

## Test coverage

Compiler tests cover the emitted limit and metadata for both compile paths:

- `limit_capped_by_max_limit`
- `limit_over_cap_requests_sentinel_row`
- `limit_exactly_at_cap_no_sentinel`
- `limit_below_cap_no_sentinel`
- `no_explicit_limit_requests_sentinel_row`
- `variable_length_limit_over_cap_requests_sentinel_row`
- `max_limit_zero_compiles`

Runtime integration tests exercise real result counts around the 500-row boundary:

- `no_explicit_limit_under_and_at_cap_emits_no_warning`
- `no_explicit_limit_over_cap_warns_and_strips_sentinel`
- `explicit_limit_variants_against_501_matches`
- `explicit_limit_over_cap_with_few_real_matches_emits_no_warning`

Closes #777
