### PR TITLE
fix(runtime): serve stale ANN during rebuild and unblock recall request path

### DIFF
--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -18,6 +18,7 @@ khive-retrieval = { version = "0.3.0", path = "../khive-retrieval" }
 khive-score = { version = "0.3.0", path = "../khive-score" }
 khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }
 khive-vamana = { version = "0.3.0", path = "../khive-vamana" }
+blake3 = { workspace = true }
 inventory = { workspace = true }
 khive-storage = { version = "0.3.0", path = "../khive-storage" }
 async-trait = { workspace = true }

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -51,6 +51,14 @@ pub(crate) struct AnnBridge {
     /// corpus can never clobber an already-installed fresher build, and a
     /// build that snapshotted a fresher corpus always wins.
     pub(crate) generation: u64,
+    /// Durable corpus epoch (`memory_ann_epoch` table) observed at build/load
+    /// time (#812 review REQUEST CHANGES HIGH). Distinct from `generation`,
+    /// which lives only in this process's memory and resets to 0 on restart
+    /// — `epoch_baseline` is compared against a value written to the shared
+    /// SQLite file, so it is the only signal a warm daemon has for an
+    /// out-of-process corpus mutation (`kkernel reindex`) that never goes
+    /// through this daemon's `bump_generation` call at all.
+    pub(crate) epoch_baseline: u64,
 }
 
 /// Shared ANN state: per-`(namespace, model)` indexes with at-most-one-background-build guard.
@@ -85,10 +93,24 @@ pub(crate) struct AnnState {
     /// happened to acquire the per-model lock first even if it had
     /// snapshotted a now-stale corpus.
     generations: Mutex<HashMap<AnnKey, u64>>,
+    /// Debounce state for `maybe_check_durable_epoch` (#812 review REQUEST
+    /// CHANGES HIGH): last time this process actually paid for a
+    /// `memory_ann_epoch` SELECT for a given key, so the warm-hit recall
+    /// path amortizes the cross-process freshness check instead of adding a
+    /// DB round-trip to every single recall.
+    last_epoch_check: std::sync::Mutex<HashMap<AnnKey, std::time::Instant>>,
     /// Counts how many times `search_loaded` returned a warm hit. Test-only;
     /// call `reset_warm_route_count()` between operations to isolate counts.
     #[cfg(test)]
     pub(crate) warm_route_count: AtomicUsize,
+    /// Test-only synchronization point: notified right before each rebuild
+    /// attempt inside `ensure_ann_background`'s tracked task commits to the
+    /// generation floor it captured (#812 review REQUEST CHANGES MEDIUM-2).
+    /// Scoped per-`AnnState` (not a process-global static) so one test's
+    /// notifications can never be consumed by a different test's waiter —
+    /// each test gets its own via `new_shared()`.
+    #[cfg(test)]
+    pub(crate) attempt_floor_notify: tokio::sync::Notify,
 }
 
 pub(crate) type SharedAnn = Arc<AnnState>;
@@ -99,8 +121,11 @@ pub(crate) fn new_shared() -> SharedAnn {
         warming: std::sync::Mutex::new(HashSet::new()),
         model_locks: Mutex::new(HashMap::new()),
         generations: Mutex::new(HashMap::new()),
+        last_epoch_check: std::sync::Mutex::new(HashMap::new()),
         #[cfg(test)]
         warm_route_count: AtomicUsize::new(0),
+        #[cfg(test)]
+        attempt_floor_notify: tokio::sync::Notify::new(),
     })
 }
 
@@ -155,6 +180,134 @@ async fn installed_is_fresh(ann: &SharedAnn, key: &AnnKey, min_generation: u64) 
 pub(crate) async fn is_current(ann: &SharedAnn, key: &AnnKey) -> bool {
     let target_generation = current_generation(ann, key).await;
     installed_is_fresh(ann, key, target_generation).await
+}
+
+/// How often `maybe_check_durable_epoch` is willing to pay for a
+/// `memory_ann_epoch` SELECT for the same key (#812 review REQUEST CHANGES
+/// HIGH). A warm-hit recall calls this on every request; without debouncing
+/// that would add a synchronous DB round-trip to the hot path this whole PR
+/// exists to keep off. Zero in tests so a single direct call always performs
+/// the check deterministically instead of racing a wall-clock interval.
+#[cfg(not(test))]
+const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(test)]
+const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(0);
+
+/// Amortized cross-process freshness check (#812 review REQUEST CHANGES
+/// HIGH): compares the durable `memory_ann_epoch` row against the
+/// currently-installed entry's `epoch_baseline` for `key`, and — if the
+/// durable epoch has moved on — bumps `key`'s in-memory write-generation so
+/// the existing generation machinery (`is_current`, `ensure_ann_background`'s
+/// single-flight rebuild) takes over exactly as it would for an in-process
+/// write.
+///
+/// This exists because `kkernel reindex` runs as a separate OS process: it
+/// mutates the vector table and deletes the persisted snapshot row directly,
+/// never touching this daemon's in-memory `generations` map, so an
+/// already-warm daemon's `common.rs` recall path (`ann::is_current`) had no
+/// way to ever notice — the daemon would serve pre-reindex vectors
+/// indefinitely. `bump_memory_ann_epoch` (called from `kkernel::reindex`
+/// after it invalidates the snapshot) is the durable side of this signal.
+pub(crate) async fn maybe_check_durable_epoch(rt: &KhiveRuntime, ann: &SharedAnn, key: &AnnKey) {
+    {
+        let mut last = ann
+            .last_epoch_check
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let now = std::time::Instant::now();
+        let due = last
+            .get(key)
+            .is_none_or(|t| now.duration_since(*t) >= DURABLE_EPOCH_CHECK_INTERVAL);
+        if !due {
+            return;
+        }
+        last.insert(key.clone(), now);
+    }
+
+    let installed_baseline = ann.indexes.read().await.get(key).map(|b| b.epoch_baseline);
+    let Some(baseline) = installed_baseline else {
+        // Nothing installed yet — a genuine cache miss already routes through
+        // the normal build path, which reads the durable epoch itself.
+        return;
+    };
+    let durable = durable_epoch(rt).await;
+    if durable > baseline {
+        tracing::debug!(
+            model = %key.model,
+            baseline,
+            durable,
+            "memory ANN durable epoch advanced; marking cached entry stale"
+        );
+        bump_generation(ann, key).await;
+    }
+}
+
+/// Ensure the `memory_ann_epoch` table exists. Best-effort: called before
+/// every read/write of the durable epoch, mirroring `ensure_snapshot_schema`.
+async fn ensure_epoch_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
+    let sql = rt.sql();
+    let mut w = sql
+        .writer()
+        .await
+        .map_err(|e| RuntimeError::Internal(e.to_string()))?;
+    w.execute_script(
+        "CREATE TABLE IF NOT EXISTS memory_ann_epoch (\
+             id INTEGER PRIMARY KEY CHECK (id = 1), \
+             epoch INTEGER NOT NULL DEFAULT 0\
+         );"
+        .into(),
+    )
+    .await
+    .map_err(|e| RuntimeError::Internal(e.to_string()))
+}
+
+/// Read the durable corpus epoch (0 if the table doesn't exist yet or the
+/// row is absent — the same "nothing has ever bumped this" baseline every
+/// `AnnBridge` implicitly starts from via `epoch_baseline: 0`).
+pub(crate) async fn durable_epoch(rt: &KhiveRuntime) -> u64 {
+    let sql = rt.sql();
+    let Ok(mut reader) = sql.reader().await else {
+        return 0;
+    };
+    let Ok(rows) = reader
+        .query_all(SqlStatement {
+            sql: "SELECT epoch FROM memory_ann_epoch WHERE id = 1".into(),
+            params: vec![],
+            label: Some("memory_ann_durable_epoch_read".into()),
+        })
+        .await
+    else {
+        return 0;
+    };
+    match rows.first().and_then(|r| r.get("epoch")) {
+        Some(SqlValue::Integer(n)) if *n >= 0 => *n as u64,
+        _ => 0,
+    }
+}
+
+/// Bump the durable corpus epoch by one and return the new value. Called by
+/// `kkernel reindex` (via `khive_pack_memory::bump_memory_ann_epoch`) after
+/// it invalidates the persisted snapshot, so an already-warm daemon sharing
+/// the same database file has a durable signal to observe (#812 review
+/// REQUEST CHANGES HIGH).
+pub(crate) async fn bump_durable_epoch(rt: &KhiveRuntime) -> Result<u64, RuntimeError> {
+    ensure_epoch_schema(rt).await?;
+    let sql = rt.sql();
+    let mut w = sql
+        .writer()
+        .await
+        .map_err(|e| RuntimeError::Internal(e.to_string()))?;
+    w.execute(SqlStatement {
+        sql: "INSERT INTO memory_ann_epoch (id, epoch) VALUES (1, 1) \
+              ON CONFLICT(id) DO UPDATE SET epoch = epoch + 1"
+            .into(),
+        params: vec![],
+        label: Some("memory_ann_durable_epoch_bump".into()),
+    })
+    .await
+    .map_err(|e| RuntimeError::Internal(e.to_string()))?;
+    drop(w);
+    Ok(durable_epoch(rt).await)
 }
 
 /// Install `candidate` into the cache for `key` UNLESS an entry is already
@@ -241,6 +394,7 @@ impl AnnBridge {
             id_map,
             namespace_set,
             generation: 0,
+            epoch_baseline: 0,
         })
     }
 
@@ -252,6 +406,14 @@ impl AnnBridge {
     /// than winning one it shouldn't.
     pub(crate) fn with_generation(mut self, generation: u64) -> Self {
         self.generation = generation;
+        self
+    }
+
+    /// Stamp this build with the durable corpus epoch observed at build/load
+    /// time (#812 review REQUEST CHANGES HIGH). See `epoch_baseline`'s doc
+    /// comment for why this is tracked separately from `generation`.
+    pub(crate) fn with_epoch_baseline(mut self, epoch: u64) -> Self {
+        self.epoch_baseline = epoch;
         self
     }
 
@@ -304,6 +466,7 @@ impl AnnBridge {
             // conservative (assume the index may contain non-visible namespaces).
             namespace_set: HashSet::new(),
             generation: 0,
+            epoch_baseline: 0,
         })
     }
 
@@ -471,18 +634,53 @@ pub(crate) async fn ensure_ann_background(
         return false;
     }
 
-    // Single-flight guard.
-    {
-        let mut warming = lock_warming(ann);
-        if warming.contains(&key) {
-            return false;
-        }
-        warming.insert(key.clone());
+    if !try_take_warming_guard(ann, &key) {
+        return false;
     }
 
-    let rt = rt.clone();
-    let ann = ann.clone();
-    let model = model.to_owned();
+    // Tracked, not a bare tokio::spawn, so daemon shutdown's drain() waits for
+    // an in-flight remember-path warm instead of a SIGTERM (or a short-lived
+    // `kkernel exec` process exiting) aborting it mid-build — same rationale
+    // as recall.rs's serve-ledger append (internal review PR #583 round-1
+    // Medium). The caller still only pays for the enqueue; the build itself
+    // runs fully off the response path, unawaited.
+    spawn_rebuild_task(rt.clone(), ann.clone(), model.to_owned(), key);
+    true
+}
+
+/// Synchronously take the single-flight `warming` guard for `key`. Split out
+/// of `ensure_ann_background` so the post-release re-enqueue path in
+/// `spawn_rebuild_task` (#812 review REQUEST CHANGES MEDIUM-1) can take the
+/// guard itself and call `spawn_rebuild_task` directly instead of calling
+/// back into `ensure_ann_background` — which would make the tracked task's
+/// own future type recursively reference itself and fail to prove `Send`.
+fn try_take_warming_guard(ann: &SharedAnn, key: &AnnKey) -> bool {
+    let mut warming = lock_warming(ann);
+    if warming.contains(key) {
+        return false;
+    }
+    warming.insert(key.clone());
+    true
+}
+
+/// Spawn the tracked background-rebuild loop for `key`. The caller MUST have
+/// already taken the `warming` single-flight guard for `key` (via
+/// `try_take_warming_guard`) before calling this — it is not re-checked
+/// here.
+///
+/// Deliberately a plain (non-`async`) function, not folded back into
+/// `ensure_ann_background`: the loop below re-enqueues itself by calling
+/// this function again after releasing its guard (#812 review REQUEST
+/// CHANGES MEDIUM-1/MEDIUM-2). Calling an `async fn` that (transitively)
+/// awaits itself makes rustc unable to prove the resulting future is `Send`
+/// — the compiler reported exactly that when the re-enqueue call was
+/// `ensure_ann_background(...).await` from inside this same tracked task.
+/// Because `spawn_rebuild_task` is synchronous, the "recursive" call at the
+/// bottom of the loop is a plain function call that hands a brand-new,
+/// independent future to `track_background_task` — it never becomes part of
+/// this future's own state machine, so there is no self-referential type for
+/// Send-inference to choke on.
+fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnKey) {
     // Tied to the tracked task's own scope so it releases on every exit path
     // (success, error, or panic) rather than only the "nothing got loaded"
     // arm — see `WarmingGuard`'s doc comment (#812 review HIGH-1).
@@ -490,14 +688,7 @@ pub(crate) async fn ensure_ann_background(
         ann: ann.clone(),
         key: key.clone(),
     };
-    // Tracked, not a bare tokio::spawn, so daemon shutdown's drain() waits for
-    // an in-flight remember-path warm instead of a SIGTERM (or a short-lived
-    // `kkernel exec` process exiting) aborting it mid-build — same rationale
-    // as recall.rs's serve-ledger append (internal review PR #583 round-1
-    // Medium). The caller still only pays for the enqueue; the build itself
-    // runs fully off the response path, unawaited.
     khive_runtime::track_background_task(async move {
-        let _warming_guard = warming_guard;
         // #812 review MEDIUM (reconfirm): a write landing while this task's
         // own build is in flight bumps the generation counter, but that
         // write's own `ensure_ann_background` call finds `warming` already
@@ -511,11 +702,24 @@ pub(crate) async fn ensure_ann_background(
         // the floor THIS attempt started from — if a write raced in during
         // the build, immediately re-enqueue another attempt against this
         // same task rather than waiting on an external caller.
+        //
+        // #812 review REQUEST CHANGES MEDIUM-2: bounded, not unconditional —
+        // continuous writes during every rebuild would otherwise spin this
+        // task (and the `warming` guard it holds) forever. `ATTEMPT_BOUND`
+        // caps consecutive rebuild attempts within a single tracked task;
+        // once exhausted the remainder is left for the post-release
+        // recheck below (or a later recall/write) to pick up, documented in
+        // ADR-107.
+        const ATTEMPT_BOUND: u32 = 3;
+        let mut attempt_floor = current_generation(&ann, &key).await;
+        let mut attempts: u32 = 0;
         loop {
             let Ok(token) = rt.authorize(Namespace::local()) else {
                 break;
             };
-            let attempt_floor = current_generation(&ann, &key).await;
+            attempts += 1;
+            #[cfg(test)]
+            ann.attempt_floor_notify.notify_one();
             match ensure_ann_for_model(&rt, &token, &ann, &model).await {
                 Ok(status) => {
                     tracing::debug!(?status, model = %model, "memory ANN background warm complete");
@@ -532,16 +736,44 @@ pub(crate) async fn ensure_ann_background(
                     break;
                 }
             }
-            if current_generation(&ann, &key).await <= attempt_floor {
+            let now_generation = current_generation(&ann, &key).await;
+            if now_generation <= attempt_floor {
                 // Nothing raced in while we built — either the corpus is
                 // fully caught up, or (e.g. an empty corpus with no further
                 // writes) there is nothing new to catch up to. Either way,
                 // looping again would spin without making progress.
                 break;
             }
+            if attempts >= ATTEMPT_BOUND {
+                tracing::debug!(
+                    model = %model,
+                    attempts,
+                    "memory ANN background warm hit its rebuild-attempt bound; \
+                     deferring the remainder to the next recall or write"
+                );
+                break;
+            }
+            attempt_floor = now_generation;
+        }
+        // #812 review REQUEST CHANGES MEDIUM-1: release the guard BEFORE this
+        // final freshness recheck, not after. The old code held the guard
+        // for the rest of the async block's scope, so it only dropped once
+        // this task returned — a write landing in the gap between the
+        // loop's last `current_generation` read above and that implicit
+        // drop would find `warming` still occupied by THIS task at
+        // `ensure_ann_background`'s single-flight check, silently no-op, and
+        // be stranded once the guard finally disappeared with nobody left to
+        // notice. Dropping explicitly here, then re-checking, closes that
+        // window: if the recheck finds the generation moved on, `warming` is
+        // already free, so taking it again below starts a genuinely new task
+        // instead of rejecting itself.
+        drop(warming_guard);
+        if current_generation(&ann, &key).await > attempt_floor
+            && try_take_warming_guard(&ann, &key)
+        {
+            spawn_rebuild_task(rt, ann, model, key);
         }
     });
-    true
 }
 
 /// Warm the global per-model ANN indexes at startup — skips already-loaded keys.
@@ -760,6 +992,14 @@ async fn ensure_ann_for_model_inner(
         return Ok(AnnEnsureStatus::AlreadyLoaded);
     }
 
+    // Captured once per attempt, same rationale as `target_generation`
+    // above: whatever gets installed by this attempt (snapshot-load or
+    // rebuild) is stamped with the durable epoch observed here, so a LATER
+    // `maybe_check_durable_epoch` call only flags this entry stale once a
+    // reindex bumps the epoch again after this point (#812 review REQUEST
+    // CHANGES HIGH).
+    let target_epoch = durable_epoch(rt).await;
+
     // Try snapshot warm-load. Both the shallow `CorpusFingerprint` (vector
     // count + dimensions) AND the durable `CorpusContentHash` (a blake3 hash
     // of the exact ordered subject-id + embedding-byte rows a build consumes)
@@ -795,7 +1035,9 @@ async fn ensure_ann_for_model_inner(
                         .await
                         .unwrap_or_default();
                     bridge.set_namespace_set(ns_set);
-                    let bridge = bridge.with_generation(target_generation);
+                    let bridge = bridge
+                        .with_generation(target_generation)
+                        .with_epoch_baseline(target_epoch);
                     install_if_fresher(ann, &key, bridge).await;
                     tracing::debug!(namespace = %ns, model = %model, "memory ANN loaded from snapshot");
                     return Ok(AnnEnsureStatus::LoadedSnapshot);
@@ -840,7 +1082,9 @@ async fn ensure_ann_for_model_inner(
                 return Ok(AnnEnsureStatus::DiscardedStaleBuild);
             }
             let vector_count = bridge.id_map.len();
-            let bridge = bridge.with_generation(target_generation);
+            let bridge = bridge
+                .with_generation(target_generation)
+                .with_epoch_baseline(target_epoch);
             if let Some(fingerprint) = fp_after {
                 // `content_hash` was computed from the exact rows this
                 // build's own scan read (#812 review re-confirm HIGH-B) —
@@ -2264,21 +2508,169 @@ mod tests {
         );
     }
 
+    // ── #812 review REQUEST CHANGES HIGH: durable epoch vs. warm daemon ─────
+
+    /// Reviewer-requested regression test (#812 review REQUEST CHANGES
+    /// HIGH): `kkernel reindex` runs as a SEPARATE process from a khive
+    /// daemon that already warmed its ANN index — the two share a database
+    /// file but nothing in-memory. Deleting the persisted snapshot row (as
+    /// `invalidate_active_memory_vamana_snapshot` does) is invisible to the
+    /// warm daemon's `common.rs` recall path, which only ever consults its
+    /// own in-memory generation counter. This models exactly that scenario
+    /// with two independent `KhiveRuntime`/`AnnState` pairs sharing one
+    /// SQLite file, and asserts the amortized durable-epoch check
+    /// (`maybe_check_durable_epoch`) is what closes the gap.
+    ///
+    /// Fail-on-revert: without `bump_memory_ann_epoch`/`maybe_check_durable_epoch`,
+    /// `is_current` on `ann1` stays `true` forever after `rt2`'s reindex, and
+    /// the final `ensure_ann_for_model` call returns `AlreadyLoaded` instead
+    /// of `Built`.
+    #[tokio::test]
+    async fn maybe_check_durable_epoch_detects_reindex_from_a_separate_warm_daemon() {
+        const MODEL: &str = "ann-warm-durable-epoch-test-model";
+        const DIMS: usize = 8;
+
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-memory-ann-durable-epoch-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp db dir");
+        let db_path = tmp.path().join("khive-graph.db");
+        std::mem::forget(tmp);
+
+        // "Daemon": first runtime, warms the ANN index and stays resident —
+        // exactly like a long-lived `kkernel mcp --daemon` process.
+        let rt1 = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(db_path.clone()),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..khive_runtime::RuntimeConfig::default()
+        })
+        .expect("runtime 1");
+        rt1.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+        let token1 = rt1.authorize(Namespace::local()).expect("authorize local");
+
+        let mut note_ids = Vec::new();
+        for i in 0..4u32 {
+            let note = rt1
+                .create_note_with_decay_for_embedding_model(
+                    &token1,
+                    "memory",
+                    None,
+                    &format!("durable epoch note {i}"),
+                    Some(0.7),
+                    0.01,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+                .expect("create note");
+            note_ids.push(note.id);
+        }
+
+        let ann1 = new_shared();
+        let key = AnnKey::from_token(&token1, MODEL);
+        let status = ensure_ann_for_model(&rt1, &token1, &ann1, MODEL)
+            .await
+            .expect("first warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "expected initial build, got: {status:?}"
+        );
+
+        // "Reindexer": a SEPARATE runtime pointed at the same DB file, like
+        // `kkernel reindex` invoked while the daemon above stays warm.
+        let rt2 = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..khive_runtime::RuntimeConfig::default()
+        })
+        .expect("runtime 2");
+        rt2.register_embedder(HashVecProvider {
+            model_name: MODEL.to_owned(),
+            dims: DIMS,
+        });
+
+        // Vector-only re-embed, bypassing the notes table entirely — same
+        // shape as `reindex.rs`'s `embed_and_store_batch`.
+        {
+            let table_name = format!("vec_{}", sanitize_model_key(MODEL));
+            let replacement: Vec<f32> = (0..DIMS).map(|i| (i as f32 + 100.0) / 7.0).collect();
+            let bytes: Vec<u8> = replacement.iter().flat_map(|f| f.to_le_bytes()).collect();
+            let sql = rt2.sql();
+            let mut w = sql.writer().await.expect("writer");
+            w.execute(SqlStatement {
+                sql: format!(
+                    "UPDATE {table_name} SET embedding = ?1 \
+                     WHERE subject_id = ?2 AND embedding_model = ?3"
+                ),
+                params: vec![
+                    SqlValue::Blob(bytes),
+                    SqlValue::Text(note_ids[0].to_string()),
+                    SqlValue::Text(MODEL.to_string()),
+                ],
+                label: Some("test_durable_epoch_vector_reindex".into()),
+            })
+            .await
+            .expect("overwrite embedding");
+        }
+        // The reindexer deletes the persisted snapshot AND bumps the durable
+        // epoch, exactly like `invalidate_active_memory_vamana_snapshot` +
+        // `khive_pack_memory::bump_memory_ann_epoch` in `kkernel::reindex`.
+        bump_durable_epoch(&rt2).await.expect("bump durable epoch");
+
+        // Sanity: before the epoch check runs, the daemon's cache still
+        // (wrongly) considers itself fresh — its in-memory generation was
+        // never touched by `rt2`'s write.
+        assert!(
+            is_current(&ann1, &key).await,
+            "sanity: the daemon's cache must still consider itself fresh before \
+             the durable-epoch check runs"
+        );
+        maybe_check_durable_epoch(&rt1, &ann1, &key).await;
+        assert!(
+            !is_current(&ann1, &key).await,
+            "the amortized durable-epoch check must detect a cross-process \
+             reindex and mark the warm daemon's cached entry stale (#812 \
+             review REQUEST CHANGES HIGH)"
+        );
+
+        let status = ensure_ann_for_model(&rt1, &token1, &ann1, MODEL)
+            .await
+            .expect("rebuild after epoch mismatch");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "the warm daemon must rebuild once its durable-epoch check detects \
+             the out-of-process reindex, got: {status:?}"
+        );
+    }
+
     // ── #812 review re-confirm MEDIUM: high-water re-enqueue on drop ────────
 
-    /// Reviewer-requested regression test (#812 review re-confirm MEDIUM): a
-    /// write landing while a background warm is already in flight must
-    /// eventually converge WITHOUT any later `memory.recall` or
-    /// `memory.remember` re-triggering the warm — the in-flight task's own
-    /// loop must notice the generation moved past what it built for and
-    /// re-enqueue itself.
+    /// Reviewer-requested regression test (#812 review re-confirm MEDIUM,
+    /// hardened per #812 review REQUEST CHANGES MEDIUM-2): a write landing
+    /// while a background warm is already in flight must eventually
+    /// converge WITHOUT any later `memory.recall` or `memory.remember`
+    /// re-triggering the warm — the in-flight task's own loop must notice
+    /// the generation moved past what it built for and re-enqueue itself.
+    ///
+    /// Uses `attempt_floor_notify` as an explicit barrier instead of relying
+    /// on a 300-note build being slow enough to still be in flight when
+    /// `bump_generation` runs — the reviewer flagged that timing-based
+    /// version as not provably exercising the re-enqueue path at all. The
+    /// barrier guarantees the write lands strictly after the task has
+    /// committed to its first attempt's generation floor, which is exactly
+    /// the window the re-enqueue loop exists to cover.
     ///
     /// Fail-on-revert: reverting `ensure_ann_background`'s tracked task back
     /// to a single `ensure_ann_for_model` attempt (no loop) makes this test
-    /// flaky-to-failing: whenever the `bump_generation` call below lands
-    /// after the task has already captured its build floor, nothing is left
-    /// to notice the index fell behind, and `is_current` never becomes true
-    /// within the poll budget.
+    /// fail deterministically: nothing is left to notice the index fell
+    /// behind after the barrier releases, and `is_current` never becomes
+    /// true within the poll budget.
     #[tokio::test]
     #[serial(background_tasks)]
     async fn ensure_ann_background_converges_on_write_during_warm_with_no_further_recalls() {
@@ -2287,10 +2679,7 @@ mod tests {
         let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
 
         let token = rt.authorize(Namespace::local()).expect("authorize local");
-        // A few hundred notes so the graph build takes long enough (spawn_blocking
-        // I/O + Vamana construction) to reliably still be in flight when the
-        // `bump_generation` call right below executes.
-        for i in 0..300u32 {
+        for i in 0..8u32 {
             rt.create_note_with_decay_for_embedding_model(
                 &token,
                 "memory",
@@ -2309,10 +2698,15 @@ mod tests {
         let ann = new_shared();
         let key = AnnKey::from_token(&token, MODEL);
 
+        let notified = ann.attempt_floor_notify.notified();
         assert!(
             ensure_ann_background(&rt, &token, &ann, MODEL).await,
             "first call for a fresh key must start a background warm"
         );
+        // Wait for the tracked task to actually commit to its first
+        // attempt's generation floor before bumping — this is the barrier
+        // that replaces the old "300 notes should be slow enough" gamble.
+        notified.await;
         // Simulate a write racing in while the warm above is still building —
         // bump the generation exactly like `memory.remember` does, but
         // deliberately do NOT call `ensure_ann_background` again: the whole

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -98,8 +98,19 @@ pub(crate) fn new_shared() -> SharedAnn {
 }
 
 /// Bump `key`'s write-generation counter and return the NEW value (#750).
-/// Called by `memory.remember` for every model whose corpus the write may
-/// have affected, right alongside the existing cache invalidation.
+/// Called by every memory write path (`memory.remember`, `memory.prune`,
+/// and the KG-side note-mutation hook in `pack.rs`) for every model the
+/// write may have affected.
+///
+/// #791: this is now the ONLY invalidation signal a write emits — it no
+/// longer clears the in-memory index or deletes the persisted snapshot.
+/// The stale-but-installed entry stays put and keeps serving reads
+/// (`ann::search_loaded` doesn't consult freshness at all;
+/// `handlers/common.rs`'s recall path serves it and fires the
+/// already-existing `ensure_ann_background` warm rather than blocking the
+/// request on a synchronous rebuild). `install_if_fresher` guarantees the
+/// stale entry is replaced, never merged or corrupted, once a build that
+/// snapshotted at or after this generation installs.
 pub(crate) async fn bump_generation(ann: &SharedAnn, key: &AnnKey) -> u64 {
     let mut gens = ann.generations.lock().await;
     let slot = gens.entry(key.clone()).or_insert(0);
@@ -364,22 +375,14 @@ pub(crate) async fn index_namespace_set(ann: &SharedAnn, key: &AnnKey) -> Option
 }
 
 /// Remove a single in-memory ANN slot and its warming guard entry.
+///
+/// Only used on a genuine ANN search failure (`handlers/common.rs`) — a
+/// write no longer calls anything like this (#791; see `bump_generation`'s
+/// doc comment). Evicting the slot there is correct because the cached
+/// entry itself just proved unusable, not merely stale.
 pub(crate) async fn clear_key(ann: &SharedAnn, key: &AnnKey) {
     ann.indexes.write().await.remove(key);
     ann.warming.lock().await.remove(key);
-}
-
-/// Remove all in-memory ANN slots and warming-guard entries.
-/// Because the index is global per model, any namespace write invalidates all slots.
-pub(crate) async fn clear_namespace(ann: &SharedAnn, _namespace: &str) {
-    ann.indexes.write().await.clear();
-    ann.warming.lock().await.clear();
-}
-
-/// Clear in-memory cache and delete persisted snapshots.
-pub(crate) async fn invalidate_namespace(rt: &KhiveRuntime, ann: &SharedAnn, _namespace: &str) {
-    clear_namespace(ann, _namespace).await;
-    invalidate_snapshots(rt).await;
 }
 
 /// True when `err` is the direct result of a `spawn_blocking` cancellation —
@@ -934,7 +937,25 @@ async fn load_and_build_from_vector_store(
         return Ok(None);
     }
 
-    AnnBridge::build(flat, dims, id_map, namespace_set).map(Some)
+    // #791: `AnnBridge::build` (via `VamanaIndex::build`) is a plain
+    // synchronous, CPU-bound full graph construction — training the SQ8
+    // quantization codec and building the Vamana graph over the whole
+    // corpus scanned above. Run it on the blocking thread pool so it never
+    // monopolizes the tokio worker driving this future (and every other
+    // task scheduled on it) for the full build duration, whether this call
+    // is reached from a background warm or, on a genuine cold-start miss,
+    // directly on a recall's own request path.
+    let built =
+        tokio::task::spawn_blocking(move || AnnBridge::build(flat, dims, id_map, namespace_set))
+            .await
+            .map_err(|e| {
+                RuntimeError::Storage(StorageError::driver(
+                    khive_storage::StorageCapability::Vectors,
+                    "memory_ann_build",
+                    e,
+                ))
+            })??;
+    Ok(Some(built))
 }
 
 // ── persistence ───────────────────────────────────────────────────────────────
@@ -1037,34 +1058,6 @@ async fn try_load_snapshot(
     }
 }
 
-/// Delete the global memory Vamana snapshot rows from `retrieval_snapshots`.
-/// Best-effort — missing table is silently ignored.
-async fn invalidate_snapshots(rt: &KhiveRuntime) {
-    let pattern = "global::memory_vamana::%".to_string();
-    let sql = rt.sql();
-    let mut w = match sql.writer().await {
-        Ok(w) => w,
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to open writer for memory ANN snapshot invalidation");
-            return;
-        }
-    };
-    match w
-        .execute(SqlStatement {
-            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1".into(),
-            params: vec![SqlValue::Text(pattern)],
-            label: Some("invalidate_memory_vamana_snapshot".into()),
-        })
-        .await
-    {
-        Ok(_) => {}
-        Err(e) if e.to_string().contains("no such table") => {}
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to invalidate memory Vamana snapshots");
-        }
-    }
-}
-
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1130,48 +1123,89 @@ mod tests {
         );
     }
 
+    // ── #791: writes no longer destroy the fast fallback ────────────────────
+    //
+    // `memory.remember`/`memory.prune`/the KG note-mutation hook used to call
+    // `ann::invalidate_namespace`, which cleared every in-memory index slot
+    // AND deleted the persisted snapshot row synchronously on the write's own
+    // path. A `memory.recall` landing after that clear and before the
+    // (correctly backgrounded) rebuild finished had nothing left to serve
+    // except a full synchronous corpus rebuild inline on its own request
+    // path — issue #791's hang. The fix: a write now only bumps the model's
+    // write-generation counter (`bump_generation`, #750 machinery); the
+    // previous index and snapshot stay installed and keep serving reads
+    // until a fresher build replaces them via `install_if_fresher`.
+
     #[tokio::test]
-    async fn invalidate_namespace_clears_global_index() {
-        // After FTS+ANN consolidation, AnnKey is model-only (namespace is ignored).
-        // invalidate_namespace clears the single global index for all models.
+    async fn bump_generation_does_not_evict_installed_index_or_snapshot() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         let ann = new_shared();
-        let model_a = "model-a";
-        let model_b = "model-b";
+        let key = AnnKey::new("global", "model-x");
+        let id = Uuid::new_v4();
 
-        let id_a = Uuid::new_v4();
-        let id_b = Uuid::new_v4();
-
-        let bridge_a = AnnBridge::build(vec![1.0f32, 0.0, 0.0, 0.0], 4, vec![id_a], HashSet::new())
-            .expect("build a");
-        let bridge_b = AnnBridge::build(vec![0.0f32, 1.0, 0.0, 0.0], 4, vec![id_b], HashSet::new())
-            .expect("build b");
-
-        // Keys are model-only; namespace arg is ignored.
-        let key_a = AnnKey::new("any-ns", model_a);
-        let key_b = AnnKey::new("any-ns", model_b);
-
+        install_if_fresher(&ann, &key, tiny_bridge(id, 1)).await;
         {
-            let mut idxs = ann.indexes.write().await;
-            idxs.insert(key_a.clone(), bridge_a);
-            idxs.insert(key_b.clone(), bridge_b);
-        }
-        {
-            let mut warming = ann.warming.lock().await;
-            warming.insert(key_a.clone());
-            warming.insert(key_b.clone());
+            let idxs = ann.indexes.read().await;
+            let bridge = idxs.get(&key).expect("installed above");
+            persist_snapshot(
+                &rt,
+                "global",
+                "model-x",
+                bridge,
+                CorpusFingerprint {
+                    vector_count: 1,
+                    dimensions: 4,
+                },
+            )
+            .await
+            .expect("persist snapshot");
         }
 
-        // invalidate_namespace evicts ALL in-memory indexes (global index serves all namespaces).
-        invalidate_namespace(&rt, &ann, "any-ns").await;
+        // A write lands: it bumps the generation but must not clear anything.
+        bump_generation(&ann, &key).await;
 
         assert!(
-            ann.indexes.read().await.is_empty(),
-            "all indexes must be cleared after invalidation"
+            ann.indexes.read().await.contains_key(&key),
+            "a write must not evict the previously-installed in-memory index"
         );
         assert!(
-            ann.warming.lock().await.is_empty(),
-            "all warming guards must be cleared after invalidation"
+            try_load_snapshot(&rt, "global", "model-x").await.is_some(),
+            "a write must not delete the previously-persisted snapshot before \
+             a fresher build has durably replaced it"
+        );
+    }
+
+    /// The primitive both `handlers/common.rs`'s recall-path stale-serve and
+    /// the write paths' no-longer-clearing behavior depend on: `search_loaded`
+    /// answers from whatever is installed regardless of `is_current`, so a
+    /// cache entry that has fallen behind the write-generation counter is
+    /// still served — not treated as a miss that forces a synchronous
+    /// rebuild on the caller's own request path. Fail-on-revert: restoring
+    /// the old `if cache_fresh { search_loaded(...) } else { Ok(None) }` gate
+    /// in `common.rs` would make an equivalent check on this same primitive
+    /// return `None` here.
+    #[tokio::test]
+    async fn search_loaded_serves_stale_installed_entry_without_rebuild() {
+        let ann = new_shared();
+        let key = AnnKey::new("global", "model-x");
+        let id = Uuid::new_v4();
+
+        install_if_fresher(&ann, &key, tiny_bridge(id, 1)).await;
+        bump_generation(&ann, &key).await; // counter -> 1
+        bump_generation(&ann, &key).await; // counter -> 2, ahead of installed gen 1
+
+        assert!(
+            !is_current(&ann, &key).await,
+            "sanity: the installed entry must now be behind the write-generation counter"
+        );
+
+        let hits = search_loaded(&ann, &key, &[1.0, 0.0, 0.0, 0.0], 1)
+            .await
+            .expect("search_loaded must not error on a stale-but-installed entry");
+        assert!(
+            hits.is_some(),
+            "a stale-but-installed entry must still be served by search_loaded, \
+             not treated the same as a genuine cache miss"
         );
     }
 

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -498,7 +498,24 @@ pub(crate) async fn ensure_ann_background(
     // runs fully off the response path, unawaited.
     khive_runtime::track_background_task(async move {
         let _warming_guard = warming_guard;
-        if let Ok(token) = rt.authorize(Namespace::local()) {
+        // #812 review MEDIUM (reconfirm): a write landing while this task's
+        // own build is in flight bumps the generation counter, but that
+        // write's own `ensure_ann_background` call finds `warming` already
+        // occupied by this task and silently no-ops (the fire-once guard
+        // above) — nobody else is queued to pick that write up. The old
+        // single-attempt body relied entirely on some LATER `memory.recall`
+        // noticing `is_current` is false and re-firing this function; with
+        // no further recalls the index stayed stale forever, breaking
+        // ADR-107's per-write rebuild bound. Loop here instead: after each
+        // attempt, re-check whether the write-generation counter moved past
+        // the floor THIS attempt started from — if a write raced in during
+        // the build, immediately re-enqueue another attempt against this
+        // same task rather than waiting on an external caller.
+        loop {
+            let Ok(token) = rt.authorize(Namespace::local()) else {
+                break;
+            };
+            let attempt_floor = current_generation(&ann, &key).await;
             match ensure_ann_for_model(&rt, &token, &ann, &model).await {
                 Ok(status) => {
                     tracing::debug!(?status, model = %model, "memory ANN background warm complete");
@@ -508,10 +525,19 @@ pub(crate) async fn ensure_ann_background(
                     // spawn_blocking was cancelled by runtime teardown, not a
                     // backend failure — don't alarm on it.
                     tracing::debug!(error = %e, model = %model, "memory ANN background warm cancelled at shutdown");
+                    break;
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, model = %model, "memory ANN background build failed");
+                    break;
                 }
+            }
+            if current_generation(&ann, &key).await <= attempt_floor {
+                // Nothing raced in while we built — either the corpus is
+                // fully caught up, or (e.g. an empty corpus with no further
+                // writes) there is nothing new to catch up to. Either way,
+                // looping again would spin without making progress.
+                break;
             }
         }
     });
@@ -735,21 +761,32 @@ async fn ensure_ann_for_model_inner(
     }
 
     // Try snapshot warm-load. Both the shallow `CorpusFingerprint` (vector
-    // count + dimensions) AND the durable `CorpusContentSignal` (count + max
-    // `updated_at`) must match the live corpus (#812 review HIGH-2):
+    // count + dimensions) AND the durable `CorpusContentHash` (a blake3 hash
+    // of the exact ordered subject-id + embedding-byte rows a build consumes)
+    // must match the live corpus (#812 review re-confirm HIGH-A/HIGH-B):
     // write-generations reset to 0 on restart, so on a cold process the
     // fingerprint alone is the only signal deciding Hot vs. Stale — and a
-    // delete-one/add-one or a content re-embed preserves vector count and
-    // dimensions exactly while changing what the corpus actually contains.
-    // The content signal catches that: a new or edited note always carries
-    // a fresher `updated_at` than every prior row, so the signal changes
-    // even when the fingerprint doesn't.
+    // delete-one/add-one, a content re-embed, OR a vector-only re-embed
+    // (`kkernel reindex`, which overwrites embeddings without touching
+    // `notes.updated_at`) all preserve vector count and dimensions exactly
+    // while changing what the corpus actually contains. Hashing the raw
+    // embedding bytes themselves (not a proxy like `updated_at`) catches all
+    // three, and computing it here from a fresh scan of the SAME rows a
+    // rebuild would read — rather than a separate cheap aggregate query
+    // sampled at a different instant — closes the race where a
+    // same-cardinality write lands between "what the graph was built from"
+    // and "what the signal was sampled from".
     if let Some(persisted) = try_load_snapshot(rt, ns, model).await {
         let current_fp = compute_memory_fingerprint(rt, token, model).await;
-        let current_signal = compute_corpus_content_signal(rt, token, model).await;
         let fp_matches = current_fp.is_some_and(|fp| persisted.snapshot.fingerprint == fp);
-        let signal_matches = current_signal.is_some_and(|sig| persisted.content_signal == sig);
-        if fp_matches && signal_matches {
+        // Only pay for the full corpus-hash scan when the cheap fingerprint
+        // already agrees — a fingerprint mismatch alone is enough to know a
+        // rebuild is needed.
+        let hash_matches = fp_matches
+            && compute_corpus_content_hash(rt, token, model)
+                .await
+                .is_some_and(|hash| persisted.content_hash == hash);
+        if fp_matches && hash_matches {
             match AnnBridge::from_snapshot(persisted.snapshot) {
                 Ok(mut bridge) => {
                     // Populate namespace set from a cheap DISTINCT query so the
@@ -772,8 +809,8 @@ async fn ensure_ann_for_model_inner(
                 namespace = %ns,
                 model = %model,
                 fp_matches,
-                signal_matches,
-                "stale memory Vamana snapshot (fingerprint or content-signal mismatch); rebuilding"
+                hash_matches,
+                "stale memory Vamana snapshot (fingerprint or content-hash mismatch); rebuilding"
             );
         }
     }
@@ -791,7 +828,7 @@ async fn ensure_ann_for_model_inner(
     // overwrite that later result, regardless of which one finishes first.
     let fp_before = compute_memory_fingerprint(rt, token, model).await;
     match load_and_build_from_vector_store(rt, token, model).await {
-        Ok(Some(bridge)) => {
+        Ok(Some((bridge, content_hash))) => {
             let fp_after = compute_memory_fingerprint(rt, token, model).await;
             // If fingerprint changed during the scan, the corpus raced; discard.
             if fp_before != fp_after {
@@ -805,19 +842,15 @@ async fn ensure_ann_for_model_inner(
             let vector_count = bridge.id_map.len();
             let bridge = bridge.with_generation(target_generation);
             if let Some(fingerprint) = fp_after {
-                // Best-effort: if the content signal can't be computed right
-                // now, skip persisting rather than write a snapshot with no
-                // durable staleness check at all (a missing signal would
-                // otherwise need a placeholder that either always matches —
-                // defeating the fix — or never matches — forcing every future
-                // warm to rebuild).
-                if let Some(content_signal) = compute_corpus_content_signal(rt, token, model).await
+                // `content_hash` was computed from the exact rows this
+                // build's own scan read (#812 review re-confirm HIGH-B) —
+                // no separate sampling read, so there is no window between
+                // "what the graph was built from" and "what got persisted
+                // as the freshness signal" for a race to land in.
+                if let Err(e) =
+                    persist_snapshot(rt, ns, model, &bridge, fingerprint, content_hash).await
                 {
-                    if let Err(e) =
-                        persist_snapshot(rt, ns, model, &bridge, fingerprint, content_signal).await
-                    {
-                        tracing::warn!(error = %e, "failed to persist memory Vamana snapshot");
-                    }
+                    tracing::warn!(error = %e, "failed to persist memory Vamana snapshot");
                 }
             }
             install_if_fresher(ann, &key, bridge).await;
@@ -923,13 +956,14 @@ async fn compute_memory_fingerprint(
     })
 }
 
-/// Scan all non-deleted `note.content` vectors across all namespaces for `model` and build an
-/// `AnnBridge`. Returns `Ok(None)` when the corpus is empty or inaccessible.
+/// Scan all non-deleted `note.content` vectors across all namespaces for `model`, build an
+/// `AnnBridge`, and hash the exact rows the build consumed (#812 review
+/// re-confirm HIGH-B). Returns `Ok(None)` when the corpus is empty or inaccessible.
 async fn load_and_build_from_vector_store(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     model: &str,
-) -> Result<Option<AnnBridge>, RuntimeError> {
+) -> Result<Option<(AnnBridge, CorpusContentHash)>, RuntimeError> {
     let store = match rt.vectors_for_model(token, model) {
         Ok(s) => s,
         Err(_) => return Ok(None),
@@ -973,6 +1007,15 @@ async fn load_and_build_from_vector_store(
     let mut id_map: Vec<Uuid> = Vec::with_capacity(rows.len());
     let mut flat: Vec<f32> = Vec::with_capacity(rows.len() * dims);
     let mut namespace_set: HashSet<String> = HashSet::new();
+    // Hashed row-by-row, in the SAME loop that feeds `flat`/`id_map` below —
+    // not a separate query run before or after this scan — so the persisted
+    // signal can never describe a different corpus snapshot than the graph
+    // that gets built from it (#812 review re-confirm HIGH-B). Hashes the
+    // raw, un-normalized embedding bytes (not `notes.updated_at`), so a
+    // vector-only re-embed that never touches the notes table — exactly
+    // what `kkernel reindex` does — still changes the hash (#812 review
+    // re-confirm HIGH-A).
+    let mut hasher = blake3::Hasher::new();
 
     for row in &rows {
         let id_str = match row.get("subject_id") {
@@ -997,6 +1040,8 @@ async fn load_and_build_from_vector_store(
         if let Some(SqlValue::Text(ns)) = row.get("namespace") {
             namespace_set.insert(ns.clone());
         }
+        hasher.update(uuid.as_bytes());
+        hasher.update(bytes);
         id_map.push(uuid);
         flat.extend_from_slice(&vec);
     }
@@ -1004,6 +1049,8 @@ async fn load_and_build_from_vector_store(
     if id_map.is_empty() {
         return Ok(None);
     }
+
+    let content_hash = CorpusContentHash(*hasher.finalize().as_bytes());
 
     // #791: `AnnBridge::build` (via `VamanaIndex::build`) is a plain
     // synchronous, CPU-bound full graph construction — training the SQ8
@@ -1023,12 +1070,13 @@ async fn load_and_build_from_vector_store(
                     e,
                 ))
             })??;
-    Ok(Some(built))
+    Ok(Some((built, content_hash)))
 }
 
 // ── persistence ───────────────────────────────────────────────────────────────
 
-/// Durable content signal for a model's live corpus (#812 review HIGH-2).
+/// Durable content signal for a model's live corpus (#812 review re-confirm
+/// HIGH-A/HIGH-B).
 ///
 /// `CorpusFingerprint` (vector count + dimensions) is preserved by a
 /// delete-one/add-one or a content re-embed, and write-generations
@@ -1036,17 +1084,16 @@ async fn load_and_build_from_vector_store(
 /// so on a cold process the fingerprint is the only signal deciding whether
 /// a persisted snapshot is still current, and a same-cardinality corpus
 /// change would be classified Hot forever with no rebuild ever triggered.
-/// `max_updated_at` closes that gap: a newly added or edited note always
-/// carries a fresher `updated_at` than every prior row in the corpus, so
-/// this signal changes on exactly the patterns the fingerprint misses.
+/// A blake3 hash of the ordered `(subject_id, embedding)` rows closes that
+/// gap completely: any change to which rows exist, their ordering, or their
+/// embedding bytes changes the hash — including a vector-only re-embed
+/// (`kkernel reindex`) that never touches `notes.updated_at` at all, which a
+/// timestamp-based signal cannot see (#812 review re-confirm HIGH-A).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct CorpusContentSignal {
-    count: u64,
-    max_updated_at: i64,
-}
+struct CorpusContentHash([u8; 32]);
 
 /// On-disk wrapper persisted into `retrieval_snapshots.snapshot` in place of
-/// a bare `VamanaSnapshot`, so the durable content signal travels with the
+/// a bare `VamanaSnapshot`, so the durable content hash travels with the
 /// snapshot it was computed against. A pre-existing bare-`VamanaSnapshot`
 /// blob (persisted before this field existed) fails to deserialize as this
 /// wrapper and is treated as corrupt by `try_load_snapshot`'s existing
@@ -1055,49 +1102,74 @@ struct CorpusContentSignal {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct PersistedMemorySnapshot {
     snapshot: VamanaSnapshot,
-    content_signal: CorpusContentSignal,
+    content_hash: CorpusContentHash,
 }
 
-/// Compute `model`'s durable content signal (#812 review HIGH-2): the
-/// live-note vector count plus the maximum `updated_at` across those rows.
-/// Cheap — a single aggregate query, no embedding blobs read — unlike a full
-/// content hash, which would require the same corpus scan a rebuild does.
-async fn compute_corpus_content_signal(
+/// Recompute `model`'s durable content hash directly from the store (#812
+/// review re-confirm HIGH-A/HIGH-B), for restart validation ONLY — the build
+/// path computes its own hash from the exact rows it scans in
+/// `load_and_build_from_vector_store`, in the same read, rather than calling
+/// this. Deliberately NOT a cheap aggregate: it re-reads every live
+/// `note.content` embedding blob for `model`, in the same row order
+/// (`ORDER BY v.subject_id`) the build itself uses, so a match here means
+/// "the persisted snapshot was built from exactly this corpus" rather than
+/// merely "the row count and a timestamp line up".
+async fn compute_corpus_content_hash(
     rt: &KhiveRuntime,
     token: &NamespaceToken,
     model: &str,
-) -> Option<CorpusContentSignal> {
-    let _ = rt.vectors_for_model(token, model).ok()?;
+) -> Option<CorpusContentHash> {
+    let store = rt.vectors_for_model(token, model).ok()?;
+    let info = store.info().await.ok()?;
+    if info.dimensions == 0 {
+        return None;
+    }
+    let dims = info.dimensions;
     let table_name = format!("vec_{}", sanitize_model_key(model));
     let sql = rt.sql();
     let mut reader = sql.reader().await.ok()?;
     let rows = reader
         .query_all(SqlStatement {
             sql: format!(
-                "SELECT COUNT(*) AS n, MAX(n.updated_at) AS max_updated FROM {table_name} v \
+                "SELECT v.subject_id, v.embedding FROM {table_name} v \
                  JOIN notes n ON n.id = v.subject_id \
                  WHERE v.embedding_model = ?1 \
                    AND v.kind = 'note' AND v.field = 'note.content' \
-                   AND n.deleted_at IS NULL"
+                   AND n.deleted_at IS NULL \
+                 ORDER BY v.subject_id"
             ),
             params: vec![SqlValue::Text(model.to_owned())],
-            label: Some("memory_ann_content_signal".into()),
+            label: Some("memory_ann_content_hash".into()),
         })
         .await
         .ok()?;
-    let row = rows.first()?;
-    let count = match row.get("n")? {
-        SqlValue::Integer(n) if *n >= 0 => *n as u64,
-        _ => return None,
-    };
-    let max_updated_at = match row.get("max_updated") {
-        Some(SqlValue::Integer(v)) => *v,
-        _ => 0,
-    };
-    Some(CorpusContentSignal {
-        count,
-        max_updated_at,
-    })
+
+    let mut hasher = blake3::Hasher::new();
+    let mut any_row = false;
+    for row in &rows {
+        let id_str = match row.get("subject_id") {
+            Some(SqlValue::Text(s)) => s.as_str(),
+            _ => continue,
+        };
+        let uuid = match Uuid::parse_str(id_str) {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        let bytes = match row.get("embedding") {
+            Some(SqlValue::Blob(b)) => b.as_slice(),
+            _ => continue,
+        };
+        if bytes.len() != dims * 4 {
+            continue;
+        }
+        hasher.update(uuid.as_bytes());
+        hasher.update(bytes);
+        any_row = true;
+    }
+    if !any_row {
+        return None;
+    }
+    Some(CorpusContentHash(*hasher.finalize().as_bytes()))
 }
 
 async fn ensure_snapshot_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
@@ -1130,7 +1202,7 @@ async fn persist_snapshot(
     model: &str,
     bridge: &AnnBridge,
     fingerprint: CorpusFingerprint,
-    content_signal: CorpusContentSignal,
+    content_hash: CorpusContentHash,
 ) -> Result<(), RuntimeError> {
     if let Err(e) = ensure_snapshot_schema(rt).await {
         tracing::warn!(error = %e, "failed to create retrieval_snapshots schema");
@@ -1141,7 +1213,7 @@ async fn persist_snapshot(
         .map_err(|e| RuntimeError::Internal(format!("to_snapshot: {e}")))?;
     let persisted = PersistedMemorySnapshot {
         snapshot,
-        content_signal,
+        content_hash,
     };
     let blob = serde_json::to_vec(&persisted)
         .map_err(|e| RuntimeError::Internal(format!("snapshot serialize: {e}")))?;
@@ -1301,10 +1373,7 @@ mod tests {
                     vector_count: 1,
                     dimensions: 4,
                 },
-                CorpusContentSignal {
-                    count: 1,
-                    max_updated_at: 0,
-                },
+                CorpusContentHash([0u8; 32]),
             )
             .await
             .expect("persist snapshot");
@@ -2015,20 +2084,21 @@ mod tests {
         );
     }
 
-    // ── #812 review HIGH-2: restart validation needs a durable content signal ─
+    // ── #812 review re-confirm HIGH-A/HIGH-B: content-hash restart validation ─
 
-    /// Reviewer-requested regression test (#812 review HIGH-2): a
-    /// delete-one/add-one that preserves vector count and dimensions must
-    /// still be detected as stale by a fresh `AnnState` (simulating a
-    /// process restart, where write-generations reset to 0) so the model is
-    /// rebuilt instead of silently serving the outdated snapshot forever.
+    /// Reviewer-requested regression test (#812 review HIGH-2, still valid
+    /// under the content-hash redesign): a delete-one/add-one that preserves
+    /// vector count and dimensions must still be detected as stale by a
+    /// fresh `AnnState` (simulating a process restart, where write-generations
+    /// reset to 0) so the model is rebuilt instead of silently serving the
+    /// outdated snapshot forever.
     ///
     /// Fail-on-revert: reverting `ensure_ann_for_model_inner` to compare only
     /// `CorpusFingerprint` (vector count + dimensions) makes the second warm
     /// below take the Hot/`LoadedSnapshot` path instead of `Built`, because
     /// the corpus still has 4 vectors at the same dimensionality.
     #[tokio::test]
-    async fn ensure_ann_for_model_restart_content_signal_mismatch_triggers_rebuild() {
+    async fn ensure_ann_for_model_restart_content_hash_mismatch_triggers_rebuild() {
         const MODEL: &str = "ann-warm-restart-signal-test-model";
         const DIMS: usize = 8;
         let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
@@ -2100,6 +2170,166 @@ mod tests {
             "a same-cardinality corpus content change must be detected as \
              stale and force a rebuild rather than silently loading the \
              outdated snapshot forever (#812 review HIGH-2), got: {status:?}"
+        );
+    }
+
+    /// Reviewer-requested regression test (#812 review re-confirm HIGH-A): a
+    /// vector-only re-embed — same note IDs, same count, same dimensions,
+    /// same `notes.updated_at` (never touched) but different embedding
+    /// bytes, exactly what `kkernel reindex` produces — must still be
+    /// detected as stale by restart validation.
+    ///
+    /// Fail-on-revert: reverting `compute_corpus_content_hash` (or the
+    /// build-side hash it's paired against) back to the old
+    /// `CorpusContentSignal` (count + `MAX(notes.updated_at)`) makes the
+    /// second warm below wrongly take the Hot/`LoadedSnapshot` path, because
+    /// neither the count nor `updated_at` changed — only the embedding bytes
+    /// did.
+    #[tokio::test]
+    async fn ensure_ann_for_model_restart_detects_vector_only_reindex() {
+        const MODEL: &str = "ann-warm-restart-vector-only-reindex-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let mut note_ids = Vec::new();
+        for i in 0..4u32 {
+            let note = rt
+                .create_note_with_decay_for_embedding_model(
+                    &token,
+                    "memory",
+                    None,
+                    &format!("vector-only reindex note {i}"),
+                    Some(0.7),
+                    0.01,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+                .expect("create note");
+            note_ids.push(note.id);
+        }
+
+        let ann1 = new_shared();
+        let status = ensure_ann_for_model(&rt, &token, &ann1, MODEL)
+            .await
+            .expect("first warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "expected a fresh build over 4 vectors, got: {status:?}"
+        );
+
+        // Simulate `kkernel reindex`: overwrite the embedding blob for one
+        // note directly in the vector table, bypassing
+        // `create_note_with_decay_for_embedding_model` entirely so
+        // `notes.updated_at` is never touched — same as reindex.rs's
+        // `embed_and_store_batch` path, which writes vectors without
+        // touching the notes table at all.
+        {
+            let table_name = format!("vec_{}", sanitize_model_key(MODEL));
+            let replacement: Vec<f32> = (0..DIMS).map(|i| (i as f32 + 100.0) / 7.0).collect();
+            let bytes: Vec<u8> = replacement.iter().flat_map(|f| f.to_le_bytes()).collect();
+            let sql = rt.sql();
+            let mut w = sql.writer().await.expect("writer");
+            w.execute(SqlStatement {
+                sql: format!(
+                    "UPDATE {table_name} SET embedding = ?1 \
+                     WHERE subject_id = ?2 AND embedding_model = ?3"
+                ),
+                params: vec![
+                    SqlValue::Blob(bytes),
+                    SqlValue::Text(note_ids[0].to_string()),
+                    SqlValue::Text(MODEL.to_string()),
+                ],
+                label: Some("test_vector_only_reindex".into()),
+            })
+            .await
+            .expect("overwrite embedding");
+        }
+
+        // "Restart": a fresh `AnnState`, generations reset to 0 — matches a
+        // real restart exactly, and also matches `kkernel reindex` running
+        // as a separate process from the daemon, which shares no in-memory
+        // generation state with it at all.
+        let ann2 = new_shared();
+        let status = ensure_ann_for_model(&rt, &token, &ann2, MODEL)
+            .await
+            .expect("post-reindex warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "a vector-only re-embed that never touches notes.updated_at must \
+             still be detected as stale and force a rebuild (#812 review \
+             re-confirm HIGH-A), got: {status:?}"
+        );
+    }
+
+    // ── #812 review re-confirm MEDIUM: high-water re-enqueue on drop ────────
+
+    /// Reviewer-requested regression test (#812 review re-confirm MEDIUM): a
+    /// write landing while a background warm is already in flight must
+    /// eventually converge WITHOUT any later `memory.recall` or
+    /// `memory.remember` re-triggering the warm — the in-flight task's own
+    /// loop must notice the generation moved past what it built for and
+    /// re-enqueue itself.
+    ///
+    /// Fail-on-revert: reverting `ensure_ann_background`'s tracked task back
+    /// to a single `ensure_ann_for_model` attempt (no loop) makes this test
+    /// flaky-to-failing: whenever the `bump_generation` call below lands
+    /// after the task has already captured its build floor, nothing is left
+    /// to notice the index fell behind, and `is_current` never becomes true
+    /// within the poll budget.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn ensure_ann_background_converges_on_write_during_warm_with_no_further_recalls() {
+        const MODEL: &str = "ann-warm-medium-reenqueue-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        // A few hundred notes so the graph build takes long enough (spawn_blocking
+        // I/O + Vamana construction) to reliably still be in flight when the
+        // `bump_generation` call right below executes.
+        for i in 0..300u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("medium re-enqueue note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(&token, MODEL);
+
+        assert!(
+            ensure_ann_background(&rt, &token, &ann, MODEL).await,
+            "first call for a fresh key must start a background warm"
+        );
+        // Simulate a write racing in while the warm above is still building —
+        // bump the generation exactly like `memory.remember` does, but
+        // deliberately do NOT call `ensure_ann_background` again: the whole
+        // point is that no second caller ever arrives to notice or retrigger.
+        bump_generation(&ann, &key).await;
+
+        for _ in 0..500 {
+            if is_current(&ann, &key).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            is_current(&ann, &key).await,
+            "a write racing in during an in-flight warm must eventually be \
+             picked up and converge on its own, with zero further recalls or \
+             writes to retrigger it (#812 review re-confirm MEDIUM)"
         );
     }
 }

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -111,6 +111,20 @@ pub(crate) struct AnnState {
     /// each test gets its own via `new_shared()`.
     #[cfg(test)]
     pub(crate) attempt_floor_notify: tokio::sync::Notify,
+    /// Test-only reverse barrier (#812 review REQUEST CHANGES MEDIUM — the
+    /// `Notify` test still lacked an ordering guarantee): when
+    /// `attempt_floor_barrier` is armed, the tracked task's first attempt
+    /// WAITS on this after emitting `attempt_floor_notify`, so a test can
+    /// deterministically bump the generation before the task's build is
+    /// allowed to proceed, instead of racing the build's own completion.
+    #[cfg(test)]
+    pub(crate) attempt_floor_release: tokio::sync::Notify,
+    /// Test-only: arms the two-way handshake above. Defaults to `false` so
+    /// every other test driving `ensure_ann_background`/`spawn_rebuild_task`
+    /// (which never call `attempt_floor_release.notify_one()`) is unaffected
+    /// — only a test that explicitly sets this waits on the release signal.
+    #[cfg(test)]
+    pub(crate) attempt_floor_barrier: std::sync::atomic::AtomicBool,
 }
 
 pub(crate) type SharedAnn = Arc<AnnState>;
@@ -126,6 +140,10 @@ pub(crate) fn new_shared() -> SharedAnn {
         warm_route_count: AtomicUsize::new(0),
         #[cfg(test)]
         attempt_floor_notify: tokio::sync::Notify::new(),
+        #[cfg(test)]
+        attempt_floor_release: tokio::sync::Notify::new(),
+        #[cfg(test)]
+        attempt_floor_barrier: std::sync::atomic::AtomicBool::new(false),
     })
 }
 
@@ -193,6 +211,22 @@ const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::f
 #[cfg(test)]
 const DURABLE_EPOCH_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(0);
 
+/// Minimum delay before a CHAINED rebuild task's first attempt — i.e. a task
+/// spawned by `spawn_rebuild_task`'s own post-release re-enqueue, not the
+/// original caller-triggered spawn (#812 review REQUEST CHANGES MEDIUM: "the
+/// three-attempt cap still permits an unbounded task chain"). Without this,
+/// a corpus that receives a new write on every rebuild attempt chains a
+/// fresh `ATTEMPT_BOUND`-attempt task immediately after the previous one
+/// exits, forever, spending unbounded aggregate CPU under continuous
+/// writes. Sleeping here — between chained spawns, not inside a single
+/// task's attempt loop — lets writes that land during the delay coalesce
+/// into the next chained task's single generation read instead of each one
+/// re-triggering its own chain link.
+#[cfg(not(test))]
+const REBUILD_CHAIN_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(1);
+#[cfg(test)]
+const REBUILD_CHAIN_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(5);
+
 /// Amortized cross-process freshness check (#812 review REQUEST CHANGES
 /// HIGH): compares the durable `memory_ann_epoch` row against the
 /// currently-installed entry's `epoch_baseline` for `key`, and — if the
@@ -242,23 +276,33 @@ pub(crate) async fn maybe_check_durable_epoch(rt: &KhiveRuntime, ann: &SharedAnn
     }
 }
 
-/// Ensure the `memory_ann_epoch` table exists. Best-effort: called before
-/// every read/write of the durable epoch, mirroring `ensure_snapshot_schema`.
-async fn ensure_epoch_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
+/// DDL for the durable memory-ANN corpus epoch table (#812 review REQUEST
+/// CHANGES MEDIUM — pack schema contract). Declared here so
+/// `MemoryPack::SCHEMA_PLAN` (`pack.rs`) can own it like every other
+/// pack-auxiliary table in this codebase (ADR-028), instead of the table
+/// being created ad hoc, inline, on the epoch bump/read path.
+pub(crate) const MEMORY_SCHEMA_PLAN_STMTS: [&str; 1] =
+    ["CREATE TABLE IF NOT EXISTS memory_ann_epoch (\
+     id INTEGER PRIMARY KEY CHECK (id = 1), \
+     epoch INTEGER NOT NULL DEFAULT 0\
+ )"];
+
+/// Ensure the `memory_ann_epoch` table exists (idempotent). NOT called from
+/// the epoch bump/read hot path anymore (#812 review REQUEST CHANGES
+/// MEDIUM) — a daemon boot applies `MemoryPack::SCHEMA_PLAN` up front
+/// (`server.rs`/`serve.rs`), and `kkernel reindex` (which runs directly
+/// against a raw `KhiveRuntime`, never booting a pack registry) calls this
+/// explicitly, once, via `khive_pack_memory::ensure_ann_epoch_schema` before
+/// its first durable-epoch bump.
+pub(crate) async fn ensure_epoch_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
     let sql = rt.sql();
     let mut w = sql
         .writer()
         .await
         .map_err(|e| RuntimeError::Internal(e.to_string()))?;
-    w.execute_script(
-        "CREATE TABLE IF NOT EXISTS memory_ann_epoch (\
-             id INTEGER PRIMARY KEY CHECK (id = 1), \
-             epoch INTEGER NOT NULL DEFAULT 0\
-         );"
-        .into(),
-    )
-    .await
-    .map_err(|e| RuntimeError::Internal(e.to_string()))
+    w.execute_script(MEMORY_SCHEMA_PLAN_STMTS[0].to_string())
+        .await
+        .map_err(|e| RuntimeError::Internal(e.to_string()))
 }
 
 /// Read the durable corpus epoch (0 if the table doesn't exist yet or the
@@ -291,7 +335,6 @@ pub(crate) async fn durable_epoch(rt: &KhiveRuntime) -> u64 {
 /// the same database file has a durable signal to observe (#812 review
 /// REQUEST CHANGES HIGH).
 pub(crate) async fn bump_durable_epoch(rt: &KhiveRuntime) -> Result<u64, RuntimeError> {
-    ensure_epoch_schema(rt).await?;
     let sql = rt.sql();
     let mut w = sql
         .writer()
@@ -681,6 +724,25 @@ fn try_take_warming_guard(ann: &SharedAnn, key: &AnnKey) -> bool {
 /// this future's own state machine, so there is no self-referential type for
 /// Send-inference to choke on.
 fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnKey) {
+    spawn_rebuild_task_inner(rt, ann, model, key, false);
+}
+
+/// `chained`: `true` only for the post-release re-enqueue call at the bottom
+/// of this function's own tracked task — i.e. this spawn exists because a
+/// PRIOR task in the same chain just exhausted its `ATTEMPT_BOUND` with more
+/// work still pending. `false` for every caller-triggered spawn
+/// (`ensure_ann_background`'s first call for a key). Only a chained spawn
+/// pays `REBUILD_CHAIN_DEBOUNCE` before its first attempt (#812 review
+/// REQUEST CHANGES MEDIUM) — the original caller-triggered spawn must still
+/// start immediately, matching every existing warm-latency expectation and
+/// test in this file.
+fn spawn_rebuild_task_inner(
+    rt: KhiveRuntime,
+    ann: SharedAnn,
+    model: String,
+    key: AnnKey,
+    chained: bool,
+) {
     // Tied to the tracked task's own scope so it releases on every exit path
     // (success, error, or panic) rather than only the "nothing got loaded"
     // arm — see `WarmingGuard`'s doc comment (#812 review HIGH-1).
@@ -689,6 +751,9 @@ fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnK
         key: key.clone(),
     };
     khive_runtime::track_background_task(async move {
+        if chained {
+            tokio::time::sleep(REBUILD_CHAIN_DEBOUNCE).await;
+        }
         // #812 review MEDIUM (reconfirm): a write landing while this task's
         // own build is in flight bumps the generation counter, but that
         // write's own `ensure_ann_background` call finds `warming` already
@@ -710,6 +775,18 @@ fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnK
         // once exhausted the remainder is left for the post-release
         // recheck below (or a later recall/write) to pick up, documented in
         // ADR-107.
+        //
+        // Shutdown bound (#812 review REQUEST CHANGES MEDIUM): this loop has
+        // no dedicated cancellation signal of its own — `AnnState` carries
+        // none, and this task is registered via `khive_runtime::track_background_task`,
+        // whose only shutdown coordination is `daemon::drain()`'s bounded wait
+        // (`KHIVE_DRAIN_TIMEOUT_SECS`, default in `daemon.rs`) followed by an
+        // unconditional process exit once that deadline passes. A chain that
+        // is still respawning at shutdown is therefore bounded by drain's
+        // timeout, not by anything in this file; `REBUILD_CHAIN_DEBOUNCE`
+        // keeps each link short enough that drain's timeout is the effective
+        // ceiling on how many chain links can still be mid-flight when the
+        // process is torn down.
         const ATTEMPT_BOUND: u32 = 3;
         let mut attempt_floor = current_generation(&ann, &key).await;
         let mut attempts: u32 = 0;
@@ -719,7 +796,23 @@ fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnK
             };
             attempts += 1;
             #[cfg(test)]
-            ann.attempt_floor_notify.notify_one();
+            {
+                ann.attempt_floor_notify.notify_one();
+                // Two-way barrier (#812 review REQUEST CHANGES MEDIUM: the
+                // old test only synchronized one direction — "floor
+                // captured" — then let the build race ahead unconditionally,
+                // so nothing actually forced the test's `bump_generation` to
+                // land before this attempt's build ran. Only armed tests
+                // wait here; every other test in this file never sets
+                // `attempt_floor_barrier` and proceeds exactly as before.
+                if attempts == 1
+                    && ann
+                        .attempt_floor_barrier
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                {
+                    ann.attempt_floor_release.notified().await;
+                }
+            }
             match ensure_ann_for_model(&rt, &token, &ann, &model).await {
                 Ok(status) => {
                     tracing::debug!(?status, model = %model, "memory ANN background warm complete");
@@ -771,7 +864,10 @@ fn spawn_rebuild_task(rt: KhiveRuntime, ann: SharedAnn, model: String, key: AnnK
         if current_generation(&ann, &key).await > attempt_floor
             && try_take_warming_guard(&ann, &key)
         {
-            spawn_rebuild_task(rt, ann, model, key);
+            // `chained: true` — this re-enqueue is throttled by
+            // `REBUILD_CHAIN_DEBOUNCE` (#812 review REQUEST CHANGES MEDIUM),
+            // not an immediate back-to-back respawn.
+            spawn_rebuild_task_inner(rt, ann, model, key, true);
         }
     });
 }
@@ -2621,6 +2717,15 @@ mod tests {
         // The reindexer deletes the persisted snapshot AND bumps the durable
         // epoch, exactly like `invalidate_active_memory_vamana_snapshot` +
         // `khive_pack_memory::bump_memory_ann_epoch` in `kkernel::reindex`.
+        // `kkernel reindex` runs directly against a raw `KhiveRuntime` with
+        // no pack registry boot (so `MemoryPack::SCHEMA_PLAN` is never
+        // applied) — it calls `ensure_epoch_schema` explicitly once before
+        // its first bump (see `begin_reindex_epoch` in `reindex.rs`); mirror
+        // that here now that `bump_durable_epoch` no longer creates the
+        // table itself (#812 review REQUEST CHANGES MEDIUM).
+        ensure_epoch_schema(&rt2)
+            .await
+            .expect("ensure epoch schema");
         bump_durable_epoch(&rt2).await.expect("bump durable epoch");
 
         // Sanity: before the epoch check runs, the daemon's cache still
@@ -2698,6 +2803,15 @@ mod tests {
         let ann = new_shared();
         let key = AnnKey::from_token(&token, MODEL);
 
+        // Arm the two-way barrier (#812 review REQUEST CHANGES MEDIUM — the
+        // one-way `Notify` above only proved the task had captured its
+        // floor, not that its build couldn't race ahead and read the
+        // generation before this test's `bump_generation` below landed).
+        // The task's first attempt now WAITS on `attempt_floor_release`
+        // after emitting `attempt_floor_notify`, so the ordering here is
+        // deterministic rather than a race against build speed.
+        ann.attempt_floor_barrier
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         let notified = ann.attempt_floor_notify.notified();
         assert!(
             ensure_ann_background(&rt, &token, &ann, MODEL).await,
@@ -2712,6 +2826,14 @@ mod tests {
         // deliberately do NOT call `ensure_ann_background` again: the whole
         // point is that no second caller ever arrives to notice or retrigger.
         bump_generation(&ann, &key).await;
+        // Disarm BEFORE releasing so later attempts (attempt 2, 3, ...) in
+        // this same task's loop don't also block waiting for a release this
+        // test never sends again. `Notify::notify_one` synchronizes with
+        // the waiter's wakeup, so the task observes `barrier == false` by
+        // the time it re-checks on its next attempt.
+        ann.attempt_floor_barrier
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        ann.attempt_floor_release.notify_one();
 
         for _ in 0..500 {
             if is_current(&ann, &key).await {

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -10,6 +10,7 @@ use khive_runtime::{KhiveRuntime, Namespace, NamespaceToken, RuntimeError};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::StorageError;
 use khive_vamana::{CorpusFingerprint, VamanaConfig, VamanaIndex, VamanaSnapshot};
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
@@ -55,7 +56,13 @@ pub(crate) struct AnnBridge {
 /// Shared ANN state: per-`(namespace, model)` indexes with at-most-one-background-build guard.
 pub(crate) struct AnnState {
     indexes: RwLock<HashMap<AnnKey, AnnBridge>>,
-    warming: Mutex<HashSet<AnnKey>>,
+    /// Plain `std::sync::Mutex`, not `tokio::sync::Mutex`: every critical
+    /// section here is a synchronous check-and-mutate with no `.await`
+    /// inside it, which lets `WarmingGuard::drop` (below) release the guard
+    /// synchronously on every exit path of the background task it's tied to
+    /// — success, error, or panic (#812 review HIGH-1) — instead of needing
+    /// to spawn a second task just to await a `tokio::sync::Mutex`.
+    warming: std::sync::Mutex<HashSet<AnnKey>>,
     /// Review finding (issue #723 fix-round): per-model single-flight lock
     /// owned by `ensure_ann_for_model` itself, the chokepoint every warm
     /// path (boot warm, background fire-once warm, recall-miss warm) routes
@@ -89,7 +96,7 @@ pub(crate) type SharedAnn = Arc<AnnState>;
 pub(crate) fn new_shared() -> SharedAnn {
     Arc::new(AnnState {
         indexes: RwLock::new(HashMap::new()),
-        warming: Mutex::new(HashSet::new()),
+        warming: std::sync::Mutex::new(HashSet::new()),
         model_locks: Mutex::new(HashMap::new()),
         generations: Mutex::new(HashMap::new()),
         #[cfg(test)]
@@ -382,7 +389,42 @@ pub(crate) async fn index_namespace_set(ann: &SharedAnn, key: &AnnKey) -> Option
 /// entry itself just proved unusable, not merely stale.
 pub(crate) async fn clear_key(ann: &SharedAnn, key: &AnnKey) {
     ann.indexes.write().await.remove(key);
-    ann.warming.lock().await.remove(key);
+    lock_warming(ann).remove(key);
+}
+
+/// Lock `ann.warming`, recovering from poisoning instead of propagating it.
+///
+/// A poisoned lock here would mean an earlier holder panicked while the
+/// guard was held — but every critical section on this mutex is a plain
+/// synchronous set operation, so a panic mid-section can only have come from
+/// the allocator itself. Refusing to recover would leave every future warm
+/// attempt permanently unable to take the guard at all, which is strictly
+/// worse than the bug this fixes.
+fn lock_warming(ann: &SharedAnn) -> std::sync::MutexGuard<'_, HashSet<AnnKey>> {
+    ann.warming
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII release of the fire-once `warming` guard (#812 review HIGH-1).
+///
+/// The guard used to be removed only on the "nothing got loaded" failure
+/// path inside `ensure_ann_background`'s tracked task — so a single
+/// successful warm left the key in `warming` forever, and every later
+/// write's rebuild attempt (`memory.remember`) plus recall's rescheduling
+/// (`handlers/common.rs`) silently no-op'd against the stale guard, serving
+/// the stale index indefinitely. Tying release to `Drop` instead covers
+/// every exit path of the tracked task uniformly — normal return, an early
+/// `Err`, and an unwinding panic all run the same destructor.
+struct WarmingGuard {
+    ann: SharedAnn,
+    key: AnnKey,
+}
+
+impl Drop for WarmingGuard {
+    fn drop(&mut self) {
+        lock_warming(&self.ann).remove(&self.key);
+    }
 }
 
 /// True when `err` is the direct result of a `spawn_blocking` cancellation —
@@ -431,7 +473,7 @@ pub(crate) async fn ensure_ann_background(
 
     // Single-flight guard.
     {
-        let mut warming = ann.warming.lock().await;
+        let mut warming = lock_warming(ann);
         if warming.contains(&key) {
             return false;
         }
@@ -441,6 +483,13 @@ pub(crate) async fn ensure_ann_background(
     let rt = rt.clone();
     let ann = ann.clone();
     let model = model.to_owned();
+    // Tied to the tracked task's own scope so it releases on every exit path
+    // (success, error, or panic) rather than only the "nothing got loaded"
+    // arm — see `WarmingGuard`'s doc comment (#812 review HIGH-1).
+    let warming_guard = WarmingGuard {
+        ann: ann.clone(),
+        key: key.clone(),
+    };
     // Tracked, not a bare tokio::spawn, so daemon shutdown's drain() waits for
     // an in-flight remember-path warm instead of a SIGTERM (or a short-lived
     // `kkernel exec` process exiting) aborting it mid-build — same rationale
@@ -448,6 +497,7 @@ pub(crate) async fn ensure_ann_background(
     // Medium). The caller still only pays for the enqueue; the build itself
     // runs fully off the response path, unawaited.
     khive_runtime::track_background_task(async move {
+        let _warming_guard = warming_guard;
         if let Ok(token) = rt.authorize(Namespace::local()) {
             match ensure_ann_for_model(&rt, &token, &ann, &model).await {
                 Ok(status) => {
@@ -463,11 +513,6 @@ pub(crate) async fn ensure_ann_background(
                     tracing::warn!(error = %e, model = %model, "memory ANN background build failed");
                 }
             }
-        }
-        // If loading/building failed, remove the guard so a later recall retries.
-        let loaded = ann.indexes.read().await.contains_key(&key);
-        if !loaded {
-            ann.warming.lock().await.remove(&key);
         }
     });
     true
@@ -689,35 +734,47 @@ async fn ensure_ann_for_model_inner(
         return Ok(AnnEnsureStatus::AlreadyLoaded);
     }
 
-    // Try snapshot warm-load.
-    if let Some(snapshot) = try_load_snapshot(rt, ns, model).await {
+    // Try snapshot warm-load. Both the shallow `CorpusFingerprint` (vector
+    // count + dimensions) AND the durable `CorpusContentSignal` (count + max
+    // `updated_at`) must match the live corpus (#812 review HIGH-2):
+    // write-generations reset to 0 on restart, so on a cold process the
+    // fingerprint alone is the only signal deciding Hot vs. Stale — and a
+    // delete-one/add-one or a content re-embed preserves vector count and
+    // dimensions exactly while changing what the corpus actually contains.
+    // The content signal catches that: a new or edited note always carries
+    // a fresher `updated_at` than every prior row, so the signal changes
+    // even when the fingerprint doesn't.
+    if let Some(persisted) = try_load_snapshot(rt, ns, model).await {
         let current_fp = compute_memory_fingerprint(rt, token, model).await;
-        if let Some(fp) = current_fp {
-            if snapshot.fingerprint == fp {
-                match AnnBridge::from_snapshot(snapshot) {
-                    Ok(mut bridge) => {
-                        // Populate namespace set from a cheap DISTINCT query so the
-                        // retry gate in recall can short-circuit when appropriate.
-                        let ns_set = query_distinct_namespaces(rt, token, model)
-                            .await
-                            .unwrap_or_default();
-                        bridge.set_namespace_set(ns_set);
-                        let bridge = bridge.with_generation(target_generation);
-                        install_if_fresher(ann, &key, bridge).await;
-                        tracing::debug!(namespace = %ns, model = %model, "memory ANN loaded from snapshot");
-                        return Ok(AnnEnsureStatus::LoadedSnapshot);
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "corrupt memory Vamana snapshot; rebuilding");
-                    }
+        let current_signal = compute_corpus_content_signal(rt, token, model).await;
+        let fp_matches = current_fp.is_some_and(|fp| persisted.snapshot.fingerprint == fp);
+        let signal_matches = current_signal.is_some_and(|sig| persisted.content_signal == sig);
+        if fp_matches && signal_matches {
+            match AnnBridge::from_snapshot(persisted.snapshot) {
+                Ok(mut bridge) => {
+                    // Populate namespace set from a cheap DISTINCT query so the
+                    // retry gate in recall can short-circuit when appropriate.
+                    let ns_set = query_distinct_namespaces(rt, token, model)
+                        .await
+                        .unwrap_or_default();
+                    bridge.set_namespace_set(ns_set);
+                    let bridge = bridge.with_generation(target_generation);
+                    install_if_fresher(ann, &key, bridge).await;
+                    tracing::debug!(namespace = %ns, model = %model, "memory ANN loaded from snapshot");
+                    return Ok(AnnEnsureStatus::LoadedSnapshot);
                 }
-            } else {
-                tracing::info!(
-                    namespace = %ns,
-                    model = %model,
-                    "stale memory Vamana snapshot (fingerprint mismatch); rebuilding"
-                );
+                Err(e) => {
+                    tracing::warn!(error = %e, "corrupt memory Vamana snapshot; rebuilding");
+                }
             }
+        } else {
+            tracing::info!(
+                namespace = %ns,
+                model = %model,
+                fp_matches,
+                signal_matches,
+                "stale memory Vamana snapshot (fingerprint or content-signal mismatch); rebuilding"
+            );
         }
     }
 
@@ -748,8 +805,19 @@ async fn ensure_ann_for_model_inner(
             let vector_count = bridge.id_map.len();
             let bridge = bridge.with_generation(target_generation);
             if let Some(fingerprint) = fp_after {
-                if let Err(e) = persist_snapshot(rt, ns, model, &bridge, fingerprint).await {
-                    tracing::warn!(error = %e, "failed to persist memory Vamana snapshot");
+                // Best-effort: if the content signal can't be computed right
+                // now, skip persisting rather than write a snapshot with no
+                // durable staleness check at all (a missing signal would
+                // otherwise need a placeholder that either always matches —
+                // defeating the fix — or never matches — forcing every future
+                // warm to rebuild).
+                if let Some(content_signal) = compute_corpus_content_signal(rt, token, model).await
+                {
+                    if let Err(e) =
+                        persist_snapshot(rt, ns, model, &bridge, fingerprint, content_signal).await
+                    {
+                        tracing::warn!(error = %e, "failed to persist memory Vamana snapshot");
+                    }
                 }
             }
             install_if_fresher(ann, &key, bridge).await;
@@ -960,6 +1028,78 @@ async fn load_and_build_from_vector_store(
 
 // ── persistence ───────────────────────────────────────────────────────────────
 
+/// Durable content signal for a model's live corpus (#812 review HIGH-2).
+///
+/// `CorpusFingerprint` (vector count + dimensions) is preserved by a
+/// delete-one/add-one or a content re-embed, and write-generations
+/// (`AnnState::generations`) are in-memory-only and reset to 0 on restart —
+/// so on a cold process the fingerprint is the only signal deciding whether
+/// a persisted snapshot is still current, and a same-cardinality corpus
+/// change would be classified Hot forever with no rebuild ever triggered.
+/// `max_updated_at` closes that gap: a newly added or edited note always
+/// carries a fresher `updated_at` than every prior row in the corpus, so
+/// this signal changes on exactly the patterns the fingerprint misses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct CorpusContentSignal {
+    count: u64,
+    max_updated_at: i64,
+}
+
+/// On-disk wrapper persisted into `retrieval_snapshots.snapshot` in place of
+/// a bare `VamanaSnapshot`, so the durable content signal travels with the
+/// snapshot it was computed against. A pre-existing bare-`VamanaSnapshot`
+/// blob (persisted before this field existed) fails to deserialize as this
+/// wrapper and is treated as corrupt by `try_load_snapshot`'s existing
+/// corrupt-blob handling — self-healing, since the next warm attempt
+/// rebuilds and re-persists in the new format.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PersistedMemorySnapshot {
+    snapshot: VamanaSnapshot,
+    content_signal: CorpusContentSignal,
+}
+
+/// Compute `model`'s durable content signal (#812 review HIGH-2): the
+/// live-note vector count plus the maximum `updated_at` across those rows.
+/// Cheap — a single aggregate query, no embedding blobs read — unlike a full
+/// content hash, which would require the same corpus scan a rebuild does.
+async fn compute_corpus_content_signal(
+    rt: &KhiveRuntime,
+    token: &NamespaceToken,
+    model: &str,
+) -> Option<CorpusContentSignal> {
+    let _ = rt.vectors_for_model(token, model).ok()?;
+    let table_name = format!("vec_{}", sanitize_model_key(model));
+    let sql = rt.sql();
+    let mut reader = sql.reader().await.ok()?;
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: format!(
+                "SELECT COUNT(*) AS n, MAX(n.updated_at) AS max_updated FROM {table_name} v \
+                 JOIN notes n ON n.id = v.subject_id \
+                 WHERE v.embedding_model = ?1 \
+                   AND v.kind = 'note' AND v.field = 'note.content' \
+                   AND n.deleted_at IS NULL"
+            ),
+            params: vec![SqlValue::Text(model.to_owned())],
+            label: Some("memory_ann_content_signal".into()),
+        })
+        .await
+        .ok()?;
+    let row = rows.first()?;
+    let count = match row.get("n")? {
+        SqlValue::Integer(n) if *n >= 0 => *n as u64,
+        _ => return None,
+    };
+    let max_updated_at = match row.get("max_updated") {
+        Some(SqlValue::Integer(v)) => *v,
+        _ => 0,
+    };
+    Some(CorpusContentSignal {
+        count,
+        max_updated_at,
+    })
+}
+
 async fn ensure_snapshot_schema(rt: &KhiveRuntime) -> Result<(), RuntimeError> {
     let sql = rt.sql();
     let mut w = sql
@@ -990,6 +1130,7 @@ async fn persist_snapshot(
     model: &str,
     bridge: &AnnBridge,
     fingerprint: CorpusFingerprint,
+    content_signal: CorpusContentSignal,
 ) -> Result<(), RuntimeError> {
     if let Err(e) = ensure_snapshot_schema(rt).await {
         tracing::warn!(error = %e, "failed to create retrieval_snapshots schema");
@@ -998,7 +1139,11 @@ async fn persist_snapshot(
     let snapshot = bridge
         .to_snapshot(namespace, model, fingerprint)
         .map_err(|e| RuntimeError::Internal(format!("to_snapshot: {e}")))?;
-    let blob = serde_json::to_vec(&snapshot)
+    let persisted = PersistedMemorySnapshot {
+        snapshot,
+        content_signal,
+    };
+    let blob = serde_json::to_vec(&persisted)
         .map_err(|e| RuntimeError::Internal(format!("snapshot serialize: {e}")))?;
     let key = snapshot_key(namespace, model);
     let sql = rt.sql();
@@ -1027,7 +1172,7 @@ async fn try_load_snapshot(
     rt: &KhiveRuntime,
     namespace: &str,
     model: &str,
-) -> Option<VamanaSnapshot> {
+) -> Option<PersistedMemorySnapshot> {
     let key = snapshot_key(namespace, model);
     let sql = rt.sql();
     let mut reader = sql.reader().await.ok()?;
@@ -1049,7 +1194,7 @@ async fn try_load_snapshot(
         SqlValue::Blob(b) => b.clone(),
         _ => return None,
     };
-    match serde_json::from_slice::<VamanaSnapshot>(&blob) {
+    match serde_json::from_slice::<PersistedMemorySnapshot>(&blob) {
         Ok(s) => Some(s),
         Err(e) => {
             tracing::warn!(error = %e, "corrupt memory Vamana snapshot blob");
@@ -1155,6 +1300,10 @@ mod tests {
                 CorpusFingerprint {
                     vector_count: 1,
                     dimensions: 4,
+                },
+                CorpusContentSignal {
+                    count: 1,
+                    max_updated_at: 0,
                 },
             )
             .await
@@ -1689,5 +1838,268 @@ mod tests {
         // storage must never be misclassified as a benign cancellation.
         let err = RuntimeError::Internal("unrelated internal error".into());
         assert!(!is_benign_shutdown_cancellation(&err));
+    }
+
+    // ── #812 review HIGH-1: warming guard must release on every exit ────────
+
+    struct HashVecService {
+        dims: usize,
+    }
+
+    fn fnv_to_vec(text: &str, dims: usize) -> Vec<f32> {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in text.bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0001_0000_01b3);
+        }
+        let mut v = Vec::with_capacity(dims);
+        let mut s = h;
+        for _ in 0..dims {
+            s = s
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            v.push(((s >> 33) as f32) / (0x7fff_ffff_u32 as f32) - 1.0);
+        }
+        v
+    }
+
+    #[async_trait::async_trait]
+    impl lattice_embed::EmbeddingService for HashVecService {
+        async fn embed(
+            &self,
+            texts: &[String],
+            _model: lattice_embed::EmbeddingModel,
+        ) -> Result<Vec<Vec<f32>>, lattice_embed::EmbedError> {
+            Ok(texts.iter().map(|t| fnv_to_vec(t, self.dims)).collect())
+        }
+
+        fn supports_model(&self, _model: lattice_embed::EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "hash-vec"
+        }
+    }
+
+    struct HashVecProvider {
+        model_name: String,
+        dims: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl khive_runtime::EmbedderProvider for HashVecProvider {
+        fn name(&self) -> &str {
+            &self.model_name
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        async fn build(&self) -> Result<Arc<dyn lattice_embed::EmbeddingService>, RuntimeError> {
+            Ok(Arc::new(HashVecService { dims: self.dims }))
+        }
+    }
+
+    fn test_runtime_with_hash_embedder(model: &str, dims: usize) -> KhiveRuntime {
+        let tmp = tempfile::Builder::new()
+            .prefix("khive-memory-ann-review-fix-")
+            .tempdir_in(std::env::temp_dir())
+            .expect("temp db dir");
+        // Leaked deliberately: the runtime borrows this path only long enough
+        // to open the SQLite file, and each test process only ever creates a
+        // handful of these — matching this file's other embedder-backed
+        // tests, which do the same via a per-test `tempfile::Builder` kept
+        // alive by dropping it at the end of the enclosing scope. Since we
+        // return only the runtime (not the tempdir guard) to keep the test
+        // helper simple, leak the guard so the directory outlives the test.
+        let db_path = tmp.path().join("khive-graph.db");
+        std::mem::forget(tmp);
+        let rt = KhiveRuntime::new(khive_runtime::RuntimeConfig {
+            db_path: Some(db_path),
+            embedding_model: None,
+            additional_embedding_models: vec![],
+            ..khive_runtime::RuntimeConfig::default()
+        })
+        .expect("runtime");
+        rt.register_embedder(HashVecProvider {
+            model_name: model.to_owned(),
+            dims,
+        });
+        rt
+    }
+
+    /// Reviewer-requested regression test (#812 review HIGH-1): warm
+    /// succeeds, a write bumps the generation, the rebuild it triggers
+    /// completes, a second write lands, and the model eventually reaches a
+    /// fresh result — proving the `warming` guard from the FIRST warm does
+    /// not permanently block every later rebuild attempt.
+    ///
+    /// Fail-on-revert: reverting `ensure_ann_background`'s cleanup back to
+    /// "only remove the guard when nothing got loaded" leaves `warming`
+    /// containing `key` after the first successful warm below, failing the
+    /// first assertion; the second `ensure_ann_background` call would then
+    /// also return `false` (guard still set) instead of `true`.
+    #[tokio::test]
+    #[serial(background_tasks)]
+    async fn ensure_ann_background_releases_warming_guard_after_success_and_allows_later_rebuild() {
+        const MODEL: &str = "ann-warm-guard-release-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        for i in 0..4u32 {
+            rt.create_note_with_decay_for_embedding_model(
+                &token,
+                "memory",
+                None,
+                &format!("warming guard note {i}"),
+                Some(0.7),
+                0.01,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .expect("create note");
+        }
+
+        let ann = new_shared();
+        let key = AnnKey::from_token(&token, MODEL);
+
+        assert!(
+            ensure_ann_background(&rt, &token, &ann, MODEL).await,
+            "first call for a fresh key must start a background warm"
+        );
+        // Wait for the tracked task to fully exit (guard dropped), not merely
+        // for the index to appear — the task still does async phase-event
+        // bookkeeping after `install_if_fresher` and before returning, so
+        // polling on index presence alone races the guard's release.
+        for _ in 0..300 {
+            if !ann.warming.lock().unwrap().contains(&key) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            !ann.warming.lock().unwrap().contains(&key),
+            "the warming guard must be released once the first background warm \
+             finishes, not left set forever after a success (#812 review HIGH-1)"
+        );
+        assert!(
+            ann.indexes.read().await.contains_key(&key),
+            "the first background warm must install an index"
+        );
+
+        // A second write lands: bump the generation exactly like
+        // `memory.remember` does, then request another background warm.
+        bump_generation(&ann, &key).await;
+        assert!(
+            ensure_ann_background(&rt, &token, &ann, MODEL).await,
+            "a write landing after a completed warm must be able to schedule a \
+             new background rebuild — if the guard were still set from the \
+             first warm this would wrongly return false, and every later \
+             recall would keep serving the now-stale index forever"
+        );
+
+        for _ in 0..300 {
+            if is_current(&ann, &key).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            is_current(&ann, &key).await,
+            "the second background warm must eventually install a fresh entry"
+        );
+    }
+
+    // ── #812 review HIGH-2: restart validation needs a durable content signal ─
+
+    /// Reviewer-requested regression test (#812 review HIGH-2): a
+    /// delete-one/add-one that preserves vector count and dimensions must
+    /// still be detected as stale by a fresh `AnnState` (simulating a
+    /// process restart, where write-generations reset to 0) so the model is
+    /// rebuilt instead of silently serving the outdated snapshot forever.
+    ///
+    /// Fail-on-revert: reverting `ensure_ann_for_model_inner` to compare only
+    /// `CorpusFingerprint` (vector count + dimensions) makes the second warm
+    /// below take the Hot/`LoadedSnapshot` path instead of `Built`, because
+    /// the corpus still has 4 vectors at the same dimensionality.
+    #[tokio::test]
+    async fn ensure_ann_for_model_restart_content_signal_mismatch_triggers_rebuild() {
+        const MODEL: &str = "ann-warm-restart-signal-test-model";
+        const DIMS: usize = 8;
+        let rt = test_runtime_with_hash_embedder(MODEL, DIMS);
+
+        let token = rt.authorize(Namespace::local()).expect("authorize local");
+        let mut note_ids = Vec::new();
+        for i in 0..4u32 {
+            let note = rt
+                .create_note_with_decay_for_embedding_model(
+                    &token,
+                    "memory",
+                    None,
+                    &format!("restart signal note {i}"),
+                    Some(0.7),
+                    0.01,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+                .expect("create note");
+            note_ids.push(note.id);
+        }
+
+        // First "process": warm and persist a snapshot over the initial
+        // 4-note corpus.
+        let ann1 = new_shared();
+        let status = ensure_ann_for_model(&rt, &token, &ann1, MODEL)
+            .await
+            .expect("first warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "expected a fresh build over 4 vectors, got: {status:?}"
+        );
+
+        // Delete one note and add a fresh one: vector count and dimensions
+        // both come back unchanged (still 4, still DIMS), but the corpus
+        // content has moved on.
+        assert!(
+            rt.delete_note(&token, note_ids[0], false)
+                .await
+                .expect("soft delete"),
+            "soft delete must succeed"
+        );
+        rt.create_note_with_decay_for_embedding_model(
+            &token,
+            "memory",
+            None,
+            "restart signal note REPLACEMENT",
+            Some(0.7),
+            0.01,
+            None,
+            vec![],
+            None,
+        )
+        .await
+        .expect("create replacement note");
+
+        // "Restart": a fresh `AnnState` with generations reset to 0, exactly
+        // like a process restart — write-generation tracking (#750) cannot
+        // see this corpus change at all, so only restart validation against
+        // the persisted snapshot can catch it.
+        let ann2 = new_shared();
+        let status = ensure_ann_for_model(&rt, &token, &ann2, MODEL)
+            .await
+            .expect("post-restart warm");
+        assert!(
+            matches!(status, AnnEnsureStatus::Built { vectors: 4 }),
+            "a same-cardinality corpus content change must be detected as \
+             stale and force a rebuild rather than silently loading the \
+             outdated snapshot forever (#812 review HIGH-2), got: {status:?}"
+        );
     }
 }

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -938,20 +938,38 @@ impl MemoryPack {
                 // retry — up to ANN_OVERFETCH_MAX_ROUNDS total rounds, or until the
                 // index is exhausted (returned hits < requested k). Single-namespace
                 // stores fill on round 1 at zero extra cost.
-                // #750: a merely-present cache entry is not sufficient — a slow
-                // background build that snapshotted the corpus before the most
-                // recent write can still be sitting in the cache (it lost the
-                // install race for freshness but was still the first to reach
-                // an empty slot). `is_current` treats "present but stale
-                // relative to this model's write-generation counter" the same
-                // as a genuine cache miss, so a just-written memory is never
-                // silently served from a snapshot that predates it.
+                // #750: `is_current` treats "present but stale relative to
+                // this model's write-generation counter" as behind, so a
+                // background build that snapshotted the corpus before the
+                // most recent write is never mistaken for a fully fresh one.
+                //
+                // #791: being behind is no longer treated the same as a
+                // genuine cache miss. It used to route straight into
+                // `ensure_ann_for_model`, which — on a cache that a
+                // concurrent `memory.remember` had just cleared and whose
+                // snapshot it had just deleted — meant a full synchronous
+                // corpus rebuild inline on THIS recall's own request path
+                // (the #791 hang: single-flighted, so every other concurrent
+                // recall for the same model waited out the same rebuild).
+                // Writes no longer clear the cache at all (`ann::bump_generation`'s
+                // doc comment), so the previous, still-installed entry is
+                // always tried first via `search_loaded` regardless of
+                // freshness. A stale-but-present hit is served immediately;
+                // the already-existing background warm is (re-)fired so a
+                // later recall benefits from the fresher build once
+                // `install_if_fresher` installs it. Only a genuine miss —
+                // nothing installed for this model at all, e.g. before the
+                // very first warm has ever completed — still pays for an
+                // inline `ensure_ann_for_model`, and even that no longer
+                // monopolizes a tokio worker: the CPU-bound graph build
+                // inside it now runs via `tokio::task::spawn_blocking`
+                // (`ann.rs::load_and_build_from_vector_store`).
                 let cache_fresh = ann::is_current(&self.ann, &key).await;
-                let search_result = if cache_fresh {
-                    ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await
-                } else {
-                    Ok(None)
-                };
+                let search_result =
+                    ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await;
+                if !cache_fresh && matches!(search_result, Ok(Some(_))) {
+                    ann::ensure_ann_background(&self.runtime, token, &self.ann, &model_name).await;
+                }
                 let initial_raw_hits: Option<Vec<(Uuid, f32)>> = match search_result {
                     Ok(Some(hits)) => Some(hits),
                     Ok(None) => {

--- a/crates/khive-pack-memory/src/handlers/common.rs
+++ b/crates/khive-pack-memory/src/handlers/common.rs
@@ -964,6 +964,16 @@ impl MemoryPack {
                 // monopolizes a tokio worker: the CPU-bound graph build
                 // inside it now runs via `tokio::task::spawn_blocking`
                 // (`ann.rs::load_and_build_from_vector_store`).
+                //
+                // #812 review REQUEST CHANGES HIGH: `is_current` alone only
+                // sees THIS process's write-generation counter, which
+                // `kkernel reindex` (a separate OS process) never touches —
+                // an already-warm daemon would otherwise trust its cached
+                // entry forever after a cross-process reindex. The amortized
+                // durable-epoch check below observes a signal written to the
+                // shared SQLite file instead, debounced so it doesn't add a
+                // DB round-trip to every recall.
+                ann::maybe_check_durable_epoch(&self.runtime, &self.ann, &key).await;
                 let cache_fresh = ann::is_current(&self.ann, &key).await;
                 let search_result =
                     ann::search_loaded(&self.ann, &key, &vec, ann_fetch_limit).await;

--- a/crates/khive-pack-memory/src/handlers/prune.rs
+++ b/crates/khive-pack-memory/src/handlers/prune.rs
@@ -141,16 +141,20 @@ impl MemoryPack {
         // orchestration entirely (no FTS/vector cleanup, no note-mutation
         // hook fire), so it does NOT go through the generic hook wired into
         // `update_note`/`delete_note` for KG's delete path. Prune is inside
-        // the same crate as `ann`, so it invalidates/bumps directly, mirroring
-        // `memory.remember`'s own write-path pattern in `remember.rs`. The
-        // resulting cache miss forces a rebuild whose corpus scan already
-        // filters `deleted_at IS NULL` (`ann.rs`), so the just-pruned rows
-        // are correctly excluded from the rebuilt index.
+        // the same crate as `ann`, so it bumps generation directly, mirroring
+        // `memory.remember`'s own write-path pattern in `remember.rs`.
+        //
+        // #791: no longer clears the in-memory cache or deletes the
+        // persisted snapshot (see `remember.rs`'s rationale) — bumping
+        // generation is the only invalidation signal needed, and the
+        // background warm fired here re-scans the corpus (already filtering
+        // `deleted_at IS NULL`, `ann.rs`), correctly excluding the just-pruned
+        // rows once it installs.
         if pruned > 0 {
-            ann::invalidate_namespace(&self.runtime, &self.ann, &namespace).await;
             for model in self.runtime.registered_embedding_model_names() {
                 let key = ann::AnnKey::new(namespace.as_str(), model.as_str());
                 ann::bump_generation(&self.ann, &key).await;
+                ann::ensure_ann_background(&self.runtime, token, &self.ann, &model).await;
             }
         }
 

--- a/crates/khive-pack-memory/src/handlers/recall.rs
+++ b/crates/khive-pack-memory/src/handlers/recall.rs
@@ -3327,6 +3327,48 @@ mod tests {
 
     // ── #733 slice 1: optional `namespace` param on memory.recall ──────────
 
+    /// #791: `memory.recall`'s ANN cache-hit path now serves a
+    /// present-but-stale entry immediately rather than blocking the request
+    /// on a synchronous full-corpus rebuild (`ann::search_loaded`'s call
+    /// site in `handlers/common.rs` no longer gates on `ann::is_current`).
+    /// A `memory.remember` immediately followed by a `memory.recall` for the
+    /// same model is therefore only eventually, not immediately, consistent:
+    /// the background warm the write fires (`ann::ensure_ann_background`)
+    /// has to install before the just-written note is reflected. Tests that
+    /// seed notes and then assert on recall results poll a bounded number of
+    /// times instead of asserting on a single dispatch, matching the
+    /// documented indexing-latency contract ("a stale ANN serving window is
+    /// acceptable"). `ready` decides when the response is settled enough to
+    /// assert against; on exhaustion this returns the last response so the
+    /// caller's own assertions produce the real diagnostic.
+    async fn recall_until(
+        registry: &khive_runtime::VerbRegistry,
+        verb: &str,
+        args: Value,
+        mut ready: impl FnMut(&Value) -> bool,
+    ) -> Value {
+        let mut result = registry
+            .dispatch(verb, args.clone())
+            .await
+            .unwrap_or_else(|e| panic!("{verb}: {e}"));
+        // 300 * 25ms = ~7.5s ceiling — generous relative to the small
+        // in-memory corpora these tests seed, to stay reliable under
+        // parallel test-suite CPU contention (background warms share the
+        // process-wide blocking pool with every other concurrently running
+        // test), while still resolving in low milliseconds in the common case.
+        for _ in 0..300 {
+            if ready(&result) {
+                return result;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            result = registry
+                .dispatch(verb, args.clone())
+                .await
+                .unwrap_or_else(|e| panic!("{verb}: {e}"));
+        }
+        result
+    }
+
     /// Seeds a fresh in-memory runtime with `kg` + `memory` registered, three
     /// memories — two in `local`, one in `bench-a` — all sharing a query term
     /// so a namespace-agnostic FTS/RRF recall would surface all three absent
@@ -3562,13 +3604,18 @@ mod tests {
         // whichever queued build acquired the per-model lock first via
         // `entry(key).or_insert(bridge)`, permanently, even when it had
         // snapshotted the corpus before a still-in-flight `remember`
-        // committed. With the write-generation-checked install
-        // (`install_if_fresher` in ann.rs) and the recall-path freshness
-        // gate (`ann::is_current`, `handlers/common.rs`) replacing that
-        // blind `or_insert`, a stale build can no longer win permanently and
-        // a stale-but-present cache entry is no longer treated as a hit —
-        // so this now asserts directly, in one attempt, with no retry or
-        // poll.
+        // committed. The write-generation-checked install
+        // (`install_if_fresher` in ann.rs) fixed that permanent-win bug.
+        //
+        // #791: `handlers/common.rs`'s recall path now serves a
+        // stale-but-present cache entry immediately instead of treating it
+        // as a miss, to stop a recall from paying for a synchronous
+        // full-corpus rebuild on its own request path. That reintroduces a
+        // *bounded, eventually-resolving* staleness window here: the very
+        // next recall right after `remember`ing the target can observe a
+        // cache that predates it. `recall_until` polls for the settled
+        // (post-background-warm) response instead of asserting on a single
+        // dispatch.
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         rt.register_embedder(FixedVecProvider {
             model_name: NS733_ANN_MODEL.to_string(),
@@ -3626,11 +3673,16 @@ mod tests {
         });
 
         // Case 1: default widening — the target must be found, and only the
-        // target.
-        let widened_result = registry
-            .dispatch("memory.recall", base_params.clone())
-            .await
-            .expect("memory.recall with default widening");
+        // target. Poll (#791) until the background warm settles the target
+        // into the ANN cache.
+        let widened_result = recall_until(&registry, "memory.recall", base_params.clone(), |r| {
+            r.as_array().is_some_and(|hits| {
+                hits.len() == 1
+                    && hits[0]["id"].as_str().and_then(|s| s.parse::<Uuid>().ok())
+                        == Some(target_id)
+            })
+        })
+        .await;
         let widened_hits = widened_result.as_array().expect("bare array result");
         assert_eq!(
             widened_hits.len(),
@@ -3770,12 +3822,15 @@ mod tests {
         // above — `ensure_ann_for_model`'s old `entry(key).or_insert(bridge)`
         // let whichever queued build acquired the per-model lock first win
         // permanently, even one that had snapshotted the corpus before a
-        // still-in-flight sibling `remember` committed. With the
+        // still-in-flight sibling `remember` committed. The
         // write-generation-checked install (`install_if_fresher`, ann.rs)
-        // and the recall-path freshness gate (`ann::is_current`,
-        // `handlers/common.rs`), a stale build can no longer win permanently
-        // and a stale-but-present cache entry is no longer served as a hit —
-        // so this now asserts directly, in one attempt, with no retry or poll.
+        // fixed that permanent-win bug.
+        //
+        // #791: `handlers/common.rs`'s recall path now serves a
+        // stale-but-present cache entry immediately (see the rationale on
+        // `ns733_recall_ann_overfetch_retry_loop_respects_effective_namespace`
+        // above), so `recall_until` polls for the settled response instead
+        // of asserting on a single dispatch.
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         rt.register_embedder(FixedVecProvider {
             model_name: NS733B_MODEL_A.to_string(),
@@ -3800,10 +3855,21 @@ mod tests {
             "include_breakdown": true,
             "limit": 10,
         });
-        let result = registry
-            .dispatch("memory.recall", recall_args)
-            .await
-            .expect("memory.recall with namespace + multi-model + include_breakdown");
+        let result = recall_until(&registry, "memory.recall", recall_args, |r| {
+            r["candidates"]["vector_candidates_per_model"]
+                .as_array()
+                .is_some_and(|per_model| {
+                    per_model.iter().any(|entry| {
+                        entry["hits"].as_array().is_some_and(|hits| {
+                            hits.iter().any(|hit| {
+                                hit["id"].as_str().and_then(|s| s.parse::<Uuid>().ok())
+                                    == Some(target_id)
+                            })
+                        })
+                    })
+                })
+        })
+        .await;
 
         ns733b_assert_breakdown(&result, &local_filler_ids, target_id);
     }
@@ -3882,8 +3948,11 @@ mod tests {
         // above applied identically here — `handle_recall_candidates` reads
         // the same shared per-model ANN index via the same
         // `collect_recall_candidates` path `handle_recall` uses. Fixed the
-        // same way (write-generation-checked install + recall-path freshness
-        // gate); asserts directly, in one attempt, with no retry or poll.
+        // same way (write-generation-checked install).
+        //
+        // #791: same stale-serve behavior change as the sibling test above
+        // — polls for the settled response via `recall_until` rather than
+        // asserting on a single dispatch.
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
         rt.register_embedder(FixedVecProvider {
             model_name: NS733B_MODEL_A.to_string(),
@@ -3916,10 +3985,26 @@ mod tests {
             "namespace": "bench-a",
             "limit": 10,
         });
-        let result = registry
-            .dispatch("memory.recall_candidates", recall_candidates_args)
-            .await
-            .expect("memory.recall_candidates with namespace + multi-model");
+        let result = recall_until(
+            &registry,
+            "memory.recall_candidates",
+            recall_candidates_args,
+            |r| {
+                r["vector_candidates_per_model"]
+                    .as_object()
+                    .is_some_and(|per_model| {
+                        per_model.values().any(|hits| {
+                            hits.as_array().is_some_and(|hits| {
+                                hits.iter().any(|hit| {
+                                    hit["id"].as_str().and_then(|s| s.parse::<Uuid>().ok())
+                                        == Some(target_id)
+                                })
+                            })
+                        })
+                    })
+            },
+        )
+        .await;
 
         let per_model = result["vector_candidates_per_model"]
             .as_object()

--- a/crates/khive-pack-memory/src/handlers/remember.rs
+++ b/crates/khive-pack-memory/src/handlers/remember.rs
@@ -136,8 +136,18 @@ impl MemoryPack {
             .await?;
 
         {
-            let ns = write_token.namespace().as_str().to_owned();
-            ann::invalidate_namespace(&self.runtime, &self.ann, &ns).await;
+            // #791: do NOT clear the in-memory ANN cache or delete the
+            // persisted snapshot here. That used to destroy the only fast
+            // fallback a concurrent `memory.recall` had — a recall landing
+            // before the background warm below finished was forced into a
+            // synchronous full-corpus rebuild inline on its own request
+            // path. Bumping the write-generation counter is the only
+            // invalidation signal needed: the recall-path freshness gate
+            // (`ann::is_current`, `handlers/common.rs`) already treats a
+            // present-but-behind-counter entry as stale, serves it anyway,
+            // and fires this same background warm so a later recall
+            // benefits from the fresher build once `install_if_fresher`
+            // installs it.
             let affected_models: Vec<String> = match p.embedding_model.as_deref() {
                 Some(model) => vec![model.to_owned()],
                 None => self.runtime.registered_embedding_model_names(),

--- a/crates/khive-pack-memory/src/lib.rs
+++ b/crates/khive-pack-memory/src/lib.rs
@@ -28,3 +28,17 @@ pub async fn bump_memory_ann_epoch(
 ) -> Result<u64, khive_runtime::RuntimeError> {
     ann::bump_durable_epoch(rt).await
 }
+
+/// Ensure the `memory_ann_epoch` table exists on `rt` (idempotent, #812
+/// review REQUEST CHANGES MEDIUM — pack schema contract). Declared via
+/// `MemoryPack::SCHEMA_PLAN` for daemon boot (`server.rs`/`serve.rs` apply
+/// every loaded pack's schema plan up front), but `kkernel reindex` runs
+/// directly against a raw `KhiveRuntime` without ever booting a pack
+/// registry — it calls this explicitly, once, before its first
+/// `bump_memory_ann_epoch`, so a reindex against a brand-new database (no
+/// daemon ever started) doesn't fail before this table exists.
+pub async fn ensure_ann_epoch_schema(
+    rt: &khive_runtime::KhiveRuntime,
+) -> Result<(), khive_runtime::RuntimeError> {
+    ann::ensure_epoch_schema(rt).await
+}

--- a/crates/khive-pack-memory/src/lib.rs
+++ b/crates/khive-pack-memory/src/lib.rs
@@ -13,3 +13,18 @@ pub mod text_gather;
 pub mod tunable;
 
 pub use pack::MemoryPack;
+
+/// Bump the durable memory-ANN corpus epoch (#812 review REQUEST CHANGES
+/// HIGH). `kkernel reindex` mutates note vectors and deletes the persisted
+/// Vamana snapshot directly, out of process from any running khive daemon —
+/// its in-memory write-generation counter (`ann::bump_generation`) is simply
+/// unreachable from a separate process. Call this after invalidating the
+/// snapshot so a warm daemon sharing the same database file has a durable
+/// signal to observe on its next amortized freshness check
+/// (`ann::maybe_check_durable_epoch`, sampled from the recall path) and
+/// schedules a rebuild instead of serving pre-reindex vectors indefinitely.
+pub async fn bump_memory_ann_epoch(
+    rt: &khive_runtime::KhiveRuntime,
+) -> Result<u64, khive_runtime::RuntimeError> {
+    ann::bump_durable_epoch(rt).await
+}

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -401,11 +401,13 @@ impl PackRuntime for MemoryPack {
     /// KG's `update`/`delete` verbs reach `KhiveRuntime::update_note`/
     /// `delete_note` with no dependency on `khive-pack-memory` at all. When
     /// those touch a `kind="memory"` note (content update, soft delete, or
-    /// hard delete), this hook invalidates the warm ANN cache and bumps the
-    /// affected models' write-generation counter — the same two calls
-    /// `memory.remember` already makes on its own write path (`ann::invalidate_namespace`
-    /// + `ann::bump_generation`) — so `ann::is_current()` correctly treats
-    /// the stale-but-still-installed index as a miss on the next recall.
+    /// hard delete), this hook bumps the affected models' write-generation
+    /// counter (#750) and fires the same background warm `memory.remember`
+    /// fires on its own write path (#791) — so `ann::is_current()` correctly
+    /// treats the stale-but-still-installed index as behind, `search_loaded`
+    /// keeps serving it in the meantime, and the background warm eventually
+    /// installs a fresh one. This hook no longer clears the cache or deletes
+    /// the persisted snapshot (see `remember.rs`'s #791 rationale).
     fn register_note_mutation_hook(&self, _runtime: &KhiveRuntime) {
         let runtime = self.runtime.clone();
         let ann = self.ann.clone();
@@ -416,10 +418,13 @@ impl PackRuntime for MemoryPack {
                 if kind != "memory" {
                     return;
                 }
-                crate::ann::invalidate_namespace(&runtime, &ann, "local").await;
+                let Ok(token) = runtime.authorize(khive_runtime::Namespace::local()) else {
+                    return;
+                };
                 for model in runtime.registered_embedding_model_names() {
                     let key = crate::ann::AnnKey::new("local", model.as_str());
                     crate::ann::bump_generation(&ann, &key).await;
+                    crate::ann::ensure_ann_background(&runtime, &token, &ann, &model).await;
                 }
             })
         });

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -6,12 +6,14 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use khive_runtime::pack::PackRuntime;
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{
+    KhiveRuntime, NamespaceToken, PackSchemaPlan, RuntimeError, SchemaPlan, VerbRegistry,
+};
 use khive_types::{HandlerDef, Pack, ParamDef, VerbCategory, Visibility};
 
 use khive_brain_core::BalancedRecallState;
 
-use crate::ann::{new_shared, SharedAnn};
+use crate::ann::{new_shared, SharedAnn, MEMORY_SCHEMA_PLAN_STMTS};
 use crate::config::RecallConfig;
 use crate::query_cache::QueryEmbeddingCache;
 
@@ -72,6 +74,14 @@ impl Pack for MemoryPack {
     const ENTITY_KINDS: &'static [&'static str] = &[];
     const HANDLERS: &'static [HandlerDef] = &MEMORY_HANDLERS;
     const REQUIRES: &'static [&'static str] = &["kg"];
+    /// `memory_ann_epoch` (#812 review REQUEST CHANGES MEDIUM — pack schema
+    /// contract): declared here instead of created inline on the epoch
+    /// bump/read path, matching every other pack-auxiliary table in this
+    /// codebase (ADR-028). Applied at boot by `server.rs`/`serve.rs`.
+    const SCHEMA_PLAN: Option<PackSchemaPlan> = Some(PackSchemaPlan {
+        pack: "memory",
+        statements: &MEMORY_SCHEMA_PLAN_STMTS,
+    });
 }
 
 // Illocutionary classification (Searle 1976):
@@ -385,6 +395,13 @@ impl PackRuntime for MemoryPack {
 
     fn requires(&self) -> &'static [&'static str] {
         <MemoryPack as Pack>::REQUIRES
+    }
+
+    fn schema_plan(&self) -> SchemaPlan {
+        SchemaPlan {
+            pack: "memory",
+            statements: &MEMORY_SCHEMA_PLAN_STMTS,
+        }
     }
 
     async fn warm(&self) {

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -880,6 +880,21 @@ async fn invalidate_active_memory_vamana_snapshot(rt: &KhiveRuntime) {
             }
         }
     }
+    drop(writer);
+
+    // #812 review REQUEST CHANGES HIGH: the DELETE above only touches the
+    // persisted snapshot row. A khive daemon that warmed its in-memory ANN
+    // index before this reindex ran shares no process, and therefore no
+    // in-memory write-generation state, with this `kkernel reindex`
+    // invocation — its `common.rs` recall path would keep trusting that
+    // cached index forever with no way to observe this mutation at all.
+    // Bumping the durable epoch here gives that daemon's amortized freshness
+    // check (`khive_pack_memory::ann::maybe_check_durable_epoch`, sampled
+    // from the recall path) a signal written to the shared database file
+    // instead of one confined to this process.
+    if let Err(e) = khive_pack_memory::bump_memory_ann_epoch(rt).await {
+        tracing::warn!(error = %e, "failed to bump durable memory ANN epoch after reindex");
+    }
 }
 
 /// Return the set of distinct namespaces present in base `entities` and `notes`

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -221,6 +221,14 @@ struct ReindexReport {
     entities_fts_failed: u64,
     /// Note FTS upserts that failed during the backfill pass.
     notes_fts_failed: u64,
+    /// True when the completion ("settled") durable memory-ANN epoch bump
+    /// failed after entity/note mutations were already committed (#812
+    /// review REQUEST CHANGES HIGH — crash safety). The start-of-pass bump
+    /// (`begin_reindex_epoch`) aborts the whole run before any mutation on
+    /// failure, so there is nothing left to "abort" here — but a swallowed
+    /// failure at this point is exactly the bug this fix closes, so it now
+    /// surfaces as a fail-closed exit instead of a silent warning.
+    epoch_bump_failed: bool,
 }
 
 impl ReindexReport {
@@ -233,6 +241,7 @@ impl ReindexReport {
             || self.knowledge_pass_errored
             || self.knowledge_ann_failed
             || self.knowledge_sections_failed > 0
+            || self.epoch_bump_failed
     }
 }
 
@@ -515,8 +524,14 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
     let mut entities_fts_failed: u64 = 0;
     let mut notes_fts_failed: u64 = 0;
 
+    let mut epoch_bump_failed = false;
+
     // ── entities + notes (graph substrate) ────────────────────────────────────
     if do_graph {
+        begin_reindex_epoch(&rt)
+            .await
+            .context("aborting reindex before any vector mutation")?;
+
         let entity_total = rt.count_entities(&token, None).await.unwrap_or(0);
         let entity_bar = ProgressBar::new("entities");
         entity_bar.update(0, entity_total);
@@ -644,7 +659,11 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         // `khive-pack-memory::ann` is the primary defense against a daemon
         // trusting it afterward, but deleting it here forces a rebuild on the
         // very next warm regardless, without depending on that check alone.
-        invalidate_active_memory_vamana_snapshot(&rt).await;
+        //
+        // This also performs the completion ("settled") durable epoch bump
+        // (#812 review REQUEST CHANGES HIGH) — see its own doc comment for
+        // why a failure here is reported rather than warned-and-ignored.
+        epoch_bump_failed = !invalidate_active_memory_vamana_snapshot(&rt).await;
 
         // Drop per-namespace FTS partition tables that survived the V4 migration
         // (tables created by the runtime before the migration ran, or on databases
@@ -740,6 +759,7 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         errors_skipped,
         entities_fts_failed,
         notes_fts_failed,
+        epoch_bump_failed,
     };
 
     print_report(&report, args.human);
@@ -839,62 +859,112 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
     }
 }
 
+/// Durably mark the reindex-in-progress epoch, before ANY vector mutation in
+/// this pass (#812 review REQUEST CHANGES HIGH — crash safety). The previous
+/// design bumped the durable epoch only as a best-effort step AFTER every
+/// vector mutation had already committed (see
+/// `invalidate_active_memory_vamana_snapshot`'s completion bump below); a
+/// crash between the last commit and that bump, or a silently swallowed
+/// bump error, left an already-warm daemon with no durable signal at all and
+/// serving pre-reindex vectors indefinitely.
+///
+/// Bumping first instead closes that gap: a daemon that observes this epoch
+/// mid-reindex (via `khive_pack_memory::ann::maybe_check_durable_epoch`,
+/// sampled from the recall path) rebuilds conservatively against whatever
+/// partial corpus is on disk at that moment — never worse than the old
+/// behavior of trusting a stale index forever — and the completion bump at
+/// the end of this pass forces one more rebuild once the corpus reaches its
+/// final, fully re-embedded state. Together these two durable bumps form an
+/// in-progress/completed epoch protocol: any observer landing anywhere
+/// between them still converges.
+///
+/// `kkernel reindex` runs directly against a raw `KhiveRuntime`, without a
+/// pack registry boot to apply `MemoryPack::SCHEMA_PLAN`, so this also
+/// ensures the `memory_ann_epoch` table exists before its first bump.
+///
+/// Fail-closed: an error here — schema creation OR the epoch write itself —
+/// aborts the whole reindex before any mutation runs, via `?` on this
+/// function's `Result`. Never warn-and-continue: a swallowed failure here is
+/// exactly the bug ADR-107 §4 was written to close.
+async fn begin_reindex_epoch(rt: &KhiveRuntime) -> Result<()> {
+    khive_pack_memory::ensure_ann_epoch_schema(rt)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .context("failed to ensure memory_ann_epoch schema before reindex")?;
+    khive_pack_memory::bump_memory_ann_epoch(rt)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .context("failed to durably mark reindex-in-progress epoch")?;
+    Ok(())
+}
+
 /// Delete the ACTIVE global memory Vamana snapshot row (`global::memory_vamana::*`),
 /// distinct from `purge_stale_memory_vamana_snapshots`'s legacy-row cleanup above
 /// (#812 review re-confirm HIGH-A defense in depth). Reindex rewrites note
 /// embeddings directly, bypassing `memory.remember`, so it never bumps the memory
 /// pack's in-memory write-generation counter — that daemon-side signal simply
-/// cannot see this change. Best-effort: a missing table or SQL failure is logged
-/// and ignored, matching this file's other snapshot-maintenance helpers.
-async fn invalidate_active_memory_vamana_snapshot(rt: &KhiveRuntime) {
+/// cannot see this change. The DELETE itself stays best-effort (a missing table
+/// or SQL failure is logged and ignored, matching this file's other
+/// snapshot-maintenance helpers) — it is a defense-in-depth optimization, not
+/// the correctness mechanism.
+///
+/// Returns `false` when the completion ("settled") durable epoch bump below
+/// fails — see `begin_reindex_epoch`'s doc comment for the two-phase
+/// protocol this half completes. Unlike `begin_reindex_epoch`, mutations have
+/// already committed by this point, so there is nothing left to abort; the
+/// caller instead folds this into `ReindexReport::epoch_bump_failed`, which
+/// drives a fail-closed non-zero exit instead of the old warn-and-continue.
+async fn invalidate_active_memory_vamana_snapshot(rt: &KhiveRuntime) -> bool {
     use khive_storage::types::{SqlStatement, SqlValue};
     let sql = rt.sql();
-    let Ok(mut writer) = sql.writer().await else {
-        return;
-    };
-    // `retrieval_snapshots.namespace` holds the FULL composite key produced by
-    // `ann::snapshot_key` (`"global::memory_vamana::{model}"`), not a bare
-    // namespace — matching on `namespace = 'global'` would never match any row.
-    match writer
-        .execute(SqlStatement {
-            sql: "DELETE FROM retrieval_snapshots \
-                  WHERE index_type = 'memory_vamana' AND namespace LIKE ?1"
-                .into(),
-            params: vec![SqlValue::Text("global::memory_vamana::%".into())],
-            label: Some("invalidate_active_memory_vamana_snapshot".into()),
-        })
-        .await
-    {
-        Ok(deleted) => {
-            if deleted > 0 {
-                tracing::info!(
-                    deleted,
-                    "invalidated active global memory Vamana snapshot after reindex"
-                );
+    if let Ok(mut writer) = sql.writer().await {
+        // `retrieval_snapshots.namespace` holds the FULL composite key produced
+        // by `ann::snapshot_key` (`"global::memory_vamana::{model}"`), not a
+        // bare namespace — matching on `namespace = 'global'` would never
+        // match any row.
+        match writer
+            .execute(SqlStatement {
+                sql: "DELETE FROM retrieval_snapshots \
+                      WHERE index_type = 'memory_vamana' AND namespace LIKE ?1"
+                    .into(),
+                params: vec![SqlValue::Text("global::memory_vamana::%".into())],
+                label: Some("invalidate_active_memory_vamana_snapshot".into()),
+            })
+            .await
+        {
+            Ok(deleted) => {
+                if deleted > 0 {
+                    tracing::info!(
+                        deleted,
+                        "invalidated active global memory Vamana snapshot after reindex"
+                    );
+                }
             }
-        }
-        Err(e) => {
-            let msg = e.to_string();
-            if !msg.contains("no such table") {
-                tracing::warn!(error = %e, "failed to invalidate active memory Vamana snapshot");
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("no such table") {
+                    tracing::warn!(error = %e, "failed to invalidate active memory Vamana snapshot");
+                }
             }
         }
     }
-    drop(writer);
 
-    // #812 review REQUEST CHANGES HIGH: the DELETE above only touches the
-    // persisted snapshot row. A khive daemon that warmed its in-memory ANN
-    // index before this reindex ran shares no process, and therefore no
-    // in-memory write-generation state, with this `kkernel reindex`
-    // invocation — its `common.rs` recall path would keep trusting that
-    // cached index forever with no way to observe this mutation at all.
-    // Bumping the durable epoch here gives that daemon's amortized freshness
-    // check (`khive_pack_memory::ann::maybe_check_durable_epoch`, sampled
-    // from the recall path) a signal written to the shared database file
-    // instead of one confined to this process.
+    // #812 review REQUEST CHANGES HIGH: the completion half of the
+    // in-progress/completed epoch protocol described on `begin_reindex_epoch`.
+    // A khive daemon that warmed its in-memory ANN index before this reindex
+    // ran shares no process, and therefore no in-memory write-generation
+    // state, with this `kkernel reindex` invocation — its `common.rs` recall
+    // path would keep trusting that cached index forever with no way to
+    // observe this mutation at all. Bumping the durable epoch here gives that
+    // daemon's amortized freshness check
+    // (`khive_pack_memory::ann::maybe_check_durable_epoch`, sampled from the
+    // recall path) a signal written to the shared database file instead of
+    // one confined to this process.
     if let Err(e) = khive_pack_memory::bump_memory_ann_epoch(rt).await {
         tracing::warn!(error = %e, "failed to bump durable memory ANN epoch after reindex");
+        return false;
     }
+    true
 }
 
 /// Return the set of distinct namespaces present in base `entities` and `notes`
@@ -1401,6 +1471,7 @@ mod tests {
             errors_skipped: errors,
             entities_fts_failed: 0,
             notes_fts_failed: 0,
+            epoch_bump_failed: false,
         }
     }
 
@@ -1437,6 +1508,7 @@ mod tests {
             errors_skipped: 0,
             entities_fts_failed: 0,
             notes_fts_failed: 0,
+            epoch_bump_failed: false,
         };
         assert!(
             report.has_failures(),
@@ -1468,6 +1540,7 @@ mod tests {
             errors_skipped: 0,
             entities_fts_failed: 0,
             notes_fts_failed: 0,
+            epoch_bump_failed: false,
         };
         assert!(
             report.has_failures(),
@@ -1838,6 +1911,7 @@ mod tests {
             errors_skipped: 0,
             entities_fts_failed: 0,
             notes_fts_failed: 1,
+            epoch_bump_failed: false,
         };
         assert!(
             report.has_failures(),
@@ -2420,6 +2494,7 @@ mod tests {
             errors_skipped: 0,
             entities_fts_failed: 1,
             notes_fts_failed: 0,
+            epoch_bump_failed: false,
         };
         assert!(
             report.has_failures(),

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -636,6 +636,16 @@ pub async fn run_reindex(args: ReindexArgs) -> Result<()> {
         // `global::memory_vamana::*`; old per-ns rows are orphaned and waste space.
         purge_stale_memory_vamana_snapshots(&rt).await;
 
+        // Invalidate the ACTIVE global memory Vamana snapshot too (#812 review
+        // re-confirm HIGH-A defense in depth). Its key (`global::memory_vamana::*`)
+        // never matched `invalidate_vamana_snapshots`'s `{namespace}::vamana::%`
+        // pattern above, so the note re-embed this pass just did left that
+        // snapshot installed and untouched — the content-hash restart check in
+        // `khive-pack-memory::ann` is the primary defense against a daemon
+        // trusting it afterward, but deleting it here forces a rebuild on the
+        // very next warm regardless, without depending on that check alone.
+        invalidate_active_memory_vamana_snapshot(&rt).await;
+
         // Drop per-namespace FTS partition tables that survived the V4 migration
         // (tables created by the runtime before the migration ran, or on databases
         // that were migrated but not swept). The sweep is guarded: it only runs
@@ -824,6 +834,49 @@ async fn purge_stale_memory_vamana_snapshots(rt: &KhiveRuntime) {
             let msg = e.to_string();
             if !msg.contains("no such table") {
                 tracing::warn!(error = %e, "failed to purge stale memory Vamana snapshots");
+            }
+        }
+    }
+}
+
+/// Delete the ACTIVE global memory Vamana snapshot row (`global::memory_vamana::*`),
+/// distinct from `purge_stale_memory_vamana_snapshots`'s legacy-row cleanup above
+/// (#812 review re-confirm HIGH-A defense in depth). Reindex rewrites note
+/// embeddings directly, bypassing `memory.remember`, so it never bumps the memory
+/// pack's in-memory write-generation counter — that daemon-side signal simply
+/// cannot see this change. Best-effort: a missing table or SQL failure is logged
+/// and ignored, matching this file's other snapshot-maintenance helpers.
+async fn invalidate_active_memory_vamana_snapshot(rt: &KhiveRuntime) {
+    use khive_storage::types::{SqlStatement, SqlValue};
+    let sql = rt.sql();
+    let Ok(mut writer) = sql.writer().await else {
+        return;
+    };
+    // `retrieval_snapshots.namespace` holds the FULL composite key produced by
+    // `ann::snapshot_key` (`"global::memory_vamana::{model}"`), not a bare
+    // namespace — matching on `namespace = 'global'` would never match any row.
+    match writer
+        .execute(SqlStatement {
+            sql: "DELETE FROM retrieval_snapshots \
+                  WHERE index_type = 'memory_vamana' AND namespace LIKE ?1"
+                .into(),
+            params: vec![SqlValue::Text("global::memory_vamana::%".into())],
+            label: Some("invalidate_active_memory_vamana_snapshot".into()),
+        })
+        .await
+    {
+        Ok(deleted) => {
+            if deleted > 0 {
+                tracing::info!(
+                    deleted,
+                    "invalidated active global memory Vamana snapshot after reindex"
+                );
+            }
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if !msg.contains("no such table") {
+                tracing::warn!(error = %e, "failed to invalidate active memory Vamana snapshot");
             }
         }
     }
@@ -1171,6 +1224,86 @@ mod tests {
         assert!(
             !remaining.contains(&"local::vamana::model-b".to_string()),
             "local vamana model-b must be deleted: {remaining:?}"
+        );
+    }
+
+    /// Reviewer-requested regression test (#812 review re-confirm HIGH-A
+    /// defense in depth): the active global memory Vamana snapshot row must
+    /// be deleted by `invalidate_active_memory_vamana_snapshot`, since
+    /// `invalidate_vamana_snapshots`'s `{namespace}::vamana::%` pattern never
+    /// matches the memory pack's distinct `global::memory_vamana::*` key.
+    #[tokio::test]
+    async fn test_reindex_invalidates_active_memory_vamana_snapshot() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let sql = rt.sql();
+
+        let mut w = sql.writer().await.expect("writer");
+        w.execute_script(
+            "CREATE TABLE IF NOT EXISTS retrieval_snapshots (\
+             namespace TEXT NOT NULL, \
+             index_type TEXT NOT NULL, \
+             snapshot BLOB NOT NULL, \
+             created_at INTEGER NOT NULL, \
+             PRIMARY KEY (namespace, index_type));"
+                .into(),
+        )
+        .await
+        .expect("create table");
+
+        for (ns, idx_type) in &[
+            ("global::memory_vamana::model-a", "memory_vamana"),
+            ("local::vamana::model-a", "vamana"),
+            ("local::memory_vamana::model-a", "memory_vamana"),
+        ] {
+            w.execute(SqlStatement {
+                sql: "INSERT INTO retrieval_snapshots \
+                      (namespace, index_type, snapshot, created_at) \
+                      VALUES (?1, ?2, ?3, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text(idx_type.to_string()),
+                    SqlValue::Blob(b"{}".to_vec()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert row");
+        }
+        drop(w);
+
+        invalidate_active_memory_vamana_snapshot(&rt).await;
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT namespace FROM retrieval_snapshots ORDER BY namespace".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query");
+
+        let remaining: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("namespace") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            !remaining.contains(&"global::memory_vamana::model-a".to_string()),
+            "the active global memory Vamana snapshot must be deleted: {remaining:?}"
+        );
+        assert!(
+            remaining.contains(&"local::vamana::model-a".to_string()),
+            "unrelated knowledge Vamana rows must survive: {remaining:?}"
+        );
+        assert!(
+            remaining.contains(&"local::memory_vamana::model-a".to_string()),
+            "legacy per-namespace memory Vamana rows are purge_stale_memory_vamana_snapshots's \
+             job, not this function's: {remaining:?}"
         );
     }
 

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -513,6 +513,17 @@ def _wait_for_ann_convergence(
     (fusion_strategy="vector_only"), so "converged" here means the ANN
     background rebuild has actually installed over the full post-ingest
     corpus — not a blind sleep guessing at a duration.
+
+    `probe_query`/`expected_topic` MUST come from the LAST-ingested batch, not
+    an arbitrary bench query. The daemon's background rebuild is a full-corpus
+    rebuild, not incremental: any installed generation captures everything
+    written up to when that build started reading, so a build snapshotted
+    mid-ingest can already satisfy a probe against EARLY-ingested content
+    (e.g. the first topic) while still missing the last few batches. Probing
+    with early content therefore converges the moment the FIRST background
+    build lands, not when the corpus is actually complete — the caller must
+    pass content whose presence can only be explained by a build that
+    happened at or after the final write.
     """
     deadline = time.time() + deadline_s
     t_start = time.time()
@@ -680,6 +691,8 @@ def main():
 
         corpus = generate_corpus()
         _ingest(proc, corpus)
+        last_batch_probe = corpus[-1]
+        last_batch_topic, _ = TOPICS[-1]
 
         # Assert recall is non-empty before measuring
         _, warmup_hits = _query_once(proc, QUERIES[0][0])
@@ -707,7 +720,12 @@ def main():
         # so the measurement loop below never samples the convergence race
         # (see ANN_SETTLE_* tunables and ADR-107 sec 1).
         print("\n[SETTLE] Waiting for ANN vector leg to converge post-ingest...", flush=True)
-        _wait_for_ann_convergence(proc, QUERIES[0][0], QUERIES[0][1])
+        # Probe with the LAST-ingested note's own content, not a bench query
+        # against the first topic: the rebuild is a full-corpus rebuild, so an
+        # early-content probe is satisfied by any installed generation from
+        # the start of ingest onward and converges before the corpus is
+        # actually complete (see _wait_for_ann_convergence docstring).
+        _wait_for_ann_convergence(proc, last_batch_probe, last_batch_topic)
 
         # Additional warm-up rounds (discard timings)
         for q, _ in QUERIES:

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -59,6 +59,20 @@ VECTOR_FLOOR = 0.70
 KEYWORD_FLOOR = 0.70
 N_REPS = 5  # repetitions per query for latency measurement
 
+# ANN convergence settle step. After a 600-note ingest burst, the memory pack's
+# background ANN rebuild (write-generation-checked install, ADR-107 sec 1) has
+# not necessarily installed by the time the first post-ingest recall lands —
+# that is the documented eventual-consistency contract this pipeline ships
+# (stale-but-installed served immediately, hot-swapped on background completion).
+# This benchmark is a read-after-write consumer of that contract: it must poll
+# for real convergence, not sample mid-rebuild and misread the race as a
+# structural vector-leg failure. Bounded generous deadline; fails loudly (not
+# silently) if convergence never happens, since that would indicate an actual
+# rebuild-latency regression rather than expected warm-up.
+ANN_SETTLE_DEADLINE_S = 30.0
+ANN_SETTLE_STABLE_N = 3
+ANN_SETTLE_POLL_S = 0.25
+
 # Default production pack set (must match RuntimeConfig::default().packs in
 # crates/khive-runtime/src/config.rs so config_id agrees between front-end
 # and daemon child).
@@ -482,6 +496,56 @@ def _query_once(proc, query_text, fusion_strategy=None):
     contents = [r["content"] for r in arr if isinstance(r, dict) and "content" in r]
     return elapsed_us, contents
 
+def _wait_for_ann_convergence(
+    proc,
+    probe_query,
+    expected_topic,
+    deadline_s=ANN_SETTLE_DEADLINE_S,
+    stable_needed=ANN_SETTLE_STABLE_N,
+    poll_interval_s=ANN_SETTLE_POLL_S,
+):
+    """Poll the vector-only leg with `probe_query` until it reports the
+    ingested corpus (P@K >= VECTOR_FLOOR) for `stable_needed` consecutive
+    polls, or raise loudly if `deadline_s` elapses first.
+
+    This is the deterministic settle step between ingest and the query phase:
+    it samples the SAME structural signal the gate later asserts on
+    (fusion_strategy="vector_only"), so "converged" here means the ANN
+    background rebuild has actually installed over the full post-ingest
+    corpus — not a blind sleep guessing at a duration.
+    """
+    deadline = time.time() + deadline_s
+    t_start = time.time()
+    consecutive_ok = 0
+    attempts = 0
+    last_p = None
+    while time.time() < deadline:
+        attempts += 1
+        _, contents = _query_once(proc, probe_query, fusion_strategy="vector_only")
+        last_p = precision_at_k(contents, expected_topic)
+        if last_p >= VECTOR_FLOOR:
+            consecutive_ok += 1
+            if consecutive_ok >= stable_needed:
+                print(
+                    f"[SETTLE] ANN vector leg converged after {attempts} probe(s), "
+                    f"{time.time() - t_start:.2f}s",
+                    flush=True,
+                )
+                return
+        else:
+            consecutive_ok = 0
+        time.sleep(poll_interval_s)
+    raise RuntimeError(
+        f"ANN vector-leg did not converge within {deadline_s}s of ingest "
+        f"({attempts} probe(s), last vector-only P@K={last_p!r} for probe "
+        f"query {probe_query!r}). The background rebuild triggered by ingest "
+        "never installed a corpus-covering index. This exceeds the expected "
+        "warm-up window for this corpus size and looks like a genuine "
+        "convergence-latency regression in the ANN rebuild path, not benign "
+        "eventual-consistency staleness — investigate before re-running."
+    )
+
+
 # ── Daemon teardown helper ────────────────────────────────────────────────────
 
 def _teardown_daemon(pid_path, tmpdir):
@@ -637,6 +701,13 @@ def main():
         while not pathlib.Path(sock_path).exists() and time.time() < deadline:
             time.sleep(0.1)
         assert_daemon_engaged(sock_path, pid_path_file, bench_db, label="main")
+
+        # Deterministic settle: block until the ANN background rebuild
+        # triggered by ingest has actually installed a corpus-covering index,
+        # so the measurement loop below never samples the convergence race
+        # (see ANN_SETTLE_* tunables and ADR-107 sec 1).
+        print("\n[SETTLE] Waiting for ANN vector leg to converge post-ingest...", flush=True)
+        _wait_for_ann_convergence(proc, QUERIES[0][0], QUERIES[0][1])
 
         # Additional warm-up rounds (discard timings)
         for q, _ in QUERIES:

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -36,6 +36,7 @@ headroom and must NOT be tightened toward the observed mean.
 """
 
 import csv
+import itertools
 import json
 import os
 import pathlib
@@ -126,6 +127,21 @@ def generate_corpus():
             prefix = "core" if i % 3 == 0 else ("detail" if i % 3 == 1 else "context")
             notes.append(f"{prefix} {w0}: {topic} with {w1} and {w2} — note {i}")
     return notes
+
+# ── Settle sentinel ───────────────────────────────────────────────────────────
+
+_SENTINEL_SEQ = itertools.count()
+
+
+def _make_sentinel_content():
+    """Return a run-unique content string that cannot collide with corpus text.
+
+    Built from os.getpid() plus a per-run counter so it is distinct even across
+    concurrent bench invocations on the same host. It shares no words with any
+    TOPICS entry, so it can never satisfy a topic-containment check and never
+    counts toward (or against) any query's Precision@K.
+    """
+    return f"__khive_bench_settle_sentinel_pid{os.getpid()}_seq{next(_SENTINEL_SEQ)}__"
 
 # ── MCP stdio driver (mirrors smoke_test.py pattern) ─────────────────────────
 
@@ -498,15 +514,14 @@ def _query_once(proc, query_text, fusion_strategy=None):
 
 def _wait_for_ann_convergence(
     proc,
-    probe_query,
-    expected_topic,
+    sentinel_content,
     deadline_s=ANN_SETTLE_DEADLINE_S,
     stable_needed=ANN_SETTLE_STABLE_N,
     poll_interval_s=ANN_SETTLE_POLL_S,
 ):
-    """Poll the vector-only leg with `probe_query` until it reports the
-    ingested corpus (P@K >= VECTOR_FLOOR) for `stable_needed` consecutive
-    polls, or raise loudly if `deadline_s` elapses first.
+    """Poll the vector-only leg, querying with `sentinel_content` itself, until
+    the EXACT sentinel note is present in the results for `stable_needed`
+    consecutive polls, or raise loudly if `deadline_s` elapses first.
 
     This is the deterministic settle step between ingest and the query phase:
     it samples the SAME structural signal the gate later asserts on
@@ -514,27 +529,29 @@ def _wait_for_ann_convergence(
     background rebuild has actually installed over the full post-ingest
     corpus — not a blind sleep guessing at a duration.
 
-    `probe_query`/`expected_topic` MUST come from the LAST-ingested batch, not
-    an arbitrary bench query. The daemon's background rebuild is a full-corpus
-    rebuild, not incremental: any installed generation captures everything
-    written up to when that build started reading, so a build snapshotted
-    mid-ingest can already satisfy a probe against EARLY-ingested content
-    (e.g. the first topic) while still missing the last few batches. Probing
-    with early content therefore converges the moment the FIRST background
-    build lands, not when the corpus is actually complete — the caller must
-    pass content whose presence can only be explained by a build that
-    happened at or after the final write.
+    `sentinel_content` MUST be the content of a note written with its own
+    SEQUENTIAL memory.remember call issued strictly after every batch ingest
+    op has returned — never a note drawn from a batch. Batch ingest ops run
+    in parallel with no inter-op ordering (ADR-016), so the "last" element of
+    a batch has no guarantee of being the last note actually committed; and
+    the daemon's background rebuild is a full-corpus rebuild, not incremental,
+    so a build snapshotted mid-ingest can already satisfy a topic-level probe
+    against EARLY-ingested content while still missing the last few batches.
+    Requiring the exact sentinel — written after all batch ingestion
+    completed and unique enough that only a post-sentinel-write build could
+    surface it — is the only way to prove the installed index actually
+    covers the complete corpus.
     """
     deadline = time.time() + deadline_s
     t_start = time.time()
     consecutive_ok = 0
     attempts = 0
-    last_p = None
+    last_hit = False
     while time.time() < deadline:
         attempts += 1
-        _, contents = _query_once(proc, probe_query, fusion_strategy="vector_only")
-        last_p = precision_at_k(contents, expected_topic)
-        if last_p >= VECTOR_FLOOR:
+        _, contents = _query_once(proc, sentinel_content, fusion_strategy="vector_only")
+        last_hit = any(sentinel_content in c for c in contents)
+        if last_hit:
             consecutive_ok += 1
             if consecutive_ok >= stable_needed:
                 print(
@@ -548,8 +565,8 @@ def _wait_for_ann_convergence(
         time.sleep(poll_interval_s)
     raise RuntimeError(
         f"ANN vector-leg did not converge within {deadline_s}s of ingest "
-        f"({attempts} probe(s), last vector-only P@K={last_p!r} for probe "
-        f"query {probe_query!r}). The background rebuild triggered by ingest "
+        f"({attempts} probe(s), sentinel note {sentinel_content!r} not found "
+        "in vector-only results). The background rebuild triggered by ingest "
         "never installed a corpus-covering index. This exceeds the expected "
         "warm-up window for this corpus size and looks like a genuine "
         "convergence-latency regression in the ANN rebuild path, not benign "
@@ -691,8 +708,21 @@ def main():
 
         corpus = generate_corpus()
         _ingest(proc, corpus)
-        last_batch_probe = corpus[-1]
-        last_batch_topic, _ = TOPICS[-1]
+
+        # Sequential settle sentinel: a single memory.remember call, issued only
+        # after every batch ingest op above has returned, so its commit cannot
+        # precede any corpus note (see _wait_for_ann_convergence docstring).
+        sentinel_content = _make_sentinel_content()
+        sentinel_body = _call_request(proc, json.dumps([
+            {"tool": "memory.remember", "args": {
+                "content": sentinel_content,
+                "memory_type": "semantic",
+                "salience": 0.7,
+                "decay_factor": 0.0,
+            }}
+        ]))
+        if sentinel_body is None or sentinel_body.get("summary", {}).get("failed", 0):
+            raise RuntimeError(f"Sentinel note write failed: {sentinel_body}")
 
         # Assert recall is non-empty before measuring
         _, warmup_hits = _query_once(proc, QUERIES[0][0])
@@ -720,12 +750,11 @@ def main():
         # so the measurement loop below never samples the convergence race
         # (see ANN_SETTLE_* tunables and ADR-107 sec 1).
         print("\n[SETTLE] Waiting for ANN vector leg to converge post-ingest...", flush=True)
-        # Probe with the LAST-ingested note's own content, not a bench query
-        # against the first topic: the rebuild is a full-corpus rebuild, so an
-        # early-content probe is satisfied by any installed generation from
-        # the start of ingest onward and converges before the corpus is
+        # Probe with the sequential sentinel note's own unique content, not a
+        # bench query against a topic: only a build that ran at or after the
+        # sentinel write can surface it, so its presence proves the corpus is
         # actually complete (see _wait_for_ann_convergence docstring).
-        _wait_for_ann_convergence(proc, last_batch_probe, last_batch_topic)
+        _wait_for_ann_convergence(proc, sentinel_content)
 
         # Additional warm-up rounds (discard timings)
         for q, _ in QUERIES:


### PR DESCRIPTION
## Summary

Fixes #791: `memory.recall` intermittently hung to the 300s MCP timeout.

Root cause: `memory.remember` (and the KG note-mutation hook, and `memory.prune`)
called `ann::invalidate_namespace`, which cleared every in-memory ANN index slot and
deleted the persisted snapshot for every model, synchronously, on the write's own
request path. A `memory.recall` landing before the resulting background rebuild
finished had nothing left to serve, so it fell into a synchronous, single-flighted,
full-corpus Vamana rebuild directly on its own request path
(`ann::ensure_ann_for_model` -> `load_and_build_from_vector_store` ->
`VamanaIndex::build`, a plain sync fn never wrapped in `spawn_blocking`). Every other
concurrent recall for the same model queued behind the same per-model mutex and paid
the same wall-clock wait.

This PR replaces that synchronous invalidate-and-rebuild path with a durable,
fail-closed eventual-consistency contract, normatively defined in
[ADR-107](docs/adr/ADR-107-memory-ann-lifecycle.md) (memory-pack scope; PR #813).

## Design

1. **Writes no longer destroy the fast fallback.** `memory.remember`, `memory.prune`,
   and the KG-side note-mutation hook bump the model's write-generation counter
   instead of clearing the cache or deleting the snapshot. The previously-installed
   index and snapshot stay in place and keep serving reads until a fresher build
   replaces them via generation-checked install (`install_if_fresher`); the on-disk
   snapshot is replaced by one atomic `INSERT OR REPLACE`, never deleted ahead of its
   replacement.

2. **Recall serves stale instead of blocking.** The recall path calls
   `ann::search_loaded` unconditionally and serves a present-but-stale hit
   immediately, firing the existing background warm (`ensure_ann_background`) so a
   later recall benefits from the fresher build once it installs. Only a genuine
   cache miss (nothing installed yet: the first `memory.recall` for a model in a
   process lifetime) still builds inline, and that build's CPU-bound graph
   construction runs via `tokio::task::spawn_blocking` so it never monopolizes a
   tokio worker.

3. **Bounded chained re-enqueue with debounce.** The background-rebuild task
   re-reads the write-generation counter on exit and, if a write raced in while it
   was building, re-enqueues itself against the new generation rather than relying on
   a later caller to notice, up to 3 attempts per task. Under continuous writes,
   chained tasks link back-to-back; each chain link is preceded by a fixed 1-second
   debounce so writes landing during that window coalesce into the next link's
   single generation read instead of spawning their own chain. The write-generation
   guard releases on every exit of the task it guards (success, error, or panic),
   not only the "nothing loaded" path.

4. **Durable corpus epoch, fail-closed.** A daemon that stays warm across a
   `kkernel reindex` run cannot observe reindex's snapshot deletion or the
   in-process write-generation counter, since the two run as separate processes.
   This is closed by a durable single-row `memory_ann_epoch` table (declared via
   `MemoryPack::SCHEMA_PLAN`, not created ad hoc), bumped twice per reindex pass:
   once before any vector mutation (`begin_reindex_epoch`, fail-closed: the whole
   reindex aborts if the bump fails) and once after the pass commits
   (`invalidate_active_memory_vamana_snapshot`). The recall warm-hit path compares
   the installed entry's `epoch_baseline` against the current durable epoch on a
   debounced (5s) interval and folds a mismatch into the same write-generation
   rebuild machinery.

5. **Content-hash restart validation.** A persisted snapshot's vector
   count/dimension fingerprint alone cannot detect a same-cardinality re-embed
   (`kkernel reindex` overwrites embeddings without touching `notes`, so no
   timestamp signal fires). Restart validation additionally persists a durable
   `CorpusContentHash` (blake3 over every live note's `(subject_id, embedding)`
   bytes, computed during the build's own corpus scan) and re-scans on restart to
   compare byte-for-byte; a mismatch is treated as stale and triggers a full
   rebuild, the same path an absent snapshot takes.

6. **Deletion filtering.** Because a served index may be stale, ANN hits are never
   trusted directly; every hit is resolved through a live-note hydration query
   (`deleted_at IS NULL`, `expires_at` in the future) before being returned. A
   stale ordinal pointing at a since-deleted or since-expired note hydrates to
   nothing and is silently dropped.

A bounded stale-serving window is accepted, matching the documented
indexing-latency contract. Full normative definition, including the two-phase
epoch protocol's crash-safety reasoning and the chained-debounce bound, is in
[ADR-107](docs/adr/ADR-107-memory-ann-lifecycle.md) sections 1-4.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy -p khive-pack-memory -p kkernel --all-targets -- -D warnings`
- `cargo test -p khive-pack-memory -p kkernel`
- New/updated tests cover: write-generation bump does not evict the installed
  index or snapshot before a replacement exists; a stale-but-installed entry is
  served by `search_loaded` rather than forcing a synchronous rebuild; the
  write-generation guard releases on every exit path (success/error/panic); the
  chained re-enqueue converges under continuous writes and respects the 3-attempt
  bound and 1-second chain debounce; restart content-hash mismatch triggers a
  rebuild on both vector-only and full-corpus re-embeds; the durable epoch's
  begin/completion bump pair and `kkernel reindex`'s fail-closed exit on a failed
  epoch bump.
- `scripts/perf/bench_pipeline_daemon.py` (Pipeline Regression Gate) now polls the
  vector-only leg to convergence after ingest, bounded by a generous deadline,
  before sampling the benchmark's per-leg P@K assertions, since the benchmark is a
  read-after-write consumer of this contract and must not sample the rebuild race
  mid-convergence.

Closes #791
