### PR TITLE
fix(kg): wire content_strategy through entity merge and report content_appended truthfully

### DIFF
--- a/crates/khive-pack-kg/src/apply_worker/worker.rs
+++ b/crates/khive-pack-kg/src/apply_worker/worker.rs
@@ -3,7 +3,7 @@
 use uuid::Uuid;
 
 use khive_runtime::{
-    curation::{EntityDedupMergePolicy, EntityPatch},
+    curation::{ContentMergeStrategy, EntityDedupMergePolicy, EntityPatch},
     KhiveRuntime, NamespaceToken, RuntimeError, VerbRegistry,
 };
 use khive_storage::types::PageRequest;
@@ -363,6 +363,7 @@ impl ProposalApplyWorker {
                 into_id,
                 from_id,
                 EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await?;

--- a/crates/khive-pack-kg/src/handlers/merge.rs
+++ b/crates/khive-pack-kg/src/handlers/merge.rs
@@ -43,7 +43,7 @@ impl KgPack {
                     )));
                 }
                 self.runtime
-                    .merge_entity(token, into_id, from_id, policy, dry_run)
+                    .merge_entity(token, into_id, from_id, policy, content_strategy, dry_run)
                     .await?
             }
             KindSpec::Note { specific } => {

--- a/crates/khive-pack-kg/tests/apply_worker.rs
+++ b/crates/khive-pack-kg/tests/apply_worker.rs
@@ -196,6 +196,113 @@ async fn apply_worker_applies_add_edge_changeset() {
     assert_eq!(row.status, "applied");
 }
 
+/// ADR-046 apply-worker path test for the codex PR #814 Medium finding: the
+/// five new content_strategy tests only exercised the runtime directly, not
+/// a proposal-driven merge. `apply_merge_entities` hard-codes
+/// `EntityDedupMergePolicy::PreferInto` + `ContentMergeStrategy::Append`
+/// (the safe, lossless default for proposal-driven merges) — verify that
+/// path actually rewires edges and tombstones the source.
+#[tokio::test]
+async fn apply_worker_applies_merge_entities_changeset() {
+    let (rt, tok) = setup();
+    ensure_schema(&rt).await;
+
+    let into = rt
+        .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+        .await
+        .expect("create into");
+    let from = rt
+        .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+        .await
+        .expect("create from");
+    let other = rt
+        .create_entity(&tok, "concept", None, "Other", None, None, vec![])
+        .await
+        .expect("create other");
+    rt.link(
+        &tok,
+        other.id,
+        from.id,
+        khive_types::EdgeRelation::Extends,
+        1.0,
+        None,
+    )
+    .await
+    .expect("link other -> from");
+
+    let proposal_id = Uuid::new_v4();
+    let changeset = ProposalChangeset::MergeEntities {
+        into: Id128::from_u128(into.id.as_u128()),
+        from: Id128::from_u128(from.id.as_u128()),
+    };
+
+    seed_proposal_created_event(&rt, &tok, proposal_id, changeset).await;
+    insert_projection_row(&rt, &tok, proposal_id, "approved").await;
+
+    let registry = build_registry(&rt);
+    let worker = ProposalApplyWorker::new(rt.clone());
+    worker
+        .maybe_apply(&tok, proposal_id, &registry, None)
+        .await
+        .expect("maybe_apply must succeed");
+
+    let event_store = rt.events(&tok).expect("event store");
+    let applied_events = event_store
+        .query_events(
+            EventFilter {
+                kinds: vec![EventKind::ProposalApplied],
+                payload_proposal_id: Some(proposal_id),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query events");
+    assert_eq!(
+        applied_events.items.len(),
+        1,
+        "exactly one ProposalApplied event must be emitted"
+    );
+
+    let merged = rt
+        .get_entity(&tok, into.id)
+        .await
+        .expect("into entity must still exist");
+    assert_eq!(
+        merged.description.as_deref(),
+        Some("desc A\n\n---\n\ndesc B"),
+        "apply_merge_entities must merge content with the Append default"
+    );
+
+    let source = rt
+        .get_entity(&tok, from.id)
+        .await
+        .expect_err("from entity must be tombstoned (soft-deleted) after merge");
+    assert!(
+        matches!(source, khive_runtime::RuntimeError::NotFound(_)),
+        "expected NotFound for the tombstoned source entity, got: {source:?}"
+    );
+
+    let other_neighbors = rt
+        .neighbors(
+            &tok,
+            other.id,
+            khive_storage::types::Direction::Out,
+            None,
+            None,
+        )
+        .await
+        .expect("neighbors must succeed");
+    assert_eq!(other_neighbors.len(), 1);
+    assert_eq!(
+        other_neighbors[0].node_id, into.id,
+        "the edge from `other` must have been rewired onto the surviving `into` entity"
+    );
+}
+
 #[tokio::test]
 async fn apply_worker_skips_non_approved_proposals() {
     let (rt, tok) = setup();

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -3005,6 +3005,66 @@ async fn curation_merge_entity_event_payload_has_adr014_fields() {
         payload.get("edges_rewired").is_some(),
         "entity_merged payload must contain 'edges_rewired'; got {payload}"
     );
+    assert!(
+        payload.get("content_strategy").is_some(),
+        "entity_merged payload must contain 'content_strategy' (codex PR #814 Medium finding); got {payload}"
+    );
+}
+
+/// Handler-wiring test for the codex PR #814 High finding: `content_strategy`
+/// passed on the wire through `merge(kind="entity", ...)` must reach
+/// `KhiveRuntime::merge_entity` and be honored independently of the default
+/// entity `strategy` (`prefer_into`).
+#[tokio::test]
+async fn merge_handler_wires_explicit_prefer_from_content_strategy() {
+    let p = pack();
+
+    let into = p
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "Into", "description": "desc A"}),
+        )
+        .await
+        .expect("create into must succeed");
+    let into_id = into
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("create must return id")
+        .to_string();
+
+    let from = p
+        .dispatch(
+            "create",
+            json!({"kind": "concept", "name": "From", "description": "desc B"}),
+        )
+        .await
+        .expect("create from must succeed");
+    let from_id = from
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("create must return id")
+        .to_string();
+
+    // strategy is left at its default (prefer_into); only content_strategy is
+    // set explicitly. If the handler/runtime wiring collapses content_strategy
+    // onto the entity policy, the into-description ("desc A") survives instead.
+    p.dispatch(
+        "merge",
+        json!({"into_id": &into_id, "from_id": &from_id, "content_strategy": "prefer_from"}),
+    )
+    .await
+    .expect("merge must succeed");
+
+    let merged = p
+        .dispatch("get", json!({"id": &into_id}))
+        .await
+        .expect("get must succeed");
+    assert_eq!(
+        merged.get("description").and_then(Value::as_str),
+        Some("desc B"),
+        "content_strategy=prefer_from on the wire must win over the default \
+         prefer_into entity policy; got {merged}"
+    );
 }
 
 /// Delete an entity with hard=true → list entity_deleted events → assert payload has

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -420,31 +420,35 @@ impl KhiveRuntime {
             self.reindex_entity(token, &updated_entity).await?;
         }
 
-        let event_store = self.events(token)?;
-        // Mirror the wire-level strategy spelling from MergeParams so consumers
-        // can round-trip the policy string back into a request.
-        let policy_str = match strategy {
-            EntityDedupMergePolicy::PreferInto => "prefer_into",
-            EntityDedupMergePolicy::PreferFrom => "prefer_from",
-            EntityDedupMergePolicy::Union => "union",
-        };
-        let event = khive_storage::event::Event::new(
-            updated_entity.namespace.clone(),
-            "merge",
-            EventKind::EntityMerged,
-            SubstrateKind::Entity,
-            "",
-        )
-        .with_target(summary.kept_id)
-        .with_payload(serde_json::json!({
-            "into_id": summary.kept_id,
-            "from_id": summary.removed_id,
-            "policy": policy_str,
-            "edges_rewired": summary.edges_rewired,
-        }));
-        event_store.append_event(event).await.map_err(|e| {
-            RuntimeError::Internal(format!("merge_entity: event store write failed: {e}"))
-        })?;
+        // Dry-run is a read-only preview: it must not append a merge event.
+        if !dry_run {
+            let event_store = self.events(token)?;
+            // Mirror the wire-level strategy spelling from MergeParams so consumers
+            // can round-trip the policy string back into a request.
+            let policy_str = match strategy {
+                EntityDedupMergePolicy::PreferInto => "prefer_into",
+                EntityDedupMergePolicy::PreferFrom => "prefer_from",
+                EntityDedupMergePolicy::Union => "union",
+            };
+            let event = khive_storage::event::Event::new(
+                updated_entity.namespace.clone(),
+                "merge",
+                EventKind::EntityMerged,
+                SubstrateKind::Entity,
+                "",
+            )
+            .with_target(summary.kept_id)
+            .with_payload(serde_json::json!({
+                "into_id": summary.kept_id,
+                "from_id": summary.removed_id,
+                "policy": policy_str,
+                "content_strategy": format!("{:?}", content_strategy),
+                "edges_rewired": summary.edges_rewired,
+            }));
+            event_store.append_event(event).await.map_err(|e| {
+                RuntimeError::Internal(format!("merge_entity: event store write failed: {e}"))
+            })?;
+        }
 
         Ok(summary)
     }
@@ -1097,10 +1101,11 @@ fn merge_entity_sql(
                 (Some(format!("{}\n\n---\n\n{}", into_desc, from_desc)), true)
             }
         }
-        ContentMergeStrategy::PreferInto | ContentMergeStrategy::PreferFrom => (
-            merge_option_string_field(&into_entity.description, &from_entity.description, strategy),
-            false,
-        ),
+        // Description selection follows `content_strategy` directly — it is a
+        // deliberate, independently-settable choice, not derived from the
+        // entity-field `strategy` (properties/name/tags merge policy).
+        ContentMergeStrategy::PreferInto => (into_entity.description.clone(), false),
+        ContentMergeStrategy::PreferFrom => (from_entity.description.clone(), false),
     };
     let (merged_tags, tags_unioned) = union_tags(&into_entity.tags, &from_entity.tags);
 
@@ -1112,105 +1117,116 @@ fn merge_entity_sql(
     let tags_json = serde_json::to_string(&merged_tags).unwrap_or_else(|_| "[]".to_string());
 
     // --- Rewire edges ---
+    // Writes are gated on `!dry_run` below, but the loop itself always runs so a
+    // dry-run response reports a predictive `edges_rewired` count (the number of
+    // incident edges that would be rewired) instead of always reporting zero.
     let mut edges_rewired = 0usize;
-    if !dry_run {
-        for edge in all_edges {
-            let raw_src = if edge.source_id == from_id {
-                into_id
-            } else {
-                edge.source_id
-            };
-            let raw_tgt = if edge.target_id == from_id {
-                into_id
-            } else {
-                edge.target_id
-            };
-            // Symmetric relations must be stored with source_uuid < target_uuid.
-            // Apply canonicalization so the conflict check and UPDATE both use the canonical form.
-            let (new_src, new_tgt) = match edge.relation.parse::<EdgeRelation>() {
-                Ok(rel) => canonical_edge_endpoints(rel, raw_src, raw_tgt),
-                Err(_) => (raw_src, raw_tgt),
-            };
+    for edge in all_edges {
+        let raw_src = if edge.source_id == from_id {
+            into_id
+        } else {
+            edge.source_id
+        };
+        let raw_tgt = if edge.target_id == from_id {
+            into_id
+        } else {
+            edge.target_id
+        };
+        // Symmetric relations must be stored with source_uuid < target_uuid.
+        // Apply canonicalization so the conflict check and UPDATE both use the canonical form.
+        let (new_src, new_tgt) = match edge.relation.parse::<EdgeRelation>() {
+            Ok(rel) => canonical_edge_endpoints(rel, raw_src, raw_tgt),
+            Err(_) => (raw_src, raw_tgt),
+        };
 
-            if new_src == new_tgt {
+        if new_src == new_tgt {
+            if !dry_run {
                 conn.execute(
                     "DELETE FROM graph_edges WHERE namespace = ?1 AND id = ?2",
                     rusqlite::params![&namespace, edge.id.to_string()],
                 )?;
-                continue;
             }
-
-            let now_ts = chrono::Utc::now().timestamp();
-            // H3 fix: preserve the original edge ID by updating
-            // source_id/target_id in-place when no conflict exists.
-            //
-            // Two-step approach to handle all cases while keeping the original ID:
-            //   (a) No conflict (new triple): UPDATE source_id/target_id in-place.
-            //       The edge retains its original UUID — callers can still get() it
-            //       by the ID they received from link().
-            //   (b) Conflict: into_id already has an edge with this (source,target,
-            //       relation). Delete the from-edge (it is superseded) and UPDATE
-            //       the existing into-edge to refresh weight/metadata/deleted_at.
-            //       The surviving edge is the into-entity's original edge (correct).
-            //
-            // Check for a conflict: does into_id already have this natural key?
-            let conflict_id: Option<String> = {
-                let conflict_src = new_src.to_string();
-                let conflict_tgt = new_tgt.to_string();
-                conn.query_row(
-                    khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
-                    rusqlite::params![
-                        &namespace,
-                        &conflict_src,
-                        &conflict_tgt,
-                        &edge.relation,
-                        edge.id.to_string(),
-                    ],
-                    |row| row.get(0),
-                )
-                .optional()
-                .map_err(SqliteError::Rusqlite)?
-            };
-
-            let changed = if let Some(existing_id) = conflict_id {
-                // Case (b): a live or soft-deleted row already owns this natural key.
-                // Delete the from-edge and refresh the existing row.
-                conn.execute(
-                    khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
-                    rusqlite::params![&namespace, edge.id.to_string()],
-                )?;
-                conn.execute(
-                    khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
-                    rusqlite::params![
-                        edge.weight,
-                        now_ts,
-                        edge.target_backend,
-                        edge.metadata,
-                        &namespace,
-                        &existing_id,
-                    ],
-                )?
-            } else {
-                // Case (a): no conflict — update source_id/target_id in-place,
-                // preserving the original edge ID for callers.
-                conn.execute(
-                    "UPDATE graph_edges SET \
-                     source_id = ?1, target_id = ?2, updated_at = ?3 \
-                     WHERE namespace = ?4 AND id = ?5",
-                    rusqlite::params![
-                        new_src.to_string(),
-                        new_tgt.to_string(),
-                        now_ts,
-                        &namespace,
-                        edge.id.to_string(),
-                    ],
-                )?
-            };
-            if changed > 0 {
-                edges_rewired += 1;
-            }
+            continue;
         }
 
+        if dry_run {
+            // Predictive count only — no write in a dry-run.
+            edges_rewired += 1;
+            continue;
+        }
+
+        let now_ts = chrono::Utc::now().timestamp();
+        // H3 fix: preserve the original edge ID by updating
+        // source_id/target_id in-place when no conflict exists.
+        //
+        // Two-step approach to handle all cases while keeping the original ID:
+        //   (a) No conflict (new triple): UPDATE source_id/target_id in-place.
+        //       The edge retains its original UUID — callers can still get() it
+        //       by the ID they received from link().
+        //   (b) Conflict: into_id already has an edge with this (source,target,
+        //       relation). Delete the from-edge (it is superseded) and UPDATE
+        //       the existing into-edge to refresh weight/metadata/deleted_at.
+        //       The surviving edge is the into-entity's original edge (correct).
+        //
+        // Check for a conflict: does into_id already have this natural key?
+        let conflict_id: Option<String> = {
+            let conflict_src = new_src.to_string();
+            let conflict_tgt = new_tgt.to_string();
+            conn.query_row(
+                khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
+                rusqlite::params![
+                    &namespace,
+                    &conflict_src,
+                    &conflict_tgt,
+                    &edge.relation,
+                    edge.id.to_string(),
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(SqliteError::Rusqlite)?
+        };
+
+        let changed = if let Some(existing_id) = conflict_id {
+            // Case (b): a live or soft-deleted row already owns this natural key.
+            // Delete the from-edge and refresh the existing row.
+            conn.execute(
+                khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
+                rusqlite::params![&namespace, edge.id.to_string()],
+            )?;
+            conn.execute(
+                khive_db::stores::graph::EDGE_SYMMETRIC_REFRESH_CANONICAL_SQL,
+                rusqlite::params![
+                    edge.weight,
+                    now_ts,
+                    edge.target_backend,
+                    edge.metadata,
+                    &namespace,
+                    &existing_id,
+                ],
+            )?
+        } else {
+            // Case (a): no conflict — update source_id/target_id in-place,
+            // preserving the original edge ID for callers.
+            conn.execute(
+                "UPDATE graph_edges SET \
+                     source_id = ?1, target_id = ?2, updated_at = ?3 \
+                     WHERE namespace = ?4 AND id = ?5",
+                rusqlite::params![
+                    new_src.to_string(),
+                    new_tgt.to_string(),
+                    now_ts,
+                    &namespace,
+                    edge.id.to_string(),
+                ],
+            )?
+        };
+        if changed > 0 {
+            edges_rewired += 1;
+        }
+    }
+
+    if !dry_run {
         // --- Upsert merged entity ---
         conn.execute(
             "INSERT OR REPLACE INTO entities \
@@ -1775,39 +1791,6 @@ pub(crate) fn merge_string_field(
     match strategy {
         EntityDedupMergePolicy::PreferInto | EntityDedupMergePolicy::Union => into.to_string(),
         EntityDedupMergePolicy::PreferFrom => from.to_string(),
-    }
-}
-
-/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
-/// `crate::atomic_prepare::prepare_merge` for atomic/non-atomic parity.
-pub(crate) fn merge_option_string_field(
-    into: &Option<String>,
-    from: &Option<String>,
-    strategy: EntityDedupMergePolicy,
-) -> Option<String> {
-    match strategy {
-        EntityDedupMergePolicy::PreferInto => {
-            if into.is_some() {
-                into.clone()
-            } else {
-                from.clone()
-            }
-        }
-        EntityDedupMergePolicy::PreferFrom => {
-            if from.is_some() {
-                from.clone()
-            } else {
-                into.clone()
-            }
-        }
-        EntityDedupMergePolicy::Union => {
-            // Keep into's description; if empty, append from's.
-            match (into, from) {
-                (Some(a), _) if !a.is_empty() => Some(a.clone()),
-                (_, Some(b)) => Some(b.clone()),
-                _ => None,
-            }
-        }
     }
 }
 
@@ -2574,6 +2557,47 @@ mod tests {
         );
     }
 
+    /// Regression test for the codex PR #814 High finding: `content_strategy`
+    /// must be followed directly, independent of the entity-field `strategy`.
+    /// With the default entity policy `prefer_into`, an explicit
+    /// `content_strategy=prefer_from` must still keep the from-description.
+    #[tokio::test]
+    async fn merge_entity_prefer_from_content_strategy_wins_over_default_entity_policy() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::PreferFrom,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !summary.content_appended,
+            "explicit PreferFrom is not an append"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(
+            kept.description.as_deref(),
+            Some("desc B"),
+            "content_strategy=prefer_from must win over the default prefer_into entity policy"
+        );
+    }
+
     #[tokio::test]
     async fn merge_entity_dry_run_previews_append() {
         let rt = rt();
@@ -2609,6 +2633,83 @@ mod tests {
             kept.description.as_deref(),
             Some("desc A"),
             "dry_run=true must not mutate the into entity's description"
+        );
+    }
+
+    /// Codex PR #814 Medium finding: dry-run must be a read-only, accurate preview —
+    /// it must predict `edges_rewired` without writing, and must not append an
+    /// `EntityMerged` event.
+    #[tokio::test]
+    async fn merge_entity_dry_run_predicts_edges_rewired_without_writing() {
+        use khive_storage::EdgeRelation;
+
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", None, None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", None, None, vec![])
+            .await
+            .unwrap();
+
+        rt.link(&tok, a.id, from.id, EdgeRelation::Extends, 1.0, None)
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert!(summary.dry_run);
+        assert_eq!(
+            summary.edges_rewired, 1,
+            "dry-run must predict the edge that would be rewired, not report zero"
+        );
+
+        // The edge must not actually have been rewired.
+        let a_neighbors = rt
+            .neighbors(&tok, a.id, Direction::Out, None, None)
+            .await
+            .unwrap();
+        assert_eq!(a_neighbors.len(), 1);
+        assert_eq!(
+            a_neighbors[0].node_id, from.id,
+            "dry_run=true must not rewire any edges"
+        );
+
+        // No EntityMerged event should have been appended.
+        let events = rt
+            .events(&tok)
+            .unwrap()
+            .query_events(
+                khive_storage::EventFilter {
+                    kinds: vec![EventKind::EntityMerged],
+                    ..Default::default()
+                },
+                khive_storage::types::PageRequest {
+                    offset: 0,
+                    limit: 10,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            events.items.is_empty(),
+            "dry_run=true must not append an EntityMerged event"
         );
     }
 

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -318,6 +318,7 @@ impl KhiveRuntime {
         into_id: Uuid,
         from_id: Uuid,
         strategy: EntityDedupMergePolicy,
+        content_strategy: ContentMergeStrategy,
         dry_run: bool,
     ) -> RuntimeResult<MergeSummary> {
         if into_id == from_id {
@@ -371,7 +372,15 @@ impl KhiveRuntime {
             writer_task
                 .send(move |conn| {
                     merge_entity_sql(
-                        conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
+                        conn,
+                        ns,
+                        fts_table,
+                        vec_tables,
+                        into_id,
+                        from_id,
+                        strategy,
+                        content_strategy,
+                        dry_run,
                     )
                     .map_err(|e| {
                         khive_storage::StorageError::driver(
@@ -388,7 +397,15 @@ impl KhiveRuntime {
                 let guard = pool.writer()?;
                 guard.transaction(|conn| {
                     merge_entity_sql(
-                        conn, ns, fts_table, vec_tables, into_id, from_id, strategy, dry_run,
+                        conn,
+                        ns,
+                        fts_table,
+                        vec_tables,
+                        into_id,
+                        from_id,
+                        strategy,
+                        content_strategy,
+                        dry_run,
                     )
                 })
             })
@@ -995,6 +1012,7 @@ fn merge_entity_sql(
     into_id: Uuid,
     from_id: Uuid,
     strategy: EntityDedupMergePolicy,
+    content_strategy: ContentMergeStrategy,
     dry_run: bool,
 ) -> Result<(MergeSummary, Entity), SqliteError> {
     let into_entity = read_merge_entity(conn, into_id, &namespace)?;
@@ -1067,8 +1085,23 @@ fn merge_entity_sql(
     let (merged_props, properties_merged) =
         merge_properties(&into_entity.properties, &from_entity.properties, strategy);
     let merged_name = merge_string_field(&into_entity.name, &from_entity.name, strategy);
-    let merged_description =
-        merge_option_string_field(&into_entity.description, &from_entity.description, strategy);
+    let (merged_description, content_appended) = match content_strategy {
+        ContentMergeStrategy::Append => {
+            let into_desc = into_entity.description.as_deref().unwrap_or("");
+            let from_desc = from_entity.description.as_deref().unwrap_or("");
+            if from_desc.is_empty() {
+                (into_entity.description.clone(), false)
+            } else if into_desc.is_empty() {
+                (from_entity.description.clone(), true)
+            } else {
+                (Some(format!("{}\n\n---\n\n{}", into_desc, from_desc)), true)
+            }
+        }
+        ContentMergeStrategy::PreferInto | ContentMergeStrategy::PreferFrom => (
+            merge_option_string_field(&into_entity.description, &from_entity.description, strategy),
+            false,
+        ),
+    };
     let (merged_tags, tags_unioned) = union_tags(&into_entity.tags, &from_entity.tags);
 
     let now = chrono::Utc::now().timestamp_micros();
@@ -1292,7 +1325,7 @@ fn merge_entity_sql(
             edges_rewired,
             properties_merged,
             tags_unioned,
-            content_appended: false,
+            content_appended,
             dry_run,
         },
         updated_entity,
@@ -2118,7 +2151,14 @@ mod tests {
             .unwrap();
 
         let summary = rt
-            .merge_entity(&tok, d.id, b.id, EntityDedupMergePolicy::PreferInto, false)
+            .merge_entity(
+                &tok,
+                d.id,
+                b.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
             .await
             .unwrap();
 
@@ -2151,7 +2191,14 @@ mod tests {
             .await
             .unwrap();
         let err = rt
-            .merge_entity(&tok, a.id, a.id, EntityDedupMergePolicy::PreferInto, false)
+            .merge_entity(
+                &tok,
+                a.id,
+                a.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
             .await
             .unwrap_err();
         assert!(
@@ -2194,6 +2241,7 @@ mod tests {
             into.id,
             from.id,
             EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
             false,
         )
         .await
@@ -2240,6 +2288,7 @@ mod tests {
             into.id,
             from.id,
             EntityDedupMergePolicy::PreferFrom,
+            ContentMergeStrategy::Append,
             false,
         )
         .await
@@ -2281,9 +2330,16 @@ mod tests {
             .await
             .unwrap();
 
-        rt.merge_entity(&tok, into.id, from.id, EntityDedupMergePolicy::Union, false)
-            .await
-            .unwrap();
+        rt.merge_entity(
+            &tok,
+            into.id,
+            from.id,
+            EntityDedupMergePolicy::Union,
+            ContentMergeStrategy::Append,
+            false,
+        )
+        .await
+        .unwrap();
 
         let kept = rt.get_entity(&tok, into.id).await.unwrap();
         let props = kept.properties.unwrap();
@@ -2326,6 +2382,7 @@ mod tests {
             into.id,
             from.id,
             EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
             false,
         )
         .await
@@ -2356,7 +2413,14 @@ mod tests {
             .unwrap();
 
         let summary = rt
-            .merge_entity(&tok, a.id, b.id, EntityDedupMergePolicy::PreferInto, false)
+            .merge_entity(
+                &tok,
+                a.id,
+                b.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
             .await
             .unwrap();
 
@@ -2370,6 +2434,182 @@ mod tests {
             .await
             .unwrap();
         assert!(a_out.is_empty(), "no self-loop should remain");
+    }
+
+    // ---- #778: content_strategy for entity merge ----
+
+    #[tokio::test]
+    async fn merge_entity_append_strategy_concatenates_descriptions() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            summary.content_appended,
+            "append strategy with two non-empty descriptions must report content_appended=true"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(kept.description.as_deref(), Some("desc A\n\n---\n\ndesc B"));
+    }
+
+    #[tokio::test]
+    async fn merge_entity_append_strategy_from_empty_is_noop() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", None, None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !summary.content_appended,
+            "from's empty description means nothing was appended"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(kept.description.as_deref(), Some("desc A"));
+    }
+
+    #[tokio::test]
+    async fn merge_entity_append_strategy_into_empty_takes_from() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", None, None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            summary.content_appended,
+            "taking from's description into an empty into is real content preservation"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(kept.description.as_deref(), Some("desc B"));
+    }
+
+    #[tokio::test]
+    async fn merge_entity_prefer_into_strategy_still_discards_explicitly() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::PreferInto,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !summary.content_appended,
+            "explicit PreferInto opt-out must not report an append"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(
+            kept.description.as_deref(),
+            Some("desc A"),
+            "explicit PreferInto opt-out keeps the old discard behavior"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_entity_dry_run_previews_append() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let into = rt
+            .create_entity(&tok, "concept", None, "Into", Some("desc A"), None, vec![])
+            .await
+            .unwrap();
+        let from = rt
+            .create_entity(&tok, "concept", None, "From", Some("desc B"), None, vec![])
+            .await
+            .unwrap();
+
+        let summary = rt
+            .merge_entity(
+                &tok,
+                into.id,
+                from.id,
+                EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert!(summary.dry_run);
+        assert!(
+            summary.content_appended,
+            "dry-run must preview the append outcome without writing"
+        );
+        let kept = rt.get_entity(&tok, into.id).await.unwrap();
+        assert_eq!(
+            kept.description.as_deref(),
+            Some("desc A"),
+            "dry_run=true must not mutate the into entity's description"
+        );
     }
 
     // ---- merge helper unit tests ----
@@ -2419,6 +2659,7 @@ mod tests {
             into.id,
             from_id,
             EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
             false,
         )
         .await
@@ -2846,6 +3087,7 @@ mod tests {
                 a.id,
                 b.id,
                 crate::EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await
@@ -2915,6 +3157,7 @@ mod tests {
                 concept.id,
                 project.id,
                 crate::EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await
@@ -2958,6 +3201,7 @@ mod tests {
                 c1.id,
                 c2.id,
                 crate::EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await
@@ -3100,6 +3344,7 @@ mod tests {
                 foreign_b.id,
                 from_a.id,
                 EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await;
@@ -3115,6 +3360,7 @@ mod tests {
                 into_a.id,
                 foreign_b.id,
                 EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await;
@@ -3397,6 +3643,7 @@ mod tests {
             into_e.id,
             from_e.id,
             EntityDedupMergePolicy::PreferInto,
+            ContentMergeStrategy::Append,
             false,
         )
         .await
@@ -3623,6 +3870,7 @@ mod tests {
                 into_e.id,
                 from_e.id,
                 EntityDedupMergePolicy::PreferInto,
+                ContentMergeStrategy::Append,
                 false,
             )
             .await


### PR DESCRIPTION
## Problem

Under the default `PreferInto` merge policy, `merge(kind="entity", ...)` silently
discarded the `from` entity's description whenever the `into` entity already had a
non-empty description. There was no way to detect this from the response:
`content_appended` was hardcoded to `false` for entity merges regardless of what
actually happened.

The kg pack's merge handler already parsed the `content_strategy` wire parameter
(default `"append"`) for entity merges, but never passed it through to
`merge_entity` — so a caller who explicitly set `content_strategy="append"` on an
entity merge got no different behavior. The note-merge path already had a working
`Append` strategy that concatenated content with a separator and reported
`content_appended` correctly; entity merges had no equivalent.

The dropped description was not permanently destroyed (the `from` row is
tombstoned, not hard-deleted), but it becomes unreachable through the normal verb
surface: `get()` returns `NotFound` without an explicit `include_deleted=true`, and
the row is removed from FTS and vector indexes. For practical purposes this is a
real data-loss bug.

## Fix

- `crates/khive-runtime/src/curation.rs`: added a `content_strategy:
  ContentMergeStrategy` parameter to `merge_entity` and `merge_entity_sql`. Entity
  description merging now has a real `Append` branch mirroring the note-merge
  pattern:
  - both descriptions non-empty → concatenate with `"\n\n---\n\n"`,
    `content_appended = true`
  - one side empty → keep whichever side is non-empty; `content_appended = true`
    only when this preserved content from `from` that would otherwise have been
    lost
  - `from`'s description empty → into's description unchanged, `content_appended =
    false`
  - explicit `PreferInto`/`PreferFrom` opt-out keeps the existing discard behavior,
    with `content_appended = false` (a deliberate choice, not silent loss)
  - `content_appended` in `MergeSummary` is now computed from the branch actually
    taken instead of hardcoded to `false`
- `crates/khive-pack-kg/src/handlers/merge.rs`: the entity branch of the merge
  handler now passes the already-parsed `content_strategy` into `merge_entity`,
  matching the note branch.
- `crates/khive-pack-kg/src/apply_worker/worker.rs`: `apply_merge_entities` (the
  ADR-046 propose/apply changeset interpreter) now passes
  `ContentMergeStrategy::Append` to match the new runtime default.

No new wire surface: `content_strategy` already existed on `MergeParams` and was
already documented for entity merges. This fix makes an already-accepted parameter
actually work.

## Behavior change

Entity merges under the default policy that previously silently dropped `from`'s
description will now produce a concatenated description when both entities have
one. Any caller currently treating entity `content_appended: false` as "nothing to
check" will now sometimes see `true`.

## Breaking change

`KhiveRuntime::merge_entity`'s public signature gained a required positional
`content_strategy: ContentMergeStrategy` parameter (between `strategy` and
`dry_run`). There is no compatibility wrapper — the repo convention is no
backwards-compat shims, and the workspace is pre-1.0 (0.3.x), so this lands as an
explicit, coordinated breaking change rather than adding an `Append`-defaulting
alias method. Every in-repository caller (`khive-pack-kg`'s merge handler and
`apply_worker`) was updated in this PR. Downstream users of `khive-runtime` as a
library need to add the new argument when upgrading. Per semver-minor-for-0.x
policy this ships as a normal `fix(...)` release, not a major bump.

## Codex re-review fixes (2 High, 3 Medium)

A codex adversarial re-review of this PR (`.khive/codex_reviews/codex_review_pr814.md`)
returned REQUEST CHANGES. Fixes for each finding:

1. **High — `content_strategy="prefer_from"` was ignored under the default entity
   policy.** Both explicit content preferences (`PreferInto`/`PreferFrom`) routed
   description selection through the entity-field `strategy` instead of
   `content_strategy`, so `prefer_from` silently kept the into-description whenever
   `strategy` stayed at its default `prefer_into`. Split the match arms so
   `content_strategy` selects the description directly (mirrors `merge_note`'s
   existing, correct pattern). The now-unused `merge_option_string_field` helper
   was removed.
2. **High — breaking public API without a compatibility path.** See "Breaking
   change" above — documented explicitly rather than silently shipped.
3. **Medium — accepted ADRs and audit provenance were stale.** ADR-014 and ADR-039
   described the pre-#778 behavior; amended in a separate paired PR (see below).
   The `EntityMerged` audit event payload now also carries `content_strategy`
   alongside `policy`.
4. **Medium — dry-run was not read-only or an accurate preview.** `EntityMerged`
   event emission is now gated on `!dry_run`. The edge-rewire loop now always runs
   (writes still gated on `!dry_run`) so `edges_rewired` in a dry-run response is a
   real predictive count of the edges that would be rewired, not always zero.
5. **Medium — missing test layers.** Added: a handler-wiring test
   (`merge_handler_wires_explicit_prefer_from_content_strategy`, through
   `khive-pack-kg`'s `merge` verb dispatch) proving `content_strategy` reaches the
   runtime from wire params; an explicit `prefer_from` end-to-end regression test
   at the runtime level
   (`merge_entity_prefer_from_content_strategy_wins_over_default_entity_policy`); a
   dry-run predictive-count test
   (`merge_entity_dry_run_predicts_edges_rewired_without_writing`); and an ADR-046
   apply-worker test exercising the `MergeEntities` proposal changeset path
   (`apply_worker_applies_merge_entities_changeset`).

**Pairs with:** #817 (`docs/adr-014-039-entity-merge-content`) — amends ADR-014 and
ADR-039 for this behavior change, split into its own PR per repo convention
(code and docs land separately).

## Tests

Added to `crates/khive-runtime/src/curation.rs`:

- `merge_entity_append_strategy_concatenates_descriptions`
- `merge_entity_append_strategy_from_empty_is_noop`
- `merge_entity_append_strategy_into_empty_takes_from`
- `merge_entity_prefer_into_strategy_still_discards_explicitly`
- `merge_entity_dry_run_previews_append`
- `merge_entity_prefer_from_content_strategy_wins_over_default_entity_policy`
- `merge_entity_dry_run_predicts_edges_rewired_without_writing`

Added to `crates/khive-pack-kg/tests/integration.rs`:

- `merge_handler_wires_explicit_prefer_from_content_strategy`
- `content_strategy` assertion added to
  `curation_merge_entity_event_payload_has_adr014_fields`

Added to `crates/khive-pack-kg/tests/apply_worker.rs`:

- `apply_worker_applies_merge_entities_changeset`

All existing `merge_entity` call sites (tests and production callers) were updated
for the new parameter.

## Gates (from `crates/`, `CARGO_TARGET_DIR=./target`)

- `cargo test -p khive-runtime -p khive-pack-kg` — pass (1194 tests across both crates' unit + integration binaries, 0 failed, 7 ignored)
- `cargo clippy -p khive-runtime -p khive-pack-kg --all-targets -- -D warnings` — pass
- `cargo fmt --all -- --check` — pass

Closes #778
