### PR TITLE
fix(runtime): normalize compact hex prefixes before LIKE-scanning hyphenated ids

### DIFF
--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -451,9 +451,27 @@ fn row_uuid(row: &khive_storage::types::SqlRow) -> Option<Uuid> {
     }
 }
 
+/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
+/// character itself (`\`) so a caller-supplied path is matched literally
+/// under `LIKE ... ESCAPE '\'` rather than as a pattern.
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 /// Find an existing `document` entity whose `properties.source_uri` or `name`
 /// matches `path` (ADR-086 keying convention). Returns `None` when no match —
 /// v0 never creates documents on the ingester's behalf (skip the edge).
+///
+/// An exact `source_uri`/`name` match always wins over the suffix-`LIKE`
+/// fallback: the two are queried separately so a wildcard-broadened
+/// candidate can never shadow an exact one under an unordered `LIMIT 1`.
 async fn find_document_for_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -463,29 +481,45 @@ async fn find_document_for_path(
         .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or(path);
-    let like_pattern = format!("%{path}");
     let sql = runtime.sql();
+    let namespace = token.namespace().as_str().to_string();
+
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let row = r
+    let exact_row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
                   AND deleted_at IS NULL \
-                  AND (json_extract(properties,'$.source_uri')=?2 \
-                       OR json_extract(properties,'$.source_uri') LIKE ?3 \
-                       OR name=?4) \
+                  AND (json_extract(properties,'$.source_uri')=?2 OR name=?3) \
                   LIMIT 1"
                 .into(),
             params: vec![
-                SqlValue::Text(token.namespace().as_str().to_string()),
+                SqlValue::Text(namespace.clone()),
                 SqlValue::Text(path.to_string()),
-                SqlValue::Text(like_pattern),
                 SqlValue::Text(file_name.to_string()),
             ],
-            label: Some("git_ingest_find_document_for_path".into()),
+            label: Some("git_ingest_find_document_for_path_exact".into()),
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    Ok(row.and_then(|r| row_uuid(&r)))
+    if let Some(id) = exact_row.and_then(|r| row_uuid(&r)) {
+        return Ok(Some(id));
+    }
+
+    let like_pattern = format!("%{}", escape_like(path));
+    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
+    let like_row = r
+        .query_row(SqlStatement {
+            sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
+                  AND deleted_at IS NULL \
+                  AND json_extract(properties,'$.source_uri') LIKE ?2 ESCAPE '\\' \
+                  LIMIT 1"
+                .into(),
+            params: vec![SqlValue::Text(namespace), SqlValue::Text(like_pattern)],
+            label: Some("git_ingest_find_document_for_path_like".into()),
+        })
+        .await
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(like_row.and_then(|r| row_uuid(&r)))
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -1567,5 +1601,73 @@ mod compact_prefix_resolver_tests {
 
         let resolved = resolve_id(&rt, &token, &compact[..16]).await.unwrap();
         assert_eq!(resolved, Some(project.id));
+    }
+}
+
+/// PR #816 r3 Major finding: `find_document_for_path` bound an unescaped
+/// path into a `LIKE` pattern (`%`/`_` in a filename became pattern
+/// wildcards) and picked whichever candidate the unordered `LIMIT 1` scan
+/// happened to return first, even when an exact match existed.
+#[cfg(test)]
+mod find_document_for_path_tests {
+    use super::*;
+    use khive_runtime::Namespace;
+
+    async fn create_document(rt: &KhiveRuntime, token: &NamespaceToken, source_uri: &str) -> Uuid {
+        rt.create_entity(
+            token,
+            "document",
+            None,
+            source_uri,
+            None,
+            Some(json!({ "source_uri": source_uri })),
+            vec![],
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn path_with_like_wildcards_resolves_only_itself() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        // Neither document's `source_uri` matches `path` exactly, so
+        // resolution must fall through to the suffix-`LIKE` scan. Under the
+        // pre-fix unescaped pattern, `%` matches zero-or-more chars and `_`
+        // matches exactly one char, so this decoy (`100` + "" + "Q" +
+        // `done.rs`) would incorrectly satisfy `LIKE '%src/100%_done.rs'`.
+        // With `%`/`_` escaped, the pattern requires the literal substring
+        // `100%_done.rs` and the decoy no longer matches.
+        let path = "src/100%_done.rs";
+        let decoy_source_uri = "prefix/src/100Qdone.rs";
+        create_document(&rt, &token, decoy_source_uri).await;
+
+        let resolved = find_document_for_path(&rt, &token, path).await.unwrap();
+        assert_eq!(
+            resolved, None,
+            "a % or _ in the path must be matched literally, not as a LIKE wildcard"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_match_wins_over_wildcard_broadened_candidate() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let path = "crates/khive-pack-git/src/ingest.rs";
+        let broadened_suffix_path = "other/crates/khive-pack-git/src/ingest.rs";
+        // Created first so an unordered `LIMIT 1` scan without exact-match
+        // priority would be free to return it instead of the exact match.
+        create_document(&rt, &token, broadened_suffix_path).await;
+        let exact_id = create_document(&rt, &token, path).await;
+
+        let resolved = find_document_for_path(&rt, &token, path).await.unwrap();
+        assert_eq!(
+            resolved,
+            Some(exact_id),
+            "an exact source_uri match must always win over a suffix-LIKE candidate"
+        );
     }
 }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -469,9 +469,11 @@ fn escape_like(input: &str) -> String {
 /// matches `path` (ADR-086 keying convention). Returns `None` when no match —
 /// v0 never creates documents on the ingester's behalf (skip the edge).
 ///
-/// An exact `source_uri`/`name` match always wins over the suffix-`LIKE`
-/// fallback: the two are queried separately so a wildcard-broadened
-/// candidate can never shadow an exact one under an unordered `LIMIT 1`.
+/// Exact and suffix-`LIKE` candidates are selected in a single query/snapshot
+/// so a document inserted between an exact-match read and a fallback read
+/// can never be missed by the exact branch, and a wildcard-broadened match
+/// can never shadow an exact one: the `ORDER BY` ranks exact matches first,
+/// with `id` as a deterministic tiebreaker.
 async fn find_document_for_path(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -483,43 +485,30 @@ async fn find_document_for_path(
         .unwrap_or(path);
     let sql = runtime.sql();
     let namespace = token.namespace().as_str().to_string();
+    let like_pattern = format!("%{}", escape_like(path));
 
     let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let exact_row = r
+    let row = r
         .query_row(SqlStatement {
             sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
                   AND deleted_at IS NULL \
-                  AND (json_extract(properties,'$.source_uri')=?2 OR name=?3) \
+                  AND (json_extract(properties,'$.source_uri')=?2 OR name=?3 \
+                       OR json_extract(properties,'$.source_uri') LIKE ?4 ESCAPE '\\') \
+                  ORDER BY CASE WHEN json_extract(properties,'$.source_uri')=?2 OR name=?3 \
+                                THEN 0 ELSE 1 END, id \
                   LIMIT 1"
                 .into(),
             params: vec![
-                SqlValue::Text(namespace.clone()),
+                SqlValue::Text(namespace),
                 SqlValue::Text(path.to_string()),
                 SqlValue::Text(file_name.to_string()),
+                SqlValue::Text(like_pattern),
             ],
-            label: Some("git_ingest_find_document_for_path_exact".into()),
+            label: Some("git_ingest_find_document_for_path".into()),
         })
         .await
         .map_err(|e| anyhow!("{e}"))?;
-    if let Some(id) = exact_row.and_then(|r| row_uuid(&r)) {
-        return Ok(Some(id));
-    }
-
-    let like_pattern = format!("%{}", escape_like(path));
-    let mut r = sql.reader().await.map_err(|e| anyhow!("{e}"))?;
-    let like_row = r
-        .query_row(SqlStatement {
-            sql: "SELECT id FROM entities WHERE kind='document' AND namespace=?1 \
-                  AND deleted_at IS NULL \
-                  AND json_extract(properties,'$.source_uri') LIKE ?2 ESCAPE '\\' \
-                  LIMIT 1"
-                .into(),
-            params: vec![SqlValue::Text(namespace), SqlValue::Text(like_pattern)],
-            label: Some("git_ingest_find_document_for_path_like".into()),
-        })
-        .await
-        .map_err(|e| anyhow!("{e}"))?;
-    Ok(like_row.and_then(|r| row_uuid(&r)))
+    Ok(row.and_then(|r| row_uuid(&r)))
 }
 
 /// Read the last-ingested cursor value for `(project_id, kind)`, if any.
@@ -1668,6 +1657,31 @@ mod find_document_for_path_tests {
             resolved,
             Some(exact_id),
             "an exact source_uri match must always win over a suffix-LIKE candidate"
+        );
+    }
+
+    /// PR #816 r5 Major finding: running the exact-match read and the
+    /// LIKE-fallback read as two separate awaited queries left a TOCTOU gap
+    /// where a document inserted between them could still lose to the
+    /// unordered fallback `LIMIT 1`. Resolution must now happen in one
+    /// query/snapshot: both candidates are visible to the same `SELECT`, and
+    /// the `ORDER BY` — not read ordering — decides the exact match wins.
+    #[tokio::test]
+    async fn single_query_snapshot_prefers_exact_over_broadened() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+
+        let path = "crates/khive-pack-git/src/toctou.rs";
+        let broadened_suffix_path = "other/crates/khive-pack-git/src/toctou.rs";
+        let exact_id = create_document(&rt, &token, path).await;
+        create_document(&rt, &token, broadened_suffix_path).await;
+
+        let resolved = find_document_for_path(&rt, &token, path).await.unwrap();
+        assert_eq!(
+            resolved,
+            Some(exact_id),
+            "a single query covering both exact and broadened candidates \
+             must still rank the exact match first, regardless of insertion order"
         );
     }
 }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1509,3 +1509,63 @@ mod truncation_tests {
         );
     }
 }
+
+/// PR #816 Minor finding 4: `resolve_id`/`resolve_project_id` call the
+/// public `resolve_prefix_unfiltered` resolver without their own all-hex
+/// gate, so a `%`-bearing (or otherwise non-hex) `project` argument reached
+/// the bound `LIKE` pattern unfiltered. The runtime resolver boundary
+/// (`resolve_prefix_inner`) now rejects non-hex/non-hyphen input itself, so
+/// these callers inherit the fix without needing their own gate.
+#[cfg(test)]
+mod compact_prefix_resolver_tests {
+    use super::*;
+    use khive_runtime::Namespace;
+
+    #[tokio::test]
+    async fn resolve_project_id_rejects_like_wildcard_input() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let project = rt
+            .create_entity(
+                &token,
+                "project",
+                None,
+                "WildcardIngestTest",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let compact = project.id.simple().to_string();
+        let wildcard_input = format!("{}%", &compact[..8]);
+
+        let resolved = resolve_project_id(&rt, &wildcard_input).await.unwrap();
+        assert_eq!(
+            resolved, None,
+            "a %-bearing project argument must not resolve via a wildcard LIKE scan"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_id_resolves_compact_prefix_over_8_chars() {
+        let rt = KhiveRuntime::memory().unwrap();
+        let token = rt.authorize(Namespace::local()).unwrap();
+        let project = rt
+            .create_entity(
+                &token,
+                "project",
+                None,
+                "CompactIngestTest",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let compact = project.id.simple().to_string();
+
+        let resolved = resolve_id(&rt, &token, &compact[..16]).await.unwrap();
+        assert_eq!(resolved, Some(project.id));
+    }
+}

--- a/crates/khive-pack-kg/src/handlers/get.rs
+++ b/crates/khive-pack-kg/src/handlers/get.rs
@@ -5,7 +5,9 @@ use std::str::FromStr;
 use serde_json::Value;
 use uuid::Uuid;
 
-use khive_runtime::{NamespaceToken, Resolved, RuntimeError, VerbRegistry};
+use khive_runtime::{
+    hex_prefix_to_uuid_pattern, NamespaceToken, Resolved, RuntimeError, VerbRegistry,
+};
 use khive_storage::event::Event;
 use khive_storage::types::{SqlRow, SqlStatement, SqlValue};
 use khive_types::EventKind;
@@ -179,7 +181,7 @@ impl KgPack {
                 vec![SqlValue::Text(raw_id.to_string()), SqlValue::Text(ns)],
             )
         } else if raw_id.len() >= 8 && raw_id.chars().all(|c| c.is_ascii_hexdigit()) {
-            let pattern = format!("{}%", raw_id);
+            let pattern = format!("{}%", hex_prefix_to_uuid_pattern(raw_id));
             (
                 "SELECT proposal_id FROM proposals_open \
                  WHERE proposal_id LIKE ?1 AND namespace = ?2 LIMIT 2"

--- a/crates/khive-pack-kg/src/handlers/proposal.rs
+++ b/crates/khive-pack-kg/src/handlers/proposal.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use serde_json::Value;
 use uuid::Uuid;
 
-use khive_runtime::{NamespaceToken, RuntimeError, VerbRegistry};
+use khive_runtime::{hex_prefix_to_uuid_pattern, NamespaceToken, RuntimeError, VerbRegistry};
 use khive_storage::types::{SqlStatement, SqlValue};
 use khive_storage::SubstrateKind;
 use khive_types::{
@@ -32,7 +32,7 @@ impl KgPack {
         }
         if raw.len() >= 8 && raw.chars().all(|c| c.is_ascii_hexdigit()) {
             let ns = token.namespace().as_str().to_owned();
-            let pattern = format!("{}%", raw);
+            let pattern = format!("{}%", hex_prefix_to_uuid_pattern(raw));
             let sql = self.runtime.sql();
             let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
             let rows = reader

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7251,6 +7251,46 @@ async fn get_proposal_wire_key_is_id_not_proposal_id() {
     );
 }
 
+/// #773: `get(id=<compact-hex-prefix>)` on an open proposal must resolve via
+/// `proposals_open`'s own `LIKE` scan (get.rs:181), independent of the
+/// `resolve_prefix_inner` fan-in point. Before the fix, any compact prefix
+/// longer than 8 chars structurally could not match the hyphenated
+/// `proposal_id` column.
+#[tokio::test]
+async fn get_proposal_by_compact_hex_prefix_over_8_chars() {
+    let f = pack_with_events();
+
+    let propose_result = f
+        .dispatch(
+            "propose",
+            json!({
+                "title": "CompactPrefixProposalTest",
+                "description": "get must resolve a >8-char compact prefix",
+                "changeset": changeset_add_entity(),
+            }),
+        )
+        .await
+        .expect("propose must succeed");
+    let pid = propose_result["id"]
+        .as_str()
+        .expect("propose must return id")
+        .to_string();
+
+    let compact = pid.replace('-', "");
+    let prefix = &compact[..16];
+
+    let get_result = f
+        .dispatch("get", json!({ "id": prefix }))
+        .await
+        .expect("get must resolve the proposal via compact prefix");
+
+    assert_eq!(
+        get_result.get("id").and_then(|v| v.as_str()),
+        Some(pid.as_str()),
+        "get(id=<compact prefix>) must resolve to the proposal; got {get_result}"
+    );
+}
+
 /// review(id=..., proposal_id=...) must be rejected by #[serde(deny_unknown_fields)].
 ///
 /// ReviewParams declares `id` (required) with deny_unknown_fields — `proposal_id` is

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -7291,6 +7291,84 @@ async fn get_proposal_by_compact_hex_prefix_over_8_chars() {
     );
 }
 
+/// PR #816 Major finding 1: `review(id=<compact-hex-prefix>)` must resolve
+/// via `resolve_proposal_uuid` (proposal.rs), independent of `get`'s own
+/// `proposals_open` scan. Before the fix, `resolve_proposal_uuid` built the
+/// `LIKE` pattern from the raw compact prefix instead of normalizing it with
+/// `hex_prefix_to_uuid_pattern`, so any prefix longer than 8 chars
+/// structurally could not match the hyphenated `proposal_id` column.
+#[tokio::test]
+async fn review_proposal_by_compact_hex_prefix_over_8_chars() {
+    let f = pack_with_events();
+
+    let propose_result = f
+        .dispatch(
+            "propose",
+            json!({
+                "title": "CompactPrefixReviewTest",
+                "description": "review must resolve a >8-char compact prefix",
+                "changeset": changeset_add_entity(),
+            }),
+        )
+        .await
+        .expect("propose must succeed");
+    let pid = propose_result["id"]
+        .as_str()
+        .expect("propose must return id")
+        .to_string();
+
+    let compact = pid.replace('-', "");
+    let prefix = &compact[..16];
+
+    let review_result = f
+        .dispatch("review", json!({ "id": prefix, "decision": "approve" }))
+        .await
+        .expect("review must resolve the proposal via compact prefix");
+
+    assert_eq!(
+        review_result.get("id").and_then(|v| v.as_str()),
+        Some(pid.as_str()),
+        "review(id=<compact prefix>) must resolve to the proposal; got {review_result}"
+    );
+}
+
+/// PR #816 Major finding 1: `withdraw(id=<compact-hex-prefix>)` must resolve
+/// via `resolve_proposal_uuid` (proposal.rs) the same way `review` does.
+#[tokio::test]
+async fn withdraw_proposal_by_compact_hex_prefix_over_8_chars() {
+    let f = pack_with_events();
+
+    let propose_result = f
+        .dispatch(
+            "propose",
+            json!({
+                "title": "CompactPrefixWithdrawTest",
+                "description": "withdraw must resolve a >8-char compact prefix",
+                "changeset": changeset_add_entity(),
+            }),
+        )
+        .await
+        .expect("propose must succeed");
+    let pid = propose_result["id"]
+        .as_str()
+        .expect("propose must return id")
+        .to_string();
+
+    let compact = pid.replace('-', "");
+    let prefix = &compact[..16];
+
+    let withdraw_result = f
+        .dispatch("withdraw", json!({ "id": prefix }))
+        .await
+        .expect("withdraw must resolve the proposal via compact prefix");
+
+    assert_eq!(
+        withdraw_result.get("id").and_then(|v| v.as_str()),
+        Some(pid.as_str()),
+        "withdraw(id=<compact prefix>) must resolve to the proposal; got {withdraw_result}"
+    );
+}
+
 /// review(id=..., proposal_id=...) must be rejected by #[serde(deny_unknown_fields)].
 ///
 /// ReviewParams declares `id` (required) with deny_unknown_fields — `proposal_id` is

--- a/crates/khive-pack-knowledge/src/knowledge/search.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/search.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use khive_runtime::{KhiveRuntime, NamespaceToken, RuntimeError};
+use khive_runtime::{hex_prefix_to_uuid_pattern, KhiveRuntime, NamespaceToken, RuntimeError};
 use khive_score::DeterministicScore;
 use khive_storage::types::{SqlStatement, SqlValue};
 
@@ -706,11 +706,12 @@ async fn load_domain_by_id_or_slug(
                 && id.len() <= 36
                 && id.chars().all(|c| c.is_ascii_hexdigit() || c == '-');
             if is_hex {
+                let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
                 let rows = reader
                     .query_all(SqlStatement {
                         sql: "SELECT * FROM knowledge_domains WHERE id LIKE ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 2".into(),
                         params: vec![
-                            SqlValue::Text(format!("{id}%")),
+                            SqlValue::Text(pattern),
                             SqlValue::Text(ns.to_owned()),
                         ],
                         label: None,
@@ -768,11 +769,12 @@ async fn load_atom_by_id_or_slug(
                 && id.len() <= 36
                 && id.chars().all(|c| c.is_ascii_hexdigit() || c == '-');
             if is_hex {
+                let pattern = format!("{}%", hex_prefix_to_uuid_pattern(&id));
                 let rows = reader
                     .query_all(SqlStatement {
                         sql: "SELECT * FROM knowledge_atoms WHERE id LIKE ?1 AND namespace = ?2 AND deleted_at IS NULL LIMIT 2".into(),
                         params: vec![
-                            SqlValue::Text(format!("{id}%")),
+                            SqlValue::Text(pattern),
                             SqlValue::Text(ns.to_owned()),
                         ],
                         label: None,

--- a/crates/khive-pack-knowledge/tests/integration.rs
+++ b/crates/khive-pack-knowledge/tests/integration.rs
@@ -1919,6 +1919,178 @@ async fn compose_returns_markdown_for_domain() {
     );
 }
 
+/// PR #816 Major finding 2: `knowledge.compose` accepts compact hex prefixes
+/// for domains but must normalize them (`hex_prefix_to_uuid_pattern`) before
+/// binding the `LIKE` pattern — a >8-char compact prefix could not match the
+/// hyphenated `id` column before the fix.
+#[tokio::test]
+async fn compose_resolves_domain_by_compact_hex_prefix_over_8_chars() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                { "slug": "atom-a", "name": "Atom A", "content": "content of atom a dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom");
+
+    f.dispatch(
+        "knowledge.upsert_domains",
+        json!({
+            "domains": [
+                {
+                    "slug": "test-domain",
+                    "name": "Test Domain", "description": "dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity",
+                    "members": ["atom-a"]
+                }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert domain");
+
+    let domain_resp = f
+        .dispatch("knowledge.get", json!({ "id": "test-domain" }))
+        .await
+        .expect("get domain");
+    let domain_id = domain_resp["id"].as_str().expect("domain id").to_string();
+    let compact = domain_id.replace('-', "");
+    let prefix = &compact[..16];
+
+    let resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "domain_ids": [prefix],
+                "query": "content"
+            }),
+        )
+        .await
+        .expect("compose from compact domain prefix must resolve");
+
+    let atoms = resp["data"]["atoms"].as_array().expect("atoms");
+    assert!(
+        !atoms.is_empty(),
+        "compose from compact domain prefix should include member atoms"
+    );
+}
+
+/// PR #816 Major finding 2: same normalization requirement for atom ids.
+#[tokio::test]
+async fn compose_resolves_atom_by_compact_hex_prefix_over_8_chars() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                {
+                    "slug": "rag-overview",
+                    "name": "RAG Overview",
+                    "content": "Retrieval-augmented generation combines retrieval with generation. dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity"
+                }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom");
+
+    let atom_resp = f
+        .dispatch("knowledge.get", json!({ "id": "rag-overview" }))
+        .await
+        .expect("get atom");
+    let atom_id = atom_resp["id"].as_str().expect("atom id").to_string();
+    let compact = atom_id.replace('-', "");
+    let prefix = &compact[..16];
+
+    let resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "atom_ids": [prefix],
+                "query": "retrieval augmented generation"
+            }),
+        )
+        .await
+        .expect("compose from compact atom prefix must resolve");
+
+    let atoms = resp["data"]["atoms"].as_array().expect("atoms");
+    assert_eq!(atoms.len(), 1, "expected exactly 1 atom");
+    assert_eq!(
+        atoms[0]["slug"].as_str(),
+        Some("rag-overview"),
+        "compact atom prefix must resolve to the correct atom"
+    );
+}
+
+/// PR #816 Major finding 2 (precedence): an all-hex slug must still win over
+/// prefix interpretation. Atom B's slug is deliberately set to the same
+/// hex string as the first 16 chars of atom A's compact id — a value that
+/// is *also* a syntactically valid compact prefix. Because `compose` tries
+/// an exact slug match before falling back to prefix scanning, this must
+/// resolve atom B (by slug), never atom A (by prefix collision).
+#[tokio::test]
+async fn compose_atom_all_hex_slug_wins_over_prefix_interpretation() {
+    let f = pack(rt());
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                { "slug": "atom-x", "name": "Atom X", "content": "atom x content dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom x");
+
+    let atom_x_resp = f
+        .dispatch("knowledge.get", json!({ "id": "atom-x" }))
+        .await
+        .expect("get atom x");
+    let atom_x_id = atom_x_resp["id"].as_str().expect("atom x id").to_string();
+    let hex_slug = atom_x_id.replace('-', "")[..16].to_string();
+
+    f.dispatch(
+        "knowledge.upsert_atoms",
+        json!({
+            "atoms": [
+                { "slug": hex_slug.clone(), "name": "Atom Y", "content": "atom y content dense sparse retrieval corpus benchmark search latency gradient descent transformer attention vector index nearest neighbor ranking fusion pipeline embedding rerank cosine similarity" }
+            ]
+        }),
+    )
+    .await
+    .expect("upsert atom y with all-hex slug");
+
+    let resp = f
+        .dispatch(
+            "knowledge.compose",
+            json!({
+                "atom_ids": [hex_slug.clone()],
+                "query": "atom content"
+            }),
+        )
+        .await
+        .expect("compose by all-hex slug must resolve");
+
+    let atoms = resp["data"]["atoms"].as_array().expect("atoms");
+    assert_eq!(atoms.len(), 1, "expected exactly 1 atom");
+    assert_eq!(
+        atoms[0]["slug"].as_str(),
+        Some(hex_slug.as_str()),
+        "all-hex slug must resolve to the atom with that slug, not a prefix collision"
+    );
+    assert_eq!(
+        atoms[0]["name"].as_str(),
+        Some("Atom Y"),
+        "must resolve atom Y by slug, never atom X by prefix interpretation"
+    );
+}
+
 #[tokio::test]
 async fn compose_rejects_missing_ids() {
     let f = pack(rt());

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -78,8 +78,9 @@ pub use operations::{
     arm_vector_fail, arm_vector_fail_after,
 };
 pub use operations::{
-    base_entity_endpoint_rules, base_entity_rule_allows, endpoint_matches, merge_entry_metadata,
-    EdgeEndpointKind, EntityCreateSpec, LinkSpec, NoteSearchHit, QueryResult, Resolved,
+    base_entity_endpoint_rules, base_entity_rule_allows, endpoint_matches,
+    hex_prefix_to_uuid_pattern, merge_entry_metadata, EdgeEndpointKind, EntityCreateSpec, LinkSpec,
+    NoteSearchHit, QueryResult, Resolved,
 };
 pub use pack::{
     resolve_explicit_namespace, DispatchHook, HandlerDef, KindHook, NoteKindSpec,

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -180,6 +180,28 @@ pub struct NoteSearchHit {
     pub snippet: Option<String>,
 }
 
+/// Re-insert hyphens at canonical UUID positions (8-4-4-4-12) into a
+/// hyphen-free hex prefix, so a `LIKE '<pattern>%'` scan against the
+/// hyphenated `id` column matches correctly (#773). Prefixes that already
+/// contain a hyphen are passed through unchanged. No-op for len <= 8
+/// (already correct). Truncates at 32 hex chars (a full UUID); longer input
+/// is the caller's problem (still hex-only per the existing acceptance
+/// gate).
+pub fn hex_prefix_to_uuid_pattern(prefix: &str) -> String {
+    if prefix.contains('-') {
+        return prefix.to_string();
+    }
+    const BOUNDARIES: [usize; 4] = [8, 13, 18, 23]; // post-hyphen-insertion offsets
+    let mut out = String::with_capacity(36);
+    for c in prefix.chars().take(32) {
+        if BOUNDARIES.contains(&out.len()) {
+            out.push('-');
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn text_preview(text: &str, max_chars: usize) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -3176,7 +3198,7 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Option<Uuid>> {
         use khive_storage::types::{SqlStatement, SqlValue};
 
-        let pattern = format!("{}%", prefix);
+        let pattern = format!("{}%", hex_prefix_to_uuid_pattern(prefix));
 
         let tables = [
             ("entities", true),
@@ -6442,6 +6464,149 @@ mod tests {
 
         let resolved = rt.resolve_prefix(&tok, prefix).await.unwrap();
         assert_eq!(resolved, Some(entity.id));
+    }
+
+    #[test]
+    fn hex_prefix_to_uuid_pattern_inserts_hyphens_at_canonical_boundaries() {
+        let full = "aabbccdd112240008000000000000ab1";
+        let cases: &[(usize, &str)] = &[
+            (1, "a"),
+            (7, "aabbccd"),
+            (8, "aabbccdd"),
+            (9, "aabbccdd-1"),
+            (12, "aabbccdd-1122"),
+            (13, "aabbccdd-1122-4"),
+            (16, "aabbccdd-1122-4000"),
+            (18, "aabbccdd-1122-4000-80"),
+            (20, "aabbccdd-1122-4000-8000"),
+            (23, "aabbccdd-1122-4000-8000-000"),
+            (24, "aabbccdd-1122-4000-8000-0000"),
+            (28, "aabbccdd-1122-4000-8000-00000000"),
+            (31, "aabbccdd-1122-4000-8000-000000000ab"),
+        ];
+        for (len, expected) in cases {
+            let input = &full[..*len];
+            assert_eq!(
+                hex_prefix_to_uuid_pattern(input),
+                *expected,
+                "len={len} input={input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hex_prefix_to_uuid_pattern_full_32_char_matches_canonical_uuid() {
+        let compact = "aabbccdd112240008000000000000ab1";
+        // 32 hex chars only (truncate any extras beyond a full UUID).
+        let compact32 = &compact[..32];
+        assert_eq!(
+            hex_prefix_to_uuid_pattern(compact32),
+            "aabbccdd-1122-4000-8000-000000000ab1"
+        );
+    }
+
+    #[test]
+    fn hex_prefix_to_uuid_pattern_passes_through_hyphenated_input() {
+        let hyphenated = "aabbccdd-1122-4000-8000-000000000ab1";
+        assert_eq!(hex_prefix_to_uuid_pattern(hyphenated), hyphenated);
+
+        let partial = "aabbccdd-11";
+        assert_eq!(hex_prefix_to_uuid_pattern(partial), partial);
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_compact_9_to_31_char_matches() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(
+                &tok,
+                "concept",
+                None,
+                "CompactPrefixTest",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let compact = entity.id.simple().to_string();
+
+        for len in [9, 12, 16, 20, 24, 28, 31] {
+            let prefix = &compact[..len];
+            let resolved = rt.resolve_prefix(&tok, prefix).await.unwrap();
+            assert_eq!(
+                resolved,
+                Some(entity.id),
+                "compact prefix of len {len} should resolve"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_compact_full_32_char_matches() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "Full32Test", None, None, vec![])
+            .await
+            .unwrap();
+        let compact = entity.id.simple().to_string();
+        assert_eq!(compact.len(), 32);
+
+        let resolved = rt.resolve_prefix(&tok, &compact).await.unwrap();
+        assert_eq!(resolved, Some(entity.id));
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_boundary_at_hyphen_positions() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "BoundaryTest", None, None, vec![])
+            .await
+            .unwrap();
+        let compact = entity.id.simple().to_string();
+
+        for len in [8, 12, 16, 20, 24] {
+            let prefix = &compact[..len];
+            let resolved = rt.resolve_prefix(&tok, prefix).await.unwrap();
+            assert_eq!(
+                resolved,
+                Some(entity.id),
+                "boundary prefix of len {len} should resolve"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_prefix_ambiguous_still_detected_after_normalization() {
+        use khive_storage::entity::Entity;
+
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let id_a = Uuid::parse_str("aabbccdd-1111-4000-8000-000000000001").unwrap();
+        let id_b = Uuid::parse_str("aabbccdd-1111-4000-8000-000000000002").unwrap();
+
+        let mut entity_a = Entity::new("local", "concept", "AmbigCompactA");
+        entity_a.id = id_a;
+        let mut entity_b = Entity::new("local", "concept", "AmbigCompactB");
+        entity_b.id = id_b;
+
+        let store = rt.entities(&tok).unwrap();
+        store.upsert_entity(entity_a).await.unwrap();
+        store.upsert_entity(entity_b).await.unwrap();
+
+        // Shared 20-char compact prefix (past the first hyphen boundary).
+        let shared_compact = &id_a.simple().to_string()[..20];
+        let err = rt.resolve_prefix(&tok, shared_compact).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                RuntimeError::AmbiguousPrefix { ref matches, .. } if matches.len() == 2
+            ),
+            "shared compact prefix must still return AmbiguousPrefix; got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -184,16 +184,19 @@ pub struct NoteSearchHit {
 /// hyphen-free hex prefix, so a `LIKE '<pattern>%'` scan against the
 /// hyphenated `id` column matches correctly (#773). Prefixes that already
 /// contain a hyphen are passed through unchanged. No-op for len <= 8
-/// (already correct). Truncates at 32 hex chars (a full UUID); longer input
-/// is the caller's problem (still hex-only per the existing acceptance
-/// gate).
+/// (already correct). Input longer than 32 hex chars is NOT truncated: the
+/// extra hex chars are appended past the canonical 12-char final segment
+/// with no further hyphen, so the resulting `LIKE` pattern requires literal
+/// characters beyond position 36 that no real (36-char) UUID string can
+/// ever have — the scan naturally fails closed instead of silently
+/// resolving `<valid-32-hex><extra-hex>` to the valid UUID.
 pub fn hex_prefix_to_uuid_pattern(prefix: &str) -> String {
     if prefix.contains('-') {
         return prefix.to_string();
     }
     const BOUNDARIES: [usize; 4] = [8, 13, 18, 23]; // post-hyphen-insertion offsets
     let mut out = String::with_capacity(36);
-    for c in prefix.chars().take(32) {
+    for c in prefix.chars() {
         if BOUNDARIES.contains(&out.len()) {
             out.push('-');
         }
@@ -3197,6 +3200,18 @@ impl KhiveRuntime {
         include_deleted: bool,
     ) -> RuntimeResult<Option<Uuid>> {
         use khive_storage::types::{SqlStatement, SqlValue};
+
+        // Resolver-boundary gate (#816 Minor): every caller is expected to
+        // pre-validate hex-only input, but this is the single choke point
+        // every `resolve_prefix*` variant funnels through, so re-validate
+        // here too. A prefix containing anything other than hex digits and
+        // canonical hyphen separators (`%`, `_`, or other LIKE-wildcard /
+        // injection-shaped input) never matches a real id and is rejected
+        // before it can reach the LIKE pattern, instead of relying on bound
+        // params alone to neutralize wildcard semantics.
+        if !prefix.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+            return Ok(None);
+        }
 
         let pattern = format!("{}%", hex_prefix_to_uuid_pattern(prefix));
 
@@ -6497,11 +6512,30 @@ mod tests {
     #[test]
     fn hex_prefix_to_uuid_pattern_full_32_char_matches_canonical_uuid() {
         let compact = "aabbccdd112240008000000000000ab1";
-        // 32 hex chars only (truncate any extras beyond a full UUID).
         let compact32 = &compact[..32];
         assert_eq!(
             hex_prefix_to_uuid_pattern(compact32),
             "aabbccdd-1122-4000-8000-000000000ab1"
+        );
+    }
+
+    /// PR #816 Minor finding 3: input longer than 32 hex chars is NOT
+    /// truncated — the extra chars land past the canonical 12-char final
+    /// segment with no further hyphen, so the pattern can never match a real
+    /// (36-char) stored `id`, instead of silently truncating down to a
+    /// pattern that matches the valid 32-char UUID.
+    #[test]
+    fn hex_prefix_to_uuid_pattern_overlong_input_is_not_truncated() {
+        let compact32 = "aabbccdd112240008000000000000ab1";
+        let overlong = format!("{compact32}extrahex");
+        let pattern = hex_prefix_to_uuid_pattern(&overlong);
+        assert_eq!(
+            pattern, "aabbccdd-1122-4000-8000-000000000ab1extrahex",
+            "overlong input must keep its extra chars, not truncate to the valid UUID"
+        );
+        assert_ne!(
+            pattern, "aabbccdd-1122-4000-8000-000000000ab1",
+            "overlong pattern must not collapse to the canonical 36-char UUID form"
         );
     }
 
@@ -6556,6 +6590,54 @@ mod tests {
 
         let resolved = rt.resolve_prefix(&tok, &compact).await.unwrap();
         assert_eq!(resolved, Some(entity.id));
+    }
+
+    /// PR #816 Minor finding 3 (integration level): a valid 32-char compact
+    /// id with extra trailing hex chars appended must fail to resolve, not
+    /// silently resolve to the valid entity via truncation.
+    #[tokio::test]
+    async fn resolve_prefix_rejects_overlong_all_hex_input() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "OverlongTest", None, None, vec![])
+            .await
+            .unwrap();
+        let compact = entity.id.simple().to_string();
+        assert_eq!(compact.len(), 32);
+
+        let overlong = format!("{compact}ab");
+        let resolved = rt.resolve_prefix(&tok, &overlong).await.unwrap();
+        assert_eq!(
+            resolved, None,
+            "a 32-char id plus extra hex chars must not resolve to the valid entity"
+        );
+    }
+
+    /// PR #816 Minor finding 4: the `resolve_prefix*` boundary rejects
+    /// non-hex/non-hyphen input (e.g. LIKE wildcards `%`/`_`) instead of
+    /// letting it reach the bound `LIKE` pattern unfiltered — covers callers
+    /// (like khive-pack-git/src/ingest.rs) that resolve raw input without
+    /// their own all-hex gate.
+    #[tokio::test]
+    async fn resolve_prefix_rejects_like_wildcard_input() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let entity = rt
+            .create_entity(&tok, "concept", None, "WildcardTest", None, None, vec![])
+            .await
+            .unwrap();
+        let compact = entity.id.simple().to_string();
+        // A caller that forgot to hex-gate might pass a `%`-bearing string
+        // straight through, hoping to broaden a scan; the resolver boundary
+        // must reject it instead of running it as a wildcard LIKE.
+        let wildcard_prefix = format!("{}%", &compact[..8]);
+
+        let resolved = rt.resolve_prefix(&tok, &wildcard_prefix).await.unwrap();
+        assert_eq!(
+            resolved, None,
+            "prefix containing a LIKE wildcard must be rejected, not resolved"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Compact (hyphen-free) hex UUID prefixes longer than 8 characters could never resolve to a stored record. Every id-prefix resolver shares one acceptance gate (`len() >= 8 && all_hex`) that accepts compact prefixes of any length, but the `LIKE '<prefix>%'` pattern was built from the raw, unnormalized candidate. Stored `id` columns always use the canonical `8-4-4-4-12` hyphenated form, so any accepted prefix past 8 characters placed a hex digit where a hyphen belongs, and the scan could never match — not even a full 32-character hyphen-free UUID.

This affected every by-id verb across every loaded pack that accepts a short hex prefix (kg get/update/delete/merge/resolve/propose/review/withdraw, gtd transition/complete, comm reply/read/thread, schedule cancel, session resume/export, brain auto_feedback, knowledge get/cite, memory remember source_id). All of them silently returned `NotFound`/`InvalidInput`, indistinguishable from "the record genuinely doesn't exist."

## Changes

- Add `hex_prefix_to_uuid_pattern` in `khive-runtime::operations`, which re-inserts hyphens at the canonical boundaries before a compact prefix is used to build a `LIKE` pattern. Prefixes that already contain a hyphen pass through unchanged; behavior for prefixes of 8 characters or fewer is unchanged.
- Apply the helper at the two places that build the `LIKE` pattern from a raw prefix:
  - `resolve_prefix_inner` in `khive-runtime/src/operations.rs` — the shared fan-in point behind `resolve_prefix`/`resolve_prefix_unfiltered`/`resolve_prefix_including_deleted`/`resolve_prefix_unfiltered_including_deleted`, and through them every pack's by-id resolver.
  - `try_get_proposal_payload` in `khive-pack-kg/src/handlers/get.rs` — an independent `LIKE` query over `proposals_open` that is not routed through `resolve_prefix_inner`.
- Export `hex_prefix_to_uuid_pattern` from `khive-runtime`'s public surface so `khive-pack-kg` can share it.

The fix keeps the `id LIKE 'x%'` prefix-scan shape intact rather than wrapping the column in `REPLACE(id, '-', '')`, which would force a full table scan on this hot path.

## Test plan

- [x] `hex_prefix_to_uuid_pattern` unit test: table-driven hyphen placement for input lengths 1 through 31.
- [x] `resolve_prefix_compact_9_to_31_char_matches`: compact prefixes of length 9, 12, 16, 20, 24, 28, 31 all resolve to the same entity.
- [x] `resolve_prefix_compact_full_32_char_matches`: a full 32-char hyphen-stripped UUID resolves.
- [x] `resolve_prefix_boundary_at_hyphen_positions`: prefixes of exactly 8, 12, 16, 20, 24 compact chars (straddling each hyphen boundary) resolve correctly.
- [x] `resolve_prefix_ambiguous_still_detected_after_normalization`: two entities sharing a >8-char compact prefix still trip `AmbiguousPrefix`.
- [x] `hex_prefix_to_uuid_pattern_passes_through_hyphenated_input`: already-hyphenated input is unchanged.
- [x] `get_proposal_by_compact_hex_prefix_over_8_chars`: the independent `get.rs` proposal lookup resolves a >8-char compact prefix.
- [x] `cargo test -p khive-runtime -p khive-pack-kg`
- [x] `cargo clippy -p khive-runtime -p khive-pack-kg --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #773
