### PR TITLE
docs(adr): amend ADR-014 and ADR-039 for entity-merge content_strategy

### DIFF
--- a/docs/adr/ADR-014-curation-operations.md
+++ b/docs/adr/ADR-014-curation-operations.md
@@ -178,9 +178,36 @@ The two `MergeStrategy` names previously used (curation merge and snapshot merge
 now live in different namespaces with explicit names. No naming overload between
 substrate dedup and graph versioning.
 
+### `content_strategy`: description merge is independent of `policy` (amendment, #778/#814)
+
+`policy` (`EntityDedupMergePolicy`) governs `name`, `properties`, and `tags`.
+Description merge is governed by its own parameter, `content_strategy`
+(`ContentMergeStrategy`, defined in ADR-039 for note merge and shared here):
+
+```rust
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentMergeStrategy {
+    /// Default. Concatenates `into`'s and `from`'s descriptions with a
+    /// `\n\n---\n\n` separator. Lossless — the only default that never
+    /// discards content.
+    #[default]
+    Append,
+    /// Keeps `into`'s description unchanged; `from`'s description is discarded.
+    PreferInto,
+    /// Replaces `into`'s description with `from`'s description.
+    PreferFrom,
+}
+```
+
+`content_strategy` is selected directly — it is **not** derived from `policy`.
+An explicit `content_strategy=prefer_from` takes effect even when `policy`
+stays at its default `prefer_into`, and vice versa: the two parameters are
+independently settable, matching the note-merge design in ADR-039.
+
 ### `merge_entity` semantics
 
-`merge_entity(namespace, into_id, from_id, policy)`:
+`merge_entity(namespace, into_id, from_id, policy, content_strategy, dry_run)`:
 
 ```text
 1. Resolve namespace via NamespaceToken (ADR-007).
@@ -193,10 +220,10 @@ substrate dedup and graph versioning.
    b. If rewire produces a self-loop: drop the edge.
    c. Otherwise: upsert with DO UPDATE semantics (ADR-009) on the unique triple
       (namespace, source, target, relation).
-7. Merge entity fields per policy:
-   - name:        per policy
-   - description: per policy
-   - properties:  per policy (deep-merge for Union; key-add for PreferInto;
+7. Merge entity fields:
+   - name:        per `policy`
+   - description: per `content_strategy` (independent of `policy` — see above)
+   - properties:  per `policy` (deep-merge for Union; key-add for PreferInto;
                   full-override for PreferFrom)
    - tags:        always unioned
    - entity_type: per policy (validated via EntityTypeRegistry)
@@ -206,8 +233,13 @@ substrate dedup and graph versioning.
    The entity row is NOT hard-deleted; it carries merged_into provenance.
 10. Commit transaction.
 11. Emit MergeEvent for audit trail (entity_merged event with into_id, from_id,
-    edges_rewired count, policy).
+    edges_rewired count, policy, content_strategy). Skipped when `dry_run` is true.
 ```
+
+`dry_run=true` short-circuits all writes in step 6 (edge rewire), step 8 (upsert +
+reindex), step 9 (tombstone), and step 11 (event emission) — it is a read-only
+preview. `edges_rewired` in the returned summary is still accurate: it counts the
+edges that _would_ be rewired, computed without writing.
 
 Returns:
 
@@ -218,6 +250,8 @@ pub struct MergeSummary {
     pub edges_rewired: usize,
     pub properties_merged: usize,
     pub tags_unioned: usize,
+    pub content_appended: bool,
+    pub dry_run: bool,
 }
 ```
 

--- a/docs/adr/ADR-039-note-merge.md
+++ b/docs/adr/ADR-039-note-merge.md
@@ -61,9 +61,10 @@ struct MergeParams {
 ```
 
 `kind` absent or `"entity"` (or any entity-substrate granular kind) routes to the
-existing `merge_entity` path unchanged. `kind = "note"` (or any note-substrate
-granular kind such as `"observation"`, `"insight"`, `"task"`) routes to the new
-`merge_note` path defined below.
+`merge_entity` path. `kind = "note"` (or any note-substrate granular kind such as
+`"observation"`, `"insight"`, `"task"`) routes to the new `merge_note` path defined
+below. **Amendment (#778/#814):** `merge_entity`'s signature and description-merge
+behavior were _not_ left unchanged — see below.
 
 `substrate` is not a field on `MergeParams` — it is the internal resolved value
 after the registry maps `kind` to its storage family.
@@ -71,6 +72,14 @@ after the registry maps `kind` to its storage family.
 ### Content strategy
 
 Note content requires its own merge policy because entities have no content field.
+`ContentMergeStrategy` is defined once here and reused, unchanged, by entity merge
+(ADR-014 amendment, #778/#814) to govern the entity `description` field — entities
+have no `content` field, but `description` plays the same "freeform text body"
+role and needed the same three-way choice. `merge_entity` gained a `content_strategy`
+parameter (previously description selection silently followed the entity `policy`
+field, which could not express "prefer_from content but prefer_into everything
+else"). Both merge paths share the type; the behavior tables below apply verbatim
+to entity `description` with `content` read as `description`.
 
 | Value              | Behaviour                                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Documentation-only companion to #814 (issue #778), which changed `merge_entity`'s behavior and public signature. This PR amends the two ADRs that described the old behavior.

- **ADR-014** (Curation Operations): documents the new `ContentMergeStrategy` parameter on `merge_entity`, independent of `EntityDedupMergePolicy`; updates the `merge_entity` signature and field-level merge rules; documents that `dry_run=true` is now fully read-only with a predictive `edges_rewired` count; updates the documented `MergeSummary` shape.
- **ADR-039** (Note Merge): corrects the claim that the `merge_entity` path was left "unchanged" by the kind-discriminator dispatch decision, and notes that `ContentMergeStrategy` is now shared between `merge_note` and `merge_entity` rather than note-only.

No code changes.

**Pairs with:** #814 (fix/778-merge-content-strategy) — merge only after (or alongside) that PR, since it documents the behavior #814 ships.

## Test plan

- [x] `deno fmt --check docs/adr/ADR-014-curation-operations.md docs/adr/ADR-039-note-merge.md` passes
- [ ] Reviewer confirms the amended text matches the shipped behavior in #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)