### PR TITLE
fix(runtime): escape LIKE wildcards in Vamana snapshot invalidation (#819)

### DIFF
--- a/crates/khive-pack-knowledge/src/knowledge/vamana.rs
+++ b/crates/khive-pack-knowledge/src/knowledge/vamana.rs
@@ -818,8 +818,23 @@ async fn live_content_hash(
 /// Called after any vector-corpus mutation to guarantee `ensure_ann_for_model` cannot
 /// load a snapshot that no longer matches the live corpus.  Best-effort: if
 /// the `retrieval_snapshots` table doesn't exist yet, the call is a no-op.
+/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
+/// character itself (`\`) so a caller-supplied namespace is matched literally
+/// under `LIKE ... ESCAPE '\'` rather than as a pattern (#819: an
+/// underscore-bearing namespace like `a_b` must not also match `aXb`).
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 pub(crate) async fn invalidate_snapshot(rt: &KhiveRuntime, namespace: &str) {
-    let pattern = format!("{namespace}::vamana::%");
+    let pattern = format!("{}::vamana::%", escape_like(namespace));
     let sql = rt.sql();
     let mut w = match sql.writer().await {
         Ok(w) => w,
@@ -830,7 +845,7 @@ pub(crate) async fn invalidate_snapshot(rt: &KhiveRuntime, namespace: &str) {
     };
     match w
         .execute(SqlStatement {
-            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1".into(),
+            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1 ESCAPE '\\'".into(),
             params: vec![SqlValue::Text(pattern)],
             label: Some("invalidate_vamana_snapshot".into()),
         })
@@ -1212,6 +1227,71 @@ mod tests {
         assert!(
             !remaining.contains(&"local::vamana::model-b".to_string()),
             "vamana model-b must be deleted: {remaining:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_snapshot_does_not_cross_underscore_namespace() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let sql = rt.sql();
+
+        let mut w = sql.writer().await.expect("writer");
+        w.execute_script(
+            "CREATE TABLE IF NOT EXISTS retrieval_snapshots (\
+             namespace TEXT NOT NULL, index_type TEXT NOT NULL, \
+             snapshot BLOB NOT NULL, created_at INTEGER NOT NULL, \
+             PRIMARY KEY (namespace, index_type));"
+                .into(),
+        )
+        .await
+        .expect("create table");
+
+        // "a_b" and "aXb" are distinct namespaces (the `_` in "a_b" is a
+        // literal underscore, not a wildcard). Before #819's fix, invalidating
+        // "a_b" also deleted "aXb"'s row because `_` is a single-character
+        // LIKE wildcard.
+        for ns in &["a_b::vamana::model-a", "aXb::vamana::model-a"] {
+            w.execute(SqlStatement {
+                sql: "INSERT INTO retrieval_snapshots (namespace, index_type, snapshot, created_at) VALUES (?1, ?2, ?3, 0)".into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text("vamana".to_string()),
+                    SqlValue::Blob(b"{}".to_vec()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert");
+        }
+        drop(w);
+
+        invalidate_snapshot(&rt, "a_b").await;
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT namespace FROM retrieval_snapshots ORDER BY namespace".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query");
+
+        let remaining: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("namespace") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            remaining.contains(&"aXb::vamana::model-a".to_string()),
+            "unrelated namespace 'aXb' must survive invalidating 'a_b': {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&"a_b::vamana::model-a".to_string()),
+            "'a_b' own snapshot must still be deleted: {remaining:?}"
         );
     }
 

--- a/crates/kkernel/src/reindex.rs
+++ b/crates/kkernel/src/reindex.rs
@@ -788,10 +788,25 @@ fn finish(report: &ReindexReport, best_effort: bool) -> Result<()> {
     result
 }
 
+/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
+/// character itself (`\`) so a caller-supplied namespace is matched literally
+/// under `LIKE ... ESCAPE '\'` rather than as a pattern (#819: an
+/// underscore-bearing namespace like `a_b` must not also match `aXb`).
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyhow::Result<()> {
     use khive_storage::types::{SqlStatement, SqlValue};
 
-    let pattern = format!("{namespace}::vamana::%");
+    let pattern = format!("{}::vamana::%", escape_like(namespace));
     let sql = rt.sql();
     let mut writer = sql
         .writer()
@@ -800,7 +815,7 @@ async fn invalidate_vamana_snapshots(rt: &KhiveRuntime, namespace: &str) -> anyh
 
     match writer
         .execute(SqlStatement {
-            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1".into(),
+            sql: "DELETE FROM retrieval_snapshots WHERE namespace LIKE ?1 ESCAPE '\\'".into(),
             params: vec![SqlValue::Text(pattern)],
             label: Some("invalidate_vamana_snapshots".into()),
         })
@@ -1309,6 +1324,78 @@ mod tests {
         assert!(
             !remaining.contains(&"local::vamana::model-b".to_string()),
             "local vamana model-b must be deleted: {remaining:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reindex_invalidate_does_not_cross_underscore_namespace() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let sql = rt.sql();
+
+        let mut w = sql.writer().await.expect("writer");
+        w.execute_script(
+            "CREATE TABLE IF NOT EXISTS retrieval_snapshots (\
+             namespace TEXT NOT NULL, \
+             index_type TEXT NOT NULL, \
+             snapshot BLOB NOT NULL, \
+             created_at INTEGER NOT NULL, \
+             PRIMARY KEY (namespace, index_type));"
+                .into(),
+        )
+        .await
+        .expect("create table");
+
+        // "a_b" and "aXb" are distinct namespaces (the `_` in "a_b" is a
+        // literal underscore, not a wildcard). Before #819's fix, invalidating
+        // "a_b" also deleted "aXb"'s row because `_` is a single-character
+        // LIKE wildcard.
+        for ns in &["a_b::vamana::model-a", "aXb::vamana::model-a"] {
+            w.execute(SqlStatement {
+                sql: "INSERT INTO retrieval_snapshots \
+                      (namespace, index_type, snapshot, created_at) \
+                      VALUES (?1, ?2, ?3, 0)"
+                    .into(),
+                params: vec![
+                    SqlValue::Text(ns.to_string()),
+                    SqlValue::Text("vamana".to_string()),
+                    SqlValue::Blob(b"{}".to_vec()),
+                ],
+                label: None,
+            })
+            .await
+            .expect("insert row");
+        }
+        drop(w);
+
+        invalidate_vamana_snapshots(&rt, "a_b")
+            .await
+            .expect("invalidate");
+
+        let mut r = sql.reader().await.expect("reader");
+        let rows = r
+            .query_all(SqlStatement {
+                sql: "SELECT namespace FROM retrieval_snapshots ORDER BY namespace".into(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("query");
+
+        let remaining: Vec<String> = rows
+            .iter()
+            .filter_map(|row| match row.get("namespace") {
+                Some(SqlValue::Text(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            remaining.contains(&"aXb::vamana::model-a".to_string()),
+            "unrelated namespace 'aXb' must survive invalidating 'a_b': {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&"a_b::vamana::model-a".to_string()),
+            "'a_b' own snapshot must still be deleted: {remaining:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fixes #819: Vamana snapshot invalidation built `LIKE` patterns by interpolating the caller namespace directly (`{namespace}::vamana::%`) with no `ESCAPE` clause. Since namespace names may legally contain `_` (a SQLite `LIKE` single-character wildcard), invalidating namespace `a_b` also matched and deleted namespace `aXb`'s Vamana snapshot rows.
- Escapes `%`, `_`, and `\` in the namespace before building the pattern and adds `ESCAPE '\'` at both call sites: `invalidate_vamana_snapshots` in `crates/kkernel/src/reindex.rs` and `invalidate_snapshot` in `crates/khive-pack-knowledge/src/knowledge/vamana.rs`. Mirrors the existing `escape_like` helper already used for the same bug class in `crates/khive-pack-git/src/ingest.rs`.
- Issue #818 is related but out of scope for this branch.

## Test plan
- [x] Added regression tests in both crates seeding an underscore-bearing namespace (`a_b`) alongside a namespace differing only by that wildcard-position character (`aXb`); asserts the unrelated namespace's snapshot survives invalidation.
- [x] Verified both new tests fail against the pre-fix `LIKE` pattern (both rows deleted) and pass after the fix.
- [x] `cargo test -p kkernel -p khive-pack-knowledge` — all pass (from `crates/`, `CARGO_TARGET_DIR=./target`)
- [x] `cargo clippy -p kkernel -p khive-pack-knowledge --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)