### PR TITLE
fix(gtd): push status/assignee/priority filters into SQL for next/tasks

### DIFF
--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -871,6 +871,62 @@ impl NoteStore for SqlNoteStore {
         .await
     }
 
+    async fn query_notes_filtered_bounded(
+        &self,
+        namespace: &str,
+        filter: &NoteFilter,
+        max_rows: u32,
+    ) -> Result<Vec<Note>, StorageError> {
+        for pf in &filter.property_filters {
+            validate_json_path(&pf.json_path)?;
+        }
+        if let Some((path, _)) = &filter.order_by {
+            validate_json_path(path)?;
+        }
+
+        let namespace = namespace.to_string();
+        let filter = filter.clone();
+        let limit_i64 = i64::from(max_rows) + 1;
+
+        self.with_reader("query_notes_filtered_bounded", move |conn| {
+            let (where_sql, mut data_params) = build_note_filter_where(&namespace, &filter)?;
+            data_params.push(Box::new(limit_i64));
+            let limit_idx = data_params.len();
+
+            // Tie-break on `id` in addition to the primary sort key so the
+            // snapshot ordering is fully deterministic even when many rows
+            // share the same `created_at` (or the same custom sort value).
+            let order_clause = match &filter.order_by {
+                Some((path, dir)) => {
+                    let dir_str = match dir {
+                        SortDir::Asc => "ASC",
+                        SortDir::Desc => "DESC",
+                    };
+                    format!(" ORDER BY {} {dir_str}, id ASC", json_extract_expr(path))
+                }
+                None => " ORDER BY created_at DESC, id ASC".to_string(),
+            };
+
+            let data_sql = format!(
+                "SELECT id, namespace, kind, status, name, content, salience, decay_factor, \
+                 expires_at, properties, created_at, updated_at, deleted_at \
+                 FROM notes{where_sql}{order_clause} LIMIT ?{limit_idx}",
+            );
+
+            let mut stmt = conn.prepare(&data_sql)?;
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                data_params.iter().map(|p| p.as_ref()).collect();
+            let rows = stmt.query_map(param_refs.as_slice(), read_note)?;
+
+            let mut items = Vec::new();
+            for row in rows {
+                items.push(row?);
+            }
+            Ok(items)
+        })
+        .await
+    }
+
     async fn count_notes(&self, namespace: &str, kind: Option<&str>) -> Result<u64, StorageError> {
         let namespace = namespace.to_string();
         let kind = kind.map(|k| k.to_string());

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -428,7 +428,7 @@ fn build_note_filter_where(
     }
 
     for pf in &filter.property_filters {
-        match pf.op {
+        match &pf.op {
             FilterOp::EqOrMissing => {
                 let expr = json_extract_expr(&pf.json_path);
                 params.push(sql_value_param(&pf.value)?);
@@ -448,6 +448,36 @@ fn build_note_filter_where(
                 let n = params.len();
                 conditions.push(format!("({type_expr} IS NULL OR {type_expr} != ?{n})"));
             }
+            FilterOp::In(values) => {
+                let expr = json_extract_expr(&pf.json_path);
+                if values.is_empty() {
+                    // An empty set can never match any row.
+                    conditions.push("0".to_string());
+                    continue;
+                }
+                let mut placeholders = Vec::with_capacity(values.len());
+                for v in values {
+                    params.push(sql_value_param(v)?);
+                    placeholders.push(format!("?{}", params.len()));
+                }
+                conditions.push(format!("{expr} IN ({})", placeholders.join(", ")));
+            }
+            FilterOp::NotInOrMissing(values) => {
+                let expr = json_extract_expr(&pf.json_path);
+                if values.is_empty() {
+                    // Nothing to exclude — every row (including missing) matches.
+                    continue;
+                }
+                let mut placeholders = Vec::with_capacity(values.len());
+                for v in values {
+                    params.push(sql_value_param(v)?);
+                    placeholders.push(format!("?{}", params.len()));
+                }
+                conditions.push(format!(
+                    "({expr} IS NULL OR {expr} NOT IN ({}))",
+                    placeholders.join(", ")
+                ));
+            }
             _ => {
                 let expr = json_extract_expr(&pf.json_path);
                 let op = match pf.op {
@@ -457,7 +487,11 @@ fn build_note_filter_where(
                     FilterOp::Lte => "<=",
                     FilterOp::Gt => ">",
                     FilterOp::Gte => ">=",
-                    FilterOp::EqOrMissing | FilterOp::JsonTypeEq | FilterOp::JsonTypeNeMissing => {
+                    FilterOp::EqOrMissing
+                    | FilterOp::JsonTypeEq
+                    | FilterOp::JsonTypeNeMissing
+                    | FilterOp::In(_)
+                    | FilterOp::NotInOrMissing(_) => {
                         unreachable!()
                     }
                 };

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -327,12 +327,23 @@ pub(crate) async fn resolve_context_entity_id(
     }
 }
 
+/// Status a task is treated as when the `status` property is missing/empty.
+/// Property filters that select this value must use `FilterOp::EqOrMissing`
+/// (not plain `Eq`) so legacy rows without a stored `status` still match —
+/// `json_extract` on an absent path is SQL `NULL`, which never equals a text
+/// literal.
+const DEFAULT_STATUS: &str = "inbox";
+
+/// Priority a task is treated as when the `priority` property is missing/empty.
+/// Same `EqOrMissing` rule as [`DEFAULT_STATUS`] applies.
+const DEFAULT_PRIORITY: &str = "p2";
+
 /// Status used internally on a task. Defaults to "inbox" when missing/empty.
 fn task_status(props: Option<&Value>) -> String {
     props
         .and_then(|p| p.get("status"))
         .and_then(|v| v.as_str())
-        .unwrap_or("inbox")
+        .unwrap_or(DEFAULT_STATUS)
         .to_string()
 }
 
@@ -342,7 +353,7 @@ fn priority_rank(props: Option<&Value>) -> u8 {
     let raw = props
         .and_then(|p| p.get("priority"))
         .and_then(|v| v.as_str())
-        .unwrap_or("p2")
+        .unwrap_or(DEFAULT_PRIORITY)
         .to_ascii_lowercase();
     match raw.as_str() {
         "p0" => 0,
@@ -370,12 +381,12 @@ pub fn render_task(note: &khive_storage::note::Note) -> Value {
     let status = props
         .get("status")
         .and_then(|v| v.as_str())
-        .unwrap_or("inbox")
+        .unwrap_or(DEFAULT_STATUS)
         .to_string();
     let priority = props
         .get("priority")
         .and_then(|v| v.as_str())
-        .unwrap_or("p2")
+        .unwrap_or(DEFAULT_PRIORITY)
         .to_string();
     let assignee = props.get("assignee").cloned().unwrap_or(Value::Null);
     let due = props.get("due").cloned().unwrap_or(Value::Null);
@@ -439,17 +450,29 @@ const TASK_SCAN_PAGE_SIZE: u32 = 500;
 /// Safety cap on pages scanned by [`fetch_all_matching_tasks`] — bounds
 /// worst-case memory/latency for a pathological namespace while covering
 /// realistic actionable-task backlogs. Issue #772: this must not reintroduce
-/// a silent fixed-window cap, so hitting this bound is a loud `tracing::warn!`,
-/// never a quiet truncation.
+/// a silent fixed-window cap. When the store reports more matching rows than
+/// this bound covers, the scan is aborted up front with an explicit error
+/// (see [`TASK_SCAN_MAX_ROWS`]) rather than silently returning a truncated,
+/// possibly priority-incomplete result.
 const TASK_SCAN_MAX_PAGES: u32 = 40;
 
+/// Total matching rows [`fetch_all_matching_tasks`] will scan before refusing
+/// the query outright. A query whose `COUNT(*)` exceeds this must be rejected
+/// before any priority sort runs — sorting a partial candidate set can hide
+/// an older, higher-priority task that fell outside the scan window.
+const TASK_SCAN_MAX_ROWS: u64 = TASK_SCAN_MAX_PAGES as u64 * TASK_SCAN_PAGE_SIZE as u64;
+
 /// Fetch every `task` note matching `property_filters`, paging through the
-/// store until exhausted (or the safety cap is hit) rather than pre-fetching
-/// a single fixed-size unfiltered window. The predicate is pushed into SQL via
+/// store until exhausted rather than pre-fetching a single fixed-size
+/// unfiltered window. The predicate is pushed into SQL via
 /// `query_notes_filtered`, so the candidate set this returns is bounded by how
 /// many tasks actually match — not by how many task notes of any status exist
 /// (the #772 bug: a fixed unfiltered window could be entirely filled by newer
 /// non-matching churn, hiding older matching tasks regardless of priority).
+///
+/// If the first page's `total` exceeds [`TASK_SCAN_MAX_ROWS`], this returns
+/// `Err(InvalidInput)` instead of scanning a truncated subset — callers must
+/// narrow the filters (e.g. add `assignee`) so the result stays complete.
 async fn fetch_all_matching_tasks(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -486,20 +509,34 @@ async fn fetch_all_matching_tasks(
             )
             .await
             .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
+        if page_idx == 0 {
+            if let Some(total) = page.total {
+                if total > TASK_SCAN_MAX_ROWS {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "gtd: {total} tasks match this query, which exceeds the \
+                         {TASK_SCAN_MAX_ROWS}-row scan bound; narrow the filters \
+                         (e.g. specify assignee) and retry so results stay complete \
+                         and priority-ordered instead of being silently truncated"
+                    )));
+                }
+            }
+        }
         let fetched = page.items.len() as u32;
         notes.extend(page.items);
         if fetched < TASK_SCAN_PAGE_SIZE {
             return Ok(notes);
         }
         offset += TASK_SCAN_PAGE_SIZE;
-        if page_idx + 1 == TASK_SCAN_MAX_PAGES {
-            tracing::warn!(
-                namespace = token.namespace().as_str(),
-                scanned = TASK_SCAN_MAX_PAGES * TASK_SCAN_PAGE_SIZE,
-                "gtd: task scan hit safety cap; results may be incomplete"
-            );
-        }
     }
+    // Reached only if the matching-row count grew past TASK_SCAN_MAX_ROWS
+    // between the first page's COUNT(*) and this scan completing (concurrent
+    // writes) — the up-front check above is the primary defense. Warn loudly
+    // rather than silently return a possibly priority-incomplete set.
+    tracing::warn!(
+        namespace = token.namespace().as_str(),
+        scanned = TASK_SCAN_MAX_ROWS,
+        "gtd: task scan hit safety cap after total-based check passed; results may be incomplete"
+    );
     Ok(notes)
 }
 
@@ -1112,7 +1149,17 @@ impl GtdPack {
         let mut property_filters = vec![match status_filter.as_deref() {
             Some(want) => PropertyFilter {
                 json_path: "$.status".to_string(),
-                op: FilterOp::Eq,
+                // A legacy task with no stored `status` property is treated as
+                // `inbox` everywhere else in this pack (`task_status`,
+                // `render_task`). `json_extract` on an absent path is SQL
+                // NULL, which `Eq` never matches, so an explicit
+                // `status="inbox"` query would silently exclude those rows —
+                // `EqOrMissing` restores the "absent counts as default" rule.
+                op: if want == DEFAULT_STATUS {
+                    FilterOp::EqOrMissing
+                } else {
+                    FilterOp::Eq
+                },
                 value: SqlValue::Text(want.to_string()),
             },
             None => PropertyFilter {
@@ -1135,11 +1182,19 @@ impl GtdPack {
             // Priorities are always stored lowercase (`task_create`/
             // `prepare_transition` normalize via `to_ascii_lowercase`), so an
             // exact-match SQL predicate on the lowercased input reproduces
-            // the prior `eq_ignore_ascii_case` behavior.
+            // the prior `eq_ignore_ascii_case` behavior. A legacy task with no
+            // stored `priority` renders as `p2` (`priority_rank`,
+            // `render_task`), so `priority="p2"` must also match the missing
+            // case via `EqOrMissing` — plain `Eq` never matches SQL NULL.
+            let want = want.to_ascii_lowercase();
             property_filters.push(PropertyFilter {
                 json_path: "$.priority".to_string(),
-                op: FilterOp::Eq,
-                value: SqlValue::Text(want.to_ascii_lowercase()),
+                op: if want == DEFAULT_PRIORITY {
+                    FilterOp::EqOrMissing
+                } else {
+                    FilterOp::Eq
+                },
+                value: SqlValue::Text(want),
             });
         }
 

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -444,35 +444,32 @@ fn ts_to_rfc(micros: i64) -> String {
     micros_to_iso(micros)
 }
 
-/// Page size used when scanning every row matching a pushed-down task filter.
-const TASK_SCAN_PAGE_SIZE: u32 = 500;
+/// Safety cap on matching rows [`fetch_all_matching_tasks`] will accept in a
+/// single snapshot query before refusing the request outright. A query
+/// matching more than this many rows is rejected before any priority sort
+/// runs — sorting a partial candidate set can hide an older, higher-priority
+/// task that fell outside the scan window.
+const TASK_SCAN_MAX_ROWS: u32 = 20_000;
 
-/// Safety cap on pages scanned by [`fetch_all_matching_tasks`] — bounds
-/// worst-case memory/latency for a pathological namespace while covering
-/// realistic actionable-task backlogs. Issue #772: this must not reintroduce
-/// a silent fixed-window cap. When the store reports more matching rows than
-/// this bound covers, the scan is aborted up front with an explicit error
-/// (see [`TASK_SCAN_MAX_ROWS`]) rather than silently returning a truncated,
-/// possibly priority-incomplete result.
-const TASK_SCAN_MAX_PAGES: u32 = 40;
-
-/// Total matching rows [`fetch_all_matching_tasks`] will scan before refusing
-/// the query outright. A query whose `COUNT(*)` exceeds this must be rejected
-/// before any priority sort runs — sorting a partial candidate set can hide
-/// an older, higher-priority task that fell outside the scan window.
-const TASK_SCAN_MAX_ROWS: u64 = TASK_SCAN_MAX_PAGES as u64 * TASK_SCAN_PAGE_SIZE as u64;
-
-/// Fetch every `task` note matching `property_filters`, paging through the
-/// store until exhausted rather than pre-fetching a single fixed-size
-/// unfiltered window. The predicate is pushed into SQL via
-/// `query_notes_filtered`, so the candidate set this returns is bounded by how
-/// many tasks actually match — not by how many task notes of any status exist
-/// (the #772 bug: a fixed unfiltered window could be entirely filled by newer
-/// non-matching churn, hiding older matching tasks regardless of priority).
+/// Fetch every `task` note matching `property_filters` in a single bounded
+/// snapshot query, instead of pre-fetching a fixed-size unfiltered window.
+/// The predicate is pushed into SQL via `query_notes_filtered_bounded`, so
+/// the candidate set this returns is bounded by how many tasks actually
+/// match — not by how many task notes of any status exist (the #772 bug: a
+/// fixed unfiltered window could be entirely filled by newer non-matching
+/// churn, hiding older matching tasks regardless of priority).
 ///
-/// If the first page's `total` exceeds [`TASK_SCAN_MAX_ROWS`], this returns
-/// `Err(InvalidInput)` instead of scanning a truncated subset — callers must
-/// narrow the filters (e.g. add `assignee`) so the result stays complete.
+/// `query_notes_filtered_bounded` fetches at most `TASK_SCAN_MAX_ROWS + 1`
+/// rows in one SQL statement with deterministic ordering — one consistent
+/// snapshot, not a `COUNT(*)` followed by independent paged reads that a
+/// concurrent insert could split across (issue #825 round 2: the prior
+/// page-loop version re-queried the store per page with no transaction
+/// spanning them, so a row inserted between pages could appear duplicated
+/// across a page boundary, or the scan could hit its cap and still return
+/// `Ok` with an incomplete set). If `TASK_SCAN_MAX_ROWS + 1` rows come back,
+/// this returns `Err(InvalidInput)` instead of ever returning a possibly
+/// truncated result — callers must narrow the filters (e.g. add `assignee`)
+/// so the result stays complete.
 async fn fetch_all_matching_tasks(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -495,48 +492,20 @@ async fn fetch_all_matching_tasks(
     };
     let store = runtime.notes(token)?;
 
-    let mut notes = Vec::new();
-    let mut offset: u32 = 0;
-    for page_idx in 0..TASK_SCAN_MAX_PAGES {
-        let page = store
-            .query_notes_filtered(
-                token.namespace().as_str(),
-                &filter,
-                PageRequest {
-                    limit: TASK_SCAN_PAGE_SIZE,
-                    offset: offset.into(),
-                },
-            )
-            .await
-            .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
-        if page_idx == 0 {
-            if let Some(total) = page.total {
-                if total > TASK_SCAN_MAX_ROWS {
-                    return Err(RuntimeError::InvalidInput(format!(
-                        "gtd: {total} tasks match this query, which exceeds the \
-                         {TASK_SCAN_MAX_ROWS}-row scan bound; narrow the filters \
-                         (e.g. specify assignee) and retry so results stay complete \
-                         and priority-ordered instead of being silently truncated"
-                    )));
-                }
-            }
-        }
-        let fetched = page.items.len() as u32;
-        notes.extend(page.items);
-        if fetched < TASK_SCAN_PAGE_SIZE {
-            return Ok(notes);
-        }
-        offset += TASK_SCAN_PAGE_SIZE;
+    let notes = store
+        .query_notes_filtered_bounded(token.namespace().as_str(), &filter, TASK_SCAN_MAX_ROWS)
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered_bounded: {e}")))?;
+
+    if notes.len() as u32 > TASK_SCAN_MAX_ROWS {
+        return Err(RuntimeError::InvalidInput(format!(
+            "gtd: more than {TASK_SCAN_MAX_ROWS} tasks match this query, which exceeds the \
+             {TASK_SCAN_MAX_ROWS}-row scan bound; narrow the filters \
+             (e.g. specify assignee) and retry so results stay complete \
+             and priority-ordered instead of being silently truncated"
+        )));
     }
-    // Reached only if the matching-row count grew past TASK_SCAN_MAX_ROWS
-    // between the first page's COUNT(*) and this scan completing (concurrent
-    // writes) — the up-front check above is the primary defense. Warn loudly
-    // rather than silently return a possibly priority-incomplete set.
-    tracing::warn!(
-        namespace = token.namespace().as_str(),
-        scanned = TASK_SCAN_MAX_ROWS,
-        "gtd: task scan hit safety cap after total-based check passed; results may be incomplete"
-    );
+
     Ok(notes)
 }
 

--- a/crates/khive-pack-gtd/src/handlers.rs
+++ b/crates/khive-pack-gtd/src/handlers.rs
@@ -19,7 +19,8 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use khive_runtime::{micros_to_iso, KhiveRuntime, NamespaceToken, Resolved, RuntimeError};
-use khive_storage::types::{SqlStatement, SqlValue};
+use khive_storage::note::{FilterOp, NoteFilter, PropertyFilter};
+use khive_storage::types::{PageRequest, SqlStatement, SqlValue};
 
 use crate::schema::{
     allowed_transitions, can_transition, is_actionable, is_terminal, is_valid_priority,
@@ -432,6 +433,76 @@ fn ts_to_rfc(micros: i64) -> String {
     micros_to_iso(micros)
 }
 
+/// Page size used when scanning every row matching a pushed-down task filter.
+const TASK_SCAN_PAGE_SIZE: u32 = 500;
+
+/// Safety cap on pages scanned by [`fetch_all_matching_tasks`] — bounds
+/// worst-case memory/latency for a pathological namespace while covering
+/// realistic actionable-task backlogs. Issue #772: this must not reintroduce
+/// a silent fixed-window cap, so hitting this bound is a loud `tracing::warn!`,
+/// never a quiet truncation.
+const TASK_SCAN_MAX_PAGES: u32 = 40;
+
+/// Fetch every `task` note matching `property_filters`, paging through the
+/// store until exhausted (or the safety cap is hit) rather than pre-fetching
+/// a single fixed-size unfiltered window. The predicate is pushed into SQL via
+/// `query_notes_filtered`, so the candidate set this returns is bounded by how
+/// many tasks actually match — not by how many task notes of any status exist
+/// (the #772 bug: a fixed unfiltered window could be entirely filled by newer
+/// non-matching churn, hiding older matching tasks regardless of priority).
+async fn fetch_all_matching_tasks(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    property_filters: Vec<PropertyFilter>,
+) -> Result<Vec<khive_storage::note::Note>, RuntimeError> {
+    let namespaces = if token.visible_namespaces().len() > 1 {
+        token
+            .visible_namespaces()
+            .iter()
+            .map(|ns| ns.as_str().to_owned())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let filter = NoteFilter {
+        kind: Some("task".to_string()),
+        property_filters,
+        namespaces,
+        ..Default::default()
+    };
+    let store = runtime.notes(token)?;
+
+    let mut notes = Vec::new();
+    let mut offset: u32 = 0;
+    for page_idx in 0..TASK_SCAN_MAX_PAGES {
+        let page = store
+            .query_notes_filtered(
+                token.namespace().as_str(),
+                &filter,
+                PageRequest {
+                    limit: TASK_SCAN_PAGE_SIZE,
+                    offset: offset.into(),
+                },
+            )
+            .await
+            .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
+        let fetched = page.items.len() as u32;
+        notes.extend(page.items);
+        if fetched < TASK_SCAN_PAGE_SIZE {
+            return Ok(notes);
+        }
+        offset += TASK_SCAN_PAGE_SIZE;
+        if page_idx + 1 == TASK_SCAN_MAX_PAGES {
+            tracing::warn!(
+                namespace = token.namespace().as_str(),
+                scanned = TASK_SCAN_MAX_PAGES * TASK_SCAN_PAGE_SIZE,
+                "gtd: task scan hit safety cap; results may be incomplete"
+            );
+        }
+    }
+    Ok(notes)
+}
+
 /// Load a task note and verify (a) it exists, (b) namespace matches, (c) it is
 /// actually `kind = "task"`. Used by `complete` and `transition`.
 async fn load_task(
@@ -784,44 +855,47 @@ impl GtdPack {
         // the `limit` ParamDef instead (issue #744 fallback ask 1).
         let limit = p.limit.unwrap_or(10).clamp(1, 200);
 
-        // Pull a broad window of recent tasks, filter in-memory by GTD status.
-        // 500 covers typical inbox/next/active backlogs without paging.
-        let notes = self
-            .runtime()
-            .list_notes(token, Some("task"), 500, 0)
-            .await?;
+        // #772: push the actionable-status (+ optional assignee) predicate into
+        // SQL via `query_notes_filtered` and scan every matching page, instead
+        // of pre-fetching a fixed unfiltered recency window and filtering in
+        // Rust — a fixed window silently drops actionable tasks once enough
+        // newer non-matching task notes (any status) fill it. The candidate
+        // set is now bounded by how many `next`/`active` tasks actually exist.
+        let mut property_filters = vec![PropertyFilter {
+            json_path: "$.status".to_string(),
+            op: FilterOp::In(vec![
+                SqlValue::Text("next".to_string()),
+                SqlValue::Text("active".to_string()),
+            ]),
+            value: SqlValue::Null,
+        }];
+        if let Some(want) = p.assignee.as_deref() {
+            property_filters.push(PropertyFilter {
+                json_path: "$.assignee".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text(want.to_string()),
+            });
+        }
+        let notes = fetch_all_matching_tasks(self.runtime(), token, property_filters).await?;
 
         // Build a quick lookup map of task UUID → GTD status so dependency
-        // filtering (scenario-gtd C2) can check blocker states in O(1).
+        // filtering (scenario-gtd C2) can check blocker states in O(1). Every
+        // note here already passed the actionable(+assignee) SQL filter above
+        // (and `deleted_at IS NULL`, enforced unconditionally by
+        // `query_notes_filtered`).
         use std::collections::HashMap;
         let mut status_by_id: HashMap<uuid::Uuid, String> = notes
             .iter()
-            .filter(|n| n.deleted_at.is_none())
             .map(|n| (n.id, task_status(n.properties.as_ref())))
             .collect();
 
-        // Collect actionable candidates (before dependency check) so we can
-        // determine which blocker UUIDs are outside the 500-task window.
-        let candidates: Vec<&khive_storage::note::Note> = notes
-            .iter()
-            .filter(|n| n.deleted_at.is_none())
-            .filter(|n| is_actionable(&task_status(n.properties.as_ref())))
-            .filter(|n| match p.assignee.as_deref() {
-                None => true,
-                Some(want) => {
-                    n.properties
-                        .as_ref()
-                        .and_then(|v| v.get("assignee"))
-                        .and_then(|v| v.as_str())
-                        == Some(want)
-                }
-            })
-            .collect();
+        let candidates: Vec<&khive_storage::note::Note> = notes.iter().collect();
 
         // Gather all dependency UUIDs referenced by candidates that are not
-        // already in status_by_id — these are blockers older than the 500-task
-        // scan window.  Fetch them in one batch so the dependency filter below
-        // can evaluate their status correctly regardless of window position.
+        // already in status_by_id — these are blockers whose status isn't
+        // `next`/`active` (the common case: a `done` blocker).  Fetch them in
+        // one batch so the dependency filter below can evaluate their status
+        // correctly regardless of scan-page position.
         let missing_dep_ids: Vec<uuid::Uuid> = candidates
             .iter()
             .flat_map(|n| {
@@ -997,7 +1071,7 @@ impl GtdPack {
         // note in `handle_next` above (bare-array response shape rules out an
         // additive `truncated` field).
         let limit = p.limit.unwrap_or(50).clamp(1, 200);
-        let offset = p.offset.unwrap_or(0) as usize;
+        let offset = p.offset.unwrap_or(0);
 
         // Normalize status filter once.
         let status_filter: Option<String> = match p.status.as_deref() {
@@ -1021,50 +1095,84 @@ impl GtdPack {
             }
         }
 
-        let window = (offset as u32).saturating_add(limit).saturating_add(500);
-        let notes = self
+        // #772: push status/assignee/priority predicates into SQL via
+        // `query_notes_filtered` and use its real `PageRequest{limit, offset}`
+        // for pagination. The previous `list_notes(..., window, 0)` always
+        // refetched from offset 0 and grew an unfiltered window by a fixed
+        // +500 fudge factor — a fixed number of newer non-matching tasks could
+        // still hide older matches (e.g. `tasks(status="done")` returning
+        // empty even though done tasks exist), and deep pages re-scanned the
+        // same rows since the underlying fetch offset never advanced.
+        //
+        // When no status= is provided, exclude terminal states (done,
+        // cancelled) so the default listing shows only active work, while
+        // still counting a task with no `status` property yet as `inbox`
+        // (non-terminal, included) — hence `NotInOrMissing` rather than `Ne`,
+        // which would silently drop rows where `$.status` is absent.
+        let mut property_filters = vec![match status_filter.as_deref() {
+            Some(want) => PropertyFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text(want.to_string()),
+            },
+            None => PropertyFilter {
+                json_path: "$.status".to_string(),
+                op: FilterOp::NotInOrMissing(vec![
+                    SqlValue::Text("done".to_string()),
+                    SqlValue::Text("cancelled".to_string()),
+                ]),
+                value: SqlValue::Null,
+            },
+        }];
+        if let Some(want) = p.assignee.as_deref() {
+            property_filters.push(PropertyFilter {
+                json_path: "$.assignee".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text(want.to_string()),
+            });
+        }
+        if let Some(want) = p.priority.as_deref() {
+            // Priorities are always stored lowercase (`task_create`/
+            // `prepare_transition` normalize via `to_ascii_lowercase`), so an
+            // exact-match SQL predicate on the lowercased input reproduces
+            // the prior `eq_ignore_ascii_case` behavior.
+            property_filters.push(PropertyFilter {
+                json_path: "$.priority".to_string(),
+                op: FilterOp::Eq,
+                value: SqlValue::Text(want.to_ascii_lowercase()),
+            });
+        }
+
+        let namespaces = if token.visible_namespaces().len() > 1 {
+            token
+                .visible_namespaces()
+                .iter()
+                .map(|ns| ns.as_str().to_owned())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let filter = NoteFilter {
+            kind: Some("task".to_string()),
+            property_filters,
+            namespaces,
+            ..Default::default()
+        };
+        let page = self
             .runtime()
-            .list_notes(token, Some("task"), window, 0)
-            .await?;
+            .notes(token)?
+            .query_notes_filtered(
+                token.namespace().as_str(),
+                &filter,
+                PageRequest {
+                    limit,
+                    offset: offset.into(),
+                },
+            )
+            .await
+            .map_err(|e| RuntimeError::Internal(format!("query_notes_filtered: {e}")))?;
 
-        // When no status= is provided, exclude terminal states (done, cancelled)
-        // so the default listing shows only active work. Pass status= explicitly
-        // to see terminal tasks (e.g. tasks(status="done") for review).
-        let filtered: Vec<&khive_storage::note::Note> = notes
-            .iter()
-            .filter(|n| n.deleted_at.is_none())
-            .filter(|n| match status_filter.as_deref() {
-                None => !is_terminal(&task_status(n.properties.as_ref())),
-                Some(want) => task_status(n.properties.as_ref()) == want,
-            })
-            .filter(|n| match p.assignee.as_deref() {
-                None => true,
-                Some(want) => {
-                    n.properties
-                        .as_ref()
-                        .and_then(|v| v.get("assignee"))
-                        .and_then(|v| v.as_str())
-                        == Some(want)
-                }
-            })
-            .filter(|n| match p.priority.as_deref() {
-                None => true,
-                Some(want) => n
-                    .properties
-                    .as_ref()
-                    .and_then(|v| v.get("priority"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.eq_ignore_ascii_case(want))
-                    .unwrap_or(false),
-            })
-            .collect();
-
-        let result: Vec<Value> = filtered
-            .into_iter()
-            .skip(offset)
-            .take(limit as usize)
-            .map(render_task)
-            .collect();
+        let result: Vec<Value> = page.items.iter().map(render_task).collect();
         Ok(Value::Array(result))
     }
 

--- a/crates/khive-pack-gtd/tests/integration.rs
+++ b/crates/khive-pack-gtd/tests/integration.rs
@@ -2477,6 +2477,55 @@ async fn next_returns_explicit_error_when_matches_exceed_scan_bound() {
     );
 }
 
+/// #825 round 2 boundary test: exactly `TASK_SCAN_MAX_ROWS` (20,000) matching
+/// rows must succeed — the bound is "reject when more than 20,000 rows
+/// match", not "reject at or above 20,000".
+#[tokio::test]
+async fn next_succeeds_when_matches_exactly_at_scan_bound() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let tasks: Vec<Note> = (0..20_000_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some(format!("task-{i}")),
+            content: format!("task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "next"})),
+            created_at: now + i64::from(i),
+            updated_at: now + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    note_store
+        .upsert_notes(tasks)
+        .await
+        .expect("insert tasks at scan bound");
+
+    let pack = pack(runtime);
+    let result = pack
+        .dispatch("gtd.next", json!({"limit": 5}))
+        .await
+        .expect("gtd.next must succeed when matches are exactly at the scan bound");
+    let arr = result.as_array().unwrap();
+    assert_eq!(
+        arr.len(),
+        5,
+        "gtd.next must still honor the requested limit"
+    );
+}
+
 /// Regression for a push-down bug where an explicit `status="inbox"` filter
 /// used a plain `Eq` predicate against `json_extract(properties, '$.status')`.
 /// `json_extract` on a legacy row with no stored `status` key evaluates to

--- a/crates/khive-pack-gtd/tests/integration.rs
+++ b/crates/khive-pack-gtd/tests/integration.rs
@@ -2270,3 +2270,226 @@ async fn complete_blocks_secret_in_result() {
         "gtd.complete with secret in result must be rejected; got: {result:?}"
     );
 }
+
+// ── Issue #772: fixed-window pre-fetch-then-filter regression tests ─────────
+
+/// `gtd.next` must surface an actionable task even when 500+ newer,
+/// non-actionable task notes exist. Before the fix, `handle_next` pre-fetched
+/// only the newest 500 task notes (unfiltered) via `list_notes` and applied
+/// the actionable-status filter afterward in Rust — an older `next`/`active`
+/// task falling outside that fixed window was silently invisible regardless
+/// of priority.
+#[tokio::test]
+async fn next_finds_actionable_task_older_than_fixed_window() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    // An old, actionable p0 task — created long before any filler task.
+    let old_ts = chrono::Utc::now().timestamp_micros() - 1_000_000_000_000; // ~11 days ago
+    let old_task = Note {
+        id: uuid::Uuid::new_v4(),
+        namespace: "local".to_string(),
+        kind: "task".to_string(),
+        status: "active".to_string(),
+        name: Some("ancient-p0".to_string()),
+        content: "ancient p0 task".to_string(),
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(json!({"status": "next", "priority": "p0"})),
+        created_at: old_ts,
+        updated_at: old_ts,
+        deleted_at: None,
+    };
+    note_store
+        .upsert_note(old_task)
+        .await
+        .expect("insert old task");
+
+    // Pad with 501 newer, non-actionable (inbox) task notes — more than the
+    // legacy fixed 500-row window, none of which are actionable themselves.
+    let now = chrono::Utc::now().timestamp_micros();
+    let fillers: Vec<Note> = (0..501_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some(format!("filler-{i}")),
+            content: format!("filler task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "inbox"})),
+            created_at: now + i64::from(i),
+            updated_at: now + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    note_store
+        .upsert_notes(fillers)
+        .await
+        .expect("insert fillers");
+
+    let pack = pack(runtime);
+    let result = pack.dispatch("gtd.next", json!({})).await.unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(
+        arr.iter()
+            .any(|t| t["title"].as_str() == Some("ancient-p0")),
+        "gtd.next must surface an actionable p0 task older than 500 newer \
+         non-actionable tasks (issue #772); result: {result:?}"
+    );
+    assert_eq!(
+        arr[0]["title"], "ancient-p0",
+        "the ancient p0 task must sort first by priority"
+    );
+}
+
+/// `gtd.tasks(status="done")` must surface a done task even when 500+ newer,
+/// non-done task notes exist. Before the fix, `handle_tasks` pre-fetched
+/// `offset + limit + 500` task notes (unfiltered, always from offset 0) via
+/// `list_notes` and applied the status filter afterward in Rust — an older
+/// `done` task falling outside that window was silently invisible.
+#[tokio::test]
+async fn tasks_finds_done_task_older_than_fixed_window() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    let old_ts = chrono::Utc::now().timestamp_micros() - 1_000_000_000_000;
+    let old_task = Note {
+        id: uuid::Uuid::new_v4(),
+        namespace: "local".to_string(),
+        kind: "task".to_string(),
+        status: "active".to_string(),
+        name: Some("ancient-done".to_string()),
+        content: "ancient done task".to_string(),
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(json!({"status": "done"})),
+        created_at: old_ts,
+        updated_at: old_ts,
+        deleted_at: None,
+    };
+    note_store
+        .upsert_note(old_task)
+        .await
+        .expect("insert old done task");
+
+    // The legacy default window was offset(0) + limit(50) + 500 = 550; 600
+    // newer non-done fillers exceed that so the always-offset-0 fetch never
+    // reached the ancient done task.
+    let now = chrono::Utc::now().timestamp_micros();
+    let fillers: Vec<Note> = (0..600_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some(format!("filler-{i}")),
+            content: format!("filler task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "inbox"})),
+            created_at: now + i64::from(i),
+            updated_at: now + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    note_store
+        .upsert_notes(fillers)
+        .await
+        .expect("insert fillers");
+
+    let pack = pack(runtime);
+    let result = pack
+        .dispatch("gtd.tasks", json!({"status": "done"}))
+        .await
+        .unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(
+        arr.iter()
+            .any(|t| t["title"].as_str() == Some("ancient-done")),
+        "gtd.tasks(status=\"done\") must surface a done task older than the \
+         legacy fixed pre-fetch window (issue #772); result: {result:?}"
+    );
+}
+
+/// `gtd.tasks` pages must not overlap: real SQL-level `LIMIT`/`OFFSET`
+/// pagination (this fix) must keep behaving correctly for the common case
+/// where every row already matches the filter, guarding against a regression
+/// back to any offset-0-refetch pattern.
+#[tokio::test]
+async fn tasks_pagination_returns_disjoint_pages() {
+    use khive_storage::note::Note;
+    use std::collections::HashSet;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let tasks: Vec<Note> = (0..60_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some(format!("task-{i}")),
+            content: format!("task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "next"})),
+            created_at: now + i64::from(i),
+            updated_at: now + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    note_store.upsert_notes(tasks).await.expect("insert tasks");
+
+    let pack = pack(runtime);
+    let page1 = pack
+        .dispatch("gtd.tasks", json!({"limit": 20, "offset": 0}))
+        .await
+        .unwrap();
+    let page2 = pack
+        .dispatch("gtd.tasks", json!({"limit": 20, "offset": 20}))
+        .await
+        .unwrap();
+
+    let ids1: HashSet<&str> = page1
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["full_id"].as_str().unwrap())
+        .collect();
+    let ids2: HashSet<&str> = page2
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["full_id"].as_str().unwrap())
+        .collect();
+
+    assert_eq!(ids1.len(), 20);
+    assert_eq!(ids2.len(), 20);
+    assert!(
+        ids1.is_disjoint(&ids2),
+        "pages at different offsets must not overlap (issue #772 offset-0 \
+         refetch bug); page1={ids1:?} page2={ids2:?}"
+    );
+}

--- a/crates/khive-pack-gtd/tests/integration.rs
+++ b/crates/khive-pack-gtd/tests/integration.rs
@@ -2427,14 +2427,14 @@ async fn tasks_finds_done_task_older_than_fixed_window() {
     );
 }
 
-/// `gtd.tasks` pages must not overlap: real SQL-level `LIMIT`/`OFFSET`
-/// pagination (this fix) must keep behaving correctly for the common case
-/// where every row already matches the filter, guarding against a regression
-/// back to any offset-0-refetch pattern.
+/// #772 follow-up (Major finding): when more tasks match the actionable
+/// filter than the scan safety bound covers, `gtd.next` must return an
+/// explicit error asking the caller to narrow the query instead of silently
+/// sorting and truncating a partial candidate set — a partial set can hide
+/// an older, higher-priority task that fell outside the scan window.
 #[tokio::test]
-async fn tasks_pagination_returns_disjoint_pages() {
+async fn next_returns_explicit_error_when_matches_exceed_scan_bound() {
     use khive_storage::note::Note;
-    use std::collections::HashSet;
 
     let runtime = rt();
     let token = runtime
@@ -2443,7 +2443,7 @@ async fn tasks_pagination_returns_disjoint_pages() {
     let note_store = runtime.notes(&token).expect("note store");
 
     let now = chrono::Utc::now().timestamp_micros();
-    let tasks: Vec<Note> = (0..60_u32)
+    let tasks: Vec<Note> = (0..20_001_u32)
         .map(|i| Note {
             id: uuid::Uuid::new_v4(),
             namespace: "local".to_string(),
@@ -2460,7 +2460,195 @@ async fn tasks_pagination_returns_disjoint_pages() {
             deleted_at: None,
         })
         .collect();
+    note_store
+        .upsert_notes(tasks)
+        .await
+        .expect("insert tasks over scan bound");
+
+    let pack = pack(runtime);
+    let err = pack
+        .dispatch("gtd.next", json!({}))
+        .await
+        .expect_err("gtd.next must reject a query matching more rows than the scan bound covers");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeds") && msg.contains("scan bound"),
+        "error must explain the scan bound was exceeded; got: {msg}"
+    );
+}
+
+/// Regression for a push-down bug where an explicit `status="inbox"` filter
+/// used a plain `Eq` predicate against `json_extract(properties, '$.status')`.
+/// `json_extract` on a legacy row with no stored `status` key evaluates to
+/// SQL `NULL`, which `Eq` never matches, even though every other code path
+/// (`task_status`, `render_task`) treats a missing `status` as `"inbox"`.
+/// The filter must use `EqOrMissing` so `status="inbox"` also surfaces tasks
+/// that predate the `status` property being written at all.
+#[tokio::test]
+async fn tasks_status_inbox_filter_matches_legacy_task_missing_status_property() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let legacy_task = Note {
+        id: uuid::Uuid::new_v4(),
+        namespace: "local".to_string(),
+        kind: "task".to_string(),
+        status: "active".to_string(),
+        name: Some("legacy-no-status".to_string()),
+        content: "task predating the status property".to_string(),
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(json!({})),
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+    note_store
+        .upsert_note(legacy_task)
+        .await
+        .expect("insert legacy task");
+
+    let pack = pack(runtime);
+    let result = pack
+        .dispatch("gtd.tasks", json!({"status": "inbox"}))
+        .await
+        .unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(
+        arr.iter()
+            .any(|t| t["title"].as_str() == Some("legacy-no-status")),
+        "gtd.tasks(status=\"inbox\") must surface a legacy task with no stored \
+         status property, since a missing status defaults to inbox everywhere \
+         else; result: {result:?}"
+    );
+}
+
+/// Same bug as above, for `priority="p2"`: a legacy task with no stored
+/// `priority` property renders as `p2` (`priority_rank`, `render_task`), so
+/// an explicit `priority="p2"` filter must also match it via `EqOrMissing`.
+#[tokio::test]
+async fn tasks_priority_p2_filter_matches_legacy_task_missing_priority_property() {
+    use khive_storage::note::Note;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let legacy_task = Note {
+        id: uuid::Uuid::new_v4(),
+        namespace: "local".to_string(),
+        kind: "task".to_string(),
+        status: "active".to_string(),
+        name: Some("legacy-no-priority".to_string()),
+        content: "task predating the priority property".to_string(),
+        salience: None,
+        decay_factor: None,
+        expires_at: None,
+        properties: Some(json!({"status": "next"})),
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+    note_store
+        .upsert_note(legacy_task)
+        .await
+        .expect("insert legacy task");
+
+    let pack = pack(runtime);
+    let result = pack
+        .dispatch("gtd.tasks", json!({"priority": "p2"}))
+        .await
+        .unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(
+        arr.iter()
+            .any(|t| t["title"].as_str() == Some("legacy-no-priority")),
+        "gtd.tasks(priority=\"p2\") must surface a legacy task with no stored \
+         priority property, since a missing priority renders as p2 everywhere \
+         else; result: {result:?}"
+    );
+}
+
+/// `gtd.tasks` pages must not overlap, and must stay complete, even when
+/// 500+ newer *non-matching* task notes exist alongside the matching set.
+///
+/// A weaker version of this test (matching rows only, no filler) would still
+/// pass under the pre-#772 implementation: with nothing to fill the old
+/// fixed-size unfiltered pre-fetch window, plain offset slicing over an
+/// all-matching set can look correct by coincidence. This version plants
+/// 600 newer `done` filler rows (excluded by the default status filter) so
+/// the old "pre-fetch `offset + limit + 500` unfiltered rows, then filter in
+/// Rust" behavior would have its window consumed by fillers and either drop
+/// matching rows or return short/overlapping pages. Real SQL-side
+/// `LIMIT`/`OFFSET` pagination over the pushed-down filter must still return
+/// full, disjoint pages containing only the expected matching records.
+#[tokio::test]
+async fn tasks_pagination_returns_disjoint_pages() {
+    use khive_storage::note::Note;
+    use std::collections::HashSet;
+
+    let runtime = rt();
+    let token = runtime
+        .authorize(khive_runtime::Namespace::local())
+        .unwrap();
+    let note_store = runtime.notes(&token).expect("note store");
+
+    // Matching set: 60 non-terminal tasks with older timestamps.
+    let base_ts = chrono::Utc::now().timestamp_micros() - 1_000_000_000_000;
+    let tasks: Vec<Note> = (0..60_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "active".to_string(),
+            name: Some(format!("task-{i}")),
+            content: format!("task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "next"})),
+            created_at: base_ts + i64::from(i),
+            updated_at: base_ts + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    let expected_ids: HashSet<uuid::Uuid> = tasks.iter().map(|t| t.id).collect();
     note_store.upsert_notes(tasks).await.expect("insert tasks");
+
+    // Non-matching filler: 600 `done` tasks, all newer than the matching set,
+    // excluded by `gtd.tasks`' default status filter (done/cancelled).
+    let now = chrono::Utc::now().timestamp_micros();
+    let fillers: Vec<Note> = (0..600_u32)
+        .map(|i| Note {
+            id: uuid::Uuid::new_v4(),
+            namespace: "local".to_string(),
+            kind: "task".to_string(),
+            status: "done".to_string(),
+            name: Some(format!("filler-{i}")),
+            content: format!("filler task {i}"),
+            salience: None,
+            decay_factor: None,
+            expires_at: None,
+            properties: Some(json!({"status": "done"})),
+            created_at: now + i64::from(i),
+            updated_at: now + i64::from(i),
+            deleted_at: None,
+        })
+        .collect();
+    note_store
+        .upsert_notes(fillers)
+        .await
+        .expect("insert fillers");
 
     let pack = pack(runtime);
     let page1 = pack
@@ -2469,6 +2657,10 @@ async fn tasks_pagination_returns_disjoint_pages() {
         .unwrap();
     let page2 = pack
         .dispatch("gtd.tasks", json!({"limit": 20, "offset": 20}))
+        .await
+        .unwrap();
+    let page3 = pack
+        .dispatch("gtd.tasks", json!({"limit": 20, "offset": 40}))
         .await
         .unwrap();
 
@@ -2484,12 +2676,35 @@ async fn tasks_pagination_returns_disjoint_pages() {
         .iter()
         .map(|t| t["full_id"].as_str().unwrap())
         .collect();
+    let ids3: HashSet<&str> = page3
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["full_id"].as_str().unwrap())
+        .collect();
 
-    assert_eq!(ids1.len(), 20);
-    assert_eq!(ids2.len(), 20);
+    assert_eq!(ids1.len(), 20, "page1 must be full; got {ids1:?}");
+    assert_eq!(ids2.len(), 20, "page2 must be full; got {ids2:?}");
+    assert_eq!(ids3.len(), 20, "page3 must be full; got {ids3:?}");
     assert!(
-        ids1.is_disjoint(&ids2),
+        ids1.is_disjoint(&ids2) && ids2.is_disjoint(&ids3) && ids1.is_disjoint(&ids3),
         "pages at different offsets must not overlap (issue #772 offset-0 \
-         refetch bug); page1={ids1:?} page2={ids2:?}"
+         refetch bug); page1={ids1:?} page2={ids2:?} page3={ids3:?}"
+    );
+
+    let all_returned: HashSet<uuid::Uuid> = ids1
+        .iter()
+        .chain(ids2.iter())
+        .chain(ids3.iter())
+        .map(|s| uuid::Uuid::parse_str(s).unwrap())
+        .collect();
+    assert_eq!(
+        all_returned.len(),
+        60,
+        "all 60 matching tasks must be covered across the 3 pages; got {all_returned:?}"
+    );
+    assert!(
+        all_returned.is_subset(&expected_ids),
+        "returned tasks must be exactly the matching set, no filler rows leaked in"
     );
 }

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -245,6 +245,19 @@ pub enum FilterOp {
     /// Equivalent to `json_type IS NULL OR json_type != value`.
     /// Used for unread filter: matches any `$.read` that is NOT the JSON boolean true.
     JsonTypeNeMissing,
+    /// Matches rows where `json_extract(properties, path)` equals any value in
+    /// the set. A row with a missing/NULL property does not match — use
+    /// `NotInOrMissing` with the complementary set when "absent" should count
+    /// as included. `PropertyFilter.value` is unused for this op; the set
+    /// lives in the variant itself.
+    In(Vec<SqlValue>),
+    /// Matches rows where the property is missing/NULL OR its value is not in
+    /// the set. Used for "exclude a small closed set of terminal values, but
+    /// treat a still-unset property as included" (e.g. GTD default task
+    /// listing excludes `done`/`cancelled` while a task with no `status` yet
+    /// still counts as `inbox`, i.e. included). `PropertyFilter.value` is
+    /// unused for this op; the set lives in the variant itself.
+    NotInOrMissing(Vec<SqlValue>),
 }
 
 /// A single `json_extract(properties, '$.field') op value` predicate.

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -323,6 +323,24 @@ pub trait NoteStore: Send + Sync + 'static {
         filter: &NoteFilter,
         page: PageRequest,
     ) -> StorageResult<Page<Note>>;
+    /// Fetch up to `max_rows + 1` notes matching `filter` in a single
+    /// deterministically-ordered SQL statement, with no separate `COUNT(*)`
+    /// and no pagination loop.
+    ///
+    /// A single statement observes one consistent snapshot for its entire
+    /// execution, so the result cannot be split across a concurrent insert
+    /// the way a `COUNT(*)` followed by independent `LIMIT`/`OFFSET` pages
+    /// can. Callers detect the over-bound case by checking whether the
+    /// returned `Vec` has more than `max_rows` items — that means at least
+    /// `max_rows + 1` rows matched and the caller must reject the query
+    /// rather than silently return a truncated, possibly priority-incomplete
+    /// set.
+    async fn query_notes_filtered_bounded(
+        &self,
+        namespace: &str,
+        filter: &NoteFilter,
+        max_rows: u32,
+    ) -> StorageResult<Vec<Note>>;
     /// Count notes in a namespace, optionally filtered by kind.
     async fn count_notes(&self, namespace: &str, kind: Option<&str>) -> StorageResult<u64>;
 

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -502,7 +502,14 @@ minimal. Operators who want GTD configure it explicitly.
 - The `task` note kind is not a compile-time enum value. Validators must consult
   `VerbRegistry::all_note_kinds()`, not hard-coded sets.
   Mitigated: ADR-017's pattern; new packs work the same way.
-- `next` / `tasks` scan up to 500 recent tasks and filter in-memory. Fine for
+- `next` / `tasks` push status/assignee/priority predicates into SQL via
+  `query_notes_filtered` (issue #772) and page through every matching row (up
+  to 500 per page, 40 pages) instead of pre-fetching a fixed unfiltered
+  recency window. This keeps the candidate set bounded by how many tasks
+  actually match, not by how much unrelated churn exists. If a query matches
+  more than the 20,000-row scan bound, the op returns an explicit error
+  asking the caller to narrow the filters (e.g. add `assignee`) rather than
+  silently truncating and risking a hidden older `p0` task. Fine for
   personal/agent workloads (typical inboxes < 50 actionable items); will need
   property indexes or a v2 SQL path at hundreds-of-thousands scale.
 - Same-status transitions are no-ops, which can surprise callers expecting a write.

--- a/docs/adr/ADR-019-gtd-pack.md
+++ b/docs/adr/ADR-019-gtd-pack.md
@@ -502,16 +502,27 @@ minimal. Operators who want GTD configure it explicitly.
 - The `task` note kind is not a compile-time enum value. Validators must consult
   `VerbRegistry::all_note_kinds()`, not hard-coded sets.
   Mitigated: ADR-017's pattern; new packs work the same way.
-- `next` / `tasks` push status/assignee/priority predicates into SQL via
-  `query_notes_filtered` (issue #772) and page through every matching row (up
-  to 500 per page, 40 pages) instead of pre-fetching a fixed unfiltered
-  recency window. This keeps the candidate set bounded by how many tasks
-  actually match, not by how much unrelated churn exists. If a query matches
-  more than the 20,000-row scan bound, the op returns an explicit error
-  asking the caller to narrow the filters (e.g. add `assignee`) rather than
-  silently truncating and risking a hidden older `p0` task. Fine for
-  personal/agent workloads (typical inboxes < 50 actionable items); will need
-  property indexes or a v2 SQL path at hundreds-of-thousands scale.
+- `next` and `tasks` both push status/assignee/priority predicates into SQL
+  (issue #772) instead of pre-fetching a fixed unfiltered recency window, but
+  they bound the candidate set differently:
+  - `next` must priority-sort the _entire_ actionable (`next`/`active`) set
+    before applying the caller's `limit`, so it fetches every matching row
+    in one deterministically-ordered snapshot query
+    (`query_notes_filtered_bounded`, capped at 20,001 rows) rather than a
+    page loop — a page loop's separate `COUNT(*)` and per-page reads have no
+    spanning transaction, so a concurrent insert between pages can duplicate
+    or skip a boundary row. If more than 20,000 rows match, `next` returns an
+    explicit `InvalidInput` error asking the caller to narrow the filters
+    (e.g. add `assignee`) rather than ever sorting and returning a possibly
+    priority-incomplete set.
+  - `tasks` has no such bound: it is a caller-paginated `list`-style verb —
+    the caller supplies `limit`/`offset` via `query_notes_filtered` and pages
+    through results themselves, the same as any other paginated query verb.
+    There is no server-side row cap or over-bound rejection for `tasks`.
+
+  Fine for personal/agent workloads (typical inboxes < 50 actionable items);
+  `next`'s full-scan-then-sort will need property indexes or a v2 SQL path
+  (e.g. `ORDER BY` pushed into SQL) at hundreds-of-thousands scale.
 - Same-status transitions are no-ops, which can surprise callers expecting a write.
   Mitigated: `transitioned: false` + `note` field in the response body.
 - `depends_on` redundancy (property + edge) requires both writes to succeed for


### PR DESCRIPTION
## Summary

Fixes #772. `gtd.next` and `gtd.tasks` pre-fetched a fixed unfiltered recency
window of task notes (500 rows, or `offset+limit+500`) and applied
status/assignee/priority filtering afterward in Rust. Any actionable or
matching task older than that window was silently invisible regardless of
priority; `gtd.tasks` additionally always fetched from offset 0, so deep
pages could never reach rows beyond the window.

- Added `FilterOp::In` and `FilterOp::NotInOrMissing` to `khive-storage`
  (compiled in `khive-db`'s `build_note_filter_where`), additive only -
  existing `khive-pack-comm`/`schedule`/`session` call sites are unaffected.
- `handle_next` now pushes `status IN (next, active)` + optional assignee
  into SQL and pages through every matching row, keeping the existing
  dependency-blocker enrichment and priority sort unchanged.
- `handle_tasks` now pushes status/assignee/priority into SQL and uses real
  `PageRequest{limit, offset}` pagination instead of Rust-side skip/take over
  an always-offset-0 fetch.

## Test plan

- [x] New regression tests confirmed to FAIL on pre-fix source, PASS after:
  - `next_finds_actionable_task_older_than_fixed_window`
  - `tasks_finds_done_task_older_than_fixed_window`
  - `tasks_pagination_returns_disjoint_pages` (non-regression correctness check)
- [x] `cargo test -p khive-storage -p khive-db -p khive-pack-gtd` - all pass
- [x] `cargo clippy -p khive-storage -p khive-db -p khive-pack-gtd --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all -- --check` - clean
- [x] `cargo check --workspace` - clean

Co-Authored-By: Claude <noreply@anthropic.com>