### PR TITLE
fix(runtime): guard link()/link_many() against concurrent hard-delete (#769)

### DIFF
--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -52,6 +52,25 @@ const EDGE_NATURAL_KEY_CONFLICT_SET: &str = "weight = excluded.weight, \
      metadata = excluded.metadata, \
      target_backend = excluded.target_backend";
 
+/// A `WHERE`-clause fragment asserting the id bound to `id_param` (an SQL
+/// placeholder like `?3`) resolves to a live edge endpoint — an
+/// undeleted entity or note, an event (append-only, no `deleted_at`), or an
+/// undeleted edge (the `annotates` relation's target may be any substrate,
+/// including another edge; ADR-002/ADR-055). Shared by
+/// [`edge_insert_guarded_by_endpoints_statement`] and
+/// [`edge_endpoints_exist`] (#769) so the two "does this endpoint still
+/// exist" probes — the guarded single-row insert and the guarded batch
+/// pre-check — can never drift on which substrates count as valid
+/// endpoints.
+fn endpoint_exists_clause(id_param: &str) -> String {
+    format!(
+        "EXISTS (SELECT 1 FROM entities WHERE id = {id_param} AND deleted_at IS NULL) \
+         OR EXISTS (SELECT 1 FROM notes WHERE id = {id_param} AND deleted_at IS NULL) \
+         OR EXISTS (SELECT 1 FROM events WHERE id = {id_param}) \
+         OR EXISTS (SELECT 1 FROM graph_edges WHERE id = {id_param} AND deleted_at IS NULL)"
+    )
+}
+
 /// The exact natural-key-upserting `INSERT ... ON CONFLICT` this store's
 /// `upsert_edge` issues. Canonicalizes symmetric-relation endpoints first,
 /// matching `upsert_edge`'s own call to `canonical_edge_endpoints`.
@@ -132,16 +151,15 @@ pub fn edge_insert_guarded_by_endpoints_statement(
     now: i64,
     metadata: Option<&str>,
 ) -> SqlStatement {
+    let src_exists = endpoint_exists_clause("?3");
+    let tgt_exists = endpoint_exists_clause("?4");
     SqlStatement {
         sql: format!(
             "INSERT INTO graph_edges \
               (namespace, id, source_id, target_id, relation, weight, \
                created_at, updated_at, metadata) \
               SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8 \
-              WHERE (EXISTS (SELECT 1 FROM entities WHERE id = ?3 AND deleted_at IS NULL) \
-                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?3 AND deleted_at IS NULL)) \
-                AND (EXISTS (SELECT 1 FROM entities WHERE id = ?4 AND deleted_at IS NULL) \
-                     OR EXISTS (SELECT 1 FROM notes WHERE id = ?4 AND deleted_at IS NULL)) \
+              WHERE ({src_exists}) AND ({tgt_exists}) \
               ON CONFLICT(namespace, source_id, target_id, relation) DO UPDATE SET \
                   {EDGE_NATURAL_KEY_CONFLICT_SET}"
         ),
@@ -892,13 +910,11 @@ fn edge_endpoints_exist(
     source_id: Uuid,
     target_id: Uuid,
 ) -> Result<bool, rusqlite::Error> {
+    let src_exists = endpoint_exists_clause("?1");
+    let tgt_exists = endpoint_exists_clause("?2");
+    let sql = format!("SELECT ({src_exists}) AND ({tgt_exists})");
     conn.query_row(
-        "SELECT \
-            (EXISTS (SELECT 1 FROM entities WHERE id = ?1 AND deleted_at IS NULL) \
-             OR EXISTS (SELECT 1 FROM notes WHERE id = ?1 AND deleted_at IS NULL)) \
-         AND \
-            (EXISTS (SELECT 1 FROM entities WHERE id = ?2 AND deleted_at IS NULL) \
-             OR EXISTS (SELECT 1 FROM notes WHERE id = ?2 AND deleted_at IS NULL))",
+        &sql,
         rusqlite::params![source_id.to_string(), target_id.to_string()],
         |row| row.get::<_, bool>(0),
     )

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -937,6 +937,31 @@ fn edge_endpoints_exist(
     )
 }
 
+/// DML-only guarded single-row insert shared by both the legacy (flag-off)
+/// and WriterTask-routed (flag-on) `upsert_edge_guarded` paths.
+///
+/// Runs the guarded `INSERT` and, if it was refused, the missing-endpoint
+/// probe on the SAME connection with no gap for another writer to intervene
+/// between them, PROVIDED the caller holds the connection under a single
+/// write-locked transaction (either the WriterTask's own `BEGIN IMMEDIATE`,
+/// or an explicit one the flag-off caller opens around this call — round-4
+/// codex Medium: the singleton fallback previously ran the insert and the
+/// probe as two separate autocommit statements).
+fn edge_insert_guarded(
+    conn: &rusqlite::Connection,
+    statement: &SqlStatement,
+    source_id: Uuid,
+    target_id: Uuid,
+) -> Result<GuardedWriteOutcome, rusqlite::Error> {
+    let mut stmt = conn.prepare(&statement.sql)?;
+    bind_params(&mut stmt, &statement.params)?;
+    if stmt.raw_execute()? > 0 {
+        return Ok(GuardedWriteOutcome::Written);
+    }
+    let missing = edge_endpoints_exist(conn, source_id, target_id)?;
+    Ok(GuardedWriteOutcome::Refused(missing))
+}
+
 /// DML-only guarded batch upsert loop shared by both the legacy (flag-off)
 /// and WriterTask-routed (flag-on) `upsert_edges_guarded` paths, mirroring
 /// [`batch_upsert_edges`]'s split.
@@ -1071,21 +1096,44 @@ impl GraphStore for SqlGraphStore {
             edge.created_at.timestamp_micros(),
             metadata_str.as_deref(),
         );
+
+        // Same WriterTask routing as `upsert_edges_guarded` — the
+        // WriterTask's run loop owns its own `BEGIN IMMEDIATE`, so the
+        // insert and the missing-endpoint probe below already run inside
+        // one write-locked transaction; a bare `BEGIN IMMEDIATE` here would
+        // violate SQLite's nested-transaction rule.
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    edge_insert_guarded(conn, &statement, source_id, target_id)
+                        .map_err(|e| map_err(e, "upsert_edge_guarded"))
+                })
+                .await;
+        }
+
+        // Flag-off (singleton) path: wrap the insert and the refused-probe
+        // in one explicit transaction so nothing can change an endpoint
+        // between them (round-4 codex Medium — this fallback previously
+        // ran the two as separate autocommit statements on the standalone
+        // writer connection).
         self.with_writer("upsert_edge_guarded", move |conn| {
-            let mut stmt = conn.prepare(&statement.sql)?;
-            bind_params(&mut stmt, &statement.params)?;
-            if stmt.raw_execute()? > 0 {
-                return Ok(GuardedWriteOutcome::Written);
+            conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle =
+                khive_storage::tx_registry::register(Some("graph_upsert_edge_guarded".to_string()));
+
+            let outcome = match edge_insert_guarded(conn, &statement, source_id, target_id) {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    return Err(e);
+                }
+            };
+
+            if let Err(e) = conn.execute_batch("COMMIT") {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
             }
-            // Refused: probe which endpoint(s) were missing in the SAME
-            // writer closure as the insert above — same connection, same
-            // exclusive writer-lock hold, so nothing can delete or recreate
-            // an endpoint between the refused insert and this probe. This is
-            // what makes the reported `MissingEndpoints` an in-transaction
-            // fact rather than a reconstruction from a later, separately
-            // scheduled async read (round-2 codex Medium 1).
-            let missing = edge_endpoints_exist(conn, source_id, target_id)?;
-            Ok(GuardedWriteOutcome::Refused(missing))
+            Ok(outcome)
         })
         .await
     }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -958,6 +958,15 @@ fn edge_insert_guarded(
     if stmt.raw_execute()? > 0 {
         return Ok(GuardedWriteOutcome::Written);
     }
+    // Test-only observation point for the exact insert-to-probe seam this
+    // function's doc comment describes: a no-op in every non-test build,
+    // and a no-op in test builds unless a test has installed a barrier for
+    // this precise (source_id, target_id) pair (see
+    // `tests::insert_probe_seam` in graph_tests.rs). Lets the round-4/-5
+    // atomicity regression test force a racer to run at this seam instead
+    // of guessing at it with sleeps.
+    #[cfg(test)]
+    tests::insert_probe_seam::hook((source_id, target_id));
     let missing = edge_endpoints_exist(conn, source_id, target_id)?;
     Ok(GuardedWriteOutcome::Refused(missing))
 }

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -879,6 +879,78 @@ fn batch_upsert_edges(
     })
 }
 
+/// Standalone existence probe for both endpoints of a would-be edge,
+/// matching exactly the `WHERE EXISTS(...)` shape
+/// [`edge_insert_guarded_by_endpoints_statement`] embeds in its own guarded
+/// `INSERT`. Used by [`batch_upsert_edges_guarded`] to pre-check an entire
+/// batch, inside one write-locked transaction, before issuing any `INSERT`
+/// (#769) — SQLite's `BEGIN IMMEDIATE` holds the write lock for the whole
+/// closure, so nothing can delete an endpoint between this check and the
+/// batch's inserts.
+fn edge_endpoints_exist(
+    conn: &rusqlite::Connection,
+    source_id: Uuid,
+    target_id: Uuid,
+) -> Result<bool, rusqlite::Error> {
+    conn.query_row(
+        "SELECT \
+            (EXISTS (SELECT 1 FROM entities WHERE id = ?1 AND deleted_at IS NULL) \
+             OR EXISTS (SELECT 1 FROM notes WHERE id = ?1 AND deleted_at IS NULL)) \
+         AND \
+            (EXISTS (SELECT 1 FROM entities WHERE id = ?2 AND deleted_at IS NULL) \
+             OR EXISTS (SELECT 1 FROM notes WHERE id = ?2 AND deleted_at IS NULL))",
+        rusqlite::params![source_id.to_string(), target_id.to_string()],
+        |row| row.get::<_, bool>(0),
+    )
+}
+
+/// DML-only guarded batch upsert loop shared by both the legacy (flag-off)
+/// and WriterTask-routed (flag-on) `upsert_edges_guarded` paths, mirroring
+/// [`batch_upsert_edges`]'s split.
+///
+/// Pre-checks every edge's endpoints with [`edge_endpoints_exist`] BEFORE
+/// issuing any `INSERT` — if any endpoint is missing, the function returns
+/// immediately with `affected: 0` and issues no writes at all, so the
+/// caller's enclosing transaction has nothing to roll back (#769). Only
+/// once every edge has been confirmed does it fall through to the plain
+/// [`edge_upsert_statement`] writes, identical to `batch_upsert_edges`.
+fn batch_upsert_edges_guarded(
+    conn: &rusqlite::Connection,
+    edges: &[Edge],
+    attempted: u64,
+) -> Result<BatchWriteSummary, rusqlite::Error> {
+    for edge in edges {
+        let (source_id, target_id) =
+            canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+        if !edge_endpoints_exist(conn, source_id, target_id)? {
+            return Ok(BatchWriteSummary {
+                attempted,
+                affected: 0,
+                failed: attempted,
+                first_error: format!(
+                    "edge endpoint no longer exists at write time: source {source_id} or target {target_id}"
+                ),
+            });
+        }
+    }
+
+    let mut affected = 0u64;
+    for edge in edges {
+        let statement = edge_upsert_statement(edge);
+        let mut stmt = conn.prepare(&statement.sql)?;
+        bind_params(&mut stmt, &statement.params)?;
+        stmt.raw_execute()?;
+        affected += 1;
+    }
+
+    Ok(BatchWriteSummary {
+        attempted,
+        affected,
+        failed: 0,
+        first_error: String::new(),
+    })
+}
+
 #[async_trait]
 impl GraphStore for SqlGraphStore {
     async fn upsert_edge(&self, edge: Edge) -> Result<(), StorageError> {
@@ -918,6 +990,72 @@ impl GraphStore for SqlGraphStore {
                 khive_storage::tx_registry::register(Some("graph_upsert_edges".to_string()));
 
             let summary = match batch_upsert_edges(conn, &edges, attempted) {
+                Ok(summary) => summary,
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    return Err(e);
+                }
+            };
+
+            if let Err(e) = conn.execute_batch("COMMIT") {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+            Ok(summary)
+        })
+        .await
+    }
+
+    async fn upsert_edge_guarded(&self, edge: Edge) -> Result<bool, StorageError> {
+        let (source_id, target_id) =
+            canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
+        let metadata_str = edge
+            .metadata
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        let statement = edge_insert_guarded_by_endpoints_statement(
+            &edge.namespace,
+            Uuid::from(edge.id),
+            source_id,
+            target_id,
+            edge.relation,
+            edge.weight,
+            edge.created_at.timestamp_micros(),
+            metadata_str.as_deref(),
+        );
+        self.with_writer("upsert_edge_guarded", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
+        })
+        .await
+    }
+
+    async fn upsert_edges_guarded(
+        &self,
+        edges: Vec<Edge>,
+    ) -> Result<BatchWriteSummary, StorageError> {
+        let attempted = edges.len() as u64;
+
+        // Same WriterTask routing as `upsert_edges` — the guard's pre-check
+        // runs inside the WriterTask's own `BEGIN IMMEDIATE`, so a missing
+        // endpoint is caught before any `INSERT` in this batch runs at all.
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| {
+                    batch_upsert_edges_guarded(conn, &edges, attempted)
+                        .map_err(|e| map_err(e, "upsert_edges_guarded"))
+                })
+                .await;
+        }
+
+        self.with_writer("upsert_edges_guarded", move |conn| {
+            conn.execute_batch("BEGIN IMMEDIATE")?;
+            let _tx_handle = khive_storage::tx_registry::register(Some(
+                "graph_upsert_edges_guarded".to_string(),
+            ));
+
+            let summary = match batch_upsert_edges_guarded(conn, &edges, attempted) {
                 Ok(summary) => summary,
                 Err(e) => {
                     let _ = conn.execute_batch("ROLLBACK");

--- a/crates/khive-db/src/stores/graph.rs
+++ b/crates/khive-db/src/stores/graph.rs
@@ -9,8 +9,9 @@ use uuid::Uuid;
 use khive_storage::error::StorageError;
 use khive_storage::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
-    EdgeSortField, GraphPath, NeighborHit, NeighborQuery, Page, PageRequest, PathNode,
-    SortDirection, SortOrder, SqlStatement, SqlValue, TraversalRequest,
+    EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome,
+    MissingEndpoints, NeighborHit, NeighborQuery, Page, PageRequest, PathNode, SortDirection,
+    SortOrder, SqlStatement, SqlValue, TraversalRequest,
 };
 use khive_storage::GraphStore;
 use khive_storage::LinkId;
@@ -904,19 +905,35 @@ fn batch_upsert_edges(
 /// batch, inside one write-locked transaction, before issuing any `INSERT`
 /// (#769) — SQLite's `BEGIN IMMEDIATE` holds the write lock for the whole
 /// closure, so nothing can delete an endpoint between this check and the
-/// batch's inserts.
+/// batch's inserts. Also used by [`SqlGraphStore::upsert_edge_guarded`] to
+/// name which endpoint(s) were missing after a refused single-row insert,
+/// in the SAME writer closure as the insert itself — this is what makes the
+/// resulting `MissingEndpoints` an in-transaction fact rather than a
+/// reconstruction from a later, separately-scheduled read (round-2 codex
+/// Medium 1).
+///
+/// Returns per-endpoint existence rather than a single AND'd bool so callers
+/// can report exactly which side was missing instead of a generic
+/// "source or target" message.
 fn edge_endpoints_exist(
     conn: &rusqlite::Connection,
     source_id: Uuid,
     target_id: Uuid,
-) -> Result<bool, rusqlite::Error> {
+) -> Result<MissingEndpoints, rusqlite::Error> {
     let src_exists = endpoint_exists_clause("?1");
     let tgt_exists = endpoint_exists_clause("?2");
-    let sql = format!("SELECT ({src_exists}) AND ({tgt_exists})");
+    let sql = format!("SELECT ({src_exists}), ({tgt_exists})");
     conn.query_row(
         &sql,
         rusqlite::params![source_id.to_string(), target_id.to_string()],
-        |row| row.get::<_, bool>(0),
+        |row| {
+            let src_exists: bool = row.get(0)?;
+            let tgt_exists: bool = row.get(1)?;
+            Ok(MissingEndpoints {
+                source: !src_exists,
+                target: !tgt_exists,
+            })
+        },
     )
 }
 
@@ -930,22 +947,34 @@ fn edge_endpoints_exist(
 /// caller's enclosing transaction has nothing to roll back (#769). Only
 /// once every edge has been confirmed does it fall through to the plain
 /// [`edge_upsert_statement`] writes, identical to `batch_upsert_edges`.
+///
+/// The refusing entry's index and its `MissingEndpoints` are captured by
+/// this same pre-check pass and returned as `GuardedBatchOutcome::refused`
+/// — the runtime layer no longer re-probes endpoints after the fact
+/// (round-2 codex Medium 1).
 fn batch_upsert_edges_guarded(
     conn: &rusqlite::Connection,
     edges: &[Edge],
     attempted: u64,
-) -> Result<BatchWriteSummary, rusqlite::Error> {
-    for edge in edges {
+) -> Result<GuardedBatchOutcome, rusqlite::Error> {
+    for (index, edge) in edges.iter().enumerate() {
         let (source_id, target_id) =
             canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
-        if !edge_endpoints_exist(conn, source_id, target_id)? {
-            return Ok(BatchWriteSummary {
-                attempted,
-                affected: 0,
-                failed: attempted,
-                first_error: format!(
-                    "edge endpoint no longer exists at write time: source {source_id} or target {target_id}"
-                ),
+        let missing = edge_endpoints_exist(conn, source_id, target_id)?;
+        if missing.any() {
+            return Ok(GuardedBatchOutcome {
+                summary: BatchWriteSummary {
+                    attempted,
+                    affected: 0,
+                    failed: attempted,
+                    first_error: format!(
+                        "batch entry {index}: edge endpoint no longer exists at write time: source {source_id} or target {target_id}"
+                    ),
+                },
+                refused: Some(GuardedBatchRefusal {
+                    entry_index: index,
+                    missing,
+                }),
             });
         }
     }
@@ -959,11 +988,14 @@ fn batch_upsert_edges_guarded(
         affected += 1;
     }
 
-    Ok(BatchWriteSummary {
-        attempted,
-        affected,
-        failed: 0,
-        first_error: String::new(),
+    Ok(GuardedBatchOutcome {
+        summary: BatchWriteSummary {
+            attempted,
+            affected,
+            failed: 0,
+            first_error: String::new(),
+        },
+        refused: None,
     })
 }
 
@@ -1022,7 +1054,7 @@ impl GraphStore for SqlGraphStore {
         .await
     }
 
-    async fn upsert_edge_guarded(&self, edge: Edge) -> Result<bool, StorageError> {
+    async fn upsert_edge_guarded(&self, edge: Edge) -> Result<GuardedWriteOutcome, StorageError> {
         let (source_id, target_id) =
             canonical_edge_endpoints(edge.relation, edge.source_id, edge.target_id);
         let metadata_str = edge
@@ -1042,7 +1074,18 @@ impl GraphStore for SqlGraphStore {
         self.with_writer("upsert_edge_guarded", move |conn| {
             let mut stmt = conn.prepare(&statement.sql)?;
             bind_params(&mut stmt, &statement.params)?;
-            Ok(stmt.raw_execute()? > 0)
+            if stmt.raw_execute()? > 0 {
+                return Ok(GuardedWriteOutcome::Written);
+            }
+            // Refused: probe which endpoint(s) were missing in the SAME
+            // writer closure as the insert above — same connection, same
+            // exclusive writer-lock hold, so nothing can delete or recreate
+            // an endpoint between the refused insert and this probe. This is
+            // what makes the reported `MissingEndpoints` an in-transaction
+            // fact rather than a reconstruction from a later, separately
+            // scheduled async read (round-2 codex Medium 1).
+            let missing = edge_endpoints_exist(conn, source_id, target_id)?;
+            Ok(GuardedWriteOutcome::Refused(missing))
         })
         .await
     }
@@ -1050,7 +1093,7 @@ impl GraphStore for SqlGraphStore {
     async fn upsert_edges_guarded(
         &self,
         edges: Vec<Edge>,
-    ) -> Result<BatchWriteSummary, StorageError> {
+    ) -> Result<GuardedBatchOutcome, StorageError> {
         let attempted = edges.len() as u64;
 
         // Same WriterTask routing as `upsert_edges` — the guard's pre-check

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -19,6 +19,57 @@ fn setup_memory_store() -> SqlGraphStore {
     SqlGraphStore::new_scoped(pool, false, "default")
 }
 
+/// Like [`setup_memory_store`] but also seeds minimal `entities`/`notes`
+/// tables (id + deleted_at only) so the `#769` guarded-write tests can
+/// exercise the real `WHERE EXISTS(entities...) OR EXISTS(notes...)` probes
+/// `edge_insert_guarded_by_endpoints_statement` and `edge_endpoints_exist`
+/// issue against those tables.
+fn setup_memory_store_with_substrates() -> (Arc<ConnectionPool>, SqlGraphStore) {
+    let config = PoolConfig {
+        path: None,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(config).unwrap());
+
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE TABLE entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
+                 CREATE TABLE notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
+                 CREATE TABLE events (id TEXT PRIMARY KEY);",
+            )
+            .unwrap();
+    }
+
+    let store = SqlGraphStore::new_scoped(Arc::clone(&pool), false, "default");
+    (pool, store)
+}
+
+fn insert_live_entity(pool: &ConnectionPool, id: Uuid) {
+    let writer = pool.writer().unwrap();
+    writer
+        .conn()
+        .execute(
+            "INSERT INTO entities (id, deleted_at) VALUES (?1, NULL)",
+            rusqlite::params![id.to_string()],
+        )
+        .unwrap();
+}
+
+fn hard_delete_entity(pool: &ConnectionPool, id: Uuid) {
+    let writer = pool.writer().unwrap();
+    writer
+        .conn()
+        .execute(
+            "DELETE FROM entities WHERE id = ?1",
+            rusqlite::params![id.to_string()],
+        )
+        .unwrap();
+}
+
 fn make_edge(source: Uuid, target: Uuid, relation: EdgeRelation, weight: f64) -> Edge {
     let now = Utc::now();
     Edge {
@@ -2575,4 +2626,148 @@ async fn upsert_edge_routes_through_writer_task_when_flag_enabled() {
         fetched.is_some(),
         "edge must be committed and readable after queuing behind the occupier"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #769 — commit-time endpoint guard for canonical `link`/`link_many`
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upsert_edge_guarded_succeeds_when_both_endpoints_exist() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let source = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    insert_live_entity(&pool, source);
+    insert_live_entity(&pool, target);
+
+    let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
+    let edge_id = edge.id;
+    let written = store.upsert_edge_guarded(edge).await.unwrap();
+
+    assert!(
+        written,
+        "guarded write must succeed when both endpoints exist"
+    );
+    assert!(store.get_edge(edge_id).await.unwrap().is_some());
+}
+
+/// Reproduces #769's failure scenario at the layer where the bug actually
+/// lived: an endpoint that existed when a caller validated it (mirrored here
+/// by `insert_live_entity`) is hard-deleted before the edge write reaches
+/// storage (mirrored by `hard_delete_entity`) — the exact window a
+/// concurrent MCP request could land in between `KhiveRuntime::link`'s async
+/// `validate_edge_relation_endpoints` read and its write. Before #769's fix,
+/// `SqlGraphStore::upsert_edge` had no such check and would have inserted
+/// this edge unconditionally, leaving it permanently dangling.
+#[tokio::test]
+async fn upsert_edge_guarded_returns_false_when_target_hard_deleted_before_write() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let source = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    insert_live_entity(&pool, source);
+    insert_live_entity(&pool, target);
+
+    // Simulates a concurrent hard-delete landing between prepare-time
+    // validation and this write.
+    hard_delete_entity(&pool, target);
+
+    let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
+    let edge_id = edge.id;
+    let written = store.upsert_edge_guarded(edge).await.unwrap();
+
+    assert!(
+        !written,
+        "guarded write must refuse an edge whose target vanished before commit"
+    );
+    assert!(
+        store.get_edge(edge_id).await.unwrap().is_none(),
+        "no dangling edge may be persisted"
+    );
+}
+
+#[tokio::test]
+async fn upsert_edge_guarded_returns_false_when_source_hard_deleted_before_write() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let source = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    insert_live_entity(&pool, source);
+    insert_live_entity(&pool, target);
+
+    hard_delete_entity(&pool, source);
+
+    let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
+    let edge_id = edge.id;
+    let written = store.upsert_edge_guarded(edge).await.unwrap();
+
+    assert!(
+        !written,
+        "guarded write must refuse an edge whose source vanished before commit"
+    );
+    assert!(store.get_edge(edge_id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn upsert_edges_guarded_succeeds_when_all_endpoints_exist() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    insert_live_entity(&pool, a);
+    insert_live_entity(&pool, b);
+    insert_live_entity(&pool, c);
+
+    let edges = vec![
+        make_edge(a, b, EdgeRelation::Extends, 1.0),
+        make_edge(b, c, EdgeRelation::Extends, 1.0),
+    ];
+    let ids: Vec<_> = edges.iter().map(|e| e.id).collect();
+
+    let summary = store.upsert_edges_guarded(edges).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(summary.affected, 2);
+
+    for id in ids {
+        assert!(store.get_edge(id).await.unwrap().is_some());
+    }
+}
+
+/// Batch form of #769's regression: one edge in the batch targets an
+/// endpoint that vanished before commit. The whole batch must be rejected —
+/// no edge from it, including the ones whose endpoints were still live,
+/// may be persisted (all-or-nothing, matching `create_many`'s existing
+/// validation-failure contract).
+#[tokio::test]
+async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
+    let (pool, store) = setup_memory_store_with_substrates();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    insert_live_entity(&pool, a);
+    insert_live_entity(&pool, b);
+    insert_live_entity(&pool, c);
+
+    // b's endpoint vanishes before the batch write — mirrors a concurrent
+    // hard-delete landing between per-spec validation and `link_many`'s
+    // single batched write.
+    hard_delete_entity(&pool, b);
+
+    let edges = vec![
+        make_edge(a, b, EdgeRelation::Extends, 1.0), // dangling endpoint
+        make_edge(a, c, EdgeRelation::Extends, 1.0), // both endpoints live
+    ];
+    let ids: Vec<_> = edges.iter().map(|e| e.id).collect();
+
+    let summary = store.upsert_edges_guarded(edges).await.unwrap();
+    assert_eq!(summary.attempted, 2);
+    assert_eq!(
+        summary.affected, 0,
+        "no edge from the batch may be persisted when any endpoint is missing"
+    );
+
+    for id in ids {
+        assert!(
+            store.get_edge(id).await.unwrap().is_none(),
+            "batch must be all-or-nothing: {id:?} must not be persisted"
+        );
+    }
 }

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2642,10 +2642,11 @@ async fn upsert_edge_guarded_succeeds_when_both_endpoints_exist() {
 
     let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
     let edge_id = edge.id;
-    let written = store.upsert_edge_guarded(edge).await.unwrap();
+    let outcome = store.upsert_edge_guarded(edge).await.unwrap();
 
-    assert!(
-        written,
+    assert_eq!(
+        outcome,
+        khive_storage::GuardedWriteOutcome::Written,
         "guarded write must succeed when both endpoints exist"
     );
     assert!(store.get_edge(edge_id).await.unwrap().is_some());
@@ -2673,12 +2674,17 @@ async fn upsert_edge_guarded_returns_false_when_target_hard_deleted_before_write
 
     let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
     let edge_id = edge.id;
-    let written = store.upsert_edge_guarded(edge).await.unwrap();
+    let outcome = store.upsert_edge_guarded(edge).await.unwrap();
 
-    assert!(
-        !written,
-        "guarded write must refuse an edge whose target vanished before commit"
-    );
+    match outcome {
+        khive_storage::GuardedWriteOutcome::Refused(missing) => {
+            assert!(missing.target, "target must be reported missing");
+            assert!(!missing.source, "source was never deleted");
+        }
+        other => panic!(
+            "guarded write must refuse an edge whose target vanished before commit, got {other:?}"
+        ),
+    }
     assert!(
         store.get_edge(edge_id).await.unwrap().is_none(),
         "no dangling edge may be persisted"
@@ -2697,12 +2703,17 @@ async fn upsert_edge_guarded_returns_false_when_source_hard_deleted_before_write
 
     let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
     let edge_id = edge.id;
-    let written = store.upsert_edge_guarded(edge).await.unwrap();
+    let outcome = store.upsert_edge_guarded(edge).await.unwrap();
 
-    assert!(
-        !written,
-        "guarded write must refuse an edge whose source vanished before commit"
-    );
+    match outcome {
+        khive_storage::GuardedWriteOutcome::Refused(missing) => {
+            assert!(missing.source, "source must be reported missing");
+            assert!(!missing.target, "target was never deleted");
+        }
+        other => panic!(
+            "guarded write must refuse an edge whose source vanished before commit, got {other:?}"
+        ),
+    }
     assert!(store.get_edge(edge_id).await.unwrap().is_none());
 }
 
@@ -2722,9 +2733,10 @@ async fn upsert_edges_guarded_succeeds_when_all_endpoints_exist() {
     ];
     let ids: Vec<_> = edges.iter().map(|e| e.id).collect();
 
-    let summary = store.upsert_edges_guarded(edges).await.unwrap();
-    assert_eq!(summary.attempted, 2);
-    assert_eq!(summary.affected, 2);
+    let outcome = store.upsert_edges_guarded(edges).await.unwrap();
+    assert_eq!(outcome.summary.attempted, 2);
+    assert_eq!(outcome.summary.affected, 2);
+    assert!(outcome.refused.is_none());
 
     for id in ids {
         assert!(store.get_edge(id).await.unwrap().is_some());
@@ -2757,12 +2769,24 @@ async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
     ];
     let ids: Vec<_> = edges.iter().map(|e| e.id).collect();
 
-    let summary = store.upsert_edges_guarded(edges).await.unwrap();
-    assert_eq!(summary.attempted, 2);
+    let outcome = store.upsert_edges_guarded(edges).await.unwrap();
+    assert_eq!(outcome.summary.attempted, 2);
     assert_eq!(
-        summary.affected, 0,
+        outcome.summary.affected, 0,
         "no edge from the batch may be persisted when any endpoint is missing"
     );
+    let refusal = outcome
+        .refused
+        .expect("refused batch entry must be reported");
+    assert_eq!(
+        refusal.entry_index, 0,
+        "the first entry (a, b) is the one with the missing endpoint"
+    );
+    assert!(
+        refusal.missing.target,
+        "b (the batch entry's target) must be reported missing"
+    );
+    assert!(!refusal.missing.source, "a was never deleted");
 
     for id in ids {
         assert!(

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -4,6 +4,82 @@ use khive_storage::types::{Direction, TraversalOptions};
 use serial_test::serial;
 use std::collections::HashSet;
 
+/// Deterministic barrier at the exact insert-to-probe seam
+/// [`edge_insert_guarded`] calls into (via `#[cfg(test)] hook(...)`) after a
+/// guarded `INSERT` is refused, before the missing-endpoint probe runs.
+///
+/// A pure wall-clock race at this seam is not observable: a refused,
+/// zero-row `INSERT` autocommits (and so releases SQLite's write lock)
+/// before returning, and the probe that follows it is a plain `SELECT`,
+/// which never blocks on a writer in WAL mode. Two back-to-back Rust calls
+/// on the same thread with no `.await` between them leave no real window
+/// for another OS thread to interleave — a racer would have to win a
+/// same-thread, no-I/O footrace against its own scheduling latency, which
+/// it structurally cannot do. This module replaces that footrace with a
+/// real rendezvous: the guarded call blocks at the seam until the test
+/// releases it, so the racer's write is forced to land in the seam's
+/// window on unwrapped (pre-fix) code, and forced to block behind the
+/// still-open `BEGIN IMMEDIATE` on wrapped (fixed) code.
+///
+/// Scoped by `(source_id, target_id)` rather than global so unrelated
+/// `upsert_edge_guarded` calls from other tests running concurrently in the
+/// same process are unaffected (`hook` is a no-op unless its key matches an
+/// installed barrier).
+pub(super) mod insert_probe_seam {
+    use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    struct Barrier {
+        key: (Uuid, Uuid),
+        reached_tx: SyncSender<()>,
+        proceed_rx: Receiver<()>,
+    }
+
+    static BARRIER: Mutex<Option<Barrier>> = Mutex::new(None);
+
+    /// Installs a barrier for the given `(source_id, target_id)` key.
+    /// Returns the `reached` receiver (fires once the guarded call has
+    /// executed its `INSERT` and is parked at the seam) and the `proceed`
+    /// sender the caller uses to release it.
+    pub(crate) fn install(key: (Uuid, Uuid)) -> (Receiver<()>, SyncSender<()>) {
+        let (reached_tx, reached_rx) = sync_channel(0);
+        let (proceed_tx, proceed_rx) = sync_channel(0);
+        *BARRIER.lock().unwrap() = Some(Barrier {
+            key,
+            reached_tx,
+            proceed_rx,
+        });
+        (reached_rx, proceed_tx)
+    }
+
+    /// Clears any still-installed barrier. Safe to call unconditionally
+    /// after a test finishes, whether or not `hook` ever consumed it.
+    pub(crate) fn uninstall() {
+        *BARRIER.lock().unwrap() = None;
+    }
+
+    /// Called from the production insert-then-probe seam. A no-op unless a
+    /// barrier for this exact key is currently installed. Single-use: takes
+    /// the barrier out of the static the moment it matches, so a second
+    /// call with the same key (there is none in this test) would fall
+    /// through as a no-op rather than re-blocking.
+    pub(crate) fn hook(key: (Uuid, Uuid)) {
+        let barrier = {
+            let mut guard = BARRIER.lock().unwrap();
+            match guard.as_ref() {
+                Some(barrier) if barrier.key == key => guard.take(),
+                _ => None,
+            }
+        };
+        let Some(barrier) = barrier else {
+            return;
+        };
+        let _ = barrier.reached_tx.send(());
+        let _ = barrier.proceed_rx.recv();
+    }
+}
+
 fn setup_memory_store() -> SqlGraphStore {
     let config = PoolConfig {
         path: None,
@@ -2796,7 +2872,7 @@ async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
     }
 }
 
-/// Round-4 codex Medium: on the flag-off, file-backed singleton fallback
+/// Round-4/-5 codex Medium: on the flag-off, file-backed singleton fallback
 /// (`SqlGraphStore::with_writer`'s `is_file_backed` branch, no `WriterTask`),
 /// `upsert_edge_guarded` must run its guarded `INSERT` and, when refused,
 /// the missing-endpoint probe inside ONE `BEGIN IMMEDIATE` transaction —
@@ -2804,17 +2880,31 @@ async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
 /// interleave between, recreating the endpoint after the insert was
 /// refused but before the probe explains why.
 ///
-/// Forces the interleaving deterministically rather than racing on timing:
-/// an independent connection to the SAME database file grabs the write
-/// lock BEFORE the guarded call is even spawned and holds it while the
-/// guarded call's own standalone-writer connection blocks on its own
-/// `BEGIN IMMEDIATE`. Releasing that lock leaves the guarded call as the
-/// only contender, so it is guaranteed to acquire it before a third,
-/// later-spawned connection ("the racer") gets a chance to recreate the
-/// missing target. With the fix, the guarded call's insert and its
-/// missing-endpoint probe therefore always observe the same, still-missing
-/// target inside one held write lock, regardless of what the racer does
-/// immediately afterward.
+/// Round-5 sabotage-verified that a purely timing-based version of this
+/// test (sleeps guessing when the guarded call was "probably" parked on
+/// the write lock, then "probably" holding it) still passed with the
+/// round-5 transaction wrapping removed: a refused, zero-row `INSERT`
+/// autocommits — and so releases the write lock — before the guarded
+/// call's Rust code even returns from it, and the probe that follows is a
+/// plain `SELECT`, which never blocks on a writer in WAL mode. The two
+/// statements run back to back on the same thread with no `.await`
+/// between them, so there is no real scheduling gap for a racer on
+/// another OS thread to win; a sleep-based racer is really racing its own
+/// wake-up latency against a same-thread, no-I/O continuation, and loses
+/// every time.
+///
+/// So this version does not race at all. [`insert_probe_seam`] has
+/// production code itself (`edge_insert_guarded`, `#[cfg(test)]`-only)
+/// park the guarded call at the exact seam between its `INSERT` and its
+/// probe, keyed on this test's own `(source, target)` pair so unrelated
+/// concurrent tests are unaffected. The racer's write is then forced to
+/// attempt landing at that exact seam:
+///   - unwrapped (pre-fix) code holds no lock at the seam, so the racer's
+///     write always lands before the probe resumes — reproducing #769's
+///     residual bug (the probe wrongly reports the target as not missing).
+///   - wrapped (fixed) code still holds its `BEGIN IMMEDIATE` at the seam,
+///     so the racer blocks behind it and cannot land until after the
+///     probe (and the guarded call's `COMMIT`) has already run.
 #[tokio::test]
 async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleton_path() {
     let dir = tempfile::tempdir().unwrap();
@@ -2859,53 +2949,72 @@ async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleto
     let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
     let edge_id = edge.id;
 
-    // Grab the file's write lock from an independent connection before the
-    // guarded call is spawned, so its own `open_standalone_writer`
-    // connection is guaranteed to block on `BEGIN IMMEDIATE` rather than run.
-    let occupier = rusqlite::Connection::open(&path).unwrap();
-    occupier
-        .busy_timeout(std::time::Duration::from_secs(30))
-        .unwrap();
-    occupier.execute_batch("BEGIN IMMEDIATE").unwrap();
+    // Install the seam barrier before spawning the guarded call, keyed on
+    // the exact (source, target) pair `edge_insert_guarded` canonicalizes
+    // to and passes into `insert_probe_seam::hook` (Extends is not a
+    // symmetric relation, so canonicalization is a no-op here).
+    let (reached_rx, proceed_tx) = insert_probe_seam::install((source, target));
 
     let guarded_task = {
         let store = Arc::clone(&store);
         tokio::spawn(async move { store.upsert_edge_guarded(edge).await })
     };
 
-    // Give the guarded call's blocking task time to actually issue its own
-    // `BEGIN IMMEDIATE` and start waiting on the lock we hold.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Deterministic rendezvous: blocks until the guarded call has actually
+    // executed its refused INSERT and is parked at the seam. No sleep, no
+    // guess — a real signal sent from production code at that exact point.
+    tokio::task::spawn_blocking(move || reached_rx.recv())
+        .await
+        .expect("waiting for the seam signal must not panic")
+        .expect("guarded call must reach the insert-to-probe seam");
 
-    // Release the lock. The guarded call, already parked in SQLite's busy
-    // retry loop, is the only contender and will acquire it next.
-    occupier.execute_batch("COMMIT").unwrap();
-
-    // Give the guarded call a moment to actually re-acquire the now-free
-    // lock before the racer even opens a connection, so the racer is the
-    // one left waiting rather than the other way around.
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-
-    // Only now attempt to recreate the missing target — from a THIRD
-    // connection racing the guarded call for the lock the guarded call
-    // should already be holding.
+    // Now attempt to recreate the missing target from an independent
+    // connection while the guarded call is parked exactly at the seam. On
+    // unwrapped (pre-fix) code nothing holds the write lock here, so this
+    // succeeds immediately; on wrapped (fixed) code the guarded call's own
+    // BEGIN IMMEDIATE is still open, so this blocks until it commits.
     let racer_path = path.clone();
+    let (racer_started_tx, racer_started_rx) = std::sync::mpsc::sync_channel::<()>(0);
     let racer = tokio::task::spawn_blocking(move || {
         let conn = rusqlite::Connection::open(&racer_path).unwrap();
-        conn.busy_timeout(std::time::Duration::from_secs(30))
+        conn.busy_timeout(std::time::Duration::from_secs(2))
             .unwrap();
+        let _ = racer_started_tx.send(());
         conn.execute(
             "INSERT INTO entities (id, deleted_at) VALUES (?1, NULL)",
             rusqlite::params![target.to_string()],
         )
-        .unwrap();
     });
+
+    // Deterministic signal that the racer has actually dispatched its
+    // INSERT to SQLite, then a bounded settle window for it to either
+    // complete (unwrapped code: no lock in the way) or genuinely start
+    // blocking on the guarded call's still-open transaction (fixed code).
+    // This window never has to race the guarded call itself — the guarded
+    // call cannot move past the seam until `proceed_tx` fires below.
+    tokio::task::spawn_blocking(move || racer_started_rx.recv())
+        .await
+        .expect("waiting for the racer-started signal must not panic")
+        .expect("racer must signal before attempting its INSERT");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Release the guarded call. On unwrapped code the racer's write has
+    // already landed by now, so the probe below will (wrongly) see the
+    // target as present. On wrapped code the racer is still blocked behind
+    // the open transaction, so the probe still sees it missing.
+    proceed_tx
+        .send(())
+        .expect("guarded call must still be waiting at the seam");
 
     let outcome = guarded_task
         .await
         .expect("guarded task must not panic")
         .unwrap();
-    racer.await.expect("racer task must not panic");
+    racer
+        .await
+        .expect("racer task must not panic")
+        .expect("racer's INSERT must eventually succeed");
+    insert_probe_seam::uninstall();
 
     match outcome {
         khive_storage::GuardedWriteOutcome::Refused(missing) => {

--- a/crates/khive-db/src/stores/graph_tests.rs
+++ b/crates/khive-db/src/stores/graph_tests.rs
@@ -2795,3 +2795,135 @@ async fn upsert_edges_guarded_writes_nothing_when_one_endpoint_vanishes() {
         );
     }
 }
+
+/// Round-4 codex Medium: on the flag-off, file-backed singleton fallback
+/// (`SqlGraphStore::with_writer`'s `is_file_backed` branch, no `WriterTask`),
+/// `upsert_edge_guarded` must run its guarded `INSERT` and, when refused,
+/// the missing-endpoint probe inside ONE `BEGIN IMMEDIATE` transaction —
+/// not as two separate autocommit statements a concurrent writer could
+/// interleave between, recreating the endpoint after the insert was
+/// refused but before the probe explains why.
+///
+/// Forces the interleaving deterministically rather than racing on timing:
+/// an independent connection to the SAME database file grabs the write
+/// lock BEFORE the guarded call is even spawned and holds it while the
+/// guarded call's own standalone-writer connection blocks on its own
+/// `BEGIN IMMEDIATE`. Releasing that lock leaves the guarded call as the
+/// only contender, so it is guaranteed to acquire it before a third,
+/// later-spawned connection ("the racer") gets a chance to recreate the
+/// missing target. With the fix, the guarded call's insert and its
+/// missing-endpoint probe therefore always observe the same, still-missing
+/// target inside one held write lock, regardless of what the racer does
+/// immediately afterward.
+#[tokio::test]
+async fn upsert_edge_guarded_probe_is_atomic_with_insert_on_file_backed_singleton_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("guarded_atomic_singleton.db");
+
+    let pool_cfg = PoolConfig {
+        path: Some(path.clone()),
+        write_queue_enabled: false,
+        ..PoolConfig::default()
+    };
+    let pool = Arc::new(ConnectionPool::new(pool_cfg).unwrap());
+    {
+        let writer = pool.writer().unwrap();
+        writer.conn().execute_batch(GRAPH_DDL).unwrap();
+        writer
+            .conn()
+            .execute_batch(
+                "CREATE TABLE entities (id TEXT PRIMARY KEY, deleted_at INTEGER);
+                 CREATE TABLE notes (id TEXT PRIMARY KEY, deleted_at INTEGER);
+                 CREATE TABLE events (id TEXT PRIMARY KEY);",
+            )
+            .unwrap();
+    }
+    assert!(
+        pool.writer_task_handle().unwrap().is_none(),
+        "this test targets the no-WriterTask singleton fallback"
+    );
+
+    let store = Arc::new(SqlGraphStore::new_scoped(
+        Arc::clone(&pool),
+        true,
+        "default",
+    ));
+
+    let source = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    insert_live_entity(&pool, source);
+    // target is intentionally never created — it is genuinely missing
+    // for the entire test, so any observed "exists" state can only come
+    // from the racer's later insert.
+
+    let edge = make_edge(source, target, EdgeRelation::Extends, 1.0);
+    let edge_id = edge.id;
+
+    // Grab the file's write lock from an independent connection before the
+    // guarded call is spawned, so its own `open_standalone_writer`
+    // connection is guaranteed to block on `BEGIN IMMEDIATE` rather than run.
+    let occupier = rusqlite::Connection::open(&path).unwrap();
+    occupier
+        .busy_timeout(std::time::Duration::from_secs(30))
+        .unwrap();
+    occupier.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+    let guarded_task = {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move { store.upsert_edge_guarded(edge).await })
+    };
+
+    // Give the guarded call's blocking task time to actually issue its own
+    // `BEGIN IMMEDIATE` and start waiting on the lock we hold.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Release the lock. The guarded call, already parked in SQLite's busy
+    // retry loop, is the only contender and will acquire it next.
+    occupier.execute_batch("COMMIT").unwrap();
+
+    // Give the guarded call a moment to actually re-acquire the now-free
+    // lock before the racer even opens a connection, so the racer is the
+    // one left waiting rather than the other way around.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    // Only now attempt to recreate the missing target — from a THIRD
+    // connection racing the guarded call for the lock the guarded call
+    // should already be holding.
+    let racer_path = path.clone();
+    let racer = tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&racer_path).unwrap();
+        conn.busy_timeout(std::time::Duration::from_secs(30))
+            .unwrap();
+        conn.execute(
+            "INSERT INTO entities (id, deleted_at) VALUES (?1, NULL)",
+            rusqlite::params![target.to_string()],
+        )
+        .unwrap();
+    });
+
+    let outcome = guarded_task
+        .await
+        .expect("guarded task must not panic")
+        .unwrap();
+    racer.await.expect("racer task must not panic");
+
+    match outcome {
+        khive_storage::GuardedWriteOutcome::Refused(missing) => {
+            assert!(
+                missing.target,
+                "target was missing for the entire guarded write and must be \
+                 reported so, even though the racer recreated it immediately \
+                 afterward"
+            );
+            assert!(!missing.source, "source was always live");
+        }
+        other => panic!(
+            "guarded write must refuse an edge whose target never existed \
+             during the write, got {other:?}"
+        ),
+    }
+    assert!(
+        store.get_edge(edge_id).await.unwrap().is_none(),
+        "no dangling edge may be persisted"
+    );
+}

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -3,9 +3,53 @@
 use std::fmt;
 
 use thiserror::Error;
+use uuid::Uuid;
 
 /// Convenience alias for `Result<T, RuntimeError>`.
 pub type RuntimeResult<T> = Result<T, RuntimeError>;
+
+/// A guarded edge write (`link`/`link_many`) was refused because one or both
+/// endpoints no longer existed at write time (#769). Names the exact
+/// endpoint(s) missing instead of a generic "source or target" message, and,
+/// for a batch write, which entry in the batch failed first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuardedWriteFailure {
+    /// Index of the failing entry within a `link_many` batch. `None` for the
+    /// singleton `link` path, which has no batch to index into.
+    pub entry_index: Option<usize>,
+    /// The source endpoint id, present only when it is the (or one of the)
+    /// missing endpoint(s).
+    pub missing_source: Option<Uuid>,
+    /// The target endpoint id, present only when it is the (or one of the)
+    /// missing endpoint(s).
+    pub missing_target: Option<Uuid>,
+}
+
+impl fmt::Display for GuardedWriteFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut missing = Vec::new();
+        if let Some(source) = self.missing_source {
+            missing.push(format!("source {source}"));
+        }
+        if let Some(target) = self.missing_target {
+            missing.push(format!("target {target}"));
+        }
+        let missing = if missing.is_empty() {
+            "endpoint(s)".to_string()
+        } else {
+            missing.join(" and ")
+        };
+        match self.entry_index {
+            Some(index) => write!(
+                f,
+                "batch entry {index}: {missing} no longer exist at write time"
+            ),
+            None => write!(f, "{missing} no longer exist at write time"),
+        }
+    }
+}
+
+impl std::error::Error for GuardedWriteFailure {}
 
 /// A single missing pack dependency.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +142,9 @@ pub enum RuntimeError {
 
     #[error("internal: {0}")]
     Internal(String),
+
+    #[error("guarded edge write refused: {0}")]
+    GuardedWriteFailed(GuardedWriteFailure),
 
     #[error("missing pack dependency: {0}")]
     MissingPackDependency(MissingPackDependency),

--- a/crates/khive-runtime/src/lib.rs
+++ b/crates/khive-runtime/src/lib.rs
@@ -53,7 +53,7 @@ pub use embedder_registry::{EmbedderProvider, EmbedderRegistry, LatticeEmbedderP
 pub use engine_config::{
     config_from_env, BackendConfig, BackendKind, ConfigError, EngineConfig, KhiveConfig, PackConfig,
 };
-pub use error::{fts_text_leg_or_err, RuntimeError, RuntimeResult};
+pub use error::{fts_text_leg_or_err, GuardedWriteFailure, RuntimeError, RuntimeResult};
 pub use fusion::FusionStrategy;
 pub use graph_traversal::PathNode;
 pub use khive_db::{

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -6988,6 +6988,154 @@ mod tests {
         assert_eq!(edge.relation, EdgeRelation::Extends);
     }
 
+    // ---- #769: commit-time endpoint guard vs concurrent hard-delete ----
+
+    /// Deterministic form of the regression, exercised directly at the
+    /// write step `link` performs after prepare-time validation: build the
+    /// exact `Edge` `link` would build, delete the target the way a
+    /// concurrent racer would, and confirm the guarded write refuses it.
+    #[tokio::test]
+    async fn link_write_time_guard_blocks_dangling_edge_after_target_vanishes() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        rt.validate_edge_relation_endpoints(&tok, a.id, x.id, EdgeRelation::Extends)
+            .await
+            .expect("prepare-time validation must pass while X is live");
+
+        assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
+
+        let now = chrono::Utc::now();
+        let edge = Edge {
+            id: LinkId::from(Uuid::new_v4()),
+            namespace: tok.namespace().as_str().to_string(),
+            source_id: a.id,
+            target_id: x.id,
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            metadata: None,
+            target_backend: None,
+        };
+        let written = rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edge_guarded(edge)
+            .await
+            .unwrap();
+        assert!(
+            !written,
+            "guarded write must refuse an edge whose target vanished before commit"
+        );
+
+        let edges = rt
+            .list_edges(
+                &tok,
+                crate::curation::EdgeListFilter {
+                    source_id: Some(a.id),
+                    target_id: Some(x.id),
+                    relations: vec![EdgeRelation::Extends],
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .await
+            .unwrap();
+        assert!(
+            edges.is_empty(),
+            "no dangling edge may be persisted after the guarded write refused it"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_many_writes_nothing_when_one_target_vanishes_before_write() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        let specs = vec![
+            LinkSpec {
+                namespace: None,
+                source_id: a.id,
+                target_id: x.id,
+                relation: EdgeRelation::Extends,
+                weight: 1.0,
+                metadata: None,
+            },
+            LinkSpec {
+                namespace: None,
+                source_id: a.id,
+                target_id: b.id,
+                relation: EdgeRelation::Extends,
+                weight: 1.0,
+                metadata: None,
+            },
+        ];
+
+        // Both specs validate fine at build_edge time (X and B both live).
+        let mut edges = Vec::with_capacity(specs.len());
+        for spec in &specs {
+            edges.push(rt.build_edge(&tok, spec).await.unwrap());
+        }
+
+        // X vanishes before the batched write — mirrors a concurrent
+        // hard-delete landing between per-spec validation and link_many's
+        // single guarded batch write.
+        assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
+
+        let summary = rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edges_guarded(edges)
+            .await
+            .unwrap();
+        assert_eq!(
+            summary.affected, 0,
+            "no edge from the batch may be persisted when any endpoint vanished"
+        );
+
+        let edges = rt
+            .list_edges(
+                &tok,
+                crate::curation::EdgeListFilter {
+                    source_id: Some(a.id),
+                    relations: vec![EdgeRelation::Extends],
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .await
+            .unwrap();
+        assert!(
+            edges.is_empty(),
+            "link_many's guarded batch must be all-or-nothing: the live A-B edge \
+             must not have been persisted alongside the doomed A-X edge"
+        );
+    }
+
     #[tokio::test]
     async fn create_note_annotates_phantom_returns_not_found() {
         let rt = rt();

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -24,11 +24,16 @@ use khive_storage::types::{
 use khive_storage::{Edge, EdgeRelation, Entity, EntityFilter, Event, EventFilter};
 use khive_types::{EdgeEndpointRule, EndpointKind, EventKind, SubstrateKind};
 
+use khive_db::stores::entity::entity_hard_delete_statement;
+use khive_db::stores::graph::{edge_hard_delete_statement, purge_incident_edges_statement};
+use khive_db::stores::note::note_hard_delete_statement;
 use khive_db::SqliteError;
 use rusqlite::OptionalExtension;
 
+use crate::atomic_plan::{AffectedRowGuard, DeletePlan, PlanStatement, PostCommitEffect};
+use crate::atomic_runner::{run_atomic_unit, AtomicOpFailure, AtomicOpPlan, AtomicRunOutcome};
 use crate::curation::{entity_fts_document, note_fts_document};
-use crate::error::{RuntimeError, RuntimeResult};
+use crate::error::{GuardedWriteFailure, RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
 // Test-only failure injection for `create_note_inner`.
@@ -1720,9 +1725,22 @@ impl KhiveRuntime {
         // read above — a concurrent hard-delete landing between that read and
         // this write can no longer create a durably dangling edge.
         if !self.graph(token)?.upsert_edge_guarded(edge).await? {
-            return Err(RuntimeError::NotFound(format!(
-                "link source {source_id} or target {target_id} no longer exists at write time"
-            )));
+            // Re-probe each endpoint individually (read-only, best-effort) so
+            // the error names exactly which one vanished instead of a generic
+            // "source or target" message (codex REJECT Medium 3).
+            let missing_source = self
+                .resolve_edge_endpoint(token, source_id)
+                .await?
+                .is_none();
+            let missing_target = self
+                .resolve_edge_endpoint(token, target_id)
+                .await?
+                .is_none();
+            return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
+                entry_index: None,
+                missing_source: missing_source.then_some(source_id),
+                missing_target: missing_target.then_some(target_id),
+            }));
         }
 
         // H1 fix: read back the persisted row by natural key so the returned
@@ -3497,6 +3515,68 @@ impl KhiveRuntime {
         Ok(None)
     }
 
+    /// Hard-delete a single graph node (entity, note, or edge-as-node row)
+    /// AND purge its incident edges in ONE write transaction.
+    ///
+    /// #768/#769: the endpoint row delete and the incident-edge cascade used
+    /// to run as two independently-committing storage calls. A concurrent
+    /// guarded write (`upsert_edge_guarded`/`upsert_edges_guarded`) landing
+    /// between them could see the endpoint still live, insert a fresh edge
+    /// against it, and then survive the cascade that already ran — a
+    /// durably dangling edge with no second purge. Routing both statements
+    /// through one [`run_atomic_unit`] call closes the window: since every
+    /// write (this one and the guarded insert) funnels through the same
+    /// single-writer queue, a concurrent guarded write either fully commits
+    /// before this unit starts (and its edge is then swept by the purge
+    /// below, in the same transaction as the row delete) or fully commits
+    /// after this unit has already committed (and its own endpoint-existence
+    /// check then sees the endpoint gone and refuses the write) — there is
+    /// no state in which it can observe the endpoint alive with edges
+    /// already purged.
+    ///
+    /// `row_statement` is the exact hard-delete `DELETE` for the target row
+    /// (entity, note, or edge). Returns `Ok(true)` if the row was deleted,
+    /// `Ok(false)` if it no longer existed (lost a race with a concurrent
+    /// delete of the same row) — never an error for that case, matching the
+    /// non-atomic bool-returning shape callers had before this fix.
+    async fn atomic_hard_delete_with_edge_purge(
+        &self,
+        row_statement: SqlStatement,
+        node_id: Uuid,
+    ) -> RuntimeResult<bool> {
+        let plan = AtomicOpPlan::Delete(DeletePlan {
+            target_id: node_id,
+            statements: vec![
+                PlanStatement {
+                    statement: row_statement,
+                    guard: Some(AffectedRowGuard::exactly(1)),
+                },
+                PlanStatement {
+                    statement: purge_incident_edges_statement(node_id),
+                    guard: None,
+                },
+            ],
+            post_commit: PostCommitEffect::None,
+        });
+        match run_atomic_unit(self.sql().as_ref(), vec![plan]).await {
+            Ok(AtomicRunOutcome::Committed { .. }) => Ok(true),
+            Ok(AtomicRunOutcome::RolledBack {
+                failure: AtomicOpFailure::GuardFailed { .. },
+                ..
+            }) => Ok(false),
+            Ok(AtomicRunOutcome::RolledBack {
+                failure: AtomicOpFailure::SqlError { message, .. },
+                ..
+            }) => Err(RuntimeError::Internal(format!(
+                "hard delete + edge purge for {node_id} failed: {message}"
+            ))),
+            Err(e) => Err(RuntimeError::Internal(format!(
+                "hard delete + edge purge for {node_id}: atomic unit seam failure: {}",
+                e.0
+            ))),
+        }
+    }
+
     /// Delete a note by ID, enforcing namespace isolation.
     ///
     /// On hard delete, cascades to remove all incident edges (both inbound and
@@ -3541,12 +3621,14 @@ impl KhiveRuntime {
         );
         let record_ns = note.namespace.clone();
 
-        // On hard delete, cascade-remove all incident edges (including soft-deleted) and clean up
-        // indexes. Uses purge_incident_edges so that already-soft-deleted edges are also removed,
-        // preventing dangling graph_edges rows (ADR-002 no-dangling-references).
-        if hard {
-            let graph = self.graph(&record_tok)?;
-            graph.purge_incident_edges(id).await?;
+        // On hard delete, the row delete and the incident-edge cascade (including
+        // already-soft-deleted edges) run as ONE write transaction (#768/#769) —
+        // see `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
+        // commit; it is best-effort and idempotent, unlike the row/edge pair.
+        let deleted = if hard {
+            let deleted = self
+                .atomic_hard_delete_with_edge_purge(note_hard_delete_statement(id), id)
+                .await?;
             self.text_for_notes(&record_tok)?
                 .delete_document(&record_ns, id)
                 .await?;
@@ -3558,19 +3640,21 @@ impl KhiveRuntime {
                     .delete(id)
                     .await?;
             }
-        }
-
-        let deleted = note_store.delete_note(id, mode).await?;
-        if !hard && deleted {
-            self.text_for_notes(&record_tok)?
-                .delete_document(&record_ns, id)
-                .await?;
-            for model_name in self.registered_embedding_model_names() {
-                self.vectors_for_model(&record_tok, &model_name)?
-                    .delete(id)
+            deleted
+        } else {
+            let deleted = note_store.delete_note(id, mode).await?;
+            if deleted {
+                self.text_for_notes(&record_tok)?
+                    .delete_document(&record_ns, id)
                     .await?;
+                for model_name in self.registered_embedding_model_names() {
+                    self.vectors_for_model(&record_tok, &model_name)?
+                        .delete(id)
+                        .await?;
+                }
             }
-        }
+            deleted
+        };
         if deleted {
             let event_store = self.events(token)?;
             let event = khive_storage::event::Event::new(
@@ -3807,19 +3891,23 @@ impl KhiveRuntime {
                 .map_err(|e| RuntimeError::Internal(format!("entity namespace invalid: {e}")))?,
         );
 
-        // On hard delete, cascade-remove all incident edges (including soft-deleted) to prevent
-        // dangling refs. Uses purge_incident_edges so that already-soft-deleted edges are also
-        // removed (ADR-002 no-dangling-references).
-        if hard {
-            let graph = self.graph(&record_tok)?;
-            graph.purge_incident_edges(id).await?;
+        // On hard delete, the row delete and the incident-edge cascade (including
+        // already-soft-deleted edges) run as ONE write transaction (#768/#769) —
+        // see `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
+        // commit; it is best-effort and idempotent, unlike the row/edge pair.
+        let deleted = if hard {
+            let deleted = self
+                .atomic_hard_delete_with_edge_purge(entity_hard_delete_statement(id), id)
+                .await?;
             self.remove_from_indexes(&record_tok, id).await?;
-        }
-
-        let deleted = self.entities(token)?.delete_entity(id, mode).await?;
-        if !hard && deleted {
-            self.remove_from_indexes(&record_tok, id).await?;
-        }
+            deleted
+        } else {
+            let deleted = self.entities(token)?.delete_entity(id, mode).await?;
+            if deleted {
+                self.remove_from_indexes(&record_tok, id).await?;
+            }
+            deleted
+        };
         if deleted {
             let event_store = self.events(token)?;
             let ns = entity.namespace.clone();
@@ -4439,14 +4527,17 @@ impl KhiveRuntime {
         let graph = self.graph(&record_tok)?;
 
         // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
-        // already-soft-deleted ones — to prevent dangling graph_edges rows (ADR-002).
+        // already-soft-deleted ones — to prevent dangling graph_edges rows (ADR-002). The row
+        // delete and the cascade purge run as ONE write transaction (#768/#769) — see
+        // `atomic_hard_delete_with_edge_purge`.
         // On soft delete the cascade is skipped (data-vs-view principle: soft-deleting the base
         // edge does not cascade to annotation edges; only a hard purge cleans up incident rows).
-        if hard {
-            graph.purge_incident_edges(edge_id).await?;
-        }
-
-        let deleted = graph.delete_edge(LinkId::from(edge_id), mode).await?;
+        let deleted = if hard {
+            self.atomic_hard_delete_with_edge_purge(edge_hard_delete_statement(edge_id), edge_id)
+                .await?
+        } else {
+            graph.delete_edge(LinkId::from(edge_id), mode).await?
+        };
         if deleted {
             // Audit event: use the record's namespace (record_ns), not the caller's namespace.
             let event_store = self.events(&record_tok)?;
@@ -4576,9 +4667,35 @@ impl KhiveRuntime {
             .upsert_edges_guarded(edges.clone())
             .await?;
         if summary.affected != edges.len() as u64 {
-            return Err(RuntimeError::NotFound(
-                "link_many: one or more edge endpoints no longer exist at write time".to_string(),
-            ));
+            // Re-probe each entry in batch order (read-only, best-effort) to find
+            // the first one with a missing endpoint and report its index — the
+            // storage-layer summary only carries a free-text `first_error`, not
+            // a structured endpoint/index pair (codex REJECT Medium 3).
+            for (index, edge) in edges.iter().enumerate() {
+                let missing_source = self
+                    .resolve_edge_endpoint(token, edge.source_id)
+                    .await?
+                    .is_none();
+                let missing_target = self
+                    .resolve_edge_endpoint(token, edge.target_id)
+                    .await?
+                    .is_none();
+                if missing_source || missing_target {
+                    return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
+                        entry_index: Some(index),
+                        missing_source: missing_source.then_some(edge.source_id),
+                        missing_target: missing_target.then_some(edge.target_id),
+                    }));
+                }
+            }
+            // Every endpoint re-checked as present (e.g. deleted then
+            // recreated after the guarded write ran) — fall back to the
+            // storage layer's own diagnostic instead of claiming a phantom
+            // failing entry.
+            return Err(RuntimeError::NotFound(format!(
+                "link_many: one or more edge endpoints no longer exist at write time: {}",
+                summary.first_error
+            )));
         }
 
         // H1-bulk fix: read back each persisted edge by natural key so callers
@@ -7134,6 +7251,300 @@ mod tests {
             "link_many's guarded batch must be all-or-nothing: the live A-B edge \
              must not have been persisted alongside the doomed A-X edge"
         );
+    }
+
+    // ---- #768/#769: hard-delete row + incident-edge purge is ONE transaction ----
+    //
+    // Six tests below cover both orderings (write-then-delete, and a
+    // concurrent write raced against delete via `tokio::join!`) across all
+    // three hard-delete paths that cascade-purge incident edges: entity,
+    // note, and edge-as-node. No sleeps — the "concurrent" tests assert an
+    // invariant that must hold for EITHER interleaving the async scheduler
+    // picks, rather than forcing one specific interleaving, so they are
+    // deterministic (never flaky) without a barrier.
+
+    fn raw_edge(source_id: Uuid, target_id: Uuid, ns: &str) -> Edge {
+        let now = chrono::Utc::now();
+        Edge {
+            id: LinkId::from(Uuid::new_v4()),
+            namespace: ns.to_string(),
+            source_id,
+            target_id,
+            relation: EdgeRelation::Extends,
+            weight: 1.0,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            metadata: None,
+            target_backend: None,
+        }
+    }
+
+    async fn assert_no_edges_touch(rt: &KhiveRuntime, tok: &NamespaceToken, node_id: Uuid) {
+        let as_source = rt
+            .list_edges(
+                tok,
+                crate::curation::EdgeListFilter {
+                    source_id: Some(node_id),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .await
+            .unwrap();
+        let as_target = rt
+            .list_edges(
+                tok,
+                crate::curation::EdgeListFilter {
+                    target_id: Some(node_id),
+                    ..Default::default()
+                },
+                10,
+                0,
+            )
+            .await
+            .unwrap();
+        assert!(
+            as_source.is_empty() && as_target.is_empty(),
+            "no edge may reference hard-deleted node {node_id}: source-side={as_source:?} \
+             target-side={as_target:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_delete_entity_purges_edge_written_before_delete() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        let edge = raw_edge(a.id, x.id, tok.namespace().as_str());
+        assert!(rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edge_guarded(edge)
+            .await
+            .unwrap());
+
+        assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
+        assert_no_edges_touch(&rt, &tok, x.id).await;
+    }
+
+    #[tokio::test]
+    async fn hard_delete_entity_concurrent_with_guarded_write_never_leaves_dangling_edge() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        let delete_rt = std::sync::Arc::clone(&rt);
+        let delete_tok = tok.clone();
+        let delete_task =
+            tokio::spawn(async move { delete_rt.delete_entity(&delete_tok, x.id, true).await });
+
+        let write_rt = std::sync::Arc::clone(&rt);
+        let write_tok = tok.clone();
+        let ns = tok.namespace().as_str().to_string();
+        let write_task = tokio::spawn(async move {
+            let edge = raw_edge(a.id, x.id, &ns);
+            write_rt
+                .graph(&write_tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+        });
+
+        let (deleted, _written) = tokio::join!(delete_task, write_task);
+        deleted.unwrap().unwrap();
+        assert_no_edges_touch(&rt, &tok, x.id).await;
+    }
+
+    #[tokio::test]
+    async fn hard_delete_note_purges_edge_written_before_delete() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "note content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let edge = raw_edge(a.id, n.id, tok.namespace().as_str());
+        assert!(rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edge_guarded(edge)
+            .await
+            .unwrap());
+
+        assert!(rt.delete_note(&tok, n.id, true).await.unwrap());
+        assert_no_edges_touch(&rt, &tok, n.id).await;
+    }
+
+    #[tokio::test]
+    async fn hard_delete_note_concurrent_with_guarded_write_never_leaves_dangling_edge() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "note content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let delete_rt = std::sync::Arc::clone(&rt);
+        let delete_tok = tok.clone();
+        let note_id = n.id;
+        let delete_task =
+            tokio::spawn(async move { delete_rt.delete_note(&delete_tok, note_id, true).await });
+
+        let write_rt = std::sync::Arc::clone(&rt);
+        let write_tok = tok.clone();
+        let ns = tok.namespace().as_str().to_string();
+        let write_task = tokio::spawn(async move {
+            let edge = raw_edge(a.id, note_id, &ns);
+            write_rt
+                .graph(&write_tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+        });
+
+        let (deleted, _written) = tokio::join!(delete_task, write_task);
+        deleted.unwrap().unwrap();
+        assert_no_edges_touch(&rt, &tok, note_id).await;
+    }
+
+    #[tokio::test]
+    async fn hard_delete_edge_endpoint_purges_annotating_edge_written_before_delete() {
+        let rt = rt();
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "note content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let base_edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.8, None)
+            .await
+            .unwrap();
+        let base_edge_id = Uuid::from(base_edge.id);
+
+        // An edge whose TARGET is another edge — the "edge-as-node" case
+        // `delete_edge`'s cascade must sweep.
+        let annotating = raw_edge(n.id, base_edge_id, tok.namespace().as_str());
+        assert!(rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edge_guarded(annotating)
+            .await
+            .unwrap());
+
+        assert!(rt.delete_edge(&tok, base_edge_id, true).await.unwrap());
+        assert_no_edges_touch(&rt, &tok, base_edge_id).await;
+    }
+
+    #[tokio::test]
+    async fn hard_delete_edge_endpoint_concurrent_with_guarded_write_never_leaves_dangling_edge() {
+        let rt = std::sync::Arc::new(rt());
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let b = rt
+            .create_entity(&tok, "concept", None, "B", None, None, vec![])
+            .await
+            .unwrap();
+        let n = rt
+            .create_note(
+                &tok,
+                "observation",
+                None,
+                "note content",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .unwrap();
+        let base_edge = rt
+            .link(&tok, a.id, b.id, EdgeRelation::Extends, 0.8, None)
+            .await
+            .unwrap();
+        let base_edge_id = Uuid::from(base_edge.id);
+
+        let delete_rt = std::sync::Arc::clone(&rt);
+        let delete_tok = tok.clone();
+        let delete_task =
+            tokio::spawn(
+                async move { delete_rt.delete_edge(&delete_tok, base_edge_id, true).await },
+            );
+
+        let write_rt = std::sync::Arc::clone(&rt);
+        let write_tok = tok.clone();
+        let ns = tok.namespace().as_str().to_string();
+        let write_task = tokio::spawn(async move {
+            let edge = raw_edge(n.id, base_edge_id, &ns);
+            write_rt
+                .graph(&write_tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+        });
+
+        let (deleted, _written) = tokio::join!(delete_task, write_task);
+        deleted.unwrap().unwrap();
+        assert_no_edges_touch(&rt, &tok, base_edge_id).await;
     }
 
     #[tokio::test]

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1715,7 +1715,15 @@ impl KhiveRuntime {
             metadata,
             target_backend: None,
         };
-        self.graph(token)?.upsert_edge(edge).await?;
+        // #769: `upsert_edge_guarded` re-checks both endpoints exist as part
+        // of the same write, not the separate `validate_edge_relation_endpoints`
+        // read above — a concurrent hard-delete landing between that read and
+        // this write can no longer create a durably dangling edge.
+        if !self.graph(token)?.upsert_edge_guarded(edge).await? {
+            return Err(RuntimeError::NotFound(format!(
+                "link source {source_id} or target {target_id} no longer exists at write time"
+            )));
+        }
 
         // H1 fix: read back the persisted row by natural key so the returned
         // edge ID is always the one stored in the database, not the locally
@@ -4557,7 +4565,21 @@ impl KhiveRuntime {
         for spec in &specs {
             edges.push(self.build_edge(token, spec).await?);
         }
-        self.graph(token)?.upsert_edges(edges.clone()).await?;
+        // #769: `upsert_edges_guarded` re-checks every edge's endpoints as
+        // part of the same write, not the separate per-spec `build_edge`
+        // validation reads above. A concurrent hard-delete of any endpoint
+        // landing between those reads and this write aborts the whole batch
+        // (all-or-nothing, no partial write) instead of persisting a
+        // dangling edge.
+        let summary = self
+            .graph(token)?
+            .upsert_edges_guarded(edges.clone())
+            .await?;
+        if summary.affected != edges.len() as u64 {
+            return Err(RuntimeError::NotFound(
+                "link_many: one or more edge endpoints no longer exist at write time".to_string(),
+            ));
+        }
 
         // H1-bulk fix: read back each persisted edge by natural key so callers
         // always receive the stored row ID, not the pre-upsert generated UUID.

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -1723,24 +1723,22 @@ impl KhiveRuntime {
         // #769: `upsert_edge_guarded` re-checks both endpoints exist as part
         // of the same write, not the separate `validate_edge_relation_endpoints`
         // read above — a concurrent hard-delete landing between that read and
-        // this write can no longer create a durably dangling edge.
-        if !self.graph(token)?.upsert_edge_guarded(edge).await? {
-            // Re-probe each endpoint individually (read-only, best-effort) so
-            // the error names exactly which one vanished instead of a generic
-            // "source or target" message (codex REJECT Medium 3).
-            let missing_source = self
-                .resolve_edge_endpoint(token, source_id)
-                .await?
-                .is_none();
-            let missing_target = self
-                .resolve_edge_endpoint(token, target_id)
-                .await?
-                .is_none();
-            return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
-                entry_index: None,
-                missing_source: missing_source.then_some(source_id),
-                missing_target: missing_target.then_some(target_id),
-            }));
+        // this write can no longer create a durably dangling edge. Which
+        // endpoint(s) were missing is reported by the guard's own
+        // in-transaction probe (`GuardedWriteOutcome::Refused`), not
+        // reconstructed here by re-reading the endpoints after the fact: a
+        // second concurrent write landing between the refusal and a
+        // post-hoc read could otherwise misreport which endpoint was
+        // actually missing at write time (round-2 codex Medium 1).
+        match self.graph(token)?.upsert_edge_guarded(edge).await? {
+            khive_storage::GuardedWriteOutcome::Written => {}
+            khive_storage::GuardedWriteOutcome::Refused(missing) => {
+                return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
+                    entry_index: None,
+                    missing_source: missing.source.then_some(source_id),
+                    missing_target: missing.target.then_some(target_id),
+                }));
+            }
         }
 
         // H1 fix: read back the persisted row by natural key so the returned
@@ -4661,40 +4659,31 @@ impl KhiveRuntime {
         // validation reads above. A concurrent hard-delete of any endpoint
         // landing between those reads and this write aborts the whole batch
         // (all-or-nothing, no partial write) instead of persisting a
-        // dangling edge.
-        let summary = self
+        // dangling edge. The failing entry's index and its missing
+        // endpoint(s) come from the guard's own in-transaction pre-check
+        // (`GuardedBatchOutcome::refused`), not a post-hoc re-read of the
+        // batch after the write already failed (round-2 codex Medium 1).
+        let outcome = self
             .graph(token)?
             .upsert_edges_guarded(edges.clone())
             .await?;
-        if summary.affected != edges.len() as u64 {
-            // Re-probe each entry in batch order (read-only, best-effort) to find
-            // the first one with a missing endpoint and report its index — the
-            // storage-layer summary only carries a free-text `first_error`, not
-            // a structured endpoint/index pair (codex REJECT Medium 3).
-            for (index, edge) in edges.iter().enumerate() {
-                let missing_source = self
-                    .resolve_edge_endpoint(token, edge.source_id)
-                    .await?
-                    .is_none();
-                let missing_target = self
-                    .resolve_edge_endpoint(token, edge.target_id)
-                    .await?
-                    .is_none();
-                if missing_source || missing_target {
-                    return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
-                        entry_index: Some(index),
-                        missing_source: missing_source.then_some(edge.source_id),
-                        missing_target: missing_target.then_some(edge.target_id),
-                    }));
-                }
-            }
-            // Every endpoint re-checked as present (e.g. deleted then
-            // recreated after the guarded write ran) — fall back to the
-            // storage layer's own diagnostic instead of claiming a phantom
-            // failing entry.
+        if let Some(refusal) = outcome.refused {
+            return Err(RuntimeError::GuardedWriteFailed(GuardedWriteFailure {
+                entry_index: Some(refusal.entry_index),
+                missing_source: refusal
+                    .missing
+                    .source
+                    .then_some(edges[refusal.entry_index].source_id),
+                missing_target: refusal
+                    .missing
+                    .target
+                    .then_some(edges[refusal.entry_index].target_id),
+            }));
+        }
+        if outcome.summary.affected != edges.len() as u64 {
             return Err(RuntimeError::NotFound(format!(
                 "link_many: one or more edge endpoints no longer exist at write time: {}",
-                summary.first_error
+                outcome.summary.first_error
             )));
         }
 
@@ -7144,16 +7133,20 @@ mod tests {
             metadata: None,
             target_backend: None,
         };
-        let written = rt
+        let outcome = rt
             .graph(&tok)
             .unwrap()
             .upsert_edge_guarded(edge)
             .await
             .unwrap();
-        assert!(
-            !written,
-            "guarded write must refuse an edge whose target vanished before commit"
-        );
+        match outcome {
+            khive_storage::GuardedWriteOutcome::Refused(missing) => {
+                assert!(missing.target, "target must be reported missing");
+            }
+            other => panic!(
+                "guarded write must refuse an edge whose target vanished before commit, got {other:?}"
+            ),
+        }
 
         let edges = rt
             .list_edges(
@@ -7222,15 +7215,19 @@ mod tests {
         // single guarded batch write.
         assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
 
-        let summary = rt
+        let outcome = rt
             .graph(&tok)
             .unwrap()
             .upsert_edges_guarded(edges)
             .await
             .unwrap();
         assert_eq!(
-            summary.affected, 0,
+            outcome.summary.affected, 0,
             "no edge from the batch may be persisted when any endpoint vanished"
+        );
+        assert!(
+            outcome.refused.is_some(),
+            "refused batch entry must be reported"
         );
 
         let edges = rt
@@ -7326,12 +7323,14 @@ mod tests {
             .unwrap();
 
         let edge = raw_edge(a.id, x.id, tok.namespace().as_str());
-        assert!(rt
-            .graph(&tok)
-            .unwrap()
-            .upsert_edge_guarded(edge)
-            .await
-            .unwrap());
+        assert_eq!(
+            rt.graph(&tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+                .unwrap(),
+            khive_storage::GuardedWriteOutcome::Written
+        );
 
         assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
         assert_no_edges_touch(&rt, &tok, x.id).await;
@@ -7394,12 +7393,14 @@ mod tests {
             .unwrap();
 
         let edge = raw_edge(a.id, n.id, tok.namespace().as_str());
-        assert!(rt
-            .graph(&tok)
-            .unwrap()
-            .upsert_edge_guarded(edge)
-            .await
-            .unwrap());
+        assert_eq!(
+            rt.graph(&tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+                .unwrap(),
+            khive_storage::GuardedWriteOutcome::Written
+        );
 
         assert!(rt.delete_note(&tok, n.id, true).await.unwrap());
         assert_no_edges_touch(&rt, &tok, n.id).await;
@@ -7482,12 +7483,14 @@ mod tests {
         // An edge whose TARGET is another edge — the "edge-as-node" case
         // `delete_edge`'s cascade must sweep.
         let annotating = raw_edge(n.id, base_edge_id, tok.namespace().as_str());
-        assert!(rt
-            .graph(&tok)
-            .unwrap()
-            .upsert_edge_guarded(annotating)
-            .await
-            .unwrap());
+        assert_eq!(
+            rt.graph(&tok)
+                .unwrap()
+                .upsert_edge_guarded(annotating)
+                .await
+                .unwrap(),
+            khive_storage::GuardedWriteOutcome::Written
+        );
 
         assert!(rt.delete_edge(&tok, base_edge_id, true).await.unwrap());
         assert_no_edges_touch(&rt, &tok, base_edge_id).await;
@@ -7545,6 +7548,143 @@ mod tests {
         let (deleted, _written) = tokio::join!(delete_task, write_task);
         deleted.unwrap().unwrap();
         assert_no_edges_touch(&rt, &tok, base_edge_id).await;
+    }
+
+    // ---- #769 round-2 codex Medium 3: file-backed, both write-queue configs ----
+    //
+    // The six tests above run against `KhiveRuntime::memory()` and race
+    // delete against the guarded write via `tokio::join!` with no explicit
+    // ordering control, so the scheduler could run them fully sequentially
+    // on one thread without ever exercising real interleaving, and neither
+    // the file-backed storage path nor `write_queue_enabled: true`
+    // (`KHIVE_WRITE_QUEUE=1`, the `WriterTask`-routed write path in
+    // `SqlGraphStore`) is covered at all. The four tests below close both
+    // gaps: file-backed databases, one run with the writer queue off
+    // (default) and one with it on, each provably forcing the guarded write
+    // to land on one specific side of the delete — fully committed before
+    // the delete starts (swept by the delete's cascade) and attempted only
+    // after the delete has already committed (refused by the guard) — via
+    // plain `.await` sequencing rather than a race whose outcome the test
+    // does not control.
+
+    fn file_backed_runtime(
+        dir: &tempfile::TempDir,
+        name: &str,
+        write_queue_enabled: bool,
+    ) -> KhiveRuntime {
+        let path = dir.path().join(name);
+        if write_queue_enabled {
+            std::env::set_var("KHIVE_WRITE_QUEUE", "1");
+        } else {
+            std::env::remove_var("KHIVE_WRITE_QUEUE");
+        }
+        let rt = KhiveRuntime::new(crate::config::RuntimeConfig {
+            db_path: Some(path),
+            packs: vec!["kg".to_string()],
+            brain_profile: None,
+            actor_id: None,
+            ..crate::config::RuntimeConfig::no_embeddings()
+        })
+        .unwrap();
+        std::env::remove_var("KHIVE_WRITE_QUEUE");
+        rt
+    }
+
+    async fn assert_guarded_write_committed_before_delete_is_swept(rt: &KhiveRuntime) {
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        // Write lands fully committed while X is still live — squarely
+        // inside the window before the delete's cascade runs.
+        let edge = raw_edge(a.id, x.id, tok.namespace().as_str());
+        assert_eq!(
+            rt.graph(&tok)
+                .unwrap()
+                .upsert_edge_guarded(edge)
+                .await
+                .unwrap(),
+            khive_storage::GuardedWriteOutcome::Written,
+            "write must succeed while both endpoints are still live"
+        );
+
+        assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
+        assert_no_edges_touch(rt, &tok, x.id).await;
+    }
+
+    async fn assert_guarded_write_attempted_after_delete_is_refused(rt: &KhiveRuntime) {
+        let tok = NamespaceToken::local();
+        let a = rt
+            .create_entity(&tok, "concept", None, "A", None, None, vec![])
+            .await
+            .unwrap();
+        let x = rt
+            .create_entity(&tok, "concept", None, "X", None, None, vec![])
+            .await
+            .unwrap();
+
+        // The delete's transaction has fully committed before the guarded
+        // write is even attempted — squarely after the window has closed.
+        assert!(rt.delete_entity(&tok, x.id, true).await.unwrap());
+
+        let edge = raw_edge(a.id, x.id, tok.namespace().as_str());
+        let outcome = rt
+            .graph(&tok)
+            .unwrap()
+            .upsert_edge_guarded(edge)
+            .await
+            .unwrap();
+        match outcome {
+            khive_storage::GuardedWriteOutcome::Refused(missing) => {
+                assert!(
+                    missing.target,
+                    "target must be reported missing once the delete has committed"
+                );
+                assert!(!missing.source, "source was never deleted");
+            }
+            other => panic!(
+                "guarded write attempted after the delete committed must be refused, got {other:?}"
+            ),
+        }
+        assert_no_edges_touch(rt, &tok, x.id).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(khive_write_queue_env)]
+    async fn guarded_write_before_delete_swept_file_backed_write_queue_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = file_backed_runtime(&dir, "guard_before_off.db", false);
+        assert_guarded_write_committed_before_delete_is_swept(&rt).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(khive_write_queue_env)]
+    async fn guarded_write_after_delete_refused_file_backed_write_queue_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = file_backed_runtime(&dir, "guard_after_off.db", false);
+        assert_guarded_write_attempted_after_delete_is_refused(&rt).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(khive_write_queue_env)]
+    async fn guarded_write_before_delete_swept_file_backed_write_queue_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = file_backed_runtime(&dir, "guard_before_on.db", true);
+        assert_guarded_write_committed_before_delete_is_swept(&rt).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(khive_write_queue_env)]
+    async fn guarded_write_after_delete_refused_file_backed_write_queue_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = file_backed_runtime(&dir, "guard_after_on.db", true);
+        assert_guarded_write_attempted_after_delete_is_refused(&rt).await;
     }
 
     #[tokio::test]

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -17,6 +17,19 @@ pub trait GraphStore: Send + Sync + 'static {
     async fn upsert_edge(&self, edge: Edge) -> StorageResult<()>;
     /// Insert or update a batch of edges.
     async fn upsert_edges(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
+    /// Insert or update a single edge, re-checking that both endpoints still
+    /// exist (and are not soft-deleted) as part of the same write, not a
+    /// separate prior read. Closes the TOCTOU window between an async
+    /// prepare-time existence check and a later, unconditional write: a
+    /// concurrent hard-delete of an endpoint that lands between the two can
+    /// otherwise leave a durably dangling edge (#769). Returns `false`
+    /// (nothing written) when either endpoint is gone at write time, `true`
+    /// when the edge was inserted or updated.
+    async fn upsert_edge_guarded(&self, edge: Edge) -> StorageResult<bool>;
+    /// Batch form of [`GraphStore::upsert_edge_guarded`]. All-or-nothing:
+    /// if any edge's endpoints are missing at write time, no edge from the
+    /// batch is persisted and `BatchWriteSummary::affected` is `0`.
+    async fn upsert_edges_guarded(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
     /// Fetch an edge by link ID, returning `None` if absent. Filters soft-deleted rows.
     async fn get_edge(&self, id: LinkId) -> StorageResult<Option<Edge>>;
     /// Fetch an edge by link ID including soft-deleted rows. Used by the runtime hard-delete path

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -8,8 +8,8 @@ use crate::capability::StorageCapability;
 use crate::error::StorageError;
 use crate::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
-    EdgeSortField, GraphPath, LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortOrder,
-    StorageResult, TraversalRequest,
+    EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedWriteOutcome, LinkId, NeighborHit,
+    NeighborQuery, Page, PageRequest, SortOrder, StorageResult, TraversalRequest,
 };
 
 /// Directed edge CRUD and graph traversal over the knowledge graph.
@@ -24,15 +24,20 @@ pub trait GraphStore: Send + Sync + 'static {
     /// separate prior read. Closes the TOCTOU window between an async
     /// prepare-time existence check and a later, unconditional write: a
     /// concurrent hard-delete of an endpoint that lands between the two can
-    /// otherwise leave a durably dangling edge (#769). Returns `false`
-    /// (nothing written) when either endpoint is gone at write time, `true`
-    /// when the edge was inserted or updated.
+    /// otherwise leave a durably dangling edge (#769).
+    ///
+    /// Returns [`GuardedWriteOutcome::Refused`] naming exactly which
+    /// endpoint(s) were missing, determined by the guard's own in-transaction
+    /// probe — never reconstructed by a caller re-reading the endpoints after
+    /// the write already failed, since a concurrent write landing between the
+    /// refusal and any such later read could misreport which endpoint was
+    /// actually missing at write time (round-2 codex Medium 1).
     ///
     /// Default returns `StorageError::Unsupported`: a backend that does not
     /// override this method cannot honor the endpoint-existence guarantee,
     /// and silently falling back to [`GraphStore::upsert_edge`] would
     /// reintroduce the TOCTOU window this method exists to close.
-    async fn upsert_edge_guarded(&self, _edge: Edge) -> StorageResult<bool> {
+    async fn upsert_edge_guarded(&self, _edge: Edge) -> StorageResult<GuardedWriteOutcome> {
         Err(StorageError::Unsupported {
             capability: StorageCapability::Graph,
             operation: "upsert_edge_guarded".into(),
@@ -41,11 +46,14 @@ pub trait GraphStore: Send + Sync + 'static {
     }
     /// Batch form of [`GraphStore::upsert_edge_guarded`]. All-or-nothing:
     /// if any edge's endpoints are missing at write time, no edge from the
-    /// batch is persisted and `BatchWriteSummary::affected` is `0`.
+    /// batch is persisted, `BatchWriteSummary::affected` is `0`, and
+    /// `GuardedBatchOutcome::refused` names the first failing batch entry and
+    /// its missing endpoint(s) — determined by the same in-transaction
+    /// pre-check that aborted the batch, not a post-hoc re-read.
     ///
     /// Default returns `StorageError::Unsupported`, for the same reason as
     /// [`GraphStore::upsert_edge_guarded`]'s default.
-    async fn upsert_edges_guarded(&self, _edges: Vec<Edge>) -> StorageResult<BatchWriteSummary> {
+    async fn upsert_edges_guarded(&self, _edges: Vec<Edge>) -> StorageResult<GuardedBatchOutcome> {
         Err(StorageError::Unsupported {
             capability: StorageCapability::Graph,
             operation: "upsert_edges_guarded".into(),

--- a/crates/khive-storage/src/graph.rs
+++ b/crates/khive-storage/src/graph.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use khive_types::EdgeRelation;
 use uuid::Uuid;
 
+use crate::capability::StorageCapability;
+use crate::error::StorageError;
 use crate::types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
     EdgeSortField, GraphPath, LinkId, NeighborHit, NeighborQuery, Page, PageRequest, SortOrder,
@@ -25,11 +27,31 @@ pub trait GraphStore: Send + Sync + 'static {
     /// otherwise leave a durably dangling edge (#769). Returns `false`
     /// (nothing written) when either endpoint is gone at write time, `true`
     /// when the edge was inserted or updated.
-    async fn upsert_edge_guarded(&self, edge: Edge) -> StorageResult<bool>;
+    ///
+    /// Default returns `StorageError::Unsupported`: a backend that does not
+    /// override this method cannot honor the endpoint-existence guarantee,
+    /// and silently falling back to [`GraphStore::upsert_edge`] would
+    /// reintroduce the TOCTOU window this method exists to close.
+    async fn upsert_edge_guarded(&self, _edge: Edge) -> StorageResult<bool> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "upsert_edge_guarded".into(),
+            message: "this backend does not implement guarded edge writes".into(),
+        })
+    }
     /// Batch form of [`GraphStore::upsert_edge_guarded`]. All-or-nothing:
     /// if any edge's endpoints are missing at write time, no edge from the
     /// batch is persisted and `BatchWriteSummary::affected` is `0`.
-    async fn upsert_edges_guarded(&self, edges: Vec<Edge>) -> StorageResult<BatchWriteSummary>;
+    ///
+    /// Default returns `StorageError::Unsupported`, for the same reason as
+    /// [`GraphStore::upsert_edge_guarded`]'s default.
+    async fn upsert_edges_guarded(&self, _edges: Vec<Edge>) -> StorageResult<BatchWriteSummary> {
+        Err(StorageError::Unsupported {
+            capability: StorageCapability::Graph,
+            operation: "upsert_edges_guarded".into(),
+            message: "this backend does not implement guarded edge writes".into(),
+        })
+    }
     /// Fetch an edge by link ID, returning `None` if absent. Filters soft-deleted rows.
     async fn get_edge(&self, id: LinkId) -> StorageResult<Option<Edge>>;
     /// Fetch an edge by link ID including soft-deleted rows. Used by the runtime hard-delete path

--- a/crates/khive-storage/src/lib.rs
+++ b/crates/khive-storage/src/lib.rs
@@ -37,10 +37,11 @@ pub use vectors::VectorStore;
 
 pub use types::{
     BatchWriteSummary, DeleteMode, DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage,
-    EdgeSortField, GraphPath, IndexRebuildScope, LinkId, NeighborHit, NeighborQuery,
-    OrphanSweepConfig, OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp,
-    SortDirection, SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector,
-    SqlRow, SqlStatement, SqlValue, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
+    EdgeSortField, GraphPath, GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome,
+    IndexRebuildScope, LinkId, MissingEndpoints, NeighborHit, NeighborQuery, OrphanSweepConfig,
+    OrphanSweepResult, Page, PageRequest, PathNode, PropertyFilter, PropertyOp, SortDirection,
+    SortOrder, SparseRecord, SparseSearchHit, SparseSearchRequest, SparseVector, SqlRow,
+    SqlStatement, SqlValue, TextDocument, TextFilter, TextGatherMode, TextIndexStats,
     TextQueryMode, TextSearchHit, TextSearchOptions, TextSearchRequest, TextTermStats,
     TextTermStatsRequest, TimeRange, TraversalOptions, TraversalRequest, VectorIndexKind,
     VectorMetadataFilter, VectorRecord, VectorSearchHit, VectorSearchRequest,

--- a/crates/khive-storage/src/types/graph.rs
+++ b/crates/khive-storage/src/types/graph.rs
@@ -9,6 +9,8 @@ use uuid::Uuid;
 
 use khive_types::EdgeRelation;
 
+use super::BatchWriteSummary;
+
 /// A type-safe link ID (wraps Uuid).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct LinkId(pub Uuid);
@@ -455,6 +457,54 @@ pub struct GraphPath {
     pub root_id: Uuid,
     pub nodes: Vec<PathNode>,
     pub total_weight: f64,
+}
+
+/// Which of a would-be edge's two endpoints were missing when a guarded
+/// write's in-transaction existence check refused it (#769 round-2 codex
+/// Medium 1). Produced by the guard's own commit-time probe, not a
+/// post-hoc read after the write already failed, so a concurrent
+/// hard-delete landing after the guard ran cannot make this outcome lie
+/// about which endpoint was actually missing at write time.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MissingEndpoints {
+    pub source: bool,
+    pub target: bool,
+}
+
+impl MissingEndpoints {
+    /// True if at least one endpoint was reported missing.
+    pub fn any(&self) -> bool {
+        self.source || self.target
+    }
+}
+
+/// Outcome of [`crate::GraphStore::upsert_edge_guarded`], determined entirely
+/// inside the guard's own storage transaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GuardedWriteOutcome {
+    /// The edge was inserted or updated; both endpoints existed at write time.
+    Written,
+    /// The write was refused; `MissingEndpoints` names which endpoint(s) were
+    /// gone at write time.
+    Refused(MissingEndpoints),
+}
+
+/// Which batch entry a guarded batch write refused on, and why, determined
+/// inside the same in-transaction pre-check that aborted the batch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GuardedBatchRefusal {
+    /// Index of the first batch entry whose endpoint(s) were missing.
+    pub entry_index: usize,
+    pub missing: MissingEndpoints,
+}
+
+/// Outcome of [`crate::GraphStore::upsert_edges_guarded`]. `refused` is
+/// `Some` exactly when `summary.affected == 0` after a guard refusal;
+/// `None` when every edge in the batch was written.
+#[derive(Clone, Debug)]
+pub struct GuardedBatchOutcome {
+    pub summary: BatchWriteSummary,
+    pub refused: Option<GuardedBatchRefusal>,
 }
 
 #[cfg(test)]

--- a/crates/khive-storage/src/types/mod.rs
+++ b/crates/khive-storage/src/types/mod.rs
@@ -14,8 +14,9 @@ pub type StorageResult<T> = Result<T, StorageError>;
 
 pub use graph::{
     DirectedNeighborHit, Direction, Edge, EdgeFilter, EdgeSeekPage, EdgeSortField, GraphPath,
-    LinkId, NeighborHit, NeighborQuery, PathNode, SortDirection, SortOrder, TimeRange,
-    TraversalOptions, TraversalRequest,
+    GuardedBatchOutcome, GuardedBatchRefusal, GuardedWriteOutcome, LinkId, MissingEndpoints,
+    NeighborHit, NeighborQuery, PathNode, SortDirection, SortOrder, TimeRange, TraversalOptions,
+    TraversalRequest,
 };
 pub use pagination::{Page, PageRequest};
 pub use sparse::{


### PR DESCRIPTION
## Summary

Fixes #769: canonical `link()`/`link_many()` validated edge endpoints with a
separate async read, then wrote the edge with an unconditional
`INSERT ... ON CONFLICT`. A concurrent hard-delete landing between the
validation read and the write could leave a durably dangling edge, since
`graph_edges` carries no foreign key.

Root cause: `KhiveRuntime::link`/`link_many` called
`validate_edge_relation_endpoints` (an async read), then
`graph.upsert_edge`/`upsert_edges` (a separate, unconditional write). The
atomic `link` path already had a commit-time `WHERE EXISTS` guard
(`edge_insert_guarded_by_endpoints_statement`), but it was wired only into
the atomic-batch path, not the canonical one.

## Fix

- Added `GraphStore::upsert_edge_guarded`/`upsert_edges_guarded`, reusing the
  existing guarded `INSERT ... SELECT ... WHERE EXISTS(...)` builder for the
  single-edge path, and a pre-check-then-write batch loop (inside one
  `BEGIN IMMEDIATE`) for the batch path so a missing endpoint aborts the
  whole batch with zero rows written.
- Wired `KhiveRuntime::link`/`link_many` to the guarded calls. Zero affected
  rows now surfaces as `RuntimeError::NotFound` instead of a silent no-op
  success.
- Broadened the guard's existence check from entities/notes only to
  entities, notes, events, and edges, matching
  `substrate_exists_by_id`'s actual definition of "exists" (the `annotates`
  relation may target any substrate). The narrower check was initially
  written and caught real regressions in existing `annotates`-to-event and
  annotates-to-edge tests before being widened; those tests pass unchanged
  now.
- `link_with_target_backend` (the cross-backend coordinator path) has the
  same structural shape but is out of scope here pending a
  `SubstrateCoordinator`-owner review noted in the prep brief; flagged as a
  follow-up, not silently left unaddressed.
- Round-2 codex REJECT fixes (commit `e7459661`): hard-delete's incident-edge
  purge and the endpoint row delete now run in ONE transaction (was two
  independently-committing storage calls), the `GraphStore` trait addition
  got `Unsupported` defaults so external implementors keep compiling, and
  the guarded-write failure type now names the exact missing endpoint(s)
  (and batch index) instead of a generic message.
- Round-2 codex Medium fixes (this update): the guarded-write failure
  outcome is now produced entirely inside the storage transaction itself
  (`GuardedWriteOutcome`/`GuardedBatchOutcome`) instead of being
  reconstructed by the runtime with a post-hoc read after the write was
  already refused; and the concurrency regression suite now includes
  file-backed tests with explicit `.await`-ordering for both
  `write_queue_enabled` states, not just in-memory `tokio::join!` races.

Refs #768, cascade subcase only. `e7459661`'s commit message says "Fixes
#768" — that is not accurate as a full close. That commit implements only
the hard-delete's edge-purge cascade running atomically with the row
delete. #768 also covers SQLite-backed index cleanup, the audit-event
append, and `update_entity`/`merge_entity` consistency (both currently
commit their row write, then reindex/append as separate, independently
fallible steps) — none of which this PR touches. #768 should stay open
until those remain. See the tracking comment on #768 for the itemized
breakdown.

## Test plan

- [x] `cargo test -p khive-db` (new guarded-upsert unit tests, single and
      batch, endpoint-missing and endpoint-live cases)
- [x] `cargo test -p khive-runtime` (new deterministic write-time-guard
      regression tests for `link` and `link_many`; file-backed
      write-queue-on/off ordering tests; all pre-existing `link_*`/
      `annotates_*`/hard-delete tests pass unchanged)
- [x] `cargo clippy -p khive-storage -p khive-db -p khive-runtime --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
