### PR TITLE
fix(pack-comm): make comm.probe cursor commit-order safe (#780)

### DIFF
--- a/crates/khive-db/sql/007-notes-seq.sql
+++ b/crates/khive-db/sql/007-notes-seq.sql
@@ -25,3 +25,16 @@ CREATE TABLE IF NOT EXISTS notes_seq (
 );
 
 CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);
+
+-- Backfill: every note that already existed on a pre-V7 (V6 and earlier)
+-- database has no `notes_seq` row yet. `comm.probe`'s query INNER JOINs
+-- `notes` to `notes_seq`, so without this backfill every pre-existing
+-- inbound message would silently vanish from `new_messages`, `cursor_us`,
+-- and `stale_unread_count` the moment a populated database is upgraded to
+-- V7 -- the exact bug this migration exists to fix, reintroduced at the
+-- boundary. Ordered by `(created_at, id)` so the backfilled sequence
+-- preserves the same visible ordering `comm.probe` already presents to
+-- callers. This migration runs exactly once per database (tracked by
+-- `_schema_migrations`), so the full-table scan here is a one-time cost.
+INSERT OR IGNORE INTO notes_seq (note_id)
+SELECT id FROM notes ORDER BY created_at ASC, id ASC;

--- a/crates/khive-db/sql/007-notes-seq.sql
+++ b/crates/khive-db/sql/007-notes-seq.sql
@@ -1,0 +1,27 @@
+-- V7: durable, non-reusing sequence for `notes` (khive #827).
+--
+-- `notes` has a TEXT PRIMARY KEY (`id`), so SQLite assigns it an *implicit*
+-- rowid. Two things make an implicit rowid unsafe as a durable cursor key:
+--   1. VACUUM may renumber implicit rowids (khive exposes `memory.vacuum`).
+--   2. SQLite reuses the highest rowid after that row is deleted (khive
+--      exposes a public hard delete of notes), so a later insert can land on
+--      a rowid a caller's cursor has already passed, permanently excluding
+--      that message from `comm.probe`.
+--
+-- `notes_seq` fixes both: its primary key is an explicit `INTEGER PRIMARY
+-- KEY AUTOINCREMENT` column. An explicit integer primary key is never
+-- renumbered by VACUUM (only implicit-rowid tables are), and AUTOINCREMENT
+-- makes SQLite track the high-water mark in `sqlite_sequence`, so a value is
+-- never reused even after its row is deleted.
+--
+-- Exactly one row is assigned per note `id`, the first time that id is
+-- inserted (`INSERT OR IGNORE`), by the single writer inside the same
+-- transaction as the note insert. The value then stays fixed for that note's
+-- lifetime, including across an `INSERT OR REPLACE` delete+reinsert of the
+-- same id (which churns `notes.rowid` but leaves `notes_seq` untouched).
+CREATE TABLE IF NOT EXISTS notes_seq (
+    seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+    note_id TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);

--- a/crates/khive-db/sql/008-notes-seq-repair.sql
+++ b/crates/khive-db/sql/008-notes-seq-repair.sql
@@ -1,0 +1,22 @@
+-- V8: repair partially-populated `notes_seq` ledgers (khive #827 round 3).
+--
+-- V7 (`007-notes-seq.sql`) backfilled `notes_seq` with an unconditional
+-- `INSERT OR IGNORE ... SELECT`, then recorded itself as applied in
+-- `_schema_migrations` -- so V7's body never runs again on that database.
+-- A database that ran V7, then received exactly one post-upgrade note
+-- (correctly assigned its own `notes_seq` row via `assign_note_seq`), ends
+-- up with a *partially populated* `notes_seq`: one note mapped, every
+-- pre-V7 note still missing a row, and no migration left that will ever
+-- revisit them. `comm.probe`'s `INNER JOIN notes_seq` silently drops every
+-- one of those older notes forever.
+--
+-- This migration repairs any note still missing a `notes_seq` row,
+-- regardless of how many rows already exist -- the anti-join targets
+-- missing ids specifically, not "notes_seq is empty" -- so it is correct
+-- to layer on top of any prior state: a fresh V7 backfill, a partial
+-- backfill, or an already fully populated ledger. `INSERT OR IGNORE` makes
+-- it idempotent and safe to run more than once.
+INSERT OR IGNORE INTO notes_seq (note_id)
+SELECT n.id FROM notes n
+WHERE NOT EXISTS (SELECT 1 FROM notes_seq s WHERE s.note_id = n.id)
+ORDER BY n.created_at ASC, n.id ASC;

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -1,5 +1,8 @@
 -- Notes table and supporting indexes.
 -- Applied idempotently by StorageBackend::notes_for_namespace on every store access.
+-- Cheap on every call (CREATE ... IF NOT EXISTS is a catalog lookup, not a
+-- table scan) -- unlike the notes_seq repair, which is gated separately
+-- (see `stores/note.rs::repair_notes_seq` and `StorageBackend::notes_for_namespace`).
 
 CREATE TABLE IF NOT EXISTS notes (
     id           TEXT PRIMARY KEY,
@@ -33,20 +36,13 @@ CREATE TABLE IF NOT EXISTS notes_seq (
 
 CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);
 
--- Repair, mirroring `sql/008-notes-seq-repair.sql` (khive #827 round 3) --
--- see that file for the full rationale. This DDL runs on every
--- `notes_for_namespace` call (not just once, like the versioned migration),
--- including for callers that build a store directly and never call
--- `run_migrations`. It targets notes MISSING a `notes_seq` row specifically
--- -- via an anti-join, not "the table is globally empty" -- because a
--- database can have a partially populated `notes_seq` (e.g. one post-V7
--- note landed through `assign_note_seq` before this lazy path ever ran):
--- checking global emptiness alone would see that one row and skip repairing
--- every older, still-unmapped note, permanently excluding them from
--- `comm.probe`. `INSERT OR IGNORE` makes this idempotent and cheap once the
--- ledger is fully populated -- the anti-join still scans `notes`, but every
--- row it finds is already excluded by `idx_notes_seq_note_id`.
-INSERT OR IGNORE INTO notes_seq (note_id)
-SELECT n.id FROM notes n
-WHERE NOT EXISTS (SELECT 1 FROM notes_seq s WHERE s.note_id = n.id)
-ORDER BY n.created_at ASC, n.id ASC;
+-- The notes_seq anti-join repair (khive #827 round 3) used to run here, on
+-- every `notes_for_namespace` call. On a large, already-repaired ledger that
+-- is a full `notes` scan plus a temp B-tree for the ORDER BY on every single
+-- store acquisition, serializing every caller behind the writer mutex for no
+-- benefit once the ledger has nothing left to repair (khive #827 round 4).
+-- The repair itself now lives in `stores/note.rs::repair_notes_seq` (still
+-- sourced from `sql/008-notes-seq-repair.sql`, same anti-join) and is invoked
+-- by `StorageBackend::notes_for_namespace`, gated to run at most once per
+-- backend/pool for the process's lifetime via an atomic counter on
+-- `StorageBackend`.

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -33,17 +33,20 @@ CREATE TABLE IF NOT EXISTS notes_seq (
 
 CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);
 
--- Backfill, mirroring `sql/007-notes-seq.sql` (khive #827) -- see that file
--- for the full rationale. This DDL runs on every `notes_for_namespace` call
--- (not just once, like the versioned migration), including for callers that
--- build a store directly and never call `run_migrations`. Without this, a
--- populated database opened only through this lazy path would keep every
--- pre-existing note permanently invisible to `comm.probe`. The `WHERE NOT
--- EXISTS` guard keeps this a one-time cost per database: once any row is
--- present in `notes_seq` -- either from this backfill or from the first
--- real insert going through `assign_note_seq` -- every later call skips the
--- full-table scan.
+-- Repair, mirroring `sql/008-notes-seq-repair.sql` (khive #827 round 3) --
+-- see that file for the full rationale. This DDL runs on every
+-- `notes_for_namespace` call (not just once, like the versioned migration),
+-- including for callers that build a store directly and never call
+-- `run_migrations`. It targets notes MISSING a `notes_seq` row specifically
+-- -- via an anti-join, not "the table is globally empty" -- because a
+-- database can have a partially populated `notes_seq` (e.g. one post-V7
+-- note landed through `assign_note_seq` before this lazy path ever ran):
+-- checking global emptiness alone would see that one row and skip repairing
+-- every older, still-unmapped note, permanently excluding them from
+-- `comm.probe`. `INSERT OR IGNORE` makes this idempotent and cheap once the
+-- ledger is fully populated -- the anti-join still scans `notes`, but every
+-- row it finds is already excluded by `idx_notes_seq_note_id`.
 INSERT OR IGNORE INTO notes_seq (note_id)
-SELECT id FROM notes
-WHERE NOT EXISTS (SELECT 1 FROM notes_seq)
-ORDER BY created_at ASC, id ASC;
+SELECT n.id FROM notes n
+WHERE NOT EXISTS (SELECT 1 FROM notes_seq s WHERE s.note_id = n.id)
+ORDER BY n.created_at ASC, n.id ASC;

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -20,3 +20,15 @@ CREATE TABLE IF NOT EXISTS notes (
 CREATE INDEX IF NOT EXISTS idx_notes_namespace ON notes(namespace);
 CREATE INDEX IF NOT EXISTS idx_notes_kind ON notes(namespace, kind);
 CREATE INDEX IF NOT EXISTS idx_notes_created ON notes(created_at DESC);
+
+-- Durable, non-reusing sequence for notes (khive #827). Kept in sync with
+-- `sql/007-notes-seq.sql` (the versioned-migration copy) — see that file for
+-- the full rationale. Duplicated here, belt-and-suspenders style, because
+-- this DDL is applied lazily on every `notes_for_namespace` call, independent
+-- of whether `run_migrations` has run against this connection.
+CREATE TABLE IF NOT EXISTS notes_seq (
+    seq     INTEGER PRIMARY KEY AUTOINCREMENT,
+    note_id TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);

--- a/crates/khive-db/sql/notes-ddl.sql
+++ b/crates/khive-db/sql/notes-ddl.sql
@@ -32,3 +32,18 @@ CREATE TABLE IF NOT EXISTS notes_seq (
 );
 
 CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);
+
+-- Backfill, mirroring `sql/007-notes-seq.sql` (khive #827) -- see that file
+-- for the full rationale. This DDL runs on every `notes_for_namespace` call
+-- (not just once, like the versioned migration), including for callers that
+-- build a store directly and never call `run_migrations`. Without this, a
+-- populated database opened only through this lazy path would keep every
+-- pre-existing note permanently invisible to `comm.probe`. The `WHERE NOT
+-- EXISTS` guard keeps this a one-time cost per database: once any row is
+-- present in `notes_seq` -- either from this backfill or from the first
+-- real insert going through `assign_note_seq` -- every later call skips the
+-- full-table scan.
+INSERT OR IGNORE INTO notes_seq (note_id)
+SELECT id FROM notes
+WHERE NOT EXISTS (SELECT 1 FROM notes_seq)
+ORDER BY created_at ASC, id ASC;

--- a/crates/khive-db/src/backend.rs
+++ b/crates/khive-db/src/backend.rs
@@ -5,6 +5,7 @@
 //! `TextSearch`, `SqlAccess`). File-backed for production; in-memory for tests.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use rusqlite::OptionalExtension;
@@ -19,6 +20,13 @@ pub struct StorageBackend {
     pool: Arc<ConnectionPool>,
     is_file_backed: bool,
     path: Option<std::path::PathBuf>,
+    /// How many times the lazy `notes_seq` anti-join repair has actually
+    /// executed against this backend's pool. Gates `notes_for_namespace` so
+    /// the repair (a full `notes` scan) runs at most once per backend for
+    /// the process's lifetime instead of on every store acquisition (khive
+    /// #827 round 4 perf finding). Also exposed via
+    /// `notes_seq_repair_run_count` for regression tests.
+    notes_seq_repair_runs: AtomicUsize,
 }
 
 impl StorageBackend {
@@ -39,6 +47,7 @@ impl StorageBackend {
             pool: Arc::new(pool),
             is_file_backed: true,
             path: Some(resolved),
+            notes_seq_repair_runs: AtomicUsize::new(0),
         })
     }
 
@@ -69,6 +78,7 @@ impl StorageBackend {
             pool: Arc::new(pool),
             is_file_backed: true,
             path: Some(resolved),
+            notes_seq_repair_runs: AtomicUsize::new(0),
         })
     }
 
@@ -88,6 +98,7 @@ impl StorageBackend {
             pool: Arc::new(pool),
             is_file_backed: false,
             path: None,
+            notes_seq_repair_runs: AtomicUsize::new(0),
         })
     }
 
@@ -216,10 +227,30 @@ impl StorageBackend {
         let writer = self.pool.try_writer()?;
         note::ensure_notes_schema(writer.conn())?;
 
+        // The anti-join repair is a full `notes` scan -- gate it to run at
+        // most once per backend/pool. `try_writer()` blocks for exclusive
+        // access to the single writer connection for this whole function,
+        // so this load-then-run-then-store is race-free: no other caller on
+        // this pool can observe or advance `notes_seq_repair_runs` while we
+        // hold the writer guard (khive #827 round 4 perf finding).
+        if self.notes_seq_repair_runs.load(Ordering::Relaxed) == 0 {
+            note::repair_notes_seq(writer.conn())?;
+            self.notes_seq_repair_runs.fetch_add(1, Ordering::Relaxed);
+        }
+
         Ok(Arc::new(note::SqlNoteStore::new(
             Arc::clone(&self.pool),
             self.is_file_backed,
         )))
+    }
+
+    /// How many times the lazy `notes_seq` anti-join repair has actually
+    /// executed against this backend's pool. Exposed for regression tests
+    /// asserting the repair runs at most once per backend for the process's
+    /// lifetime, not once per `notes_for_namespace` call (khive #827 round 4
+    /// perf finding).
+    pub fn notes_seq_repair_run_count(&self) -> usize {
+        self.notes_seq_repair_runs.load(Ordering::Relaxed)
     }
 
     /// Get an EventStore for the default namespace.

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -112,6 +112,8 @@ const V5_UP: &str = include_str!("../sql/005-unique-comm-external-id.sql");
 
 const V6_UP: &str = include_str!("../sql/006-brain-retune-driver.sql");
 
+const V7_UP: &str = include_str!("../sql/007-notes-seq.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -150,6 +152,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 6,
         name: "brain_retune_driver",
         up: V6_UP,
+    },
+    VersionedMigration {
+        version: 7,
+        name: "notes_seq",
+        up: V7_UP,
     },
 ];
 

--- a/crates/khive-db/src/migrations.rs
+++ b/crates/khive-db/src/migrations.rs
@@ -114,6 +114,8 @@ const V6_UP: &str = include_str!("../sql/006-brain-retune-driver.sql");
 
 const V7_UP: &str = include_str!("../sql/007-notes-seq.sql");
 
+const V8_UP: &str = include_str!("../sql/008-notes-seq-repair.sql");
+
 /// DDL for the `_embedding_models` registry table.
 ///
 /// Shared between the V1 schema and the belt-and-suspenders creation in
@@ -157,6 +159,11 @@ pub const MIGRATIONS: &[VersionedMigration] = &[
         version: 7,
         name: "notes_seq",
         up: V7_UP,
+    },
+    VersionedMigration {
+        version: 8,
+        name: "notes_seq_repair",
+        up: V8_UP,
     },
 ];
 

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -690,35 +690,20 @@ impl NoteStore for SqlNoteStore {
     async fn upsert_notes(&self, notes: Vec<Note>) -> Result<BatchWriteSummary, StorageError> {
         let attempted = notes.len() as u64;
 
-        // ADR-067 Component A: when the write queue is enabled, route
-        // through the pool-wide WriterTask. DML-only closure — no BEGIN
-        // IMMEDIATE/COMMIT/ROLLBACK here, since the WriterTask's run loop
-        // owns the transaction (a bare BEGIN IMMEDIATE here would violate
-        // SQLite's nested-transaction rule).
-        if let Some(writer_task) = &self.writer_task {
-            return writer_task
-                .send(move |conn| {
-                    batch_upsert_notes(conn, &notes, attempted)
-                        .map_err(|e| map_err(e, "upsert_notes"))
-                })
-                .await;
-        }
-
-        // Flag-off (default) path: byte-for-byte unchanged from pre-ADR-067
-        // behavior — the closure owns its own BEGIN IMMEDIATE/COMMIT/ROLLBACK
-        // via the pool-mutex writer.
-        self.with_writer("upsert_notes", move |conn| {
-            conn.execute_batch("BEGIN IMMEDIATE")?;
+        // khive #827 Finding 2 (round 3): route through `with_writer_tx`
+        // instead of hand-rolling BEGIN IMMEDIATE/COMMIT/ROLLBACK here. The
+        // old flag-off path only rolled back when the final COMMIT failed —
+        // an earlier error from `batch_upsert_notes` (e.g. a failed
+        // `assign_note_seq`) propagated via `?` straight out of the closure,
+        // skipping ROLLBACK entirely and leaving BEGIN IMMEDIATE open on the
+        // shared pool-mutex connection, poisoning every later write on that
+        // connection. `with_writer_tx` rolls back on ANY error from `f`, on
+        // both the flag-on (WriterTask, which wraps its own transaction) and
+        // flag-off (pool-mutex) paths.
+        self.with_writer_tx("upsert_notes", move |conn| {
             let _tx_handle =
                 khive_storage::tx_registry::register(Some("note_upsert_batch".to_string()));
-
-            let summary = batch_upsert_notes(conn, &notes, attempted)?;
-
-            if let Err(e) = conn.execute_batch("COMMIT") {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-            Ok(summary)
+            batch_upsert_notes(conn, &notes, attempted)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -81,6 +81,35 @@ pub fn note_upsert_statement(note: &Note) -> SqlStatement {
     }
 }
 
+/// The exact `properties`/`updated_at` `UPDATE` this store's
+/// `update_note_properties` issues. A real `UPDATE` never triggers SQLite's
+/// `INSERT OR REPLACE` delete+insert, so the row's `rowid` stays stable
+/// across the call (#780: `comm.read` relies on this to avoid churning the
+/// `rowid`-backed `comm.probe` cursor).
+pub fn note_update_properties_statement(
+    id: Uuid,
+    properties: &Option<serde_json::Value>,
+    updated_at: i64,
+) -> SqlStatement {
+    let properties_str = properties
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_default());
+    SqlStatement {
+        sql: "UPDATE notes SET properties = ?1, updated_at = ?2 \
+              WHERE id = ?3 AND deleted_at IS NULL"
+            .to_string(),
+        params: vec![
+            match properties_str {
+                Some(p) => SqlValue::Text(p),
+                None => SqlValue::Null,
+            },
+            SqlValue::Integer(updated_at),
+            SqlValue::Text(id.to_string()),
+        ],
+        label: Some("note-update-properties".to_string()),
+    }
+}
+
 /// The exact soft-delete `UPDATE` this store's `delete_note(Soft)` issues.
 pub fn note_soft_delete_statement(id: Uuid, deleted_at: i64) -> SqlStatement {
     SqlStatement {
@@ -488,6 +517,21 @@ impl NoteStore for SqlNoteStore {
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
             Ok(())
+        })
+        .await
+    }
+
+    async fn update_note_properties(
+        &self,
+        id: Uuid,
+        properties: Option<serde_json::Value>,
+        updated_at: i64,
+    ) -> Result<bool, StorageError> {
+        let statement = note_update_properties_statement(id, &properties, updated_at);
+        self.with_writer("update_note_properties", move |conn| {
+            let mut stmt = conn.prepare(&statement.sql)?;
+            bind_params(&mut stmt, &statement.params)?;
+            Ok(stmt.raw_execute()? > 0)
         })
         .await
     }

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -341,7 +341,10 @@ fn batch_upsert_notes(
                 note.deleted_at,
             ],
         ) {
-            Ok(_) => affected += 1,
+            Ok(_) => {
+                assign_note_seq(conn, &id_str)?;
+                affected += 1;
+            }
             Err(e) => {
                 if first_error.is_empty() {
                     first_error = e.to_string();
@@ -357,6 +360,20 @@ fn batch_upsert_notes(
         failed,
         first_error,
     })
+}
+
+/// Assign a note id its durable, non-reusing sequence number the first time
+/// it is inserted (khive #827 — see `sql/007-notes-seq.sql`). `INSERT OR
+/// IGNORE` makes this idempotent across an `INSERT OR REPLACE`
+/// delete+reinsert of the same note id: the sequence value is fixed at the
+/// note's first insert and never reassigned, unlike `notes`' own implicit
+/// rowid.
+fn assign_note_seq(conn: &rusqlite::Connection, note_id: &str) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT OR IGNORE INTO notes_seq (note_id) VALUES (?1)",
+        rusqlite::params![note_id],
+    )?;
+    Ok(())
 }
 
 fn build_note_where(
@@ -511,11 +528,13 @@ fn build_note_filter_where(
 #[async_trait]
 impl NoteStore for SqlNoteStore {
     async fn upsert_note(&self, note: Note) -> Result<(), StorageError> {
+        let id_str = note.id.to_string();
         let statement = note_upsert_statement(&note);
         self.with_writer("upsert_note", move |conn| {
             let mut stmt = conn.prepare(&statement.sql)?;
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
+            assign_note_seq(conn, &id_str)?;
             Ok(())
         })
         .await
@@ -579,6 +598,7 @@ impl NoteStore for SqlNoteStore {
             )?;
 
             if rows > 0 {
+                assign_note_seq(conn, &id_str)?;
                 return Ok(true);
             }
 

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -188,15 +188,18 @@ impl SqlNoteStore {
     /// `KHIVE_WRITE_QUEUE=1` and a handle is available; otherwise fall back
     /// to the legacy pool-mutex path (ADR-067 Component A, Fork C slice 2).
     ///
-    /// This is the ONE routing point for every `with_writer` caller in this
-    /// store (`upsert_note`, `try_insert_note`, `delete_note`). `f` must be
+    /// This is the routing point for single-statement `with_writer` callers
+    /// in this store (`update_note_properties`, `delete_note`). `f` must be
     /// DML-only — on the flag-on path it runs inside the WriterTask's own
     /// transaction, so a bare `BEGIN IMMEDIATE` would violate SQLite's
     /// nested-transaction rule. `upsert_notes` (the batch method) does its
     /// own flag check and returns early on `Some`, so its fallback call
     /// into this helper only ever executes on the flag-off path
     /// (`self.writer_task` is `None` by construction whenever that call is
-    /// reached) — no double-routing.
+    /// reached) — no double-routing. Callers whose `f` issues more than one
+    /// DML statement that must land atomically together (`upsert_note`,
+    /// `try_insert_note`) use [`Self::with_writer_tx`] instead — see its doc
+    /// comment (khive #827 Finding 2).
     async fn with_writer<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
     where
         F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
@@ -212,6 +215,54 @@ impl SqlNoteStore {
         tokio::task::spawn_blocking(move || {
             let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
             f(guard.conn()).map_err(|e| map_err(e, op))
+        })
+        .await
+        .map_err(|e| StorageError::driver(StorageCapability::Notes, op, e))?
+    }
+
+    /// Like [`Self::with_writer`], but for callers whose closure issues more
+    /// than one DML statement that must land atomically together (khive
+    /// #827 Finding 2): a single-note insert immediately followed by
+    /// `assign_note_seq`. On the flag-on path the WriterTask already wraps
+    /// every request in its own `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`, so `f`
+    /// is sent unwrapped, same as `with_writer`. On the flag-off (pool-mutex)
+    /// path, `with_writer` runs `f` in SQLite's default autocommit mode --
+    /// each statement inside `f` is its own implicit transaction -- so a
+    /// crash or interleaving between the insert and the sequence assignment
+    /// can strand a note that `comm.probe`'s `INNER JOIN notes_seq` will
+    /// never see again. This wraps that path in one explicit transaction,
+    /// matching `upsert_notes`' own flag-off branch.
+    async fn with_writer_tx<F, R>(&self, op: &'static str, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<R, rusqlite::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        if let Some(writer_task) = &self.writer_task {
+            return writer_task
+                .send(move |conn| f(conn).map_err(|e| map_err(e, op)))
+                .await;
+        }
+
+        let pool = Arc::clone(&self.pool);
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.try_writer().map_err(|e| map_sqlite_err(e, op))?;
+            let conn = guard.conn();
+            conn.execute_batch("BEGIN IMMEDIATE")
+                .map_err(|e| map_err(e, op))?;
+
+            match f(conn) {
+                Ok(value) => match conn.execute_batch("COMMIT") {
+                    Ok(()) => Ok(value),
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        Err(map_err(e, op))
+                    }
+                },
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(map_err(e, op))
+                }
+            }
         })
         .await
         .map_err(|e| StorageError::driver(StorageCapability::Notes, op, e))?
@@ -530,7 +581,7 @@ impl NoteStore for SqlNoteStore {
     async fn upsert_note(&self, note: Note) -> Result<(), StorageError> {
         let id_str = note.id.to_string();
         let statement = note_upsert_statement(&note);
-        self.with_writer("upsert_note", move |conn| {
+        self.with_writer_tx("upsert_note", move |conn| {
             let mut stmt = conn.prepare(&statement.sql)?;
             bind_params(&mut stmt, &statement.params)?;
             stmt.raw_execute()?;
@@ -574,7 +625,7 @@ impl NoteStore for SqlNoteStore {
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
 
-        self.with_writer("try_insert_note", move |conn| {
+        self.with_writer_tx("try_insert_note", move |conn| {
             let rows = conn.execute(
                 "INSERT OR IGNORE INTO notes \
                  (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -960,8 +960,25 @@ impl NoteStore for SqlNoteStore {
 
 const NOTES_DDL: &str = include_str!("../../sql/notes-ddl.sql");
 
+/// Same anti-join repair as `sql/008-notes-seq-repair.sql` (the V8 forward
+/// migration) -- shared via `include_str!` from that single source file
+/// rather than duplicated as SQL text. `INSERT OR IGNORE` targets notes
+/// still missing a `notes_seq` row specifically, so it is correct to run
+/// against a fresh ledger, a partially populated one, or an already fully
+/// repaired one.
+const NOTES_SEQ_REPAIR_DDL: &str = include_str!("../../sql/008-notes-seq-repair.sql");
+
 pub(crate) fn ensure_notes_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(NOTES_DDL)
+}
+
+/// Anti-join backfill of `notes_seq` for any note still missing a row
+/// (khive #827 round 3). Scans `notes` in full, so callers MUST gate this to
+/// run at most once per backend/pool rather than on every store acquisition
+/// (khive #827 round 4 perf finding) -- see
+/// `StorageBackend::notes_for_namespace`.
+pub(crate) fn repair_notes_seq(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(NOTES_SEQ_REPAIR_DDL)
 }
 
 #[cfg(test)]

--- a/crates/khive-db/src/stores/note.rs
+++ b/crates/khive-db/src/stores/note.rs
@@ -83,9 +83,11 @@ pub fn note_upsert_statement(note: &Note) -> SqlStatement {
 
 /// The exact `properties`/`updated_at` `UPDATE` this store's
 /// `update_note_properties` issues. A real `UPDATE` never triggers SQLite's
-/// `INSERT OR REPLACE` delete+insert, so the row's `rowid` stays stable
-/// across the call (#780: `comm.read` relies on this to avoid churning the
-/// `rowid`-backed `comm.probe` cursor).
+/// `INSERT OR REPLACE` delete+insert, so the row is patched in place (#780).
+/// The `comm.probe` cursor is keyed on `notes_seq.seq`, which is fixed at
+/// first insert and survives a delete+reinsert of the same note id, so this
+/// is defensive rather than load-bearing for cursor correctness; a metadata
+/// patch should never rewrite the row regardless.
 pub fn note_update_properties_statement(
     id: Uuid,
     properties: &Option<serde_json::Value>,

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -386,6 +386,87 @@ async fn test_try_insert_note_pk_collision_returns_error_not_dedup() {
     );
 }
 
+// ── #827 Finding 2: single-note insert + notes_seq assignment atomicity ────
+
+/// Regression for #827 Finding 2: on the default flag-off (pool-mutex) path,
+/// `upsert_note` used to issue its INSERT into `notes` and `assign_note_seq`
+/// as two separate autocommit statements, so a crash or interleaving
+/// between them could strand a note with no `notes_seq` row -- permanently
+/// invisible to `comm.probe`'s `INNER JOIN notes_seq`. A `BEFORE INSERT`
+/// trigger on `notes_seq` injects a failure for one specific note id,
+/// simulating exactly that crash point (the `notes` INSERT has already run
+/// by the time this fires); the note row must not survive either, proving
+/// both statements now land in one transaction.
+#[tokio::test]
+async fn test_upsert_note_insert_and_seq_assignment_are_atomic() {
+    let store = setup_memory_store();
+
+    let fail_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap();
+    {
+        let writer = store.pool.try_writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!(
+                "CREATE TRIGGER inject_seq_failure_upsert BEFORE INSERT ON notes_seq \
+                 WHEN NEW.note_id = '{fail_id}' \
+                 BEGIN SELECT RAISE(ABORT, 'injected failure for #827 atomicity test'); END;"
+            ))
+            .unwrap();
+    }
+
+    let mut note = make_note("ns1", "message", "atomic test upsert_note");
+    note.id = fail_id;
+
+    let result = store.upsert_note(note).await;
+    assert!(
+        result.is_err(),
+        "the injected notes_seq trigger failure must surface as an error"
+    );
+
+    let fetched = store.get_note(fail_id).await.unwrap();
+    assert!(
+        fetched.is_none(),
+        "the note insert must roll back together with the failed sequence \
+         assignment, not strand the note without a notes_seq row: {fetched:?}"
+    );
+}
+
+/// Same regression as `test_upsert_note_insert_and_seq_assignment_are_atomic`
+/// for `try_insert_note`'s flag-off path.
+#[tokio::test]
+async fn test_try_insert_note_insert_and_seq_assignment_are_atomic() {
+    let store = setup_memory_store();
+
+    let fail_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap();
+    {
+        let writer = store.pool.try_writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!(
+                "CREATE TRIGGER inject_seq_failure_try_insert BEFORE INSERT ON notes_seq \
+                 WHEN NEW.note_id = '{fail_id}' \
+                 BEGIN SELECT RAISE(ABORT, 'injected failure for #827 atomicity test'); END;"
+            ))
+            .unwrap();
+    }
+
+    let mut note = make_note("ns1", "message", "atomic test try_insert_note");
+    note.id = fail_id;
+
+    let result = store.try_insert_note(note).await;
+    assert!(
+        result.is_err(),
+        "the injected notes_seq trigger failure must surface as an error"
+    );
+
+    let fetched = store.get_note(fail_id).await.unwrap();
+    assert!(
+        fetched.is_none(),
+        "the note insert must roll back together with the failed sequence \
+         assignment, not strand the note without a notes_seq row: {fetched:?}"
+    );
+}
+
 /// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
 /// InvalidInput for both list paths instead of silently narrowing to a
 /// negative i64 offset.

--- a/crates/khive-db/src/stores/note_tests.rs
+++ b/crates/khive-db/src/stores/note_tests.rs
@@ -467,6 +467,86 @@ async fn test_try_insert_note_insert_and_seq_assignment_are_atomic() {
     );
 }
 
+/// Regression for #827 round-3 Finding 2: on the flag-off (pool-mutex)
+/// path, `upsert_notes` used to run `batch_upsert_notes` inside a hand-rolled
+/// `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`, but only wired `ROLLBACK` to a
+/// failed `COMMIT` -- an error from `batch_upsert_notes` itself (e.g. a
+/// failed `assign_note_seq` mid-batch) propagated via `?` straight out of
+/// the closure, skipping `ROLLBACK` and leaving `BEGIN IMMEDIATE` open on
+/// the shared pool-mutex connection. A `BEFORE INSERT` trigger fails the
+/// sequence assignment for the SECOND note in a two-note batch (the first
+/// note's insert and `assign_note_seq` must already have succeeded by the
+/// time this fires); the whole batch must roll back -- neither note must
+/// survive -- and the connection must not be left poisoned: a subsequent
+/// write through the same pool must still succeed.
+#[tokio::test]
+async fn test_upsert_notes_batch_rolls_back_fully_on_mid_batch_seq_failure() {
+    let store = setup_memory_store();
+
+    let fail_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-0000000000cc").unwrap();
+    {
+        let writer = store.pool.try_writer().unwrap();
+        writer
+            .conn()
+            .execute_batch(&format!(
+                "CREATE TRIGGER inject_seq_failure_batch BEFORE INSERT ON notes_seq \
+                 WHEN NEW.note_id = '{fail_id}' \
+                 BEGIN SELECT RAISE(ABORT, 'injected mid-batch failure for #827 round-3 test'); END;"
+            ))
+            .unwrap();
+    }
+
+    let mut note_ok = make_note(
+        "ns1",
+        "message",
+        "first note in batch, seq assignment succeeds",
+    );
+    let ok_id = note_ok.id;
+    let mut note_fail = make_note(
+        "ns1",
+        "message",
+        "second note in batch, seq assignment fails",
+    );
+    note_fail.id = fail_id;
+    // Ensure iteration order is deterministic: note_ok first, note_fail second.
+    note_ok.created_at = 1_000_000;
+    note_fail.created_at = 1_000_001;
+
+    let result = store.upsert_notes(vec![note_ok, note_fail]).await;
+    assert!(
+        result.is_err(),
+        "the injected mid-batch notes_seq trigger failure must surface as an error, not a \
+         partial BatchWriteSummary: {result:?}"
+    );
+
+    let fetched_ok = store.get_note(ok_id).await.unwrap();
+    assert!(
+        fetched_ok.is_none(),
+        "the whole batch must roll back -- the first note (whose own insert and seq \
+         assignment succeeded) must not survive a later note's failure in the same batch: \
+         {fetched_ok:?}"
+    );
+    let fetched_fail = store.get_note(fail_id).await.unwrap();
+    assert!(
+        fetched_fail.is_none(),
+        "the failed note must not survive either: {fetched_fail:?}"
+    );
+
+    // The pool-mutex connection must not be left with an open transaction --
+    // a subsequent write on the same pool must succeed.
+    let next_note = make_note("ns1", "message", "write after rolled-back batch");
+    let next_id = next_note.id;
+    store
+        .upsert_note(next_note)
+        .await
+        .expect("a write after the rolled-back batch must succeed, not hang on an open BEGIN");
+    let fetched_next = store.get_note(next_id).await.unwrap();
+    assert!(
+        fetched_next.is_some(),
+        "the post-rollback write must actually land"
+    );
+}
+
 /// STORAGE-AUD-003 / #485: PageRequest.offset > i64::MAX must return
 /// InvalidInput for both list paths instead of silently narrowing to a
 /// negative i64 offset.

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -30,6 +30,8 @@ criterion = { workspace = true }
 toml = { workspace = true }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime", features = ["fault-injection"] }
 lattice-embed = { workspace = true }
+rusqlite = { workspace = true, features = ["bundled", "column_decltype"] }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "comm_bench"

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -30,21 +30,29 @@ Args:
 
 - `actor` (required) — actor label whose inbound queue is probed, e.g.
   `"lambda:leo"`.
-- `since_us` (optional) — cursor in Unix microseconds; only messages with
-  `created_at > since_us` are returned.
+- `since_us` (optional): cursor from a previous `comm.probe` response's
+  `cursor_us`; only messages committed after that cursor are returned.
 - `stale_minutes` (optional, default 20) — unread age threshold in minutes.
 
 Returns:
 
-- `cursor_us` — max `created_at` (µs) over all inbound messages for the
-  actor, or `0` if none exist.
+- `cursor_us`: an opaque, monotonically increasing token (currently backed
+  by SQLite `rowid`), or `0` if no inbound messages exist for the actor.
+  Round-trip it as the next call's `since_us`; do not treat it as a
+  timestamp or compute elapsed time from it (#780).
 - `new_messages` — up to 100 newest matching rows, each `{id, created_at_us,
-  from_actor, subject?}`, ordered ascending (newest-last).
+  from_actor, subject?}`, ordered ascending (newest-last) by `created_at`.
+  `created_at_us` is a real display timestamp, useful for "how long ago did
+  this arrive", but it is not the cursor and carries no ordering guarantee
+  relative to `cursor_us`.
 - `stale_unread_count` — count of inbound unread messages older than
   `stale_minutes`.
 
 The response shape is frozen: it is a public polling contract and must stay
-minimal and stable.
+minimal and stable. `cursor_us`/`since_us` keep their `_us`-suffixed wire
+names for backward compatibility even though the value is no longer a
+microsecond timestamp (issue #780); the representation is deliberately
+opaque so it can change again without a breaking rename.
 
 ## Dual-write delivery
 

--- a/crates/khive-pack-comm/README.md
+++ b/crates/khive-pack-comm/README.md
@@ -37,7 +37,8 @@ Args:
 Returns:
 
 - `cursor_us`: an opaque, monotonically increasing token (currently backed
-  by SQLite `rowid`), or `0` if no inbound messages exist for the actor.
+  by the durable `notes_seq.seq` commit-order sequence), or `0` if no
+  inbound messages exist for the actor.
   Round-trip it as the next call's `since_us`; do not treat it as a
   timestamp or compute elapsed time from it (#780).
 - `new_messages` — up to 100 newest matching rows, each `{id, created_at_us,

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -318,9 +318,11 @@ pub(crate) async fn handle_read(
 
     // Merge `read: true` into properties and patch in place via a real
     // `UPDATE` (not `upsert_note`'s `INSERT OR REPLACE`): the latter
-    // silently reassigns the row's `rowid` on a primary-key conflict, which
-    // would let a mark-as-read bump a message's `rowid` past the current
-    // `comm.probe` cursor and resurrect it as "new" on the next poll (#780).
+    // silently deletes and re-inserts the row on a primary-key conflict
+    // (#780). The `comm.probe` cursor is keyed on `notes_seq.seq`, which is
+    // fixed at first insert and survives such churn, so this is defensive
+    // rather than load-bearing; a metadata patch should never rewrite the
+    // row regardless.
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
     props["read"] = json!(true);
     let updated_at = Utc::now().timestamp_micros();

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -1481,16 +1481,35 @@ pub(crate) async fn handle_probe(
     })
 }
 
-/// Above this bound, a caller-supplied `since_us` is treated as a
-/// pre-upgrade persisted-timestamp cursor rather than a `notes_seq` value
-/// (#827): `notes_seq` starts at 1 and grows by exactly one per note ever
-/// inserted, so no real deployment comes anywhere near this bound, while any
-/// real Unix-microsecond timestamp from after 1970-01-12 already exceeds it
-/// by three orders of magnitude. A cursor above the bound is reset to
-/// baseline (treated as absent) instead of being compared against
-/// `notes_seq.seq`, where its enormous magnitude would silently suppress
-/// every message forever.
-const PROBE_CURSOR_PLAUSIBLE_MAX: i64 = 1_000_000_000_000;
+/// A caller-supplied `since_us` above `notes_seq`'s durable high-water mark
+/// (`sqlite_sequence.seq` for the `notes_seq` table) cannot be a genuine
+/// cursor -- `notes_seq` starts at 1 and grows by exactly one per note ever
+/// inserted, so no value this store ever handed out can exceed the highest
+/// value it has ever assigned. Such a `since_us` is a pre-upgrade
+/// persisted-timestamp cursor (#827): a real Unix-microsecond timestamp from
+/// after 1970-01-12 already exceeds any realistic note count by orders of
+/// magnitude. Comparing against the actual high-water mark, instead of a
+/// fixed ceiling, keeps this correct forever as `notes_seq` grows -- a fixed
+/// ceiling would eventually reset a legitimate high sequence value to
+/// baseline, contradicting `comm.probe`'s opaque round-trip contract
+/// (`vocab.rs`).
+async fn notes_seq_high_water_mark(
+    reader: &mut Box<dyn khive_storage::sql::SqlReader>,
+) -> Result<i64, RuntimeError> {
+    let row = reader
+        .query_row(khive_storage::types::SqlStatement {
+            sql: "SELECT seq FROM sqlite_sequence WHERE name = 'notes_seq'".into(),
+            params: vec![],
+            label: Some("comm_probe_notes_seq_hwm".into()),
+        })
+        .await
+        .map_err(RuntimeError::Storage)?;
+
+    match row.and_then(|r| r.get("seq").cloned()) {
+        Some(SqlValue::Integer(v)) => Ok(v),
+        _ => Ok(0),
+    }
+}
 
 async fn query_probe(
     runtime: &KhiveRuntime,
@@ -1499,12 +1518,18 @@ async fn query_probe(
     since_us: Option<i64>,
     stale_cutoff_us: i64,
 ) -> Result<ProbeResponse, RuntimeError> {
+    let sql = runtime.sql();
+    let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
+
+    let high_water_mark = notes_seq_high_water_mark(&mut reader).await?;
+
     let effective_since = match since_us {
-        Some(v) if v > PROBE_CURSOR_PLAUSIBLE_MAX => {
+        Some(v) if v > high_water_mark => {
             tracing::warn!(
                 actor,
                 since_us = v,
-                "comm.probe: since_us exceeds the plausible notes_seq range; treating it as a \
+                high_water_mark,
+                "comm.probe: since_us exceeds the notes_seq high-water mark; treating it as a \
                  stale pre-upgrade timestamp cursor and resetting to baseline"
             );
             None
@@ -1528,8 +1553,6 @@ async fn query_probe(
         label: Some("comm_probe".into()),
     };
 
-    let sql = runtime.sql();
-    let mut reader = sql.reader().await.map_err(RuntimeError::Storage)?;
     let rows = reader
         .query_all(statement)
         .await

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -1373,52 +1373,65 @@ pub(crate) struct ProbeMessage {
 /// skips comm schema-plan application, this query fails loudly instead of
 /// silently degrading to a table scan.
 ///
-/// `cursor_us`/`since_us` are keyed on SQLite `rowid`, not `created_at`
-/// (#780): `created_at` is an application-clock read taken before a note's
-/// write acquires the writer critical section, so two concurrent writers can
-/// commit out of stamp order, so a `created_at`-keyed cursor can then advance
-/// past a row that committed *after* it, permanently hiding that row from
-/// every later probe. `rowid` is assigned by SQLite exactly once, inside the
-/// one active writer transaction, so it is monotonic with commit order by
-/// construction. The wire field names keep the `_us` suffix (frozen contract,
-/// ADR-D5) but the value is an opaque monotonic token, not a microsecond
-/// timestamp; do not revert this to `created_at`. `created_at_us` on each
-/// `new_messages` entry is unaffected: it stays a real display timestamp,
-/// still ordered ascending by `created_at` for readability, and carries no
-/// cursor guarantee of its own.
+/// `cursor_us`/`since_us` are keyed on `notes_seq.seq`, not SQLite `rowid`
+/// and not `created_at` (#780, #827):
+///
+/// - `created_at` is an application-clock read taken before a note's write
+///   acquires the writer critical section, so two concurrent writers can
+///   commit out of stamp order; a `created_at`-keyed cursor can then advance
+///   past a row that committed *after* it, permanently hiding that row from
+///   every later probe.
+/// - `notes.rowid` looked monotonic with commit order, but `notes` has a
+///   TEXT PRIMARY KEY, so that rowid is *implicit*: SQLite may renumber it
+///   on `VACUUM` (khive exposes `memory.vacuum`), and reuses the highest
+///   rowid once that row is hard-deleted (khive exposes a public hard
+///   delete), either of which can permanently exclude a later message whose
+///   rowid lands at or below an already-issued cursor.
+///
+/// `notes_seq.seq` fixes both: it is assigned once, inside the same writer
+/// transaction as the note's insert, from a dedicated `INTEGER PRIMARY KEY
+/// AUTOINCREMENT` sequence that VACUUM never renumbers and SQLite never
+/// reuses (see `sql/007-notes-seq.sql`). The wire field names keep the `_us`
+/// suffix (frozen contract, ADR-D5) but the value is an opaque monotonic
+/// token, not a microsecond timestamp; do not revert this to `created_at` or
+/// `rowid`. `created_at_us` on each `new_messages` entry is unaffected: it
+/// stays a real display timestamp, still ordered ascending by `created_at`
+/// for readability, and carries no cursor guarantee of its own.
 const PROBE_SQL: &str = "WITH \
 stats AS ( \
     SELECT \
-        COALESCE(MAX(rowid), 0) AS cursor_us, \
+        COALESCE(MAX(notes_seq.seq), 0) AS cursor_us, \
         COALESCE(SUM( \
             CASE \
-                WHEN (json_type(properties, '$.read') IS NULL \
-                      OR json_type(properties, '$.read') != 'true') \
-                     AND created_at < ?4 \
+                WHEN (json_type(notes.properties, '$.read') IS NULL \
+                      OR json_type(notes.properties, '$.read') != 'true') \
+                     AND notes.created_at < ?4 \
                 THEN 1 ELSE 0 \
             END \
         ), 0) AS stale_unread_count \
     FROM notes INDEXED BY idx_comm_message_to_actor \
-    WHERE namespace = ?1 \
-      AND kind = 'message' \
-      AND deleted_at IS NULL \
-      AND json_extract(properties, '$.to_actor') = ?2 \
-      AND json_extract(properties, '$.direction') = 'inbound' \
+    JOIN notes_seq ON notes_seq.note_id = notes.id \
+    WHERE notes.namespace = ?1 \
+      AND notes.kind = 'message' \
+      AND notes.deleted_at IS NULL \
+      AND json_extract(notes.properties, '$.to_actor') = ?2 \
+      AND json_extract(notes.properties, '$.direction') = 'inbound' \
 ), \
 new_rows AS ( \
     SELECT \
-        id, \
-        created_at AS created_at_us, \
-        COALESCE(json_extract(properties, '$.from_actor'), namespace) AS from_actor, \
-        json_extract(properties, '$.subject') AS subject \
+        notes.id, \
+        notes.created_at AS created_at_us, \
+        COALESCE(json_extract(notes.properties, '$.from_actor'), notes.namespace) AS from_actor, \
+        json_extract(notes.properties, '$.subject') AS subject \
     FROM notes INDEXED BY idx_comm_message_to_actor \
-    WHERE namespace = ?1 \
-      AND kind = 'message' \
-      AND deleted_at IS NULL \
-      AND json_extract(properties, '$.to_actor') = ?2 \
-      AND json_extract(properties, '$.direction') = 'inbound' \
-      AND (?3 IS NULL OR rowid > ?3) \
-    ORDER BY created_at DESC \
+    JOIN notes_seq ON notes_seq.note_id = notes.id \
+    WHERE notes.namespace = ?1 \
+      AND notes.kind = 'message' \
+      AND notes.deleted_at IS NULL \
+      AND json_extract(notes.properties, '$.to_actor') = ?2 \
+      AND json_extract(notes.properties, '$.direction') = 'inbound' \
+      AND (?3 IS NULL OR notes_seq.seq > ?3) \
+    ORDER BY notes.created_at DESC \
     LIMIT 100 \
 ) \
 SELECT \
@@ -1468,6 +1481,17 @@ pub(crate) async fn handle_probe(
     })
 }
 
+/// Above this bound, a caller-supplied `since_us` is treated as a
+/// pre-upgrade persisted-timestamp cursor rather than a `notes_seq` value
+/// (#827): `notes_seq` starts at 1 and grows by exactly one per note ever
+/// inserted, so no real deployment comes anywhere near this bound, while any
+/// real Unix-microsecond timestamp from after 1970-01-12 already exceeds it
+/// by three orders of magnitude. A cursor above the bound is reset to
+/// baseline (treated as absent) instead of being compared against
+/// `notes_seq.seq`, where its enormous magnitude would silently suppress
+/// every message forever.
+const PROBE_CURSOR_PLAUSIBLE_MAX: i64 = 1_000_000_000_000;
+
 async fn query_probe(
     runtime: &KhiveRuntime,
     namespace: &str,
@@ -1475,7 +1499,20 @@ async fn query_probe(
     since_us: Option<i64>,
     stale_cutoff_us: i64,
 ) -> Result<ProbeResponse, RuntimeError> {
-    let since_param = match since_us {
+    let effective_since = match since_us {
+        Some(v) if v > PROBE_CURSOR_PLAUSIBLE_MAX => {
+            tracing::warn!(
+                actor,
+                since_us = v,
+                "comm.probe: since_us exceeds the plausible notes_seq range; treating it as a \
+                 stale pre-upgrade timestamp cursor and resetting to baseline"
+            );
+            None
+        }
+        other => other,
+    };
+
+    let since_param = match effective_since {
         Some(v) => SqlValue::Integer(v),
         None => SqlValue::Null,
     };
@@ -1533,6 +1570,18 @@ async fn query_probe(
             from_actor,
             subject,
         });
+    }
+
+    // Never let the returned cursor regress below what the caller already
+    // holds (#827): if the message that previously held the highest
+    // `notes_seq.seq` was hard-deleted since the last probe, `MAX(seq)` over
+    // the remaining rows can be smaller than a cursor already handed out.
+    // Clamping here, rather than in SQL, keeps the single indexed query a
+    // pure aggregate with no extra branch.
+    if let Some(floor) = effective_since {
+        if cursor_us < floor {
+            cursor_us = floor;
+        }
     }
 
     Ok(ProbeResponse {

--- a/crates/khive-pack-comm/src/handlers.rs
+++ b/crates/khive-pack-comm/src/handlers.rs
@@ -283,7 +283,7 @@ pub(crate) async fn handle_read(
     let id = resolve_id(runtime, token, &p.id, "read").await?;
 
     let store = runtime.notes(token)?;
-    let mut note = store
+    let note = store
         .get_note(id)
         .await
         .map_err(|e| RuntimeError::Internal(format!("read: get_note: {e}")))?
@@ -316,16 +316,19 @@ pub(crate) async fn handle_read(
         )));
     }
 
-    // Merge `read: true` into properties.
+    // Merge `read: true` into properties and patch in place via a real
+    // `UPDATE` (not `upsert_note`'s `INSERT OR REPLACE`): the latter
+    // silently reassigns the row's `rowid` on a primary-key conflict, which
+    // would let a mark-as-read bump a message's `rowid` past the current
+    // `comm.probe` cursor and resurrect it as "new" on the next poll (#780).
     let mut props = note.properties.clone().unwrap_or_else(|| json!({}));
     props["read"] = json!(true);
-    note.properties = Some(props.clone());
-    note.updated_at = Utc::now().timestamp_micros();
+    let updated_at = Utc::now().timestamp_micros();
 
     store
-        .upsert_note(note)
+        .update_note_properties(id, Some(props.clone()), updated_at)
         .await
-        .map_err(|e| RuntimeError::Internal(format!("read: upsert_note: {e}")))?;
+        .map_err(|e| RuntimeError::Internal(format!("read: update_note_properties: {e}")))?;
 
     Ok(
         json!({ "id": short_id(id), "full_id": id.as_hyphenated().to_string(), "read": true, "properties": props }),
@@ -1369,10 +1372,24 @@ pub(crate) struct ProbeMessage {
 /// idx_comm_message_to_actor` is a regression fence: if a custom bootstrap
 /// skips comm schema-plan application, this query fails loudly instead of
 /// silently degrading to a table scan.
+///
+/// `cursor_us`/`since_us` are keyed on SQLite `rowid`, not `created_at`
+/// (#780): `created_at` is an application-clock read taken before a note's
+/// write acquires the writer critical section, so two concurrent writers can
+/// commit out of stamp order, so a `created_at`-keyed cursor can then advance
+/// past a row that committed *after* it, permanently hiding that row from
+/// every later probe. `rowid` is assigned by SQLite exactly once, inside the
+/// one active writer transaction, so it is monotonic with commit order by
+/// construction. The wire field names keep the `_us` suffix (frozen contract,
+/// ADR-D5) but the value is an opaque monotonic token, not a microsecond
+/// timestamp; do not revert this to `created_at`. `created_at_us` on each
+/// `new_messages` entry is unaffected: it stays a real display timestamp,
+/// still ordered ascending by `created_at` for readability, and carries no
+/// cursor guarantee of its own.
 const PROBE_SQL: &str = "WITH \
 stats AS ( \
     SELECT \
-        COALESCE(MAX(created_at), 0) AS cursor_us, \
+        COALESCE(MAX(rowid), 0) AS cursor_us, \
         COALESCE(SUM( \
             CASE \
                 WHEN (json_type(properties, '$.read') IS NULL \
@@ -1400,7 +1417,7 @@ new_rows AS ( \
       AND deleted_at IS NULL \
       AND json_extract(properties, '$.to_actor') = ?2 \
       AND json_extract(properties, '$.direction') = 'inbound' \
-      AND (?3 IS NULL OR created_at > ?3) \
+      AND (?3 IS NULL OR rowid > ?3) \
     ORDER BY created_at DESC \
     LIMIT 100 \
 ) \

--- a/crates/khive-pack-comm/src/vocab.rs
+++ b/crates/khive-pack-comm/src/vocab.rs
@@ -377,7 +377,7 @@ pub(crate) static COMM_HANDLERS: [HandlerDef; 11] = [
                 name: "since_us",
                 param_type: "integer",
                 required: false,
-                description: "Cursor in Unix microseconds; only messages with created_at > since_us are returned.",
+                description: "Opaque cursor round-tripped from a previous comm.probe response's cursor_us; only messages committed after it are returned. Omit for a baseline-first probe. Not a computable timestamp.",
             },
             ParamDef {
                 name: "stale_minutes",

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -146,7 +146,7 @@ async fn probe_cursor_advances_and_filters_since_us() {
 }
 
 /// Regression for #780: the probe cursor must be keyed on commit order
-/// (SQLite `rowid`), not the application-clock `created_at` stamped before a
+/// (the durable `notes_seq.seq`), not the application-clock `created_at` stamped before a
 /// write acquires the writer critical section. Two concurrent writers can
 /// commit out of stamp order; a `created_at`-keyed cursor then permanently
 /// hides whichever row committed second but stamped an earlier clock read.
@@ -191,9 +191,9 @@ async fn probe_survives_out_of_order_commit_vs_created_at() {
     let second_messages = second["new_messages"].as_array().expect("array");
 
     // Under the OLD created_at-keyed cursor, t_low <= cursor_1 (t_high) would
-    // exclude the loser forever. Under the FIXED rowid-keyed cursor, the
-    // loser's rowid is still greater than cursor_1's, regardless of its
-    // created_at value.
+    // exclude the loser forever. Under the FIXED commit-order cursor
+    // (`notes_seq.seq`), the loser's sequence is still greater than
+    // cursor_1's, regardless of its created_at value.
     assert_eq!(
         second_messages.len(),
         1,
@@ -582,10 +582,11 @@ async fn probe_query_plan_uses_the_to_actor_index() {
 
 /// Regression for #780's paired hazard: `comm.read` must patch a message's
 /// `properties` via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE`
-/// (a SQLite DELETE+INSERT on a primary-key conflict, which reassigns the
-/// row's implicit `rowid`). If `comm.read` churned `rowid`, marking an
-/// already-probed message as read could bump its `rowid` past the current
-/// cursor, resurrecting it as "new" on the next poll.
+/// (a SQLite DELETE+INSERT on a primary-key conflict, which rewrites the
+/// row). The cursor is now keyed on `notes_seq.seq`, which is fixed at first
+/// insert and survives such churn, so this guards the defensive in-place
+/// invariant: marking an already-probed message as read must never make it
+/// resurface as "new" on the next poll.
 #[tokio::test]
 async fn probe_read_does_not_resurrect_message_via_rowid_churn() {
     let (registry, rt) = build_registry();
@@ -593,7 +594,7 @@ async fn probe_read_does_not_resurrect_message_via_rowid_churn() {
 
     let id = plant_inbound_message(&rt, actor, "lambda:khive", 1_000_000, None, false).await;
 
-    // Probe past it: the cursor now covers this message's rowid.
+    // Probe past it: the cursor now covers this message's commit-order key.
     let first = registry
         .dispatch("comm.probe", json!({ "actor": actor }))
         .await

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -8,8 +8,13 @@
 //! `build_registry()` fixture intentionally does not apply schema plans, and
 //! changing it would be a behavior change for unrelated tests in that file.
 
+use std::sync::Arc;
+
 use khive_pack_comm::CommPack;
-use khive_runtime::{KhiveRuntime, Namespace, VerbRegistry, VerbRegistryBuilder};
+use khive_runtime::{
+    AllowAllGate, BackendId, KhiveRuntime, Namespace, RuntimeConfig, VerbRegistry,
+    VerbRegistryBuilder,
+};
 use khive_storage::note::Note;
 use khive_storage::types::DeleteMode;
 use serde_json::json;
@@ -806,5 +811,180 @@ async fn probe_resets_implausible_pre_upgrade_timestamp_cursor_to_baseline() {
         1,
         "an implausible pre-upgrade timestamp cursor must reset to baseline, not \
          permanently suppress messages: {messages:?}"
+    );
+}
+
+/// Regression for #827 Finding 3: `notes_seq` has no fixed ceiling on how
+/// high a legitimate sequence value can grow. A `since_us` far above the
+/// old fixed `1_000_000_000_000` cutoff, but still at or below the actual
+/// `notes_seq` high-water mark, must round-trip normally -- not be reset to
+/// baseline. This directly exercises `comm.probe`'s opaque round-trip
+/// contract (`vocab.rs`): whatever `cursor_us` a probe hands back must work
+/// as `since_us` on the next call, at any magnitude.
+#[tokio::test]
+async fn probe_round_trips_a_legitimately_high_sequence_cursor() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    // Plant enough messages to push notes_seq comfortably past the old fixed
+    // 1_000_000_000_000 cutoff would have been irrelevant at this count, so
+    // instead directly advance the `notes_seq` AUTOINCREMENT high-water mark
+    // past that bound, then plant one real message after it.
+    // The comm pack's notes DDL bootstrap (`notes-ddl.sql`) already registers
+    // a `notes_seq` row in `sqlite_sequence` (at `seq = 0`) as a side effect
+    // of its own idempotent backfill `INSERT ... SELECT`, even before any
+    // real note is ever inserted -- so this advances that existing row via
+    // `UPDATE` rather than inserting a second, conflicting one (SQLite's
+    // AUTOINCREMENT bookkeeping does not enforce uniqueness on `name` at the
+    // SQL layer, so a duplicate row would silently be ignored by the
+    // engine's internal lookup).
+    let sql = rt.sql();
+    {
+        let mut writer = sql.writer().await.expect("writer");
+        writer
+            .execute_script(
+                "UPDATE sqlite_sequence SET seq = 2000000000000 WHERE name = 'notes_seq';"
+                    .to_string(),
+            )
+            .await
+            .expect("advance notes_seq high-water mark");
+    }
+
+    let t1 = 1_000_000_i64;
+    plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
+
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+    assert!(
+        cursor_1 > 1_000_000_000_000,
+        "the planted message's sequence value must exceed the old fixed cutoff: {cursor_1}"
+    );
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 1);
+
+    let t2 = 2_000_000_i64;
+    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    let messages = second["new_messages"].as_array().expect("array");
+    assert_eq!(
+        messages.len(),
+        1,
+        "a legitimately high sequence cursor must round-trip, not be reset to \
+         baseline and replay the first message: {messages:?}"
+    );
+    assert_eq!(messages[0]["id"], json!(id2.to_string()));
+}
+
+/// Regression for #827 Finding 1: `V7` (`sql/007-notes-seq.sql`) must
+/// backfill `notes_seq` for every note that already existed on a populated
+/// V6 database, not just notes inserted after the upgrade. Without the
+/// backfill, `comm.probe`'s `INNER JOIN notes_seq` would silently drop every
+/// pre-existing inbound message from `new_messages`, `cursor_us`, and
+/// `stale_unread_count` forever.
+#[tokio::test]
+async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("v6_upgrade.db");
+    let actor = "lambda:leo";
+    let pre_existing_id = Uuid::new_v4();
+
+    // Build a V6-state database directly: apply only migrations up to V6,
+    // then insert a pre-existing inbound message the old way -- `notes_seq`
+    // does not exist yet at V6, so this note has no sequence row.
+    {
+        let backend = khive_db::StorageBackend::sqlite(&path).expect("open v6 backend");
+        let writer = backend.pool().try_writer().expect("writer");
+        let conn = writer.conn();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS _schema_migrations ( \
+                 version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at INTEGER NOT NULL);",
+        )
+        .expect("create migration tracking table");
+
+        let now = chrono::Utc::now().timestamp_micros();
+        for migration in khive_db::migrations::MIGRATIONS
+            .iter()
+            .filter(|m| m.version <= 6)
+        {
+            conn.execute_batch(migration.up)
+                .unwrap_or_else(|e| panic!("apply V{}: {e}", migration.version));
+            conn.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![migration.version, migration.name, now],
+            )
+            .unwrap_or_else(|e| panic!("record V{}: {e}", migration.version));
+        }
+
+        conn.execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+              properties, created_at, updated_at, deleted_at) \
+             VALUES (?1, 'local', 'message', 'active', NULL, 'pre-existing v6 message', \
+                     NULL, NULL, NULL, ?2, ?3, ?3, NULL)",
+            rusqlite::params![
+                pre_existing_id.to_string(),
+                json!({
+                    "direction": "inbound",
+                    "to_actor": actor,
+                    "from_actor": "lambda:khive",
+                    "read": false,
+                })
+                .to_string(),
+                1_000_000_i64,
+            ],
+        )
+        .expect("insert pre-existing v6 message");
+    }
+
+    // Reopen through the normal runtime boot path -- this runs
+    // `run_migrations` to latest, including V7's backfill.
+    let config = RuntimeConfig {
+        db_path: Some(path.clone()),
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "comm".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    };
+    let runtime = KhiveRuntime::new(config).expect("runtime reopens and migrates to latest");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(CommPack::new(runtime.clone()));
+    let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(runtime.backend());
+
+    let result = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds after v6->v7 upgrade");
+
+    let messages = result["new_messages"].as_array().expect("array");
+    assert_eq!(
+        messages.len(),
+        1,
+        "the pre-existing V6 message must be backfilled into notes_seq and appear \
+         in the first probe after upgrading to V7: {messages:?}"
+    );
+    assert_eq!(messages[0]["id"], json!(pre_existing_id.to_string()));
+    assert!(
+        result["cursor_us"].as_i64().unwrap() > 0,
+        "cursor_us must reflect the backfilled pre-existing message: {result}"
     );
 }

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -988,3 +988,195 @@ async fn probe_backfills_pre_existing_messages_across_v6_to_v7_upgrade() {
         "cursor_us must reflect the backfilled pre-existing message: {result}"
     );
 }
+
+/// Regression for #827 round-3 Finding 1: the *original* V7 migration (head
+/// 87c25939, before round 2 added a backfill) only created `notes_seq` --
+/// it never backfilled anything. A database that already ran that original
+/// V7 body has `version = 7` recorded in `_schema_migrations`, so
+/// `run_migrations` will never re-run V7's body again, no matter how it is
+/// edited later. Round 2 (9b829cf4) edited `007-notes-seq.sql` in place to
+/// add a backfill -- but on a database that already applied the original
+/// V7, that edited body never executes, and round 2's *lazy* bootstrap
+/// backfill (`notes-ddl.sql`) was itself gated on `notes_seq` being
+/// globally empty. The moment exactly one note lands a `notes_seq` row
+/// through the ordinary write path, that guard sees a non-empty table and
+/// skips -- permanently stranding every older, still-unmapped note.
+///
+/// This builds exactly that ledger directly in SQLite: apply V1..V6, then
+/// the original (backfill-less) V7 body, recording `version = 7`; insert
+/// three pre-existing notes with no `notes_seq` row; insert one
+/// post-upgrade note WITH a manually assigned `notes_seq` row (partial
+/// population); and advance `sqlite_sequence` for `notes_seq` to a value
+/// far above any row actually present (a stale high-water mark, as if
+/// earlier rows had since been deleted). Reopening through the current
+/// code (V8's forward repair migration plus the fixed anti-join lazy
+/// bootstrap) must recover all three older notes in the very first probe.
+#[tokio::test]
+async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("v7_partial_upgrade.db");
+    let actor = "lambda:leo";
+    let counterpart = "lambda:khive";
+
+    let old_ids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+    let post_upgrade_id = Uuid::new_v4();
+
+    // The exact original V7 body (khive#827 head 87c25939): creates
+    // `notes_seq` but performs no backfill at all.
+    const V7_ORIGINAL_NO_BACKFILL: &str = "\
+        CREATE TABLE IF NOT EXISTS notes_seq ( \
+            seq     INTEGER PRIMARY KEY AUTOINCREMENT, \
+            note_id TEXT NOT NULL UNIQUE \
+        ); \
+        CREATE INDEX IF NOT EXISTS idx_notes_seq_note_id ON notes_seq(note_id);";
+
+    {
+        let backend = khive_db::StorageBackend::sqlite(&path).expect("open backend");
+        let writer = backend.pool().try_writer().expect("writer");
+        let conn = writer.conn();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS _schema_migrations ( \
+                 version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at INTEGER NOT NULL);",
+        )
+        .expect("create migration tracking table");
+
+        let now = chrono::Utc::now().timestamp_micros();
+        for migration in khive_db::migrations::MIGRATIONS
+            .iter()
+            .filter(|m| m.version <= 6)
+        {
+            conn.execute_batch(migration.up)
+                .unwrap_or_else(|e| panic!("apply V{}: {e}", migration.version));
+            conn.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![migration.version, migration.name, now],
+            )
+            .unwrap_or_else(|e| panic!("record V{}: {e}", migration.version));
+        }
+
+        // Apply the ORIGINAL (backfill-less) V7 body and record it as
+        // applied, simulating a database that upgraded before round 2.
+        conn.execute_batch(V7_ORIGINAL_NO_BACKFILL)
+            .expect("apply original backfill-less V7");
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at) VALUES (7, 'notes_seq', ?1)",
+            rusqlite::params![now],
+        )
+        .expect("record original V7 as applied");
+
+        // Three pre-existing (older) notes, inserted with no notes_seq row --
+        // exactly what the original V7 leaves behind.
+        for (i, id) in old_ids.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO notes \
+                 (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+                  properties, created_at, updated_at, deleted_at) \
+                 VALUES (?1, 'local', 'message', 'active', NULL, ?2, \
+                         NULL, NULL, NULL, ?3, ?4, ?4, NULL)",
+                rusqlite::params![
+                    id.to_string(),
+                    format!("pre-existing note {i}"),
+                    json!({
+                        "direction": "inbound",
+                        "to_actor": actor,
+                        "from_actor": counterpart,
+                        "read": false,
+                    })
+                    .to_string(),
+                    1_000_000_i64 + i as i64,
+                ],
+            )
+            .unwrap_or_else(|e| panic!("insert pre-existing note {i}: {e}"));
+        }
+
+        // One post-upgrade note, inserted the normal way -- WITH a
+        // notes_seq row, simulating `assign_note_seq` having run for it.
+        conn.execute(
+            "INSERT INTO notes \
+             (id, namespace, kind, status, name, content, salience, decay_factor, expires_at, \
+              properties, created_at, updated_at, deleted_at) \
+             VALUES (?1, 'local', 'message', 'active', NULL, 'post-upgrade note', \
+                     NULL, NULL, NULL, ?2, ?3, ?3, NULL)",
+            rusqlite::params![
+                post_upgrade_id.to_string(),
+                json!({
+                    "direction": "inbound",
+                    "to_actor": actor,
+                    "from_actor": counterpart,
+                    "read": false,
+                })
+                .to_string(),
+                2_000_000_i64,
+            ],
+        )
+        .expect("insert post-upgrade note");
+        conn.execute(
+            "INSERT INTO notes_seq (note_id) VALUES (?1)",
+            rusqlite::params![post_upgrade_id.to_string()],
+        )
+        .expect("assign notes_seq row to post-upgrade note");
+
+        // Advance the AUTOINCREMENT high-water mark far past the one row
+        // actually present, simulating earlier notes_seq rows having since
+        // been deleted (e.g. a hard-deleted note). The repair must still
+        // work correctly against a ledger whose next-assigned seq values
+        // are nowhere near contiguous with created_at order.
+        conn.execute(
+            "UPDATE sqlite_sequence SET seq = 500 WHERE name = 'notes_seq'",
+            [],
+        )
+        .expect("advance stale notes_seq high-water mark");
+    }
+
+    // Reopen through the normal runtime boot path -- this runs
+    // `run_migrations` to latest (including V8's forward repair) and the
+    // fixed anti-join lazy bootstrap.
+    let config = RuntimeConfig {
+        db_path: Some(path.clone()),
+        default_namespace: Namespace::local(),
+        embedding_model: None,
+        additional_embedding_models: vec![],
+        gate: Arc::new(AllowAllGate),
+        packs: vec!["kg".to_string(), "comm".to_string()],
+        backend_id: BackendId::main(),
+        brain_profile: None,
+        visible_namespaces: vec![],
+        allowed_outbound_namespaces: vec![],
+        actor_id: None,
+    };
+    let runtime = KhiveRuntime::new(config).expect("runtime reopens and migrates to latest");
+
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(khive_pack_kg::KgPack::new(runtime.clone()));
+    builder.register(CommPack::new(runtime.clone()));
+    let registry = builder.build().expect("registry builds");
+    registry.apply_schema_plans(runtime.backend());
+
+    let result = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds after partial-ledger v7->v8 upgrade");
+
+    let messages = result["new_messages"].as_array().expect("array");
+    let returned_ids: Vec<String> = messages
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+
+    for id in &old_ids {
+        assert!(
+            returned_ids.contains(&id.to_string()),
+            "pre-existing note {id} left unmapped by the original V7 must be repaired \
+             and appear in the first probe after upgrade: {returned_ids:?}"
+        );
+    }
+    assert!(
+        returned_ids.contains(&post_upgrade_id.to_string()),
+        "the already-mapped post-upgrade note must still appear: {returned_ids:?}"
+    );
+    assert_eq!(
+        messages.len(),
+        4,
+        "all three older notes plus the post-upgrade note must be visible: {messages:?}"
+    );
+}

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -102,27 +102,99 @@ async fn probe_cursor_advances_and_filters_since_us() {
 
     let t1 = 1_000_000_i64;
     let t2 = 2_000_000_i64;
-    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
     plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
 
-    let result = registry
-        .dispatch("comm.probe", json!({ "actor": actor, "since_us": t1 }))
+    // `cursor_us` is an opaque token round-tripped from a prior probe
+    // response (#780) -- not a raw timestamp a caller computes itself.
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 1);
+
+    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
         .await
         .expect("probe succeeds");
 
-    assert_eq!(
-        result["cursor_us"],
-        json!(t2),
-        "cursor is the max created_at"
+    assert!(
+        second["cursor_us"].as_i64().unwrap() > cursor_1,
+        "cursor advances past the previous token"
     );
-    let messages = result["new_messages"].as_array().expect("array");
+    let messages = second["new_messages"].as_array().expect("array");
     assert_eq!(
         messages.len(),
         1,
-        "only the message strictly newer than since_us is returned: {messages:?}"
+        "only the message planted after cursor_1 is returned: {messages:?}"
     );
     assert_eq!(messages[0]["id"], json!(id2.to_string()));
     assert_eq!(messages[0]["created_at_us"], json!(t2));
+}
+
+/// Regression for #780: the probe cursor must be keyed on commit order
+/// (SQLite `rowid`), not the application-clock `created_at` stamped before a
+/// write acquires the writer critical section. Two concurrent writers can
+/// commit out of stamp order; a `created_at`-keyed cursor then permanently
+/// hides whichever row committed second but stamped an earlier clock read.
+#[tokio::test]
+async fn probe_survives_out_of_order_commit_vs_created_at() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let t_high = 5_000_000_i64;
+    let t_low = 1_000_000_i64;
+
+    // "Winner" of the writer-lock race: commits FIRST, but its clock read
+    // (taken before the race) is LATER.
+    let id_winner = plant_inbound_message(&rt, actor, "lambda:khive", t_high, None, false).await;
+
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+    let first_messages = first["new_messages"].as_array().expect("array");
+    assert!(
+        first_messages
+            .iter()
+            .any(|m| m["id"] == json!(id_winner.to_string())),
+        "first probe must see the winner message: {first_messages:?}"
+    );
+
+    // "Loser": commits SECOND, but its clock read (taken before it lost the
+    // writer-lock race) is EARLIER than the winner's.
+    let id_loser = plant_inbound_message(&rt, actor, "lambda:khive", t_low, None, false).await;
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    let second_messages = second["new_messages"].as_array().expect("array");
+
+    // Under the OLD created_at-keyed cursor, t_low <= cursor_1 (t_high) would
+    // exclude the loser forever. Under the FIXED rowid-keyed cursor, the
+    // loser's rowid is still greater than cursor_1's, regardless of its
+    // created_at value.
+    assert_eq!(
+        second_messages.len(),
+        1,
+        "the loser message must be visible to the next probe, not permanently \
+         skipped: {second_messages:?}"
+    );
+    assert_eq!(second_messages[0]["id"], json!(id_loser.to_string()));
 }
 
 #[tokio::test]
@@ -369,7 +441,11 @@ async fn probe_ignores_messages_addressed_to_other_actors() {
         1,
         "a probe for one actor must not see another actor's inbound messages: {messages:?}"
     );
-    assert_eq!(result["cursor_us"], json!(1_000_000));
+    assert!(
+        result["cursor_us"].as_i64().unwrap() > 0,
+        "cursor must advance for the actor's own message, independent of the other \
+         actor's row: {result}"
+    );
 }
 
 #[tokio::test]
@@ -495,5 +571,44 @@ async fn probe_query_plan_uses_the_to_actor_index() {
     assert!(
         plan_text.contains("idx_comm_message_to_actor"),
         "query plan must use idx_comm_message_to_actor: {plan_text}"
+    );
+}
+
+/// Regression for #780's paired hazard: `comm.read` must patch a message's
+/// `properties` via a real `UPDATE`, not `upsert_note`'s `INSERT OR REPLACE`
+/// (a SQLite DELETE+INSERT on a primary-key conflict, which reassigns the
+/// row's implicit `rowid`). If `comm.read` churned `rowid`, marking an
+/// already-probed message as read could bump its `rowid` past the current
+/// cursor, resurrecting it as "new" on the next poll.
+#[tokio::test]
+async fn probe_read_does_not_resurrect_message_via_rowid_churn() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let id = plant_inbound_message(&rt, actor, "lambda:khive", 1_000_000, None, false).await;
+
+    // Probe past it: the cursor now covers this message's rowid.
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 1);
+
+    registry
+        .dispatch("comm.read", json!({ "id": id.to_string() }))
+        .await
+        .expect("comm.read succeeds");
+
+    let second = registry
+        .dispatch("comm.probe", json!({ "actor": actor, "since_us": cursor }))
+        .await
+        .expect("probe succeeds");
+    let second_messages = second["new_messages"].as_array().expect("array");
+    assert!(
+        second_messages.is_empty(),
+        "marking a message read must not resurrect it as new: {second_messages:?}"
     );
 }

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -1180,3 +1180,62 @@ async fn probe_repairs_partial_notes_seq_left_by_original_v7_on_reopen() {
         "all three older notes plus the post-upgrade note must be visible: {messages:?}"
     );
 }
+
+/// Regression for #827 round-4 perf finding: the notes_seq anti-join repair
+/// (`stores/note.rs::repair_notes_seq`, the same statement as V8's forward
+/// migration) used to run its full `notes` table scan plus a temp B-tree for
+/// the `ORDER BY` on *every* `notes_for_namespace` call -- on a large,
+/// already-repaired ledger that serialized every caller behind the writer
+/// mutex for a scan that could never find anything to repair. It must now
+/// run at most once per backend (`StorageBackend`) for the process's
+/// lifetime, gated by an atomic counter, not once per store acquisition.
+///
+/// Verified via `StorageBackend::notes_seq_repair_run_count` -- an actual
+/// count of how many times the repair statement executed -- not via timing,
+/// per the fix's own requirement that this be observable deterministically.
+#[tokio::test]
+async fn notes_seq_repair_runs_once_per_backend_not_per_store_acquisition() {
+    let (_registry, runtime) = build_registry();
+    let token = runtime
+        .authorize(Namespace::local())
+        .expect("authorize local namespace");
+
+    // `build_registry()` already acquired a NoteStore once (to create the
+    // `notes` table before applying schema plans), and `KhiveRuntime::new`/
+    // `memory()` already ran `run_migrations` (including V8's forward
+    // repair) before that -- so by this point the ledger is fully repaired
+    // and the lazy repair has run exactly once.
+    assert_eq!(
+        runtime.backend().notes_seq_repair_run_count(),
+        1,
+        "the first store acquisition on this backend must run the repair exactly once"
+    );
+
+    // Plant a genuine message so there is real traffic through the store on
+    // each acquisition below, then repeatedly re-acquire the NoteStore --
+    // the exact shape of every real request dispatch through
+    // `KhiveRuntime::notes`.
+    let note_id = plant_inbound_message(
+        &runtime,
+        "lambda:leo",
+        "lambda:khive",
+        1_000_000,
+        None,
+        false,
+    )
+    .await;
+    for _ in 0..5 {
+        let store = runtime.notes(&token).expect("notes store");
+        assert!(
+            store.get_note(note_id).await.expect("get_note").is_some(),
+            "the store returned on each acquisition must still be fully functional"
+        );
+    }
+
+    assert_eq!(
+        runtime.backend().notes_seq_repair_run_count(),
+        1,
+        "repeated store acquisition on an already-repaired ledger must not \
+         re-run the notes_seq anti-join repair"
+    );
+}

--- a/crates/khive-pack-comm/tests/probe.rs
+++ b/crates/khive-pack-comm/tests/probe.rs
@@ -11,6 +11,7 @@
 use khive_pack_comm::CommPack;
 use khive_runtime::{KhiveRuntime, Namespace, VerbRegistry, VerbRegistryBuilder};
 use khive_storage::note::Note;
+use khive_storage::types::DeleteMode;
 use serde_json::json;
 use uuid::Uuid;
 
@@ -610,5 +611,200 @@ async fn probe_read_does_not_resurrect_message_via_rowid_churn() {
     assert!(
         second_messages.is_empty(),
         "marking a message read must not resurrect it as new: {second_messages:?}"
+    );
+}
+
+/// Regression for #827 Finding 1(a): `notes` has a TEXT PRIMARY KEY, so it
+/// carries an *implicit* rowid that SQLite may renumber on `VACUUM` (khive
+/// exposes `memory.vacuum`). The cursor must survive a VACUUM between probes
+/// without losing or replaying any message.
+#[tokio::test]
+async fn probe_survives_vacuum_between_probes() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let t1 = 1_000_000_i64;
+    plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
+
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+    assert_eq!(first["new_messages"].as_array().unwrap().len(), 1);
+
+    // VACUUM the whole database between probes. If the cursor were still
+    // keyed on `notes`' implicit rowid, VACUUM could renumber it and either
+    // lose or replay messages relative to a previously issued cursor.
+    let sql = rt.sql();
+    {
+        let mut writer = sql.writer().await.expect("writer");
+        writer
+            .execute_script_top_level("VACUUM;".to_string())
+            .await
+            .expect("vacuum succeeds");
+    }
+
+    let t2 = 2_000_000_i64;
+    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    let messages = second["new_messages"].as_array().expect("array");
+    assert_eq!(
+        messages.len(),
+        1,
+        "VACUUM must not lose or replay messages: {messages:?}"
+    );
+    assert_eq!(messages[0]["id"], json!(id2.to_string()));
+
+    // Repeating the same `since_us` (simulating a retried poll) must not
+    // replay the first message either.
+    let replay_check = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    let replay_messages = replay_check["new_messages"].as_array().expect("array");
+    assert_eq!(
+        replay_messages.len(),
+        1,
+        "the first message must not be replayed after VACUUM: {replay_messages:?}"
+    );
+    assert_eq!(replay_messages[0]["id"], json!(id2.to_string()));
+}
+
+/// Regression for #827 Finding 1(b): SQLite reuses the highest rowid of a
+/// plain (non-AUTOINCREMENT) rowid table once that row is deleted. `notes`
+/// exposes a public hard delete, so deleting the note that currently holds
+/// the highest `notes_seq.seq` and then inserting a new note must not let
+/// the new note be silently excluded by a stale cursor.
+#[tokio::test]
+async fn probe_survives_delete_of_highest_seq_note_before_next_insert() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let t1 = 1_000_000_i64;
+    let id1 = plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
+
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+
+    let token = rt
+        .authorize(Namespace::local())
+        .expect("authorize local namespace");
+    let store = rt.notes(&token).expect("notes store");
+    let deleted = store
+        .delete_note(id1, DeleteMode::Hard)
+        .await
+        .expect("hard delete succeeds");
+    assert!(deleted, "the planted note must exist before deletion");
+
+    let t2 = 2_000_000_i64;
+    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    let messages = second["new_messages"].as_array().expect("array");
+    assert_eq!(
+        messages.len(),
+        1,
+        "a note inserted after the highest-seq note is hard-deleted must still be \
+         visible, not permanently excluded by rowid reuse: {messages:?}"
+    );
+    assert_eq!(messages[0]["id"], json!(id2.to_string()));
+}
+
+/// Regression for #827: the returned cursor must never regress below a
+/// caller-supplied `since_us`. `stats.cursor_us` is `MAX(notes_seq.seq)`
+/// over the currently-matching rows, so hard-deleting the row that held the
+/// highest seq can otherwise make a later probe report a smaller cursor than
+/// one it already handed out.
+#[tokio::test]
+async fn probe_cursor_never_regresses_below_caller_supplied_since_us() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let t1 = 1_000_000_i64;
+    let t2 = 2_000_000_i64;
+    plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
+    let id2 = plant_inbound_message(&rt, actor, "lambda:khive", t2, None, false).await;
+
+    let first = registry
+        .dispatch("comm.probe", json!({ "actor": actor }))
+        .await
+        .expect("probe succeeds");
+    let cursor_1 = first["cursor_us"]
+        .as_i64()
+        .expect("cursor_us is an integer");
+
+    let token = rt
+        .authorize(Namespace::local())
+        .expect("authorize local namespace");
+    let store = rt.notes(&token).expect("notes store");
+    store
+        .delete_note(id2, DeleteMode::Hard)
+        .await
+        .expect("hard delete succeeds");
+
+    let second = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": cursor_1 }),
+        )
+        .await
+        .expect("probe succeeds");
+    assert!(
+        second["cursor_us"].as_i64().unwrap() >= cursor_1,
+        "cursor must never regress below a previously issued since_us: {second}"
+    );
+}
+
+/// Regression for #827 Finding 2: a pre-upgrade persisted cursor was a raw
+/// Unix-microsecond `created_at` timestamp -- vastly larger than any real
+/// `notes_seq` value. Passing one back as `since_us` must reset to baseline
+/// instead of permanently suppressing every message.
+#[tokio::test]
+async fn probe_resets_implausible_pre_upgrade_timestamp_cursor_to_baseline() {
+    let (registry, rt) = build_registry();
+    let actor = "lambda:leo";
+
+    let t1 = 1_000_000_i64;
+    plant_inbound_message(&rt, actor, "lambda:khive", t1, None, false).await;
+
+    let stale_timestamp_cursor = 1_751_932_800_000_000_i64;
+    let result = registry
+        .dispatch(
+            "comm.probe",
+            json!({ "actor": actor, "since_us": stale_timestamp_cursor }),
+        )
+        .await
+        .expect("probe succeeds");
+
+    let messages = result["new_messages"].as_array().expect("array");
+    assert_eq!(
+        messages.len(),
+        1,
+        "an implausible pre-upgrade timestamp cursor must reset to baseline, not \
+         permanently suppress messages: {messages:?}"
     );
 }

--- a/crates/khive-storage/src/note.rs
+++ b/crates/khive-storage/src/note.rs
@@ -296,6 +296,22 @@ pub trait NoteStore: Send + Sync + 'static {
     async fn get_note_including_deleted(&self, id: Uuid) -> StorageResult<Option<Note>>;
     /// Delete a note by UUID using the specified delete mode.
     async fn delete_note(&self, id: Uuid, mode: DeleteMode) -> StorageResult<bool>;
+    /// Patch `properties`/`updated_at` on an existing note in place via a real
+    /// `UPDATE`, leaving every other column (including the row's `rowid`)
+    /// untouched.
+    ///
+    /// Unlike `upsert_note` (an `INSERT OR REPLACE`, which on a primary-key
+    /// conflict is a SQLite DELETE+INSERT that silently reassigns the row's
+    /// implicit `rowid`), this never churns `rowid`, which is required by any
+    /// caller relying on `rowid` as a stable, monotonically-increasing cursor (#780).
+    /// Returns `true` when a live (non-soft-deleted) row with this `id` was
+    /// found and updated, `false` otherwise.
+    async fn update_note_properties(
+        &self,
+        id: Uuid,
+        properties: Option<Value>,
+        updated_at: i64,
+    ) -> StorageResult<bool>;
     /// Query notes by namespace and optional kind with pagination.
     async fn query_notes(
         &self,

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -958,14 +958,19 @@ a single cheap indexed query. Returns a `cursor_us` high-water mark, a `stale_un
 of inbound messages unread past the staleness window, and a `new_messages` array of up to
 100 inbound rows `{id, created_at_us, from_actor, subject?}` newer than `since_us`.
 
+`cursor_us`/`since_us` is an opaque, monotonically increasing token, not a Unix microsecond
+timestamp: round-trip whatever the previous `comm.probe` response returned as the next
+call's `since_us`, and omit it for a baseline-first probe.
+
 | Param           | Type    | Required | Notes                                               |
 | --------------- | ------- | -------- | --------------------------------------------------- |
 | `actor`         | string  | yes      | Actor label whose inbound mail is probed.           |
-| `since_us`      | integer | no       | Microsecond-epoch cursor; only newer rows returned. |
+| `since_us`      | integer | no       | Opaque cursor from a prior response's `cursor_us`.  |
 | `stale_minutes` | integer | no       | Staleness window for the unread count (default 20). |
 
 ```
-request(ops="comm.probe(actor=\"lambda:leo\", since_us=1751932800000000)")
+request(ops="comm.probe(actor=\"lambda:leo\")")
+request(ops="comm.probe(actor=\"lambda:leo\", since_us=42)")
 ```
 
 ### `comm.health` — Assertive


### PR DESCRIPTION
## Summary

- `comm.probe` advanced its cursor on `COALESCE(MAX(created_at), 0)`, but `created_at` is an application-clock read taken before a note's write acquires the writer critical section. Two concurrent writers can commit out of stamp order, so the cursor could advance past a row that commits *after* it but was stamped with an earlier `created_at` — that row becomes permanently invisible to every future probe.
- Fixed by keying `PROBE_SQL`'s `cursor_us` and the `since_us` filter on SQLite `rowid` instead of `created_at`. `rowid` is assigned by SQLite exactly once, inside the one active writer transaction, so it is monotonic with commit order by construction. Wire field names (`cursor_us`, `since_us`) are unchanged; the value is now documented as an opaque monotonic token, not a microsecond timestamp. Display fields (`created_at_us`, ordering) are untouched.
- **Paired fix (same consistency story, mandatory per the issue):** `comm.read` mutated the read flag via get-note + `upsert_note` (`INSERT OR REPLACE`), which on a primary-key conflict is a SQLite DELETE+INSERT that silently reassigns the row's `rowid`. With a `rowid`-keyed cursor, that churn could bump an already-probed message's `rowid` past the current cursor and resurrect it as "new" on a later poll. Added `NoteStore::update_note_properties`, a narrow `properties`/`updated_at` `UPDATE` that never touches `rowid`, and switched `handle_read` to use it.

## Root cause

`created_at` (khive-storage/src/note.rs `Note::new`) is stamped by the caller before any lock is acquired; the writer mutex (khive-db/src/pool.rs) only serializes *commit* order, not *stamp* order. A probe keyed on `created_at` conflates the two, so the newest-stamped-but-not-yet-committed row can "poison" the cursor against an older-stamped row that commits later.

## Test plan

- [x] Added `probe_survives_out_of_order_commit_vs_created_at` (khive-pack-comm/tests/probe.rs): plants a later-`created_at` message that commits first, then an earlier-`created_at` message that commits second; asserts the second is still visible via the first probe's cursor. Verified this fails against the old `created_at`-keyed SQL.
- [x] Added `probe_read_does_not_resurrect_message_via_rowid_churn`: probes past a message, marks it read via `comm.read`, probes again with the same cursor, asserts it does not reappear. Verified this fails when the rowid-cursor fix lands *without* the `handle_read` fix (confirming both halves are required together).
- [x] Updated `probe_cursor_advances_and_filters_since_us` and `probe_ignores_messages_addressed_to_other_actors`, which asserted `cursor_us` against literal `created_at` values that no longer hold once the cursor is `rowid`-based.
- [x] `cargo test -p khive-pack-comm -p khive-db -p khive-storage -p khive-runtime` — all green (275+14+50+130+16+774 passed, 0 failed)
- [x] `cargo clippy -p khive-pack-comm -p khive-db -p khive-storage -p khive-runtime --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)