### PR TITLE
fix(db): decode FeedbackExplicit signal observation from target_id

### DIFF
--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -453,8 +453,21 @@ fn decode_event_observations(event: &Event) -> Result<Vec<EventObservation>, rus
 }
 
 fn payload_uuid_array(event: &Event, field: &'static str) -> Result<Vec<Uuid>, rusqlite::Error> {
+    Ok(payload_uuid_array_opt(event, field)?.unwrap_or_default())
+}
+
+/// Like [`payload_uuid_array`], but distinguishes an absent `field` (`Ok(None)`)
+/// from a present-but-malformed one (`Err`). Callers that fall back across a
+/// chain of alternative field names (e.g. `decode_rank_observations`'s
+/// `selected`/`reranked`/`final_scores`) need that distinction: collapsing
+/// "missing" into `Ok(vec![])` makes every later field in the chain
+/// unreachable, since `Result::or_else` only fires on `Err`.
+fn payload_uuid_array_opt(
+    event: &Event,
+    field: &'static str,
+) -> Result<Option<Vec<Uuid>>, rusqlite::Error> {
     let Some(values) = event.payload.get(field) else {
-        return Ok(Vec::new());
+        return Ok(None);
     };
     let Some(array) = values.as_array() else {
         return Err(invalid_payload(event.kind, field, "expected array"));
@@ -468,7 +481,42 @@ fn payload_uuid_array(event: &Event, field: &'static str) -> Result<Vec<Uuid>, r
                 .ok_or_else(|| invalid_payload(event.kind, field, "expected UUID string"))
                 .and_then(|s| Uuid::parse_str(s).map_err(|e| invalid_payload(event.kind, field, e)))
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+/// Decode a field shaped like `RerankExecutedPayload::reranked`/`final_scores`
+/// (`Vec<(Id128, ..)>`, which serde serializes as an array of 2+-element JSON
+/// arrays `[uuid, ...]`) into the UUID leading each tuple. Absent field is
+/// `Ok(None)`; present-but-wrong-shape is `Err`, matching
+/// [`payload_uuid_array_opt`]'s missing-vs-malformed contract.
+fn payload_uuid_tuple_array_opt(
+    event: &Event,
+    field: &'static str,
+) -> Result<Option<Vec<Uuid>>, rusqlite::Error> {
+    let Some(values) = event.payload.get(field) else {
+        return Ok(None);
+    };
+    let Some(array) = values.as_array() else {
+        return Err(invalid_payload(event.kind, field, "expected array"));
+    };
+
+    array
+        .iter()
+        .map(|entry| {
+            let tuple = entry
+                .as_array()
+                .ok_or_else(|| invalid_payload(event.kind, field, "expected [uuid, ..] tuple"))?;
+            tuple
+                .first()
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    invalid_payload(event.kind, field, "expected UUID string as tuple[0]")
+                })
+                .and_then(|s| Uuid::parse_str(s).map_err(|e| invalid_payload(event.kind, field, e)))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
 }
 
 fn payload_uuid(event: &Event, field: &'static str) -> Result<Option<Uuid>, rusqlite::Error> {
@@ -506,9 +554,16 @@ fn decode_rank_observations(event: &Event) -> Result<Vec<EventObservation>, rusq
         });
     }
 
-    let selected = payload_uuid_array(event, "selected")
-        .or_else(|_| payload_uuid_array(event, "reranked"))
-        .or_else(|_| payload_uuid_array(event, "final_scores"))?;
+    // `selected` is the flat untyped convenience shape; `reranked` and
+    // `final_scores` are `RerankExecutedPayload`'s actual typed fields,
+    // serialized as `[uuid, ..]` tuples, not flat UUID strings. Each is
+    // tried in turn only when the previous field is absent (`None`) — a
+    // present-but-malformed field errors immediately instead of masking
+    // the problem by falling through to the next candidate.
+    let selected = payload_uuid_array_opt(event, "selected")?
+        .or(payload_uuid_tuple_array_opt(event, "reranked")?)
+        .or(payload_uuid_tuple_array_opt(event, "final_scores")?)
+        .unwrap_or_default();
     for (position, entity_id) in selected.into_iter().enumerate() {
         let position_u32 = u32::try_from(position).map_err(|_| {
             invalid_payload(
@@ -576,7 +631,16 @@ fn decode_signal_observation(event: &Event) -> Result<Vec<EventObservation>, rus
     Ok(vec![EventObservation {
         event_id: event.id,
         entity_id,
-        referent_kind: ReferentKind::Entity,
+        // ADR-041 permits both entity and note signal targets. `brain.feedback`
+        // threads the resolved target's substrate onto the event (Finding 1,
+        // round-1 codex review of #831); pre-fix events all carry the old
+        // `SubstrateKind::Event` placeholder and fall back to Entity, matching
+        // the decoder's prior hard-coded behavior for that historical data.
+        referent_kind: if event.substrate == SubstrateKind::Note {
+            ReferentKind::Note
+        } else {
+            ReferentKind::Entity
+        },
         role: ObservationRole::Signal,
         position: 0,
     }])

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -485,35 +485,56 @@ fn payload_uuid_array_opt(
         .map(Some)
 }
 
-/// Decode a field shaped like `RerankExecutedPayload::reranked`/`final_scores`
-/// (`Vec<(Id128, ..)>`, which serde serializes as an array of 2+-element JSON
-/// arrays `[uuid, ...]`) into the UUID leading each tuple. Absent field is
+/// Decode `RerankExecutedPayload::final_scores` (`Vec<(Id128, f32)>` per
+/// `khive_types::event::RerankExecutedPayload`) into the UUID leading each
+/// tuple. Deserializes through that exact typed tuple shape, so a tuple that
+/// is not precisely two elements, or whose second element is not a finite
+/// score, is rejected rather than silently accepted. Absent field is
 /// `Ok(None)`; present-but-wrong-shape is `Err`, matching
 /// [`payload_uuid_array_opt`]'s missing-vs-malformed contract.
-fn payload_uuid_tuple_array_opt(
+fn payload_final_scores_uuid_array_opt(
     event: &Event,
     field: &'static str,
 ) -> Result<Option<Vec<Uuid>>, rusqlite::Error> {
     let Some(values) = event.payload.get(field) else {
         return Ok(None);
     };
-    let Some(array) = values.as_array() else {
-        return Err(invalid_payload(event.kind, field, "expected array"));
-    };
+    let tuples: Vec<(khive_types::Id128, f32)> = serde_json::from_value(values.clone())
+        .map_err(|e| invalid_payload(event.kind, field, e))?;
+    tuples
+        .into_iter()
+        .map(|(id, score)| {
+            if !score.is_finite() {
+                return Err(invalid_payload(event.kind, field, "score is not finite"));
+            }
+            Ok(Uuid::from_bytes(*id.as_bytes()))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
 
-    array
-        .iter()
-        .map(|entry| {
-            let tuple = entry
-                .as_array()
-                .ok_or_else(|| invalid_payload(event.kind, field, "expected [uuid, ..] tuple"))?;
-            tuple
-                .first()
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    invalid_payload(event.kind, field, "expected UUID string as tuple[0]")
-                })
-                .and_then(|s| Uuid::parse_str(s).map_err(|e| invalid_payload(event.kind, field, e)))
+/// Decode `RerankExecutedPayload::reranked` (`Vec<(Id128, Vec<(String, f32)>)>`
+/// per `khive_types::event::RerankExecutedPayload`) into the UUID leading each
+/// tuple. Same exact-shape decoding contract as
+/// [`payload_final_scores_uuid_array_opt`], applied to `reranked`'s
+/// per-reranker sub-score shape instead of a single scalar score.
+fn payload_reranked_uuid_array_opt(
+    event: &Event,
+    field: &'static str,
+) -> Result<Option<Vec<Uuid>>, rusqlite::Error> {
+    let Some(values) = event.payload.get(field) else {
+        return Ok(None);
+    };
+    let tuples: Vec<(khive_types::Id128, Vec<(String, f32)>)> =
+        serde_json::from_value(values.clone())
+            .map_err(|e| invalid_payload(event.kind, field, e))?;
+    tuples
+        .into_iter()
+        .map(|(id, scores)| {
+            if !scores.iter().all(|(_, s)| s.is_finite()) {
+                return Err(invalid_payload(event.kind, field, "score is not finite"));
+            }
+            Ok(Uuid::from_bytes(*id.as_bytes()))
         })
         .collect::<Result<Vec<_>, _>>()
         .map(Some)
@@ -554,15 +575,19 @@ fn decode_rank_observations(event: &Event) -> Result<Vec<EventObservation>, rusq
         });
     }
 
-    // `selected` is the flat untyped convenience shape; `reranked` and
-    // `final_scores` are `RerankExecutedPayload`'s actual typed fields,
-    // serialized as `[uuid, ..]` tuples, not flat UUID strings. Each is
-    // tried in turn only when the previous field is absent (`None`) — a
-    // present-but-malformed field errors immediately instead of masking
-    // the problem by falling through to the next candidate.
+    // `selected` is the flat untyped convenience shape; `final_scores` and
+    // `reranked` are `RerankExecutedPayload`'s actual typed fields,
+    // serialized as `[uuid, ..]` tuples, not flat UUID strings. Per
+    // ADR-042 §5, `final_scores` is the ordered rerank output (positions
+    // match output order); `reranked` is per-reranker audit/debug data
+    // with no ordering guarantee, so it is only a legacy fallback when
+    // `final_scores` is absent. Each is tried in turn only when the
+    // previous field is absent (`None`) — a present-but-malformed field
+    // errors immediately instead of masking the problem by falling
+    // through to the next candidate.
     let selected = payload_uuid_array_opt(event, "selected")?
-        .or(payload_uuid_tuple_array_opt(event, "reranked")?)
-        .or(payload_uuid_tuple_array_opt(event, "final_scores")?)
+        .or(payload_final_scores_uuid_array_opt(event, "final_scores")?)
+        .or(payload_reranked_uuid_array_opt(event, "reranked")?)
         .unwrap_or_default();
     for (position, entity_id) in selected.into_iter().enumerate() {
         let position_u32 = u32::try_from(position).map_err(|_| {

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -603,8 +603,8 @@ fn push_selected_observations(
 }
 
 /// `RecallExecuted`/`SearchExecuted` payloads carry a flat `selected: Vec<Uuid>`
-/// field (ADR-041 §"Projection rules") — that is their entire typed selected
-/// contract, so it is the only field consulted here.
+/// field (ADR-041 §"Projection rules"). These payloads are untyped JSON; the
+/// ADR-041 projection contract makes `selected` the only field consulted here.
 fn decode_recall_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
     let mut rows = decode_candidate_observations(event)?;
     let selected = payload_uuid_array_opt(event, "selected")?.unwrap_or_default();

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -570,7 +570,7 @@ fn decode_target_observation(event: &Event) -> Result<Vec<EventObservation>, rus
 }
 
 fn decode_signal_observation(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
-    let Some(entity_id) = payload_uuid(event, "about_id")? else {
+    let Some(entity_id) = event.target_id else {
         return Ok(Vec::new());
     };
     Ok(vec![EventObservation {

--- a/crates/khive-db/src/stores/event.rs
+++ b/crates/khive-db/src/stores/event.rs
@@ -437,8 +437,8 @@ pub async fn append_event_on_writer(
 
 fn decode_event_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
     match event.kind {
-        EventKind::RerankExecuted => decode_rank_observations(event),
-        EventKind::RecallExecuted | EventKind::SearchExecuted => decode_rank_observations(event),
+        EventKind::RerankExecuted => decode_rerank_observations(event),
+        EventKind::RecallExecuted | EventKind::SearchExecuted => decode_recall_observations(event),
         EventKind::LinkCreated => decode_link_observations(event),
         EventKind::EntityCreated
         | EventKind::EntityUpdated
@@ -458,8 +458,8 @@ fn payload_uuid_array(event: &Event, field: &'static str) -> Result<Vec<Uuid>, r
 
 /// Like [`payload_uuid_array`], but distinguishes an absent `field` (`Ok(None)`)
 /// from a present-but-malformed one (`Err`). Callers that fall back across a
-/// chain of alternative field names (e.g. `decode_rank_observations`'s
-/// `selected`/`reranked`/`final_scores`) need that distinction: collapsing
+/// chain of alternative field names (e.g. `decode_rerank_observations`'s
+/// `final_scores`/`reranked`) need that distinction: collapsing
 /// "missing" into `Ok(vec![])` makes every later field in the chain
 /// unreachable, since `Result::or_else` only fires on `Err`.
 fn payload_uuid_array_opt(
@@ -552,7 +552,7 @@ fn payload_uuid(event: &Event, field: &'static str) -> Result<Option<Uuid>, rusq
         .map_err(|e| invalid_payload(event.kind, field, e))
 }
 
-fn decode_rank_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
+fn decode_candidate_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
     let mut rows = Vec::new();
 
     for (position, entity_id) in payload_uuid_array(event, "candidates")?
@@ -575,20 +575,14 @@ fn decode_rank_observations(event: &Event) -> Result<Vec<EventObservation>, rusq
         });
     }
 
-    // `selected` is the flat untyped convenience shape; `final_scores` and
-    // `reranked` are `RerankExecutedPayload`'s actual typed fields,
-    // serialized as `[uuid, ..]` tuples, not flat UUID strings. Per
-    // ADR-042 §5, `final_scores` is the ordered rerank output (positions
-    // match output order); `reranked` is per-reranker audit/debug data
-    // with no ordering guarantee, so it is only a legacy fallback when
-    // `final_scores` is absent. Each is tried in turn only when the
-    // previous field is absent (`None`) — a present-but-malformed field
-    // errors immediately instead of masking the problem by falling
-    // through to the next candidate.
-    let selected = payload_uuid_array_opt(event, "selected")?
-        .or(payload_final_scores_uuid_array_opt(event, "final_scores")?)
-        .or(payload_reranked_uuid_array_opt(event, "reranked")?)
-        .unwrap_or_default();
+    Ok(rows)
+}
+
+fn push_selected_observations(
+    event: &Event,
+    selected: Vec<Uuid>,
+    rows: &mut Vec<EventObservation>,
+) -> Result<(), rusqlite::Error> {
     for (position, entity_id) in selected.into_iter().enumerate() {
         let position_u32 = u32::try_from(position).map_err(|_| {
             invalid_payload(
@@ -605,6 +599,34 @@ fn decode_rank_observations(event: &Event) -> Result<Vec<EventObservation>, rusq
             position: position_u32,
         });
     }
+    Ok(())
+}
+
+/// `RecallExecuted`/`SearchExecuted` payloads carry a flat `selected: Vec<Uuid>`
+/// field (ADR-041 §"Projection rules") — that is their entire typed selected
+/// contract, so it is the only field consulted here.
+fn decode_recall_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
+    let mut rows = decode_candidate_observations(event)?;
+    let selected = payload_uuid_array_opt(event, "selected")?.unwrap_or_default();
+    push_selected_observations(event, selected, &mut rows)?;
+    Ok(rows)
+}
+
+/// `RerankExecutedPayload` (`khive_types::event::RerankExecutedPayload`) has no
+/// `selected` field at all — a stray `selected` key in the raw payload is not
+/// part of its typed contract and must never be consulted. Per ADR-042 §5,
+/// `final_scores` is the ordered rerank output (positions match output
+/// order); `reranked` is per-reranker audit/debug data with no ordering
+/// guarantee, so it is only a legacy fallback for events emitted before
+/// `final_scores` existed. `reranked` is tried only when `final_scores` is
+/// absent (`None`) — a present-but-malformed `final_scores` errors
+/// immediately instead of masking the problem by falling through.
+fn decode_rerank_observations(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
+    let mut rows = decode_candidate_observations(event)?;
+    let selected = payload_final_scores_uuid_array_opt(event, "final_scores")?
+        .or(payload_reranked_uuid_array_opt(event, "reranked")?)
+        .unwrap_or_default();
+    push_selected_observations(event, selected, &mut rows)?;
 
     Ok(rows)
 }

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -188,6 +188,60 @@ async fn append_event_writes_observations_atomically() {
 }
 
 #[tokio::test]
+async fn feedback_explicit_projects_signal_observation_from_target_id() {
+    // Regression test for #811: the emitter (khive-pack-brain's `brain.feedback`
+    // handler) sets `event.target_id` via `Event::with_target`, never a payload
+    // `about_id` field. The decoder must read the field the emitter actually
+    // writes so the round trip survives.
+    let store = setup_memory_store();
+    let target = Uuid::new_v4();
+    let event = Event::new(
+        "default",
+        "brain.feedback",
+        EventKind::FeedbackExplicit,
+        SubstrateKind::Event,
+        "agent:test",
+    )
+    .with_target(target)
+    .with_payload(json!({ "signal": "useful" }));
+    let event_id = event.id;
+
+    store.append_event(event).await.unwrap();
+
+    let pool = Arc::clone(&store.pool);
+    let event_id_str = event_id.to_string();
+    let (signal_count, observed_entity_id): (i64, String) =
+        tokio::task::spawn_blocking(move || {
+            let guard = pool.reader().unwrap();
+            let conn = guard.conn();
+            let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM event_observations WHERE event_id = ?1 AND role = 'signal'",
+                [&event_id_str],
+                |r| r.get(0),
+            )
+            .unwrap();
+            let entity_id: String = conn
+            .query_row(
+                "SELECT entity_id FROM event_observations WHERE event_id = ?1 AND role = 'signal'",
+                [&event_id_str],
+                |r| r.get(0),
+            )
+            .unwrap();
+            (count, entity_id)
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(signal_count, 1, "expected one signal observation row");
+    assert_eq!(
+        observed_entity_id,
+        target.to_string(),
+        "signal observation must carry the feedback's target_id"
+    );
+}
+
+#[tokio::test]
 async fn invalid_projection_payload_aborts_event_insert() {
     let store = setup_memory_store();
     let mut event = make_event("default");

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -144,7 +144,7 @@ async fn append_event_writes_observations_atomically() {
     let candidate = Uuid::new_v4();
     let selected = Uuid::new_v4();
     let mut event = make_event("default");
-    event.kind = EventKind::RerankExecuted;
+    event.kind = EventKind::SearchExecuted;
     event.payload = json!({
         "candidates": [candidate.to_string()],
         "selected": [selected.to_string()],
@@ -212,11 +212,11 @@ async fn selected_uuids_for(store: &SqlEventStore, event_id: Uuid) -> Vec<String
 async fn rerank_executed_falls_back_to_reranked_when_final_scores_field_is_absent() {
     // Regression test (round-1 codex review of #831, Finding 2): legacy
     // events emitted before `final_scores` existed carry only `reranked`.
-    // The decoder must still fall through from the absent `selected` field,
-    // through the absent `final_scores` field, to the tuple-shaped
-    // `reranked` field instead of silently projecting zero `selected` rows.
-    // Constructed via a hand-rolled `json!` (not the typed struct) so the
-    // `final_scores` key is genuinely absent, not present-and-empty.
+    // The decoder must still fall through from the absent `final_scores`
+    // field to the tuple-shaped `reranked` field instead of silently
+    // projecting zero `selected` rows. Constructed via a hand-rolled
+    // `json!` (not the typed struct) so the `final_scores` key is
+    // genuinely absent, not present-and-empty.
     let store = setup_memory_store();
     let candidate = Uuid::new_v4();
     let reranked_winner = Uuid::new_v4();
@@ -290,6 +290,62 @@ async fn rerank_executed_prefers_final_scores_order_over_reranked_when_both_pres
         selected,
         vec![a.to_string(), b.to_string()],
         "selected order must follow `final_scores`, not `reranked`"
+    );
+}
+
+#[tokio::test]
+async fn rerank_executed_ignores_stray_selected_field_and_uses_final_scores() {
+    // Regression test (round-3 codex review of #831, Major finding):
+    // `RerankExecutedPayload` (khive_types::event::RerankExecutedPayload)
+    // has no `selected` field at all. The serde helper does not deny
+    // unknown fields, so a payload carrying the typed fields plus a stray
+    // `selected` key must still be projected from `final_scores` only —
+    // the stray field must never be consulted, even when its order
+    // differs completely from `final_scores`.
+    let store = setup_memory_store();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let stray_selected_winner = Uuid::new_v4();
+
+    let payload = khive_types::RerankExecutedPayload {
+        served_by_profile_id: Some("profile-a".to_string()),
+        model_id: khive_types::Id128::from_u128(1),
+        candidates: vec![
+            khive_types::Id128::from_bytes(*a.as_bytes()),
+            khive_types::Id128::from_bytes(*b.as_bytes()),
+        ],
+        reranked: vec![],
+        // authoritative ordered output: a before b
+        final_scores: vec![
+            (khive_types::Id128::from_bytes(*a.as_bytes()), 0.9),
+            (khive_types::Id128::from_bytes(*b.as_bytes()), 0.4),
+        ],
+        latency_us: 1200,
+        hook_applied: false,
+        hook_target_match: false,
+    };
+
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    let mut payload_value = serde_json::to_value(&payload).unwrap();
+    // Inject a stray `selected` field with an entirely different order
+    // than `final_scores` — this field is not part of the typed contract
+    // and must not affect projection.
+    payload_value.as_object_mut().unwrap().insert(
+        "selected".to_string(),
+        json!([stray_selected_winner.to_string()]),
+    );
+    event.payload = payload_value;
+    let event_id = event.id;
+
+    store.append_event(event).await.unwrap();
+
+    let selected = selected_uuids_for(&store, event_id).await;
+    assert_eq!(
+        selected,
+        vec![a.to_string(), b.to_string()],
+        "stray `selected` field must be ignored for RerankExecuted; \
+         projection must follow `final_scores` only"
     );
 }
 
@@ -589,7 +645,7 @@ async fn query_events_filters_by_observed() {
     let store = setup_memory_store();
     let entity_id = Uuid::new_v4();
     let mut event = make_event("default");
-    event.kind = EventKind::RerankExecuted;
+    event.kind = EventKind::SearchExecuted;
     event.payload = json!({
         "candidates": [entity_id.to_string()],
         "selected": []
@@ -619,7 +675,7 @@ async fn query_events_filters_by_selected() {
     let store = setup_memory_store();
     let entity_id = Uuid::new_v4();
     let mut event = make_event("default");
-    event.kind = EventKind::RerankExecuted;
+    event.kind = EventKind::SearchExecuted;
     event.payload = json!({
         "candidates": [],
         "selected": [entity_id.to_string()]

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -188,6 +188,71 @@ async fn append_event_writes_observations_atomically() {
 }
 
 #[tokio::test]
+async fn rerank_executed_projects_selected_from_real_typed_payload() {
+    // Regression test (round-1 codex review of #831, Finding 2): a real
+    // `RerankExecutedPayload` has no `selected` field — its fields are
+    // `reranked: Vec<(Id128, Vec<(String, f32)>)>` and
+    // `final_scores: Vec<(Id128, f32)>`, which serde serializes as arrays of
+    // `[uuid, ..]` tuples, not flat UUID strings. Push a real payload
+    // (constructed via the typed struct, not a hand-rolled `json!`) through
+    // serialization into `append_event`'s projection and confirm the
+    // decoder falls through from the absent `selected` field to the
+    // tuple-shaped `reranked`/`final_scores` fields instead of silently
+    // projecting zero `selected` rows.
+    let store = setup_memory_store();
+    let candidate = Uuid::new_v4();
+    let reranked_winner = Uuid::new_v4();
+
+    let payload = khive_types::RerankExecutedPayload {
+        served_by_profile_id: Some("profile-a".to_string()),
+        model_id: khive_types::Id128::from_u128(1),
+        candidates: vec![khive_types::Id128::from_bytes(*candidate.as_bytes())],
+        reranked: vec![(
+            khive_types::Id128::from_bytes(*reranked_winner.as_bytes()),
+            vec![("relevance".to_string(), 0.9)],
+        )],
+        final_scores: vec![],
+        latency_us: 1200,
+        hook_applied: false,
+        hook_target_match: false,
+    };
+    let payload_json = serde_json::to_value(&payload).unwrap();
+    assert!(
+        payload_json.get("selected").is_none(),
+        "the typed RerankExecutedPayload contract has no `selected` field; \
+         sanity-check that this test exercises the fallback, not the alias"
+    );
+
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = payload_json;
+    let event_id = event.id;
+
+    store.append_event(event).await.unwrap();
+
+    let pool = Arc::clone(&store.pool);
+    let event_id_str = event_id.to_string();
+    let selected_entity_id: String = tokio::task::spawn_blocking(move || {
+        let guard = pool.reader().unwrap();
+        let conn = guard.conn();
+        conn.query_row(
+            "SELECT entity_id FROM event_observations WHERE event_id = ?1 AND role = 'selected'",
+            [&event_id_str],
+            |r| r.get(0),
+        )
+        .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        selected_entity_id,
+        reranked_winner.to_string(),
+        "selected observation must decode the UUID leading the `reranked` tuple"
+    );
+}
+
+#[tokio::test]
 async fn feedback_explicit_projects_signal_observation_from_target_id() {
     // Regression test for #811: the emitter (khive-pack-brain's `brain.feedback`
     // handler) sets `event.target_id` via `Event::with_target`, never a payload

--- a/crates/khive-db/src/stores/event_tests.rs
+++ b/crates/khive-db/src/stores/event_tests.rs
@@ -187,69 +187,229 @@ async fn append_event_writes_observations_atomically() {
     assert_eq!(selected_count, 1, "expected one selected observation row");
 }
 
+async fn selected_uuids_for(store: &SqlEventStore, event_id: Uuid) -> Vec<String> {
+    let pool = Arc::clone(&store.pool);
+    let event_id_str = event_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        let guard = pool.reader().unwrap();
+        let conn = guard.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT entity_id FROM event_observations \
+                 WHERE event_id = ?1 AND role = 'selected' ORDER BY position",
+            )
+            .unwrap();
+        stmt.query_map([&event_id_str], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<Vec<String>, _>>()
+            .unwrap()
+    })
+    .await
+    .unwrap()
+}
+
 #[tokio::test]
-async fn rerank_executed_projects_selected_from_real_typed_payload() {
-    // Regression test (round-1 codex review of #831, Finding 2): a real
-    // `RerankExecutedPayload` has no `selected` field — its fields are
-    // `reranked: Vec<(Id128, Vec<(String, f32)>)>` and
-    // `final_scores: Vec<(Id128, f32)>`, which serde serializes as arrays of
-    // `[uuid, ..]` tuples, not flat UUID strings. Push a real payload
-    // (constructed via the typed struct, not a hand-rolled `json!`) through
-    // serialization into `append_event`'s projection and confirm the
-    // decoder falls through from the absent `selected` field to the
-    // tuple-shaped `reranked`/`final_scores` fields instead of silently
-    // projecting zero `selected` rows.
+async fn rerank_executed_falls_back_to_reranked_when_final_scores_field_is_absent() {
+    // Regression test (round-1 codex review of #831, Finding 2): legacy
+    // events emitted before `final_scores` existed carry only `reranked`.
+    // The decoder must still fall through from the absent `selected` field,
+    // through the absent `final_scores` field, to the tuple-shaped
+    // `reranked` field instead of silently projecting zero `selected` rows.
+    // Constructed via a hand-rolled `json!` (not the typed struct) so the
+    // `final_scores` key is genuinely absent, not present-and-empty.
     let store = setup_memory_store();
     let candidate = Uuid::new_v4();
     let reranked_winner = Uuid::new_v4();
 
-    let payload = khive_types::RerankExecutedPayload {
-        served_by_profile_id: Some("profile-a".to_string()),
-        model_id: khive_types::Id128::from_u128(1),
-        candidates: vec![khive_types::Id128::from_bytes(*candidate.as_bytes())],
-        reranked: vec![(
-            khive_types::Id128::from_bytes(*reranked_winner.as_bytes()),
-            vec![("relevance".to_string(), 0.9)],
-        )],
-        final_scores: vec![],
-        latency_us: 1200,
-        hook_applied: false,
-        hook_target_match: false,
-    };
-    let payload_json = serde_json::to_value(&payload).unwrap();
-    assert!(
-        payload_json.get("selected").is_none(),
-        "the typed RerankExecutedPayload contract has no `selected` field; \
-         sanity-check that this test exercises the fallback, not the alias"
-    );
-
     let mut event = make_event("default");
     event.kind = EventKind::RerankExecuted;
-    event.payload = payload_json;
+    event.payload = json!({
+        "candidates": [candidate.to_string()],
+        "reranked": [[reranked_winner.to_string(), [["relevance", 0.9]]]],
+    });
     let event_id = event.id;
 
     store.append_event(event).await.unwrap();
 
-    let pool = Arc::clone(&store.pool);
-    let event_id_str = event_id.to_string();
-    let selected_entity_id: String = tokio::task::spawn_blocking(move || {
-        let guard = pool.reader().unwrap();
-        let conn = guard.conn();
-        conn.query_row(
-            "SELECT entity_id FROM event_observations WHERE event_id = ?1 AND role = 'selected'",
-            [&event_id_str],
-            |r| r.get(0),
-        )
-        .unwrap()
-    })
-    .await
-    .unwrap();
-
+    let selected = selected_uuids_for(&store, event_id).await;
     assert_eq!(
-        selected_entity_id,
-        reranked_winner.to_string(),
-        "selected observation must decode the UUID leading the `reranked` tuple"
+        selected,
+        vec![reranked_winner.to_string()],
+        "selected observation must decode the UUID leading the `reranked` tuple \
+         when `final_scores` is absent"
     );
+}
+
+#[tokio::test]
+async fn rerank_executed_prefers_final_scores_order_over_reranked_when_both_present() {
+    // Finding 1 (round-2 codex review of #831): ADR-042 §5 defines
+    // `final_scores` as the ordered rerank output and `reranked` as
+    // unordered per-reranker audit/debug data. When both are present and
+    // their orderings differ, `final_scores`' order must win.
+    let store = setup_memory_store();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+
+    let payload = khive_types::RerankExecutedPayload {
+        served_by_profile_id: Some("profile-a".to_string()),
+        model_id: khive_types::Id128::from_u128(1),
+        candidates: vec![
+            khive_types::Id128::from_bytes(*a.as_bytes()),
+            khive_types::Id128::from_bytes(*b.as_bytes()),
+        ],
+        // audit-only ordering: b before a
+        reranked: vec![
+            (
+                khive_types::Id128::from_bytes(*b.as_bytes()),
+                vec![("relevance".to_string(), 0.4)],
+            ),
+            (
+                khive_types::Id128::from_bytes(*a.as_bytes()),
+                vec![("relevance".to_string(), 0.9)],
+            ),
+        ],
+        // authoritative ordered output: a before b
+        final_scores: vec![
+            (khive_types::Id128::from_bytes(*a.as_bytes()), 0.9),
+            (khive_types::Id128::from_bytes(*b.as_bytes()), 0.4),
+        ],
+        latency_us: 1200,
+        hook_applied: false,
+        hook_target_match: false,
+    };
+
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = serde_json::to_value(&payload).unwrap();
+    let event_id = event.id;
+
+    store.append_event(event).await.unwrap();
+
+    let selected = selected_uuids_for(&store, event_id).await;
+    assert_eq!(
+        selected,
+        vec![a.to_string(), b.to_string()],
+        "selected order must follow `final_scores`, not `reranked`"
+    );
+}
+
+#[tokio::test]
+async fn rerank_executed_uses_final_scores_when_reranked_is_empty() {
+    // Finding 1 companion case: `reranked` present-but-empty, `final_scores`
+    // populated. `final_scores` must still be used (not skipped just
+    // because `reranked` happens to come first lexically in the payload).
+    let store = setup_memory_store();
+    let winner = Uuid::new_v4();
+
+    let payload = khive_types::RerankExecutedPayload {
+        served_by_profile_id: None,
+        model_id: khive_types::Id128::from_u128(1),
+        candidates: vec![khive_types::Id128::from_bytes(*winner.as_bytes())],
+        reranked: vec![],
+        final_scores: vec![(khive_types::Id128::from_bytes(*winner.as_bytes()), 0.75)],
+        latency_us: 800,
+        hook_applied: false,
+        hook_target_match: false,
+    };
+
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = serde_json::to_value(&payload).unwrap();
+    let event_id = event.id;
+
+    store.append_event(event).await.unwrap();
+
+    let selected = selected_uuids_for(&store, event_id).await;
+    assert_eq!(
+        selected,
+        vec![winner.to_string()],
+        "final_scores must be used even when reranked is present-but-empty"
+    );
+}
+
+#[tokio::test]
+async fn rerank_executed_final_scores_single_element_tuple_rejected() {
+    // Finding 2 (round-2 codex review of #831): the typed contract
+    // (`RerankExecutedPayload::final_scores: Vec<(Id128, f32)>`) requires
+    // exact two-element tuples. A one-element tuple must error, and the
+    // event insert must roll back rather than silently accepting it.
+    let store = setup_memory_store();
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = json!({
+        "candidates": [],
+        "final_scores": [[Uuid::new_v4().to_string()]],
+    });
+    let event_id = event.id;
+
+    let result = store.append_event(event).await;
+    assert!(result.is_err(), "single-element tuple must be rejected");
+
+    let fetched = store.get_event(event_id).await.unwrap();
+    assert!(fetched.is_none(), "event row must not exist after rollback");
+}
+
+#[tokio::test]
+async fn rerank_executed_final_scores_extra_element_tuple_rejected() {
+    // Finding 2: extra-element tuples must also be rejected, not
+    // silently truncated to the first two elements.
+    let store = setup_memory_store();
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = json!({
+        "candidates": [],
+        "final_scores": [[Uuid::new_v4().to_string(), 0.5, "extra"]],
+    });
+    let event_id = event.id;
+
+    let result = store.append_event(event).await;
+    assert!(result.is_err(), "extra-element tuple must be rejected");
+
+    let fetched = store.get_event(event_id).await.unwrap();
+    assert!(fetched.is_none(), "event row must not exist after rollback");
+}
+
+#[tokio::test]
+async fn rerank_executed_final_scores_non_numeric_second_element_rejected() {
+    // Finding 2: the second element of a `final_scores` tuple must be the
+    // typed contract's `f32` score, not an arbitrary value.
+    let store = setup_memory_store();
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = json!({
+        "candidates": [],
+        "final_scores": [[Uuid::new_v4().to_string(), "not-a-number"]],
+    });
+    let event_id = event.id;
+
+    let result = store.append_event(event).await;
+    assert!(result.is_err(), "non-numeric score must be rejected");
+
+    let fetched = store.get_event(event_id).await.unwrap();
+    assert!(fetched.is_none(), "event row must not exist after rollback");
+}
+
+#[tokio::test]
+async fn rerank_executed_reranked_malformed_sub_scores_rejected() {
+    // Finding 2: `reranked`'s second element must be the typed contract's
+    // `Vec<(String, f32)>` sub-score list, not an arbitrary value.
+    let store = setup_memory_store();
+    let mut event = make_event("default");
+    event.kind = EventKind::RerankExecuted;
+    event.payload = json!({
+        "candidates": [],
+        "reranked": [[Uuid::new_v4().to_string(), "not-an-array"]],
+    });
+    let event_id = event.id;
+
+    let result = store.append_event(event).await;
+    assert!(
+        result.is_err(),
+        "malformed reranked sub-scores must be rejected"
+    );
+
+    let fetched = store.get_event(event_id).await.unwrap();
+    assert!(fetched.is_none(), "event row must not exist after rollback");
 }
 
 #[tokio::test]

--- a/crates/khive-pack-brain/src/handlers.rs
+++ b/crates/khive-pack-brain/src/handlers.rs
@@ -1271,19 +1271,24 @@ impl BrainPack {
         // reject the feedback loop's own recalled targets. NotFound only for a
         // genuinely absent UUID.
         use khive_runtime::Resolved;
-        match self
+        // ADR-041 permits both entity and note signal targets; the resolved
+        // substrate is threaded onto the emitted event below (Finding 1,
+        // round-1 codex review of #831) so the decoder can tell entity and
+        // note signal observations apart instead of hard-coding entity.
+        let target_substrate = match self
             .runtime
             .resolve_by_id(token, target)
             .await
             .map_err(|e| RuntimeError::InvalidInput(e.to_string()))?
         {
-            Some(Resolved::Entity(_)) | Some(Resolved::Note(_)) => {}
+            Some(Resolved::Entity(_)) => khive_types::SubstrateKind::Entity,
+            Some(Resolved::Note(_)) => khive_types::SubstrateKind::Note,
             _ => {
                 return Err(RuntimeError::NotFound(format!(
                     "target_id {target:?} not found"
                 )));
             }
-        }
+        };
 
         // Compute the effective serving profile (explicit, else a matching
         // actor+namespace binding, else the system default — #697), then
@@ -1449,7 +1454,7 @@ impl BrainPack {
                         namespace_for_event,
                         "brain.feedback",
                         khive_types::EventKind::FeedbackExplicit,
-                        khive_types::SubstrateKind::Event,
+                        target_substrate,
                         "brain",
                     )
                     .with_target(target)
@@ -1491,7 +1496,7 @@ impl BrainPack {
                 token.namespace().as_str().to_string(),
                 "brain.feedback",
                 khive_types::EventKind::FeedbackExplicit,
-                khive_types::SubstrateKind::Event,
+                target_substrate,
                 "brain",
             )
             .with_target(target)

--- a/crates/khive-pack-brain/src/tests.rs
+++ b/crates/khive-pack-brain/src/tests.rs
@@ -1458,6 +1458,65 @@ async fn w4_c4_feedback_accepts_valid_target_and_profile() {
     assert_eq!(result["signal"], json!("useful"));
 }
 
+/// Regression test (round-1 codex review of #831, Finding 1): ADR-041
+/// permits `brain.feedback` targets on entities AND notes, but the emitted
+/// event previously always carried `SubstrateKind::Event`, so the
+/// `event_observations` decoder hard-coded `ReferentKind::Entity` and the
+/// `observed_as_signal` synthetic-edge query lowering only admitted entity
+/// referents — a note target's signal observation existed in storage but
+/// was unreachable from `observed_as_signal`. Feed a REAL stored note
+/// through `brain.feedback` end-to-end and confirm it resolves via the
+/// canonical ADR-041 §11 GQL query.
+#[tokio::test]
+async fn feedback_note_target_resolves_through_observed_as_signal() {
+    let (pack, rt) = make_pack();
+    let registry = empty_registry();
+    let token = rt.authorize(Namespace::local()).unwrap();
+
+    let note = rt
+        .create_note(
+            &token,
+            "observation",
+            None,
+            "a real stored note used as a feedback target",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create test note");
+
+    let result = pack
+        .dispatch(
+            "brain.feedback",
+            json!({"target_id": note.id.to_string(), "signal": "useful", "served_by_profile_id": "balanced-recall-v1"}),
+            &registry,
+            &token,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result["emitted"], json!(true));
+
+    let rows = rt
+        .query(&token, "MATCH (ev)-[:observed_as_signal]->(t) RETURN t")
+        .await
+        .unwrap();
+
+    let note_id_str = note.id.to_string();
+    let found = rows.iter().any(|row| {
+        row.columns.iter().any(|col| match &col.value {
+            khive_storage::types::SqlValue::Text(s) => s == &note_id_str,
+            khive_storage::types::SqlValue::Uuid(u) => u.to_string() == note_id_str,
+            _ => false,
+        })
+    });
+    assert!(
+        found,
+        "note feedback target must resolve through observed_as_signal; rows: {:?}",
+        rows
+    );
+}
+
 // H1: brain.create_profile creates a new inactive profile.
 #[tokio::test]
 async fn w4_h1_create_profile_creates_new_profile() {

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -462,11 +462,12 @@ fn compile_fixed_length(
                     ));
                     // Admit exactly the in-code legal (role, referent_kind) pairs:
                     // candidate/selected -> note only; target -> entity or note;
-                    // signal -> entity only.
+                    // signal -> entity or note (ADR-041 permits both substrates
+                    // as brain.feedback targets).
                     where_parts.push(format!(
                         "(({e_alias}.role IN ('candidate', 'selected') AND {e_alias}.referent_kind = 'note') \
                           OR ({e_alias}.role = 'target' AND {e_alias}.referent_kind IN ('entity', 'note')) \
-                          OR ({e_alias}.role = 'signal' AND {e_alias}.referent_kind = 'entity'))"
+                          OR ({e_alias}.role = 'signal' AND {e_alias}.referent_kind IN ('entity', 'note')))"
                     ));
                 } else {
                     // Standard canonical edge: join graph_edges.
@@ -2599,17 +2600,17 @@ mod tests {
         );
     }
 
-    /// `observed_as_signal` only admits entity referents (brain feedback signals
-    /// target entities, never notes).
+    /// `observed_as_signal` admits entity OR note referents (ADR-041: brain
+    /// feedback signals may target either substrate).
     #[test]
-    fn synthetic_edge_observed_as_signal_compiles_entity_referents() {
+    fn synthetic_edge_observed_as_signal_compiles_entity_and_note_referents() {
         let q = gql::parse("MATCH (ev)-[:observed_as_signal]->(t) RETURN t.id LIMIT 10").unwrap();
         let compiled = compile(&q, &opts()).unwrap();
         assert!(
             compiled
                 .sql
-                .contains("e0.role = 'signal' AND e0.referent_kind = 'entity'"),
-            "signal role must be admitted only against entity referents; sql: {}",
+                .contains("e0.role = 'signal' AND e0.referent_kind IN ('entity', 'note')"),
+            "signal role must be admitted against entity or note referents; sql: {}",
             compiled.sql
         );
     }

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -61,9 +61,10 @@ fn primary_node_source(alias: &str) -> String {
 }
 
 /// Union of entity/note tables that can legally bind to a synthetic
-/// `observed_as_*` target (issue #468): `observed_as_target` admits entity OR
-/// note referents, `observed_as_signal` admits entity referents. This source
-/// lets the target join stay entity-capable instead of hard-coding `notes`.
+/// `observed_as_*` target (issue #468): `observed_as_target` and
+/// `observed_as_signal` both admit entity OR note referents (ADR-041
+/// Amendment A2). This source lets the target join stay entity-capable
+/// instead of hard-coding `notes`.
 const OBSERVATION_TARGET_SQL: &str = "\
     SELECT id, namespace, kind, entity_type, name, description, \
            NULL AS content, NULL AS status, NULL AS salience, \

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -836,7 +836,8 @@ async fn synthetic_edge_observed_as_selected_returns_memory_note() {
     // implementation calls `decode_recall_observations`, which reads
     // `payload["selected"]` and inserts a row into `event_observations` with
     // role="selected" and entity_id=memory_id. (`selected` is part of
-    // `SearchExecuted`/`RecallExecuted`'s typed contract per ADR-041 —
+    // `SearchExecuted`/`RecallExecuted`'s ADR-041 projection contract;
+    // their payloads are untyped JSON —
     // unlike `RerankExecuted`, which projects `selected` rows from
     // `final_scores`/`reranked` instead, since its typed payload has no
     // `selected` field.)

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -831,16 +831,20 @@ async fn synthetic_edge_observed_as_selected_returns_memory_note() {
         .unwrap();
     let memory_id = memory_note.id;
 
-    // Step 2: create an event of kind RerankExecuted with a payload that
+    // Step 2: create an event of kind SearchExecuted with a payload that
     // includes `selected: [memory_id]`.  The storage layer's `append_event`
-    // implementation calls `decode_rank_observations`, which reads
+    // implementation calls `decode_recall_observations`, which reads
     // `payload["selected"]` and inserts a row into `event_observations` with
-    // role="selected" and entity_id=memory_id.
+    // role="selected" and entity_id=memory_id. (`selected` is part of
+    // `SearchExecuted`/`RecallExecuted`'s typed contract per ADR-041 —
+    // unlike `RerankExecuted`, which projects `selected` rows from
+    // `final_scores`/`reranked` instead, since its typed payload has no
+    // `selected` field.)
     let event_store = rt.events(&tok).unwrap();
     let mut event = Event::new(
         ns,
-        "rerank",
-        EventKind::RerankExecuted,
+        "search",
+        EventKind::SearchExecuted,
         SubstrateKind::Note,
         "agent:test",
     );

--- a/docs/adr/ADR-041-event-provenance-projection.md
+++ b/docs/adr/ADR-041-event-provenance-projection.md
@@ -573,7 +573,7 @@ The generated V13 SQL adds `events.session_id TEXT`, creates `event_observations
   → `Selected` note rows.
 - `LinkCreated`: `payload.source_id` and `payload.target_id` → two entity `Target`
   rows at `position=0` and `position=1`.
-- `FeedbackExplicit`: `payload.about_id` → entity `Signal` row.
+- `FeedbackExplicit`: `event.target_id` → entity `Signal` row (Amendment A1).
 
 ### PackEventConsumer dispatch update
 
@@ -618,6 +618,28 @@ files own this behavior. Consumers that need event observations read the shipped
    isolation via the JOIN to `events.namespace`. No `namespace` column on the
    projection itself; correct by construction but worth noting in the implementation
    comment.
+
+---
+
+## Amendment A1: `FeedbackExplicit` signal decodes from `target_id`, not `payload.about_id` (2026-07-10, khive#811)
+
+§3's per-verb role mapping and §"Implementation"'s decoder examples originally specified
+`FeedbackExplicit: payload.about_id → entity Signal row`. No emitter ever wrote a payload
+`about_id` field — `brain.feedback` (`crates/khive-pack-brain/src/handlers.rs`) sets the
+feedback subject via `Event::with_target(target)`, i.e. `event.target_id`, matching every
+other target-carrying event kind (`EntityUpdated`, `NoteUpdated`, `TaskTransitioned`, …).
+`decode_signal_observation` (`crates/khive-db/src/stores/event.rs`) read the nonexistent
+payload field instead, so every `FeedbackExplicit` event projected zero `Signal` rows —
+the projection was silently empty for the entire lifetime of this ADR's implementation.
+
+This is a decoder bug, not an emitter bug: `event.target_id` is the correct, already-shipped
+carrier for "the entity/note this event is about" across every other decoded event kind, and
+changing the emitter to duplicate that value into `payload.about_id` would introduce a
+redundant field with no consumer. The fix makes `decode_signal_observation` read
+`event.target_id`, consistent with `decode_target_observation`.
+
+The role mapping in §3 (`FeedbackExplicit` → `Signal`) and its intent are unchanged — only
+the field the decoder reads to populate it.
 
 ---
 

--- a/docs/adr/ADR-041-event-provenance-projection.md
+++ b/docs/adr/ADR-041-event-provenance-projection.md
@@ -573,7 +573,8 @@ The generated V13 SQL adds `events.session_id TEXT`, creates `event_observations
   → `Selected` note rows.
 - `LinkCreated`: `payload.source_id` and `payload.target_id` → two entity `Target`
   rows at `position=0` and `position=1`.
-- `FeedbackExplicit`: `event.target_id` → entity `Signal` row (Amendment A1).
+- `FeedbackExplicit`: `event.target_id` → entity **or note** `Signal` row, per
+  `event.substrate` (Amendment A1, A2).
 
 ### PackEventConsumer dispatch update
 
@@ -640,6 +641,22 @@ redundant field with no consumer. The fix makes `decode_signal_observation` read
 
 The role mapping in §3 (`FeedbackExplicit` → `Signal`) and its intent are unchanged — only
 the field the decoder reads to populate it.
+
+---
+
+## Amendment A2: `FeedbackExplicit` `Signal` rows admit entity or note referents (2026-07-10, khive#831)
+
+§3 and Amendment A1 described the `FeedbackExplicit` → `Signal` projection as entity-only.
+`brain.feedback` targets can resolve to either an entity or a note, but the emitted event
+carried a fixed `SubstrateKind::Event` placeholder, so `decode_signal_observation`
+hard-coded `ReferentKind::Entity` and `observed_as_signal` (`crates/khive-query/src/compilers/sql.rs`)
+only admitted entity referents — a note-typed feedback target could never be resolved
+through `observed_as_signal`.
+
+The fix threads the resolved target's actual substrate (`Entity`/`Note`) onto the emitted
+event, `decode_signal_observation` picks `ReferentKind` from `event.substrate` (falling
+back to `Entity` for pre-fix historical events still carrying the `SubstrateKind::Event`
+placeholder), and `observed_as_signal` admits both entity and note referents.
 
 ---
 


### PR DESCRIPTION
## Root cause

`decode_signal_observation` (`crates/khive-db/src/stores/event.rs`) projects `event_observations` rows for `FeedbackExplicit` events by reading `payload.about_id`. No emitter ever writes that field.

The only emitter, `brain.feedback` (`crates/khive-pack-brain/src/handlers.rs:1451` and `:1493`), builds the event via:

```rust
Event::new(namespace, "brain.feedback", EventKind::FeedbackExplicit, SubstrateKind::Event, "brain")
    .with_target(target)
    .with_payload(data)
```

`.with_target(target)` sets `event.target_id`, not `payload["about_id"]`. Every real `FeedbackExplicit` event therefore projects zero `Signal` observation rows — `decode_signal_observation` always hits its `payload_uuid(event, "about_id")? == None` early return and returns `Ok(Vec::new())`. This is a silently-empty projection, not a hard failure, so nothing surfaced it until #811's recon.

## ADR contract

[ADR-041](docs/adr/ADR-041-event-provenance-projection.md) §3/§Implementation is the governing contract and specified the (nonexistent) `payload.about_id` field. Checked against the emitter, `event.target_id` is the side that's actually shipped and consistent with every other target-carrying event kind (`EntityUpdated`, `NoteUpdated`, `TaskTransitioned`, `LinkCreated`'s source/target) — all of which the decoder already reads from `target_id`/well-known payload fields, never a role-specific alias. Verdict: **the decoder was wrong, not the emitter.** Adding a duplicate `about_id` payload field to the emitter would be a redundant field with no consumer.

Fixed the decoder side and added **Amendment A1** to ADR-041 documenting the corrected contract (`event.target_id`, not `payload.about_id`) and why the emitter side was judged correct.

## Fix

```rust
fn decode_signal_observation(event: &Event) -> Result<Vec<EventObservation>, rusqlite::Error> {
    let Some(entity_id) = event.target_id else {
        return Ok(Vec::new());
    };
    ...
```

Mirrors `decode_target_observation`'s existing `event.target_id` read.

## Test evidence

Added `feedback_explicit_projects_signal_observation_from_target_id` in `crates/khive-db/src/stores/event_tests.rs`: builds a `FeedbackExplicit` event the same way the real emitter does (`Event::new(...).with_target(target)`, no `about_id` in payload), appends it through `SqlEventStore::append_event`, and asserts one `event_observations` row with `role = 'signal'` and `entity_id = target` exists. Before the fix this test fails (0 rows); after the fix it passes.

```
$ cargo test -p khive-db
test result: ok. 249 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out  (contract tests)

$ cargo clippy -p khive-db --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — clean

$ cargo fmt --all -- --check
(clean)
```

Fixes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)