### PR TITLE
fix(query): accept integer literals in GQL inline property maps

### DIFF
--- a/crates/khive-query/docs/design.md
+++ b/crates/khive-query/docs/design.md
@@ -92,6 +92,73 @@ edges that join against `event_observations`, not `graph_edges`.
 - Event nodes do not have `entity_type` or arbitrary `properties` -- these are
   rejected at compile time with an actionable error.
 
+### Inline Property-Map Literal Grammar (issues #755, #832)
+
+Node patterns support an inline property map: `(n:kind {key: value, ...})`. The
+grammar for `value` (shared with WHERE-clause condition values, via the same
+`parse_value` parser) is:
+
+```text
+value      = string | integer | float | bool
+string     = "'" ... "'" | '"' ... '"'
+integer    = ["-"] digit+                     -- no "." in the lexeme
+float      = ["-"] digit+ "." digit+          -- "." required
+bool       = "true" | "false"                 -- case-insensitive
+```
+
+**Type binding:**
+
+- `string` binds as SQL `TEXT` with `COLLATE NOCASE` (case-insensitive
+  equality against the property's stored JSON string).
+- `integer` binds as `QueryValue::Integer(i64)` -- the full `i64` range
+  (`i64::MIN..=i64::MAX`) is supported, including magnitudes beyond `f64`'s
+  exact-integer limit of 2^53. An integer lexeme outside `i64` range is a
+  **parse-time error** (`QueryError::Parse`), not a silent truncation or a
+  fallback to a lossy float.
+- `float` binds as `QueryValue::Float(f64)`. A float lexeme whose magnitude
+  overflows `f64` to `Infinity` (or otherwise fails to parse as finite) is a
+  **parse-time error** (`QueryError::Parse`); non-finite values never reach
+  the compiler. The compiler additionally re-checks `is_finite()` on every
+  numeric parameter it binds (in `compile_property_equality` and in WHERE
+  condition compilation) as defense-in-depth, returning `InvalidInput` if a
+  non-finite value is ever constructed by a caller outside the parser (e.g. a
+  hand-built AST).
+- `bool` binds as `QueryValue::Integer(0)` / `QueryValue::Integer(1)`, no
+  `COLLATE`.
+
+**`entity_type` is string-only.** `entity_type` is lifted out of the property
+map into `NodePattern.entity_type` and compiled to the dedicated
+`entity_type` column (never `json_extract`). A non-string `entity_type`
+value (e.g. `{entity_type: 54}`) is rejected at parse time with
+`QueryError::Parse`.
+
+**Why integer and float are distinct literal kinds, not one numeric type:**
+entity/note properties are stored as JSON, and SQLite's `json_extract`
+returns a JSON number as either its INTEGER or REAL storage class depending
+on whether the JSON literal had a decimal point. Prior to #832, every numeric
+literal parsed to `f64` and compiled to `QueryValue::Float` (`REAL`)
+regardless of source form; large integers (`2^53+1` and beyond, including
+`i64::MAX`/`i64::MIN`) silently rounded to the nearest representable `f64`
+before comparison, so an equality or MATCH-map filter on the *exact* stored
+integer could round-trip to a different number and either false-match or
+(more commonly) silently match zero rows. Splitting the literal grammar at
+parse time -- an integer lexeme has no `.`, a float lexeme requires one --
+lets the compiler bind `QueryValue::Integer` for integer literals and
+preserve exact `i64` precision through to the SQLite parameter.
+
+**Unsupported forms (rejected, not silently coerced):**
+
+- Scientific notation (`1e10`, `1.5e-3`) is not part of the grammar -- the
+  lexer only consumes ASCII digits and a single `.`; an `e`/`E` character
+  ends the numeric lexeme and the parser then expects a delimiter (`,` or
+  `}`), producing a parse error.
+- `null` is not a recognized value literal in either the inline property map
+  or WHERE conditions.
+- A quoted numeric string (e.g. `{number: '54'}`) is a deliberate `TEXT`
+  literal and is never coerced to a number -- it matches JSON strings only,
+  not the JSON-number storage class. See the #755 commit for the full
+  rationale.
+
 ## Invariants and Failure Modes
 
 ### Invariants
@@ -111,11 +178,14 @@ edges that join against `event_observations`, not `graph_edges`.
 
 ### Failure Modes
 
-- `QueryError::Parse` -- malformed input syntax
+- `QueryError::Parse` -- malformed input syntax; also an integer literal
+  outside `i64` range or a float literal that overflows to a non-finite
+  value (issue #832)
 - `QueryError::Validation` -- namespace in query text, unknown relation, inverted
   hop range, malformed pattern shape
 - `QueryError::InvalidInput` -- depth exceeds cap, limit overflows `i64`,
-  non-finite float parameter
+  non-finite float parameter (defense-in-depth re-check at compile time; the
+  parser already rejects non-finite float literals, issue #832)
 - `QueryError::Unsupported` -- zero-hop range, repeated node variable, mixed
   fixed+variable chains, SPARQL `*` paths, OR spanning both endpoints
 - `QueryError::Compile` -- empty pattern, unknown variable in RETURN/WHERE, mixed
@@ -162,4 +232,4 @@ SELECT DISTINCT ... FROM traverse t JOIN entities r ... WHERE ... LIMIT ?
   `compile` to catch hand-constructed malformed ASTs.
 - The `parse_auto` fallback for unrecognized prefixes uses the GQL parser.
 
-Last reviewed: 2026-06-06
+Last reviewed: 2026-07-10

--- a/crates/khive-query/docs/design.md
+++ b/crates/khive-query/docs/design.md
@@ -102,9 +102,13 @@ grammar for `value` (shared with WHERE-clause condition values, via the same
 value      = string | integer | float | bool
 string     = "'" ... "'" | '"' ... '"'
 integer    = ["-"] digit+                     -- no "." in the lexeme
-float      = ["-"] digit+ "." digit+          -- "." required
+float      = ["-"] digit+ "." digit+          -- "." required, digits on both sides
 bool       = "true" | "false"                 -- case-insensitive
 ```
+
+The lexer enforces this grammar exactly, not `f64::parse`'s looser rules: `1.` and
+`-.5` (digits missing on one side of the dot) are rejected with `QueryError::Parse`,
+same as `.5`.
 
 **Type binding:**
 

--- a/crates/khive-query/src/ast.rs
+++ b/crates/khive-query/src/ast.rs
@@ -178,6 +178,13 @@ pub enum CompareOp {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConditionValue {
     String(String),
+    /// An integer literal (no decimal point in the source lexeme), preserved
+    /// as `i64` so it binds as `QueryValue::Integer` and compares exactly
+    /// against `json_extract`'s INTEGER storage class -- `f64` cannot
+    /// represent every `i64` exactly past 2^53, which silently rounds large
+    /// literals (e.g. `9007199254740993`) to the wrong value (issue #832).
+    Integer(i64),
+    /// A float literal (decimal point present in the source lexeme).
     Number(f64),
     Bool(bool),
 }

--- a/crates/khive-query/src/ast.rs
+++ b/crates/khive-query/src/ast.rs
@@ -129,7 +129,7 @@ pub struct NodePattern {
     /// Governed subtype within the kind (e.g. "researcher" within "person").
     /// Compiled to `entity_type = ?` — a direct column, not a property extraction.
     pub entity_type: Option<String>,
-    pub properties: HashMap<String, String>,
+    pub properties: HashMap<String, ConditionValue>,
 }
 
 /// An edge binding in the MATCH pattern with optional relation filters, direction, and hop bounds.
@@ -175,7 +175,7 @@ pub enum CompareOp {
 }
 
 /// Right-hand side value in a WHERE condition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ConditionValue {
     String(String),
     Number(f64),

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -215,6 +215,40 @@ fn namespace_filter(alias: &str, opts: &CompileOptions, params: &mut Vec<QueryVa
     }
 }
 
+/// Compile an inline property-map equality (`{key: value}`) to a parameterized
+/// SQL predicate, either against a direct text column (`text_column`, for keys
+/// like `name`/`content` that are stored as dedicated columns) or against
+/// `json_extract(<alias>.properties, '$.<key>')`.
+///
+/// String values bind as `TEXT` with `COLLATE NOCASE` (case-insensitive match,
+/// matching prior behavior). Number and Bool values bind as `REAL`/`INTEGER` —
+/// SQLite's `json_extract` returns JSON numbers/booleans as numeric storage
+/// classes, so a numeric literal must compare against a numeric parameter, not
+/// a `COLLATE NOCASE` text comparison that can never match (issue #755).
+fn compile_property_equality(
+    alias: &str,
+    key: &str,
+    value: &ConditionValue,
+    text_column: Option<&str>,
+    params: &mut Vec<QueryValue>,
+) -> String {
+    let is_string = matches!(value, ConditionValue::String(_));
+    match value {
+        ConditionValue::String(s) => params.push(QueryValue::Text(s.clone())),
+        ConditionValue::Number(n) => params.push(QueryValue::Float(*n)),
+        ConditionValue::Bool(b) => params.push(QueryValue::Integer(if *b { 1 } else { 0 })),
+    }
+    let collate = if is_string { " COLLATE NOCASE" } else { "" };
+    match text_column {
+        Some(col) => format!("{alias}.{col} = ?{}{collate}", params.len()),
+        None => format!(
+            "json_extract({alias}.properties, '$.{}') = ?{}{collate}",
+            key.replace('\'', "''"),
+            params.len()
+        ),
+    }
+}
+
 /// Returns `(source_indices, target_indices)` for synthetic `observed_as_*` edge endpoints.
 fn synthetic_endpoint_node_indices(
     elements: &[PatternElement],
@@ -339,17 +373,18 @@ fn compile_fixed_length(
                     let mut props: Vec<_> = np.properties.iter().collect();
                     props.sort_by_key(|(k, _)| k.as_str());
                     for (key, val) in props {
-                        params.push(QueryValue::Text(val.clone()));
-                        if key == "name" || key == "content" {
-                            where_parts
-                                .push(format!("{alias}.{key} = ?{} COLLATE NOCASE", params.len()));
+                        let text_column = if key == "name" || key == "content" {
+                            Some(key.as_str())
                         } else {
-                            where_parts.push(format!(
-                                "json_extract({alias}.properties, '$.{}') = ?{} COLLATE NOCASE",
-                                key.replace('\'', "''"),
-                                params.len()
-                            ));
-                        }
+                            None
+                        };
+                        where_parts.push(compile_property_equality(
+                            &alias,
+                            key,
+                            val,
+                            text_column,
+                            &mut params,
+                        ));
                     }
                 } else {
                     where_parts.push(format!("{alias}.deleted_at IS NULL"));
@@ -372,17 +407,14 @@ fn compile_fixed_length(
                     let mut props: Vec<_> = np.properties.iter().collect();
                     props.sort_by_key(|(k, _)| k.as_str());
                     for (key, val) in props {
-                        params.push(QueryValue::Text(val.clone()));
-                        if key == "name" {
-                            where_parts
-                                .push(format!("{alias}.name = ?{} COLLATE NOCASE", params.len()));
-                        } else {
-                            where_parts.push(format!(
-                                "json_extract({alias}.properties, '$.{}') = ?{} COLLATE NOCASE",
-                                key.replace('\'', "''"),
-                                params.len()
-                            ));
-                        }
+                        let text_column = if key == "name" { Some("name") } else { None };
+                        where_parts.push(compile_property_equality(
+                            &alias,
+                            key,
+                            val,
+                            text_column,
+                            &mut params,
+                        ));
                     }
                 }
 
@@ -1054,16 +1086,14 @@ fn compile_variable_length(
     let mut start_props: Vec<_> = start.properties.iter().collect();
     start_props.sort_by_key(|(k, _)| k.as_str());
     for (key, val) in start_props {
-        params.push(QueryValue::Text(val.clone()));
-        if key == "name" {
-            start_conditions.push(format!("s.name = ?{} COLLATE NOCASE", params.len()));
-        } else {
-            start_conditions.push(format!(
-                "json_extract(s.properties, '$.{}') = ?{} COLLATE NOCASE",
-                key.replace('\'', "''"),
-                params.len()
-            ));
-        }
+        let text_column = if key == "name" { Some("name") } else { None };
+        start_conditions.push(compile_property_equality(
+            "s",
+            key,
+            val,
+            text_column,
+            &mut params,
+        ));
     }
 
     // Relation filter
@@ -1140,16 +1170,14 @@ fn compile_variable_length(
     let mut end_props: Vec<_> = end.properties.iter().collect();
     end_props.sort_by_key(|(k, _)| k.as_str());
     for (key, val) in end_props {
-        params.push(QueryValue::Text(val.clone()));
-        if key == "name" {
-            end_conditions.push(format!("r.name = ?{} COLLATE NOCASE", params.len()));
-        } else {
-            end_conditions.push(format!(
-                "json_extract(r.properties, '$.{}') = ?{} COLLATE NOCASE",
-                key.replace('\'', "''"),
-                params.len()
-            ));
-        }
+        let text_column = if key == "name" { Some("name") } else { None };
+        end_conditions.push(compile_property_equality(
+            "r",
+            key,
+            val,
+            text_column,
+            &mut params,
+        ));
     }
 
     // WHERE clause conditions for variable-length patterns.

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -221,32 +221,46 @@ fn namespace_filter(alias: &str, opts: &CompileOptions, params: &mut Vec<QueryVa
 /// `json_extract(<alias>.properties, '$.<key>')`.
 ///
 /// String values bind as `TEXT` with `COLLATE NOCASE` (case-insensitive match,
-/// matching prior behavior). Number and Bool values bind as `REAL`/`INTEGER` —
-/// SQLite's `json_extract` returns JSON numbers/booleans as numeric storage
-/// classes, so a numeric literal must compare against a numeric parameter, not
-/// a `COLLATE NOCASE` text comparison that can never match (issue #755).
+/// matching prior behavior). Integer values bind as `INTEGER`, and Bool values
+/// bind as `INTEGER` (0/1) — SQLite's `json_extract` returns JSON
+/// numbers/booleans as numeric storage classes, so a numeric literal must
+/// compare against a numeric parameter, not a `COLLATE NOCASE` text
+/// comparison that can never match (issue #755). Integer literals bind as
+/// `QueryValue::Integer` rather than `Float` so values beyond `f64`'s exact
+/// 2^53 integer range (and both `i64` bounds) survive round-trip (issue
+/// #832). Float values are rejected here if non-finite, matching the
+/// `is_finite()` invariant enforced by WHERE-clause compilation
+/// (see `docs/design.md`).
 fn compile_property_equality(
     alias: &str,
     key: &str,
     value: &ConditionValue,
     text_column: Option<&str>,
     params: &mut Vec<QueryValue>,
-) -> String {
+) -> Result<String, QueryError> {
     let is_string = matches!(value, ConditionValue::String(_));
     match value {
         ConditionValue::String(s) => params.push(QueryValue::Text(s.clone())),
-        ConditionValue::Number(n) => params.push(QueryValue::Float(*n)),
+        ConditionValue::Integer(n) => params.push(QueryValue::Integer(*n)),
+        ConditionValue::Number(n) => {
+            if !n.is_finite() {
+                return Err(QueryError::InvalidInput(
+                    "non-finite float (NaN or Infinity) is not a valid query parameter".into(),
+                ));
+            }
+            params.push(QueryValue::Float(*n));
+        }
         ConditionValue::Bool(b) => params.push(QueryValue::Integer(if *b { 1 } else { 0 })),
     }
     let collate = if is_string { " COLLATE NOCASE" } else { "" };
-    match text_column {
+    Ok(match text_column {
         Some(col) => format!("{alias}.{col} = ?{}{collate}", params.len()),
         None => format!(
             "json_extract({alias}.properties, '$.{}') = ?{}{collate}",
             key.replace('\'', "''"),
             params.len()
         ),
-    }
+    })
 }
 
 /// Returns `(source_indices, target_indices)` for synthetic `observed_as_*` edge endpoints.
@@ -384,7 +398,7 @@ fn compile_fixed_length(
                             val,
                             text_column,
                             &mut params,
-                        ));
+                        )?);
                     }
                 } else {
                     where_parts.push(format!("{alias}.deleted_at IS NULL"));
@@ -414,7 +428,7 @@ fn compile_fixed_length(
                             val,
                             text_column,
                             &mut params,
-                        ));
+                        )?);
                     }
                 }
 
@@ -771,6 +785,10 @@ fn compile_single_condition(
             };
             format!("{col_expr} {op_str} ?{}{}", params.len(), collate)
         }
+        ConditionValue::Integer(n) => {
+            params.push(QueryValue::Integer(*n));
+            format!("{col_expr} {op_str} ?{}", params.len())
+        }
         ConditionValue::Number(n) => {
             if !n.is_finite() {
                 return Err(QueryError::InvalidInput(
@@ -897,6 +915,10 @@ fn compile_var_len_condition(
                 ""
             };
             format!("{col_expr} {op_str} ?{}{collate}", params.len())
+        }
+        ConditionValue::Integer(n) => {
+            params.push(QueryValue::Integer(*n));
+            format!("{col_expr} {op_str} ?{}", params.len())
         }
         ConditionValue::Number(n) => {
             if !n.is_finite() {
@@ -1093,7 +1115,7 @@ fn compile_variable_length(
             val,
             text_column,
             &mut params,
-        ));
+        )?);
     }
 
     // Relation filter
@@ -1177,7 +1199,7 @@ fn compile_variable_length(
             val,
             text_column,
             &mut params,
-        ));
+        )?);
     }
 
     // WHERE clause conditions for variable-length patterns.

--- a/crates/khive-query/src/parsers/gql.rs
+++ b/crates/khive-query/src/parsers/gql.rs
@@ -167,7 +167,7 @@ impl Parser {
         }
     }
 
-    fn parse_props(&mut self) -> Result<HashMap<String, String>, QueryError> {
+    fn parse_props(&mut self) -> Result<HashMap<String, ConditionValue>, QueryError> {
         self.expect_char('{')?;
         let mut props = HashMap::new();
         loop {
@@ -181,7 +181,7 @@ impl Parser {
             }
             let key = self.parse_ident()?;
             self.expect_char(':')?;
-            let val = self.parse_string_literal()?;
+            let val = self.parse_value()?;
             if props.insert(key.clone(), val).is_some() {
                 return Err(self.err(format!("duplicate property '{key}'")));
             }
@@ -237,7 +237,11 @@ impl Parser {
 
         // Lift entity_type out of properties so the SQL compiler targets the
         // dedicated column instead of json_extract(properties, '$.entity_type').
-        let entity_type = properties.remove("entity_type");
+        let entity_type = match properties.remove("entity_type") {
+            Some(ConditionValue::String(s)) => Some(s),
+            Some(_) => return Err(self.err("entity_type must be a string literal")),
+            None => None,
+        };
 
         self.expect_char(')')?;
         Ok(NodePattern {
@@ -561,7 +565,10 @@ mod tests {
         let q = parse("MATCH (a {name: 'LoRA'})-[:extends|variant_of*1..3]->(b) RETURN b LIMIT 20")
             .unwrap();
         let nodes: Vec<_> = q.pattern.nodes().collect();
-        assert_eq!(nodes[0].properties.get("name").unwrap(), "LoRA");
+        assert_eq!(
+            nodes[0].properties.get("name").unwrap(),
+            &ConditionValue::String("LoRA".into())
+        );
 
         let edges: Vec<_> = q.pattern.edges().collect();
         assert_eq!(edges[0].relations, vec!["extends", "variant_of"]);

--- a/crates/khive-query/src/parsers/gql.rs
+++ b/crates/khive-query/src/parsers/gql.rs
@@ -151,9 +151,28 @@ impl Parser {
                     }
                 }
                 let s: String = self.input[start..self.pos].iter().collect();
+                // No decimal point: integer lexeme -- parse as i64 so the value
+                // survives round-trip past 2^53 (f64's exact-integer limit) and
+                // both i64 bounds. Scientific notation is not part of this
+                // grammar (the loop above only consumes digits and '.'), so an
+                // integer lexeme is always plain decimal digits.
+                if !s.contains('.') {
+                    let n: i64 = s.parse().map_err(|_| {
+                        self.err(format!(
+                            "integer literal '{s}' out of supported range \
+                             ({} to {})",
+                            i64::MIN,
+                            i64::MAX
+                        ))
+                    })?;
+                    return Ok(ConditionValue::Integer(n));
+                }
                 let n: f64 = s
                     .parse()
                     .map_err(|_| self.err(format!("invalid number: {s}")))?;
+                if !n.is_finite() {
+                    return Err(self.err(format!("float literal '{s}' is not finite")));
+                }
                 Ok(ConditionValue::Number(n))
             }
             _ => {

--- a/crates/khive-query/src/parsers/gql.rs
+++ b/crates/khive-query/src/parsers/gql.rs
@@ -143,20 +143,37 @@ impl Parser {
                 if c == '-' {
                     self.advance();
                 }
-                while let Some(c) = self.peek() {
-                    if c.is_ascii_digit() || c == '.' {
+                // Grammar (docs/design.md): integer = ["-"] digit+ ; float = ["-"]
+                // digit+ "." digit+ -- digits are required on both sides of the
+                // dot. Reject "1." and "-.5" instead of delegating the bare
+                // lexeme to f64::parse, which accepts both.
+                let int_start = self.pos;
+                while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                    self.advance();
+                }
+                if self.pos == int_start {
+                    return Err(self.err("expected digit after '-'"));
+                }
+                let mut has_frac = false;
+                if self.peek() == Some('.') {
+                    has_frac = true;
+                    self.advance();
+                    let frac_start = self.pos;
+                    while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
                         self.advance();
-                    } else {
-                        break;
+                    }
+                    if self.pos == frac_start {
+                        return Err(self.err(
+                            "float literal must have digits after '.' (e.g. '1.0', not '1.')",
+                        ));
                     }
                 }
                 let s: String = self.input[start..self.pos].iter().collect();
                 // No decimal point: integer lexeme -- parse as i64 so the value
                 // survives round-trip past 2^53 (f64's exact-integer limit) and
                 // both i64 bounds. Scientific notation is not part of this
-                // grammar (the loop above only consumes digits and '.'), so an
-                // integer lexeme is always plain decimal digits.
-                if !s.contains('.') {
+                // grammar, so an integer lexeme is always plain decimal digits.
+                if !has_frac {
                     let n: i64 = s.parse().map_err(|_| {
                         self.err(format!(
                             "integer literal '{s}' out of supported range \

--- a/crates/khive-query/src/parsers/sparql.rs
+++ b/crates/khive-query/src/parsers/sparql.rs
@@ -330,7 +330,7 @@ fn triples_to_ast(
     let return_items: Vec<ReturnItem> =
         return_items.into_iter().map(ReturnItem::Variable).collect();
     let mut node_kinds: HashMap<String, String> = HashMap::new();
-    let mut node_props: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut node_props: HashMap<String, HashMap<String, ConditionValue>> = HashMap::new();
     let mut edges: Vec<(String, String, String, usize, usize)> = Vec::new(); // (src, tgt, rel, min, max)
     let mut where_cond_list: Vec<Condition> = Vec::new();
 
@@ -359,7 +359,7 @@ fn triples_to_ast(
                     node_props
                         .entry(triple.subject)
                         .or_default()
-                        .insert(name, val);
+                        .insert(name, ConditionValue::String(val));
                 }
                 Object::NumberLiteral(val) => {
                     where_cond_list.push(Condition {
@@ -373,7 +373,7 @@ fn triples_to_ast(
                     node_props
                         .entry(triple.subject)
                         .or_default()
-                        .insert(name, val);
+                        .insert(name, ConditionValue::String(val));
                 }
             },
         }
@@ -498,7 +498,7 @@ fn triples_to_ast(
 
     let first_var = &ordered_edges[0].0;
     let mut first_props = node_props.get(first_var).cloned().unwrap_or_default();
-    let first_entity_type = first_props.remove("entity_type");
+    let first_entity_type = extract_entity_type(&mut first_props)?;
     elements.push(PatternElement::Node(NodePattern {
         variable: Some(first_var.clone()),
         kind: node_kinds.get(first_var).cloned(),
@@ -515,7 +515,7 @@ fn triples_to_ast(
             max_hops: *max_hops,
         }));
         let mut tgt_props = node_props.get(tgt).cloned().unwrap_or_default();
-        let tgt_entity_type = tgt_props.remove("entity_type");
+        let tgt_entity_type = extract_entity_type(&mut tgt_props)?;
         elements.push(PatternElement::Node(NodePattern {
             variable: Some(tgt.clone()),
             kind: node_kinds.get(tgt).cloned(),
@@ -530,6 +530,21 @@ fn triples_to_ast(
         return_items,
         limit,
     })
+}
+
+/// Lift `entity_type` out of a node's property map, requiring a string literal —
+/// the same constraint the GQL inline-map parser enforces.
+fn extract_entity_type(
+    props: &mut HashMap<String, ConditionValue>,
+) -> Result<Option<String>, QueryError> {
+    match props.remove("entity_type") {
+        Some(ConditionValue::String(s)) => Ok(Some(s)),
+        Some(_) => Err(QueryError::Parse {
+            message: "entity_type must be a string literal".into(),
+            position: 0,
+        }),
+        None => Ok(None),
+    }
 }
 
 /// Parse a SPARQL query string into a [`GqlQuery`] AST. Errors on invalid or unsupported syntax.
@@ -628,7 +643,10 @@ mod tests {
     fn variable_length_plus() {
         let q = parse("SELECT ?b WHERE { ?a :name 'LoRA' . ?a :extends+ ?b . }").unwrap();
         let nodes: Vec<_> = q.pattern.nodes().collect();
-        assert_eq!(nodes[0].properties.get("name").unwrap(), "LoRA");
+        assert_eq!(
+            nodes[0].properties.get("name").unwrap(),
+            &ConditionValue::String("LoRA".into())
+        );
 
         let edges: Vec<_> = q.pattern.edges().collect();
         assert_eq!(edges[0].min_hops, 1);
@@ -660,7 +678,10 @@ mod tests {
             parse("SELECT ?a WHERE { ?a a :concept . ?a :domain 'attention' . ?a :extends+ ?b . }")
                 .unwrap();
         let nodes: Vec<_> = q.pattern.nodes().collect();
-        assert_eq!(nodes[0].properties.get("domain").unwrap(), "attention");
+        assert_eq!(
+            nodes[0].properties.get("domain").unwrap(),
+            &ConditionValue::String("attention".into())
+        );
     }
 
     #[test]

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -663,10 +663,11 @@ fn gql_inline_property_map_integer_compiles_to_numeric_param() {
     let has_numeric_param = compiled
         .params
         .iter()
-        .any(|p| matches!(p, QueryValue::Float(n) if *n == 54.0));
+        .any(|p| matches!(p, QueryValue::Integer(54)));
     assert!(
         has_numeric_param,
-        "integer literal must bind as a numeric QueryValue, not text; params: {:?}",
+        "integer literal must bind as QueryValue::Integer, not Float or text \
+         (Float loses precision past 2^53 -- issue #832); params: {:?}",
         compiled.params
     );
 
@@ -770,5 +771,151 @@ fn variable_length_inline_property_map_integer_compiles_to_numeric_param() {
     assert!(compiled
         .params
         .iter()
-        .any(|p| matches!(p, QueryValue::Float(n) if *n == 54.0)));
+        .any(|p| matches!(p, QueryValue::Integer(54))));
+}
+
+#[test]
+fn variable_length_inline_property_map_large_integer_binds_exact_i64() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: 9007199254740993})-[:extends*1..2]->(b) RETURN b",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Integer(9007199254740993))));
+}
+
+// --- Issue #832: integer literal precision (2^53+1, i64 bounds, overflow) ---
+
+#[test]
+fn gql_inline_property_map_large_integer_binds_exact_i64_not_lossy_float() {
+    // 2^53 + 1 = 9007199254740993 is the smallest positive integer that
+    // cannot be represented exactly as f64 -- it rounds to 9007199254740992.0.
+    // A JSON-number property with this value must be matched by an exact i64
+    // parameter, not a lossy float.
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:artifact {number: 9007199254740993}) RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(
+        compiled
+            .params
+            .iter()
+            .any(|p| matches!(p, QueryValue::Integer(9007199254740993))),
+        "large integer literal must bind as the exact i64, not a rounded f64; params: {:?}",
+        compiled.params
+    );
+}
+
+#[test]
+fn gql_inline_property_map_i64_max_binds_exact() {
+    let q = parse(
+        QueryLanguage::Gql,
+        &format!("MATCH (n:artifact {{number: {}}}) RETURN n", i64::MAX),
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Integer(n) if *n == i64::MAX)));
+}
+
+#[test]
+fn gql_inline_property_map_i64_min_binds_exact() {
+    let q = parse(
+        QueryLanguage::Gql,
+        &format!("MATCH (n:artifact {{number: {}}}) RETURN n", i64::MIN),
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Integer(n) if *n == i64::MIN)));
+}
+
+#[test]
+fn gql_where_equality_large_integer_binds_exact_i64_not_lossy_float() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:artifact) WHERE n.number = 9007199254740993 RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(
+        compiled
+            .params
+            .iter()
+            .any(|p| matches!(p, QueryValue::Integer(9007199254740993))),
+        "WHERE equality with a large integer literal must bind exact i64; params: {:?}",
+        compiled.params
+    );
+}
+
+#[test]
+fn gql_where_equality_i64_bounds_bind_exact() {
+    for bound in [i64::MIN, i64::MAX] {
+        let q = parse(
+            QueryLanguage::Gql,
+            &format!("MATCH (n:artifact) WHERE n.number = {bound} RETURN n"),
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled
+                .params
+                .iter()
+                .any(|p| matches!(p, QueryValue::Integer(n) if *n == bound)),
+            "bound {bound} must bind exact; params: {:?}",
+            compiled.params
+        );
+    }
+}
+
+#[test]
+fn gql_inline_property_map_integer_overflow_rejected_at_parse_time() {
+    // i64::MAX + 1 -- one digit sequence beyond the supported integer range.
+    let overflow = "9223372036854775808";
+    let err = parse(
+        QueryLanguage::Gql,
+        &format!("MATCH (n:artifact {{number: {overflow}}}) RETURN n"),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QueryError::Parse { .. }),
+        "out-of-range integer literal must be rejected at parse time, not silently \
+         truncated or coerced to float; got: {err:?}"
+    );
+}
+
+#[test]
+fn gql_where_equality_integer_overflow_rejected_at_parse_time() {
+    let overflow = "9223372036854775808";
+    let err = parse(
+        QueryLanguage::Gql,
+        &format!("MATCH (n:artifact) WHERE n.number = {overflow} RETURN n"),
+    )
+    .unwrap_err();
+    assert!(matches!(err, QueryError::Parse { .. }));
+}
+
+#[test]
+fn gql_inline_property_map_float_overflow_rejected() {
+    // A decimal literal (has a '.') whose magnitude overflows f64 to infinity.
+    let huge = format!("{}.0", "9".repeat(400));
+    let err = parse(
+        QueryLanguage::Gql,
+        &format!("MATCH (n:document {{score: {huge}}}) RETURN n"),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QueryError::Parse { .. }),
+        "non-finite float literal must be rejected, not silently bound as Infinity; got: {err:?}"
+    );
 }

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -625,3 +625,150 @@ fn parse_auto_sparql() {
         ]
     );
 }
+
+// --- Issue #755: inline property-map integer literals ---
+
+#[test]
+fn gql_inline_property_map_accepts_integer_literal() {
+    // Previously a parse error: "expected string literal".
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: 54}) RETURN n",
+    );
+    assert!(q.is_ok(), "integer literal must parse: {:?}", q.err());
+}
+
+#[test]
+fn gql_inline_property_map_accepts_negative_integer_literal() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {offset: -54}) RETURN n",
+    );
+    assert!(
+        q.is_ok(),
+        "negative integer literal must parse: {:?}",
+        q.err()
+    );
+}
+
+#[test]
+fn gql_inline_property_map_integer_compiles_to_numeric_param() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: 54}) RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+
+    let has_numeric_param = compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Float(n) if *n == 54.0));
+    assert!(
+        has_numeric_param,
+        "integer literal must bind as a numeric QueryValue, not text; params: {:?}",
+        compiled.params
+    );
+
+    let number_predicate = compiled
+        .sql
+        .lines()
+        .find(|l| l.contains("'$.number'"))
+        .unwrap_or(&compiled.sql);
+    assert!(
+        !number_predicate.contains("COLLATE NOCASE"),
+        "numeric comparison must not use text COLLATE NOCASE; sql: {}",
+        compiled.sql
+    );
+}
+
+#[test]
+fn gql_inline_property_map_integer_matches_json_number_not_json_string() {
+    // Regression for the root cause: json_extract() returns a JSON number as a
+    // SQLite numeric storage class. Binding it as QueryValue::Text produced a
+    // predicate that could never match (TEXT vs INTEGER/REAL never compare
+    // equal in SQLite), which is exactly the silent-mismatch bug in #755.
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: 54}) RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(
+        compiled
+            .params
+            .iter()
+            .any(|p| matches!(p, QueryValue::Integer(_) | QueryValue::Float(_))),
+        "must bind a numeric parameter so it compares equal to json_extract's \
+         numeric result; params: {:?}",
+        compiled.params
+    );
+}
+
+#[test]
+fn gql_inline_property_map_quoted_number_still_binds_as_text() {
+    // Decided behavior (documented in PR body for #755): a quoted numeric
+    // string in an inline property map is a deliberate string literal and
+    // keeps matching JSON strings only — it must NOT be coerced to a number.
+    // This is what previously produced the "silently matches nothing" trap
+    // against a JSON-number-typed property; the fix is that the *unquoted*
+    // form (above) now works, not that the quoted form starts matching numbers.
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: '54'}) RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    let has_text_param = compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Text(s) if s == "54"));
+    assert!(
+        has_text_param,
+        "quoted numeric literal must still bind as TEXT; params: {:?}",
+        compiled.params
+    );
+}
+
+#[test]
+fn gql_inline_property_map_accepts_float_and_bool_literals() {
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {score: 4.5, archived: true}) RETURN n",
+    );
+    assert!(q.is_ok(), "float/bool literals must parse: {:?}", q.err());
+    let compiled = compile(&q.unwrap(), &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Float(n) if *n == 4.5)));
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Integer(1))));
+}
+
+#[test]
+fn gql_inline_property_map_entity_type_must_be_string() {
+    let err = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {entity_type: 54}) RETURN n",
+    )
+    .unwrap_err();
+    assert!(matches!(err, QueryError::Parse { .. }));
+}
+
+#[test]
+fn variable_length_inline_property_map_integer_compiles_to_numeric_param() {
+    // Same fix, exercised through the variable-length (recursive CTE) compile path.
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:pull_request {number: 54})-[:extends*1..2]->(b) RETURN b",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Float(n) if *n == 54.0)));
+}

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -879,6 +879,50 @@ fn gql_where_equality_i64_bounds_bind_exact() {
 }
 
 #[test]
+fn variable_length_where_i64_bounds_bind_exact() {
+    // Exercises the variable-length WHERE compiler branch (compile_var_len_condition,
+    // sql.rs:919), not the start-node inline property map path already covered above.
+    for bound in [i64::MIN, i64::MAX] {
+        let q = parse(
+            QueryLanguage::Gql,
+            &format!("MATCH (a)-[:extends*1..3]->(b) WHERE b.number = {bound} RETURN b"),
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled
+                .params
+                .iter()
+                .any(|p| matches!(p, QueryValue::Integer(n) if *n == bound)),
+            "variable-length WHERE bound {bound} must bind exact i64; params: {:?}",
+            compiled.params
+        );
+    }
+}
+
+#[test]
+fn variable_length_end_node_inline_property_map_i64_bounds_bind_exact() {
+    // Exercises the end-node inline-map CTE path (end.properties compiled via
+    // compile_property_equality), not the start-node inline map already covered above.
+    for bound in [i64::MIN, i64::MAX] {
+        let q = parse(
+            QueryLanguage::Gql,
+            &format!("MATCH (a)-[:extends*1..3]->(b:artifact {{number: {bound}}}) RETURN b"),
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled
+                .params
+                .iter()
+                .any(|p| matches!(p, QueryValue::Integer(n) if *n == bound)),
+            "end-node inline-map bound {bound} must bind exact i64; params: {:?}",
+            compiled.params
+        );
+    }
+}
+
+#[test]
 fn gql_inline_property_map_integer_overflow_rejected_at_parse_time() {
     // i64::MAX + 1 -- one digit sequence beyond the supported integer range.
     let overflow = "9223372036854775808";
@@ -918,4 +962,63 @@ fn gql_inline_property_map_float_overflow_rejected() {
         matches!(err, QueryError::Parse { .. }),
         "non-finite float literal must be rejected, not silently bound as Infinity; got: {err:?}"
     );
+}
+
+// --- Numeric literal grammar (docs/design.md): digits required on both
+// sides of the dot. `1.`, `-.5`, and `.5` must all be rejected, not
+// delegated to f64::parse's looser rules. ---
+
+#[test]
+fn gql_inline_property_map_trailing_dot_float_rejected() {
+    let err = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {score: 1.}) RETURN n",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QueryError::Parse { .. }),
+        "'1.' has no digits after the dot and must be rejected; got: {err:?}"
+    );
+}
+
+#[test]
+fn gql_inline_property_map_negative_leading_dot_float_rejected() {
+    let err = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {score: -.5}) RETURN n",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QueryError::Parse { .. }),
+        "'-.5' has no digits before the dot and must be rejected; got: {err:?}"
+    );
+}
+
+#[test]
+fn gql_inline_property_map_leading_dot_float_rejected() {
+    let err = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {score: .5}) RETURN n",
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QueryError::Parse { .. }),
+        "'.5' has no digits before the dot and must be rejected; got: {err:?}"
+    );
+}
+
+#[test]
+fn gql_inline_property_map_well_formed_float_still_parses() {
+    // Digits on both sides of the dot must keep working (regression guard
+    // against over-tightening the grammar check).
+    let q = parse(
+        QueryLanguage::Gql,
+        "MATCH (n:document {score: 1.5}) RETURN n",
+    )
+    .unwrap();
+    let compiled = compile(&q, &opts()).unwrap();
+    assert!(compiled
+        .params
+        .iter()
+        .any(|p| matches!(p, QueryValue::Float(n) if *n == 1.5)));
 }

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -345,6 +345,62 @@ async fn query_via_gql() {
 }
 
 // =============================================================================
+// GQL inline property-map integer literals (issue #755)
+//
+// Properties are stored as JSON values; `number: 54` in the entity's props
+// blob is a JSON number, so `json_extract` returns SQLite's INTEGER/REAL
+// storage class for it. An inline `{number: 54}` match must bind a numeric
+// parameter so the comparison actually compares equal; a quoted `{number:
+// '54'}` is a deliberate string literal and must keep comparing against JSON
+// strings only (it must not start matching the JSON number).
+// =============================================================================
+
+#[tokio::test]
+async fn query_via_gql_inline_property_map_integer_literal_matches_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let props = serde_json::json!({"number": 54});
+    rt.create_entity(&tok, "artifact", None, "PR #54", None, Some(props), vec![])
+        .await
+        .unwrap();
+
+    let rows = rt
+        .query(&tok, "MATCH (n:artifact {number: 54}) RETURN n")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "unquoted integer literal must match the JSON-number property"
+    );
+}
+
+#[tokio::test]
+async fn query_via_gql_inline_property_map_quoted_number_does_not_match_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let props = serde_json::json!({"number": 54});
+    rt.create_entity(&tok, "artifact", None, "PR #54", None, Some(props), vec![])
+        .await
+        .unwrap();
+
+    let rows = rt
+        .query(&tok, "MATCH (n:artifact {number: '54'}) RETURN n")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        0,
+        "quoted string literal must not match a JSON-number property; \
+         this is the decided behavior, not a residual bug"
+    );
+}
+
+// =============================================================================
 // GQL query truncation warning (issue #777)
 //
 // The compiler cannot infer truncation from the requested LIMIT alone — it

--- a/crates/khive-runtime/tests/integration.rs
+++ b/crates/khive-runtime/tests/integration.rs
@@ -401,6 +401,116 @@ async fn query_via_gql_inline_property_map_quoted_number_does_not_match_json_num
 }
 
 // =============================================================================
+// GQL integer literal precision against real SQLite (issue #832)
+//
+// f64 cannot represent every i64 exactly past 2^53: 9007199254740993 (2^53+1)
+// rounds to 9007199254740992.0 as a float. A JSON-number property storing the
+// exact large value must still be matched by an inline-map or WHERE-equality
+// integer literal, both of which now bind QueryValue::Integer instead of a
+// lossy QueryValue::Float.
+// =============================================================================
+
+#[tokio::test]
+async fn query_via_gql_inline_property_map_large_integer_matches_exact_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let props = serde_json::json!({"number": 9007199254740993i64});
+    rt.create_entity(&tok, "artifact", None, "big", None, Some(props), vec![])
+        .await
+        .unwrap();
+
+    let rows = rt
+        .query(
+            &tok,
+            "MATCH (n:artifact {number: 9007199254740993}) RETURN n",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "2^53+1 integer literal must match the exact JSON-number property, not round to 2^53"
+    );
+}
+
+#[tokio::test]
+async fn query_via_gql_where_equality_large_integer_matches_exact_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    let props = serde_json::json!({"number": 9007199254740993i64});
+    rt.create_entity(&tok, "artifact", None, "big", None, Some(props), vec![])
+        .await
+        .unwrap();
+
+    let rows = rt
+        .query(
+            &tok,
+            "MATCH (n:artifact) WHERE n.number = 9007199254740993 RETURN n",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+}
+
+#[tokio::test]
+async fn query_via_gql_inline_property_map_i64_bounds_match_exact_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    for bound in [i64::MIN, i64::MAX] {
+        let props = serde_json::json!({"number": bound});
+        rt.create_entity(&tok, "artifact", None, "bound", None, Some(props), vec![])
+            .await
+            .unwrap();
+
+        let rows = rt
+            .query(
+                &tok,
+                &format!("MATCH (n:artifact {{number: {bound}}}) RETURN n"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "i64 bound {bound} must match its exact JSON-number property"
+        );
+    }
+}
+
+#[tokio::test]
+async fn query_via_gql_where_equality_i64_bounds_match_exact_json_number() {
+    let rt = rt();
+    let tok = rt.authorize(Namespace::local()).unwrap();
+
+    for bound in [i64::MIN, i64::MAX] {
+        let props = serde_json::json!({"number": bound});
+        rt.create_entity(&tok, "artifact", None, "bound", None, Some(props), vec![])
+            .await
+            .unwrap();
+
+        let rows = rt
+            .query(
+                &tok,
+                &format!("MATCH (n:artifact) WHERE n.number = {bound} RETURN n"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "i64 bound {bound} must match its exact JSON-number property via WHERE equality"
+        );
+    }
+}
+
+// =============================================================================
 // GQL query truncation warning (issue #777)
 //
 // The compiler cannot infer truncation from the requested LIMIT alone — it


### PR DESCRIPTION
## Root cause

GQL inline node-property patterns (`{key: value}`) only accepted string literals — `parse_props()` in `crates/khive-query/src/parsers/gql.rs` called `parse_string_literal()` unconditionally, so `MATCH (n:pull_request {number:54}) RETURN n` failed to parse (`expected string literal`).

The documented workaround, `{number:'54'}`, silently matched nothing. Entity/note properties are stored as a JSON blob; the SQL compiler always bound property-map values as `QueryValue::Text` and compared with `json_extract(properties, '$.number') = ?N COLLATE NOCASE`. SQLite's `json_extract` returns a JSON number as an INTEGER/REAL storage class, and SQLite never considers TEXT equal to INTEGER/REAL regardless of collation — so a quoted numeric literal can never match a JSON-number property. The WHERE-clause path (`b.number = 54`) already worked because `ConditionValue::Number` binds a numeric `QueryValue::Float`.

`NodePattern.properties` was typed `HashMap<String, String>`, which structurally could not carry a numeric literal through to the compiler — the parser-level restriction and the compiler-level TEXT binding were two faces of the same root cause.

## Fix

- `NodePattern.properties` is now `HashMap<String, ConditionValue>` (`crates/khive-query/src/ast.rs`), reusing the `String`/`Number`/`Bool` literal type already used by WHERE clause conditions.
- GQL's `parse_props()` (`crates/khive-query/src/parsers/gql.rs`) now calls the existing `parse_value()` parser (already exercised by the WHERE-clause grammar), so inline maps accept string, integer, negative integer, float, and bool literals — the same literal grammar WHERE already accepts, per the issue's "Expected" section.
- SPARQL's triple-to-property lowering (`crates/khive-query/src/parsers/sparql.rs`) wraps string/kind objects in `ConditionValue::String` to match the new property-map type. Numeric-literal triples in SPARQL were already routed through the WHERE-condition path (`triples_to_ast`) rather than inline properties, so SPARQL numeric literals were unaffected by this bug — only the value-type plumbing changed.
- Added `compile_property_equality()` in the SQL compiler (`crates/khive-query/src/compilers/sql.rs`): string values bind as `TEXT` with `COLLATE NOCASE` (unchanged case-insensitive behavior), number values bind as `REAL` with no `COLLATE`, and bool values bind as `INTEGER` — matching how `json_extract` returns JSON numbers/booleans as numeric SQLite storage classes. Applied at all four inline-property-map compile sites: the fixed-length node path, the observation-target node path, and the variable-length (recursive CTE) start/end node paths.
- `entity_type` (lifted out of the property map into its own dedicated column) must still resolve to a string literal; a non-string value (`{entity_type: 54}`) now returns a clear parse error instead of silently producing a nonsensical comparison.

## Decided behavior for quoted numeric strings

A quoted numeric literal, `{number: '54'}`, is a deliberate string literal and **keeps matching JSON strings only** — it is not coerced to a number. This is intentional: `khive` properties are typed JSON, and silently reinterpreting a quoted string as a number would be its own source of surprising behavior (e.g. a property that is genuinely the string `"054"` or `"1e3"`). The silent-mismatch trap from the issue is closed by making the unquoted form (`{number: 54}`) work correctly, not by having the quoted form start matching numbers it was never meant to represent.

## Test evidence

`khive-query` unit + integration tests (`crates/khive-query/src/parsers/gql.rs`, `crates/khive-query/tests/compile_integration.rs`):
- Parser accepts integer, negative integer, float, and bool inline literals.
- `entity_type` with a non-string literal is rejected with a parse error.
- Compiled SQL binds a numeric `QueryValue` (no `COLLATE NOCASE`) for numeric inline properties, and still binds `QueryValue::Text` + `COLLATE NOCASE` for quoted strings — exercised across both the fixed-length and variable-length (recursive CTE) compile paths.

`khive-runtime` end-to-end regression against a real SQLite runtime (`crates/khive-runtime/tests/integration.rs`):
- `query_via_gql_inline_property_map_integer_literal_matches_json_number`: an entity created with JSON property `{"number": 54}` is matched by `MATCH (n:artifact {number: 54}) RETURN n`.
- `query_via_gql_inline_property_map_quoted_number_does_not_match_json_number`: the same entity returns zero rows for `MATCH (n:artifact {number: '54'}) RETURN n`, documenting the decided quoted-string behavior.

```
cargo test -p khive-query -p khive-runtime   # 65 + 142 + 46 + 8 unit/integration tests pass
cargo clippy -p khive-query -p khive-runtime --all-targets -- -D warnings   # clean
cargo fmt --all -- --check   # clean
```

Fixes #755