### PR TITLE
fix(db): escape LIKE wildcards in entity name-prefix resolution

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -380,6 +380,22 @@ fn parse_uuid(s: &str) -> Result<Uuid, rusqlite::Error> {
     })
 }
 
+/// Escape SQLite `LIKE` wildcard characters (`%`, `_`) and the escape
+/// character itself (`\`) so a caller-supplied name is matched literally
+/// under `LIKE ... ESCAPE '\'` rather than as a pattern (#818: an
+/// entity named e.g. `a_b` must not also match `aXb`, and a name containing
+/// `%` must not silently widen into a broad substring scan).
+fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn build_entity_where(
     namespace: &str,
     filter: &EntityFilter,
@@ -448,8 +464,8 @@ fn build_entity_where(
     }
 
     if let Some(ref prefix) = filter.name_prefix {
-        params.push(Box::new(format!("{}%", prefix)));
-        conditions.push(format!("name LIKE ?{}", params.len()));
+        params.push(Box::new(format!("{}%", escape_like(prefix))));
+        conditions.push(format!("name LIKE ?{} ESCAPE '\\'", params.len()));
     }
 
     if !filter.tags_any.is_empty() {
@@ -600,6 +616,22 @@ impl EntityStore for SqlEntityStore {
             };
 
             let (where_sql, mut data_params) = build_entity_where(&namespace, &filter);
+
+            // #818: when a name_prefix filter is active, an exact
+            // case-insensitive match must never be pushed out of the page by
+            // pattern candidates that merely share the prefix. Rank exact
+            // matches first (deterministic tiebreak via created_at) so page
+            // truncation can never hide the record a caller resolved by name.
+            let order_by = if let Some(ref prefix) = filter.name_prefix {
+                data_params.push(Box::new(prefix.to_ascii_lowercase()));
+                format!(
+                    "CASE WHEN LOWER(name) = ?{} THEN 0 ELSE 1 END, created_at DESC",
+                    data_params.len()
+                )
+            } else {
+                "created_at DESC".to_string()
+            };
+
             data_params.push(Box::new(limit_i64));
             data_params.push(Box::new(offset_i64));
 
@@ -609,8 +641,8 @@ impl EntityStore for SqlEntityStore {
             let data_sql = format!(
                 "SELECT id, namespace, kind, entity_type, name, description, properties, tags, \
                  created_at, updated_at, deleted_at, merged_into, merge_event_id \
-                 FROM entities{} ORDER BY created_at DESC LIMIT ?{} OFFSET ?{}",
-                where_sql, limit_idx, offset_idx,
+                 FROM entities{} ORDER BY {} LIMIT ?{} OFFSET ?{}",
+                where_sql, order_by, limit_idx, offset_idx,
             );
 
             let mut stmt = conn.prepare(&data_sql)?;

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -184,6 +184,100 @@ async fn test_query_by_name_prefix() {
 }
 
 #[tokio::test]
+async fn test_query_by_name_prefix_escapes_underscore_wildcard() {
+    let store = setup_memory_store_ns("ns1");
+
+    // The real entity's name contains a literal underscore.
+    store
+        .upsert_entity(make_entity("ns1", "concept", "a_b"))
+        .await
+        .unwrap();
+
+    // 150 decoys that would match the *unescaped* LIKE pattern "a_b%"
+    // (`_` as a wildcard matches any single character) but must not match
+    // once the wildcard is escaped. Created after "a_b" so a page ordered
+    // by created_at DESC with LIMIT 100 would push "a_b" out unless exact
+    // matches are also ranked first.
+    for i in 0..150 {
+        store
+            .upsert_entity(make_entity("ns1", "concept", &format!("aXb-{i:03}")))
+            .await
+            .unwrap();
+    }
+
+    let result = store
+        .query_entities(
+            "ns1",
+            EntityFilter {
+                name_prefix: Some("a_b".to_string()),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = result.items.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"a_b"),
+        "exact match 'a_b' must survive escaping and page ordering despite 150 wildcard-matching decoys; got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("aXb")),
+        "escaped '_' must not match decoy names like 'aXb-000'; got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_query_by_name_prefix_escapes_percent_wildcard() {
+    let store = setup_memory_store_ns("ns1");
+
+    // The real entity's name contains a literal percent sign.
+    store
+        .upsert_entity(make_entity("ns1", "concept", "50%off"))
+        .await
+        .unwrap();
+
+    // 150 decoys that would match the *unescaped* LIKE pattern "50%off%"
+    // (`%` as a wildcard matches any sequence, including across "-") but
+    // must not match once the wildcard is escaped.
+    for i in 0..150 {
+        store
+            .upsert_entity(make_entity("ns1", "concept", &format!("50-off-{i:03}")))
+            .await
+            .unwrap();
+    }
+
+    let result = store
+        .query_entities(
+            "ns1",
+            EntityFilter {
+                name_prefix: Some("50%off".to_string()),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = result.items.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"50%off"),
+        "exact match '50%off' must survive escaping and page ordering despite 150 wildcard-matching decoys; got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("50-off-")),
+        "escaped '%' must not match decoy names like '50-off-000'; got {names:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_count_entities() {
     let store = setup_memory_store_ns("ns1");
 

--- a/crates/khive-db/src/stores/entity_tests.rs
+++ b/crates/khive-db/src/stores/entity_tests.rs
@@ -277,6 +277,53 @@ async fn test_query_by_name_prefix_escapes_percent_wildcard() {
     );
 }
 
+// Regression for a round-1 gap on #818/#834: the two tests above prove
+// escaping keeps decoys out of the WHERE clause entirely, so they pass even
+// without the exact-match-first ORDER BY CASE. This test isolates that
+// ordering: every decoy genuinely matches the LIKE pattern "Base%" (no
+// wildcard characters, escaping plays no role) and is newer than the exact
+// match, so a page ordered only by `created_at DESC` would fill entirely with
+// decoys and strand "Base" past the LIMIT 100 boundary. It fails if the
+// `ORDER BY CASE WHEN LOWER(name) = ... THEN 0 ELSE 1 END` clause is removed.
+#[tokio::test]
+async fn test_query_by_name_prefix_exact_match_ranked_before_many_matching_decoys() {
+    let store = setup_memory_store_ns("ns1");
+
+    store
+        .upsert_entity(make_entity("ns1", "concept", "Base"))
+        .await
+        .unwrap();
+
+    for i in 0..150 {
+        store
+            .upsert_entity(make_entity("ns1", "concept", &format!("Base-{i:03}")))
+            .await
+            .unwrap();
+    }
+
+    let result = store
+        .query_entities(
+            "ns1",
+            EntityFilter {
+                name_prefix: Some("Base".to_string()),
+                ..Default::default()
+            },
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = result.items.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"Base"),
+        "exact match 'Base' must be ranked ahead of 150 newer, genuinely prefix-matching \
+         decoys within a LIMIT 100 page; got {names:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_count_entities() {
     let store = setup_memory_store_ns("ns1");

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -2023,6 +2023,98 @@ async fn link_by_name_exact_match_succeeds() {
 }
 
 #[tokio::test]
+async fn link_by_name_with_underscore_resolves_exactly() {
+    let pack = pack();
+
+    // Entity name contains a literal underscore, a SQLite LIKE
+    // single-character wildcard (#818).
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "a_b", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create 'a_b' must succeed");
+
+    // A decoy whose name only the *unescaped* wildcard form of "a_b" would
+    // match (`_` matching any single character).
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "aXb", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create 'aXb' must succeed");
+
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "TargetEntity", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create TargetEntity must succeed");
+
+    // Resolving "a_b" by name must find the exact entity, not be rejected as
+    // ambiguous with "aXb" and not silently resolve to the decoy.
+    let result = pack
+        .dispatch(
+            "link",
+            json!({
+                "source_id": "a_b",
+                "target_id": "TargetEntity",
+                "relation": "extends"
+            }),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "link by exact name 'a_b' must succeed despite an unescaped-wildcard-matching decoy; got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn link_by_name_with_percent_resolves_exactly() {
+    let pack = pack();
+
+    // Entity name contains a literal percent sign, a SQLite LIKE
+    // any-sequence wildcard (#818).
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "50%off", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create '50%off' must succeed");
+
+    // A decoy whose name only the *unescaped* wildcard form of "50%off"
+    // would match (`%` matching any sequence, including across "-").
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "50-off-promo", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create '50-off-promo' must succeed");
+
+    pack.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "TargetEntity", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create TargetEntity must succeed");
+
+    let result = pack
+        .dispatch(
+            "link",
+            json!({
+                "source_id": "50%off",
+                "target_id": "TargetEntity",
+                "relation": "extends"
+            }),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "link by exact name '50%off' must succeed despite an unescaped-wildcard-matching decoy; got: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn list_event_kind_returns_array() {
     let pack = pack_with_events();
     // Create an entity first so there are audit events to find.

--- a/crates/khive-pack-kg/tests/integration.rs
+++ b/crates/khive-pack-kg/tests/integration.rs
@@ -2114,6 +2114,71 @@ async fn link_by_name_with_percent_resolves_exactly() {
     );
 }
 
+/// Regression for a round-1 gap on #818/#834: the two tests above prove
+/// escaping keeps wildcard decoys out of the WHERE clause entirely, so they
+/// pass even without exact-match-first ordering. This test isolates that
+/// ordering through the real `link`-by-name verb path: every decoy genuinely
+/// matches the name-prefix "Base" (no wildcard characters, so escaping plays
+/// no role) and is created after the exact match, filling the 100-row
+/// resolution page with newer rows. It fails if the `ORDER BY CASE` in
+/// `query_entities` were removed, even though the WHERE clause and escaping
+/// remain correct.
+#[tokio::test]
+async fn link_by_name_exact_match_wins_over_many_prefix_matching_decoys() {
+    let rt = KhiveRuntime::memory().expect("in-memory runtime must succeed");
+    let token = rt.authorize(Namespace::local()).expect("authorize local");
+    let mut builder = VerbRegistryBuilder::new();
+    builder.register(KgPack::new(rt.clone()));
+    let f = Fixture {
+        registry: builder.build().expect("registry builds"),
+    };
+
+    // The exact-match entity is created first (oldest by created_at).
+    rt.create_entity(&token, "concept", None, "Base", None, None, vec![])
+        .await
+        .expect("create 'Base' must succeed");
+
+    // 150 decoys that genuinely match the name-prefix "Base" (no wildcard
+    // chars), created after "Base", seeded directly through the runtime to
+    // skip dispatch overhead.
+    for i in 0..150 {
+        rt.create_entity(
+            &token,
+            "concept",
+            None,
+            &format!("Base-{i:03}"),
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("create decoy must succeed");
+    }
+
+    f.dispatch(
+        "create",
+        json!({"kind": "entity", "name": "TargetEntity", "entity_kind": "concept"}),
+    )
+    .await
+    .expect("create TargetEntity must succeed");
+
+    let result = f
+        .dispatch(
+            "link",
+            json!({
+                "source_id": "Base",
+                "target_id": "TargetEntity",
+                "relation": "extends"
+            }),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "link by exact name 'Base' must resolve despite 150 newer, genuinely prefix-matching \
+         decoys filling the resolution page; got: {result:?}"
+    );
+}
+
 #[tokio::test]
 async fn list_event_kind_returns_array() {
     let pack = pack_with_events();


### PR DESCRIPTION
## Summary

- Fixes #818: entity name resolution (`resolve_uuid_async` → `resolve_name_async` in `khive-pack-kg/src/handlers/common.rs`) builds an `EntityFilter.name_prefix` from raw user input that `khive-db`'s `build_entity_where` bound unescaped as `name LIKE '<prefix>%'`. Names containing `%` or `_` (SQLite `LIKE` wildcards) broadened the match far beyond a literal prefix. Combined with the query's `LIMIT 100` page (ordered `created_at DESC`), enough wildcard-matched decoy rows created after the real entity could push the true exact match past the page boundary — the caller's post-fetch exact-match filter would then see zero candidates and report `NotFound`, even though the entity existed.
- Escapes `%`, `_`, and `\` in the prefix before binding and adds `ESCAPE '\'` to the `LIKE` clause in `crates/khive-db/src/stores/entity.rs`. This mirrors the `escape_like` helper pattern already used for the same bug class in `khive-pack-git/src/ingest.rs`, `kkernel/src/reindex.rs`, and `khive-pack-knowledge/src/knowledge/vamana.rs` (#819, PR #824). Those three crates sit downstream of `khive-db` in the dependency graph (`types → score → storage → db → query → runtime → pack-kg / pack-gtd → mcp`), so their existing helpers aren't reachable from `khive-db`; this adds a local `escape_like` copy in `khive-db` following the same established per-crate pattern rather than inventing a new cross-crate abstraction for a single call site.
- As defense in depth against page truncation even with the escape fix (a literal-prefix match could in principle still share a crowded page with 100+ other literally-prefixed rows), `query_entities` now ranks an exact case-insensitive name match first via `ORDER BY CASE WHEN LOWER(name) = ... THEN 0 ELSE 1 END, created_at DESC` whenever `name_prefix` is set. This mirrors the exact-before-pattern ordering already used in `find_document_for_path` (`khive-pack-git/src/ingest.rs`) — the issue's stated fix direction was both "escape wildcards" and "prefer exact-match candidates before pattern candidates so an exact hit can never lose to page truncation."

## Root cause

`crates/khive-db/src/stores/entity.rs:450` (pre-fix) bound `format!("{}%", prefix)` directly as a `LIKE` pattern with no escaping and no `ESCAPE` clause. `crates/khive-pack-kg/src/handlers/common.rs:199-244` (`resolve_name_async`) is the sole caller — it sets `name_prefix` to the raw, unresolved identifier string whenever a caller passes an entity name instead of a UUID or hex prefix (e.g. `link(source_id="50%off", ...)`), fetches page 1 (limit 100, `created_at DESC`), and then filters that page in Rust for a case-insensitive exact match. With enough decoy rows matching the *broadened, unescaped* pattern created after the real entity, the real entity fell outside the 100-row page and resolution failed.

## Test plan

- [x] Added `test_query_by_name_prefix_escapes_underscore_wildcard` and `test_query_by_name_prefix_escapes_percent_wildcard` in `crates/khive-db/src/stores/entity_tests.rs` — each seeds the real entity (`a_b` / `50%off`) plus 150 decoy entities matching only the *unescaped* wildcard form, created afterward so an unescaped/unordered page would truncate the real match. Verified these fail against the pre-fix code (exact match absent from the page) and pass after the fix.
- [x] Added `link_by_name_with_underscore_resolves_exactly` and `link_by_name_with_percent_resolves_exactly` in `crates/khive-pack-kg/tests/integration.rs` — exercise the actual `link` verb end-to-end with wildcard-bearing entity names plus a small decoy, proving the real-world resolution path still works.
- [x] `cargo test -p khive-db -p khive-pack-kg` (from `crates/`, `CARGO_TARGET_DIR=./target`) — 278 + 14 + 131 + 6 + 3 + 223 + 11 = all passing, including the 4 new tests.
- [x] `cargo clippy -p khive-db -p khive-pack-kg --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)