### PR TITLE
fix(pack-git): mask credentials in issue titles without dropping notes

### DIFF
--- a/crates/khive-pack-git/src/hook.rs
+++ b/crates/khive-pack-git/src/hook.rs
@@ -95,8 +95,12 @@ impl KindHook for CommitHook {
     }
 }
 
-/// The governed `state_reason` value set for `issue` (ADR-088 §3).
-const ISSUE_STATE_REASONS: &[&str] = &["completed", "not_planned", "reopened", "duplicate"];
+/// The governed `state_reason` value set for `issue` (ADR-088 §3). `pub(crate)`
+/// so `ingest::MaskedIssueFields` can classify against the same set at the
+/// masking boundary, before an ungoverned (possibly credential-shaped) raw
+/// value can reach this hook's error path.
+pub(crate) const ISSUE_STATE_REASONS: &[&str] =
+    &["completed", "not_planned", "reopened", "duplicate"];
 
 /// `KindHook` shared by `issue` and `pull_request` — both require
 /// `properties.number` and `properties.project_id`, and, when present,
@@ -149,9 +153,12 @@ impl KindHook for IssueLikeHook {
         }
 
         if let Some(reason) = props.get("state_reason").and_then(Value::as_str) {
+            // The raw value is never interpolated into this error: it is
+            // caller-controlled (for `issue`, sourced from GitHub) and may be
+            // credential-shaped. Only the static governed set is echoed.
             if self.kind == "issue" && !ISSUE_STATE_REASONS.contains(&reason) {
                 return Err(RuntimeError::InvalidInput(format!(
-                    "issue properties.state_reason {reason:?} invalid — valid: {}",
+                    "issue properties.state_reason is not one of the governed values — valid: {}",
                     ISSUE_STATE_REASONS.join(", ")
                 )));
             }

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1505,6 +1505,7 @@ async fn ingest_issues(
 
             let raw_body = issue.body.unwrap_or_default();
             let content = secret_gate::mask_secrets(&raw_body).into_owned();
+            let safe_title = secret_gate::mask_secrets(&issue.title).into_owned();
             let labels: Vec<String> = issue
                 .labels
                 .unwrap_or_default()
@@ -1513,7 +1514,7 @@ async fn ingest_issues(
                 .collect();
             let mut properties = json!({
                 "number": issue.number,
-                "title": issue.title,
+                "title": safe_title,
                 "author": issue.author.and_then(|a| a.login),
                 "created_at": issue.created_at,
                 "closed_at": issue.closed_at,
@@ -1527,10 +1528,8 @@ async fn ingest_issues(
             if let Some(reason) = issue.state_reason.as_deref().filter(|r| !r.is_empty()) {
                 properties["state_reason"] = json!(reason.to_ascii_lowercase());
             }
-            let name = refs::truncate_chars(
-                &format!("#{} {}", issue.number, issue.title),
-                NAME_MAX_CHARS,
-            );
+            let name =
+                refs::truncate_chars(&format!("#{} {}", issue.number, safe_title), NAME_MAX_CHARS);
 
             budget.try_consume();
             let result = match registry

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1138,6 +1138,42 @@ struct GhPr {
     body: Option<String>,
 }
 
+/// Every externally controlled issue string (title, body, label names,
+/// author login) funnels through this constructor before it can reach
+/// `properties`/`content`/the note name. There is no way to read a raw
+/// field back out of this struct -- the only fields it exposes are already
+/// masked -- so a call site cannot forget to mask one without a compile
+/// error, and a future new external string only needs to be added here
+/// once to be covered everywhere it's used.
+struct MaskedIssueFields {
+    title: String,
+    body: String,
+    author_login: Option<String>,
+    labels: Vec<String>,
+}
+
+impl MaskedIssueFields {
+    fn new(
+        title: &str,
+        body: Option<String>,
+        author: Option<GhAuthor>,
+        labels: Option<Vec<GhLabel>>,
+    ) -> Self {
+        Self {
+            title: secret_gate::mask_secrets(title).into_owned(),
+            body: secret_gate::mask_secrets(&body.unwrap_or_default()).into_owned(),
+            author_login: author
+                .and_then(|a| a.login)
+                .map(|login| secret_gate::mask_secrets(&login).into_owned()),
+            labels: labels
+                .unwrap_or_default()
+                .into_iter()
+                .map(|l| secret_gate::mask_secrets(&l.name).into_owned())
+                .collect(),
+        }
+    }
+}
+
 fn gh_json(repo: &Path, args: &[&str]) -> Result<String> {
     // gh has no `-C` flag (unlike git) — repo targeting is via working directory.
     let output = Command::new("gh")
@@ -1503,22 +1539,17 @@ async fn ingest_issues(
                 break;
             }
 
-            let raw_body = issue.body.unwrap_or_default();
-            let content = secret_gate::mask_secrets(&raw_body).into_owned();
-            let safe_title = secret_gate::mask_secrets(&issue.title).into_owned();
-            let labels: Vec<String> = issue
-                .labels
-                .unwrap_or_default()
-                .into_iter()
-                .map(|l| l.name)
-                .collect();
+            let masked =
+                MaskedIssueFields::new(&issue.title, issue.body, issue.author, issue.labels);
+            let content = masked.body;
+            let safe_title = masked.title;
             let mut properties = json!({
                 "number": issue.number,
                 "title": safe_title,
-                "author": issue.author.and_then(|a| a.login),
+                "author": masked.author_login,
                 "created_at": issue.created_at,
                 "closed_at": issue.closed_at,
-                "labels": labels,
+                "labels": masked.labels,
                 "project_id": project_id.to_string(),
             });
             // gh reports stateReason as "" for open issues and UPPERCASE enum values

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 use khive_runtime::{secret_gate, KhiveRuntime, NamespaceToken, VerbRegistry};
 use khive_storage::types::{SqlStatement, SqlValue};
 
+use crate::hook;
 use crate::refs;
 
 /// Which record kinds a `run_ingest` pass processes. `Default` selects all
@@ -1154,7 +1155,20 @@ struct MaskedIssueFields {
     created_at: Option<String>,
     closed_at: Option<String>,
     updated_at: Option<String>,
-    state_reason: Option<String>,
+    state_reason: StateReasonField,
+}
+
+/// The classified outcome of parsing a raw `stateReason` string against the
+/// governed enum (`hook::ISSUE_STATE_REASONS`, ADR-088 §3) at the masking
+/// boundary. `Rejected` never carries the raw string forward -- the ingest
+/// loop must reject the record with a warning that names only the field,
+/// never its value (round-3 codex finding: a credential-shaped `stateReason`
+/// must never reach `report.warnings` or the hook's own error path).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StateReasonField {
+    Absent,
+    Valid(String),
+    Rejected,
 }
 
 impl MaskedIssueFields {
@@ -1186,10 +1200,28 @@ impl MaskedIssueFields {
             created_at: canonical_issue_timestamp("createdAt", number, created_at, warnings),
             closed_at: canonical_issue_timestamp("closedAt", number, closed_at, warnings),
             updated_at: canonical_issue_timestamp("updatedAt", number, updated_at, warnings),
-            state_reason: state_reason
-                .filter(|r| !r.is_empty())
-                .map(|r| r.to_ascii_lowercase()),
+            state_reason: canonical_issue_state_reason(state_reason),
         }
+    }
+}
+
+/// Classifies a raw `stateReason` string against the governed enum
+/// (`hook::ISSUE_STATE_REASONS`, ADR-088 §3) at the masking boundary. GitHub
+/// reports `stateReason` as `""` for open issues and an UPPERCASE enum value
+/// (e.g. `NOT_PLANNED`) for closed ones, so case is normalized before the
+/// membership check. A value that is present, non-empty, and not one of the
+/// four governed values is classified `Rejected` -- the caller must reject
+/// the whole record with a warning naming only the field, never echoing this
+/// (possibly credential-shaped) raw string.
+fn canonical_issue_state_reason(raw: Option<String>) -> StateReasonField {
+    let Some(raw) = raw.filter(|r| !r.is_empty()) else {
+        return StateReasonField::Absent;
+    };
+    let lowered = raw.to_ascii_lowercase();
+    if hook::ISSUE_STATE_REASONS.contains(&lowered.as_str()) {
+        StateReasonField::Valid(lowered)
+    } else {
+        StateReasonField::Rejected
     }
 }
 
@@ -1547,21 +1579,28 @@ async fn ingest_issues(
     let mut window_complete = true;
 
     'paging: loop {
-        let mut page = fetch_issue_page(repo, floor.as_deref())?;
+        let page = fetch_issue_page(repo, floor.as_deref())?;
         let page_len = page.len();
+        // The ENTIRE fetched page is classified (masked strings, canonicalized
+        // timestamps, governed-enum `state_reason`) before anything else --
+        // including the sort and the paging cursor derivation below -- touches
+        // it. A raw `GhIssue.updated_at` must never reach the sort comparator,
+        // `last_updated_at`, or (via `decide_page_outcome`'s `Continue`) a
+        // future `gh --search updated:>=` argument (round-3 codex finding: a
+        // credential-shaped `updatedAt` could otherwise sort last and leak
+        // into process arguments through the paging floor).
+        let mut masked_page: Vec<MaskedIssueFields> = page
+            .into_iter()
+            .map(|issue| MaskedIssueFields::new(issue, &mut report.warnings))
+            .collect();
         // See `ingest_prs`: the frozen-cursor retry guarantee requires
         // walking records in nondecreasing updated_at order, which `--search
         // sort:updated-asc` does not itself guarantee across ties — sort
-        // defensively.
-        page.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
-        let last_updated_at = page.last().and_then(|i| i.updated_at.clone());
+        // defensively, using the canonicalized (not raw) timestamp.
+        masked_page.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        let last_updated_at = masked_page.last().and_then(|i| i.updated_at.clone());
 
-        for issue in page {
-            // Every field is classified (masked strings, canonicalized
-            // timestamps) before anything else touches it -- `issue` is
-            // consumed here, so nothing downstream can read a raw field.
-            let masked = MaskedIssueFields::new(issue, &mut report.warnings);
-
+        for masked in masked_page {
             let is_new = since
                 .as_deref()
                 .zip(masked.updated_at.as_deref())
@@ -1595,6 +1634,23 @@ async fn ingest_issues(
 
             let number = masked.number;
             let updated_at = masked.updated_at.clone();
+
+            // `stateReason` was already parsed into the governed enum at the
+            // masking boundary (`canonical_issue_state_reason`). An ungoverned
+            // value is rejected here, before the record is ever built or
+            // dispatched -- the warning names only the field, never the raw
+            // (possibly credential-shaped) value, matching ADR-088's
+            // fail-closed/no-silent-coercion contract while preserving the
+            // per-record warn-and-skip / frozen-cursor-retry behavior shared
+            // with every other create-failure path in this loop.
+            if masked.state_reason == StateReasonField::Rejected {
+                report.warnings.push(format!(
+                    "issue #{number}: stateReason is not one of the governed values, record skipped"
+                ));
+                cursor_stalled = true;
+                continue;
+            }
+
             let content = masked.body;
             let safe_title = masked.title;
             let mut properties = json!({
@@ -1606,11 +1662,7 @@ async fn ingest_issues(
                 "labels": masked.labels,
                 "project_id": project_id.to_string(),
             });
-            // gh reports stateReason as "" for open issues and UPPERCASE enum values
-            // (NOT_PLANNED) for closed ones; the kind hook governs any PRESENT value
-            // against the lowercase GitHub stateReason enum, so normalize case and encode
-            // "open / no reason" as absent.
-            if let Some(reason) = masked.state_reason {
+            if let StateReasonField::Valid(reason) = masked.state_reason {
                 properties["state_reason"] = json!(reason);
             }
             let name = refs::truncate_chars(&format!("#{number} {safe_title}"), NAME_MAX_CHARS);

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1138,29 +1138,42 @@ struct GhPr {
     body: Option<String>,
 }
 
-/// Every externally controlled issue string (title, body, label names,
-/// author login) funnels through this constructor before it can reach
-/// `properties`/`content`/the note name. There is no way to read a raw
-/// field back out of this struct -- the only fields it exposes are already
-/// masked -- so a call site cannot forget to mask one without a compile
-/// error, and a future new external string only needs to be added here
-/// once to be covered everywhere it's used.
+/// Every `GhIssue` field funnels through this constructor before it can
+/// reach `properties`/`content`/the note name/the paging cursor. `new`
+/// consumes `GhIssue` by value and destructures it exhaustively (no `..`),
+/// so the original `issue` binding no longer exists after the call -- a
+/// call site has no way to read a raw field back out, and a future new
+/// `GhIssue` field forces a compile error here before it can silently skip
+/// this boundary.
 struct MaskedIssueFields {
+    number: u64,
     title: String,
     body: String,
     author_login: Option<String>,
     labels: Vec<String>,
+    created_at: Option<String>,
+    closed_at: Option<String>,
+    updated_at: Option<String>,
+    state_reason: Option<String>,
 }
 
 impl MaskedIssueFields {
-    fn new(
-        title: &str,
-        body: Option<String>,
-        author: Option<GhAuthor>,
-        labels: Option<Vec<GhLabel>>,
-    ) -> Self {
+    fn new(issue: GhIssue, warnings: &mut Vec<String>) -> Self {
+        let GhIssue {
+            number,
+            title,
+            author,
+            created_at,
+            closed_at,
+            updated_at,
+            labels,
+            state_reason,
+            body,
+        } = issue;
+
         Self {
-            title: secret_gate::mask_secrets(title).into_owned(),
+            number,
+            title: secret_gate::mask_secrets(&title).into_owned(),
             body: secret_gate::mask_secrets(&body.unwrap_or_default()).into_owned(),
             author_login: author
                 .and_then(|a| a.login)
@@ -1170,6 +1183,42 @@ impl MaskedIssueFields {
                 .into_iter()
                 .map(|l| secret_gate::mask_secrets(&l.name).into_owned())
                 .collect(),
+            created_at: canonical_issue_timestamp("createdAt", number, created_at, warnings),
+            closed_at: canonical_issue_timestamp("closedAt", number, closed_at, warnings),
+            updated_at: canonical_issue_timestamp("updatedAt", number, updated_at, warnings),
+            state_reason: state_reason
+                .filter(|r| !r.is_empty())
+                .map(|r| r.to_ascii_lowercase()),
+        }
+    }
+}
+
+/// Parses a GitHub issue timestamp into its canonical RFC3339 form. GitHub's
+/// API always returns valid RFC3339 timestamps; a value that fails to parse
+/// is untrusted/malformed input (round-2 codex finding: a credential-shaped
+/// string is exactly this case) and must never reach `properties` or the
+/// paging cursor as a raw string. On parse failure the field is rejected
+/// (becomes absent) and a warning is recorded -- without the raw value,
+/// which may itself be secret-shaped -- rather than letting an unparseable
+/// string silently pass the generic recursive secret scan downstream. The
+/// issue itself is still ingested; only this one field is dropped.
+fn canonical_issue_timestamp(
+    field: &'static str,
+    number: u64,
+    raw: Option<String>,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    let raw = raw?;
+    match chrono::DateTime::parse_from_rfc3339(&raw) {
+        Ok(dt) => Some(
+            dt.with_timezone(&Utc)
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        ),
+        Err(_) => {
+            warnings.push(format!(
+                "issue #{number}: {field} is not a valid RFC3339 timestamp, field dropped"
+            ));
+            None
         }
     }
 }
@@ -1508,19 +1557,24 @@ async fn ingest_issues(
         let last_updated_at = page.last().and_then(|i| i.updated_at.clone());
 
         for issue in page {
+            // Every field is classified (masked strings, canonicalized
+            // timestamps) before anything else touches it -- `issue` is
+            // consumed here, so nothing downstream can read a raw field.
+            let masked = MaskedIssueFields::new(issue, &mut report.warnings);
+
             let is_new = since
                 .as_deref()
-                .zip(issue.updated_at.as_deref())
+                .zip(masked.updated_at.as_deref())
                 .map(|(cursor, updated)| updated >= cursor)
                 .unwrap_or(true);
 
-            if find_by_number(runtime, token, "issue", project_id, issue.number)
+            if find_by_number(runtime, token, "issue", project_id, masked.number)
                 .await?
                 .is_some()
             {
                 report.issues_skipped_existing += 1;
                 if !cursor_stalled {
-                    if let Some(u) = &issue.updated_at {
+                    if let Some(u) = &masked.updated_at {
                         if max_updated
                             .as_deref()
                             .map(|m| u.as_str() > m)
@@ -1539,16 +1593,16 @@ async fn ingest_issues(
                 break;
             }
 
-            let masked =
-                MaskedIssueFields::new(&issue.title, issue.body, issue.author, issue.labels);
+            let number = masked.number;
+            let updated_at = masked.updated_at.clone();
             let content = masked.body;
             let safe_title = masked.title;
             let mut properties = json!({
-                "number": issue.number,
+                "number": number,
                 "title": safe_title,
                 "author": masked.author_login,
-                "created_at": issue.created_at,
-                "closed_at": issue.closed_at,
+                "created_at": masked.created_at,
+                "closed_at": masked.closed_at,
                 "labels": masked.labels,
                 "project_id": project_id.to_string(),
             });
@@ -1556,11 +1610,10 @@ async fn ingest_issues(
             // (NOT_PLANNED) for closed ones; the kind hook governs any PRESENT value
             // against the lowercase GitHub stateReason enum, so normalize case and encode
             // "open / no reason" as absent.
-            if let Some(reason) = issue.state_reason.as_deref().filter(|r| !r.is_empty()) {
-                properties["state_reason"] = json!(reason.to_ascii_lowercase());
+            if let Some(reason) = masked.state_reason {
+                properties["state_reason"] = json!(reason);
             }
-            let name =
-                refs::truncate_chars(&format!("#{} {}", issue.number, safe_title), NAME_MAX_CHARS);
+            let name = refs::truncate_chars(&format!("#{number} {safe_title}"), NAME_MAX_CHARS);
 
             budget.try_consume();
             let result = match registry
@@ -1578,9 +1631,7 @@ async fn ingest_issues(
             {
                 Ok(v) => v,
                 Err(e) => {
-                    report
-                        .warnings
-                        .push(format!("create issue #{}: {e}", issue.number));
+                    report.warnings.push(format!("create issue #{number}: {e}"));
                     cursor_stalled = true;
                     continue;
                 }
@@ -1598,7 +1649,7 @@ async fn ingest_issues(
 
             report.issues_ingested += 1;
             if !cursor_stalled {
-                if let Some(u) = &issue.updated_at {
+                if let Some(u) = &updated_at {
                     if max_updated
                         .as_deref()
                         .map(|m| u.as_str() > m)

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -921,6 +921,249 @@ async fn ingest_masks_credential_shaped_issue_author_login_without_dropping_note
     );
 }
 
+/// PR #835 round-2 codex finding (Major): `created_at`/`closed_at` bypassed
+/// `MaskedIssueFields` entirely and entered `properties` as arbitrary raw
+/// strings, so a credential-shaped `createdAt` tripped the runtime's
+/// recursive secret-gate scan on `properties` and silently dropped the
+/// whole issue. The fix parses every issue timestamp into a canonical
+/// RFC3339 form (or rejects it) before it ever reaches `properties` -- a
+/// credential-shaped value is not a valid timestamp, so it is rejected
+/// (becomes `null`) rather than persisted raw, and the issue itself must
+/// still be ingested.
+#[tokio::test]
+async fn ingest_rejects_credential_shaped_issue_created_at_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-created-at-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+    let issue_json = json!([{
+        "number": 20,
+        "title": "Investigate credential-shaped createdAt",
+        "author": {"login": "octocat"},
+        "createdAt": fake_token,
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "an unparseable createdAt must not drop the issue: {report:?}"
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert!(
+        item["properties"]["created_at"].is_null(),
+        "an unparseable createdAt must be rejected, not persisted raw: {:?}",
+        item["properties"]["created_at"]
+    );
+    let dumped = item.to_string();
+    assert!(
+        !dumped.contains(fake_token),
+        "raw credential-shaped createdAt must not survive anywhere in the stored record: {dumped}"
+    );
+}
+
+/// Sibling of the `createdAt` regression above, for `closedAt` (ingest.rs
+/// line ~1550 in the round-2 finding).
+#[tokio::test]
+async fn ingest_rejects_credential_shaped_issue_closed_at_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-closed-at-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    let issue_json = json!([{
+        "number": 21,
+        "title": "Investigate credential-shaped closedAt",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": fake_token,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "an unparseable closedAt must not drop the issue: {report:?}"
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert!(
+        item["properties"]["closed_at"].is_null(),
+        "an unparseable closedAt must be rejected, not persisted raw: {:?}",
+        item["properties"]["closed_at"]
+    );
+    let dumped = item.to_string();
+    assert!(
+        !dumped.contains(fake_token),
+        "raw credential-shaped closedAt must not survive anywhere in the stored record: {dumped}"
+    );
+}
+
+/// `updatedAt` is not stored in `properties` at all -- it is only used to
+/// advance the paging cursor (ingest.rs line ~1632 in the round-2 finding).
+/// A credential-shaped `updatedAt` must still not drop the issue, and the
+/// cursor persisted to `git_mirror_cursor` must never contain the raw
+/// value; it must advance only from a sibling record's validated,
+/// canonicalized timestamp.
+#[tokio::test]
+async fn ingest_rejects_credential_shaped_issue_updated_at_and_cursor_never_persists_raw_value() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-updated-at-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE";
+    let issue_json = json!([
+        {
+            "number": 22,
+            "title": "Credential-shaped updatedAt",
+            "author": {"login": "octocat"},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "closedAt": null,
+            "updatedAt": fake_token,
+            "labels": [],
+            "stateReason": "",
+            "body": ""
+        },
+        {
+            "number": 23,
+            "title": "Clean sibling issue",
+            "author": {"login": "octocat"},
+            "createdAt": "2026-01-02T00:00:00Z",
+            "closedAt": null,
+            "updatedAt": "2026-01-02T00:00:00Z",
+            "labels": [],
+            "stateReason": "",
+            "body": ""
+        }
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 2,
+        "an unparseable updatedAt must not drop the issue: {report:?}"
+    );
+
+    let cursor = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written from the sibling issue's valid updatedAt");
+    assert!(
+        !cursor.contains(fake_token),
+        "the paging cursor must never persist a raw credential-shaped updatedAt: {cursor:?}"
+    );
+    assert!(
+        cursor.starts_with("2026-01-02"),
+        "the cursor must advance to the sibling issue's valid, canonicalized updatedAt: {cursor:?}"
+    );
+}
+
 /// Multiple credential spans across both the title and the body of the same
 /// PR must all be masked, and exactly one PR note must be written.
 #[tokio::test]

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -599,6 +599,161 @@ async fn ingest_masks_credential_shaped_pr_title_without_dropping_note() {
     );
 }
 
+/// Issue #801: a credential-shaped issue title (sibling site of #763/#785)
+/// must be masked in place rather than causing the whole issue note to be
+/// rejected by the runtime's recursive `properties` secret scan.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_issue_title_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-title-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let issue_json = json!([{
+        "number": 11,
+        "title": format!("Rotate leaked {fake_token} immediately"),
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the issue must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("issue #11")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    let stored_name = item["name"].as_str().expect("name is string");
+    let stored_title = item["properties"]["title"]
+        .as_str()
+        .expect("properties.title is string");
+    assert!(
+        !stored_name.contains(fake_token) && !stored_title.contains(fake_token),
+        "raw credential must not survive into name or properties.title: \
+         name={stored_name:?}, title={stored_title:?}"
+    );
+    assert!(
+        stored_name.contains("***MASKED***") && stored_title.contains("***MASKED***"),
+        "masked marker must be present in both name and properties.title: \
+         name={stored_name:?}, title={stored_title:?}"
+    );
+}
+
+/// A clean (non-credential) issue title and an empty body must pass through
+/// `ingest_issues` unchanged -- guards against a future over-aggressive
+/// masking regression that the detector-positive test above cannot catch.
+#[tokio::test]
+async fn ingest_leaves_clean_issue_title_unmasked() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-clean-title-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let issue_json = json!([{
+        "number": 12,
+        "title": "Fix the flaky retry test",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(report.issues_ingested, 1, "{report:?}");
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert_eq!(
+        item["name"].as_str().unwrap(),
+        "#12 Fix the flaky retry test"
+    );
+    assert_eq!(
+        item["properties"]["title"].as_str().unwrap(),
+        "Fix the flaky retry test"
+    );
+}
+
 /// Multiple credential spans across both the title and the body of the same
 /// PR must all be masked, and exactly one PR note must be written.
 #[tokio::test]

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -754,6 +754,173 @@ async fn ingest_leaves_clean_issue_title_unmasked() {
     );
 }
 
+/// PR #835 round-1 codex finding: the runtime secret gate recursively scans
+/// every string in `properties` (not just `title`), so a credential-shaped
+/// label name previously tripped the gate on `create()` even after the
+/// title was masked, silently dropping the whole issue note.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_issue_label_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-label-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    let issue_json = json!([{
+        "number": 13,
+        "title": "Rotate the leaked deploy key",
+        "author": {"login": "octocat"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [{"name": fake_token}],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the issue must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("issue #13")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    let stored_labels = item["properties"]["labels"]
+        .as_array()
+        .expect("properties.labels is array");
+    assert_eq!(stored_labels.len(), 1);
+    let stored_label = stored_labels[0].as_str().expect("label is string");
+    assert!(
+        !stored_label.contains(fake_token),
+        "raw credential must not survive into properties.labels: {stored_label:?}"
+    );
+    assert!(
+        stored_label.contains("***MASKED***"),
+        "masked marker must be present in properties.labels: {stored_label:?}"
+    );
+}
+
+/// Same finding as above, for the author login field: a credential-shaped
+/// login previously tripped the recursive secret gate on `properties` and
+/// silently dropped the issue note.
+#[tokio::test]
+async fn ingest_masks_credential_shaped_issue_author_login_without_dropping_note() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "issue-login-credential-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    let fake_token = "ghp_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+    let issue_json = json!([{
+        "number": 14,
+        "title": "Investigate flaky CI runner",
+        "author": {"login": fake_token},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let report = run_ingest(
+        &rt,
+        &token,
+        &registry,
+        IngestOptions::unbounded(repo.clone(), project_id.to_string()),
+    )
+    .await
+    .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 1,
+        "the issue must not be dropped: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains("issue #14")),
+        "no silent-drop warning may be reported: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    let stored_author = item["properties"]["author"]
+        .as_str()
+        .expect("properties.author is string");
+    assert!(
+        !stored_author.contains(fake_token),
+        "raw credential must not survive into properties.author: {stored_author:?}"
+    );
+    assert!(
+        stored_author.contains("***MASKED***"),
+        "masked marker must be present in properties.author: {stored_author:?}"
+    );
+}
+
 /// Multiple credential spans across both the title and the body of the same
 /// PR must all be masked, and exactly one PR note must be written.
 #[tokio::test]

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -1639,6 +1639,93 @@ async fn issue_hook_rejects_ungoverned_state_reason() {
     );
 }
 
+/// Round-3 codex finding (Major): before this fix, the masking boundary only
+/// lowercased `stateReason` -- validation against the governed enum was left
+/// entirely to `IssueLikeHook::prepare_create`, whose error interpolated the
+/// raw value verbatim (`"issue properties.state_reason {reason:?} invalid"`).
+/// That error propagated straight into `ingest_issues`'s `report.warnings`
+/// (`format!("create issue #{number}: {e}")`), so a credential-shaped
+/// `stateReason` landed in the ingest report before the secret gate (which
+/// only scans title/body/labels/author) ever had a chance to see it.
+///
+/// This drives the full `run_ingest` path with a credential-shaped
+/// `stateReason` and asserts it never appears anywhere in `report.warnings`,
+/// is never persisted as an issue record, and the record is cleanly
+/// warn-and-skipped (fail-closed, matching ADR-088 §3) rather than silently
+/// coerced or dropped-but-created.
+#[tokio::test]
+async fn issue_ingest_never_echoes_credential_shaped_state_reason() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "state-reason-leak-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    const CREDENTIAL: &str = "ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE1";
+
+    let issue_json = json!([
+        {"number": 42, "title": "credential-shaped stateReason", "author": {"login": "a"},
+         "createdAt": "2026-01-01T00:00:00Z", "closedAt": "2026-01-01T00:00:00Z",
+         "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "stateReason": CREDENTIAL, "body": ""}
+    ])
+    .to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.pull_requests = false;
+    opts.include.commits = false;
+
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, 0,
+        "the ungoverned-stateReason record must be rejected, not created: {report:?}"
+    );
+    assert!(
+        !report.warnings.is_empty(),
+        "the rejection must be reported as a warning: {report:?}"
+    );
+    assert!(
+        report.warnings.iter().any(|w| w.contains("issue #42")),
+        "the warning must name the rejected record: {:?}",
+        report.warnings
+    );
+    assert!(
+        report.warnings.iter().all(|w| !w.contains(CREDENTIAL)),
+        "the raw credential-shaped stateReason must never appear in report.warnings: {:?}",
+        report.warnings
+    );
+
+    let issues_list = registry
+        .dispatch("list", json!({"kind": "issue", "limit": 10}))
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert!(
+        items.is_empty(),
+        "the ungoverned record must never land: {items:?}"
+    );
+}
+
 #[tokio::test]
 async fn issue_hook_requires_properties_project_id() {
     let (_rt, _token, registry) = fixture().await;
@@ -2015,6 +2102,147 @@ async fn gh_boundary_contract_and_partial_ingest_failure() {
         1,
         "the frozen cursor retries the failed record every pass, not just once: {:?}",
         report2.warnings
+    );
+}
+
+// ── round-3 codex finding (Major): raw `updatedAt` must never reach the
+//    paging floor via a full page ─────────────────────────────────────────
+
+/// Before this fix, `ingest_issues` sorted the raw `Vec<GhIssue>` and derived
+/// its paging continuation floor (`last_updated_at`) from the raw,
+/// pre-`MaskedIssueFields` `updated_at` before `MaskedIssueFields::new` ever
+/// ran. A credential-shaped raw value sorts LAST under raw ASCII string
+/// comparison (any letter-leading string outranks a digit-leading RFC3339
+/// timestamp), so it could become the next `gh --search updated:>=...`
+/// argument -- exposing it in process arguments -- or, once dropped by
+/// canonicalization, corrupt the frozen-cursor invariant.
+///
+/// This test forces the vulnerable branch directly: a page of exactly
+/// `PAGE_LIMIT` (1000) issues, one of which has a credential-shaped raw
+/// `updatedAt` that fails RFC3339 parsing. Under the fix, the ENTIRE page is
+/// masked/canonicalized before sorting, so the malformed record's
+/// `updated_at` becomes `None` and sorts FIRST, never becoming
+/// `last_updated_at`. Asserts the raw value never appears in any recorded
+/// `gh` invocation's argv, in the persisted paging cursor, or in any
+/// persisted issue record, and that a full page still triggers a
+/// continuation fetch (not a false `WindowComplete`) -- pagination remains
+/// resumable.
+#[tokio::test]
+async fn issue_full_page_never_leaks_raw_updated_at_into_paging_floor() {
+    let _guard = ENV_MUTEX.lock().await;
+    let (rt, token, registry) = fixture().await;
+
+    let project_id = create(
+        &registry,
+        json!({"kind": "project", "name": "full-page-repo"}),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo: PathBuf = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mk repo dir");
+    init_repo(&repo);
+    write(&repo, "README.md", "hello\n");
+    commit(&repo, &["README.md"], "Initial commit");
+
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mk bin dir");
+    let log_dir = dir.path().join("log");
+    std::fs::create_dir_all(&log_dir).expect("mk log dir");
+
+    // Mirrors `ingest.rs`'s private `PAGE_LIMIT` -- `gh {pr,issue} list
+    // --search` never returns more than this many results per page.
+    const PAGE_LIMIT: usize = 1000;
+    const CREDENTIAL: &str = "sk-ant-api03-FAKE1234567890FAKE1234567890FAKE1234567890FAKE";
+
+    let mut issues: Vec<Value> = (1..PAGE_LIMIT)
+        .map(|i| {
+            let minute = i / 60;
+            let second = i % 60;
+            json!({
+                "number": i,
+                "title": format!("issue {i}"),
+                "author": {"login": "a"},
+                "createdAt": "2026-01-01T00:00:00Z",
+                "closedAt": null,
+                "updatedAt": format!("2026-01-01T{minute:02}:{second:02}:00Z"),
+                "labels": [],
+                "stateReason": "",
+                "body": ""
+            })
+        })
+        .collect();
+    // Raw ASCII compare: 's' (0x73) outranks every digit (0x30-0x39), so
+    // this record's raw `updatedAt` sorts after all 999 valid timestamps
+    // above -- exactly the "sorts last" shape the finding describes.
+    issues.push(json!({
+        "number": PAGE_LIMIT,
+        "title": "issue with malformed updatedAt",
+        "author": {"login": "a"},
+        "createdAt": "2026-01-01T00:00:00Z",
+        "closedAt": null,
+        "updatedAt": CREDENTIAL,
+        "labels": [],
+        "stateReason": "",
+        "body": ""
+    }));
+    assert_eq!(
+        issues.len(),
+        PAGE_LIMIT,
+        "page must be exactly PAGE_LIMIT-sized to force the continuation branch"
+    );
+    let issue_json = Value::Array(issues).to_string();
+
+    write_fake_gh(&bin_dir, &log_dir, "[]", &issue_json);
+    let _path_guard = PathGuard::install(&bin_dir);
+
+    let mut opts = IngestOptions::unbounded(repo.clone(), project_id.to_string());
+    opts.include.pull_requests = false;
+    opts.include.commits = false;
+
+    let report = run_ingest(&rt, &token, &registry, opts)
+        .await
+        .expect("ingest ok");
+
+    assert_eq!(
+        report.issues_ingested, PAGE_LIMIT as u64,
+        "every record lands -- the malformed record only loses its updated_at field: {report:?}"
+    );
+
+    let args_log = std::fs::read_to_string(log_dir.join("args.log")).expect("read args.log");
+    assert!(
+        !args_log.contains(CREDENTIAL),
+        "the raw credential-shaped updatedAt must never reach a gh invocation's argv \
+         (paging floor leak): {args_log}"
+    );
+    // A full (PAGE_LIMIT-sized) page must trigger a second `gh issue list`
+    // invocation -- proving pagination did not silently treat the full page
+    // as window-complete.
+    let issue_invocations = args_log.lines().filter(|l| l.starts_with("issue ")).count();
+    assert!(
+        issue_invocations >= 2,
+        "a full page must be followed by a continuation fetch: {args_log}"
+    );
+
+    let cursor = read_git_cursor(&rt, project_id, "issues")
+        .await
+        .expect("cursor must be written");
+    assert!(
+        !cursor.contains(CREDENTIAL),
+        "the persisted paging cursor must never contain the raw credential value: {cursor}"
+    );
+
+    let issues_list = registry
+        .dispatch(
+            "list",
+            json!({"kind": "issue", "limit": (PAGE_LIMIT + 10) as u64}),
+        )
+        .await
+        .expect("list issues ok");
+    let items = issues_list.as_array().expect("array");
+    assert!(
+        items.iter().all(|i| !i.to_string().contains(CREDENTIAL)),
+        "no persisted issue record may contain the raw credential value"
     );
 }
 


### PR DESCRIPTION
## Root cause

`ingest_issues` in `crates/khive-pack-git/src/ingest.rs` passed the raw GitHub `issue.title` straight into `properties.title` and the note `name` before dispatching `create`. The runtime secret gate (`khive-runtime::secret_gate`) recursively scans `properties` and the `name` on every `create` call. A credential-shaped issue title (e.g. `ghp_...`) trips that gate, `create` returns `Err`, and the pre-existing per-record failure handling in `ingest_issues` records a warning and retries the record on the next pass — the issue note never lands until the title stops looking like a credential.

This is the sibling site of #763/PR #785, which fixed the identical bug in `ingest_prs` (PR body/title). Issue ingestion never got the equivalent fix.

## Fix

Mirror the `ingest_prs` fix: mask the title once via `secret_gate::mask_secrets` before it is used anywhere gated, and use the masked `safe_title` for both `properties.title` and the note `name`. The original title is never stored in the raw form used to trip the gate; the masked value with `***MASKED***` markers is what gets persisted, so the record is created successfully instead of being rejected.

The gate itself is untouched — only the pack-level ingest path changes what it feeds into `create`.

## Loud failure on residual drops

The existing per-record path in `ingest_issues` already treats any `create` failure as loud, not silent: a failed record pushes `report.warnings.push(format!("create issue #{}: {e}", ...))`, does not increment `issues_ingested`, and leaves the cursor frozen so the record is retried on the next pass (same mechanism `ingest_prs`/`ingest_commits` use, and already covered by the `issue_hook_rejects_ungoverned_state_reason`-style tests in `acceptance.rs`). Masking the title removes the common trigger for that failure path; if a masked record still cannot be stored for some other reason, it is still counted (not silently dropped) via that same warnings/cursor-stall mechanism.

## Test evidence

Added two regression tests to `crates/khive-pack-git/tests/acceptance.rs`:

- `ingest_masks_credential_shaped_issue_title_without_dropping_note` — an issue titled with an obviously-fake `ghp_AAAA...` token shape ingests successfully (`issues_ingested == 1`), produces no drop warning, and both the stored `name` and `properties.title` carry `***MASKED***` with the raw token absent.
- `ingest_leaves_clean_issue_title_unmasked` — a clean, non-credential title passes through byte-for-byte unchanged, guarding against future over-aggressive masking.

```
cargo test -p khive-pack-git       # 70 unit + 34 acceptance passed, 0 failed
cargo clippy -p khive-pack-git --all-targets -- -D warnings   # clean
cargo fmt --all -- --check          # clean
```

Fixes #801