### PR TITLE
fix(tests): deterministic ANN warm barrier (#844) + self-heal reset completeness (#843)

### DIFF
--- a/crates/khive-mcp/src/daemon.rs
+++ b/crates/khive-mcp/src/daemon.rs
@@ -1489,11 +1489,33 @@ pub(crate) static DRAIN_EXIT_INVOKED_COUNT: std::sync::atomic::AtomicUsize =
 pub(crate) fn reset_self_heal_counters() {
     REEXEC_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
     DRAIN_EXIT_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+    clear_pending_self_heal();
 }
 
 #[cfg(all(test, not(unix)))]
 pub(crate) fn reset_self_heal_counters() {
     DRAIN_EXIT_INVOKED_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+    clear_pending_self_heal();
+}
+
+/// Clear whatever `PENDING_SELF_HEAL` currently holds (#843). A test that
+/// exercises `forward_or_spawn`'s protocol-mismatch path end to end (e.g.
+/// `forward_or_spawn_rejects_old_daemon_and_returns_protocol_mismatch_error`)
+/// arms it via `trigger_bridge_self_heal` but never takes the action back
+/// out — that is `fire_pending_self_heal`'s job, and asserting the forwarding
+/// behavior alone has no reason to call it. Left armed, that leftover slot
+/// is invisible to `reset_self_heal_counters` resetting only the two
+/// invocation counters, so a later test in the same binary (e.g.
+/// `fire_pending_self_heal_is_a_no_op_when_nothing_is_armed`) can inherit it
+/// under multi-threaded test ordering and observe a spurious fire. Every
+/// existing test that intentionally arms the slot does so AFTER calling
+/// `reset_self_heal_counters`, never before, so clearing it here changes no
+/// test's semantics.
+#[cfg(test)]
+fn clear_pending_self_heal() {
+    *PENDING_SELF_HEAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
 }
 
 /// Test double for [`reexec_in_place`]: a real `exec()` would replace the test

--- a/crates/khive-pack-memory/src/ann.rs
+++ b/crates/khive-pack-memory/src/ann.rs
@@ -125,6 +125,17 @@ pub(crate) struct AnnState {
     /// — only a test that explicitly sets this waits on the release signal.
     #[cfg(test)]
     pub(crate) attempt_floor_barrier: std::sync::atomic::AtomicBool,
+    /// Test-only completion signal: notified whenever `WarmingGuard::drop`
+    /// releases `key` from `warming` (#844). A test that fires a warm-up
+    /// recall has no other way to observe that the background rebuild the
+    /// recall (or a preceding `memory.remember`) triggered has actually
+    /// finished — `ensure_ann_background`'s only return value is whether it
+    /// started a task, and `track_background_task` itself hands back no
+    /// `JoinHandle` (it is deliberately fire-and-forget in production, see
+    /// its doc comment). `wait_until_warm_idle` below pairs with this to give
+    /// tests a deterministic barrier instead of polling on a sleep loop.
+    #[cfg(test)]
+    pub(crate) warming_idle: tokio::sync::Notify,
 }
 
 pub(crate) type SharedAnn = Arc<AnnState>;
@@ -144,6 +155,8 @@ pub(crate) fn new_shared() -> SharedAnn {
         attempt_floor_release: tokio::sync::Notify::new(),
         #[cfg(test)]
         attempt_floor_barrier: std::sync::atomic::AtomicBool::new(false),
+        #[cfg(test)]
+        warming_idle: tokio::sync::Notify::new(),
     })
 }
 
@@ -630,6 +643,26 @@ struct WarmingGuard {
 impl Drop for WarmingGuard {
     fn drop(&mut self) {
         lock_warming(&self.ann).remove(&self.key);
+        #[cfg(test)]
+        self.ann.warming_idle.notify_waiters();
+    }
+}
+
+/// Test-only: await until `key` is no longer in the `warming` single-flight
+/// set (#844) — i.e. every background rebuild task that was in flight for it
+/// has finished (or none ever started). Creates the `Notified` future before
+/// checking the predicate so a release that lands between the check and the
+/// `.await` is never missed (`tokio::sync::Notify`'s documented guarantee),
+/// and loops so a chained re-enqueue that grabs the guard again after this
+/// call observed a momentary release is still waited out.
+#[cfg(test)]
+pub(crate) async fn wait_until_warm_idle(ann: &SharedAnn, key: &AnnKey) {
+    loop {
+        let notified = ann.warming_idle.notified();
+        if !lock_warming(ann).contains(key) {
+            return;
+        }
+        notified.await;
     }
 }
 

--- a/crates/khive-pack-memory/src/pack.rs
+++ b/crates/khive-pack-memory/src/pack.rs
@@ -982,6 +982,14 @@ mod note_mutation_hook_tests {
             )
             .await
             .expect("warm recall");
+        // ANN warming is asynchronous (`ann::ensure_ann_background`'s doc
+        // comment): both the seeding `memory.remember` calls above and this
+        // warm-up recall itself can fire a fire-and-forget background
+        // rebuild rather than complete it inline (#844). Wait for the
+        // single-flight `warming` guard for this key to clear before
+        // trusting `is_current` — the guard is only released once every
+        // in-flight rebuild for this key has actually finished.
+        ann::wait_until_warm_idle(&ann, &fr1_key()).await;
         assert!(
             ann::is_current(&ann, &fr1_key()).await,
             "sanity: warm-up recall must leave the ANN cache current before \


### PR DESCRIPTION
## Summary

Two independent flaky-test fixes, each landed as its own commit.

### #844 — `pack::note_mutation_hook_tests::fr2_kg_merge_invalidates_warm_ann_without_subsequent_remember`

Root cause: ANN warming is asynchronous. Both `memory.remember`'s write path
(`handlers/remember.rs`) and `memory.recall`'s stale-but-present branch
(`handlers/common.rs`) fire `ann::ensure_ann_background` as a fire-and-forget
background task. When the test's warm-up recall landed on the "cache present
but stale" fast path (because an earlier seeding `memory.remember`'s
background build had already raced ahead and installed something), the
recall returned immediately without waiting on the in-flight rebuild — so
the test's own `is_current` sanity assertion could observe a still-stale
cache.

`khive_runtime::track_background_task` is deliberately fire-and-forget in
production and hands back no `JoinHandle`, so there was nothing to await
directly. Added a minimal test-only seam in `ann.rs`: a `Notify`
(`AnnState::warming_idle`, `#[cfg(test)]`) fired from `WarmingGuard::drop`
whenever a key's single-flight `warming` guard releases, plus
`wait_until_warm_idle(ann, key)` which awaits it in a check-then-notify loop
(no missed-wakeup window, no polling sleep). The test now awaits this before
its sanity assertion instead of assuming synchronous completion. The
sanity assertion itself is unchanged.

Verified: `cargo test -p khive-pack-memory --lib` for this test — 20x
multi-threaded (default) + 5x single-threaded (`--test-threads=1`), **25/25
green**. Full crate suite: 237 passed, 0 failed, 1 ignored.

### #843 — `daemon::tests::fire_pending_self_heal_is_a_no_op_when_nothing_is_armed`

Root cause: `reset_self_heal_counters()` only zeroed the two invocation-count
atomics, leaving the `PENDING_SELF_HEAL` mutex slot untouched.
`forward_or_spawn_rejects_old_daemon_and_returns_protocol_mismatch_error`
exercises `forward_or_spawn`'s protocol-mismatch path end to end, which arms
`PENDING_SELF_HEAL` via `trigger_bridge_self_heal` but never takes the action
back out (it only asserts on the returned error). Under multi-threaded test
ordering, if that test runs before
`fire_pending_self_heal_is_a_no_op_when_nothing_is_armed` in the same binary,
the latter's `reset_self_heal_counters()` call left the armed slot in place,
and `fire_pending_self_heal()` then fired it, failing the "no-op" assertion.

Fix: `reset_self_heal_counters()` now also clears `PENDING_SELF_HEAL` via a
new `clear_pending_self_heal()` helper (both unix and non-unix cfg variants).
Every test that intentionally arms the slot does so AFTER calling
`reset_self_heal_counters`, never before, so this changes no test's intended
semantics.

Sabotage verification: reverted the fix and ran `cargo test -p khive-mcp
--lib` repeatedly to reproduce the original ordering-dependent flake. It
reproduced twice (of the runs completed before a 5-minute batch timeout),
both times failing at exactly the predicted assertion
(`daemon.rs:5242`, `left: 1, right: 0`) — confirming the root cause rather
than just asserting it. Restored the fix and ran the full `khive-mcp` lib
suite **10x multi-threaded, 10/10 green**.

## Test plan

- [x] `cargo test -p khive-pack-memory --lib` — fr2 test 20x multi-threaded + 5x single-threaded, 25/25 green; full crate suite 237 passed
- [x] `cargo test -p khive-mcp --lib` — 10x multi-threaded, 10/10 green (plus 2 reproduced failures pre-fix during sabotage verification)
- [x] `cargo clippy -p khive-pack-memory --all-targets -- -D warnings` clean
- [x] `cargo clippy -p khive-mcp --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Refs #844, #843