### PR TITLE
fix(pack-git): close scratch-cache ENOENT race behind macOS flake family (#842)

### DIFF
--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -345,23 +345,28 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
 }
 
 /// `-c maintenance.auto=false` on every clone/fetch into a cache slot, as
-/// defensive hardening: since git 2.30, `fetch`/`clone` unconditionally
-/// check `maintenance.auto` (default true) after they finish and, if set,
-/// launch `git maintenance run --auto --detach` as a detached background
-/// child. The child spawn is trace2-proven in both directions
-/// (`GIT_TRACE2_EVENT` on a live `git fetch --refetch`: with default config
-/// the child forks; with `maintenance.auto=false` it does not). When one of
-/// its auto-maintenance tasks fires, that child mutates the slot's `.git`
-/// tree (commit-graph writes, pack maintenance, lock files) concurrently
-/// with any `dir_size`/`evict_lru` walk of the same slot. Whether such a
-/// task actually fired in issue #842's historical macOS ENOENT failures is
-/// not proven -- in small repos the child typically finds no task to run
-/// and exits quickly -- so the load-bearing fix for that flake family is
-/// the descendant-vanish tolerance in `dir_size`; this flag removes the one
-/// background mutator git itself forks into our cache slots. `gc.auto=0`
-/// alone does **not** suppress the child (trace2-verified); it is kept
-/// alongside because it disables `git gc --auto`'s separate
-/// opportunistic-gc check, harmless to also turn off here.
+/// defensive hardening. `git fetch` runs auto-maintenance after it
+/// finishes when `maintenance.auto` (default true) is set, and since git
+/// 2.47 that maintenance runs as a *detached background child*
+/// (`git maintenance run --auto --detach`) that can outlive the foreground
+/// command; on 2.46 and earlier it ran synchronously. The spawn is
+/// trace2-proven in both directions on the `fetch --refetch` path
+/// (`GIT_TRACE2_EVENT`, git 2.49: with default config the child forks; with
+/// `maintenance.auto=false` it does not). The same trace showed `clone`
+/// spawning no maintenance child; the flag is applied to the clone builder
+/// too purely as harmless defensive configuration, with no trace evidence
+/// claimed for that path. When one of the detached child's tasks fires it
+/// mutates the slot's `.git` tree (commit-graph writes, pack maintenance,
+/// lock files) concurrently with any `dir_size`/`evict_lru` walk of the
+/// same slot. Whether such a task actually fired in issue #842's historical
+/// macOS ENOENT failures is not proven -- in small repos the child
+/// typically finds no task to run and exits quickly -- so the load-bearing
+/// fix for that flake family is the descendant-vanish tolerance in
+/// `dir_size`; this flag removes the one background mutator git itself can
+/// fork into our cache slots. `gc.auto=0` alone does **not** suppress the
+/// child (trace2-verified); it is kept alongside because it disables
+/// `git gc --auto`'s separate opportunistic-gc check, harmless to also turn
+/// off here.
 ///
 /// This does not mean a cache slot is naturally garbage-collected some other
 /// way instead: no cache-slot repo is ever gc'd or maintenance'd by us.

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -336,10 +336,20 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
     Err(last_err.expect("loop always sets last_err before exiting"))
 }
 
+/// `gc.auto=0` on every clone/fetch into a cache slot: git's default
+/// `gc.autoDetach=true` lets an opportunistic `gc --auto` fork and keep
+/// running in the background *after* this command already returned success
+/// -- exactly the kind of concurrent mutator that can delete a loose object
+/// `dir_size`/`evict_lru` are mid-walk over in the same slot (issue #842's
+/// macOS-only ENOENT flake family). No cache-slot repo is ever gc'd by us;
+/// eviction deletes the whole directory instead, so there is nothing for
+/// git's own gc to usefully do here.
 fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
+        .arg("-c")
+        .arg("gc.auto=0")
         .arg("clone")
         .arg("--filter=blob:none")
         .arg(url)
@@ -359,6 +369,8 @@ fn fetch(repo: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
+        .arg("-c")
+        .arg("gc.auto=0")
         .arg("-C")
         .arg(repo)
         .arg("fetch")
@@ -383,6 +395,8 @@ fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
+        .arg("-c")
+        .arg("gc.auto=0")
         .arg("-C")
         .arg(repo)
         .arg("fetch")
@@ -400,8 +414,20 @@ fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
+/// Wrap an I/O error with the operation and path it happened on -- a bare
+/// `CacheError::Io(e)` at these call sites used to surface as an opaque
+/// "No such file or directory" with no way to tell which of the many paths
+/// `dir_size`/`touch`/`evict_lru` touch actually disappeared.
+fn io_err(op: &str, path: &Path, e: std::io::Error) -> CacheError {
+    CacheError::Io(std::io::Error::new(
+        e.kind(),
+        format!("{op} {}: {e}", path.display()),
+    ))
+}
+
 fn touch(repo_dir: &Path) -> Result<(), CacheError> {
-    std::fs::write(repo_dir.join(MARKER_FILE), b"")?;
+    let marker = repo_dir.join(MARKER_FILE);
+    std::fs::write(&marker, b"").map_err(|e| io_err("touch: write marker", &marker, e))?;
     Ok(())
 }
 
@@ -409,14 +435,41 @@ fn touch(repo_dir: &Path) -> Result<(), CacheError> {
 /// throughout, so a symlink itself is sized but never traversed -- clones
 /// never legitimately contain symlinked directories pointing outside the
 /// clone, and this avoids any possibility of a symlink loop).
+///
+/// Tolerant of an entry disappearing mid-walk (a vanished entry contributes
+/// 0 bytes rather than aborting the whole size computation): a cache slot's
+/// `.git` tree can legitimately be mutated by something outside this
+/// function's control while it walks it -- git's own `gc --auto` may still
+/// be finishing a background repack from an *earlier* command despite
+/// `gc.auto=0` on every command this crate issues (a slot's history predates
+/// that setting, or an operator's own `git` invocation touched the slot), or
+/// a concurrent `evict_lru`/`ensure_clone` repair on the same slot removed
+/// it. This accounting is inherently a snapshot of a possibly-changing tree
+/// (ADR-088 Amendment 1: eviction is safe because ingest cursors live in the
+/// database, not the clone), so "the thing I was about to size is already
+/// gone" is not an error here -- it is the expected outcome of a slot that
+/// eviction (by us or a racing process) has already reclaimed.
 fn dir_size(path: &Path) -> Result<u64, CacheError> {
     let mut total = 0u64;
     let mut stack = vec![path.to_path_buf()];
     while let Some(p) = stack.pop() {
-        let md = std::fs::symlink_metadata(&p)?;
+        let md = match std::fs::symlink_metadata(&p) {
+            Ok(md) => md,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(io_err("dir_size: stat", &p, e)),
+        };
         if md.is_dir() {
-            for entry in std::fs::read_dir(&p)? {
-                stack.push(entry?.path());
+            let read_dir = match std::fs::read_dir(&p) {
+                Ok(read_dir) => read_dir,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(io_err("dir_size: read_dir", &p, e)),
+            };
+            for entry in read_dir {
+                match entry {
+                    Ok(entry) => stack.push(entry.path()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => return Err(io_err("dir_size: read_dir entry", &p, e)),
+                }
             }
         } else {
             total += md.len();
@@ -462,8 +515,18 @@ fn is_owned_entry(path: &Path) -> bool {
 /// `is_owned_entry` -- eviction never touches user-owned or non-cache paths.
 fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
     let mut entries: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
+    let read_dir =
+        std::fs::read_dir(root).map_err(|e| io_err("evict_lru: read_dir root", root, e))?;
+    for entry in read_dir {
+        let entry = match entry {
+            Ok(entry) => entry,
+            // The directory listing raced a concurrent removal of one of its
+            // own entries (e.g. another `evict_lru`/`ensure_clone` repairing
+            // the same root, or the tail of a background `gc --auto` from
+            // before `gc.auto=0` applied) -- nothing to evict there anymore.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(io_err("evict_lru: read_dir entry", root, e)),
+        };
         let p = entry.path();
         if !p.is_dir() || p == keep || !is_owned_entry(&p) {
             continue;
@@ -686,6 +749,66 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("sub")).unwrap();
         std::fs::write(dir.path().join("sub/b.txt"), b"1234567890").unwrap();
         assert_eq!(dir_size(dir.path()).unwrap(), 15);
+    }
+
+    /// Issue #842's macOS ENOENT flake family: `dir_size` walks a tree that
+    /// can legitimately be mutated out from under it (git's own background
+    /// `gc --auto`, or a racing `evict_lru`/`ensure_clone` repair on the same
+    /// slot) -- a subdirectory disappearing between `read_dir` listing it and
+    /// this walk descending into it must shrink the total, not abort the
+    /// whole computation with `CacheError::Io(NotFound)`.
+    ///
+    /// This is a genuine cross-thread filesystem race, not a fully
+    /// deterministic single-shot repro: a `std::sync::Barrier` releases both
+    /// threads at the same instant, a wide fan of sibling subdirectories
+    /// gives the walk many entries to still be processing when the deleter
+    /// runs, and the whole race is repeated many times so the window is
+    /// almost certain to be hit at least once across the loop. Pre-fix (see
+    /// the sabotage note on `dir_size` above), this reliably reproduces
+    /// `CacheError::Io` within a handful of iterations on this machine; it is
+    /// not a `sleep`-based synchronization, so it is not always the exact
+    /// same interleaving twice, but the failure is real and observable, not
+    /// theoretical.
+    #[test]
+    fn dir_size_tolerates_a_subdirectory_removed_mid_walk() {
+        for _ in 0..200 {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let root = dir.path().to_path_buf();
+            let victim = root.join("victim");
+            std::fs::create_dir_all(&victim).unwrap();
+            for i in 0..64 {
+                std::fs::write(victim.join(format!("f{i}.txt")), b"0123456789").unwrap();
+            }
+            // A wide fan of siblings so the walk still has entries left on
+            // its stack (and is plausibly still inside `victim`) at the
+            // instant the other thread deletes it.
+            for i in 0..64 {
+                let sibling = root.join(format!("sibling{i}"));
+                std::fs::create_dir_all(&sibling).unwrap();
+                std::fs::write(sibling.join("s.txt"), b"0123456789").unwrap();
+            }
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let walk_root = root.clone();
+            let walk_barrier = barrier.clone();
+            let walker = std::thread::spawn(move || {
+                walk_barrier.wait();
+                dir_size(&walk_root)
+            });
+            let delete_victim = victim.clone();
+            let deleter = std::thread::spawn(move || {
+                barrier.wait();
+                let _ = std::fs::remove_dir_all(&delete_victim);
+            });
+
+            let result = walker.join().expect("walker thread");
+            deleter.join().expect("deleter thread");
+
+            assert!(
+                result.is_ok(),
+                "dir_size must tolerate a subdirectory vanishing mid-walk, got {result:?}"
+            );
+        }
     }
 
     // ── issue #765: refetch/reclone repair primitives ──────────────────────

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -162,6 +162,11 @@ pub fn ensure_clone(canonical_url: &str) -> Result<PathBuf, CacheError> {
             return Err(CacheError::UnsafeToReplace(repo_dir));
         }
         fetch(&repo_dir)?;
+        // `repo_dir` was just fetched into and its ownership already
+        // confirmed above; it vanishing here is a real problem (e.g. a
+        // racing, non-serialized `ensure_clone`/`reclone` on the same key --
+        // see `refetch_clone`'s doc comment), not a maybe-absent slot, so
+        // propagate rather than swallow.
         let size = dir_size(&repo_dir)?;
         if size > cap {
             remove_owned_entry(&root, &repo_dir)?;
@@ -217,6 +222,9 @@ pub(crate) fn refetch_clone(canonical_url: &str) -> Result<PathBuf, CacheError> 
     fetch_refetch(&repo_dir)?;
 
     let cap = clone_max_bytes();
+    // Same reasoning as `ensure_clone`: `repo_dir`'s ownership was just
+    // re-checked and it was just fetched into, so a vanish here is a real
+    // problem to surface, not a maybe-absent slot to size as `0`.
     let size = dir_size(&repo_dir)?;
     if size > cap {
         // Route through the same ownership-guarded removal `reclone` uses
@@ -336,20 +344,43 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
     Err(last_err.expect("loop always sets last_err before exiting"))
 }
 
-/// `gc.auto=0` on every clone/fetch into a cache slot: git's default
-/// `gc.autoDetach=true` lets an opportunistic `gc --auto` fork and keep
-/// running in the background *after* this command already returned success
-/// -- exactly the kind of concurrent mutator that can delete a loose object
-/// `dir_size`/`evict_lru` are mid-walk over in the same slot (issue #842's
-/// macOS-only ENOENT flake family). No cache-slot repo is ever gc'd by us;
-/// eviction deletes the whole directory instead, so there is nothing for
-/// git's own gc to usefully do here.
+/// `-c maintenance.auto=false` on every clone/fetch into a cache slot: since
+/// git 2.30, `fetch`/`clone` unconditionally check `maintenance.auto`
+/// (default true) after they finish and, if set, launch
+/// `git maintenance run --auto --detach` as a background child that keeps
+/// running *after* the foreground command already returned success --
+/// exactly the kind of concurrent mutator that can touch a cache slot's
+/// `.git` tree (commit-graph writes, pack maintenance, lock files
+/// appearing/disappearing) while `dir_size`/`evict_lru` are mid-walk over it
+/// (issue #842's macOS-only ENOENT flake family). `gc.auto=0` alone does
+/// **not** suppress this: it was traced with `GIT_TRACE2_EVENT` against a
+/// live `git fetch --refetch` and, with only `gc.auto=0` set, git still
+/// forked `git maintenance run --auto --detach`; adding
+/// `maintenance.auto=false` on the same command produced no such child (see
+/// the implementation report for both trace2 captures). `gc.auto=0` is kept
+/// alongside it — it disables `git gc --auto`'s own, separate opportunistic-
+/// gc check, which is harmless to also turn off here, but it is not what
+/// closes the race; `maintenance.auto=false` is.
+///
+/// This does not mean a cache slot is naturally garbage-collected some other
+/// way instead: no cache-slot repo is ever gc'd or maintenance'd by us.
+/// Growth is bounded by wholesale eviction, not in-place compaction --
+/// `ensure_clone`/`refetch_clone` delete a slot outright
+/// (`remove_owned_entry`) the moment it measures over
+/// `digest_cache_clone_max_bytes` after a fetch, and `evict_lru` deletes
+/// whole least-recently-used slot directories once the cache-wide
+/// `digest_cache_max_repos`/`digest_cache_max_bytes` caps are exceeded. A
+/// slot can be fetched into repeatedly, but it can never accumulate objects
+/// past its own size cap without being deleted and re-cloned fresh, so there
+/// is nothing for git's own gc/maintenance to usefully do in a cache slot.
 fn clone(url: &str, dest: &Path) -> Result<(), CacheError> {
     let status = Command::new("git")
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
         .arg("gc.auto=0")
+        .arg("-c")
+        .arg("maintenance.auto=false")
         .arg("clone")
         .arg("--filter=blob:none")
         .arg(url)
@@ -371,6 +402,8 @@ fn fetch(repo: &Path) -> Result<(), CacheError> {
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
         .arg("gc.auto=0")
+        .arg("-c")
+        .arg("maintenance.auto=false")
         .arg("-C")
         .arg(repo)
         .arg("fetch")
@@ -397,6 +430,8 @@ fn fetch_refetch(repo: &Path) -> Result<(), CacheError> {
         .arg("core.hooksPath=/dev/null")
         .arg("-c")
         .arg("gc.auto=0")
+        .arg("-c")
+        .arg("maintenance.auto=false")
         .arg("-C")
         .arg(repo)
         .arg("fetch")
@@ -436,32 +471,42 @@ fn touch(repo_dir: &Path) -> Result<(), CacheError> {
 /// never legitimately contain symlinked directories pointing outside the
 /// clone, and this avoids any possibility of a symlink loop).
 ///
-/// Tolerant of an entry disappearing mid-walk (a vanished entry contributes
-/// 0 bytes rather than aborting the whole size computation): a cache slot's
-/// `.git` tree can legitimately be mutated by something outside this
-/// function's control while it walks it -- git's own `gc --auto` may still
-/// be finishing a background repack from an *earlier* command despite
-/// `gc.auto=0` on every command this crate issues (a slot's history predates
-/// that setting, or an operator's own `git` invocation touched the slot), or
-/// a concurrent `evict_lru`/`ensure_clone` repair on the same slot removed
-/// it. This accounting is inherently a snapshot of a possibly-changing tree
-/// (ADR-088 Amendment 1: eviction is safe because ingest cursors live in the
-/// database, not the clone), so "the thing I was about to size is already
-/// gone" is not an error here -- it is the expected outcome of a slot that
-/// eviction (by us or a racing process) has already reclaimed.
+/// Tolerant of a *descendant* disappearing mid-walk (a vanished entry
+/// beneath an existing root contributes 0 bytes rather than aborting the
+/// whole size computation): a cache slot's `.git` tree can legitimately be
+/// mutated by something outside this function's control while it walks it
+/// -- a concurrent `evict_lru`/`ensure_clone` repair on the same slot, or a
+/// background `git maintenance` child from before `maintenance.auto=false`
+/// applied to every command this crate issues. This accounting is
+/// inherently a snapshot of a possibly-changing tree (ADR-088 Amendment 1:
+/// eviction is safe because ingest cursors live in the database, not the
+/// clone), so "a thing under the root I was about to size is already gone"
+/// is not an error here.
+///
+/// The walk **root** itself vanishing is different and is NOT tolerated --
+/// it surfaces as `CacheError::Io(NotFound)` rather than silently sizing to
+/// `0`. A caller that genuinely expects the root it's sizing to sometimes be
+/// absent (rather than an existing root racing a mid-walk mutation) must
+/// check for that error explicitly and decide its own semantics at that call
+/// site (`evict_lru` does this for a listed entry that a concurrent repair
+/// deleted between `read_dir` and this call -- see there); `dir_size` itself
+/// never launders a missing root into a bare `0`, which previously let
+/// `evict_lru` report success with a missing keep slot or count a phantom
+/// candidate and evict a valid one unnecessarily.
 fn dir_size(path: &Path) -> Result<u64, CacheError> {
     let mut total = 0u64;
     let mut stack = vec![path.to_path_buf()];
     while let Some(p) = stack.pop() {
+        let is_root = p == path;
         let md = match std::fs::symlink_metadata(&p) {
             Ok(md) => md,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !is_root => continue,
             Err(e) => return Err(io_err("dir_size: stat", &p, e)),
         };
         if md.is_dir() {
             let read_dir = match std::fs::read_dir(&p) {
                 Ok(read_dir) => read_dir,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound && !is_root => continue,
                 Err(e) => return Err(io_err("dir_size: read_dir", &p, e)),
             };
             for entry in read_dir {
@@ -513,6 +558,18 @@ fn is_owned_entry(path: &Path) -> bool {
 /// satisfied. `keep` (the clone `ensure_clone` just touched) is never
 /// evicted. Only removes paths that are direct children of `root` AND pass
 /// `is_owned_entry` -- eviction never touches user-owned or non-cache paths.
+///
+/// `keep`'s own `dir_size` (below) is deliberately NOT tolerant of `keep`
+/// vanishing: every caller touches (or freshly installs) `keep` immediately
+/// before calling `evict_lru` in the same synchronous call chain, so `keep`
+/// disappearing out from under this call is not an expected repair race --
+/// it is either a genuine bug or an external actor deleting our slot, and
+/// silently sizing it to `0` would let eviction report success while the
+/// slot the caller asked to keep is actually gone. A listed *candidate*
+/// entry (below) is different -- another `evict_lru`/`ensure_clone`
+/// repairing the same root can legitimately delete it between the
+/// `read_dir` listing above and the `dir_size` call below, so that vanish is
+/// tolerated by skipping the entry rather than aborting the whole pass.
 fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
     let mut entries: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
     let read_dir =
@@ -522,8 +579,7 @@ fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
             Ok(entry) => entry,
             // The directory listing raced a concurrent removal of one of its
             // own entries (e.g. another `evict_lru`/`ensure_clone` repairing
-            // the same root, or the tail of a background `gc --auto` from
-            // before `gc.auto=0` applied) -- nothing to evict there anymore.
+            // the same root) -- nothing to evict there anymore.
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(e) => return Err(io_err("evict_lru: read_dir entry", root, e)),
         };
@@ -534,7 +590,14 @@ fn evict_lru(root: &Path, keep: &Path) -> Result<(), CacheError> {
         let mtime = std::fs::metadata(p.join(MARKER_FILE))
             .and_then(|m| m.modified())
             .unwrap_or(SystemTime::UNIX_EPOCH);
-        let size = dir_size(&p)?;
+        let size = match dir_size(&p) {
+            Ok(size) => size,
+            // `p` was listed above but a concurrent repair on the same root
+            // has since deleted it whole -- there is no slot left to weigh
+            // in eviction accounting, not a size of `0` to record.
+            Err(CacheError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
         entries.push((p, mtime, size));
     }
     entries.sort_by_key(|(_, mtime, _)| *mtime);
@@ -751,6 +814,49 @@ mod tests {
         assert_eq!(dir_size(dir.path()).unwrap(), 15);
     }
 
+    /// PR #847 round-3 Major-2: the walk root vanishing must surface as an
+    /// error, never a laundered `Ok(0)` -- distinct from a descendant
+    /// vanishing beneath a still-existing root (see the Barrier tests
+    /// below). A root that was never there to begin with is the simplest,
+    /// fully deterministic instance of "the root itself is missing".
+    #[test]
+    fn dir_size_errors_when_the_root_itself_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        let err = dir_size(&missing).expect_err("a missing root must error, not size to 0");
+        assert!(
+            matches!(&err, CacheError::Io(e) if e.kind() == std::io::ErrorKind::NotFound),
+            "expected CacheError::Io(NotFound), got {err:?}"
+        );
+    }
+
+    /// `evict_lru`'s `keep` argument: every caller (`ensure_clone`,
+    /// `refetch_clone`, `reclone`) has just touched or freshly installed
+    /// `keep` immediately before calling `evict_lru`, so `keep` vanishing is
+    /// a real problem to surface, not a maybe-absent slot -- `evict_lru`
+    /// must propagate `dir_size(keep)`'s error rather than treat it as an
+    /// empty, evictable-looking slot.
+    #[test]
+    fn evict_lru_errors_when_keep_itself_is_missing() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("KHIVE_GIT_DIGEST_CACHE_MAX_REPOS", "5");
+        std::env::set_var("KHIVE_GIT_DIGEST_CACHE_MAX_BYTES", "1000000000");
+
+        let root = dir.path().join("scratch-root");
+        std::fs::create_dir_all(&root).unwrap();
+        let missing_keep = root.join("0000000000000000");
+
+        let err = evict_lru(&root, &missing_keep).expect_err("a missing keep root must error");
+        assert!(
+            matches!(&err, CacheError::Io(e) if e.kind() == std::io::ErrorKind::NotFound),
+            "expected CacheError::Io(NotFound), got {err:?}"
+        );
+
+        std::env::remove_var("KHIVE_GIT_DIGEST_CACHE_MAX_REPOS");
+        std::env::remove_var("KHIVE_GIT_DIGEST_CACHE_MAX_BYTES");
+    }
+
     /// Issue #842's macOS ENOENT flake family: `dir_size` walks a tree that
     /// can legitimately be mutated out from under it (git's own background
     /// `gc --auto`, or a racing `evict_lru`/`ensure_clone` repair on the same
@@ -809,6 +915,60 @@ mod tests {
                 "dir_size must tolerate a subdirectory vanishing mid-walk, got {result:?}"
             );
         }
+    }
+
+    /// Companion to the test above, pinning the other half of the Major-2
+    /// contract (PR #847 round-3): when the vanishing path is the walk
+    /// **root** itself -- not a descendant beneath a still-existing root --
+    /// `dir_size` must surface an error rather than tolerate it. Same
+    /// barrier-race harness, but `root` is left empty (an empty-directory
+    /// removal is a single `rmdir` syscall, the same order of cost as the
+    /// `symlink_metadata`/`read_dir` calls `dir_size` opens with -- a
+    /// populated root, by contrast, has its own directory entry removed
+    /// *last* by `remove_dir_all` after every child, well after the
+    /// walker's first two syscalls would already have completed, which
+    /// would make the root-vanish race effectively unreachable). Pre-fix,
+    /// `dir_size` treated a disappearing root exactly like a disappearing
+    /// descendant and returned `Ok(0)`, which could let `evict_lru` report
+    /// success over a missing `keep` slot or count a phantom `0`-byte
+    /// candidate.
+    #[test]
+    fn dir_size_errors_when_the_root_is_removed_mid_walk() {
+        let mut saw_error = false;
+        for _ in 0..500 {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let root = dir.path().join("slot");
+            std::fs::create_dir_all(&root).unwrap();
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let walk_root = root.clone();
+            let walk_barrier = barrier.clone();
+            let walker = std::thread::spawn(move || {
+                walk_barrier.wait();
+                dir_size(&walk_root)
+            });
+            let delete_root = root.clone();
+            let deleter = std::thread::spawn(move || {
+                barrier.wait();
+                let _ = std::fs::remove_dir(&delete_root);
+            });
+
+            let result = walker.join().expect("walker thread");
+            deleter.join().expect("deleter thread");
+
+            match result {
+                Ok(_) => continue, // walker won the race this round; try again
+                Err(CacheError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                    saw_error = true;
+                }
+                Err(e) => panic!("unexpected error kind from a vanished root: {e:?}"),
+            }
+        }
+        assert!(
+            saw_error,
+            "root-vanish-mid-walk race was never hit across 500 iterations; \
+             widen the fixture or investigate the barrier timing"
+        );
     }
 
     // ── issue #765: refetch/reclone repair primitives ──────────────────────

--- a/crates/khive-pack-git/src/cache.rs
+++ b/crates/khive-pack-git/src/cache.rs
@@ -344,23 +344,24 @@ fn remove_dir_all_retrying(path: &Path) -> std::io::Result<()> {
     Err(last_err.expect("loop always sets last_err before exiting"))
 }
 
-/// `-c maintenance.auto=false` on every clone/fetch into a cache slot: since
-/// git 2.30, `fetch`/`clone` unconditionally check `maintenance.auto`
-/// (default true) after they finish and, if set, launch
-/// `git maintenance run --auto --detach` as a background child that keeps
-/// running *after* the foreground command already returned success --
-/// exactly the kind of concurrent mutator that can touch a cache slot's
-/// `.git` tree (commit-graph writes, pack maintenance, lock files
-/// appearing/disappearing) while `dir_size`/`evict_lru` are mid-walk over it
-/// (issue #842's macOS-only ENOENT flake family). `gc.auto=0` alone does
-/// **not** suppress this: it was traced with `GIT_TRACE2_EVENT` against a
-/// live `git fetch --refetch` and, with only `gc.auto=0` set, git still
-/// forked `git maintenance run --auto --detach`; adding
-/// `maintenance.auto=false` on the same command produced no such child (see
-/// the implementation report for both trace2 captures). `gc.auto=0` is kept
-/// alongside it — it disables `git gc --auto`'s own, separate opportunistic-
-/// gc check, which is harmless to also turn off here, but it is not what
-/// closes the race; `maintenance.auto=false` is.
+/// `-c maintenance.auto=false` on every clone/fetch into a cache slot, as
+/// defensive hardening: since git 2.30, `fetch`/`clone` unconditionally
+/// check `maintenance.auto` (default true) after they finish and, if set,
+/// launch `git maintenance run --auto --detach` as a detached background
+/// child. The child spawn is trace2-proven in both directions
+/// (`GIT_TRACE2_EVENT` on a live `git fetch --refetch`: with default config
+/// the child forks; with `maintenance.auto=false` it does not). When one of
+/// its auto-maintenance tasks fires, that child mutates the slot's `.git`
+/// tree (commit-graph writes, pack maintenance, lock files) concurrently
+/// with any `dir_size`/`evict_lru` walk of the same slot. Whether such a
+/// task actually fired in issue #842's historical macOS ENOENT failures is
+/// not proven -- in small repos the child typically finds no task to run
+/// and exits quickly -- so the load-bearing fix for that flake family is
+/// the descendant-vanish tolerance in `dir_size`; this flag removes the one
+/// background mutator git itself forks into our cache slots. `gc.auto=0`
+/// alone does **not** suppress the child (trace2-verified); it is kept
+/// alongside because it disables `git gc --auto`'s separate
+/// opportunistic-gc check, harmless to also turn off here.
 ///
 /// This does not mean a cache slot is naturally garbage-collected some other
 /// way instead: no cache-slot repo is ever gc'd or maintenance'd by us.
@@ -858,8 +859,9 @@ mod tests {
     }
 
     /// Issue #842's macOS ENOENT flake family: `dir_size` walks a tree that
-    /// can legitimately be mutated out from under it (git's own background
-    /// `gc --auto`, or a racing `evict_lru`/`ensure_clone` repair on the same
+    /// can legitimately be mutated out from under it (git's own detached
+    /// background maintenance child, or a racing `evict_lru`/`ensure_clone`
+    /// repair on the same
     /// slot) -- a subdirectory disappearing between `read_dir` listing it and
     /// this walk descending into it must shrink the total, not abort the
     /// whole computation with `CacheError::Io(NotFound)`.

--- a/crates/khive-pack-git/src/ingest.rs
+++ b/crates/khive-pack-git/src/ingest.rs
@@ -1870,8 +1870,16 @@ mod recovery_classifier_tests {
 
     /// A healthy repo: the snapshot loads on the first try, no `recover`
     /// call, no warning.
+    ///
+    /// Spawns real `git` via bare `Command::new("git")`, resolved through
+    /// the process-wide `PATH` -- must hold the same crate-wide
+    /// `cache::ENV_MUTEX` the `PATH`-shimming tests in `cache.rs` and
+    /// `recovery_tests.rs` hold while they swap `PATH` to a fake `git`, or
+    /// this test can spawn that shim instead of real git and misclassify a
+    /// healthy repo as corrupt.
     #[test]
     fn recover_commit_snapshot_returns_no_warning_when_healthy() {
+        let _env = crate::cache::ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         init_repo_with_commit(dir.path());
         let mut recover_calls = 0;
@@ -1888,8 +1896,12 @@ mod recovery_classifier_tests {
     /// An unclassified `git log` failure (nonexistent repo path -- a spawn-
     /// level/`bad object`-shaped failure, not a promisor one) must never
     /// reach `recover` at all, and must propagate as-is.
+    ///
+    /// Same crate-wide `ENV_MUTEX` requirement as the sibling test above --
+    /// `recover_commit_snapshot` spawns real `git log` through `PATH`.
     #[test]
     fn recover_commit_snapshot_never_calls_recover_for_unclassified_failures() {
+        let _env = crate::cache::ENV_MUTEX.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         // Not a git repo at all -- `git log` fails with a plain spawn/repo
         // error, not a classified promisor one.

--- a/crates/khive-pack-git/src/recovery_tests.rs
+++ b/crates/khive-pack-git/src/recovery_tests.rs
@@ -469,7 +469,7 @@ async fn refetch_failure_falls_through_to_one_reclone_and_still_self_heals() {
         std::fs::read_to_string(&args_log)
             .unwrap()
             .lines()
-            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null clone "))
+            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null -c gc.auto=0 clone "))
             .count(),
         2,
         "exactly one reclone (plus the initial ensure_clone) must occur"
@@ -780,7 +780,7 @@ async fn public_verb_partial_side_effects_survive_commit_snapshot_recovery() {
         std::fs::read_to_string(&args_log)
             .unwrap()
             .lines()
-            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null clone "))
+            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null -c gc.auto=0 clone "))
             .count(),
         1,
         "no reclone: only the initial ensure_clone's own clone"

--- a/crates/khive-pack-git/src/recovery_tests.rs
+++ b/crates/khive-pack-git/src/recovery_tests.rs
@@ -469,7 +469,9 @@ async fn refetch_failure_falls_through_to_one_reclone_and_still_self_heals() {
         std::fs::read_to_string(&args_log)
             .unwrap()
             .lines()
-            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null -c gc.auto=0 clone "))
+            .filter(|l| l.starts_with(
+                "-c core.hooksPath=/dev/null -c gc.auto=0 -c maintenance.auto=false clone "
+            ))
             .count(),
         2,
         "exactly one reclone (plus the initial ensure_clone) must occur"
@@ -780,7 +782,9 @@ async fn public_verb_partial_side_effects_survive_commit_snapshot_recovery() {
         std::fs::read_to_string(&args_log)
             .unwrap()
             .lines()
-            .filter(|l| l.starts_with("-c core.hooksPath=/dev/null -c gc.auto=0 clone "))
+            .filter(|l| l.starts_with(
+                "-c core.hooksPath=/dev/null -c gc.auto=0 -c maintenance.auto=false clone "
+            ))
             .count(),
         1,
         "no reclone: only the initial ensure_clone's own clone"

--- a/crates/khive-pack-git/tests/acceptance.rs
+++ b/crates/khive-pack-git/tests/acceptance.rs
@@ -3038,6 +3038,7 @@ async fn digest_verb_max_items_negative_and_zero_clamp_to_one() {
 
 #[tokio::test]
 async fn digest_verb_max_items_above_cap_clamps_to_two_thousand() {
+    let _guard = ENV_MUTEX.lock().await;
     let (_rt, _token, registry) = fixture().await;
     let dir = tempfile::tempdir().expect("tempdir");
     let repo = dir.path();
@@ -3061,6 +3062,7 @@ async fn digest_verb_max_items_above_cap_clamps_to_two_thousand() {
 
 #[tokio::test]
 async fn digest_verb_max_items_at_boundary_values() {
+    let _guard = ENV_MUTEX.lock().await;
     for (requested, expected_ingested) in [(1i64, 1u64), (2000i64, 1u64)] {
         let (_rt, _token, registry) = fixture().await;
         let dir = tempfile::tempdir().expect("tempdir");
@@ -3086,6 +3088,7 @@ async fn digest_verb_max_items_at_boundary_values() {
 
 #[tokio::test]
 async fn digest_verb_rejects_non_integer_max_items() {
+    let _guard = ENV_MUTEX.lock().await;
     let (_rt, _token, registry) = fixture().await;
     let dir = tempfile::tempdir().expect("tempdir");
     let repo = dir.path();


### PR DESCRIPTION
## Rounds 3-5 (current) — codex round-2 REQUEST CHANGES: two Majors fixed in round 3; rounds 4-5 scope the evidence claims to exactly what was observed

Codex round-2 reviewed 98e3dd45 with git trace2 instrumentation and found the
round-2 fix incomplete on two points. Both are fixed in this round; see
"Verification" for the trace2 captures and sabotage test.

### Major 1 — `gc.auto=0` does not suppress the detached maintenance child

Round-2's root-cause claim above ("git's default `gc.autoDetach=true` ...
`git gc --auto` ... forks and detaches ... continuing to repack/prune loose
objects") **overclaimed the mechanism** and codex correctly called it
unproven: this crate's cache-slot test fixtures are tiny and sit well below
git's default gc thresholds, so "auto-gc pruned loose objects" was never
actually demonstrated as the historical mutator.

What **is** trace2-proven (scoped precisely in rounds 4-5, per codex): `git
fetch` runs auto-maintenance when `maintenance.auto` (default `true`) is
set, and since **git 2.47** that maintenance runs as a detached background
child (`git maintenance run --auto --no-quiet --detach`) that can outlive
the foreground command (on 2.46 and earlier it ran synchronously). The
trace evidence covers the **`fetch --refetch` path only** — the same trace
showed `clone` spawning no maintenance child, so the flag on the clone
builder is harmless defensive configuration with no trace evidence claimed.
I traced a real `git fetch --refetch` against a local origin with
`GIT_TRACE2_EVENT` (git 2.49):

- **With only `-c gc.auto=0`** (round-2's fix): the detached child still
  spawns —
  `"argv":["git","maintenance","run","--auto","--no-quiet","--detach"]`
  appears in the trace2 `child_start` events.
- **With `-c gc.auto=0 -c maintenance.auto=false`** (this round's fix): no
  `maintenance` child appears anywhere in the trace2 log for the same fetch —
  only the expected `git-upload-pack`/`pack-objects`/`index-pack` children the
  fetch itself needs.

**Scope of what the trace2 evidence proves (round-4 correction, per codex
round-3):** the traces prove the detached child *spawns* with default config
and is suppressed by `maintenance.auto=false`. They do not prove the child
executed a maintenance task that mutated `.git` in the historical CI
failures — in small repos the child typically finds no task to run and
exits quickly. So `maintenance.auto=false` is **defensive hardening**: when
one of the child's auto-maintenance tasks does fire it mutates the slot's
`.git` tree (commit-graph writes, pack maintenance, lock files) concurrently
with our walks, and this flag removes the one background mutator git itself
forks into our cache slots. The **load-bearing fix** for the observed ENOENT
flake family is the `dir_size` descendant-vanish tolerance (Major 2 section
below), which handles any concurrent mutator of the walked tree — git's
child, or our own racing `evict_lru`/`ensure_clone` repair. Added to every
git invocation builder in `cache.rs` (`clone`, `fetch`, `fetch_refetch`).
`gc.auto=0` is kept alongside it — a separate, harmless knob (disables
`git gc --auto`'s own opportunistic-gc check) — but it does not suppress the
child; the doc comment on `clone` in `cache.rs` carries this same honest
framing.

**Does disabling auto maintenance mean cache repos never gc?** No — growth is
bounded by wholesale eviction, not in-place compaction, so there's nothing
useful for maintenance/gc to do in a cache slot regardless:
`ensure_clone`/`refetch_clone` (`cache.rs`) delete a slot outright via
`remove_owned_entry` the moment `dir_size` measures it over
`digest_cache_clone_max_bytes` right after a fetch — a slot can be fetched
into repeatedly, but it can never accumulate objects past its own size cap
without being deleted and re-cloned fresh. Independently, `evict_lru`
(`cache.rs`) deletes whole least-recently-used slot directories once the
cache-wide `digest_cache_max_repos`/`digest_cache_max_bytes` caps are
exceeded. Both are whole-directory removals, never in-place object pruning.

### Major 2 — `dir_size` laundered a vanished walk **root** into `Ok(0)`

`dir_size` treated `NotFound` on the exact path it was asked to size
identically to `NotFound` on a descendant found while walking — both were
silently tolerated and contributed `0` bytes. That's correct for a
mid-walk descendant (the intended fix from round 2) but wrong for the walk
root itself: a caller sizing `keep` (`evict_lru`) or a slot it just
fetched/cloned into (`ensure_clone`, `refetch_clone`) got a false `Ok(0)`
instead of an error when that root had actually vanished — `evict_lru` could
then report success over a missing `keep` slot, or record a
concurrently-evicted candidate as a phantom `0`-byte entry instead of simply
having nothing to weigh.

Fixed: `dir_size` now distinguishes the two cases by comparing the popped
path to the function's own `path` argument. `NotFound` on that exact root
path is a hard error (`CacheError::Io`); `NotFound` on anything discovered
while walking beneath an existing root is still tolerated, unchanged from
round 2. Audited every call site for which semantic it needs:

- `ensure_clone`, `refetch_clone` (`cache.rs`): already propagate via `?` —
  correct, since the root just finished being fetched/cloned into, so a
  vanish is a real problem to surface, not a maybe-absent slot.
- `install_fresh_clone`'s staging-dir sizing: already propagates via `?` with
  its existing cleanup `inspect_err` — a private, freshly-created staging
  directory vanishing is a genuine bug.
- `evict_lru`'s `keep` argument: propagates via `?` (unchanged code) — every
  caller touches or freshly installs `keep` immediately before calling
  `evict_lru`, so a vanish is a real problem, not an expected race.
- `evict_lru`'s per-candidate `dir_size(&p)` call: this is the one site that
  legitimately needs tolerance — another `evict_lru`/`ensure_clone` repairing
  the same root can delete a listed candidate between the `read_dir` listing
  and this call. Now explicitly matches `CacheError::Io(NotFound)` and skips
  the entry instead of aborting the whole eviction pass.

New regression tests pin both halves of the contract:
`dir_size_errors_when_the_root_itself_is_missing` (deterministic — root never
existed), `dir_size_errors_when_the_root_is_removed_mid_walk` (a genuine
Barrier-raced two-thread deletion, mirroring the existing tolerant-descendant
test but against an *empty* root so a single `rmdir` can race the walker's
first two syscalls — a populated root's own directory entry is removed last
by `remove_dir_all`, well after the walker), and
`evict_lru_errors_when_keep_itself_is_missing`.

## Round 2 root cause (superseded above) / fix

Every historical macOS failure in this flake family is a **scratch-cache I/O
error, `ENOENT`** — e.g.
`cache::tests::refetch_clone_updates_an_existing_slot_to_the_remote_tip`
(`cache.rs:742`) failing inside `refetch_clone` with
`CacheError::Io(No such file or directory)`. That test already holds
`cache::ENV_MUTEX`, sets its **own** unique `tempfile::tempdir()` scratch
root, and installs no `PATH` shim — the round-1 fix below does not touch it
at all, and could not have caused or cured this failure.

I audited every place this crate touches the scratch cache filesystem,
specifically checking the fleet lead's cross-process-interference hypothesis:

- **Every** test that overrides `KHIVE_GIT_DIGEST_SCRATCH_ROOT` (in
  `cache.rs` and `recovery_tests.rs`, both in the lib test binary) sets it to
  its own freshly created `tempfile::tempdir()` and holds `ENV_MUTEX` for the
  whole test. No two tests share a root, and no test leaks the override past
  its own scope (paired `set_var`/`remove_var` inside every guarded test).
- `tests/acceptance.rs` (a **separate test binary/process**) never
  constructs a `DigestSource::Remote` — every `git.digest` call there passes
  a local filesystem path as `source`. `GitPack::handle_digest` only calls
  into `cache::{ensure_clone,refetch_clone,reclone}` for a `Remote` source
  (`handlers.rs:144-160`); a local source never touches `cache.rs` at all.
  So the acceptance binary cannot be racing the lib binary's scratch cache —
  there's no shared filesystem location between them to race on, because one
  side never visits it.

That rules out cross-test and cross-binary path sharing as the mechanism.
What's proven now (see "Major 1" above for the precise evidence scope): git
2.47+ *spawns* a detached maintenance child after `fetch` — a background
process that, when one of its tasks fires, mutates the same `.git` tree our
`dir_size`/`evict_lru` walks traverse. Whether such a task actually fired in
the historical failures is not proven (spawn-only evidence); it is **not**,
as originally (and wrongly) claimed, loose-object pruning by `gc --auto`,
which the tiny test fixtures here never grow large enough to trigger. The
proven, load-bearing fix for the observed ENOENT class is the `dir_size`
descendant-vanish tolerance, which covers any concurrent mutator of the
walked tree.

### Fix applied in round 2 (still correct, extended in round 3 above)

- `dir_size`, and `evict_lru`'s directory listing, tolerate an entry
  vanishing **mid-walk beneath an existing root**: a `NotFound` there shrinks
  the running total or skips the listing entry instead of aborting the whole
  call — unchanged by round 3, which only tightens what counts as "mid-walk"
  versus "the root itself" (see Major 2 above).
- `CacheError::Io` now carries the operation and path it happened on at the
  three sites this was asked for (`touch`, `dir_size`, `evict_lru`) instead
  of an opaque `io::Error` — a future `ENOENT` here will name what vanished
  and which function was walking it.

## Round 1 (kept — internally correct, but not the cause of the ENOENT family)

The original PR round closed a **different, real** gap: two tests in
`ingest.rs`'s `recovery_classifier_tests` and three tests in
`tests/acceptance.rs` spawned real `git`/dispatched `git.digest` without
holding `cache::ENV_MUTEX`/the acceptance binary's own `ENV_MUTEX`, so they
could transiently run a concurrently-installed `PATH` shim or race a sibling
test's `KHIVE_TEST_GIT_FAIL_*` env vars. That fix (guarding all five) is
correct and stays — every test that spawns `git`/`gh` now holds the
appropriate mutex before doing so.

## Verification (round 3)

- **trace2, both directions (Major 1)**: real `git fetch --refetch` against a
  local origin, captured via `GIT_TRACE2_EVENT`.
  - `-c gc.auto=0` alone: `child_start` events include
    `["git","maintenance","run","--auto","--no-quiet","--detach"]`.
  - `-c gc.auto=0 -c maintenance.auto=false`: no `maintenance` child anywhere
    in the log for the same fetch.
- **Sabotage, Major 2**: reverted `dir_size`'s root/descendant distinction to
  round-2's uniform tolerance, ran the three new pinned tests —
  `dir_size_errors_when_the_root_itself_is_missing`,
  `dir_size_errors_when_the_root_is_removed_mid_walk`, and
  `evict_lru_errors_when_keep_itself_is_missing` all failed as expected
  (the first two asserting `0` was returned instead of an error; the barrier
  test additionally reported it never observed the error across its loop).
  Restored the fix; `git diff` confirmed clean before committing.
- `cargo test -p khive-pack-git`: **15/15** whole-crate green runs,
  multi-threaded, foreground batches of 5 — exact counts every time: 74 lib
  tests (71 prior + 3 new: the two `dir_size` root-vanish tests and
  `evict_lru_errors_when_keep_itself_is_missing`) + 41 acceptance tests, 0
  failures.
- `cargo clippy -p khive-pack-git --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Two `recovery_tests.rs` assertions hardcoded the exact `git` argv string
  logged by the `PATH` shim (`"-c core.hooksPath=/dev/null -c gc.auto=0 clone
  "`) to count clone/reclone invocations; this round's new `-c
  maintenance.auto=false` flag shifts that string, so both were updated to
  match the new argv shape and re-verified green.

## Verification (round 2, retained)

- **New regression test**
  (`cache::tests::dir_size_tolerates_a_subdirectory_removed_mid_walk`):
  races a real concurrent `std::fs::remove_dir_all` against `dir_size` via a
  `std::sync::Barrier` (not a sleep), with a wide fan of sibling directories
  to widen the window, looped 200x per run so the race is virtually certain
  to land at least once.
- Honest framing on reproducibility: this is a genuine two-thread race, not
  a single-shot deterministic repro — the exact interleaving isn't
  guaranteed identical every run. What is deterministic and repeatable:
  `dir_size` and `evict_lru` walking a tree that changes under them mid-walk
  hard-fails before the fix and tolerates it after, on every run.

Refs #842 #837 #839 #840


