### PR TITLE
feat(code-pack): kkernel code-ingest admin path + default load (ADR-085 Amendment 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ khive gives your agent:
 
 All 10 packs load by default. **78 public verbs** across the packs: the `git` pack
 contributes the `git.digest` verb plus the commit/issue/pull_request provenance note kinds
-and a batch ingester; the `code` pack contributes zero verbs by design, since its `finding`
+and a batch ingester; the `code` pack currently contributes zero verbs: its `finding`
 note kind is written only through the `kkernel code-ingest` admin CLI path, never a verb
-an agent can call (ADR-085 D1, Amendment 3). Regenerate via `request(ops="verbs()")`
+an agent can call (ADR-085 D1, Amendment 3; Amendment 2's `code.ingest` verb is accepted
+but unimplemented). Regenerate via `request(ops="verbs()")`
 before editing this line.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,12 @@ khive gives your agent:
 9. **Brain** — Bayesian profile tuning from feedback signals
 10. **Session** — persist and resume agent-session records
 
-All 9 packs load by default. **78 public verbs** across the packs — the `git` pack
+All 10 packs load by default. **78 public verbs** across the packs: the `git` pack
 contributes the `git.digest` verb plus the commit/issue/pull_request provenance note kinds
-and a batch ingester (regenerate via `request(ops="verbs()")` before editing this line).
+and a batch ingester; the `code` pack contributes zero verbs by design, since its `finding`
+note kind is written only through the `kkernel code-ingest` admin CLI path, never a verb
+an agent can call (ADR-085 D1, Amendment 3). Regenerate via `request(ops="verbs()")`
+before editing this line.
 
 If you're working on khive itself (writing code in this repo), see `CLAUDE.md` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,12 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 ```
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
-loads all 9 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git
-(78 verbs total — git contributes commit/issue/pull_request note kinds, a batch ingester,
-and the git.digest verb (ADR-088 Amendment 1); comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
+loads all 10 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git,
+code (verbs unchanged at 78: the `code` pack contributes zero verbs by design (ADR-085 D1);
+its `finding` note kind and `findings.json` ingest are reached only through the `kkernel
+code-ingest` admin CLI path (ADR-085 Amendment 3), never the MCP verb surface; git contributes
+commit/issue/pull_request note kinds, a batch ingester, and the git.digest verb (ADR-088
+Amendment 1); comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
 Ask A) added 2026-07-08; kg.resolve added 2026-07-09; regenerate via `request(ops="verbs()")` before editing this line).
 
 ### KG pack verbs (18 — ADR-017, ADR-046, ADR-089)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,10 @@ request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]")
 
 Verbs come from whichever packs are loaded via `KHIVE_PACKS` (env) or `--pack` (CLI). Default
 loads all 10 production packs: kg, gtd, memory, brain, comm, schedule, knowledge, session, git,
-code (verbs unchanged at 78: the `code` pack contributes zero verbs by design (ADR-085 D1);
-its `finding` note kind and `findings.json` ingest are reached only through the `kkernel
-code-ingest` admin CLI path (ADR-085 Amendment 3), never the MCP verb surface; git contributes
+code (verbs unchanged at 78: the `code` pack currently contributes zero verbs (ADR-085 D1;
+Amendment 2's `code.ingest` verb is accepted but unimplemented); its `finding` note kind and
+`findings.json` ingest are reached only through the `kkernel code-ingest` admin CLI path
+(ADR-085 Amendment 3), never the MCP verb surface; git contributes
 commit/issue/pull_request note kinds, a batch ingester, and the git.digest verb (ADR-088
 Amendment 1); comm.probe (#644) added 2026-07-07; brain.event_counts (ADR-103 Stage 1, #724
 Ask A) added 2026-07-08; kg.resolve added 2026-07-09; regenerate via `request(ops="verbs()")` before editing this line).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stdio, and `cargo test` finishes in 4 seconds.
 
 | Capability                  | How                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **78 verbs, 9 packs**       | KG, GTD, memory, brain, comm, schedule, knowledge, session, git: all load by default                                                                     |
+| **78 verbs, 10 packs**      | KG, GTD, memory, brain, comm, schedule, knowledge, session, git, code: all load by default                                                               |
 | **Typed entities**          | 9 closed kinds: concept, document, dataset, project, person, org, artifact, service, resource                                                            |
 | **Typed edges**             | 17 closed relations in 9 categories (structure, derivation, provenance, temporal, dependency, impl, lateral, annotation, epistemic)                      |
 | **Typed notes**             | 5 closed kinds: observation, insight, question, decision, reference                                                                                      |
@@ -63,21 +63,22 @@ request(ops="[v1(...), v2(...), v3(...)]")             # parallel batch (max 100
 request(ops="[{\"tool\":\"v1\",\"args\":{...}}, ...]") # equivalent JSON form
 ```
 
-All 9 packs load by default, giving **78 verbs** out of the box (verified against the live
+All 10 packs load by default, giving **78 verbs** out of the box (verified against the live
 `verbs()` registry, 2026-07-10; regenerate with `request(ops="verbs()")` before editing
 this table):
 
-| Pack          | Prefix       | Verbs | What it does                                                |
-| ------------- | ------------ | ----- | ----------------------------------------------------------- |
-| **kg**        | _(bare)_     | 18    | Entities, edges, notes, graph queries, reference resolution |
-| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)               |
-| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall            |
-| **brain**     | `brain.`     | 15    | Bayesian user profiles + feedback loop                      |
-| **comm**      | `comm.`      | 7     | Threaded messaging                                          |
-| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution                      |
-| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search                  |
-| **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export)       |
-| **git**       | `git.`       | 1     | Commit/issue/PR provenance ingestion into the graph         |
+| Pack          | Prefix       | Verbs | What it does                                                                      |
+| ------------- | ------------ | ----- | --------------------------------------------------------------------------------- |
+| **kg**        | _(bare)_     | 18    | Entities, edges, notes, graph queries, reference resolution                       |
+| **gtd**       | `gtd.`       | 5     | Task lifecycle (inbox → next → active → done)                                     |
+| **memory**    | `memory.`    | 5     | Salience-weighted remember / decay-ranked recall                                  |
+| **brain**     | `brain.`     | 15    | Bayesian user profiles + feedback loop                                            |
+| **comm**      | `comm.`      | 7     | Threaded messaging                                                                |
+| **schedule**  | `schedule.`  | 4     | Reminders and scheduled verb execution                                            |
+| **knowledge** | `knowledge.` | 19    | Atom-based KB with embedding rerank search                                        |
+| **session**   | `session.`   | 4     | Session record persistence (store/list/resume/export)                             |
+| **git**       | `git.`       | 1     | Commit/issue/PR provenance ingestion into the graph                               |
+| **code**      | _(none)_     | 0     | `finding` note kind only; `code.ingest` verb accepted but unimplemented (ADR-085) |
 
 `create`, `list`, `search` take `kind=entity|note` (or `kind=edge` for `list`).
 `get`, `update`, `delete`, `merge` are UUID-only: they auto-detect the record type.
@@ -246,7 +247,7 @@ global):
 kkernel --version   # confirms the binary and version you just installed
 ```
 
-All 9 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
+All 10 packs load by default, a background daemon auto-spawns to keep the runtime warm, and any
 MCP client discovers the `request` tool with the full 78-verb catalog.
 
 ### Alternative: npm
@@ -374,7 +375,7 @@ Docs: [ohdearquant.github.io/khive](https://ohdearquant.github.io/khive/) (agent
 
 ## Status
 
-**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 9
+**v0.3.0, published on [crates.io](https://crates.io/crates/khive-mcp).** 78 verbs across 10
 packs, 9 entity kinds, 17 edge relations, daemon warm startup (ADR-049), knowledge search with
 embedding rerank, Bayesian brain profiles, threaded messaging, scheduled verb execution.
 Ready for use with Claude Code and any MCP-compatible agent.

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -59,8 +59,8 @@ Pack subcommands (ADR-050):
   init          Scaffold a new declarative pack
   check         Validate a pack.yaml manifest
 
-All 7 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge)
-load by default — no --pack flags needed.
+All 10 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
+session, git, code) load by default — no --pack flags needed.
 
 Run 'khive <group> <subcommand> --help' for detailed usage.`);
 }

--- a/cli/tests/golden/help_toplevel.txt
+++ b/cli/tests/golden/help_toplevel.txt
@@ -28,7 +28,7 @@ Pack subcommands (ADR-050):
   init          Scaffold a new declarative pack
   check         Validate a pack.yaml manifest
 
-All 7 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge)
-load by default — no --pack flags needed.
+All 10 built-in packs (kg, gtd, memory, brain, comm, schedule, knowledge,
+session, git, code) load by default — no --pack flags needed.
 
 Run 'khive <group> <subcommand> --help' for detailed usage.

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -25,6 +25,7 @@ khive-pack-schedule = { version = "0.3.0", path = "../khive-pack-schedule" }
 khive-pack-knowledge = { version = "0.3.0", path = "../khive-pack-knowledge" }
 khive-pack-session = { version = "0.3.0", path = "../khive-pack-session" }
 khive-pack-git = { version = "0.3.0", path = "../khive-pack-git" }
+khive-pack-code = { version = "0.3.0", path = "../khive-pack-code" }
 uuid = { workspace = true }
 inventory = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }

--- a/crates/khive-mcp/src/args.rs
+++ b/crates/khive-mcp/src/args.rs
@@ -53,7 +53,7 @@ pub struct Args {
     /// Pack to load into the verb registry. Repeat for multiple
     /// (e.g. `--pack kg --pack gtd`). When unset, falls back to `KHIVE_PACKS`
     /// (comma- or whitespace-separated), and if that is also unset to the full
-    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge`.
+    /// production set: `kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code`.
     #[arg(long = "pack")]
     pub pack: Vec<String>,
 

--- a/crates/khive-mcp/src/pack.rs
+++ b/crates/khive-mcp/src/pack.rs
@@ -12,6 +12,8 @@ pub use khive_runtime::{KhiveRuntime, PackRegistry, VerbRegistryBuilder};
 #[doc(hidden)]
 pub use khive_pack_brain::BrainPack as _BrainPack;
 #[doc(hidden)]
+pub use khive_pack_code::CodePack as _CodePack;
+#[doc(hidden)]
 pub use khive_pack_comm::CommPack as _CommPack;
 #[doc(hidden)]
 pub use khive_pack_git::GitPack as _GitPack;

--- a/crates/khive-pack-code/src/ingest.rs
+++ b/crates/khive-pack-code/src/ingest.rs
@@ -102,6 +102,18 @@ fn tolerated_field(obj: &Map<String, Value>, key: &str) -> Option<Value> {
     }
 }
 
+/// Amendment 1 A2 governed mapping: `fixed -> resolved`, `false_positive ->
+/// invalid`, everything else (including absent/non-string status) stays
+/// `open`. The raw producer value is preserved verbatim under
+/// `properties.audit_status` regardless of how it maps here.
+fn map_producer_status_to_kind_status(audit_status: Option<&Value>) -> &'static str {
+    match audit_status.and_then(Value::as_str) {
+        Some("fixed") => "resolved",
+        Some("false_positive") => "invalid",
+        _ => "open",
+    }
+}
+
 fn require_str<'a>(
     obj: &'a Map<String, Value>,
     key: &'static str,
@@ -505,7 +517,12 @@ pub fn ingest_findings_json(
         if let Some(verification) = &finding.verification {
             props.insert("verification".into(), verification.clone());
         }
-        props.insert("kind_status".into(), json!("open"));
+        props.insert(
+            "kind_status".into(),
+            json!(map_producer_status_to_kind_status(
+                finding.audit_status.as_ref()
+            )),
+        );
         if !finding.raw.is_empty() {
             props.insert("raw".into(), Value::Object(finding.raw.clone()));
         }

--- a/crates/khive-pack-code/src/lib.rs
+++ b/crates/khive-pack-code/src/lib.rs
@@ -3,10 +3,12 @@
 //! Registers four concept subtypes (`module`, `function`, `datatype`,
 //! `interface`) via `khive-pack-kg`'s entity type registry, additive
 //! `EDGE_RULES` over the closed relation set, and the `finding` audit note
-//! kind. Contributes no verbs (ADR-085 D1); `findings.json` ingest runs
-//! through the `kkernel code-ingest` admin CLI path, not an MCP wire surface
-//! (ADR-085 Amendment 3). In the default pack set as of Amendment 3, so the
-//! `finding` note kind is live on the production surface.
+//! kind. Currently contributes no verbs (ADR-085 D1; Amendment 2's accepted
+//! `code.ingest` source-ingest verb is unimplemented); `findings.json`
+//! ingest runs through the `kkernel code-ingest` admin CLI path, not an MCP
+//! wire surface (ADR-085 Amendment 3). In the default pack set as of
+//! Amendment 3, so the `finding` note kind is live on the production
+//! surface.
 
 mod error;
 mod hook;

--- a/crates/khive-pack-code/src/lib.rs
+++ b/crates/khive-pack-code/src/lib.rs
@@ -3,9 +3,10 @@
 //! Registers four concept subtypes (`module`, `function`, `datatype`,
 //! `interface`) via `khive-pack-kg`'s entity type registry, additive
 //! `EDGE_RULES` over the closed relation set, and the `finding` audit note
-//! kind. Contributes no verbs; `findings.json` ingest is an internal Rust
-//! API (see [`ingest`]), not an MCP wire surface. Opt-in only — not part of
-//! the default pack set.
+//! kind. Contributes no verbs (ADR-085 D1); `findings.json` ingest runs
+//! through the `kkernel code-ingest` admin CLI path, not an MCP wire surface
+//! (ADR-085 Amendment 3). In the default pack set as of Amendment 3, so the
+//! `finding` note kind is live on the production surface.
 
 mod error;
 mod hook;

--- a/crates/khive-pack-code/tests/integration.rs
+++ b/crates/khive-pack-code/tests/integration.rs
@@ -565,6 +565,67 @@ fn ingest_different_content_produces_different_finding_id() {
 }
 
 #[test]
+fn ingest_maps_producer_status_fixed_to_kind_status_resolved() {
+    // ADR-085 Amendment 1 A2: the pack-owned mapper resolves the governed
+    // producer status vocabulary, not the raw passthrough this replaces.
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["status"] = json!("fixed");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+
+    let batch =
+        ingest_findings_json(&bytes, ingest_options(Some("run"))).expect("ingest must succeed");
+    let props = batch.notes[0]
+        .properties
+        .as_ref()
+        .expect("finding note must carry properties");
+    assert_eq!(
+        props["kind_status"],
+        json!("resolved"),
+        "producer status 'fixed' must normalize to kind_status 'resolved'"
+    );
+    assert_eq!(
+        props["audit_status"],
+        json!("fixed"),
+        "the raw producer value must be preserved verbatim under audit_status"
+    );
+}
+
+#[test]
+fn ingest_maps_producer_status_false_positive_to_kind_status_invalid() {
+    let mut doc = sample_findings_json();
+    doc["findings"][0]["status"] = json!("false_positive");
+    let bytes = serde_json::to_vec(&doc).expect("serializes");
+
+    let batch =
+        ingest_findings_json(&bytes, ingest_options(Some("run"))).expect("ingest must succeed");
+    let props = batch.notes[0]
+        .properties
+        .as_ref()
+        .expect("finding note must carry properties");
+    assert_eq!(
+        props["kind_status"],
+        json!("invalid"),
+        "producer status 'false_positive' must normalize to kind_status 'invalid'"
+    );
+    assert_eq!(props["audit_status"], json!("false_positive"));
+}
+
+#[test]
+fn ingest_leaves_kind_status_open_for_ungoverned_producer_status() {
+    // "open" (and any other value outside the governed set, e.g. "wontfix"
+    // as a producer term) has no mapping rule and must fall back to the
+    // finding lifecycle's initial state, per Amendment 1 A2.
+    let batch = ingest_findings_json(&valid_findings_bytes(), ingest_options(Some("run")))
+        .expect("ingest must succeed");
+    let props = batch.notes[0]
+        .properties
+        .as_ref()
+        .expect("finding note must carry properties");
+    assert_eq!(props["kind_status"], json!("open"));
+    assert_eq!(props["audit_status"], json!("open"));
+}
+
+#[test]
 fn ingest_rejects_missing_findings_array() {
     let malformed = json!({
         "audit": {

--- a/crates/khive-pack-formal/README.md
+++ b/crates/khive-pack-formal/README.md
@@ -50,7 +50,7 @@ EdgeEndpointRule {
 `khive-pack-formal` sits in the pack tier on `khive-types` (`EdgeEndpointRule`,
 `EndpointKind`) and `khive-runtime` (`Pack`, `PackRuntime`, inventory
 registration); it `REQUIRES` [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg)
-for the underlying `concept` entity substrate. Unlike the nine packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
+for the underlying `concept` entity substrate. Unlike the ten packs force-linked into the `khive-mcp` binary, `khive-pack-formal`
 is only force-linked into `kkernel` (the admin/reindex binary) — it is not part of
 the agent-facing MCP server's pack registry at all today. A deployment that
 ingests formal-math corpora (Lean/mathlib-style theorem/definition/proof graphs)

--- a/crates/khive-pack-kg/README.md
+++ b/crates/khive-pack-kg/README.md
@@ -77,9 +77,9 @@ Over MCP, the same call is issued as a DSL string:
 request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
 ```
 
-`khive-mcp` loads a default set of nine packs — `kg`, `gtd`, `memory`, `brain`,
-`comm`, `schedule`, `knowledge`, `session`, `git` — with `kg` always present;
-`KHIVE_PACKS` / `--pack` select a subset.
+`khive-mcp` loads a default set of ten packs — `kg`, `gtd`, `memory`, `brain`,
+`comm`, `schedule`, `knowledge`, `session`, `git`, `code` — with `kg` always
+present; `KHIVE_PACKS` / `--pack` select a subset.
 
 ## Where this sits
 
@@ -87,7 +87,8 @@ request(ops="create(kind=\"entity\", entity_kind=\"concept\", name=\"RoPE\")")
 `khive-query`, and `khive-storage`, and is registered into the pack runtime that
 `khive-mcp` serves. Every other pack in this workspace declares
 `REQUIRES = ["kg"]` — `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
-`session`, plus `formal` and `template` — so each depends on `kg` being loaded.
+`session`, `git`, `code`, plus `formal` and `template` — so each depends on
+`kg` being loaded.
 Governing ADRs:
 [ADR-001](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-001-entity-kind-taxonomy.md) (entity kinds),
 [ADR-002](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-002-edge-ontology.md) (edge relations),

--- a/crates/khive-pack-knowledge/README.md
+++ b/crates/khive-pack-knowledge/README.md
@@ -88,7 +88,7 @@ All 19 verbs are `Visibility::Verb` (exposed on the agent-facing MCP surface).
 [`khive-pack-kg`](https://crates.io/crates/khive-pack-kg) (a hard `REQUIRES`
 dependency for the underlying `concept`/`document` entity substrate) and
 [`khive-pack-brain`](https://crates.io/crates/khive-pack-brain) (feedback
-target). It is one of the nine packs loaded by default in `khive-mcp`. Governing
+target). It is one of the ten packs loaded by default in `khive-mcp`. Governing
 ADRs:
 [ADR-017 (Pack Standard)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-017-pack-standard.md),
 [ADR-048 (Knowledge Section Profiles)](https://github.com/ohdearquant/khive/blob/main/docs/adr/ADR-048-knowledge-section-profiles.md),

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -313,6 +313,7 @@ impl Default for RuntimeConfig {
                     "knowledge",
                     "session",
                     "git",
+                    "code",
                 ]
                 .into_iter()
                 .map(String::from)

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -1102,7 +1102,8 @@ mod tests {
         // production; its handlers are all operator-only subhandlers (0 wire verbs).
         assert!(cfg.packs.contains(&"session".to_string()));
         assert!(cfg.packs.contains(&"git".to_string()));
-        assert_eq!(cfg.packs.len(), 9);
+        assert!(cfg.packs.contains(&"code".to_string()));
+        assert_eq!(cfg.packs.len(), 10);
         if let Some(v) = prior {
             // SAFETY: single-threaded test cleanup; restores KHIVE_PACKS to its prior value.
             unsafe {

--- a/crates/kkernel/docs/usage.md
+++ b/crates/kkernel/docs/usage.md
@@ -38,7 +38,7 @@ This is the production entrypoint. The deno/npm distribution invokes it:
 # stdio MCP server (default transport) — what MCP clients spawn
 kkernel mcp --db ~/.khive/khive.db
 
-# pick packs explicitly (default loads all 9 production packs)
+# pick packs explicitly (default loads all 10 production packs)
 kkernel mcp --pack kg --pack gtd --pack knowledge
 
 # warm Unix-socket daemon (owns ANN indexes; stdio clients auto-spawn + forward to it)

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -362,11 +362,17 @@ fn preflight_secret_gate(batch: &CodeIngestBatch) -> Result<()> {
 /// thereby creating) a database purely to answer "does this id exist" would
 /// itself be the mutation the dry-run contract forbids.
 ///
-/// When the path exists, it is opened with [`StorageBackend::sqlite_read_only`]
-/// (rejects writes at the SQLite level, never creates a missing file) and
-/// existence is checked with raw `SELECT` statements over the reader
-/// connection — no migrations run and no embedding models are registered,
-/// unlike `KhiveRuntime::new`.
+/// When the path exists, existence is checked against a snapshot copy of
+/// it: `StorageBackend::sqlite_read_only`'s `SQLITE_OPEN_READ_ONLY` plus
+/// `PRAGMA query_only = ON` blocks logical writes, but SQLite still performs
+/// ordinary WAL shared-memory maintenance on open, which creates or updates
+/// the `-shm` sidecar next to whatever path it is pointed at. Opening the
+/// target path directly would therefore still touch it. Instead, the
+/// database file (and its `-wal` sidecar, if one exists — an existing WAL
+/// file holds uncheckpointed rows that a plain copy of the main db file
+/// alone would miss) are copied into a scratch temp directory first, and
+/// the read-only checks run against that copy. No migrations run and no
+/// embedding models are registered, unlike `KhiveRuntime::new`.
 async fn dry_run_report(
     db_path: Option<&Path>,
     batch: &CodeIngestBatch,
@@ -384,7 +390,7 @@ async fn dry_run_report(
         return Ok(report);
     };
 
-    let backend = StorageBackend::sqlite_read_only(db_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let (backend, _snapshot_dir) = open_read_only_snapshot(db_path)?;
     let sql = backend.sql();
     let mut reader = sql.reader().await.map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -435,6 +441,40 @@ async fn dry_run_report(
     }
 
     Ok(report)
+}
+
+/// Copy `db_path` (and its `-wal` sidecar, if present) into a fresh scratch
+/// temp directory and open the copy read-only. The caller must keep the
+/// returned `TempDir` alive for as long as the backend is used; dropping it
+/// deletes the snapshot. Any `-shm` maintenance the read-only open performs
+/// lands on this disposable copy, never on `db_path`'s own sidecar.
+fn open_read_only_snapshot(db_path: &Path) -> Result<(StorageBackend, tempfile::TempDir)> {
+    let snapshot_dir = tempfile::TempDir::new()
+        .context("failed to create a scratch directory for the dry-run db snapshot")?;
+    let file_name = db_path
+        .file_name()
+        .with_context(|| format!("{} has no file name component", db_path.display()))?;
+    let snapshot_db = snapshot_dir.path().join(file_name);
+    std::fs::copy(db_path, &snapshot_db)
+        .with_context(|| format!("failed to snapshot {} for dry-run", db_path.display()))?;
+
+    let wal_path = wal_sidecar_path(db_path);
+    if wal_path.exists() {
+        let snapshot_wal = wal_sidecar_path(&snapshot_db);
+        std::fs::copy(&wal_path, &snapshot_wal)
+            .with_context(|| format!("failed to snapshot {} for dry-run", wal_path.display()))?;
+    }
+
+    let backend =
+        StorageBackend::sqlite_read_only(&snapshot_db).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok((backend, snapshot_dir))
+}
+
+/// The `-wal` sidecar path SQLite uses alongside a WAL-mode database file.
+fn wal_sidecar_path(db_path: &Path) -> PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push("-wal");
+    PathBuf::from(name)
 }
 
 #[cfg(test)]
@@ -628,6 +668,96 @@ mod tests {
             bytes_before, bytes_after,
             "a dry run against an existing db must not change a single byte of it"
         );
+    }
+
+    /// The `-shm` sidecar path SQLite uses alongside a WAL-mode database file.
+    fn shm_sidecar_path(db_path: &std::path::Path) -> PathBuf {
+        let mut name = db_path.as_os_str().to_owned();
+        name.push("-shm");
+        PathBuf::from(name)
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_dry_run_against_existing_wal_db_leaves_sidecars_untouched() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("wal_scratch.db");
+
+        // Populate the db for real first so it exists on disk in WAL mode.
+        code_ingest_batch(base_args(findings.clone(), db.clone()))
+            .await
+            .expect("initial ingest must succeed");
+
+        // Hold a live writer connection open across the dry run below, with
+        // one uncheckpointed write on it, so the target's `-wal`/`-shm`
+        // sidecars are guaranteed present with real content going into the
+        // dry run — the "existing WAL database" scenario Finding 1
+        // reproduced against (e.g. a live daemon holding the db open while
+        // an admin separately runs `code-ingest --dry-run`).
+        let pin = StorageBackend::sqlite(&db).expect("open pin backend");
+        {
+            let sql = pin.sql();
+            let mut writer = sql.writer().await.expect("pin writer");
+            writer
+                .execute_script(
+                    "CREATE TABLE IF NOT EXISTS wal_pin_probe(x INTEGER); \
+                     INSERT INTO wal_pin_probe VALUES (1);"
+                        .to_string(),
+                )
+                .await
+                .expect("pin write to keep the wal open");
+        }
+
+        let wal_path = wal_sidecar_path(&db);
+        let shm_path = shm_sidecar_path(&db);
+        assert!(
+            wal_path.exists(),
+            "expected a live -wal sidecar before dry-run"
+        );
+        assert!(
+            shm_path.exists(),
+            "expected a live -shm sidecar before dry-run"
+        );
+
+        let db_before = std::fs::read(&db).expect("read db before dry run");
+        let wal_before = std::fs::read(&wal_path).expect("read -wal before dry run");
+        let shm_before = std::fs::read(&shm_path).expect("read -shm before dry run");
+
+        let mut args = base_args(findings, db.clone());
+        args.dry_run = true;
+        let report = code_ingest_batch(args)
+            .await
+            .expect("dry-run against an existing WAL db must succeed");
+        assert!(report.dry_run);
+
+        assert!(
+            wal_path.exists(),
+            "the existing -wal sidecar must not disappear"
+        );
+        assert!(
+            shm_path.exists(),
+            "the existing -shm sidecar must not disappear"
+        );
+
+        let db_after = std::fs::read(&db).expect("read db after dry run");
+        let wal_after = std::fs::read(&wal_path).expect("read -wal after dry run");
+        let shm_after = std::fs::read(&shm_path).expect("read -shm after dry run");
+
+        assert_eq!(
+            db_before, db_after,
+            "dry-run must not touch the main db file"
+        );
+        assert_eq!(
+            wal_before, wal_after,
+            "dry-run must not touch the existing -wal sidecar"
+        );
+        assert_eq!(
+            shm_before, shm_after,
+            "dry-run must not touch the existing -shm sidecar (Finding 1 regression)"
+        );
+
+        drop(pin);
     }
 
     #[serial]

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -9,17 +9,18 @@
 //! `--dry-run` runs the same validation and existence checks but performs
 //! no writes.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
 use clap::Parser;
 use serde::Serialize;
 
+use khive_db::StorageBackend;
 use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
-use khive_pack_code::{ingest_findings_json, CodeIngestOptions};
-use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
-use khive_storage::SubstrateKind;
+use khive_pack_code::{ingest_findings_json, CodeIngestBatch, CodeIngestOptions};
+use khive_runtime::{entity_fts_document, note_fts_document, secret_gate, KhiveRuntime, Namespace};
+use khive_storage::{SqlStatement, SqlValue, SubstrateKind};
 
 /// Arguments for `kkernel code-ingest`.
 #[derive(Parser, Debug)]
@@ -94,6 +95,14 @@ pub async fn run_code_ingest(args: CodeIngestArgs) -> Result<()> {
 
 /// Core of `run_code_ingest`, split out so tests can assert on the returned
 /// [`CodeIngestReport`] directly instead of parsing stdout.
+///
+/// Order matters here: the document is read, parsed, and fully validated
+/// (`ingest_findings_json`), then secret-gate-preflighted, entirely BEFORE
+/// any `KhiveRuntime`/database construction. This is what makes `--dry-run`
+/// (and a rejected invalid document) leave the filesystem untouched: no
+/// runtime, no migrations, no embedding-model registration happen until
+/// after validation has already succeeded and a real (non-dry-run) write is
+/// about to occur.
 async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
     let bytes = std::fs::read(&args.findings)
         .with_context(|| format!("failed to read {}", args.findings.display()))?;
@@ -110,6 +119,47 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
         brain_profile: None,
     })?;
 
+    // The write path below persists `finding` notes directly through
+    // EntityStore/NoteStore/GraphStore rather than through pack dispatch (see
+    // `preflight_secret_gate` below), so it must independently confirm the
+    // `code` pack is actually part of this run's configured pack set —
+    // otherwise a misconfigured `KHIVE_PACKS`/`--pack` could accept
+    // `finding` records into a graph that never declared the kind.
+    if !cfg.packs.iter().any(|p| p == "code") {
+        anyhow::bail!(
+            "the `code` pack is not in the configured pack set {:?}; `finding` notes require it \
+             to be loaded (set KHIVE_PACKS to include `code`, or drop --pack overrides)",
+            cfg.packs
+        );
+    }
+
+    // Whole-document validation before any runtime/database construction
+    // (fail-closed): a malformed findings.json returns Err here and the
+    // process exits nonzero with zero filesystem effect.
+    let batch = ingest_findings_json(
+        &bytes,
+        CodeIngestOptions {
+            namespace: cfg.default_namespace.as_str(),
+            observed_at: Utc::now(),
+            source_run: args.source_run.as_deref(),
+        },
+    )
+    .with_context(|| format!("{} failed validation", args.findings.display()))?;
+
+    // Preflight every entity/note content and nested property value through
+    // the same secret gate the shared `create` verb path applies
+    // (`crate::secret_gate::check`/`check_json`). This path writes directly
+    // through the storage traits rather than `registry.dispatch("create",
+    // ...)` — explicit-id creation (required for the content-derived UUIDv5
+    // identity that makes re-ingest idempotent) has no dispatch-level
+    // equivalent today — so the gate has to run here instead of being
+    // inherited for free from the shared create handler.
+    preflight_secret_gate(&batch)?;
+
+    if args.dry_run {
+        return dry_run_report(cfg.db_path.as_deref(), &batch).await;
+    }
+
     let runtime = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
     let resolved_ns = runtime.config().default_namespace.clone();
     let token = runtime
@@ -117,21 +167,8 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
         .map_err(|e| anyhow::anyhow!("{e}"))
         .context("failed to authorize namespace")?;
 
-    // Whole-document validation before any write (fail-closed): a malformed
-    // findings.json returns Err here and the process exits nonzero without
-    // touching storage.
-    let batch = ingest_findings_json(
-        &bytes,
-        CodeIngestOptions {
-            namespace: token.namespace().as_str(),
-            observed_at: Utc::now(),
-            source_run: args.source_run.as_deref(),
-        },
-    )
-    .with_context(|| format!("{} failed validation", args.findings.display()))?;
-
     let mut report = CodeIngestReport {
-        dry_run: args.dry_run,
+        dry_run: false,
         ..CodeIngestReport::default()
     };
 
@@ -148,9 +185,6 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
             continue;
         }
         report.entities_created += 1;
-        if args.dry_run {
-            continue;
-        }
         entities
             .upsert_entity(entity.clone())
             .await
@@ -179,7 +213,12 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
                                 entity.id,
                                 SubstrateKind::Entity,
                                 token.namespace().as_str(),
-                                "entity.name",
+                                // Canonical field label for the entity body
+                                // vector (khive-runtime/src/operations.rs,
+                                // curation.rs) — must match so vector
+                                // provenance metadata agrees with every
+                                // other write path.
+                                "entity.body",
                                 vec![vector],
                             )
                             .await
@@ -214,9 +253,6 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
             continue;
         }
         report.notes_created += 1;
-        if args.dry_run {
-            continue;
-        }
         notes
             .upsert_note(note.clone())
             .await
@@ -278,9 +314,6 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
             continue;
         }
         report.edges_created += 1;
-        if args.dry_run {
-            continue;
-        }
         graph
             .upsert_edge(edge.clone())
             .await
@@ -290,8 +323,124 @@ async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
     Ok(report)
 }
 
+/// Scan every entity/note content field and nested property value in `batch`
+/// through the runtime secret gate, before any storage write is attempted.
+/// Mirrors the fields `khive-runtime/src/operations.rs`'s `create_entity`/
+/// `create_note_inner` scan (name/description/properties for entities,
+/// content/name/properties for notes) so a credential embedded in finding
+/// evidence is rejected here exactly as it would be on the shared `create`
+/// verb path, rather than persisting verbatim.
+fn preflight_secret_gate(batch: &CodeIngestBatch) -> Result<()> {
+    for entity in &batch.entities {
+        secret_gate::check(&entity.name).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if let Some(description) = &entity.description {
+            secret_gate::check(description).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        if let Some(properties) = &entity.properties {
+            secret_gate::check_json(properties).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        secret_gate::check_tags(&entity.tags).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    for note in &batch.notes {
+        secret_gate::check(&note.content).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if let Some(name) = &note.name {
+            secret_gate::check(name).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        if let Some(properties) = &note.properties {
+            secret_gate::check_json(properties).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Report what `code_ingest_batch` would create/skip without writing
+/// anything.
+///
+/// When `db_path` is absent, or points at a path that does not yet exist on
+/// disk, every record is reported as would-create and nothing is touched —
+/// there is no existing state to check identity against, so opening (and
+/// thereby creating) a database purely to answer "does this id exist" would
+/// itself be the mutation the dry-run contract forbids.
+///
+/// When the path exists, it is opened with [`StorageBackend::sqlite_read_only`]
+/// (rejects writes at the SQLite level, never creates a missing file) and
+/// existence is checked with raw `SELECT` statements over the reader
+/// connection — no migrations run and no embedding models are registered,
+/// unlike `KhiveRuntime::new`.
+async fn dry_run_report(
+    db_path: Option<&Path>,
+    batch: &CodeIngestBatch,
+) -> Result<CodeIngestReport> {
+    let mut report = CodeIngestReport {
+        dry_run: true,
+        ..CodeIngestReport::default()
+    };
+
+    let existing_path = db_path.filter(|p| p.exists());
+    let Some(db_path) = existing_path else {
+        report.entities_created = batch.entities.len() as u64;
+        report.notes_created = batch.notes.len() as u64;
+        report.edges_created = batch.edges.len() as u64;
+        return Ok(report);
+    };
+
+    let backend = StorageBackend::sqlite_read_only(db_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let sql = backend.sql();
+    let mut reader = sql.reader().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    for entity in &batch.entities {
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT 1 FROM entities WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                params: vec![SqlValue::Uuid(entity.id)],
+                label: Some("code-ingest dry-run entity existence".to_string()),
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if row.is_some() {
+            report.entities_skipped_existing += 1;
+        } else {
+            report.entities_created += 1;
+        }
+    }
+    for note in &batch.notes {
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT 1 FROM notes WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                params: vec![SqlValue::Uuid(note.id)],
+                label: Some("code-ingest dry-run note existence".to_string()),
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if row.is_some() {
+            report.notes_skipped_existing += 1;
+        } else {
+            report.notes_created += 1;
+        }
+    }
+    for edge in &batch.edges {
+        let row = reader
+            .query_scalar(SqlStatement {
+                sql: "SELECT 1 FROM graph_edges WHERE id = ?1 AND deleted_at IS NULL".to_string(),
+                params: vec![SqlValue::Uuid(uuid::Uuid::from(edge.id))],
+                label: Some("code-ingest dry-run edge existence".to_string()),
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if row.is_some() {
+            report.edges_skipped_existing += 1;
+        } else {
+            report.edges_created += 1;
+        }
+    }
+
+    Ok(report)
+}
+
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use super::*;
 
     fn base_args(findings: PathBuf, db: PathBuf) -> CodeIngestArgs {
@@ -335,6 +484,7 @@ mod tests {
         path
     }
 
+    #[serial]
     #[tokio::test]
     async fn code_ingest_creates_once_then_skips_on_rerun() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
@@ -363,6 +513,7 @@ mod tests {
         assert_eq!(second.edges_skipped_existing, 1);
     }
 
+    #[serial]
     #[tokio::test]
     async fn code_ingest_dry_run_writes_nothing() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
@@ -387,6 +538,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[tokio::test]
     async fn code_ingest_rejects_invalid_document_before_any_write() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
@@ -422,6 +574,213 @@ mod tests {
             0,
             "whole-document validation must reject the sweep before any finding note is written"
         );
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_dry_run_against_nonexistent_db_creates_no_file() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("does-not-exist.db");
+        assert!(!db.exists());
+
+        let mut args = base_args(findings, db.clone());
+        args.dry_run = true;
+        let report = code_ingest_batch(args).await.expect("dry-run must succeed");
+        assert!(report.dry_run);
+        assert_eq!(report.entities_created, 1);
+        assert_eq!(report.notes_created, 1);
+        assert_eq!(report.edges_created, 1);
+        assert!(
+            !db.exists(),
+            "a dry run against a nonexistent db path must not create it"
+        );
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_dry_run_against_existing_db_does_not_mutate_it() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        // Populate the db for real first so it exists on disk.
+        code_ingest_batch(base_args(findings.clone(), db.clone()))
+            .await
+            .expect("initial ingest must succeed");
+        let bytes_before = std::fs::read(&db).expect("read db bytes before dry run");
+
+        let mut args = base_args(findings, db.clone());
+        args.dry_run = true;
+        let report = code_ingest_batch(args)
+            .await
+            .expect("dry-run against an existing db must succeed");
+        assert!(report.dry_run);
+        assert_eq!(
+            report.entities_skipped_existing, 1,
+            "the record from the prior real ingest must be reported as already existing"
+        );
+        assert_eq!(report.notes_skipped_existing, 1);
+        assert_eq!(report.edges_skipped_existing, 1);
+
+        let bytes_after = std::fs::read(&db).expect("read db bytes after dry run");
+        assert_eq!(
+            bytes_before, bytes_after,
+            "a dry run against an existing db must not change a single byte of it"
+        );
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_rejects_secret_bearing_evidence_before_any_write() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let path = tmp.path().join("secret.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "audit": {
+                    "date": "2026-07-11",
+                    "scope": "khive-pack-code",
+                    "repo": "ohdearquant/khive",
+                    "branch": "feat/adr085-code-ingest-admin",
+                    "commit": "abc1234",
+                    "standards_file": "docs/standards.md"
+                },
+                "findings": [
+                    {
+                        "id": "F-003",
+                        "title": "Example finding carrying a leaked credential",
+                        "severity": "high",
+                        "confidence": "high",
+                        "failure_scenario": "A scanner captured a live AWS key in evidence.",
+                        "evidence": "AKIAFAKEKEY1234567890",
+                        "impact": "credential AKIAFAKEKEY1234567890 must never persist verbatim"
+                    }
+                ]
+            }"#,
+        )
+        .expect("write secret-bearing fixture");
+        let db = tmp.path().join("scratch.db");
+
+        let err = code_ingest_batch(base_args(path, db.clone()))
+            .await
+            .expect_err("a secret-shaped evidence value must be rejected before any write");
+        assert!(
+            err.to_string().to_lowercase().contains("secret"),
+            "error must name the secret-gate rejection: {err}"
+        );
+        assert!(
+            !db.exists(),
+            "rejecting a secret-bearing document must leave the db path untouched"
+        );
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_fails_loud_when_code_pack_not_configured() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        let prior = std::env::var("KHIVE_PACKS").ok();
+        // SAFETY: `#[tokio::test]` gives each test its own single-threaded
+        // runtime, but process env is still global across the test binary;
+        // this mirrors the same accepted pattern (and its safety rationale)
+        // used by `default_config_packs_loads_all_production_packs` in
+        // `khive-runtime/src/runtime.rs`, restored in a `finally`-style tail.
+        unsafe {
+            std::env::set_var("KHIVE_PACKS", "kg");
+        }
+        let result = code_ingest_batch(base_args(findings, db.clone())).await;
+        unsafe {
+            match &prior {
+                Some(v) => std::env::set_var("KHIVE_PACKS", v),
+                None => std::env::remove_var("KHIVE_PACKS"),
+            }
+        }
+
+        let err = result.expect_err("a pack set without `code` must be rejected");
+        assert!(
+            err.to_string().contains("code"),
+            "error must name the missing `code` pack: {err}"
+        );
+        assert!(
+            !db.exists(),
+            "rejecting a misconfigured pack set must leave the db path untouched"
+        );
+    }
+
+    #[serial]
+    #[tokio::test]
+    async fn code_ingest_entity_vector_uses_canonical_body_field_label() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        code_ingest_batch(base_args(findings, db.clone()))
+            .await
+            .expect("ingest must succeed");
+
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(db.to_str().expect("utf8 path")),
+            config: None,
+            namespace: Namespace::parse("local").expect("valid namespace"),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve runtime config");
+        let runtime = KhiveRuntime::new(cfg).expect("runtime");
+        let sql = runtime.sql();
+        let mut reader = sql.reader().await.expect("reader");
+        let tables = reader
+            .query_all(SqlStatement {
+                sql: "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'vec_%'"
+                    .to_string(),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("list vec tables");
+        assert!(
+            !tables.is_empty(),
+            "expected at least one vector table after ingest"
+        );
+
+        // sqlite-vec creates companion/shadow tables (e.g. `_info`, vec0
+        // virtual-table internals) alongside the real vector row table, so a
+        // bare `LIKE 'vec_%'` sweep must tolerate tables that don't carry a
+        // `field` column rather than assuming every match is a row table.
+        let mut saw_entity_row = false;
+        for table in &tables {
+            let table_name = match table.get("name") {
+                Some(SqlValue::Text(s)) => s.clone(),
+                other => panic!("unexpected table name column: {other:?}"),
+            };
+            let Ok(rows) = reader
+                .query_all(SqlStatement {
+                    sql: format!("SELECT field FROM {table_name} WHERE kind = 'entity'"),
+                    params: vec![],
+                    label: None,
+                })
+                .await
+            else {
+                continue;
+            };
+            for row in rows {
+                if let Some(SqlValue::Text(field)) = row.get("field") {
+                    assert_eq!(
+                        field, "entity.body",
+                        "entity vector metadata must use the canonical 'entity.body' field \
+                         label to match khive-runtime/src/operations.rs, got {field:?}"
+                    );
+                    saw_entity_row = true;
+                }
+            }
+        }
+        assert!(saw_entity_row, "expected at least one entity vector row");
     }
 
     /// Query the persisted `finding` note count for a scratch db, independent

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -1,0 +1,453 @@
+//! `kkernel code-ingest`: admin path that ingests a validated
+//! `findings.json` sweep into the graph via
+//! `khive_pack_code::ingest::ingest_findings_json` (ADR-085 Amendment 3).
+//!
+//! The `code` pack ships zero verbs (ADR-085 D1): this CLI is the only
+//! writer of `finding` notes, and agents never hold a bulk-ingest verb (the
+//! runner-writes rule). Validation is whole-document and fail-closed: a
+//! malformed `findings.json` is rejected before any record is written.
+//! `--dry-run` runs the same validation and existence checks but performs
+//! no writes.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use clap::Parser;
+use serde::Serialize;
+
+use khive_mcp::serve::{resolve_runtime_config, RuntimeConfigInputs};
+use khive_pack_code::{ingest_findings_json, CodeIngestOptions};
+use khive_runtime::{entity_fts_document, note_fts_document, KhiveRuntime, Namespace};
+use khive_storage::SubstrateKind;
+
+/// Arguments for `kkernel code-ingest`.
+#[derive(Parser, Debug)]
+pub struct CodeIngestArgs {
+    /// Path to a validated `findings.json` sweep.
+    pub findings: PathBuf,
+
+    /// Stable sweep identity. Falls back to `audit.date:audit.commit` from
+    /// the findings document when absent.
+    #[arg(long = "source-run")]
+    pub source_run: Option<String>,
+
+    /// Database path (defaults to `~/.khive/khive.db`).
+    #[arg(long, env = "KHIVE_DB")]
+    pub db: Option<String>,
+
+    /// Namespace to write into.
+    #[arg(long, default_value = "local")]
+    pub namespace: String,
+
+    /// Validate the document and report what would happen without writing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Print human-readable output instead of JSON.
+    #[arg(long)]
+    pub human: bool,
+}
+
+/// Outcome of one `code-ingest` pass.
+#[derive(Debug, Default, Serialize)]
+pub struct CodeIngestReport {
+    pub dry_run: bool,
+    pub entities_created: u64,
+    pub entities_skipped_existing: u64,
+    pub notes_created: u64,
+    pub notes_skipped_existing: u64,
+    pub edges_created: u64,
+    pub edges_skipped_existing: u64,
+}
+
+/// Run one `kkernel code-ingest` pass: resolve config, validate the
+/// `findings.json` document as a whole (fail-closed, before any write), then
+/// persist the deterministic entity/note/edge batch record-by-record.
+/// Records whose content-derived ID already exists are reported as skipped,
+/// not overwritten: a `finding` note's lifecycle state (`kind_status`) is
+/// curated data, not something re-ingesting the same sweep should reset.
+pub async fn run_code_ingest(args: CodeIngestArgs) -> Result<()> {
+    let human = args.human;
+    let report = code_ingest_batch(args).await?;
+
+    if human {
+        println!(
+            "entities: {} created, {} skipped\nnotes: {} created, {} skipped\nedges: {} created, {} skipped{}",
+            report.entities_created,
+            report.entities_skipped_existing,
+            report.notes_created,
+            report.notes_skipped_existing,
+            report.edges_created,
+            report.edges_skipped_existing,
+            if report.dry_run {
+                "\n(dry run: nothing written)"
+            } else {
+                ""
+            },
+        );
+    } else {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    }
+    Ok(())
+}
+
+/// Core of `run_code_ingest`, split out so tests can assert on the returned
+/// [`CodeIngestReport`] directly instead of parsing stdout.
+async fn code_ingest_batch(args: CodeIngestArgs) -> Result<CodeIngestReport> {
+    let bytes = std::fs::read(&args.findings)
+        .with_context(|| format!("failed to read {}", args.findings.display()))?;
+
+    let ns = Namespace::parse(&args.namespace).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let cfg = resolve_runtime_config(RuntimeConfigInputs {
+        db: args.db.as_deref(),
+        config: None,
+        namespace: ns,
+        namespace_explicit: true,
+        actor_explicit: false,
+        no_embed: false,
+        packs: None,
+        brain_profile: None,
+    })?;
+
+    let runtime = KhiveRuntime::new(cfg).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let resolved_ns = runtime.config().default_namespace.clone();
+    let token = runtime
+        .authorize(resolved_ns)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .context("failed to authorize namespace")?;
+
+    // Whole-document validation before any write (fail-closed): a malformed
+    // findings.json returns Err here and the process exits nonzero without
+    // touching storage.
+    let batch = ingest_findings_json(
+        &bytes,
+        CodeIngestOptions {
+            namespace: token.namespace().as_str(),
+            observed_at: Utc::now(),
+            source_run: args.source_run.as_deref(),
+        },
+    )
+    .with_context(|| format!("{} failed validation", args.findings.display()))?;
+
+    let mut report = CodeIngestReport {
+        dry_run: args.dry_run,
+        ..CodeIngestReport::default()
+    };
+
+    let entities = runtime
+        .entities(&token)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    for entity in &batch.entities {
+        let existing = entities
+            .get_entity(entity.id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if existing.is_some() {
+            report.entities_skipped_existing += 1;
+            continue;
+        }
+        report.entities_created += 1;
+        if args.dry_run {
+            continue;
+        }
+        entities
+            .upsert_entity(entity.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let doc = entity_fts_document(entity);
+        let embed_body = doc.body.clone();
+        if let Ok(fts) = runtime.text(&token) {
+            if let Err(e) = fts.upsert_document(doc).await {
+                tracing::warn!(
+                    entity_id = %entity.id,
+                    error = %e,
+                    "code-ingest: entity FTS indexing failed (non-fatal)"
+                );
+            }
+        }
+        for model_name in runtime.registered_embedding_model_names() {
+            match runtime
+                .embed_document_with_model(&model_name, &embed_body)
+                .await
+            {
+                Ok(vector) => {
+                    if let Ok(vs) = runtime.vectors_for_model(&token, &model_name) {
+                        if let Err(e) = vs
+                            .insert(
+                                entity.id,
+                                SubstrateKind::Entity,
+                                token.namespace().as_str(),
+                                "entity.name",
+                                vec![vector],
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                entity_id = %entity.id,
+                                model = %model_name,
+                                error = %e,
+                                "code-ingest: entity vector insert failed (non-fatal)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    entity_id = %entity.id,
+                    model = %model_name,
+                    error = %e,
+                    "code-ingest: entity embedding failed (non-fatal)"
+                ),
+            }
+        }
+    }
+
+    let notes = runtime.notes(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
+    for note in &batch.notes {
+        let existing = notes
+            .get_note(note.id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if existing.is_some() {
+            report.notes_skipped_existing += 1;
+            continue;
+        }
+        report.notes_created += 1;
+        if args.dry_run {
+            continue;
+        }
+        notes
+            .upsert_note(note.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        if let Ok(fts) = runtime.text_for_notes(&token) {
+            if let Err(e) = fts.upsert_document(note_fts_document(note)).await {
+                tracing::warn!(
+                    note_id = %note.id,
+                    error = %e,
+                    "code-ingest: note FTS indexing failed (non-fatal)"
+                );
+            }
+        }
+        for model_name in runtime.registered_embedding_model_names() {
+            match runtime
+                .embed_document_with_model(&model_name, &note.content)
+                .await
+            {
+                Ok(vector) => {
+                    if let Ok(vs) = runtime.vectors_for_model(&token, &model_name) {
+                        if let Err(e) = vs
+                            .insert(
+                                note.id,
+                                SubstrateKind::Note,
+                                token.namespace().as_str(),
+                                "note.content",
+                                vec![vector],
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                note_id = %note.id,
+                                model = %model_name,
+                                error = %e,
+                                "code-ingest: note vector insert failed (non-fatal)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    note_id = %note.id,
+                    model = %model_name,
+                    error = %e,
+                    "code-ingest: note embedding failed (non-fatal)"
+                ),
+            }
+        }
+    }
+
+    let graph = runtime.graph(&token).map_err(|e| anyhow::anyhow!("{e}"))?;
+    for edge in &batch.edges {
+        let existing = graph
+            .get_edge(edge.id)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if existing.is_some() {
+            report.edges_skipped_existing += 1;
+            continue;
+        }
+        report.edges_created += 1;
+        if args.dry_run {
+            continue;
+        }
+        graph
+            .upsert_edge(edge.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args(findings: PathBuf, db: PathBuf) -> CodeIngestArgs {
+        CodeIngestArgs {
+            findings,
+            source_run: Some("test-run".to_string()),
+            db: Some(db.display().to_string()),
+            namespace: "local".to_string(),
+            dry_run: false,
+            human: false,
+        }
+    }
+
+    fn write_valid_findings(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("findings.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "audit": {
+                    "date": "2026-07-11",
+                    "scope": "khive-pack-code",
+                    "repo": "ohdearquant/khive",
+                    "branch": "feat/adr085-code-ingest-admin",
+                    "commit": "abc1234",
+                    "standards_file": "docs/standards.md"
+                },
+                "findings": [
+                    {
+                        "id": "F-001",
+                        "title": "Example finding for a CLI integration test",
+                        "severity": "medium",
+                        "confidence": "high",
+                        "failure_scenario": "Reproduced by running kkernel code-ingest twice.",
+                        "evidence": "code_ingest.rs test",
+                        "impact": "none, this is a test fixture"
+                    }
+                ]
+            }"#,
+        )
+        .expect("write findings.json fixture");
+        path
+    }
+
+    #[tokio::test]
+    async fn code_ingest_creates_once_then_skips_on_rerun() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        let first = code_ingest_batch(base_args(findings.clone(), db.clone()))
+            .await
+            .expect("first ingest must succeed");
+        assert_eq!(first.entities_created, 1);
+        assert_eq!(first.notes_created, 1);
+        assert_eq!(first.edges_created, 1);
+        assert_eq!(first.entities_skipped_existing, 0);
+        assert_eq!(first.notes_skipped_existing, 0);
+        assert_eq!(first.edges_skipped_existing, 0);
+
+        let second = code_ingest_batch(base_args(findings, db))
+            .await
+            .expect("re-ingesting the same sweep must succeed");
+        assert_eq!(
+            second.notes_created, 0,
+            "content-derived ids must make a re-ingest a no-op, not a duplicate write"
+        );
+        assert_eq!(second.notes_skipped_existing, 1);
+        assert_eq!(second.entities_skipped_existing, 1);
+        assert_eq!(second.edges_skipped_existing, 1);
+    }
+
+    #[tokio::test]
+    async fn code_ingest_dry_run_writes_nothing() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let findings = write_valid_findings(tmp.path());
+        let db = tmp.path().join("scratch.db");
+
+        let mut args = base_args(findings, db.clone());
+        args.dry_run = true;
+        let report = code_ingest_batch(args)
+            .await
+            .expect("dry-run must validate successfully");
+        assert!(report.dry_run);
+        assert_eq!(
+            report.notes_created, 1,
+            "dry-run still reports what would be created"
+        );
+
+        assert_eq!(
+            finding_note_count(&db).await,
+            0,
+            "a dry run must never persist the finding note"
+        );
+    }
+
+    #[tokio::test]
+    async fn code_ingest_rejects_invalid_document_before_any_write() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let path = tmp.path().join("bad.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "audit": {
+                    "date": "2026-07-11",
+                    "scope": "x",
+                    "repo": "r",
+                    "branch": "b",
+                    "commit": "c",
+                    "standards_file": "s"
+                },
+                "findings": [
+                    {"id": "F-002", "title": "bad", "severity": "high", "confidence": "low"}
+                ]
+            }"#,
+        )
+        .expect("write invalid fixture");
+        let db = tmp.path().join("scratch.db");
+
+        let err = code_ingest_batch(base_args(path, db.clone()))
+            .await
+            .expect_err("missing failure_scenario for a high-severity finding must be rejected");
+        assert!(
+            err.to_string().contains("failed validation"),
+            "error must name the failing document: {err}"
+        );
+        assert_eq!(
+            finding_note_count(&db).await,
+            0,
+            "whole-document validation must reject the sweep before any finding note is written"
+        );
+    }
+
+    /// Query the persisted `finding` note count for a scratch db, independent
+    /// of any in-process `CodeIngestReport`, proving what was actually
+    /// written to storage rather than trusting the report alone.
+    async fn finding_note_count(db: &std::path::Path) -> u64 {
+        let cfg = resolve_runtime_config(RuntimeConfigInputs {
+            db: Some(db.to_str().expect("utf8 path")),
+            config: None,
+            namespace: Namespace::parse("local").expect("valid namespace"),
+            namespace_explicit: true,
+            actor_explicit: false,
+            no_embed: false,
+            packs: None,
+            brain_profile: None,
+        })
+        .expect("resolve runtime config");
+        let runtime = KhiveRuntime::new(cfg).expect("runtime");
+        let token = runtime
+            .authorize(runtime.config().default_namespace.clone())
+            .expect("authorize");
+        runtime
+            .notes(&token)
+            .expect("notes store")
+            .count_notes("local", Some("finding"))
+            .await
+            .expect("count notes")
+    }
+}

--- a/crates/kkernel/src/code_ingest.rs
+++ b/crates/kkernel/src/code_ingest.rs
@@ -2,9 +2,9 @@
 //! `findings.json` sweep into the graph via
 //! `khive_pack_code::ingest::ingest_findings_json` (ADR-085 Amendment 3).
 //!
-//! The `code` pack ships zero verbs (ADR-085 D1): this CLI is the only
-//! writer of `finding` notes, and agents never hold a bulk-ingest verb (the
-//! runner-writes rule). Validation is whole-document and fail-closed: a
+//! Findings ingestion is deliberately not a verb (ADR-085 D1, Amendment 3
+//! C2): this CLI is the only writer of `finding` notes, and agents never
+//! hold a bulk-ingest verb (the runner-writes rule). Validation is whole-document and fail-closed: a
 //! malformed `findings.json` is rejected before any record is written.
 //! `--dry-run` runs the same validation and existence checks but performs
 //! no writes.

--- a/crates/kkernel/src/lib.rs
+++ b/crates/kkernel/src/lib.rs
@@ -1,6 +1,7 @@
 //! kkernel — khive admin/management library.
 
 mod atomic_apply;
+pub mod code_ingest;
 pub mod coordinator;
 pub mod dbpath;
 pub mod engine;

--- a/crates/kkernel/src/main.rs
+++ b/crates/kkernel/src/main.rs
@@ -17,6 +17,8 @@
 //! - `backend` — inspect registered backends (`list`, `info <name>`)
 //! - `git-ingest` — one-shot batch ingest of commit/issue/pull_request
 //!   provenance notes from a local git repository (ADR-088)
+//! - `code-ingest`: admin path that validates and ingests a `findings.json`
+//!   audit sweep into the graph as `finding` notes (ADR-085 Amendment 3)
 //!
 //! All subcommands emit JSON on stdout by default for easy piping/parsing.
 //! Pass `--human` to switch to a readable table where supported.
@@ -29,6 +31,7 @@ use clap::{Parser, Subcommand};
 
 use khive_runtime::{BackendId, KhiveConfig, KhiveRuntime, RuntimeConfig};
 use kkernel::{
+    code_ingest,
     coordinator::{BackendRegistry, SubstrateCoordinator, SubstrateCoordinatorService},
     engine, exec, git_ingest, kg, pack_introspect, reindex, sync, vector,
 };
@@ -104,6 +107,10 @@ enum Command {
     /// One-shot batch ingest of commit/issue/pull_request provenance notes
     /// from a local git repository (ADR-088).
     GitIngest(git_ingest::GitIngestArgs),
+
+    /// Validate and ingest a `findings.json` audit sweep into the graph as
+    /// `finding` notes (ADR-085 Amendment 3).
+    CodeIngest(code_ingest::CodeIngestArgs),
 }
 
 /// Database schema lifecycle subcommands.
@@ -345,6 +352,7 @@ async fn main() -> Result<()> {
         }
         Command::Backend(b) => cmd_backend(b),
         Command::GitIngest(a) => git_ingest::run_git_ingest(a).await,
+        Command::CodeIngest(a) => code_ingest::run_code_ingest(a).await,
     }
 }
 

--- a/crates/kkernel/tests/code_ingest_cli.rs
+++ b/crates/kkernel/tests/code_ingest_cli.rs
@@ -1,0 +1,345 @@
+//! Black-box CLI tests for `kkernel code-ingest` (khive#848 F7).
+//!
+//! Drives the actual compiled `kkernel` binary (`CARGO_BIN_EXE_kkernel`)
+//! rather than calling `code_ingest_batch` in-tree: the helper-level unit
+//! tests in `crates/kkernel/src/code_ingest.rs` cover the mapping logic, but
+//! only a real subprocess exercises clap argument parsing, `main`'s
+//! subcommand dispatch, the process exit code, and — most importantly — the
+//! filesystem side effects (or lack thereof) of `--dry-run` and a rejected
+//! document, which is exactly what round 1 of the PR #848 review found
+//! missing.
+
+use std::path::Path;
+use std::process::Command;
+
+use khive_db::StorageBackend;
+use khive_storage::{SqlStatement, SqlValue};
+
+fn kkernel_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_kkernel")
+}
+
+/// Query substrate row counts directly over the sqlite file rather than
+/// through `kkernel exec`: `exec`'s config resolution rejects an explicit
+/// `--db` when the ambient `$HOME/.khive/config.toml` declares `[[backends]]`
+/// (a real constraint on developer machines with a multi-backend khive
+/// setup), which is orthogonal to what this test verifies. Reading the file
+/// straight is also a more direct proof of "reached storage" than routing
+/// through another CLI surface's own config layer.
+async fn substrate_counts(db: &Path) -> (u64, u64, u64) {
+    let backend = StorageBackend::sqlite_read_only(db).expect("open scratch db read-only");
+    let sql = backend.sql();
+    let mut reader = sql.reader().await.expect("reader");
+
+    async fn count(reader: &mut dyn khive_storage::SqlReader, table: &str) -> u64 {
+        match reader
+            .query_scalar(SqlStatement {
+                sql: format!("SELECT COUNT(*) FROM {table} WHERE deleted_at IS NULL"),
+                params: vec![],
+                label: None,
+            })
+            .await
+            .expect("count query")
+        {
+            Some(SqlValue::Integer(n)) => n as u64,
+            other => panic!("unexpected count() result: {other:?}"),
+        }
+    }
+
+    let entities = count(reader.as_mut(), "entities").await;
+    let notes = count(reader.as_mut(), "notes").await;
+    let edges = count(reader.as_mut(), "graph_edges").await;
+    (entities, notes, edges)
+}
+
+/// Fetch the single `finding` note's `properties.source_run` value from the
+/// given namespace, directly over sqlite (see `substrate_counts` for why).
+async fn finding_source_run(db: &Path, namespace: &str) -> String {
+    let backend = StorageBackend::sqlite_read_only(db).expect("open scratch db read-only");
+    let sql = backend.sql();
+    let mut reader = sql.reader().await.expect("reader");
+    let row = reader
+        .query_row(SqlStatement {
+            sql: "SELECT properties FROM notes WHERE namespace = ?1 AND kind = 'finding' \
+                  AND deleted_at IS NULL"
+                .to_string(),
+            params: vec![SqlValue::Text(namespace.to_string())],
+            label: None,
+        })
+        .await
+        .expect("query finding note")
+        .expect("expected exactly one finding note in the given namespace");
+    let properties = match row.get("properties") {
+        Some(SqlValue::Text(s)) => s.clone(),
+        other => panic!("unexpected properties column: {other:?}"),
+    };
+    let parsed: serde_json::Value =
+        serde_json::from_str(&properties).expect("properties must be valid JSON");
+    parsed["source_run"]
+        .as_str()
+        .expect("finding note must carry a source_run property")
+        .to_string()
+}
+
+fn write_valid_findings(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("findings.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "audit": {
+                "date": "2026-07-11",
+                "scope": "khive-pack-code",
+                "repo": "ohdearquant/khive",
+                "branch": "feat/adr085-code-ingest-admin",
+                "commit": "abc1234",
+                "standards_file": "docs/standards.md"
+            },
+            "findings": [
+                {
+                    "id": "F-CLI-001",
+                    "title": "Example finding for a black-box CLI test",
+                    "severity": "medium",
+                    "confidence": "high",
+                    "failure_scenario": "Reproduced by running kkernel code-ingest twice.",
+                    "evidence": "code_ingest_cli.rs test",
+                    "impact": "none, this is a test fixture"
+                }
+            ]
+        }"#,
+    )
+    .expect("write findings.json fixture");
+    path
+}
+
+fn write_invalid_findings(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("bad.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "audit": {
+                "date": "2026-07-11",
+                "scope": "x",
+                "repo": "r",
+                "branch": "b",
+                "commit": "c",
+                "standards_file": "s"
+            },
+            "findings": [
+                {"id": "F-CLI-002", "title": "bad", "severity": "high", "confidence": "low"}
+            ]
+        }"#,
+    )
+    .expect("write invalid findings.json fixture");
+    path
+}
+
+fn code_ingest(args: &[&str]) -> std::process::Output {
+    Command::new(kkernel_bin())
+        .arg("code-ingest")
+        .args(args)
+        .env("KHIVE_NO_DAEMON", "1")
+        .output()
+        .expect("run kkernel code-ingest")
+}
+
+/// (a) A fresh `--dry-run` against a nonexistent `--db` path must exit 0 and
+/// leave that path nonexistent — no file, no directory, nothing.
+#[test]
+fn dry_run_against_nonexistent_db_leaves_it_nonexistent_and_exits_zero() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let findings = write_valid_findings(tmp.path());
+    let db = tmp.path().join("does-not-exist").join("scratch.db");
+    assert!(!db.exists());
+
+    let output = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--dry-run",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "a valid document under --dry-run must exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !db.exists(),
+        "--dry-run against a nonexistent db path must not create it or its parent"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be valid JSON");
+    assert_eq!(report["dry_run"], serde_json::json!(true));
+    assert_eq!(report["entities_created"], serde_json::json!(1));
+    assert_eq!(report["notes_created"], serde_json::json!(1));
+    assert_eq!(report["edges_created"], serde_json::json!(1));
+}
+
+/// (b) An invalid document against a nonexistent `--db` path must exit 1 and
+/// leave that path nonexistent.
+#[test]
+fn invalid_document_against_nonexistent_db_leaves_it_nonexistent_and_exits_nonzero() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let findings = write_invalid_findings(tmp.path());
+    let db = tmp.path().join("scratch.db");
+    assert!(!db.exists());
+
+    let output = code_ingest(&[findings.to_str().unwrap(), "--db", db.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "an invalid document must exit nonzero; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !db.exists(),
+        "rejecting an invalid document must leave the db path untouched"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed validation") || stderr.contains("failure_scenario"),
+        "stderr must explain the validation failure: {stderr}"
+    );
+}
+
+/// (c) An invalid document against an EXISTING db must exit 1 and leave the
+/// db byte-identical — no migrations, no partial writes, nothing.
+#[test]
+fn invalid_document_against_existing_db_leaves_it_byte_identical() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let valid = write_valid_findings(tmp.path());
+    let db = tmp.path().join("scratch.db");
+
+    let seed = code_ingest(&[valid.to_str().unwrap(), "--db", db.to_str().unwrap()]);
+    assert!(
+        seed.status.success(),
+        "seeding the db with a valid ingest must succeed; stderr={}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+    assert!(db.exists(), "seed ingest must create the db file");
+    let bytes_before = std::fs::read(&db).expect("read db bytes before invalid ingest");
+
+    let invalid = write_invalid_findings(tmp.path());
+    let output = code_ingest(&[invalid.to_str().unwrap(), "--db", db.to_str().unwrap()]);
+    assert!(
+        !output.status.success(),
+        "an invalid document against an existing db must exit nonzero"
+    );
+
+    let bytes_after = std::fs::read(&db).expect("read db bytes after invalid ingest");
+    assert_eq!(
+        bytes_before, bytes_after,
+        "rejecting an invalid document must not change a single byte of an existing db"
+    );
+}
+
+/// (d) A normal (non-dry-run) ingest creates the expected entity/note/edge
+/// rows, and re-running the same sweep is a content-derived-id no-op.
+#[tokio::test]
+async fn normal_ingest_creates_expected_entity_note_edge_rows() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let findings = write_valid_findings(tmp.path());
+    let db = tmp.path().join("scratch.db");
+
+    let output = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--source-run",
+        "cli-test-run",
+    ]);
+    assert!(
+        output.status.success(),
+        "normal ingest must succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be valid JSON");
+    assert_eq!(report["dry_run"], serde_json::json!(false));
+    assert_eq!(report["entities_created"], serde_json::json!(1));
+    assert_eq!(report["notes_created"], serde_json::json!(1));
+    assert_eq!(report["edges_created"], serde_json::json!(1));
+
+    let stats = substrate_counts(&db).await;
+    assert_eq!(
+        stats,
+        (1, 1, 1),
+        "expected (entities, notes, edges) = (1, 1, 1): {stats:?}"
+    );
+
+    // Re-ingesting the identical sweep must be a no-op (content-derived
+    // UUIDv5 identity), never a duplicate write.
+    let rerun = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--source-run",
+        "cli-test-run",
+    ]);
+    assert!(rerun.status.success());
+    let rerun_report: serde_json::Value =
+        serde_json::from_slice(&rerun.stdout).expect("stdout must be valid JSON");
+    assert_eq!(rerun_report["entities_created"], serde_json::json!(0));
+    assert_eq!(rerun_report["notes_created"], serde_json::json!(0));
+    assert_eq!(rerun_report["edges_created"], serde_json::json!(0));
+    assert_eq!(
+        rerun_report["entities_skipped_existing"],
+        serde_json::json!(1)
+    );
+    assert_eq!(rerun_report["notes_skipped_existing"], serde_json::json!(1));
+    assert_eq!(rerun_report["edges_skipped_existing"], serde_json::json!(1));
+
+    let stats_after_rerun = substrate_counts(&db).await;
+    assert_eq!(
+        stats_after_rerun, stats,
+        "a re-ingest no-op must not change substrate counts"
+    );
+}
+
+/// (e) `--db`, `--namespace`, and `--source-run` all reach storage: the
+/// database is created at the given path, records land in the given
+/// namespace, and the note's `source_run` property carries the given value.
+#[tokio::test]
+async fn db_namespace_and_source_run_reach_storage() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let findings = write_valid_findings(tmp.path());
+    let db = tmp.path().join("nested").join("scratch.db");
+
+    let output = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--namespace",
+        "cli-test-ns",
+        "--source-run",
+        "explicit-source-run-marker",
+    ]);
+    assert!(
+        output.status.success(),
+        "ingest must succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        db.exists(),
+        "--db must be honored, including parent dir creation"
+    );
+
+    let (entities, notes, edges) = substrate_counts(&db).await;
+    assert_eq!(
+        (entities, notes, edges),
+        (1, 1, 1),
+        "the record must be reachable in the database --db pointed at"
+    );
+
+    let source_run = finding_source_run(&db, "cli-test-ns").await;
+    assert_eq!(
+        source_run, "explicit-source-run-marker",
+        "--source-run must reach the persisted note's properties.source_run, under the \
+         explicit --namespace"
+    );
+}

--- a/crates/kkernel/tests/code_ingest_cli.rs
+++ b/crates/kkernel/tests/code_ingest_cli.rs
@@ -81,6 +81,101 @@ async fn finding_source_run(db: &Path, namespace: &str) -> String {
         .to_string()
 }
 
+/// Fetch every persisted `finding` note's `(finding_id, audit_status,
+/// kind_status)` triple in the given namespace, directly over sqlite (see
+/// `substrate_counts` for why): proves the mapper's output actually reached
+/// storage through the real CLI dispatch path, not just the in-tree mapper
+/// unit tests.
+async fn finding_status_pairs(db: &Path, namespace: &str) -> Vec<(String, String, String)> {
+    let backend = StorageBackend::sqlite_read_only(db).expect("open scratch db read-only");
+    let sql = backend.sql();
+    let mut reader = sql.reader().await.expect("reader");
+    let rows = reader
+        .query_all(SqlStatement {
+            sql: "SELECT properties FROM notes WHERE namespace = ?1 AND kind = 'finding' \
+                  AND deleted_at IS NULL"
+                .to_string(),
+            params: vec![SqlValue::Text(namespace.to_string())],
+            label: None,
+        })
+        .await
+        .expect("query finding notes");
+    rows.into_iter()
+        .map(|row| {
+            let properties = match row.get("properties") {
+                Some(SqlValue::Text(s)) => s.clone(),
+                other => panic!("unexpected properties column: {other:?}"),
+            };
+            let parsed: serde_json::Value =
+                serde_json::from_str(&properties).expect("properties must be valid JSON");
+            let finding_id = parsed["finding_id"]
+                .as_str()
+                .expect("finding note must carry finding_id")
+                .to_string();
+            let audit_status = parsed["audit_status"]
+                .as_str()
+                .expect("finding note must carry audit_status")
+                .to_string();
+            let kind_status = parsed["kind_status"]
+                .as_str()
+                .expect("finding note must carry kind_status")
+                .to_string();
+            (finding_id, audit_status, kind_status)
+        })
+        .collect()
+}
+
+fn write_three_status_findings(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("status_findings.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "audit": {
+                "date": "2026-07-11",
+                "scope": "khive-pack-code",
+                "repo": "ohdearquant/khive",
+                "branch": "feat/adr085-code-ingest-admin",
+                "commit": "abc1234",
+                "standards_file": "docs/standards.md"
+            },
+            "findings": [
+                {
+                    "id": "F-STATUS-FIXED",
+                    "title": "A finding the producer marked fixed",
+                    "severity": "medium",
+                    "confidence": "high",
+                    "failure_scenario": "Reproduced by running kkernel code-ingest twice.",
+                    "evidence": "code_ingest_cli.rs status test, fixed case",
+                    "impact": "none, this is a test fixture",
+                    "status": "fixed"
+                },
+                {
+                    "id": "F-STATUS-FALSE-POSITIVE",
+                    "title": "A finding the producer marked false_positive",
+                    "severity": "low",
+                    "confidence": "medium",
+                    "failure_scenario": "Reproduced by running kkernel code-ingest twice.",
+                    "evidence": "code_ingest_cli.rs status test, false_positive case",
+                    "impact": "none, this is a test fixture",
+                    "status": "false_positive"
+                },
+                {
+                    "id": "F-STATUS-OPEN",
+                    "title": "A finding the producer left open",
+                    "severity": "high",
+                    "confidence": "high",
+                    "failure_scenario": "Reproduced by running kkernel code-ingest twice.",
+                    "evidence": "code_ingest_cli.rs status test, open case",
+                    "impact": "none, this is a test fixture",
+                    "status": "open"
+                }
+            ]
+        }"#,
+    )
+    .expect("write status findings.json fixture");
+    path
+}
+
 fn write_valid_findings(dir: &Path) -> std::path::PathBuf {
     let path = dir.join("findings.json");
     std::fs::write(
@@ -341,5 +436,64 @@ async fn db_namespace_and_source_run_reach_storage() {
         source_run, "explicit-source-run-marker",
         "--source-run must reach the persisted note's properties.source_run, under the \
          explicit --namespace"
+    );
+}
+
+/// (f) A three-finding sweep carrying producer `status` values `fixed`,
+/// `false_positive`, and `open` must land through the real CLI dispatch
+/// path with the governed `(audit_status, kind_status)` pairs persisted:
+/// `(fixed, resolved)`, `(false_positive, invalid)`, `(open, open)`. The
+/// mapper-level unit tests in `khive-pack-code/tests/integration.rs` cover
+/// the mapping itself; this covers the plumbing from that mapper's output
+/// through to storage over the actual compiled binary (round 2 Finding 2).
+#[tokio::test]
+async fn status_mapping_reaches_storage_through_cli_dispatch() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let findings = write_three_status_findings(tmp.path());
+    let db = tmp.path().join("scratch.db");
+
+    let output = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--source-run",
+        "status-mapping-cli-test",
+    ]);
+    assert!(
+        output.status.success(),
+        "ingest must succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be valid JSON");
+    assert_eq!(report["notes_created"], serde_json::json!(3));
+
+    let mut pairs = finding_status_pairs(&db, "local").await;
+    pairs.sort();
+
+    let mut expected = vec![
+        (
+            "F-STATUS-FIXED".to_string(),
+            "fixed".to_string(),
+            "resolved".to_string(),
+        ),
+        (
+            "F-STATUS-FALSE-POSITIVE".to_string(),
+            "false_positive".to_string(),
+            "invalid".to_string(),
+        ),
+        (
+            "F-STATUS-OPEN".to_string(),
+            "open".to_string(),
+            "open".to_string(),
+        ),
+    ];
+    expected.sort();
+
+    assert_eq!(
+        pairs, expected,
+        "persisted (audit_status, kind_status) pairs must match the governed mapping for \
+         every producer status in the sweep"
     );
 }

--- a/crates/kkernel/tests/code_ingest_cli.rs
+++ b/crates/kkernel/tests/code_ingest_cli.rs
@@ -237,6 +237,35 @@ fn code_ingest(args: &[&str]) -> std::process::Output {
         .expect("run kkernel code-ingest")
 }
 
+/// The `-wal` sidecar path SQLite uses alongside a WAL-mode database file.
+fn wal_sidecar_path(db_path: &Path) -> std::path::PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push("-wal");
+    std::path::PathBuf::from(name)
+}
+
+/// The `-shm` sidecar path SQLite uses alongside a WAL-mode database file.
+fn shm_sidecar_path(db_path: &Path) -> std::path::PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push("-shm");
+    std::path::PathBuf::from(name)
+}
+
+/// File names present directly under `dir`, used to prove a dry run creates
+/// no new files anywhere in the target directory.
+fn dir_entry_names(dir: &Path) -> std::collections::BTreeSet<String> {
+    std::fs::read_dir(dir)
+        .expect("read target dir")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect()
+}
+
 /// (a) A fresh `--dry-run` against a nonexistent `--db` path must exit 0 and
 /// leave that path nonexistent — no file, no directory, nothing.
 #[test]
@@ -496,4 +525,103 @@ async fn status_mapping_reaches_storage_through_cli_dispatch() {
         "persisted (audit_status, kind_status) pairs must match the governed mapping for \
          every producer status in the sweep"
     );
+}
+
+/// (g) The binary-boundary variant of the helper-level
+/// `code_ingest_dry_run_against_existing_wal_db_leaves_sidecars_untouched`
+/// test in `code_ingest.rs`: a `--dry-run` against a db held open by a live
+/// writer connection, invoked through the actual compiled `kkernel` binary
+/// rather than `code_ingest_batch` in-tree. The WAL mutation class is caused
+/// by opening the db, so the invariant must be pinned at the binary boundary, not only at the helper function.
+#[tokio::test]
+async fn dry_run_against_existing_wal_db_held_open_by_a_writer_leaves_sidecars_untouched() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let target_dir = tmp.path();
+    let findings = write_valid_findings(target_dir);
+    let db = target_dir.join("wal_scratch.db");
+
+    let seed = code_ingest(&[findings.to_str().unwrap(), "--db", db.to_str().unwrap()]);
+    assert!(
+        seed.status.success(),
+        "seeding the db with a valid ingest must succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&seed.stdout),
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    let pin = StorageBackend::sqlite(&db).expect("open pin backend");
+    {
+        let sql = pin.sql();
+        let mut writer = sql.writer().await.expect("pin writer");
+        writer
+            .execute_script(
+                "CREATE TABLE IF NOT EXISTS wal_pin_probe(x INTEGER); \
+                 INSERT INTO wal_pin_probe VALUES (1);"
+                    .to_string(),
+            )
+            .await
+            .expect("pin write to keep the wal open");
+    }
+
+    let wal_path = wal_sidecar_path(&db);
+    let shm_path = shm_sidecar_path(&db);
+    assert!(
+        wal_path.exists(),
+        "expected a live -wal sidecar before dry-run"
+    );
+    assert!(
+        shm_path.exists(),
+        "expected a live -shm sidecar before dry-run"
+    );
+
+    let db_before = std::fs::read(&db).expect("read db before dry run");
+    let wal_before = std::fs::read(&wal_path).expect("read -wal before dry run");
+    let shm_before = std::fs::read(&shm_path).expect("read -shm before dry run");
+    let entries_before = dir_entry_names(target_dir);
+
+    let output = code_ingest(&[
+        findings.to_str().unwrap(),
+        "--db",
+        db.to_str().unwrap(),
+        "--dry-run",
+    ]);
+    assert!(
+        output.status.success(),
+        "dry-run against an existing WAL db must exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        wal_path.exists(),
+        "the existing -wal sidecar must not disappear"
+    );
+    assert!(
+        shm_path.exists(),
+        "the existing -shm sidecar must not disappear"
+    );
+
+    let entries_after = dir_entry_names(target_dir);
+    assert_eq!(
+        entries_before, entries_after,
+        "dry-run must not create any new file in the target dir"
+    );
+
+    let db_after = std::fs::read(&db).expect("read db after dry run");
+    let wal_after = std::fs::read(&wal_path).expect("read -wal after dry run");
+    let shm_after = std::fs::read(&shm_path).expect("read -shm after dry run");
+
+    assert_eq!(
+        db_before, db_after,
+        "dry-run must not touch the main db file"
+    );
+    assert_eq!(
+        wal_before, wal_after,
+        "dry-run must not touch the existing -wal sidecar"
+    );
+    assert_eq!(
+        shm_before, shm_after,
+        "dry-run must not touch the existing -shm sidecar (Finding 1 regression)"
+    );
+
+    drop(pin);
 }

--- a/docs/adr/ADR-027-dynamic-pack-loading.md
+++ b/docs/adr/ADR-027-dynamic-pack-loading.md
@@ -348,6 +348,53 @@ until 10+ packs make boilerplate painful; the current ~10 LOC per pack is accept
    for memory per ADR-033)? The registry could validate pack-specific config at load
    time. Defer to per-pack ADRs.
 
+## Amendment 1 (2026-07-11): ten-pack default, and force-link is not zero-touch
+
+**Status**: accepted
+
+The "Pack selection and shipped production default" section's seven-pack list is stale.
+The shipped `RuntimeConfig::default()` now loads ten production packs:
+
+```text
+["kg", "gtd", "memory", "brain", "comm", "schedule", "knowledge", "session", "git", "code"]
+```
+
+`session`, `git`, and `code` were added after this ADR was accepted (ADR-085 Amendment 3
+most recently, adding `code`'s admin-CLI-only ingest path). Every surface that enumerates
+the shipped default — this ADR, package READMEs, `docs/multi-backend.md` — must track the
+`RuntimeConfig::default()` pack list and verb count, not a snapshot frozen at acceptance
+time.
+
+This ADR's "Zero-touch pack addition" claim (Context, item 1) and the "zero-touch"
+framing implicit in `inventory::submit!` self-registration are correct only up to the
+crate-linking boundary. `inventory`'s linker-section registration finds every pack that is
+_linked into the binary_ — it does not cause a pack crate to be linked in the first place.
+Each binary or server crate that wants a pack available at runtime still needs, at compile
+time:
+
+1. A `Cargo.toml` dependency on that pack crate.
+2. A force-link anchor: at least one reference to a public symbol from the pack crate
+   reachable from that binary's compiled code, so the linker does not discard the crate as
+   unused. Rust does not otherwise guarantee an `inventory::submit!` static in a dependency
+   survives dead-code elimination if nothing in the dependency graph visibly uses that
+   crate.
+
+`crates/khive-mcp/src/pack.rs` and `crates/kkernel/src/lib.rs` both carry an explicit
+anchor block: one `#[doc(hidden)]` re-export or `use ... as _;` line per pack crate,
+referencing a public type so the linker cannot discard it. Adding a pack to the shipped
+default without adding it to both a `Cargo.toml` dependency list and one of these anchor
+blocks means the pack is _never registered_ at runtime, regardless of what
+`RuntimeConfig::default()` says — `khive-mcp`'s dependency on `khive-pack-code` plus its
+`CodePack` anchor line, both added after the fact, are the concrete instance of this gap
+(khive#848 round 2 review Finding 3).
+
+`cargo metadata` reports exactly one workspace binary target (`kkernel`); `khive-mcp` is a
+library consumed by that binary and by the `khive-mcp` server process it spawns, so today
+there is exactly one anchor block that must stay in sync per binary, not N. That may not
+remain true as more binaries are added — the ADR's "zero-touch" framing should be read as
+"zero-touch once a pack crate is linked into every binary that needs it," not "adding a
+pack crate to the workspace is sufficient on its own."
+
 ## References
 
 - [ADR-003](ADR-003-system-architecture.md) — `kkernel` binary; `pack list` introspection

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -500,6 +500,16 @@ is out of scope for this repository.
 
 ## Amendment 2 (2026-07-09): code.ingest verb + acceptance
 
+**Status (as of Amendment 3, 2026-07-11): accepted but deferred, not yet
+implemented.** The `code.ingest` verb this amendment specifies has no
+handler in `crates/khive-pack-code` today; the shipped pack contributes zero
+MCP verbs. Amendment 3 below documents the current (zero-verb) production
+surface and adds no verb of its own — it covers an unrelated admin CLI path
+for `findings.json`, not this amendment's Scanner/Extractor design. The
+design and acceptance recorded in this section remain the plan for when
+`code.ingest` is implemented; nothing here is being withdrawn or
+superseded, only marked not-yet-built.
+
 The base text left the Scanner/Extractor pipeline over the D2-D3 vocabulary as
 "separate ADR-069-layer work" and explicitly out of scope. That pipeline now has a
 design. This amendment specifies it as a single new verb, `code.ingest`, and closes

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -684,3 +684,67 @@ Rename detection, the deferred-edge queue (B6's v2 alternative), Lean
 shipped, commit/PR entities, and any type-checked or semantic (as opposed to
 syntactic) extraction remain out of scope for this amendment, consistent with
 D6 and the base text's Alternatives Considered.
+
+## Amendment 3 (2026-07-11): admin ingest path + default load
+
+Prior to this amendment, `ingest_findings_json` (Amendment 1 A3) was reachable
+only by linking `khive-pack-code` into a caller's own binary, and the `code`
+pack was not part of khive-mcp's default pack set, so the `finding` note kind
+existed in source but was not live on the production surface. This gap was
+identified while specifying a durable audit service (the "staged 3-pass crate
+audits" work) that needs `findings.json` sweeps to land as queryable graph
+records, not only as flat local files. This amendment closes that gap.
+
+Distinct from Amendment 2's `code.ingest` verb (an unimplemented, larger
+Scanner/Extractor design targeting dedicated map databases with symbol/call
+graphs, B1-B8 above): this amendment covers only the existing
+`ingest_findings_json` mapper and how it reaches storage. The two share the
+"ingest" word but are otherwise unrelated in scope, surface, and target
+database.
+
+### C1: The `finding` note kind is now live on the production surface
+
+This is a deliberate change, not an incidental side effect. `code` joins the
+default pack set khive-mcp and `kkernel` load when no `--pack`/`KHIVE_PACKS`
+override is given. Every default-configuration server and admin invocation
+from this point on validates and stores `finding` notes and the pack's 22
+additive `EDGE_RULES`; a caller no longer has to opt in with an explicit
+`--pack code` to make audit findings queryable. The pack still contributes
+zero MCP verbs (D1) and zero new entity kinds; only its note kind, edge
+rules, and entity-subtype registrations become reachable by default.
+
+### C2: Ingestion is an admin/runner-side path, not a verb
+
+D1's verb-less ruling stands unmodified. `ingest_findings_json` is exposed to
+operators through a new `kkernel code-ingest <findings.json>` admin CLI
+subcommand (`crates/kkernel/src/code_ingest.rs`), following the same shape as
+`kkernel git-ingest`: it builds a runtime directly from the configured pack
+set, validates the whole document before any write (Amendment 1 A3's
+fail-closed, all-or-nothing contract, unchanged), and persists the resulting
+entity/note/edge batch by content-derived id: a record whose id already
+exists is reported as skipped, never overwritten, so re-running the same
+sweep is a no-op and a `finding`'s curated lifecycle state (`kind_status`) is
+never reset by re-ingestion. `--dry-run` runs the same validation and
+existence checks and reports what would happen without writing.
+
+No MCP verb calls this path, and none is added. Agents that participate in
+an audit never hold a bulk-ingest verb; only the CLI, run by the audit
+service (or an operator), writes findings into the graph. This is the
+runner-writes rule: an agent's contract is to produce a validated
+`findings.json`, not to write graph records itself.
+
+### C3: Consuming service context
+
+The immediate consumer is a staged, 3-pass crate audit service: pass 1
+(logic/docs), pass 2 (architecture), and pass 3 (correctness/optimization)
+run per crate or per dependency-layer bundle, each pass sequenced so later
+passes see earlier passes' findings as context. Each pass's agent output is
+a `findings.json` sweep on disk, validated exactly as it always has been;
+the audit service then invokes `kkernel code-ingest` once per validated
+sweep so the run's findings become queryable graph records, serving as
+pass-context for that audit cycle and prior-findings context for the next
+one. Filing
+policy for GitHub issues is unchanged and orthogonal to this amendment: it
+still runs after pass 3 against the verify-dedupe-rank policy, never a bulk
+file-everything pass, and is not affected by whether a finding has also been
+ingested into khive.

--- a/docs/adr/ADR-085-code-pack.md
+++ b/docs/adr/ADR-085-code-pack.md
@@ -710,12 +710,19 @@ override is given. Every default-configuration server and admin invocation
 from this point on validates and stores `finding` notes and the pack's 22
 additive `EDGE_RULES`; a caller no longer has to opt in with an explicit
 `--pack code` to make audit findings queryable. The pack still contributes
-zero MCP verbs (D1) and zero new entity kinds; only its note kind, edge
-rules, and entity-subtype registrations become reachable by default.
+zero MCP verbs today and zero new entity kinds; only its note kind, edge
+rules, and entity-subtype registrations become reachable by default. (This
+is a statement of current fact, not a standing invariant: Amendment 2
+accepts a `code.ingest` source-ingest verb that remains unimplemented. The
+no-verb statements in this amendment are scoped to the findings surface.)
 
 ### C2: Ingestion is an admin/runner-side path, not a verb
 
-D1's verb-less ruling stands unmodified. `ingest_findings_json` is exposed to
+For the findings surface, D1's no-verb ruling stands unmodified: findings
+ingestion is not, and does not become, a verb. (Amendment 2's accepted
+`code.ingest` source-ingest verb is untouched by this; it targets dedicated
+map databases and has nothing to do with `findings.json`.)
+`ingest_findings_json` is exposed to
 operators through a new `kkernel code-ingest <findings.json>` admin CLI
 subcommand (`crates/kkernel/src/code_ingest.rs`), following the same shape as
 `kkernel git-ingest`: it builds a runtime directly from the configured pack

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-khive exposes exactly one MCP tool, `request`. Everything else — 78 verbs across 9
+khive exposes exactly one MCP tool, `request`. Everything else — 78 verbs across 10
 production packs — is dispatched through that single tool via a small request DSL.
 This page documents the DSL grammar, the response envelope, and every verb's full
 parameter contract, so an agent can call khive correctly without reading Rust source.
@@ -8,7 +8,7 @@ parameter contract, so an agent can call khive correctly without reading Rust so
 This page is verified against the live registry (`request(ops="verbs()")`, run
 2026-07-10) and the pack source (`crates/khive-pack-*/src/*.rs` `HandlerDef`/`ParamDef`
 struct literals). Verb count: **78**, matching both the live registry `total` field and
-the sum of the 9 pack counts below. If your server reports a different total, your
+the sum of the 10 pack counts below. If your server reports a different total, your
 `KHIVE_PACKS` configuration loads a different pack set than the default — run
 `request(ops="verbs()")` against your own server to get the authoritative list.
 
@@ -30,13 +30,19 @@ An always-machine-readable copy of this page is at
 | `knowledge` | 19    | `KHIVE_PACKS=kg,knowledge` | Yes                 |
 | `session`   | 4     | `KHIVE_PACKS=kg,session`   | Yes                 |
 | `git`       | 1     | `KHIVE_PACKS=kg,git`       | Yes                 |
+| `code`      | 0     | `KHIVE_PACKS=kg,code`      | Yes                 |
 
 `git` also registers the `commit` / `issue` / `pull_request` note kinds and the shared
 `run_ingest` core (`crates/khive-pack-git/src/ingest.rs`) that both `git.digest` and the
 `kkernel git-ingest` CLI drive.
 
-The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 9 packs: 18 + 5 + 5 +
-15 + 7 + 4 + 19 + 4 + 1 = **78 verbs**.
+`code` registers the `finding` note kind and edge rules only; its `code.ingest` verb is
+accepted but unimplemented (ADR-085), and `findings.json` ingest runs through the
+`kkernel code-ingest` admin CLI path, not the MCP verb surface — so it contributes 0
+verbs to the total below.
+
+The default binary (no `KHIVE_PACKS`/`--pack` override) loads all 10 packs: 18 + 5 + 5 +
+15 + 7 + 4 + 19 + 4 + 1 + 0 = **78 verbs**.
 
 Verb names in the `kg` pack are bare (`create`, `search`, `link`, …). Every other pack
 namespaces its verbs with a `pack.` prefix (`gtd.assign`, `memory.recall`,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ graph, and link concepts together.
 khive is a research knowledge graph runtime. When you read papers, form
 concepts, link ideas, record decisions, or track tasks, khive gives that work a
 typed, queryable graph that persists across sessions. Everything is accessible
-through 75 verbs across 9 packs, dispatched through a single MCP tool.
+through 78 verbs across 10 packs, dispatched through a single MCP tool.
 
 ## Install
 

--- a/docs/guide/specialized-packs.md
+++ b/docs/guide/specialized-packs.md
@@ -1,14 +1,14 @@
 # Specialized Packs
 
-khive's default install loads nine production packs
-(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git`, per
+khive's default install loads ten production packs
+(`kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code`, per
 `RuntimeConfig::default()` in `crates/khive-runtime/src/config.rs`). Of these,
-`git` already contributes zero verbs of its own — it registers the `commit` /
-`issue` / `pull_request` note kinds and a batch ingester for a git-lifecycle
-provenance graph (see `crates/khive-pack-git/`). Beyond the default set, khive
-also ships niche packs that extend the graph for a specific domain without
-adding verbs of their own. This guide covers the formal-math pack, the first
-of these, and how pack loading works in general.
+`code` already contributes zero verbs of its own — it registers the `finding`
+note kind and edge rules only; its `code.ingest` verb is accepted but
+unimplemented (see [ADR-085](../adr/ADR-085-code-pack.md)). Beyond the
+default set, khive also ships niche packs that extend the graph for a
+specific domain without adding verbs of their own. This guide covers the
+formal-math pack, the first of these, and how pack loading works in general.
 
 ## Pack composition model
 

--- a/docs/khive-config-example.toml
+++ b/docs/khive-config-example.toml
@@ -162,7 +162,7 @@ fusion_weight = 0.5
 #
 # Route an individual pack to a declared backend. Packs not listed here fall back to
 # `main`. The referenced backend must appear in [[backends]] above. Loadable packs:
-# kg, gtd, memory, brain, comm, schedule, knowledge, session.
+# kg, gtd, memory, brain, comm, schedule, knowledge, session, git, code.
 
 # [packs.knowledge]
 # backend = "knowledge"
@@ -185,7 +185,7 @@ fusion_weight = 0.5
 #   KHIVE_NAMESPACE=local        Legacy alias for KHIVE_ACTOR; loses to it when both are set.
 #   KHIVE_NO_EMBED=false         Disable the local embedding model (skips vector indexing).
 #                                STRICT bool: only "true"/"false" — "1" is a startup error.
-#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session
+#   KHIVE_PACKS=kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code
 #                                Packs to load when --pack is absent. Comma / space separated.
 #   KHIVE_CONFIG=./khive.toml    Path to THIS config file. Also --config. Overrides the search order.
 #   KHIVE_LOG=warn               Stderr log level (JSON results on stdout are unaffected).

--- a/docs/multi-backend.md
+++ b/docs/multi-backend.md
@@ -127,8 +127,8 @@ path   = "~/.khive/records.db"
 [packs.records]           # hypothetical operator-supplied records pack
 backend = "records"
 
-# All built-in packs (kg, memory, brain, gtd, knowledge, schedule, comm)
-# are left unlisted and therefore default to "main".
+# All built-in packs (kg, memory, brain, gtd, knowledge, schedule, comm,
+# session, git, code) are left unlisted and therefore default to "main".
 ```
 
 Fields on `[[backends]]`:
@@ -170,8 +170,8 @@ name = "records"
 kind = "sqlite"
 path = "/var/lib/your-app/records.db"
 
-# Built-in packs (kg, memory, brain, gtd, knowledge, schedule, comm)
-# are NOT listed here; they fall back to "main" automatically.
+# Built-in packs (kg, memory, brain, gtd, knowledge, schedule, comm,
+# session, git, code) are NOT listed here; they fall back to "main" automatically.
 
 [packs.records]
 backend = "records"

--- a/marketplace/khive/README.md
+++ b/marketplace/khive/README.md
@@ -2,7 +2,7 @@
 
 One plugin for the whole khive surface: a knowledge graph, GTD, memory, inter-agent comm,
 scheduling, and a domain-knowledge corpus, all served by a single MCP server (`kkernel mcp`)
-exposing one tool — `request` — that dispatches 75 verbs across 9 packs.
+exposing one tool — `request` — that dispatches 78 verbs across 10 packs.
 
 This plugin is **guidance, not a second runtime**. It ships the pattern skills that teach an
 agent how to use each pack well, plus the kg stewardship agents. The data and verbs live in the
@@ -50,9 +50,12 @@ Once installed, invoke them as `khive:digester`, `khive:polisher`, and so on.
 ## Requirements
 
 The `kg` pack is the base (entities, edges, notes); every other pack builds on it. The default
-server config loads all nine (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
-`session`, `git` — the last contributes note kinds and ingest support, no MCP-callable verbs) — this plugin currently ships pattern skills for the first seven; `session` has no
-skill yet (see the Pattern skills table above).
+server config loads all ten (`kg`, `gtd`, `memory`, `brain`, `comm`, `schedule`, `knowledge`,
+`session`, `git`, `code` — `git` contributes note kinds, a batch ingester, and the `git.digest`
+verb; `code` contributes a `finding` note kind, with ingestion reached only through the
+`kkernel code-ingest` admin CLI, no MCP-callable verb) — this plugin currently ships pattern
+skills for the first seven; `session`, `git`, and `code` have no skill yet (see the Pattern
+skills table above).
 See [INSTALL.md](../INSTALL.md) for setup, the actor config, and per-pack smoke tests.
 
 ## Links

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # khive
 
-A research knowledge graph runtime — 75 verbs, 9 packs, one MCP tool.
+A research knowledge graph runtime — 78 verbs, 10 packs, one MCP tool.
 
 [![GitHub](https://img.shields.io/github/stars/ohdearquant/khive?style=flat)](https://github.com/ohdearquant/khive)
 [![crates.io](https://img.shields.io/crates/v/khive-mcp.svg)](https://crates.io/crates/khive-mcp)
@@ -19,21 +19,22 @@ Add to `.mcp.json` (project-level or `~/.claude/mcp.json` for global):
 { "mcpServers": { "khive": { "command": "khive", "args": ["mcp"] } } }
 ```
 
-All 9 packs load by default. A background daemon auto-spawns to keep the runtime warm.
+All 10 packs load by default. A background daemon auto-spawns to keep the runtime warm.
 
 ## What you get
 
-| Pack          | Verbs | What it does                                          |
-| ------------- | ----- | ----------------------------------------------------- |
-| **kg**        | 17    | Entities, edges, notes, graph queries, proposals      |
-| **gtd**       | 5     | Task lifecycle (inbox → next → active → done)         |
-| **memory**    | 5     | Salience-weighted remember / decay-ranked recall      |
-| **brain**     | 14    | Bayesian user profiles + feedback loop                |
-| **comm**      | 7     | Threaded messaging                                    |
-| **schedule**  | 4     | Reminders and scheduled verb execution                |
-| **knowledge** | 19    | Atom-based KB with embedding rerank search            |
-| **session**   | 4     | Session record persistence (store/list/resume/export) |
-| **git**       | 0     | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester |
+| Pack          | Verbs | What it does                                                                         |
+| ------------- | ----- | ------------------------------------------------------------------------------------ |
+| **kg**        | 18    | Entities, edges, notes, graph queries, proposals                                     |
+| **gtd**       | 5     | Task lifecycle (inbox → next → active → done)                                        |
+| **memory**    | 5     | Salience-weighted remember / decay-ranked recall                                     |
+| **brain**     | 15    | Bayesian user profiles + feedback loop                                               |
+| **comm**      | 7     | Threaded messaging                                                                   |
+| **schedule**  | 4     | Reminders and scheduled verb execution                                               |
+| **knowledge** | 19    | Atom-based KB with embedding rerank search                                           |
+| **session**   | 4     | Session record persistence (store/list/resume/export)                                |
+| **git**       | 1     | Git-lifecycle note kinds (commit/issue/pull_request) + batch ingester + `git.digest` |
+| **code**      | 0     | Finding note kind; ingest is admin-CLI-only (`kkernel code-ingest`), no MCP verb     |
 
 ## Usage
 

--- a/scripts/perf/LOAD_HARNESS_RUNBOOK.md
+++ b/scripts/perf/LOAD_HARNESS_RUNBOOK.md
@@ -37,12 +37,13 @@ uv run scripts/perf/bench_load_harness.py --mode real --workers 20 --tenants 4 -
 ```
 
 Full acceptance shape (100 connections × 20 tenant namespaces, the actual
-gate target). Pass `--packs` explicitly to measure the full 8-pack production
-posture — including `session` — against a real multi-pack config:
+gate target). Pass `--packs` explicitly to measure the full 10-pack production
+posture — including `session`, `git`, and `code` — against a real multi-pack
+config:
 
 ```bash
 uv run scripts/perf/bench_load_harness.py --mode real --workers 100 --tenants 20 --ops-per-worker 50 \
-  --packs kg,gtd,memory,brain,comm,schedule,knowledge,session
+  --packs kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code
 ```
 
 `--workers` must be an exact multiple of `--tenants` (workers are split

--- a/scripts/perf/bench_load_harness.py
+++ b/scripts/perf/bench_load_harness.py
@@ -78,7 +78,7 @@ PROTOCOL_VERSION = 3
 # writes would also confound the reduced-scale WAL / write-queue gauges this harness reads. The full
 # acceptance run against a real multi-pack config opts session back in via `--packs` (see below).
 DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge"
-PRODUCTION_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session"
+PRODUCTION_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code"
 
 # ── Metal GPU serialization (machine-wide convention; real-embedder mode only)
 METAL_GPU_LOCK_PATH = os.environ.get("METAL_GPU_LOCK_PATH", "/tmp/lion-metal-gpu-test.lock")

--- a/scripts/perf/bench_pipeline_daemon.py
+++ b/scripts/perf/bench_pipeline_daemon.py
@@ -77,7 +77,7 @@ ANN_SETTLE_POLL_S = 0.25
 # Default production pack set (must match RuntimeConfig::default().packs in
 # crates/khive-runtime/src/config.rs so config_id agrees between front-end
 # and daemon child).
-_DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge"
+_DEFAULT_PACKS = "kg,gtd,memory,brain,comm,schedule,knowledge,session,git,code"
 
 TOPICS = [
     ("knowledge graph", ["entity", "edge", "relation", "graph", "node", "ontology", "triple", "schema", "link", "concept"]),

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -196,8 +196,8 @@ def main():
         assert "total" in verbs_result, f"verbs must return 'total' key: {verbs_result}"
         assert isinstance(verbs_result["verbs"], list), f"verbs must be a list: {verbs_result}"
         # Surface-contract tripwire: the default config (no --pack, KHIVE_PACKS
-        # unset) loads 9 production packs (kg, gtd, memory, brain, comm, schedule,
-        # knowledge, session, git), so verbs() returns exactly 78 user-facing
+        # unset) loads 10 production packs (kg, gtd, memory, brain, comm, schedule,
+        # knowledge, session, git, code), so verbs() returns exactly 78 user-facing
         # MCP-callable verbs (count what verbs() returns, not internal dispatch
         # arms). The session pack contributes 4 agent-facing T1 verbs
         # (store/list/resume/export), promoted from internal subhandlers to
@@ -207,16 +207,20 @@ def main():
         # (#606, verified live 2026-07-04), comm.probe (#644 read-only
         # inbound poll), and brain.event_counts (#724, ADR-103 Stage 1
         # windowed event read) are included in the count; git contributes
-        # git.digest (ADR-088 Amendment 1). Update this number when the
-        # pack set or verb surface changes; a silent drift here is the bug
-        # this assertion exists to catch.
+        # git.digest (ADR-088 Amendment 1); code contributes zero verbs
+        # (ADR-085 D1/Amendment 3 — its `finding` note kind and
+        # `findings.json` ingest are reached only via the `kkernel
+        # code-ingest` admin CLI, never this MCP verb surface). Update this
+        # number when the pack set or verb surface changes; a silent drift
+        # here is the bug this assertion exists to catch.
         assert verbs_result["total"] == 78, (
-            f"expected 78 user-facing verbs from the 9 default packs "
+            f"expected 78 user-facing verbs from the 10 default packs "
             f"(session contributes 4 T1 verbs promoted to Visibility::Verb per "
             f"ADR-083; context is the 17th kg-substrate bare verb per ADR-089; "
             f"resolve is the 18th kg-substrate bare verb per the unified-verb "
             f"draft ADR Slice 1; comm.health is #606; comm.probe is #644; "
-            f"brain.event_counts is #724/ADR-103; git contributes git.digest), "
+            f"brain.event_counts is #724/ADR-103; git contributes git.digest; "
+            f"code contributes zero verbs per ADR-085 D1/Amendment 3), "
             f"got {verbs_result['total']}: {verbs_result}"
         )
         verb_names = [v["verb"] for v in verbs_result["verbs"]]
@@ -244,6 +248,30 @@ def main():
         assert "create" in kg_verb_names, f"'create' must appear in kg-filtered verbs: {kg_verb_names}"
         assert "stats" in kg_verb_names, f"'stats' must appear in kg-filtered verbs: {kg_verb_names}"
         print(f"  [ok] verbs — {verbs_result['total']} total verbs, {kg_verbs['total']} in kg pack")
+
+        # 3b. Zero-verb pack load tripwire (khive#848 F6): `code` contributes
+        # no MCP verbs, so a stale/dropped default-pack entry for it would
+        # not show up in the verbs() total above at all. `finding` is a note
+        # kind declared ONLY by khive-pack-code's NOTE_KIND_SPECS (ADR-085
+        # D4/Amendment 3) — if `code` were missing from the default pack set,
+        # this create would be rejected as an unknown note kind. A
+        # successful create is therefore direct proof the pack is loaded
+        # under default config, independent of the verb count.
+        code_pack_finding = call_verb(proc, "create", {
+            "kind": "note",
+            "note_kind": "finding",
+            "title": "smoke-test tripwire finding",
+            "properties": {"severity": "low", "confidence": "high"},
+        })
+        assert code_pack_finding["kind"] == "finding", (
+            f"expected kind=finding (proves the zero-verb `code` pack is loaded "
+            f"under default config), got: {code_pack_finding}"
+        )
+        assert code_pack_finding["properties"]["kind_status"] == "open", (
+            f"a finding with no producer status must default kind_status to 'open': "
+            f"{code_pack_finding}"
+        )
+        print(f"  [ok] code pack loaded — create(kind=\"finding\") succeeded under default config")
 
         # 4. Get entity via get (auto-detects substrate; flat shape per W2 #454,
         #    granular kind at top level — same shape as create/list)


### PR DESCRIPTION
## What

Wires up the code pack's existing `ingest_findings_json` mapper (previously only reachable by
linking `khive-pack-code` into a caller's own binary) so a `findings.json` audit sweep can
actually reach the graph, and turns on the pack by default.

1. **`kkernel code-ingest <findings.json>`** (`crates/kkernel/src/code_ingest.rs`): a new admin
   CLI subcommand, following the same shape as `kkernel git-ingest`. The whole document is
   parsed and validated fail-closed BEFORE any runtime or database construction, so an invalid
   document (or a `--dry-run`) has zero filesystem effect: no database file is created, no
   migrations run, and an existing database is left byte-identical. Every entity/note field,
   including nested property values, is preflighted through the runtime secret gate before the
   first write (explicit content-derived UUIDv5 ids are required for idempotent re-ingest and
   cannot flow through the shared `create` dispatch path, which accepts no caller-supplied id).
   Records are keyed by content-derived id, so re-running the same sweep reports them as skipped
   rather than duplicating or overwriting a finding's curated lifecycle state. `--dry-run`
   validates and reports would-create counts; against an existing database it opens a read-only
   connection (no migrations, `query_only` pragma). `--source-run`, `--db`, and `--namespace`
   mirror the existing admin ingesters. The command fails loud if the configured pack set does
   not include `code`.
2. **Producer status normalization** (`crates/khive-pack-code/src/ingest.rs`): producer
   `fixed` maps to `kind_status=resolved` and `false_positive` to `invalid` per the ADR-085
   governed lifecycle; the raw producer value is preserved in `audit_status`.
3. **`code` joins the default pack set** (`crates/khive-runtime/src/config.rs`), and
   `khive-mcp` now links `khive-pack-code` (dependency + force-link for inventory
   registration) so the pack actually resolves in the server binary; without that link the MCP
   server fails to boot under the new default config. The `finding` note kind and the pack's 22
   additive edge rules are now live wherever khive-mcp or `kkernel` run without an explicit
   `--pack`/`KHIVE_PACKS` override. The pack currently contributes zero MCP verbs, so the total
   verb count is unchanged at 78.
4. **Doc updates** across the default-pack surfaces (`CLAUDE.md`, `AGENTS.md`, READMEs, guides,
   config example, perf scripts, CLI help), and an ADR-085 amendment recording this as a
   deliberate surface change, with the no-verb statements scoped to the findings surface.

## Why

The pack's `finding` note kind and fail-closed `ingest_findings_json` validator already existed
in source (ADR-085), but had no way to reach a real database short of writing a custom binary,
and the pack wasn't loaded by default. A durable audit pipeline that produces `findings.json`
sweeps needs those findings to land as queryable graph records rather than staying flat local
files. This closes that gap with an admin-only path: no MCP verb is added, so agents never hold
a bulk-ingest capability; only an operator or a runner invoking the CLI writes findings into the
graph.

## Surface change

Turning on the `code` pack by default makes the `finding` note kind and its edge rules live on
the production surface. This is called out explicitly in the ADR-085 amendment as a deliberate
change, not an incidental one. The pack stays verb-less on the findings surface (no new MCP
surface); ingestion stays an admin/runner-side path. The ADR's accepted-but-unimplemented
source-ingest verb design is marked deferred and is unaffected.

## Verification

- `cargo test --workspace`: all green, zero failures. This run is what surfaced the missing
  `khive-pack-code` link in the `khive-mcp` binary (27 server tests failed with
  `unknown pack name "code"` before the link landed): a boot failure that per-crate test runs
  cannot catch.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check`: clean.
- Black-box CLI tests (`crates/kkernel/tests/code_ingest_cli.rs`) against the compiled binary:
  fresh `--dry-run` leaves a nonexistent `--db` path nonexistent (exit 0); an invalid document
  against a nonexistent path creates nothing (exit 1); an invalid document against an existing
  database leaves it byte-identical; a normal ingest creates the expected entity/note/edge plus
  FTS and vector rows (vector metadata labeled with the canonical `entity.body` field); and
  `--db`/`--namespace`/`--source-run` all reach storage.
- Functional proof against a scratch database (never the production db): valid ingest, idempotent
  re-run (all skipped), dry-run against fresh and existing databases (no mutation either way),
  invalid document rejected pre-write, a finding whose evidence embeds a fake AWS key rejected by
  the secret gate before any write, and the code-pack-absent guard failing loud.

## Test plan

- [x] `cargo test --workspace` (zero failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Black-box CLI tests against the compiled `kkernel` binary
- [x] Manual functional proof against a scratch database (create, idempotent re-run, dry-run
      no-mutation, invalid input, secret-gate rejection, pack-absent guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
