### PR TITLE
docs(adr): git write surface through khive + sandboxed kkernel gateway (proposed)

### DIFF
--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -1,0 +1,332 @@
+# ADR-108: Git Write Surface Through khive (Phase B)
+
+**Status**: Proposed\
+**Date**: 2026-07-11\
+**Authors**: khive maintainers\
+**Depends on**: ADR-088 (Git-Lifecycle Pack) and its Amendment 1 (`git.digest`), ADR-018
+(Authorization Gate), ADR-017 (Pack Standard), ADR-016 (Request DSL), ADR-007 Rev 7
+(Namespace as Attribution-Only)\
+**Related**: ADR-085 (Code Pack - admin-only ingest path precedent), ADR-004 (Substrate
+Observables - `Event` store used for audit)
+
+This is a decision ADR for a human spec gate. It enumerates forks with trade-offs rather
+than picking silently. Open Questions are marked explicitly and are not resolved here.
+
+## Context
+
+`khive-pack-git` (ADR-088, amended by ADR-088 Amendment 1) is read/ingest-only today. It
+populates `commit`, `issue`, and `pull_request` notes from local `.git` history and `gh`,
+and exposes exactly one agent-facing verb, `git.digest`, which reads a repository and
+writes graph records - never git-repository state. Nothing in the current surface performs
+a `git commit`, `git push`, branch creation, or any other mutation of a git repository or
+its remote.
+
+Two design inputs motivate a write surface:
+
+1. A development-tool git wrapper is planned that routes an agent's git writes (commit,
+   branch, push) through khive instead of invoking `git`/`gh` directly. This gives the
+   khive Gate (ADR-018) a chokepoint it does not have today: git writes issued directly by
+   an agent process via shell `git` bypass khive entirely, so no policy, audit, or
+   protected-branch rule can apply to them.
+2. Once such a surface exists, fleet-level policy becomes possible: local hooks (or an
+   agent harness) can deny direct `git push` / `gh pr create` invocations and require the
+   khive-mediated path instead, giving one real enforcement point for "which principal may
+   write to which repo/branch" instead of relying on convention.
+
+Today, no such enforcement point exists. Any process with local git credentials can push to
+any branch of any repository it can reach; khive has no visibility into git writes and no
+way to deny one.
+
+The gap this ADR addresses: khive has an authorization seam (the Gate) and an audit plane
+(the `Event` substrate, ADR-004) for verb dispatch, but nothing routes git mutations through
+that seam. This ADR specs adding write verbs to the git pack, gated at dispatch, audited via
+the event plane, exactly as every other khive verb already is.
+
+## Decision
+
+This ADR proposes adding a write-verb surface to `khive-pack-git`, structurally consistent
+with the pack's existing `git.digest` verb (agent-facing, `pack.verb` namespaced per
+ADR-023) and dispatched through the same `VerbRegistry` / `Gate` seam every other verb uses.
+It deliberately does **not** fix the four forks below - those are the open decisions this
+ADR exists to present to the spec gate.
+
+### Candidate verb set (subject to Fork (a))
+
+At minimum, three write operations are named as design inputs:
+
+- `git.commit(repo, message, paths?, author?)` - stage and commit. `paths` narrows to a
+  subset of the working tree; absent, commits everything currently staged/changed
+  (exact semantics depend on Fork (a)).
+- `git.branch(repo, name, from?)` - create a branch, optionally from a named ref/SHA.
+- `git.push(repo, branch, remote?, force?)` - push a branch to a remote.
+  `force` is a parameter only for validation purposes: see the force-push rule below, which
+  makes every `force=true` request a hard deny regardless of policy.
+
+A broader candidate list, to be narrowed at the spec gate: `git.checkout`, `git.merge`,
+`git.tag`, `git.pull` (fetch+merge/rebase - arguably read-adjacent, not a write to the
+target repo's canonical history, but it mutates the local working copy), `git.fetch`
+(unambiguously read-only against the remote, local-write only).
+
+### Hard rules (not forked - these apply regardless of how the forks below resolve)
+
+1. **Force-push is always denied.** No policy, obligation, or actor grants `force=true`.
+   This is enforced at the handler, not left to policy configuration - a Gate
+   misconfiguration (e.g., a permissive `AllowAllGate` in a networked deployment) must not
+   be able to authorize a force-push. If a real workflow needs history rewrite, it is
+   explicitly out of scope for this surface; the actor uses direct git access outside
+   khive, and that access is exactly what fleet-level policy (design input 2) is meant to
+   discourage but this ADR cannot itself prevent.
+2. **Full audit via the event plane.** Every write-verb dispatch - allowed or denied -
+   produces an `AuditEvent` (ADR-018) and an `Event` record (ADR-004) with `kind =
+ "git.write"` (or a per-verb kind, e.g. `"git.commit"` - see Fork (c) for whether policy
+   objects also need finer-grained kinds). The audit record carries actor, repo, branch,
+   verb, decision, and - for `git.commit` - the resulting SHA on success. This is
+   additional to git's own commit-graph audit trail (which records _what_ changed) and
+   answers a different question: _who, through khive, asked for this write, and was it
+   allowed_.
+3. **Protected-branch rules are enforced at the Gate, not hardcoded in the pack.** The pack
+   handler does not itself know which branches are protected; it constructs a
+   `GateRequest` (actor, repo/branch as policy-input fields, verb) and the Gate decides.
+   This follows ADR-018's existing model exactly - the pack is not the policy author.
+4. **This surface never grants elevated git credentials to a caller.** The daemon process
+   that executes the write must already have write access to the target repo/remote
+   (whatever mechanism grants that - see Fork (b)); khive does not become a credential
+   escalation path. A caller who lacks git write access outside khive gains none by using
+   this verb surface if execution goes through the daemon's own credentials - this is
+   itself a consequence discussed under Fork (b), not a settled design.
+
+### Fork (a): Verb granularity
+
+**A1 - Thin, 1:1 git verbs.** `git.commit`, `git.branch`, `git.push` map directly to `git
+commit`, `git branch`, `git push`. Composable: an agent chains `commit | branch | push`
+itself, or the client-side git wrapper (design input 1) composes them.
+
+- Pro: small, predictable surface; each verb has one clear failure mode; matches the
+  existing `git.digest` precedent of one verb, one operation.
+- Con: multi-step workflows (e.g., "commit and push in one round-trip") cost multiple MCP
+  calls; partial-failure states are more visible to the caller (e.g., commit succeeds,
+  push fails) which is arguably a feature, not a bug, for audit granularity.
+
+**A2 - Task-level verbs.** `git.publish_branch(repo, branch, message, paths?)` performs
+commit + push (and branch-create if the branch does not exist) as one verb, matching the
+actual shape of "agent finished a task, wants to publish it" rather than exposing raw git
+primitives.
+
+- Pro: matches the motivating consumer (the git wrapper) more directly - one call per
+  logical action; fewer round-trips for the common path; a single Gate decision per logical
+  publish action instead of three, which may be what protected-branch policy actually wants
+  to reason about.
+- Con: a compound verb makes partial failure semantics (git succeeds at commit, fails at
+  push) a design problem inside one handler rather than a sequencing problem the caller
+  already handles; harder to compose with future automation (e.g., a wrapper that wants a
+  branch created without an immediate push cannot use `publish_branch` alone).
+
+**A3 - Both.** Ship the thin primitives (A1) and layer `publish_branch` as a convenience
+verb built from them, matching how `git.digest` is itself a convenience layer over
+`ingest::run_ingest`, which the CLI (`kkernel git-ingest`) also calls directly.
+
+**Open Question 1**: which of A1 / A2 / A3, and - if A1 or A3 - the exact verb list (is
+`git.tag` in scope for Phase B, or deferred). Not decided here.
+
+### Fork (b): Execution home
+
+**B1 - Daemon-side `git2-rs` (libgit2 bindings).** The khive daemon (`kkernel mcp
+--daemon`, ADR-049) links `git2` and performs commit/branch/push operations as native
+library calls against the repository's `.git` directory, reusing the same daemon process
+that already holds warm ANN/embedder state.
+
+- Pro: no shell-out, no argument-injection surface via a spawned process; structured error
+  types instead of parsing git's stderr; consistent with the read-side ingester
+  (`crates/khive-pack-git/src/ingest.rs`), which already shells `git log`/`git show` via
+  `std::process::Command`, not `git2` - so B1 would be a new dependency and a divergence
+  from the existing read-path implementation choice, not a continuation of it.
+- Con: `git2-rs`/libgit2 has historically lagged behind system git on some auth/transport
+  edge cases (SSH agent forwarding, some credential helpers); push authentication becomes
+  khive's problem to implement correctly (credential-helper protocol, SSH known_hosts) matching what would otherwise have been in the local git config.
+
+**B2 - Shell to system git with a hardened argument allowlist.** Continue the read-side
+pattern (`ingest.rs` already shells `git log --name-only`, etc.) for writes: construct
+`git commit -m <message> -- <paths>`, `git push <remote> <branch>` as argument vectors
+(never a shell string - `std::process::Command::new("git").args([...])`, no shell
+interpolation), with a fixed allowlist of subcommands and flags the handler is willing to
+construct. No caller-supplied argument reaches the process boundary unvalidated; e.g.
+`message` is passed as a single `-m` argument value (never concatenated into a shell
+string), and `branch`/`remote`/`paths` are validated against a restrictive character set
+before being placed in the argv array.
+
+- Pro: reuses the exact git installation and credential configuration (SSH keys, credential
+  helpers, `.netrc`, `gh auth`) the operator's environment already has working - the same
+  reasoning ADR-088 §5 used to justify `gh` CLI shelling over a direct REST client for
+  issues; consistent with the existing ingester's implementation choice.
+- Con: shelling out is a documented injection-risk pattern; the "hardened allowlist" is only
+  as strong as its implementation and needs its own adversarial review (argument vectors
+  are the safe primitive - the risk is a future edit that concatenates instead of passing
+  argv, or a flag that was not meant to be allowlisted, e.g. `--upload-pack` on push).
+
+**Open Question 2**: B1 or B2. This ADR's default lean, given the existing ingester's
+precedent (`ingest.rs` already shells system `git`) and ADR-088 §5's explicit precedent for
+preferring the operator's existing tool credentials over reimplementing transport/auth, is
+toward B2 - but this is explicitly not decided here; the spec gate may weigh the injection
+surface differently.
+
+### Fork (c): Policy declaration
+
+**C1 - Static config.** Protected-branch rules, per-repo write allowlists, and per-actor
+permissions live in `khive.toml` (or a dedicated `[git]` config block), read at daemon
+startup. Simple, no new trait surface, but every policy change requires a config edit and
+daemon restart (or a hot-reload mechanism this ADR would also need to spec).
+
+**C2 - Gate policy objects.** Reuse the existing `Gate` trait (ADR-018) unmodified: the git
+pack constructs a `GateRequest` with `namespace`, `verb` (`git.commit` etc.), and `args`
+carrying `repo`/`branch` as part of the request body; a `RegoGate` or custom `Gate` impl
+decides allow/deny using those fields as policy input, exactly as any other verb's dispatch
+does today. No new trait, no new enforcement code path - the git pack becomes another
+`Gate` consumer.
+
+- Pro: zero new authorization machinery; protected-branch and per-repo/per-actor rules are
+  expressed the same way every other khive policy is (Rego, or a custom `Gate` impl);
+  consistent with ADR-018's stated goal of one enforcement seam for all verbs.
+- Con: `repo` and `branch` are not first-class `GateRequest` fields today (`GateRequest` has
+  `actor`, `namespace`, `verb`, `args`, `context` - repo/branch would travel inside `args`,
+  which a policy author must know to inspect, rather than as typed top-level fields a policy
+  schema can rely on). This is a minor extension surface, not a new trait.
+
+**Open Question 3**: C2 is the ADR-018-consistent default - this ADR does not see a case
+for a git-specific policy mechanism when the Gate trait already exists for exactly this
+purpose. What remains open is whether `repo`/`branch` need to become typed `GateRequest`
+fields (an ADR-018 amendment) or stay inside `args` (no amendment, policy authors read
+`input.args.repo`). Left to the spec gate.
+
+### Fork (d): Composition with external-PR / fork-repo trust rules
+
+khive's standing operational rule (external-PR protocol) treats fork-PR content as
+untrusted: no auto-merge, no admin-merge, no branch-update from a fork PR without a human
+in the loop. A write surface that lets an agent `git.push` on khive's behalf intersects this
+rule in two distinct ways that need to be kept separate:
+
+1. **An agent pushing khive-authored commits to a branch it controls** (its own feature
+   branch, opening a PR) - this is the mainline use case design input 1 describes, and does
+   not touch the external-PR rule at all: it is agent-authored content being written by the
+   agent's own action, mediated by khive instead of raw git.
+2. **A write surface that could be used to write fork-PR content into a repo** (for example,
+   a future verb that applies a fork PR's diff and pushes it) is categorically different and
+   is explicitly **out of scope for Phase B as specified here**. This ADR's verb set
+   (commit / branch / push of content the calling agent itself produced) does not include
+   "apply and push a diff from an untrusted external source." If a future verb needs to
+   touch fork-PR content, it is a separate ADR that must explicitly reconcile with the
+   external-PR protocol, not an extension folded into this one.
+
+**Open Question 4**: whether the Gate policy layer (Fork (c), C2) should carry an explicit
+`source_trust` or equivalent field to make (1) vs (2) distinguishable in policy, or whether
+keeping (2) entirely unbuilt (not just unpolicied) is the correct boundary for Phase B. This
+ADR leans toward the latter - not building the capability rather than trusting policy to
+gate it correctly - but does not rule on it.
+
+## Blast radius on ADR-088
+
+This ADR is an **amendment**, not a supersession, of ADR-088. ADR-088 §6 states three
+explicit non-goals: "Not a GitHub API mirror," "Not first-class git entities," and - most
+directly relevant - **"No write-back. khive never pushes commits, comments, or state
+changes to GitHub; one-directional, git/GitHub → graph only."**
+
+This ADR proposes reversing that specific clause. Concretely:
+
+- ADR-088 §6's "No write-back" bullet is superseded by this ADR, conditioned on
+  acceptance: khive gains a write path, gated and audited, distinct from the read-only
+  ingest path ADR-088 specifies.
+- ADR-088's note-kind taxonomy (`commit`, `issue`, `pull_request`), edge usage
+  (`annotates`, `precedes` per Amendment 1's ingest enrichment), and ingester machinery are
+  entirely unaffected. Write verbs do not touch the graph-side note kinds directly; a
+  `git.commit` call may, as a follow-on convenience (not specified here - see Open Question
+  5 below), trigger a `git.digest` pass so the new commit becomes a graph record, but this
+  is a composition of two already-independent verbs, not a structural change to either.
+- ADR-088's `khive-pack-git` crate gains new handlers (write verbs) alongside its existing
+  `git.digest` handler and background ingester; `REQUIRES = ["kg"]` is unchanged, no new
+  edge relations are introduced by this ADR (write verbs do not create graph records at
+  all - they mutate a git repository, a system outside the KG substrate).
+- The pack's non-goal "khive does not build a GitHub replacement" (inherited from ADR-010)
+  is unaffected: this surface does not touch GitHub's PR/review/CI machinery, only local git
+  operations (commit, branch, push) that any git client already performs.
+
+**Open Question 5**: whether a successful `git.commit`/`git.push` should auto-trigger
+graph ingestion of the new commit (closing the loop between write and the existing
+read-side note kinds), or whether that stays a separate, caller-initiated `git.digest`
+call. Left open; a naive auto-trigger risks conflating a fast, latency-sensitive write path
+with a potentially slow ingest pass in the same call.
+
+## Threat and Risk Notes
+
+(Non-exhaustive. The full threat model for an untrusted caller belongs to ADR-109, which
+this write surface composes with.)
+
+This ADR assumes a **trusted or semi-trusted** caller (an agent already authorized to reach
+the MCP surface at all, per ADR-018's existing agent-binary trust boundary). It does not
+itself define a threat model for an untrusted caller invoking these verbs - that
+composition is explicitly deferred to ADR-109 (Fork (d) in that ADR). The rules above
+(force-push denial, protected-branch enforcement, full audit) are baseline hygiene for any
+caller class; they are necessary but not sufficient for an untrusted-caller threat model.
+
+## Alternatives Considered
+
+| Alternative                                                                      | Why not adopted outright (still may inform Open Questions)                                                                                                                                                                                                                     |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No khive write surface; keep the wrapper tool shelling raw `git`/`gh` directly   | Defeats the entire motivating premise (design input 1): no policy chokepoint, no audit, fleet-level hook denial has nothing to route through.                                                                                                                                  |
+| Generic "run arbitrary git command" verb (`git.exec(args: [...])`)               | Rejected outright, not merely forked. Defeats the hardened-allowlist premise of both B1 and B2; makes Gate policy unable to reason about the operation (`verb` would always be `git.exec`, collapsing commit/branch/push/force-push into one undifferentiated policy surface). |
+| Route git writes through the existing `git.digest` verb by adding a `write` mode | Rejected. `git.digest` is read/ingest-shaped (source, max_items, include, cursor-resumable); overloading it with write semantics conflates two operations with entirely different audit, policy, and failure-mode needs.                                                       |
+
+## Consequences
+
+### Positive (conditioned on spec-gate resolution of the Open Questions)
+
+- Gives khive a real authorization chokepoint for git writes, closing the gap design input 2
+  depends on (fleet-level hook denial of direct `git`/`gh` writes has something to route
+  through).
+- Full audit trail for git mutations performed through khive, in the same `Event` substrate
+  already used for every other verb (ADR-004), queryable via GQL/SPARQL.
+- Reuses the existing Gate trait (ADR-018) rather than inventing new authorization
+  machinery, if Fork (c) resolves to C2.
+
+### Negative
+
+- New write surface is new attack surface: a bug in the argument-construction path (Fork
+  (b), B2) or a Gate misconfiguration is now capable of mutating a real git repository, not
+  just khive's own graph. This is qualitatively different risk from every existing khive
+  verb, which is confined to khive's own storage.
+- Whichever execution home is chosen (Fork (b)), the daemon process needs standing git
+  write credentials for whatever repos this surface targets - a new secret-management
+  surface that does not exist for the read-only ingest path (`gh` read scopes are lower
+  privilege than push credentials).
+- Four genuinely open forks mean this ADR cannot be implemented as written; it requires a
+  spec-gate ruling on Open Questions 1-5 before `khive-pack-git` gains any write handler.
+
+## Open Questions
+
+1. Verb granularity (Fork (a)): A1 thin verbs, A2 task-level `publish_branch`, or A3 both.
+2. Execution home (Fork (b)): B1 daemon-side `git2-rs`, or B2 hardened system-git shell-out.
+   This ADR leans B2 for consistency with the existing ingester but does not decide it.
+3. Policy declaration (Fork (c)): confirmed lean toward C2 (Gate policy objects, no new
+   trait); open sub-question is whether `repo`/`branch` become typed `GateRequest` fields.
+4. Composition with external-PR trust rules (Fork (d)): whether policy needs an explicit
+   `source_trust` signal, or whether not building fork-diff-write capability is sufficient
+   boundary for Phase B.
+5. Whether a successful write auto-triggers `git.digest` ingestion of the new commit, or
+   stays a separate caller-initiated call.
+
+## References
+
+- ADR-088 - Git-Lifecycle Pack (amended by this ADR's proposed reversal of the "No
+  write-back" non-goal)
+- ADR-088 Amendment 1 - `git.digest`, the existing read/ingest agent-facing verb this
+  proposal is structurally modeled on
+- ADR-018 - Authorization Gate; `Gate`/`GateRequest`/`GateDecision`, the reused enforcement
+  seam (Fork (c), C2)
+- ADR-017 - Pack Standard; `HandlerDef`, `PackRuntime::dispatch`, the mechanism new verbs
+  register through
+- ADR-016 - Request DSL; the wire surface these verbs would be reachable through
+- ADR-004 - Substrate Observables; `Event` store, the audit-persistence sink (Fork rule 2)
+- ADR-007 Rev 7 - Namespace as attribution; write-verb dispatch stamps namespace/actor
+  exactly as every other verb does, no new namespace semantics
+- `crates/khive-pack-git/src/ingest.rs` - existing shell-to-system-git precedent informing
+  Fork (b)
+- `crates/khive-pack-git/src/pack.rs`, `src/handlers.rs` - existing pack structure new write
+  handlers would extend

--- a/docs/adr/ADR-108-git-write-surface.md
+++ b/docs/adr/ADR-108-git-write-surface.md
@@ -9,8 +9,9 @@
 **Related**: ADR-085 (Code Pack - admin-only ingest path precedent), ADR-004 (Substrate
 Observables - `Event` store used for audit)
 
-This is a decision ADR for a human spec gate. It enumerates forks with trade-offs rather
-than picking silently. Open Questions are marked explicitly and are not resolved here.
+This ADR enumerates forks with trade-offs rather than picking silently. The forks below were
+resolved through design review; each fork's resolution is recorded in place, and the
+Resolutions section summarizes all five rulings.
 
 ## Context
 
@@ -47,8 +48,8 @@ the event plane, exactly as every other khive verb already is.
 This ADR proposes adding a write-verb surface to `khive-pack-git`, structurally consistent
 with the pack's existing `git.digest` verb (agent-facing, `pack.verb` namespaced per
 ADR-023) and dispatched through the same `VerbRegistry` / `Gate` seam every other verb uses.
-It deliberately does **not** fix the four forks below - those are the open decisions this
-ADR exists to present to the spec gate.
+The four forks below were presented to design review; each is resolved in place, with the
+full set of rulings summarized in the Resolutions section.
 
 ### Candidate verb set (subject to Fork (a))
 
@@ -62,10 +63,11 @@ At minimum, three write operations are named as design inputs:
   `force` is a parameter only for validation purposes: see the force-push rule below, which
   makes every `force=true` request a hard deny regardless of policy.
 
-A broader candidate list, to be narrowed at the spec gate: `git.checkout`, `git.merge`,
-`git.tag`, `git.pull` (fetch+merge/rebase - arguably read-adjacent, not a write to the
-target repo's canonical history, but it mutates the local working copy), `git.fetch`
-(unambiguously read-only against the remote, local-write only).
+A broader candidate list was considered and, per the resolution to Open Question 1 below, is
+out of scope for this phase: `git.checkout`, `git.merge`, `git.tag`, `git.pull`
+(fetch+merge/rebase - arguably read-adjacent, not a write to the target repo's canonical
+history, but it mutates the local working copy), `git.fetch` (unambiguously read-only
+against the remote, local-write only).
 
 ### Hard rules (not forked - these apply regardless of how the forks below resolve)
 
@@ -125,8 +127,13 @@ primitives.
 verb built from them, matching how `git.digest` is itself a convenience layer over
 `ingest::run_ingest`, which the CLI (`kkernel git-ingest`) also calls directly.
 
-**Open Question 1**: which of A1 / A2 / A3, and - if A1 or A3 - the exact verb list (is
-`git.tag` in scope for Phase B, or deferred). Not decided here.
+**Resolution (Open Question 1 - verb granularity)**: A1, thin verbs only.
+`git.commit`, `git.branch`, and `git.push` are the Phase B verb set; `git.tag`, `git.merge`,
+`git.checkout`, `git.pull`, and `git.fetch` are out of scope for this phase. The request DSL
+already chains operations, so `git.commit() | git.push()` is a single MCP call, which
+removes the round-trip motivation for a task-level verb: the case for `publish_branch` (A2)
+dissolves under DSL chaining. `publish_branch` is deferred until wrapper usage demonstrates
+the need for it.
 
 ### Fork (b): Execution home
 
@@ -163,11 +170,13 @@ before being placed in the argv array.
   are the safe primitive - the risk is a future edit that concatenates instead of passing
   argv, or a flag that was not meant to be allowlisted, e.g. `--upload-pack` on push).
 
-**Open Question 2**: B1 or B2. This ADR's default lean, given the existing ingester's
-precedent (`ingest.rs` already shells system `git`) and ADR-088 §5's explicit precedent for
-preferring the operator's existing tool credentials over reimplementing transport/auth, is
-toward B2 - but this is explicitly not decided here; the spec gate may weigh the injection
-surface differently.
+**Resolution (Open Question 2 - execution home)**: B2, hardened system-git shell-out,
+consistent with the ingester precedent and the credential-handling reasoning in ADR-088
+section 5. This resolution binds three conditions: argv-only construction (no shell
+interpolation), a fixed subcommand and flag allowlist, and restrictive character-set
+validation on branch names, remotes, and paths. The argument-construction module also
+requires a dedicated adversarial security review at implementation time; this is a named
+requirement of this ADR, not optional.
 
 ### Fork (c): Policy declaration
 
@@ -191,11 +200,10 @@ does today. No new trait, no new enforcement code path - the git pack becomes an
   which a policy author must know to inspect, rather than as typed top-level fields a policy
   schema can rely on). This is a minor extension surface, not a new trait.
 
-**Open Question 3**: C2 is the ADR-018-consistent default - this ADR does not see a case
-for a git-specific policy mechanism when the Gate trait already exists for exactly this
-purpose. What remains open is whether `repo`/`branch` need to become typed `GateRequest`
-fields (an ADR-018 amendment) or stay inside `args` (no amendment, policy authors read
-`input.args.repo`). Left to the spec gate.
+**Resolution (Open Question 3 - policy declaration)**: `repo` and `branch` remain
+ordinary verb arguments for this phase; no ADR-018 amendment is made now. Promoting them to
+typed `GateRequest` fields is deferred until policy authoring against `input.args.repo` and
+`input.args.branch` proves error-prone in practice.
 
 ### Fork (d): Composition with external-PR / fork-repo trust rules
 
@@ -216,11 +224,11 @@ rule in two distinct ways that need to be kept separate:
    touch fork-PR content, it is a separate ADR that must explicitly reconcile with the
    external-PR protocol, not an extension folded into this one.
 
-**Open Question 4**: whether the Gate policy layer (Fork (c), C2) should carry an explicit
-`source_trust` or equivalent field to make (1) vs (2) distinguishable in policy, or whether
-keeping (2) entirely unbuilt (not just unpolicied) is the correct boundary for Phase B. This
-ADR leans toward the latter - not building the capability rather than trusting policy to
-gate it correctly - but does not rule on it.
+**Resolution (Open Question 4 - composition with external-PR / fork-repo trust rules)**:
+fork-content write capability stays unbuilt for this phase. No `source_trust` field is
+introduced on the Gate policy layer; the absence of the capability is itself the trust
+boundary. Any future fork-content write path requires a separate ADR that explicitly
+reconciles with the external-contribution review protocol.
 
 ## Blast radius on ADR-088
 
@@ -248,11 +256,11 @@ This ADR proposes reversing that specific clause. Concretely:
   is unaffected: this surface does not touch GitHub's PR/review/CI machinery, only local git
   operations (commit, branch, push) that any git client already performs.
 
-**Open Question 5**: whether a successful `git.commit`/`git.push` should auto-trigger
-graph ingestion of the new commit (closing the loop between write and the existing
-read-side note kinds), or whether that stays a separate, caller-initiated `git.digest`
-call. Left open; a naive auto-trigger risks conflating a fast, latency-sensitive write path
-with a potentially slow ingest pass in the same call.
+**Resolution (Open Question 5 - digest integration)**: no automatic digest trigger
+after writes. Digest remains caller-initiated; DSL chaining (`git.push() | git.digest()`)
+provides single-call composition when a caller wants both in one round-trip, without
+conflating a fast, latency-sensitive write path with a potentially slow ingest pass by
+default.
 
 ## Threat and Risk Notes
 
@@ -276,7 +284,7 @@ caller class; they are necessary but not sufficient for an untrusted-caller thre
 
 ## Consequences
 
-### Positive (conditioned on spec-gate resolution of the Open Questions)
+### Positive
 
 - Gives khive a real authorization chokepoint for git writes, closing the gap design input 2
   depends on (fleet-level hook denial of direct `git`/`gh` writes has something to route
@@ -296,21 +304,35 @@ caller class; they are necessary but not sufficient for an untrusted-caller thre
   write credentials for whatever repos this surface targets - a new secret-management
   surface that does not exist for the read-only ingest path (`gh` read scopes are lower
   privilege than push credentials).
-- Four genuinely open forks mean this ADR cannot be implemented as written; it requires a
-  spec-gate ruling on Open Questions 1-5 before `khive-pack-git` gains any write handler.
+- The five forks below were resolved through design review (see Resolutions); with those
+  rulings in hand, `khive-pack-git` can proceed to implement the write handlers this ADR
+  specifies.
 
-## Open Questions
+## Resolutions
 
-1. Verb granularity (Fork (a)): A1 thin verbs, A2 task-level `publish_branch`, or A3 both.
-2. Execution home (Fork (b)): B1 daemon-side `git2-rs`, or B2 hardened system-git shell-out.
-   This ADR leans B2 for consistency with the existing ingester but does not decide it.
-3. Policy declaration (Fork (c)): confirmed lean toward C2 (Gate policy objects, no new
-   trait); open sub-question is whether `repo`/`branch` become typed `GateRequest` fields.
-4. Composition with external-PR trust rules (Fork (d)): whether policy needs an explicit
+1. **Verb granularity (Fork (a))**: which of A1 / A2 / A3, and - if A1 or A3 - the exact
+   verb list (is `git.tag` in scope for Phase B, or deferred). **Resolved**: A1, thin verbs
+   only - `git.commit`, `git.branch`, `git.push`. `git.tag` and the rest of the broader
+   candidate list are out of scope for this phase. See the resolution under Fork (a) above.
+2. **Execution home (Fork (b))**: B1 daemon-side `git2-rs`, or B2 hardened system-git
+   shell-out. **Resolved**: B2, consistent with the existing ingester, bound by argv-only
+   construction, a fixed subcommand/flag allowlist, restrictive character-set validation, and
+   a dedicated adversarial security review at implementation time. See the resolution under
+   Fork (b) above.
+3. **Policy declaration (Fork (c))**: whether `repo`/`branch` become typed `GateRequest`
+   fields (an ADR-018 amendment) or stay inside `args`. **Resolved**: they stay ordinary verb
+   arguments for this phase; no ADR-018 amendment now. Promotion to typed fields is deferred
+   until policy authoring proves error-prone in practice. See the resolution under Fork (c)
+   above.
+4. **Composition with external-PR trust rules (Fork (d))**: whether policy needs an explicit
    `source_trust` signal, or whether not building fork-diff-write capability is sufficient
-   boundary for Phase B.
-5. Whether a successful write auto-triggers `git.digest` ingestion of the new commit, or
-   stays a separate caller-initiated call.
+   boundary for Phase B. **Resolved**: fork-content write capability stays unbuilt; no
+   `source_trust` field is introduced. The absence of the capability is itself the trust
+   boundary. See the resolution under Fork (d) above.
+5. **Digest integration**: whether a successful write auto-triggers `git.digest` ingestion of
+   the new commit, or stays a separate caller-initiated call. **Resolved**: no automatic
+   trigger. Digest stays caller-initiated; DSL chaining (`git.push() | git.digest()`) covers
+   the single-call case. See the resolution in Blast radius on ADR-088 above.
 
 ## References
 

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -1,0 +1,372 @@
+# ADR-109: Sandboxed kkernel Gateway for Untrusted Execution (Phase C)
+
+**Status**: Proposed\
+**Date**: 2026-07-11\
+**Authors**: khive maintainers\
+**Depends on**: ADR-018 (Authorization Gate), ADR-016 (Request DSL), ADR-017 (Pack
+Standard), ADR-007 Rev 7 (Namespace as Attribution-Only)\
+**Related**: ADR-108 (Git Write Surface - composition point, Fork (d) below), ADR-085 (Code
+Pack - precedent for an admin-CLI-only surface distinct from the agent-facing MCP surface),
+khive-cloud API-key scope model (design input for Fork (b))
+
+This is a decision ADR for a human spec gate. It enumerates forks with trade-offs rather
+than picking silently. Open Questions are marked explicitly and are not resolved here.
+
+## Context
+
+khive's existing trust model (ADR-003, reaffirmed in ADR-018 "Trust boundary alignment with
+ADR-003") has exactly two tiers today:
+
+1. **Operator binary** (`kkernel sync`, `kkernel db migrate`, `kkernel pack list`, and every
+   other CLI subcommand except `kkernel mcp`) - runs with `AllowAllGate` unconditionally.
+   Operators are trusted by definition: they have local shell access to the machine running
+   khive.
+2. **Agent binary** (`khive-mcp` / `kkernel mcp`) - the MCP `request` surface, gated per
+   ADR-018. The gate defaults to `AllowAllGate` too (personal-local deployments), but a
+   deployment can install a `RegoGate` or custom `Gate` to enforce per-actor policy.
+
+Both tiers assume the caller - operator or agent - is a principal khive already trusts to
+reach the full verb catalog (subject to whatever Gate is installed). Neither tier has a
+notion of a caller that is _not_ trusted to see the full catalog at all: a sandboxed agent
+running someone else's prompt, an external tool integration, or a process khive's operator
+does not fully control. Today, such a caller either gets the full MCP surface (if it can
+reach `kkernel mcp` at all) or nothing (if it cannot reach khive at all) - there is no
+constrained middle tier.
+
+This gap matters for two concrete scenarios: an agent running under prompt-injection risk
+(it read attacker-controlled content and might be steered into calling verbs it should not),
+and a genuinely external, semi-trusted tool integration that should be able to do a narrow,
+declared set of things and nothing else. Both need a surface with:
+
+- A fixed verb allowlist smaller than the full catalog.
+- Guaranteed namespace pinning (the caller cannot escape into another namespace's data).
+- Rate/budget caps (a runaway or malicious caller cannot exhaust resources).
+- No admin CLI verbs reachable at all (the operator-tier commands above are categorically
+  off-limits, not merely gated).
+- No filesystem-path-bearing arguments accepted (a sandboxed caller must not be able to
+  direct khive to read or write an arbitrary host path).
+- Fail-closed behavior on anything outside the declared contract - an unrecognized verb, an
+  out-of-allowlist argument shape, or a Gate infrastructure error must deny, not fall
+  through to a permissive default the way ADR-018's base Gate fails open on infrastructure
+  errors.
+
+This ADR specs a gateway **mode** for this third trust tier. It does not resolve how that
+mode is packaged (Fork (a)) or how the sandboxed caller authenticates (Fork (b)) - those are
+the open forks below.
+
+## Decision
+
+A **gateway contract** is introduced: a declared, closed set of `(verb, arg-shape)` pairs a
+sandboxed caller may invoke, plus the namespace it is pinned to and the rate/budget caps
+that apply. The contract is enforced at (or before) the same `VerbRegistry::dispatch` seam
+ADR-018 already uses for gate consultation - this ADR does not introduce a second dispatch
+path; it introduces a stricter policy input and a pre-dispatch allowlist check ahead of the
+existing `Gate::check` call.
+
+### Hard rules (not forked)
+
+1. **Verb allowlist is closed and explicit.** A sandboxed caller's request is checked
+   against the canonical `pack.verb` id (per ADR-018 Amendment 1's canonicalization step -
+   this rules out an alias-based bypass of the allowlist the same way it rules out an
+   alias-based bypass of Gate policy). A verb not on the declared list is denied before pack
+   dispatch, not passed through to the pack handler for it to reject.
+2. **Namespace is pinned, not caller-suppliable.** ADR-007 Rev 7 Rule 3 already
+   establishes that an explicit `namespace=` request parameter is the only escape from the
+   default `'local'` write/read scope. For a sandboxed caller, that escape is itself closed:
+   the gateway ignores or rejects any caller-supplied `namespace` argument and always
+   substitutes the contract-declared namespace. This does not add a new namespace mechanism
+
+- it constrains which value the existing parameter is allowed to carry for this caller
+  class.
+
+3. **No admin CLI verbs.** The gateway mode never exposes the `kkernel` subcommands listed
+   in Context (`sync`, `db migrate`, `pack list`, `git-ingest`, `code-ingest`, `reindex`,
+   etc.). These are not verbs on the `VerbRegistry` surface at all today (they are `clap`
+   subcommands on the `kkernel` binary, a structurally separate entry point from `kkernel
+ mcp`), so "no admin CLI verbs" is largely already true by construction for any caller
+   reaching khive via MCP. This rule exists to make that structural fact an explicit,
+   checked contract property rather than an incidental one, and to ensure no future verb
+   that wraps admin functionality (a hypothetical `kg.migrate` MCP verb, for example) is
+   ever added to a sandboxed allowlist without deliberate review.
+4. **No filesystem-path-bearing arguments.** Verbs whose arguments accept a filesystem path
+   (for example, a hypothetical local-source `git.digest(source=<local path>)`, per ADR-088
+   Amendment 1's `DigestSource::Local`) are either excluded from the sandboxed allowlist
+   entirely, or the contract for that verb declares path-shaped arguments as forbidden and
+   the gateway validates the argument shape before dispatch (rejecting an absolute path, a
+   `file://` URL, or a value containing path separators, depending on the verb). Which of
+   "exclude the verb" vs. "constrain its arguments" applies per verb is part of the
+   capability declaration (Fork (c)), not fixed globally here.
+5. **Rate and budget caps are enforced, not merely declared.** ADR-018 §"Why no obligation
+   enforcement in v1?" states `Obligation::RateLimit` is declared by policy but not enforced
+   by the runtime. This ADR requires that gap to close for the gateway mode specifically:
+   a sandboxed caller's dispatch path must consult and enforce a rate/budget counter (calls
+   per window, and optionally a cost-unit budget per ADR-103's resource-attribution model)
+   before dispatch proceeds. This is new runtime behavior beyond what ADR-018 ships today,
+   scoped to the gateway path only - it does not retroactively require rate-limit
+   enforcement for the operator or ungated-agent tiers.
+6. **Fail-closed on anything outside the contract.** Any of: an unrecognized verb, an
+   argument shape that does not match the declared contract, a caller-supplied namespace
+   override attempt, a Gate infrastructure error (`Err(GateError)`), or a rate/budget cap
+   exceeded - all result in denial. This explicitly reverses ADR-018's fail-open-on-`Err`
+   posture (see Rationale below) for the gateway path only; the base Gate's fail-open
+   behavior is unchanged for the operator and trusted-agent tiers.
+
+### Fork (a): Process boundary
+
+**A1 - Separate gateway binary.** A new binary (e.g. `khive-gateway`) links the same
+`VerbRegistry`/pack machinery as `khive-mcp` but is compiled with the allowlist/pinning/cap
+logic built into its own dispatch wrapper, never exposing the unconstrained
+`VerbRegistry::dispatch` entry point at all.
+
+- Pro: the constrained surface is enforced by the binary's own structure - a sandboxed
+  process that can reach only this binary cannot reach the unconstrained path even if the
+  gateway contract has a bug, because the unconstrained dispatch function is simply not
+  linked into anything the sandboxed process can invoke.
+- Con: a new binary means a new build/release/distribution artifact, new integration-test
+  surface, and a second place pack registration (`inventory::submit!`, per `kkernel`'s
+  `_pack_links` force-link pattern) must be kept correct as packs are added or removed.
+
+**A2 - Mode flag on kkernel/khive-mcp.** `kkernel mcp --gateway <contract-file>` (or an
+equivalent flag) runs the existing `khive-mcp` binary but constructs the `VerbRegistry`
+with the allowlist/pinning/cap wrapper active for the whole process lifetime, instead of the
+normal unconstrained dispatch.
+
+- Pro: no new binary; reuses the existing MCP transport, daemon-spawn (ADR-049), and pack
+  registration exactly as-is; a deployment simply launches `kkernel mcp` differently for a
+  sandboxed caller than for a trusted one.
+- Con: the safety property becomes "the flag was set correctly at launch," a configuration
+  fact rather than a structural one - a misconfigured launch (flag omitted, or a bug in flag
+  handling) silently reverts to the full unconstrained surface, which is a materially worse
+  failure mode than A1's "the binary the process can reach never had the unconstrained path
+  at all."
+
+**A3 - Daemon-side policy profile.** The warm daemon (`kkernel mcp --daemon`, ADR-049)
+already serves multiple client connections; A3 extends it to recognize a per-connection (or
+per-socket) policy profile, so the same daemon process serves both a trusted agent
+connection at full capability and a sandboxed connection at constrained capability
+simultaneously, distinguished at the transport/connection layer.
+
+- Pro: one warm daemon serves every caller class, avoiding a second cold-start process for
+  the sandboxed path (relevant since ADR-049's whole premise is that daemon warm-up cost -
+  ANN/embedder state - is expensive to pay per-process); matches the existing multi-client
+  serving model (ADR-096, "Warm Daemon Per-Request Identity") which already threads distinct
+  attribution identities through one shared backend.
+- Con: highest implementation complexity of the three - the daemon must correctly
+  demultiplex connections to policy profiles and there is exactly one shared process whose
+  compromise (a bug in the demultiplexing logic) affects every caller class at once, unlike
+  A1 where the sandboxed and trusted paths are different binaries entirely.
+
+**Open Question 1**: A1, A2, or A3. This ADR notes that A3 is the natural extension of
+ADR-096's already-shipped per-request-identity model over a shared warm backend, which is a
+point in its favor, but the "one shared process, higher blast radius on a demux bug" concern
+is real and unresolved. Left to the spec gate.
+
+### Fork (b): Authentication of the sandboxed caller
+
+**B1 - Gate-mediated identity, per ADR-018.** The sandboxed caller authenticates however the
+transport already supports (an MCP client identity, a socket-level credential), and the
+resulting `ActorRef` (`kind`, `id`) is what the Gate's `GateRequest.actor` field carries -
+no new authentication mechanism, only a new `Gate` implementation (or `PackGatePolicy`, per
+ADR-018's pack policy extension point) that recognizes a "sandboxed" actor kind and applies
+the allowlist/pinning/cap contract as policy.
+
+- Pro: zero new authentication machinery; consistent with ADR-018's existing model where
+  "how an operator's gate maps authenticated identities to allow/deny is operator policy,
+  implemented behind the trait" - the gateway contract is exactly such a policy.
+- Con: the existing `ActorRef.kind` is a free-form string (`"user" | "agent" | "lambda" |
+ "anonymous" | custom`) with no notion of a verified credential - nothing in ADR-018
+  today cryptographically authenticates that a caller claiming `kind = "agent", id =
+ "sandboxed-x"` actually is that principal. B1 alone does not add that; it only routes an
+  already-established identity through policy.
+
+**B2 - API-key scope model, relating to khive-cloud.** A sandboxed caller presents an API
+key (structurally similar to what khive-cloud's tenant model uses - capacity/API-key based
+per the pricing/access model already in design for the cloud tier) whose scope _is_ the
+gateway contract: the key itself encodes (or is looked up to yield) the verb allowlist,
+namespace pin, and rate cap, rather than those being a separately configured policy the Gate
+consults.
+
+- Pro: a single artifact (the key) is the capability - easy to issue, revoke, and audit per
+  key; matches a pattern khive-cloud already needs for tenant API keys, so the mechanism is
+  reusable rather than gateway-specific; keys can be scoped per integration without touching
+  Gate policy configuration for each one.
+- Con: introduces a new credential type and its storage/validation/revocation lifecycle
+  (key hashing, expiry, rotation) that does not exist in khive today outside the cloud-tier
+  design; for the OSS/self-hosted deployment this ADR is scoped to, standing up key issuance
+  infrastructure is a heavier lift than B1's "just configure a Gate policy."
+
+**Open Question 2**: B1, B2, or B1 now with a documented migration path to B2 once
+khive-cloud's key infrastructure exists (avoiding building two separate credential systems).
+This ADR leans toward starting with B1 - it requires no new infrastructure and is a direct
+application of ADR-018's existing extension points - with B2 as a natural later swap given
+`Gate` is a replaceable trait by design, but does not rule this out as a decision.
+
+### Fork (c): Capability declaration format
+
+**C1 - Static allowlist file/config.** A TOML or JSON file lists permitted `(pack.verb,
+arg-constraints)` tuples, read at gateway startup (whichever Fork (a) shape hosts it),
+analogous to how `RegoGate` policies live in files an operator configures (ADR-018).
+
+- Pro: simplest to author, review, and diff in a PR - a capability grant is a visible,
+  version-controllable artifact; no new policy-language dependency.
+- Con: argument-shape constraints (rule 4's path-argument exclusion, for example) are harder
+  to express richly in a flat config format than in a language with actual predicates; a
+  static file also means capability changes require a restart/reload, not a live grant.
+
+**C2 - Gate policy objects (Rego), extending ADR-018's existing mechanism.** The gateway
+contract is expressed as Rego rules evaluated by the same `RegoGate`/`regorus` engine
+ADR-018 already ships, with the allowlist, namespace pin, and rate cap as `decision`/
+`obligations` fields the gateway's pre-dispatch check consults - no new policy engine, the
+gateway is "just" a stricter default-deny Rego policy plus the enforcement additions in
+rules 2, 4, 5, and 6 above that go beyond what `Obligation` enforcement does today.
+
+- Pro: reuses ADR-018's policy language and engine entirely; a capability grant and a
+  general Gate policy are authored in the same language, reducing the number of
+  configuration surfaces an operator must learn; Rego's `default decision := {"decision":
+ "deny", ...}` pattern (already the documented fail-closed idiom in ADR-018's own example
+  policy) is a natural fit for rule 6's fail-closed requirement.
+- Con: couples the gateway's capability model to Rego/regorus even for the simplest
+  allowlist cases, where C1's flat format would suffice and be easier to audit at a glance;
+  Rego expressiveness is double-edged - a capability contract that can express arbitrary
+  predicates is also harder to statically review for "does this actually enforce a closed
+  allowlist."
+
+**Open Question 3**: C1, C2, or a restricted subset of C2 (Rego, but with a required
+`default deny` template and a lint/validation step that rejects a policy failing to
+declare a closed allowlist - addressing C2's audit-difficulty con directly). Not decided
+here.
+
+### Fork (d): Relationship to Phase B (git writes from sandboxed callers)
+
+ADR-108 (Phase B, this pair's companion ADR) specs write verbs (`git.commit`, `git.branch`,
+`git.push` at minimum) reachable by a trusted/semi-trusted caller through the normal gate.
+A sandboxed caller under this ADR's gateway mode invoking a Phase-B git-write verb is the
+literal composition of both specs, and needs explicit treatment rather than an implicit
+"the gateway contract will sort it out":
+
+- If Phase B's write-verb allowlist entry is present in a sandboxed caller's contract at
+  all, every hard rule from _both_ ADRs applies simultaneously: force-push denial
+  (ADR-108 rule 1) and gateway fail-closed-on-anything-outside-contract (this ADR's rule 6)
+  compose without conflict, since both are deny-biased. But ADR-108's Fork (d) explicitly
+  scoped its write surface to "content the calling agent itself produced" and marked
+  fork-PR/external-content writes as categorically out of scope, not merely unpolicied. A
+  sandboxed caller is, by definition, the caller class most likely to be executing
+  prompt-injected or externally-influenced instructions - which makes ADR-108's Fork (d)
+  boundary (2) (no fork-diff-write capability at all, rather than trusting policy to gate
+  it) the load-bearing protection here, not this ADR's allowlist alone. If ADR-108 resolves
+  Fork (d) toward "build it, gate it with `source_trust`," this ADR's threat model
+  (Prompt-injected agent, below) becomes materially more dangerous and needs re-review
+  before a sandboxed contract may include any git-write verb.
+- The safer default posture, and this ADR's recommendation (not a ruling): a sandboxed
+  gateway contract does not include any ADR-108 write verb until ADR-108's own Open
+  Questions are resolved and a specific, reviewed contract is drafted for that composition.
+  This is a recommendation the spec gate should either ratify or override, not a rule this
+  ADR enforces structurally.
+
+**Open Question 4**: whether the spec gate wants to rule out git-write verbs from any
+sandboxed contract as a standing policy (simplest, most conservative), or whether a future,
+narrowly-scoped contract (e.g., sandboxed callers may `git.commit` to a caller-specific
+scratch branch only, never `git.push` to a shared remote) is worth specifying once ADR-108
+lands. Not decided here.
+
+## Threat Model
+
+**Prompt-injected agent.** A sandboxed agent processes attacker-controlled content (a
+fetched web page, a file, a tool result) that contains instructions steering it toward
+calling khive verbs the operator did not intend. The gateway contract is the primary
+defense: even a fully successful injection can only reach the declared allowlist, in the
+pinned namespace, under the rate cap. This is why rule 6 (fail-closed on anything outside
+contract) is load-bearing rather than advisory - an injected agent will, by construction,
+attempt to probe or exceed the contract, and the failure mode for any probe must be deny,
+never a permissive fallback. The composition risk with ADR-108 (Fork (d) above) is the
+sharpest instance of this: a prompt-injected agent with git-write capability could be
+steered into committing or pushing attacker-chosen content, which is exactly why this ADR
+recommends excluding write verbs from sandboxed contracts by default.
+
+**Exfiltration via verbs.** A sandboxed caller with legitimate read-verb access (`search`,
+`get`, `neighbors`, `context`) could be used to exfiltrate data outside its intended
+namespace scope, either by requesting a broader read than intended or by chaining reads
+across records the operator did not mean to expose. Mitigations: rule 2 (namespace pinning,
+not caller-escapable) bounds the data surface to the contract-declared namespace regardless
+of what the caller requests; the capability declaration (Fork (c)) should, whichever format
+is chosen, allow per-verb argument constraints (e.g., a contract that permits `search` but
+caps `limit`, or excludes `context`'s `hops`/`fanout` expansion parameters) so a narrow verb
+grant cannot be used to walk far beyond the intended scope in one call. This ADR does not
+fully specify per-verb argument constraint shapes - that is part of Fork (c)'s resolution.
+
+**Resource exhaustion.** A sandboxed caller, malicious or merely buggy, issuing verbs in a
+tight loop (a runaway ANN search, repeated large `context` traversals) could degrade shared
+daemon resources (ADR-049's warm ANN/embedder state is a shared, contended resource across
+all callers per ADR-096's per-request-identity model). Rule 5 (enforced rate/budget caps)
+is the direct mitigation; this ADR requires it be actual enforcement, not the
+declared-but-unenforced `Obligation::RateLimit` ADR-018 ships today, specifically because a
+sandboxed caller is exactly the class of caller a resource-exhaustion threat model assumes
+is present. Budget accounting may reuse ADR-103's cost-unit resource-attribution model if
+that lands first; this ADR does not require it, only that some enforced counter exists for
+the gateway path.
+
+## Alternatives Considered
+
+| Alternative                                                                                                       | Why not adopted                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rely on `AllowAllGate` plus operator discipline (document "don't expose this to untrusted callers")               | This is the status quo and is exactly the gap this ADR exists to close; documentation is not enforcement, and ADR-018 itself calls `AllowAllGate` "a footgun in multi-user environments."                                                                      |
+| Extend the existing Gate to a "strict mode" that fail-closes on `Err` globally, without a separate allowlist tier | Addresses only rule 6's fail-closed requirement, not the allowlist/pinning/cap/no-admin/no-path requirements this ADR's caller class needs; conflates "stricter infra-failure handling for everyone" with "a genuinely narrower surface for one caller class." |
+| Sandbox at the OS/container level only (seccomp, container isolation), no khive-level gateway                     | Orthogonal, not a substitute - OS-level sandboxing constrains what the process can do to the _host_, not what verbs it can invoke against khive's own data once it can reach the MCP transport at all. Complements this ADR rather than replacing it.          |
+
+## Consequences
+
+### Positive (conditioned on spec-gate resolution of the Open Questions)
+
+- Gives khive a genuine third trust tier, closing the "full surface or nothing" gap between
+  the operator and trusted-agent tiers documented in Context.
+- Enforced rate/budget caps for the gateway path close a real gap ADR-018 left open
+  (`Obligation::RateLimit` declared-not-enforced) - for this caller class specifically.
+- A documented, structural place to compose with Phase B (ADR-108) rather than an implicit
+  or accidental interaction, per Fork (d).
+
+### Negative
+
+- New enforcement code path (pre-dispatch allowlist/pinning/cap check) is new surface to get
+  wrong; a bug here that fails open, rather than closed, defeats the entire ADR - this is
+  exactly why rule 6 is stated as a hard rule rather than left to per-deployment policy.
+- Whichever Fork (a) shape is chosen, this is nontrivial new engineering: a new binary
+  (A1), new flag-driven mode with a real risk of silent misconfiguration (A2), or new
+  daemon-side connection demultiplexing (A3). None of the three is a small addition.
+- Four open forks, one of them (Fork (d)) explicitly dependent on ADR-108's own unresolved
+  forks, mean this ADR cannot be implemented as written without a spec-gate ruling and,
+  for Fork (d), without ADR-108 reaching its own resolution first.
+
+## Open Questions
+
+1. Process boundary (Fork (a)): A1 separate binary, A2 mode flag, or A3 daemon-side policy
+   profile. This ADR notes A3's alignment with ADR-096's existing per-identity-over-shared-
+   backend model but does not decide.
+2. Authentication of the sandboxed caller (Fork (b)): B1 Gate-mediated ActorRef (no new
+   infra), B2 API-key scope model relating to khive-cloud, or B1-now-B2-later. This ADR
+   leans toward B1 as the lower-infrastructure starting point but does not rule.
+3. Capability declaration format (Fork (c)): C1 static allowlist file, C2 Rego policy
+   objects reusing ADR-018's engine, or a constrained C2 variant with a required
+   default-deny lint. Not decided.
+4. Relationship to Phase B (Fork (d)): whether any sandboxed contract may ever include an
+   ADR-108 git-write verb, and if so under what additional constraint (e.g., scratch-branch-
+   only, no push). This ADR recommends excluding write verbs from sandboxed contracts by
+   default until ADR-108 itself resolves, but leaves the standing policy to the spec gate.
+
+## References
+
+- ADR-018 - Authorization Gate; `Gate`, `GateRequest`, `GateDecision`, `Obligation`,
+  `PackGatePolicy`; this ADR's enforcement additions (rules 5 and 6) are explicit, scoped
+  deltas from ADR-018's declared-not-enforced `RateLimit` and fail-open-on-`Err` defaults
+- ADR-018 Amendment 1 - canonical verb identity; the allowlist check in rule 1 depends on
+  the same canonicalization step to avoid an alias-based bypass
+- ADR-016 - Request DSL; the wire surface the gateway's pre-dispatch check intercepts
+- ADR-017 - Pack Standard; `VerbRegistry`, `HandlerDef` - unchanged by this ADR, only the
+  dispatch path gains a pre-check
+- ADR-007 Rev 7 - Namespace as attribution; rule 2's namespace-pinning constrains, but does
+  not alter, the existing `namespace=` parameter mechanism
+- ADR-096 - Warm Daemon Per-Request Identity; informs Fork (a) A3
+- ADR-103 - Resource Attribution Model; potential source of the cost-unit accounting rule 5
+  may reuse
+- ADR-108 - Git Write Surface; the companion Phase B ADR this ADR's Fork (d) composes with
+- ADR-085 - Code Pack; precedent for a deliberately admin-CLI-only surface distinct from the
+  agent-facing MCP surface (`kkernel code-ingest`), informing the "no admin CLI verbs" rule

--- a/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
+++ b/docs/adr/ADR-109-sandboxed-kkernel-gateway.md
@@ -9,8 +9,9 @@ Standard), ADR-007 Rev 7 (Namespace as Attribution-Only)\
 Pack - precedent for an admin-CLI-only surface distinct from the agent-facing MCP surface),
 khive-cloud API-key scope model (design input for Fork (b))
 
-This is a decision ADR for a human spec gate. It enumerates forks with trade-offs rather
-than picking silently. Open Questions are marked explicitly and are not resolved here.
+This ADR enumerates forks with trade-offs rather than picking silently. The forks below were
+resolved through design review; each fork's resolution is recorded in place, and the
+Resolutions section summarizes all four rulings.
 
 ## Context
 
@@ -50,9 +51,9 @@ declared set of things and nothing else. Both need a surface with:
   through to a permissive default the way ADR-018's base Gate fails open on infrastructure
   errors.
 
-This ADR specs a gateway **mode** for this third trust tier. It does not resolve how that
-mode is packaged (Fork (a)) or how the sandboxed caller authenticates (Fork (b)) - those are
-the open forks below.
+This ADR specs a gateway **mode** for this third trust tier. How that mode is packaged
+(Fork (a)) and how the sandboxed caller authenticates (Fork (b)) were presented to design
+review as the forks below; each is resolved in place.
 
 ## Decision
 
@@ -61,7 +62,8 @@ sandboxed caller may invoke, plus the namespace it is pinned to and the rate/bud
 that apply. The contract is enforced at (or before) the same `VerbRegistry::dispatch` seam
 ADR-018 already uses for gate consultation - this ADR does not introduce a second dispatch
 path; it introduces a stricter policy input and a pre-dispatch allowlist check ahead of the
-existing `Gate::check` call.
+existing `Gate::check` call. The four forks below were presented to design review; each is
+resolved in place, with the full set of rulings summarized in the Resolutions section.
 
 ### Hard rules (not forked)
 
@@ -156,10 +158,15 @@ simultaneously, distinguished at the transport/connection layer.
   compromise (a bug in the demultiplexing logic) affects every caller class at once, unlike
   A1 where the sandboxed and trusted paths are different binaries entirely.
 
-**Open Question 1**: A1, A2, or A3. This ADR notes that A3 is the natural extension of
-ADR-096's already-shipped per-request-identity model over a shared warm backend, which is a
-point in its favor, but the "one shared process, higher blast radius on a demux bug" concern
-is real and unresolved. Left to the spec gate.
+**Resolution (Open Question 1 - process boundary)**: the configuration-profile
+option (A2) is rejected outright: a silent misconfiguration reverting to the full verb
+surface defeats the purpose of this ADR. This is resolved as a structural boundary. The
+recommended implementation shape is a thin gateway binary (A1) that connects to the warm
+daemon as a client, a proxy, so the sandboxed process can only ever reach the constrained
+binary while warm ANN and embedder state is still reused from the daemon. A standalone
+constrained binary is the fallback if the proxy hop proves infeasible. The in-daemon
+demultiplexer option (A3) is rejected for v1: a demux bug would have whole-surface blast
+radius. A3 is revisited only after the contract mechanism is proven in production.
 
 ### Fork (b): Authentication of the sandboxed caller
 
@@ -195,11 +202,11 @@ consults.
   design; for the OSS/self-hosted deployment this ADR is scoped to, standing up key issuance
   infrastructure is a heavier lift than B1's "just configure a Gate policy."
 
-**Open Question 2**: B1, B2, or B1 now with a documented migration path to B2 once
-khive-cloud's key infrastructure exists (avoiding building two separate credential systems).
-This ADR leans toward starting with B1 - it requires no new infrastructure and is a direct
-application of ADR-018's existing extension points - with B2 as a natural later swap given
-`Gate` is a replaceable trait by design, but does not rule this out as a decision.
+**Resolution (Open Question 2 - authentication of the sandboxed caller)**:
+transport-level identity now (B1), with a documented migration path to key-based
+authentication (B2) once the cloud key infrastructure exists. Contract documentation must
+state plainly that `ActorRef` identity is transport-level, not cryptographic, in
+open-source deployments.
 
 ### Fork (c): Capability declaration format
 
@@ -231,10 +238,9 @@ rules 2, 4, 5, and 6 above that go beyond what `Obligation` enforcement does tod
   predicates is also harder to statically review for "does this actually enforce a closed
   allowlist."
 
-**Open Question 3**: C1, C2, or a restricted subset of C2 (Rego, but with a required
-`default deny` template and a lint/validation step that rejects a policy failing to
-declare a closed allowlist - addressing C2's audit-difficulty con directly). Not decided
-here.
+**Resolution (Open Question 3 - capability declaration format)**: a restricted subset
+of C2, constrained Rego on the existing policy engine, with a required default-deny template
+and a validation lint that rejects any contract failing to declare a closed verb allowlist.
 
 ### Fork (d): Relationship to Phase B (git writes from sandboxed callers)
 
@@ -253,21 +259,19 @@ literal composition of both specs, and needs explicit treatment rather than an i
   sandboxed caller is, by definition, the caller class most likely to be executing
   prompt-injected or externally-influenced instructions - which makes ADR-108's Fork (d)
   boundary (2) (no fork-diff-write capability at all, rather than trusting policy to gate
-  it) the load-bearing protection here, not this ADR's allowlist alone. If ADR-108 resolves
-  Fork (d) toward "build it, gate it with `source_trust`," this ADR's threat model
-  (Prompt-injected agent, below) becomes materially more dangerous and needs re-review
-  before a sandboxed contract may include any git-write verb.
-- The safer default posture, and this ADR's recommendation (not a ruling): a sandboxed
-  gateway contract does not include any ADR-108 write verb until ADR-108's own Open
-  Questions are resolved and a specific, reviewed contract is drafted for that composition.
-  This is a recommendation the spec gate should either ratify or override, not a rule this
-  ADR enforces structurally.
+  it) the load-bearing protection here, not this ADR's allowlist alone. ADR-108's Fork (d)
+  resolved toward keeping fork-content write capability unbuilt rather than gating it with a
+  `source_trust` field, which keeps this ADR's threat model (Prompt-injected agent, below) at
+  its current severity; a future ADR that builds fork-content write capability would need to
+  re-review this composition before a sandboxed contract could include any git-write verb.
+- Standing policy, per the resolution of Open Question 4 below: a sandboxed gateway contract
+  does not include any ADR-108 write verb. This composition is revisited only via a new ADR,
+  once a specific, reviewed contract is drafted and demonstrated need is shown.
 
-**Open Question 4**: whether the spec gate wants to rule out git-write verbs from any
-sandboxed contract as a standing policy (simplest, most conservative), or whether a future,
-narrowly-scoped contract (e.g., sandboxed callers may `git.commit` to a caller-specific
-scratch branch only, never `git.push` to a shared remote) is worth specifying once ADR-108
-lands. Not decided here.
+**Resolution (Open Question 4 - composition with the git write surface)**:
+standing policy, no git write verb from the ADR-108 surface may appear in any sandboxed
+contract. This is revisited only via a new ADR after the write surface ships with
+demonstrated need for a narrower, sandboxed-safe composition.
 
 ## Threat Model
 
@@ -280,8 +284,8 @@ contract) is load-bearing rather than advisory - an injected agent will, by cons
 attempt to probe or exceed the contract, and the failure mode for any probe must be deny,
 never a permissive fallback. The composition risk with ADR-108 (Fork (d) above) is the
 sharpest instance of this: a prompt-injected agent with git-write capability could be
-steered into committing or pushing attacker-chosen content, which is exactly why this ADR
-recommends excluding write verbs from sandboxed contracts by default.
+steered into committing or pushing attacker-chosen content, which is exactly why this ADR's
+standing policy excludes write verbs from sandboxed contracts.
 
 **Exfiltration via verbs.** A sandboxed caller with legitimate read-verb access (`search`,
 `get`, `neighbors`, `context`) could be used to exfiltrate data outside its intended
@@ -313,9 +317,24 @@ the gateway path.
 | Extend the existing Gate to a "strict mode" that fail-closes on `Err` globally, without a separate allowlist tier | Addresses only rule 6's fail-closed requirement, not the allowlist/pinning/cap/no-admin/no-path requirements this ADR's caller class needs; conflates "stricter infra-failure handling for everyone" with "a genuinely narrower surface for one caller class." |
 | Sandbox at the OS/container level only (seccomp, container isolation), no khive-level gateway                     | Orthogonal, not a substitute - OS-level sandboxing constrains what the process can do to the _host_, not what verbs it can invoke against khive's own data once it can reach the MCP transport at all. Complements this ADR rather than replacing it.          |
 
+## Implementation Plan
+
+- Enforced rate and budget caps (rule 5) are new runtime work, not an assumed capability of
+  the existing dispatch path: `Obligation::RateLimit` is declared-but-unenforced today
+  (ADR-018), and this ADR requires actual enforcement for the gateway path. This is a named
+  implementation-phase item: the gateway dispatch path must consult and enforce a
+  rate/budget counter before dispatch proceeds, and that counter is built as part of this
+  ADR's implementation, not inherited from ADR-018.
+- The gateway process boundary (resolution of Open Question 1: a thin proxy binary in front
+  of the warm daemon) is new build/release surface and is scoped as its own implementation
+  item, separate from the pre-dispatch allowlist/pinning check.
+- The capability declaration format (resolution of Open Question 3: constrained Rego with a
+  default-deny template and a validation lint) requires the lint itself to be built; it is
+  not a byproduct of writing the Rego policy.
+
 ## Consequences
 
-### Positive (conditioned on spec-gate resolution of the Open Questions)
+### Positive
 
 - Gives khive a genuine third trust tier, closing the "full surface or nothing" gap between
   the operator and trusted-agent tiers documented in Context.
@@ -329,28 +348,34 @@ the gateway path.
 - New enforcement code path (pre-dispatch allowlist/pinning/cap check) is new surface to get
   wrong; a bug here that fails open, rather than closed, defeats the entire ADR - this is
   exactly why rule 6 is stated as a hard rule rather than left to per-deployment policy.
-- Whichever Fork (a) shape is chosen, this is nontrivial new engineering: a new binary
-  (A1), new flag-driven mode with a real risk of silent misconfiguration (A2), or new
-  daemon-side connection demultiplexing (A3). None of the three is a small addition.
-- Four open forks, one of them (Fork (d)) explicitly dependent on ADR-108's own unresolved
-  forks, mean this ADR cannot be implemented as written without a spec-gate ruling and,
-  for Fork (d), without ADR-108 reaching its own resolution first.
+- The chosen Fork (a) shape (a thin proxy binary, with a standalone constrained binary as
+  fallback) is nontrivial new engineering, per the Implementation Plan above.
+- Fork (d) ties this ADR's write-verb boundary to ADR-108: the standing policy of excluding
+  every ADR-108 write verb from sandboxed contracts holds regardless of how ADR-108's own
+  forks resolve, but any future narrower composition needs its own ADR and re-review of the
+  threat model above.
 
-## Open Questions
+## Resolutions
 
-1. Process boundary (Fork (a)): A1 separate binary, A2 mode flag, or A3 daemon-side policy
-   profile. This ADR notes A3's alignment with ADR-096's existing per-identity-over-shared-
-   backend model but does not decide.
-2. Authentication of the sandboxed caller (Fork (b)): B1 Gate-mediated ActorRef (no new
-   infra), B2 API-key scope model relating to khive-cloud, or B1-now-B2-later. This ADR
-   leans toward B1 as the lower-infrastructure starting point but does not rule.
-3. Capability declaration format (Fork (c)): C1 static allowlist file, C2 Rego policy
-   objects reusing ADR-018's engine, or a constrained C2 variant with a required
-   default-deny lint. Not decided.
-4. Relationship to Phase B (Fork (d)): whether any sandboxed contract may ever include an
-   ADR-108 git-write verb, and if so under what additional constraint (e.g., scratch-branch-
-   only, no push). This ADR recommends excluding write verbs from sandboxed contracts by
-   default until ADR-108 itself resolves, but leaves the standing policy to the spec gate.
+1. **Process boundary (Fork (a))**: A1 separate binary, A2 mode flag, or A3 daemon-side
+   policy profile. **Resolved**: the configuration-profile option (A2) is rejected outright.
+   A thin gateway binary that proxies to the warm daemon (A1) is the recommended shape; a
+   standalone constrained binary is the fallback if the proxy hop proves infeasible. The
+   in-daemon demultiplexer (A3) is rejected for v1 and revisited only after the contract
+   mechanism is proven in production. See the resolution under Fork (a) above.
+2. **Authentication of the sandboxed caller (Fork (b))**: B1 Gate-mediated `ActorRef`, B2
+   API-key scope model, or B1-now-B2-later. **Resolved**: B1-now-B2-later - transport-level
+   identity now, with a documented migration path to key-based authentication once cloud key
+   infrastructure exists. See the resolution under Fork (b) above.
+3. **Capability declaration format (Fork (c))**: C1 static allowlist file, C2 Rego policy
+   objects, or a constrained C2 variant with a required default-deny lint. **Resolved**: the
+   constrained C2 variant - Rego on the existing policy engine, with a required default-deny
+   template and a validation lint that rejects any contract lacking a closed verb allowlist.
+   See the resolution under Fork (c) above.
+4. **Relationship to Phase B (Fork (d))**: whether any sandboxed contract may ever include
+   an ADR-108 git-write verb. **Resolved**: standing policy, no ADR-108 write verb may
+   appear in any sandboxed contract. Revisited only via a new ADR once the write surface
+   ships with demonstrated need. See the resolution under Fork (d) above.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,8 @@ For historical context, see [v0 archive](../_archive/adr_v0/README.md). v0 ADRs 
 | [ADR-101](ADR-101-kg-changeset-model.md)                     | KG Change-Set Model — Producer-Agnostic Op-List with Stage-Time Stable IDs (Proposed)                           |
 | [ADR-102](ADR-102-tiered-validate-and-merge.md)              | Tiered Validate-and-Merge — Rule-Gated Fast Path and Reviewed Change-Set Path (Proposed)                        |
 | [ADR-106](ADR-106-schedule-pack-executor.md)                 | Schedule Pack Executor — Daemon-Resident Tick for the Pending-Event Drain (Accepted)                            |
+| [ADR-108](ADR-108-git-write-surface.md)                      | Git Write Surface Through khive (Phase B) (Proposed)                                                            |
+| [ADR-109](ADR-109-sandboxed-kkernel-gateway.md)              | Sandboxed kkernel Gateway for Untrusted Execution (Phase C) (Proposed)                                          |
 
 ## Closed Taxonomies — Quick Reference
 


### PR DESCRIPTION
## Summary

Two decision ADRs for the human spec gate, docs-only.

- **ADR-108** (Phase B): specs a write-verb surface for `khive-pack-git` (commit/branch/push at minimum), gated at dispatch, force-push always denied, protected-branch rules enforced at the Gate, full audit via the event plane. Amends ADR-088's "No write-back" non-goal. Forks: (a) verb granularity, (b) execution home (daemon-side git2-rs vs hardened system-git shell-out), (c) policy declaration, (d) composition with the external-PR/fork-repo trust rules.
- **ADR-109** (Phase C): specs a gateway mode giving an untrusted/semi-trusted caller a constrained kkernel/MCP surface — verb allowlist, namespace pinning, enforced rate/budget caps, no admin CLI verbs, no filesystem-path-bearing args, fail-closed outside the contract. Includes a Threat Model (prompt-injected agent, exfiltration via verbs, resource exhaustion). Forks: (a) process boundary, (b) caller authentication, (c) capability declaration format, (d) composition with ADR-108 (git writes from sandboxed callers).

Both ADRs enumerate forks with trade-offs and mark open decisions explicitly as Open Questions rather than picking silently, per the spec-gate requirement. Status: Proposed.

## Test plan

- [x] `deno fmt --check docs/adr/ADR-108-git-write-surface.md docs/adr/ADR-109-sandboxed-kkernel-gateway.md docs/adr/README.md` passes
- [x] Pre-commit hooks passed (secrets scan, EOF, merge-conflict checks)
- [x] Docs-only change, no cargo/code touched
- [ ] Human spec gate review of both ADRs' Open Questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)