### PR TITLE
fix(bench): stop libtest harness from rejecting criterion --quick in bench-track shards

### DIFF
--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "BM25 (Okapi BM25) keyword index with deterministic scoring"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-score = { version = "0.3.0", path = "../khive-score" }
 serde = { workspace = true }

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Brain primitives — Beta posteriors, section types, profile state, weight derivation"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }
 serde = { workspace = true }

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SQLite storage backend: entities, edges, notes, events, FTS5, sqlite-vec vectors."
 
+[lib]
+bench = false
+
 [dependencies]
 khive-storage = { version = "0.3.0", path = "../khive-storage" }
 khive-score = { version = "0.3.0", path = "../khive-score" }

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Cognitive primitives — Fold, Anchor, Objective, Selector"
 
+[lib]
+bench = false
+
 [features]
 # serde: enables Serialize/Deserialize derives on all fold types.
 # Enabled by default so existing callers compile without explicit opt-in.

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Rank fusion strategies (RRF, Weighted, Union) with deterministic scoring"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-score = { version = "0.3.0", path = "../khive-score" }
 serde = { workspace = true }

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "HNSW (Hierarchical Navigable Small World) vector index with INT8 quantized two-phase search"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-score = { version = "0.3.0", path = "../khive-score" }
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Brain pack — profile-oriented orchestration via Fold + Objective (ADR-032)"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Communication pack — inter-agent messaging (send, inbox, read, reply, thread) (ADR-040)"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "GTD verb pack — task lifecycle (assign/next/complete/transition) over the notes substrate"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "KG verb pack — entity/note CRUD, graph traversal, hybrid search for research knowledge graphs"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Knowledge verb pack — lore corpus (atoms/domains), TF-IDF retrieval, concept registration"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-brain-core = { version = "0.3.0", path = "../khive-brain-core" }

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Memory verb pack — remember/recall semantics with decay-aware ranking"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Schedule pack — time-triggered intent storage (remind, schedule, agenda, cancel) (ADR-040)"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types", features = ["serde"] }
 khive-runtime = { version = "0.3.0", path = "../khive-runtime" }

--- a/crates/khive-quant/Cargo.toml
+++ b/crates/khive-quant/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 rayon = { workspace = true }
 

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "GQL and SPARQL parsers with SQL compiler for knowledge graph queries."
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types" }
 thiserror = { workspace = true }

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Request DSL — parses verb-dispatch strings (function-call, JSON, and future LNDL / pipe / bash-style syntaxes) into a transport-agnostic ParsedRequest AST"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-types = { version = "0.3.0", path = "../khive-types" }
 serde = { workspace = true }

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Hybrid retrieval composer (HNSW + BM25 + fusion + graph + cross-encoder) with deterministic scoring"
 
+[lib]
+bench = false
+
 [dependencies]
 khive-hnsw    = { version = "0.3.0", path = "../khive-hnsw" }
 khive-bm25    = { version = "0.3.0", path = "../khive-bm25" }

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[lib]
+bench = false
+
 [features]
 default = ["serde"]
 serde = ["dep:serde"]

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Text analysis primitives for khive: tokenization, normalization, filtering"
 
+[lib]
+bench = false
+
 [dependencies]
 unicode-segmentation = { workspace = true, optional = true }
 rust-stemmers = { workspace = true, optional = true }

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 rayon = { workspace = true }
 memmap2 = { workspace = true }


### PR DESCRIPTION
## Problem

Bench Trend Tracking has failed on every main push since it shipped (all 4 component shards, first run 29141259783 through 29157051310). Every shard reports:

```
[bench_track] error: no criterion estimates.json found under crates/target/criterion - did `cargo bench` run?
```

## Root cause

The workflow runs `cargo bench -p <crates> -- --quick`. Cargo forwards trailing bench args to every benchmark-capable target, and each crate's library still has the default libtest bench harness enabled, so the very first target invoked is `unittests src/lib.rs`, which rejects the flag and aborts the whole invocation before any Criterion bench runs:

```
Running unittests src/lib.rs (target/release/deps/khive_bm25-...)
error: Unrecognized option: 'quick'
error: bench failed, to rerun pass `-p khive-bm25 --lib`
```

The `|| true` in the workflow swallows the abort, so the failure only surfaces later as the missing-estimates ledger error.

## Fix

Set `[lib] bench = false` on the 20 crates in the bench-track shard matrix (the standard Criterion workspace pattern), so `cargo bench` invokes only the Criterion `[[bench]]` targets, which understand `--quick`.

## Verification

Before (main, unpatched):

```
$ cargo bench -p khive-bm25 -- --quick
     Running unittests src/lib.rs (target/release/deps/khive_bm25-040223458872e244)
error: Unrecognized option: 'quick'
error: bench failed, to rerun pass `-p khive-bm25 --lib`
```

After (this branch):

```
$ cargo bench -p khive-bm25 -- --quick
Benchmarking memory_usage/docs/1000: Analyzing
memory_usage/docs/1000  time:   [49.041 µs 49.176 µs 49.717 µs]
remove_document/1k_corpus
                        time:   [2.1738 ms 2.1859 ms 2.2345 ms]
```

and `target/criterion/` now contains per-bench estimate directories, which is exactly what `bench_track.py record` consumes.

Metadata-only change: 20 files, 60 insertions, no code or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)