### PR TITLE
fix(kg): exact-name entity lookup in resolve before hybrid fallback (#849)

### DIFF
--- a/crates/khive-db/src/stores/entity.rs
+++ b/crates/khive-db/src/stores/entity.rs
@@ -468,6 +468,15 @@ fn build_entity_where(
         conditions.push(format!("name LIKE ?{} ESCAPE '\\'", params.len()));
     }
 
+    if let Some(ref exact) = filter.name_exact {
+        params.push(Box::new(exact.clone()));
+        // `entities.name` has no `COLLATE NOCASE` (see sql/schema.sql), so
+        // `=` is already SQLite's default case-sensitive BINARY comparison.
+        // `COLLATE BINARY` is spelled out here so this predicate stays
+        // correct even if the column's default collation ever changes.
+        conditions.push(format!("name = ?{} COLLATE BINARY", params.len()));
+    }
+
     if !filter.tags_any.is_empty() {
         let placeholders: Vec<String> = filter
             .tags_any

--- a/crates/khive-pack-kg/src/dispatch.rs
+++ b/crates/khive-pack-kg/src/dispatch.rs
@@ -1237,9 +1237,11 @@ mod tests {
     /// `create`/`get`/`update`/`delete`/`merge`/`link` on THIS registry) must
     /// not resolve via the ring's high-confidence exact-match stage. It is
     /// created directly on the runtime (bypassing dispatch, hence bypassing
-    /// admission entirely) so the only way `resolve` can find it at all is
-    /// the hybrid-search fallback (stage 3) — proven by a confidence below
-    /// the ring's fixed 0.95 exact-match / 0.7 substring-match bands.
+    /// admission entirely) so the only way `resolve` can find it via the ring
+    /// is stage 2 — proven by a confidence that never equals the ring's fixed
+    /// 0.95 exact-match / 0.7 substring-match bands (it instead comes from
+    /// the stage-3 exact-name storage lookup, #849, since the ref is this
+    /// entity's exact name).
     #[tokio::test]
     async fn resolve_search_result_sets_never_populate_the_ring() {
         let rt = KhiveRuntime::memory().expect("in-memory runtime");
@@ -1275,19 +1277,24 @@ mod tests {
             .await
             .expect("resolve must succeed");
         let results = result.get("results").and_then(|v| v.as_array()).unwrap();
-        if let Some(status) = results[0].get("status").and_then(|v| v.as_str()) {
-            if status == "resolved" {
-                let confidence = results[0]
-                    .get("confidence")
-                    .and_then(|v| v.as_f64())
-                    .unwrap();
-                assert!(
-                    confidence < 0.9,
-                    "a resolved hit here must come from hybrid search, not the ring \
-                     (which would score 0.95 exact / 0.7 substring); got {confidence}"
-                );
-            }
-        }
+        // The ref is this entity's exact name, so it now resolves via the
+        // stage-3 exact-name storage lookup (#849) at EXACT_NAME_CONFIDENCE
+        // (0.98) regardless of the ring — proving the ring itself stayed
+        // empty: a ring hit would score 0.95 (exact) or 0.7 (substring),
+        // never 0.98.
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("resolved")
+        );
+        let confidence = results[0]
+            .get("confidence")
+            .and_then(|v| v.as_f64())
+            .unwrap();
+        assert_eq!(
+            confidence, 0.98,
+            "a resolved hit here must come from the exact-name storage lookup, \
+             not the ring (which would score 0.95 exact / 0.7 substring); got {confidence}"
+        );
     }
 
     /// Regression for the namespace-key mismatch (review finding, 2026-07-09
@@ -1413,6 +1420,265 @@ mod tests {
         assert!(
             names.contains(&"resolve"),
             "resolve must be registered as a public verb; got {names:?}"
+        );
+    }
+
+    // ---- exact-name storage lookup (stage 3, #849) ----
+    //
+    // These entities are created directly on the runtime (bypassing
+    // `registry.dispatch`, hence bypassing ring admission entirely — same
+    // technique as `resolve_search_result_sets_never_populate_the_ring`), so
+    // the only way `resolve` can find them is the exact-name storage lookup
+    // (or, for the fallback-preserved case, hybrid search).
+
+    /// An entity that already exists but was never referenced through this
+    /// registry's ring resolves via the new exact-name storage lookup, at
+    /// `EXACT_NAME_CONFIDENCE` (0.98) — above the ring's bands, below the
+    /// absolute certainty of an id-string passthrough (1.0). Also regression
+    /// coverage for the literal #849 repro: `kind="entity"` is the bare
+    /// substrate label (no filter), not a literal `entities.kind` value.
+    #[tokio::test]
+    async fn resolve_exact_name_hit_resolves_high_confidence() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let entity = rt
+            .create_entity(&direct_tok, "concept", None, "RoLoRA", None, None, vec![])
+            .await
+            .expect("direct entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["RoLoRA"], "kind": "entity"}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("resolved"),
+            "an existing exact name must resolve even when never referenced \
+             through this session's ring: {results:?}"
+        );
+        assert_eq!(
+            results[0].get("id").and_then(|v| v.as_str()),
+            Some(entity.id.to_string().as_str())
+        );
+        assert_eq!(
+            results[0].get("confidence").and_then(|v| v.as_f64()),
+            Some(0.98)
+        );
+    }
+
+    /// Two entities sharing the exact same name resolve as `Ambiguous`,
+    /// never a silent pick, mirroring the ring's duplicate-name contract.
+    #[tokio::test]
+    async fn resolve_exact_name_ambiguous_on_duplicate_names() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        for _ in 0..2 {
+            rt.create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "duplicate exact name",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct entity create must succeed");
+        }
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["duplicate exact name"]}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("ambiguous")
+        );
+        let candidates = results[0]
+            .get("candidates")
+            .and_then(|v| v.as_array())
+            .expect("ambiguous result must carry candidates");
+        assert_eq!(candidates.len(), 2);
+    }
+
+    /// A ref with no exact-name storage match still falls through to the
+    /// hybrid-search fallback (existing stage-4 behavior preserved): a
+    /// partial-phrase query that cannot exact-match any name resolves via
+    /// search, at a confidence below the exact-name stage's 0.98.
+    #[tokio::test]
+    async fn resolve_exact_name_miss_falls_through_to_hybrid_search() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let entity = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "Existing Multi Word Fallback Target",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["Multi Word Fallback Target"]}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("resolved"),
+            "a non-exact phrase must still resolve via the preserved hybrid \
+             fallback: {results:?}"
+        );
+        assert_eq!(
+            results[0].get("id").and_then(|v| v.as_str()),
+            Some(entity.id.to_string().as_str())
+        );
+        let confidence = results[0]
+            .get("confidence")
+            .and_then(|v| v.as_f64())
+            .unwrap();
+        assert!(
+            confidence < 0.98,
+            "a hybrid-search resolution must score below the exact-name \
+             stage's confidence, proving it came from stage 4 not stage 3; \
+             got {confidence}"
+        );
+    }
+
+    /// A soft-deleted entity is invisible to the exact-name storage lookup
+    /// (`deleted_at IS NULL` is baked into `query_entities`), matching the
+    /// rest of the KG surface's soft-delete contract.
+    #[tokio::test]
+    async fn resolve_exact_name_soft_deleted_entity_not_matched() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let entity = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "soon to be deleted",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct entity create must succeed");
+        rt.delete_entity(&direct_tok, entity.id, false)
+            .await
+            .expect("soft delete must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["soon to be deleted"]}))
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("not_found"),
+            "a soft-deleted entity must not resolve by its old exact name: {results:?}"
+        );
+    }
+
+    /// A granular `kind` filter narrows the exact-name lookup: two entities
+    /// with the exact same name but different entity kinds resolve
+    /// deterministically to the one matching `kind`, instead of `Ambiguous`.
+    #[tokio::test]
+    async fn resolve_exact_name_respects_kind_filter() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let direct_tok = rt.authorize(Namespace::local()).unwrap();
+        let concept = rt
+            .create_entity(
+                &direct_tok,
+                "concept",
+                None,
+                "shared exact name",
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("direct entity create must succeed");
+        rt.create_entity(
+            &direct_tok,
+            "document",
+            None,
+            "shared exact name",
+            None,
+            None,
+            vec![],
+        )
+        .await
+        .expect("direct entity create must succeed");
+
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch(
+                "resolve",
+                json!({"refs": ["shared exact name"], "kind": "concept"}),
+            )
+            .await
+            .expect("resolve must succeed");
+        let results = result.get("results").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            results[0].get("status").and_then(|v| v.as_str()),
+            Some("resolved"),
+            "kind=\"concept\" must narrow the two same-name entities down to \
+             one match instead of surfacing Ambiguous: {results:?}"
+        );
+        assert_eq!(
+            results[0].get("id").and_then(|v| v.as_str()),
+            Some(concept.id.to_string().as_str())
+        );
+    }
+
+    /// `resolve`'s `kind` param is entity-only, matching the id-string
+    /// passthrough and ring stages: a note kind is rejected with a clear
+    /// error rather than silently over-filtering to zero matches.
+    #[tokio::test]
+    async fn resolve_kind_rejects_non_entity_kind() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let mut builder = VerbRegistryBuilder::new();
+        builder.with_default_namespace("local");
+        builder.register(KgPack::new(rt.clone()));
+        let registry = builder.build().expect("registry build");
+
+        let result = registry
+            .dispatch("resolve", json!({"refs": ["anything"], "kind": "note"}))
+            .await;
+        assert!(
+            result.is_err(),
+            "resolve(kind=\"note\") must fail loud, not silently over-filter"
         );
     }
 }

--- a/crates/khive-pack-kg/src/handlers/resolve.rs
+++ b/crates/khive-pack-kg/src/handlers/resolve.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 
 use khive_runtime::{NamespaceToken, ReferenceResolution, RuntimeError, VerbRegistry};
 
-use super::common::deser;
+use super::common::{deser, resolve_kind_spec, KindSpec};
 use super::params::ResolveParams;
 use crate::KgPack;
 
@@ -35,6 +35,26 @@ impl KgPack {
         let limit = p.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
         let ring = registry.reference_ring();
 
+        // `resolve`'s pipeline (id-string passthrough, ring, exact-name
+        // storage lookup, hybrid search) is entity-only, so `kind` here
+        // follows the same substrate-or-granular discriminant as
+        // `create`/`list`/`search` (see `resolve_kind_spec`): the bare
+        // substrate label `"entity"` means "no kind filter", not a literal
+        // `entities.kind` value. Forwarding the raw string as-is would filter
+        // every real match out (#849) — `entities.kind` only ever holds a
+        // granular value like `"concept"`, never `"entity"`.
+        let entity_kind = match &p.kind {
+            Some(raw) => match resolve_kind_spec(raw, registry)? {
+                KindSpec::Entity { specific } => specific,
+                _ => {
+                    return Err(RuntimeError::InvalidInput(format!(
+                        "resolve only supports entity kinds; kind={raw:?} is not an entity kind"
+                    )))
+                }
+            },
+            None => None,
+        };
+
         let mut results = Vec::with_capacity(p.refs.len());
         for nl_ref in &p.refs {
             let resolution = khive_runtime::resolve_reference(
@@ -43,7 +63,7 @@ impl KgPack {
                 token,
                 nl_ref,
                 limit,
-                p.kind.as_deref(),
+                entity_kind.as_deref(),
             )
             .await?;
             results.push(render_resolution(nl_ref, resolution));

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -1,7 +1,7 @@
 //! `resolve_reference`: the Layer-0 deterministic reference resolver from the
 //! "unified-verb" draft ADR (Slice 1 — resolver + ring).
 //!
-//! Turns a natural-language reference into an id through three ordered
+//! Turns a natural-language reference into an id through four ordered
 //! stages, never guessing among close candidates:
 //!
 //! 1. **Id-string passthrough.** A ref that already looks like a UUID or an
@@ -14,7 +14,12 @@
 //!    `NotFound` here, not an error — a caller resolving those uses `get`.
 //! 2. **Recently-referenced ring.** An exact (case-insensitive) or substring
 //!    match against this actor's ring (`reference_ring::ReferenceRing`).
-//! 3. **Hybrid-search fallback.** `KhiveRuntime::hybrid_search` over the
+//! 3. **Exact-name storage lookup.** A deterministic, case-sensitive match
+//!    against `entities.name` in the caller's namespace (`deleted_at IS
+//!    NULL`) — covers any entity that already exists but was never
+//!    created/get/updated/deleted/merged/linked by this actor in this
+//!    session, so stage 2's ring never saw it (#849).
+//! 4. **Hybrid-search fallback.** `KhiveRuntime::hybrid_search` over the
 //!    caller's namespace, ranked by RRF score.
 //!
 //! A single candidate clearing the stage's confidence bar resolves; multiple
@@ -24,6 +29,9 @@
 use std::str::FromStr;
 
 use uuid::Uuid;
+
+use khive_storage::types::PageRequest;
+use khive_storage::EntityFilter;
 
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::operations::Resolved;
@@ -60,6 +68,13 @@ const RING_SUBSTRING_CONFIDENCE: f64 = 0.7;
 /// against a fixed bar is meaningful. The search stage below uses its own,
 /// deliberately separate rule — see `SEARCH_RESOLVED_CONFIDENCE`.
 const RING_AUTO_RESOLVE_CONFIDENCE: f64 = 0.7;
+/// Confidence for a stage-3 exact-name storage match: a deterministic,
+/// case-sensitive equality on `entities.name` — stronger evidence than the
+/// ring's case-insensitive session cache (`RING_EXACT_CONFIDENCE`), so it
+/// sits above both ring bands, but still below the absolute certainty of an
+/// id-string passthrough (1.0), which the caller supplied directly rather
+/// than by name.
+const EXACT_NAME_CONFIDENCE: f64 = 0.98;
 /// Hybrid-search fallback: the top hit auto-resolves over a runner-up only
 /// when it leads by at least this ratio — RRF scores are not on a fixed
 /// 0..1 confidence scale, so a fixed absolute bar can't express "decisively
@@ -209,7 +224,18 @@ pub async fn resolve_reference(
         return Ok(resolution);
     }
 
-    // Stage 3: hybrid-search fallback over the namespace.
+    // Stage 3: exact-name storage lookup (#849) — a deterministic,
+    // case-sensitive match against `entities.name` in the caller's
+    // namespace, run before the hybrid-search fallback so an existing exact
+    // name always resolves regardless of FTS ranking, RRF score, or whether
+    // this actor's session ever referenced the entity (the ring's blind
+    // spot). Single match resolves; multiple exact matches are `Ambiguous`;
+    // none falls through to hybrid search unchanged.
+    if let Some(resolution) = exact_name_match(runtime, token, trimmed, entity_kind).await? {
+        return Ok(resolution);
+    }
+
+    // Stage 4: hybrid-search fallback over the namespace.
     let hits = runtime
         .hybrid_search(
             token,
@@ -279,6 +305,61 @@ fn resolve_from_candidates(candidates: Vec<ReferenceCandidate>) -> Option<Refere
         }
         _ => Some(ReferenceResolution::Ambiguous { candidates }),
     }
+}
+
+/// Stage 3 of `resolve_reference` (#849): a deterministic, case-sensitive
+/// exact match against `entities.name`, scoped to `token.namespace()` (the
+/// same single-namespace default the rest of this pipeline and the sibling
+/// by-name lookup in `khive-pack-kg`'s `resolve_name_async` use) and to
+/// `entity_kind` when the caller filtered by one. `query_entities` already
+/// excludes soft-deleted rows (`deleted_at IS NULL` is baked into every
+/// query — see `khive-db::stores::entity::build_entity_where`), so no
+/// separate filter is needed here. Returns `None` (fall through to the next
+/// stage) when nothing matches; `Some(Resolved)` on a single hit; and
+/// `Some(Ambiguous)` when the name is not unique.
+async fn exact_name_match(
+    runtime: &KhiveRuntime,
+    token: &NamespaceToken,
+    name: &str,
+    entity_kind: Option<&str>,
+) -> RuntimeResult<Option<ReferenceResolution>> {
+    let filter = EntityFilter {
+        name_prefix: Some(name.to_string()),
+        kinds: entity_kind.map(|k| vec![k.to_string()]).unwrap_or_default(),
+        ..EntityFilter::default()
+    };
+    let page = runtime
+        .entities(token)?
+        .query_entities(
+            token.namespace().as_str(),
+            filter,
+            PageRequest {
+                offset: 0,
+                limit: 100,
+            },
+        )
+        .await
+        .map_err(RuntimeError::Storage)?;
+
+    let exact: Vec<ReferenceCandidate> = page
+        .items
+        .into_iter()
+        .filter(|e| e.name == name)
+        .map(|e| ReferenceCandidate {
+            id: e.id,
+            name: Some(e.name),
+            score: EXACT_NAME_CONFIDENCE,
+        })
+        .collect();
+
+    Ok(match exact.len() {
+        0 => None,
+        1 => Some(ReferenceResolution::Resolved {
+            id: exact[0].id,
+            confidence: EXACT_NAME_CONFIDENCE,
+        }),
+        _ => Some(ReferenceResolution::Ambiguous { candidates: exact }),
+    })
 }
 
 fn is_hex_prefix(s: &str) -> bool {

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -332,9 +332,14 @@ async fn exact_name_match(
     // filter) so a namespace with many newer case variants of `name` can
     // never page the exact target out from under a `created_at DESC` sort
     // (#849, #852) — every row this query returns already equals `name`.
-    // The page is small (10, not 1): a single hit still needs `Resolved`,
-    // but multiple hits must surface every candidate for `Ambiguous`, the
-    // same way the ring and search stages report their candidate sets.
+    // The page is small (10, not 1), but the zero/one/many decision is made
+    // from `page.total` (the storage-computed COUNT(*) under the same
+    // predicate), never from `page.items.len()` — with 11+ byte-identical
+    // exact names the fetched page is still only 10 rows, and deciding from
+    // its length alone would under-report cardinality. `Ambiguous.candidates`
+    // is a bounded sample of up to 10 of the `page.total` matches, not the
+    // complete set — the variant carries no total field, so callers must not
+    // assume `candidates.len() == page.total` (#852 review r3).
     let page = runtime
         .entities(token)?
         .query_entities(
@@ -348,6 +353,8 @@ async fn exact_name_match(
         .await
         .map_err(RuntimeError::Storage)?;
 
+    let total = page.total.unwrap_or(page.items.len() as u64);
+
     let exact: Vec<ReferenceCandidate> = page
         .items
         .into_iter()
@@ -358,12 +365,15 @@ async fn exact_name_match(
         })
         .collect();
 
-    Ok(match exact.len() {
+    Ok(match total {
         0 => None,
-        1 => Some(ReferenceResolution::Resolved {
-            id: exact[0].id,
-            confidence: EXACT_NAME_CONFIDENCE,
-        }),
+        1 => exact
+            .into_iter()
+            .next()
+            .map(|top| ReferenceResolution::Resolved {
+                id: top.id,
+                confidence: EXACT_NAME_CONFIDENCE,
+            }),
         _ => Some(ReferenceResolution::Ambiguous { candidates: exact }),
     })
 }
@@ -578,5 +588,44 @@ mod tests {
                 confidence: EXACT_NAME_CONFIDENCE,
             }
         );
+    }
+
+    /// #852 review r3: the zero/one/many decision must come from the
+    /// storage-computed `page.total` (a full `COUNT(*)` under the exact-name
+    /// predicate), not from `page.items.len()`, which the stage's own
+    /// `LIMIT 10` caps regardless of true cardinality. 11 byte-identical
+    /// exact names exceed that page limit, so the fetched page can only ever
+    /// carry 10 rows — `Ambiguous` must still fire (storage says 11 total,
+    /// not the truncated 10), and the returned `candidates` are a bounded
+    /// sample of the match set, not its entirety. That truncation is an
+    /// intentional, documented contract of this stage, not a bug: this test
+    /// pins both halves so a future change can't silently drop one.
+    #[tokio::test]
+    async fn exact_name_ambiguous_decision_uses_storage_total_not_page_len() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+
+        for _ in 0..11 {
+            rt.create_entity(&token, "concept", None, "DupeExactName", None, None, vec![])
+                .await
+                .expect("create duplicate-named entity");
+        }
+
+        let resolution = resolve_reference(&rt, &ring, &token, "DupeExactName", 5, None)
+            .await
+            .expect("resolve_reference");
+
+        match resolution {
+            ReferenceResolution::Ambiguous { candidates } => {
+                assert_eq!(
+                    candidates.len(),
+                    10,
+                    "candidate set is a bounded 10-row sample of the 11 storage matches, \
+                     not the complete set"
+                );
+            }
+            other => panic!("expected Ambiguous driven by storage total (11), got {other:?}"),
+        }
     }
 }

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -324,10 +324,17 @@ async fn exact_name_match(
     entity_kind: Option<&str>,
 ) -> RuntimeResult<Option<ReferenceResolution>> {
     let filter = EntityFilter {
-        name_prefix: Some(name.to_string()),
+        name_exact: Some(name.to_string()),
         kinds: entity_kind.map(|k| vec![k.to_string()]).unwrap_or_default(),
         ..EntityFilter::default()
     };
+    // A storage-level `name = ?` predicate (not `name_prefix` + in-memory
+    // filter) so a namespace with many newer case variants of `name` can
+    // never page the exact target out from under a `created_at DESC` sort
+    // (#849, #852) — every row this query returns already equals `name`.
+    // The page is small (10, not 1): a single hit still needs `Resolved`,
+    // but multiple hits must surface every candidate for `Ambiguous`, the
+    // same way the ring and search stages report their candidate sets.
     let page = runtime
         .entities(token)?
         .query_entities(
@@ -335,7 +342,7 @@ async fn exact_name_match(
             filter,
             PageRequest {
                 offset: 0,
-                limit: 100,
+                limit: 10,
             },
         )
         .await
@@ -344,7 +351,6 @@ async fn exact_name_match(
     let exact: Vec<ReferenceCandidate> = page
         .items
         .into_iter()
-        .filter(|e| e.name == name)
         .map(|e| ReferenceCandidate {
             id: e.id,
             name: Some(e.name),
@@ -518,5 +524,59 @@ mod tests {
             .await
             .expect("resolve_reference");
         assert_eq!(resolution, ReferenceResolution::NotFound);
+    }
+
+    // Regression for #849/#852: the stage-3 exact-name lookup used to filter
+    // `name_prefix` (`LIKE 'RoLoRA%'`) in memory, and `query_entities` ranks
+    // a `name_prefix` page by `CASE WHEN LOWER(name) = prefix THEN 0 ELSE 1
+    // END, created_at DESC`. Case-insensitive variants of the target name
+    // tie for priority 0 with the true exact match, so 100+ *newer*
+    // lowercase variants can fill the `LIMIT 100` page and page the older,
+    // case-exact target out entirely — the stage then falls through to
+    // hybrid search instead of resolving deterministically. The fix issues a
+    // storage-level `name = ?` (binary) predicate instead, so decoys that
+    // merely match case-insensitively never enter the result set at all.
+    #[tokio::test]
+    async fn exact_name_stage_survives_many_newer_case_variant_decoys() {
+        let rt = KhiveRuntime::memory().expect("in-memory runtime");
+        let token = actor_token("resolver-test");
+        let ring = ReferenceRing::new();
+
+        let target = rt
+            .create_entity(&token, "concept", None, "RoLoRA", None, None, vec![])
+            .await
+            .expect("create target entity");
+
+        // Case variants of the same name, not suffixed variants: SQLite's
+        // `LIKE` is case-insensitive for ASCII, so a `rolora`-named decoy
+        // still matches the `LIKE 'RoLoRA%'` pattern the buggy `name_prefix`
+        // stage used, and the exact-match-ranking `CASE WHEN LOWER(name) =
+        // ...` ties every one of these decoys with the true target at
+        // priority 0 — leaving `created_at DESC` as the only tiebreak.
+        let decoy_cases = ["rolora", "ROLORA", "RoLoRa", "roLORA"];
+        for i in 0..120 {
+            rt.create_entity(
+                &token,
+                "concept",
+                None,
+                decoy_cases[i % decoy_cases.len()],
+                None,
+                None,
+                vec![],
+            )
+            .await
+            .expect("create decoy entity");
+        }
+
+        let resolution = resolve_reference(&rt, &ring, &token, "RoLoRA", 5, None)
+            .await
+            .expect("resolve_reference");
+        assert_eq!(
+            resolution,
+            ReferenceResolution::Resolved {
+                id: target.id,
+                confidence: EXACT_NAME_CONFIDENCE,
+            }
+        );
     }
 }

--- a/crates/khive-storage/src/entity.rs
+++ b/crates/khive-storage/src/entity.rs
@@ -87,6 +87,15 @@ pub struct EntityFilter {
     /// Filter by exact `entity_type` value. Multiple values are ORed.
     pub entity_types: Vec<String>,
     pub name_prefix: Option<String>,
+    /// Deterministic, case-sensitive equality on `entities.name` (binary
+    /// comparison — SQLite's default collation for `=` on a `TEXT` column
+    /// without an explicit `COLLATE NOCASE`). Distinct from `name_prefix`:
+    /// that stage's `LIKE` is inherently prefix-shaped and, with SQLite's
+    /// default `NOCASE`-free `LIKE` on ASCII, still ranks a page by
+    /// `created_at DESC` — a match that is exact but not the newest can be
+    /// paged out. `name_exact` skips paging risk entirely by filtering to
+    /// only rows that equal `name` at the SQL layer.
+    pub name_exact: Option<String>,
     pub tags_any: Vec<String>,
     /// When non-empty, restricts results to any of these namespaces using
     /// `namespace IN (...)`. Takes precedence over the `namespace` string


### PR DESCRIPTION
## Summary

`resolve(refs=["RoLoRA"], kind="entity")` returned `not_found` even though the `RoLoRA` entity existed and `search(kind="entity", query="RoLoRA")` found it in the same session. Fixes Fork B of #849 (the GQL `WHERE e.name = "..."` equality gap from the same issue is out of scope here).

## Root cause

Two compounding bugs in the resolve pipeline:

1. **No exact-name check against storage.** `resolve`'s only "exact" matching happened against the actor's session-scoped reference ring (`crates/khive-runtime/src/reference_resolution.rs`, stage 2). Any entity that already existed but was never `create`d/`get`/`update`d/`delete`d/`merge`d/`link`ed by this actor in this session was invisible to that stage, and the pipeline fell straight to the hybrid-search fallback — which is FTS/RRF-ranked, not exact-match, and can legitimately return `NotFound` or `Ambiguous` for a name that unambiguously exists.
2. **`kind` was forwarded unnormalized.** `crates/khive-pack-kg/src/handlers/resolve.rs:46` (before this change) passed the raw `kind` string straight into the fallback's `entity_kind` filter, unlike `create`/`list`/`search`, which normalize `kind` through `resolve_kind_spec` first. Passing the substrate label `kind="entity"` (as in the reported repro) became an `EntityFilter.kinds = ["entity"]` filter at `crates/khive-runtime/src/retrieval.rs:459`. No real entity ever matches that — `entities.kind` only ever holds a granular value like `"concept"` — so the fallback's alive-set filter silently dropped every candidate before scoring ever ran.

## Fix

- Added a deterministic, case-sensitive exact-name storage lookup as a new stage in `resolve_reference`, placed after the id-string passthrough and ring stages and before the hybrid-search fallback:
  - Single exact match → `Resolved` at a fixed 0.98 confidence (above both ring bands, below the 1.0 certainty of an id-string passthrough).
  - Multiple exact matches → `Ambiguous`, listing the candidates (never a silent pick).
  - No exact match → falls through to hybrid search unchanged.
  - Scoped to the caller's namespace and `deleted_at IS NULL`, matching the rest of the by-name lookup surface (`crates/khive-pack-kg/src/handlers/common.rs::resolve_name_async`).
- Normalized `resolve`'s `kind` param through `resolve_kind_spec`, so the bare substrate label `"entity"` means "no kind filter" (consistent with `create`/`list`/`search`) and a non-entity kind (e.g. `"note"`) is rejected with a clear error instead of silently over-filtering to zero matches.

## Tests

Added to `crates/khive-pack-kg/src/dispatch.rs`:
- exact-name hit resolves at high confidence, even for an entity never referenced through this session's ring (also the literal #849 regression case: `kind="entity"`)
- two entities sharing the exact same name resolve as `Ambiguous`
- a non-exact ref still falls through to the hybrid-search fallback (existing behavior preserved)
- a soft-deleted entity is not matched by its old exact name
- a granular `kind` filter narrows two same-name entities down to one match
- a non-entity `kind` is rejected with an error

Updated one pre-existing test (`resolve_search_result_sets_never_populate_the_ring`) whose ref happened to be an entity's exact name: it now correctly resolves via the new exact-name stage instead of the (no-longer-reached) hybrid fallback; the ring-emptiness invariant it was written to check still holds.

## Test plan

- [x] `cargo test -p khive-pack-kg` — 786 passed, 0 failed
- [x] `cargo test -p khive-runtime` — passed (reference_resolution + integration suites)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean, 0 warnings

Root cause: `crates/khive-pack-kg/src/handlers/resolve.rs:46` (unnormalized `kind` forwarding) and `crates/khive-runtime/src/reference_resolution.rs` (no exact-name-against-storage stage between the ring and hybrid-search stages).