### PR TITLE
fix(workspace): declare rust-version (MSRV 1.91.0) on every published crate (#398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ cd crates && cargo test --workspace
 make ci  # Full CI: fmt, clippy, test, build
 ```
 
-Prerequisites: Rust 1.94+ (via [rustup](https://rustup.rs)),
+Prerequisites: Rust 1.91+ (workspace MSRV) (via [rustup](https://rustup.rs)),
 Deno 2.x (for the TypeScript CLI layer, optional)
 
 - Node.js 20+ and pnpm (for frontend, optional)

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -50,6 +50,11 @@ exclude = ["khive-merge"]
 [workspace.package]
 version = "0.3.0"
 edition = "2021"
+# floor_char_boundary/ceil_char_boundary (round_char_boundary, rust-lang/rust#93743)
+# stabilized in 1.91.0; khive-pack-brain's persist.rs uses floor_char_boundary.
+# Verified by compiling a minimal probe against installed 1.90.0 (E0658,
+# unstable) vs 1.91.0 (compiles) — see issue #398.
+rust-version = "1.91.0"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/ohdearquant/khive"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -53,7 +53,7 @@ edition = "2021"
 # floor_char_boundary/ceil_char_boundary (round_char_boundary, rust-lang/rust#93743)
 # stabilized in 1.91.0; khive-pack-brain's persist.rs uses floor_char_boundary.
 # Verified by compiling a minimal probe against installed 1.90.0 (E0658,
-# unstable) vs 1.91.0 (compiles) — see issue #398.
+# unstable) vs 1.91.0 (compiles); see issue #398.
 rust-version = "1.91.0"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/khive-bm25/Cargo.toml
+++ b/crates/khive-bm25/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-bm25"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-brain-core/Cargo.toml
+++ b/crates/khive-brain-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-brain-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-changeset/Cargo.toml
+++ b/crates/khive-changeset/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-changeset"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-channel-email/Cargo.toml
+++ b/crates/khive-channel-email/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-channel-email"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-channel/Cargo.toml
+++ b/crates/khive-channel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-channel"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-db/Cargo.toml
+++ b/crates/khive-db/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-db"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-fold/Cargo.toml
+++ b/crates/khive-fold/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-fold"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-fusion/Cargo.toml
+++ b/crates/khive-fusion/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-fusion"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-gate-rego/Cargo.toml
+++ b/crates/khive-gate-rego/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-gate-rego"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-gate/Cargo.toml
+++ b/crates/khive-gate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-gate"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-hnsw/Cargo.toml
+++ b/crates/khive-hnsw/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-hnsw"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-mcp/Cargo.toml
+++ b/crates/khive-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-mcp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-brain/Cargo.toml
+++ b/crates/khive-pack-brain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-brain"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-code/Cargo.toml
+++ b/crates/khive-pack-code/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-code"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-comm/Cargo.toml
+++ b/crates/khive-pack-comm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-comm"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-formal/Cargo.toml
+++ b/crates/khive-pack-formal/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-formal"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-git/Cargo.toml
+++ b/crates/khive-pack-git/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-git"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-gtd/Cargo.toml
+++ b/crates/khive-pack-gtd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-gtd"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-kg/Cargo.toml
+++ b/crates/khive-pack-kg/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-kg"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-knowledge/Cargo.toml
+++ b/crates/khive-pack-knowledge/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-knowledge"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-memory/Cargo.toml
+++ b/crates/khive-pack-memory/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-memory"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-schedule/Cargo.toml
+++ b/crates/khive-pack-schedule/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-schedule"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-session/Cargo.toml
+++ b/crates/khive-pack-session/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-session"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-pack-template/Cargo.toml
+++ b/crates/khive-pack-template/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-pack-template"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-quant/Cargo.toml
+++ b/crates/khive-quant/Cargo.toml
@@ -3,6 +3,7 @@ name = "khive-quant"
 description = "SQ8 scalar quantization codecs (global-scale symmetric + per-dim affine) shared by HNSW and Vamana indexes."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-query"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-request/Cargo.toml
+++ b/crates/khive-request/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-request"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-retrieval/Cargo.toml
+++ b/crates/khive-retrieval/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-retrieval"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-runtime/Cargo.toml
+++ b/crates/khive-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-runtime"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-score/Cargo.toml
+++ b/crates/khive-score/Cargo.toml
@@ -3,6 +3,7 @@ name = "khive-score"
 description = "Deterministic fixed-point scoring: cross-platform ordering, aggregation (sum/avg/max/min/RRF), ranking with ID tiebreak."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-storage/Cargo.toml
+++ b/crates/khive-storage/Cargo.toml
@@ -3,6 +3,7 @@ name = "khive-storage"
 description = "Storage capability traits: SqlAccess, VectorStore, TextSearch. Zero implementations — only contracts."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-text/Cargo.toml
+++ b/crates/khive-text/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-text"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-types/Cargo.toml
+++ b/crates/khive-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "khive-types"
 description = "Core type primitives: Id128, Timestamp, Namespace, and the 3 substrate data types (Note, Entity, Event)."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-vamana/Cargo.toml
+++ b/crates/khive-vamana/Cargo.toml
@@ -3,6 +3,7 @@ name = "khive-vamana"
 description = "Batch-built Vamana ANN index for pre-normalized vector search."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-vcs-adapters/Cargo.toml
+++ b/crates/khive-vcs-adapters/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-vcs-adapters"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/khive-vcs/Cargo.toml
+++ b/crates/khive-vcs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khive-vcs"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kkernel/Cargo.toml
+++ b/crates/kkernel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kkernel"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Root cause

The 0.3.0 crates declared no `rust-version`, but `khive-pack-brain`'s `persist.rs` calls `str::floor_char_boundary`, which was unstable (`round_char_boundary` feature, rust-lang/rust#93743) before it stabilized. A consumer building with an older toolchain hit a raw `E0658` feature-gate error deep inside the dependency compile instead of cargo's clean "package requires rustc X.Y or newer" refusal.

## Determining the true MSRV

Bisected installed toolchains by compiling a minimal probe:

```rust
fn main() {
    let b = "hello".floor_char_boundary(3);
}
```

- rustc 1.90.0 → `error[E0658]: use of unstable library feature 'round_char_boundary'`
- rustc 1.91.0 → compiles cleanly

So `floor_char_boundary`/`ceil_char_boundary` stabilized in **1.91.0** — that's the workspace MSRV.

## Fix

- Added `rust-version = "1.91.0"` to `[workspace.package]` in `crates/Cargo.toml`.
- Added `rust-version.workspace = true` to every member crate that already inherits `edition.workspace = true` (37 crates — every published crate). `khive-merge` is intentionally excluded: it's a standalone forward-deployed workspace outside the main workspace's member list, with its own separate `[workspace.package]`.

## Verification

```
cargo check --workspace   # clean
```

## Test plan
- [x] `cargo check --workspace` passes with the declared MSRV
- [x] Bisection evidence (1.90.0 fails, 1.91.0 compiles) recorded in the commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)