### PR TITLE
fix(kg): accept resource entity kind in JSON/NDJSON import adapters (#530)

### DIFF
--- a/crates/khive-vcs-adapters/src/json_adapter.rs
+++ b/crates/khive-vcs-adapters/src/json_adapter.rs
@@ -27,8 +27,27 @@ impl JsonFormatAdapter {
     /// Parse `json_input` and return a ready adapter.
     ///
     /// Returns `Err(AdapterError::Parse)` if `json_input` is not valid JSON or
-    /// is not a JSON array at the top level.
+    /// is not a JSON array at the top level. Entity `kind` is validated only
+    /// against the base ADR-001 kind set (plus aliases) — pack-registered
+    /// granular kinds (e.g. `resource`, ADR-048) are rejected here. Use
+    /// [`Self::new_with_valid_kinds`] to accept a wider, caller-supplied set.
     pub fn new(json_input: &str) -> Result<Self, AdapterError> {
+        Self::new_with_valid_kinds(json_input, &[])
+    }
+
+    /// Like [`Self::new`], but entity `kind` values not recognized by the
+    /// base ADR-001 enum are additionally accepted when they exact-match
+    /// (case-insensitive) an entry in `extra_valid_kinds`.
+    ///
+    /// Callers that have a merged pack/runtime kind registry (e.g.
+    /// `KhiveRuntime::install_kind_registry`'s installed entity kinds) should
+    /// pass it here so pack-registered granular kinds like `resource` are not
+    /// rejected before the runtime even sees them (issue #530 — the JSON/NDJSON
+    /// counterpart to the archive-format fix in #529 / issue #438).
+    pub fn new_with_valid_kinds(
+        json_input: &str,
+        extra_valid_kinds: &[String],
+    ) -> Result<Self, AdapterError> {
         let value: Value =
             serde_json::from_str(json_input).map_err(|e| AdapterError::Parse(e.to_string()))?;
 
@@ -71,7 +90,7 @@ impl JsonFormatAdapter {
             if has_source && has_target {
                 edges.push(parse_edge(index, obj, &mut warnings));
             } else {
-                entities.push(parse_entity(index, obj, &mut warnings));
+                entities.push(parse_entity(index, obj, &mut warnings, extra_valid_kinds));
             }
         }
 
@@ -196,17 +215,32 @@ fn parse_entity(
     index: usize,
     mut obj: serde_json::Map<String, Value>,
     warnings: &mut Vec<String>,
+    extra_valid_kinds: &[String],
 ) -> Result<EntityRecord, AdapterError> {
     let name = extract_required_string(&mut obj, index, "name")?;
 
     let raw_kind = extract_required_string(&mut obj, index, "kind")?;
-    let kind = EntityKind::from_str(&raw_kind)
-        .map_err(|_| AdapterError::UnknownKind {
-            index,
-            kind: raw_kind.clone(),
-        })?
-        .name()
-        .to_owned();
+    let kind = match EntityKind::from_str(&raw_kind) {
+        Ok(k) => k.name().to_owned(),
+        Err(_) => {
+            // Not one of the base ADR-001 kinds (or an alias). Accept it only
+            // if the caller supplied a wider registry (pack-registered
+            // granular kinds, e.g. `resource` — ADR-048) that recognizes it;
+            // otherwise this is a genuinely unknown kind.
+            let normalized = raw_kind.trim().to_ascii_lowercase();
+            if extra_valid_kinds
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case(&normalized))
+            {
+                normalized
+            } else {
+                return Err(AdapterError::UnknownKind {
+                    index,
+                    kind: raw_kind.clone(),
+                });
+            }
+        }
+    };
 
     // ADR-020 subtype: prefer an explicit `entity_type`, else preserve a
     // `kind="paper"`-style alias (which `EntityKind::from_str` canonicalizes

--- a/crates/khive-vcs-adapters/src/json_adapter.rs
+++ b/crates/khive-vcs-adapters/src/json_adapter.rs
@@ -28,7 +28,7 @@ impl JsonFormatAdapter {
     ///
     /// Returns `Err(AdapterError::Parse)` if `json_input` is not valid JSON or
     /// is not a JSON array at the top level. Entity `kind` is validated only
-    /// against the base ADR-001 kind set (plus aliases) — pack-registered
+    /// against the base ADR-001 kind set (plus aliases): pack-registered
     /// granular kinds (e.g. `resource`, ADR-048) are rejected here. Use
     /// [`Self::new_with_valid_kinds`] to accept a wider, caller-supplied set.
     pub fn new(json_input: &str) -> Result<Self, AdapterError> {
@@ -42,7 +42,7 @@ impl JsonFormatAdapter {
     /// Callers that have a merged pack/runtime kind registry (e.g.
     /// `KhiveRuntime::install_kind_registry`'s installed entity kinds) should
     /// pass it here so pack-registered granular kinds like `resource` are not
-    /// rejected before the runtime even sees them (issue #530 — the JSON/NDJSON
+    /// rejected before the runtime even sees them (issue #530, the JSON/NDJSON
     /// counterpart to the archive-format fix in #529 / issue #438).
     pub fn new_with_valid_kinds(
         json_input: &str,
@@ -225,7 +225,7 @@ fn parse_entity(
         Err(_) => {
             // Not one of the base ADR-001 kinds (or an alias). Accept it only
             // if the caller supplied a wider registry (pack-registered
-            // granular kinds, e.g. `resource` — ADR-048) that recognizes it;
+            // granular kinds, e.g. `resource`, ADR-048) that recognizes it;
             // otherwise this is a genuinely unknown kind.
             let normalized = raw_kind.trim().to_ascii_lowercase();
             if extra_valid_kinds

--- a/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
+++ b/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
@@ -665,13 +665,13 @@ fn test_json_adapter_edge_properties_non_object_warns() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 13 — new_with_valid_kinds accepts a caller-supplied pack kind (#530)
+// Test 13 - new_with_valid_kinds accepts a caller-supplied pack kind (#530)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn test_json_adapter_default_new_still_rejects_resource_kind() {
     // Plain `new()` (no injected registry) must keep rejecting kinds outside
-    // the base ADR-001 set — `resource` is pack-registered (ADR-048), not a
+    // the base ADR-001 set: `resource` is pack-registered (ADR-048), not a
     // base kind or alias.
     let mut adapter = JsonFormatAdapter::new(r#"[{"kind":"resource","name":"X"}]"#)
         .expect("structurally valid JSON must construct");
@@ -701,7 +701,7 @@ fn test_json_adapter_new_with_valid_kinds_accepts_resource_kind() {
 #[test]
 fn test_json_adapter_new_with_valid_kinds_still_rejects_unregistered_kind() {
     // A kind that is neither a base ADR-001 kind nor present in the injected
-    // registry must still be rejected — the injected registry widens, it does
+    // registry must still be rejected: the injected registry widens, it does
     // not disable, validation.
     let valid_kinds = vec!["resource".to_string()];
     let mut adapter =

--- a/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
+++ b/crates/khive-vcs-adapters/tests/json_adapter_tests.rs
@@ -663,3 +663,53 @@ fn test_json_adapter_edge_properties_non_object_warns() {
         adapter.warnings()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 13 — new_with_valid_kinds accepts a caller-supplied pack kind (#530)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_json_adapter_default_new_still_rejects_resource_kind() {
+    // Plain `new()` (no injected registry) must keep rejecting kinds outside
+    // the base ADR-001 set — `resource` is pack-registered (ADR-048), not a
+    // base kind or alias.
+    let mut adapter = JsonFormatAdapter::new(r#"[{"kind":"resource","name":"X"}]"#)
+        .expect("structurally valid JSON must construct");
+    let first = adapter.entities().next().expect("one record present");
+    assert!(
+        matches!(first, Err(AdapterError::UnknownKind { kind, .. }) if kind == "resource"),
+        "resource must be rejected without an injected valid-kinds registry"
+    );
+}
+
+#[test]
+fn test_json_adapter_new_with_valid_kinds_accepts_resource_kind() {
+    let valid_kinds = vec!["resource".to_string()];
+    let mut adapter = JsonFormatAdapter::new_with_valid_kinds(
+        r#"[{"kind":"resource","name":"X"}]"#,
+        &valid_kinds,
+    )
+    .expect("structurally valid JSON must construct");
+    let first = adapter
+        .entities()
+        .next()
+        .expect("one record present")
+        .expect("resource kind must be accepted when present in the injected registry");
+    assert_eq!(first.kind, "resource");
+}
+
+#[test]
+fn test_json_adapter_new_with_valid_kinds_still_rejects_unregistered_kind() {
+    // A kind that is neither a base ADR-001 kind nor present in the injected
+    // registry must still be rejected — the injected registry widens, it does
+    // not disable, validation.
+    let valid_kinds = vec!["resource".to_string()];
+    let mut adapter =
+        JsonFormatAdapter::new_with_valid_kinds(r#"[{"kind":"gadget","name":"X"}]"#, &valid_kinds)
+            .expect("structurally valid JSON must construct");
+    let first = adapter.entities().next().expect("one record present");
+    assert!(
+        matches!(first, Err(AdapterError::UnknownKind { kind, .. }) if kind == "gadget"),
+        "unregistered kind must still be rejected with a non-empty valid-kinds registry"
+    );
+}

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -90,7 +90,7 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
         ..Default::default()
     };
     let runtime = KhiveRuntime::new(config)?;
-    install_import_kind_registry(&runtime)?;
+    let valid_entity_kinds = install_import_kind_registry(&runtime)?;
     let token = runtime.authorize(ns)?;
 
     let source = std::fs::read_to_string(&args.source)
@@ -112,7 +112,7 @@ pub(super) async fn cmd_import(args: ImportArgs) -> Result<()> {
                 ImportFormat::Ndjson => ndjson_to_json_array(&source)?,
                 ImportFormat::Archive => unreachable!(),
             };
-            let mut adapter = JsonFormatAdapter::new(&input)
+            let mut adapter = JsonFormatAdapter::new_with_valid_kinds(&input, &valid_entity_kinds)
                 .with_context(|| format!("parse adapter input {}", args.source.display()))?;
             if args.verbose {
                 for warning in adapter.warnings() {
@@ -230,7 +230,11 @@ pub(super) fn validate_archive_edge_weights(archive: &KgArchive) -> Result<()> {
 /// so that `runtime.import_kg` (and any other runtime-layer kind validation)
 /// accepts pack-registered kinds such as `resource`, not just the eight base
 /// `khive_types::EntityKind` variants.
-fn install_import_kind_registry(runtime: &KhiveRuntime) -> Result<()> {
+///
+/// Returns the merged entity-kind list so callers can also thread it into
+/// adapter-layer validation (see `JsonFormatAdapter::new_with_valid_kinds`,
+/// issue #530).
+fn install_import_kind_registry(runtime: &KhiveRuntime) -> Result<Vec<String>> {
     let mut builder = VerbRegistryBuilder::new();
     let names: Vec<String> = PackRegistry::discovered_names()
         .into_iter()
@@ -239,19 +243,18 @@ fn install_import_kind_registry(runtime: &KhiveRuntime) -> Result<()> {
     PackRegistry::register_packs(&names, runtime.clone(), &mut builder)
         .map_err(|n| anyhow::anyhow!("pack {n:?} declared in inventory but factory missing"))?;
     let registry = builder.build().context("building import VerbRegistry")?;
-    runtime.install_kind_registry(
-        registry
-            .all_entity_kinds()
-            .into_iter()
-            .map(str::to_string)
-            .collect(),
-        registry
-            .all_note_kinds()
-            .into_iter()
-            .map(str::to_string)
-            .collect(),
-    );
-    Ok(())
+    let entity_kinds: Vec<String> = registry
+        .all_entity_kinds()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let note_kinds: Vec<String> = registry
+        .all_note_kinds()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    runtime.install_kind_registry(entity_kinds.clone(), note_kinds);
+    Ok(entity_kinds)
 }
 
 fn adapter_edge_to_exported(edge: EdgeRecord, entity_ids: &HashSet<Uuid>) -> Result<ExportedEdge> {
@@ -606,18 +609,89 @@ mod tests {
         assert_eq!(entity.name, "ImportedResource");
     }
 
-    // NOTE: the JSON/NDJSON adapter import path (`ImportFormat::Json` /
-    // `ImportFormat::Ndjson`) goes through `khive_vcs_adapters::JsonFormatAdapter`,
-    // which independently gates entity kind through the base
-    // `khive_types::EntityKind::from_str` in `parse_entity` — before an
-    // `ExportedEntity`/`KgArchive` is even constructed, and before this module's
-    // `install_import_kind_registry` fix has any effect. Making that path accept
-    // pack-registered kinds like `resource` requires an API change to the shared
-    // `khive-vcs-adapters` crate (also consumed by `khive-vcs` sync) to accept an
-    // injected valid-kind set — architecture work beyond this issue's scope
-    // (archive.rs kind validation, per #438's evidence). Only the archive-format
-    // round-trip path (the issue's reported failure scenario) is fixed here; see
-    // `import_archive_accepts_resource_kind` above.
+    // #530 (follow-up to #438): the JSON/NDJSON adapter import path
+    // (`ImportFormat::Json` / `ImportFormat::Ndjson`) goes through
+    // `khive_vcs_adapters::JsonFormatAdapter`, which used to independently gate
+    // entity kind through the base `khive_types::EntityKind::from_str` — before
+    // an `ExportedEntity`/`KgArchive` was even constructed, and before this
+    // module's `install_import_kind_registry` had any effect. `cmd_import` now
+    // threads the merged entity-kind registry into
+    // `JsonFormatAdapter::new_with_valid_kinds`, so pack-registered granular
+    // kinds like `resource` are accepted at this layer too.
+
+    #[tokio::test]
+    async fn import_json_adapter_accepts_resource_kind() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("import-json-resource.db");
+        let entity_id = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+        let json_input =
+            format!(r#"[{{"id":"{entity_id}","kind":"resource","name":"JsonResource"}}]"#);
+        let source_path = tmp.path().join("records.json");
+        std::fs::write(&source_path, &json_input).unwrap();
+
+        let args = ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Json,
+            verbose: false,
+        };
+        cmd_import(args)
+            .await
+            .expect("JSON adapter import must accept pack-registered `resource` kind");
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let rt2 = KhiveRuntime::new(config).unwrap();
+        let tok2 = rt2.authorize(ns).unwrap();
+        let entity_uuid: Uuid = entity_id.parse().unwrap();
+        let entity = rt2.get_entity(&tok2, entity_uuid).await.unwrap();
+        assert_eq!(entity.kind, "resource");
+        assert_eq!(entity.name, "JsonResource");
+    }
+
+    #[tokio::test]
+    async fn import_ndjson_adapter_accepts_resource_kind() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("import-ndjson-resource.db");
+        let entity_id = "abababab-abab-abab-abab-abababababab";
+
+        let ndjson_input =
+            format!(r#"{{"id":"{entity_id}","kind":"resource","name":"NdjsonResource"}}"#);
+        let source_path = tmp.path().join("records.ndjson");
+        std::fs::write(&source_path, &ndjson_input).unwrap();
+
+        let args = ImportArgs {
+            source: source_path,
+            db: db_path.clone(),
+            namespace: "test-ns".to_string(),
+            format: ImportFormat::Ndjson,
+            verbose: false,
+        };
+        cmd_import(args)
+            .await
+            .expect("NDJSON adapter import must accept pack-registered `resource` kind");
+
+        let ns = Namespace::parse("test-ns").unwrap();
+        let config = RuntimeConfig {
+            db_path: Some(db_path),
+            default_namespace: ns.clone(),
+            embedding_model: None,
+            ..Default::default()
+        };
+        let rt2 = KhiveRuntime::new(config).unwrap();
+        let tok2 = rt2.authorize(ns).unwrap();
+        let entity_uuid: Uuid = entity_id.parse().unwrap();
+        let entity = rt2.get_entity(&tok2, entity_uuid).await.unwrap();
+        assert_eq!(entity.kind, "resource");
+        assert_eq!(entity.name, "NdjsonResource");
+    }
 
     #[tokio::test]
     async fn import_rejects_unregistered_entity_kind() {

--- a/crates/kkernel/src/kg/archive.rs
+++ b/crates/kkernel/src/kg/archive.rs
@@ -612,7 +612,7 @@ mod tests {
     // #530 (follow-up to #438): the JSON/NDJSON adapter import path
     // (`ImportFormat::Json` / `ImportFormat::Ndjson`) goes through
     // `khive_vcs_adapters::JsonFormatAdapter`, which used to independently gate
-    // entity kind through the base `khive_types::EntityKind::from_str` — before
+    // entity kind through the base `khive_types::EntityKind::from_str`, before
     // an `ExportedEntity`/`KgArchive` was even constructed, and before this
     // module's `install_import_kind_registry` had any effect. `cmd_import` now
     // threads the merged entity-kind registry into


### PR DESCRIPTION
## Root cause

Follow-up to #438 / PR #529, which fixed archive-format `kg import` to accept pack-registered granular entity kinds (e.g. `resource`, ADR-048) by installing the merged pack/runtime kind registry before `runtime.import_kg`. The JSON and NDJSON adapter paths still hard-rejected `resource`, because `khive_vcs_adapters::JsonFormatAdapter`'s `parse_entity` gated entity kind through the base `khive_types::EntityKind::from_str` (8 canonical kinds + aliases only) — a second validation gate one crate below where #529's fix lands.

Reproduced via CLI: `kkernel kg import --format json` and `--format ndjson` with `kind:"resource"` both failed with `Error: record 0: unknown entity kind 'resource'` (exit 1), while `--format archive` succeeded.

## Fix

`JsonFormatAdapter` gains `new_with_valid_kinds(json_input, extra_valid_kinds)`, which still canonicalizes the 8 base kinds and their aliases via `EntityKind::from_str`, but additionally accepts any kind present in the caller-supplied `extra_valid_kinds` set instead of rejecting it outright. `new()` is unchanged (delegates with an empty set), so existing callers (including `khive-vcs` sync) keep the current strict behavior unless they opt in.

`kkernel`'s `cmd_import` now threads the same merged entity-kind registry it already installs on the runtime (`install_import_kind_registry`, from #529) into the JSON/NDJSON adapter construction, so `resource` — and any other pack-registered kind — is accepted at the adapter layer too.

## Tests

```
cargo test -p khive-vcs-adapters -p kkernel
```

- `import_json_adapter_accepts_resource_kind` / `import_ndjson_adapter_accepts_resource_kind` (kkernel, CLI-level `cmd_import` round trip through a real database)
- `test_json_adapter_new_with_valid_kinds_accepts_resource_kind` / `test_json_adapter_new_with_valid_kinds_still_rejects_unregistered_kind` / `test_json_adapter_default_new_still_rejects_resource_kind` (adapter-level, khive-vcs-adapters)
- Existing `test_json_adapter_unknown_entity_kind_returns_error` and `import_rejects_unregistered_entity_kind` continue to pass unchanged — the widened registry does not disable validation, it only adds entries.

```
cargo fmt --all -- --check
cargo clippy -p khive-vcs-adapters -p kkernel --all-targets -- -D warnings
```
Both clean.

## Test plan
- [x] `kkernel kg import --format json` with `kind:"resource"` now exits 0
- [x] `kkernel kg import --format ndjson` with `kind:"resource"` now exits 0
- [x] A genuinely unregistered kind is still rejected at both the adapter and runtime layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)