### PR TITLE
fix(query): make substrate node labels (entity/note) satisfiable in GQL/SPARQL (#849)

### DIFF
--- a/crates/khive-query/Cargo.toml
+++ b/crates/khive-query/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+rusqlite = { workspace = true, features = ["bundled"] }
 
 [[bench]]
 name = "parse_bench"

--- a/crates/khive-query/src/compilers/sql.rs
+++ b/crates/khive-query/src/compilers/sql.rs
@@ -216,6 +216,51 @@ fn namespace_filter(alias: &str, opts: &CompileOptions, params: &mut Vec<QueryVa
     }
 }
 
+/// Compile a node label's `kind` predicate against a primary-substrate union
+/// source (the `entities`/`notes`/`events`/`graph_edges` union carrying a
+/// `substrate_kind` column, aliased `primary_nodes` in variable-length
+/// queries and inlined in fixed-length ones).
+///
+/// A substrate label (`entity`/`note`/`event`/`edge`) names a table, not a
+/// stored `kind` value — stored `kind` is always granular (`concept`,
+/// `task`, `observation`, ...). This mirrors the substrate/granular split in
+/// `resolve_kind_spec` (`khive-pack-kg/src/handlers/common.rs`), which the
+/// verb-dispatch surface (`create`/`list`/`search`) already applies. Without
+/// it, `kind = 'entity'` is unsatisfiable by construction: no stored row's
+/// `kind` column is ever literally `"entity"` (issue #849).
+fn kind_filter_predicate(alias: &str, kind: &str, params: &mut Vec<QueryValue>) -> String {
+    match kind {
+        "entity" | "note" | "event" | "edge" => {
+            params.push(QueryValue::Text(kind.to_string()));
+            format!("{alias}.substrate_kind = ?{}", params.len())
+        }
+        _ => {
+            params.push(QueryValue::Text(kind.to_string()));
+            format!("{alias}.kind = ?{}", params.len())
+        }
+    }
+}
+
+/// Same as [`kind_filter_predicate`], for the entity/note-only observation-
+/// target union (`referent_kind` column, issue #468) — only `entity`/`note`
+/// are legal substrate labels there.
+fn observation_kind_filter_predicate(
+    alias: &str,
+    kind: &str,
+    params: &mut Vec<QueryValue>,
+) -> String {
+    match kind {
+        "entity" | "note" => {
+            params.push(QueryValue::Text(kind.to_string()));
+            format!("{alias}.referent_kind = ?{}", params.len())
+        }
+        _ => {
+            params.push(QueryValue::Text(kind.to_string()));
+            format!("{alias}.kind = ?{}", params.len())
+        }
+    }
+}
+
 /// Compile an inline property-map equality (`{key: value}`) to a parameterized
 /// SQL predicate, either against a direct text column (`text_column`, for keys
 /// like `name`/`content` that are stored as dedicated columns) or against
@@ -347,9 +392,13 @@ fn compile_fixed_length(
                         where_parts.push(ns_filter.trim_start_matches(" AND ").to_string());
                     }
                     // `kind` on an event node filters events.kind (e.g. "recall_executed").
+                    // The bare substrate label "event" needs no filter here — the FROM
+                    // source is already the events table exclusively (issue #849).
                     if let Some(ref kind) = np.kind {
-                        params.push(QueryValue::Text(kind.clone()));
-                        where_parts.push(format!("{alias}.kind = ?{}", params.len()));
+                        if kind != "event" {
+                            params.push(QueryValue::Text(kind.clone()));
+                            where_parts.push(format!("{alias}.kind = ?{}", params.len()));
+                        }
                     }
                     // entity_type and properties are not columns on events — reject explicitly.
                     if np.entity_type.is_some() {
@@ -374,8 +423,11 @@ fn compile_fixed_length(
                     }
 
                     if let Some(ref kind) = np.kind {
-                        params.push(QueryValue::Text(kind.clone()));
-                        where_parts.push(format!("{alias}.kind = ?{}", params.len()));
+                        where_parts.push(observation_kind_filter_predicate(
+                            &alias,
+                            kind,
+                            &mut params,
+                        ));
                     }
 
                     // entity_type is NULL on note rows and populated on entity rows;
@@ -410,8 +462,7 @@ fn compile_fixed_length(
                     }
 
                     if let Some(ref kind) = np.kind {
-                        params.push(QueryValue::Text(kind.clone()));
-                        where_parts.push(format!("{alias}.kind = ?{}", params.len()));
+                        where_parts.push(kind_filter_predicate(&alias, kind, &mut params));
                     }
 
                     if let Some(ref et) = np.entity_type {
@@ -1100,8 +1151,7 @@ fn compile_variable_length(
     }
 
     if let Some(ref kind) = start.kind {
-        params.push(QueryValue::Text(kind.clone()));
-        start_conditions.push(format!("s.kind = ?{}", params.len()));
+        start_conditions.push(kind_filter_predicate("s", kind, &mut params));
     }
     if let Some(ref et) = start.entity_type {
         params.push(QueryValue::Text(et.clone()));
@@ -1184,8 +1234,7 @@ fn compile_variable_length(
         end_conditions.push(r_ns_filter.trim_start_matches(" AND ").to_string());
     }
     if let Some(ref kind) = end.kind {
-        params.push(QueryValue::Text(kind.clone()));
-        end_conditions.push(format!("r.kind = ?{}", params.len()));
+        end_conditions.push(kind_filter_predicate("r", kind, &mut params));
     }
     if let Some(ref et) = end.entity_type {
         params.push(QueryValue::Text(et.clone()));

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -5,7 +5,9 @@
 //! QUERY-AUD-002.
 
 use khive_query::ast::{QueryValue, ReturnItem};
-use khive_query::{compile, parse, parse_auto, CompileOptions, QueryError, QueryLanguage};
+use khive_query::{
+    compile, parse, parse_auto, CompileOptions, CompiledQuery, QueryError, QueryLanguage,
+};
 
 fn opts() -> CompileOptions {
     CompileOptions::default()
@@ -1021,4 +1023,236 @@ fn gql_inline_property_map_well_formed_float_still_parses() {
         .params
         .iter()
         .any(|p| matches!(p, QueryValue::Float(n) if *n == 1.5)));
+}
+
+// --- Issue #849: substrate node labels (entity/note) must be satisfiable ---
+//
+// Stored `kind` values are always granular (concept/document/task/...); the
+// substrate words entity/note/edge/event name a *table*, not a stored `kind`.
+// Compiling a bare substrate label straight into `kind = ?` (as fixed/`event`
+// filters did) makes the predicate unsatisfiable by construction. The fix
+// filters the union's `substrate_kind` discriminator column instead. These
+// tests exercise the compiled SQL shape (fixed-length + variable-length +
+// SPARQL) and, for the fixed-length case, execute the compiled SQL against a
+// minimal in-memory fixture matching `khive-db`'s substrate schema to prove
+// the query is actually satisfiable end-to-end, not just shaped correctly.
+
+mod substrate_labels {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Minimal fixture matching `crates/khive-db/sql/schema.sql`'s substrate
+    /// tables. All four must exist (even empty) because the compiler always
+    /// binds a plain node pattern through the `entities UNION notes UNION
+    /// events UNION graph_edges` primary-substrate source.
+    fn fixture_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE entities (
+                id TEXT PRIMARY KEY, namespace TEXT NOT NULL, kind TEXT NOT NULL,
+                name TEXT NOT NULL, description TEXT, properties TEXT,
+                tags TEXT NOT NULL DEFAULT '[]', created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, deleted_at INTEGER,
+                entity_type TEXT, merged_into TEXT, merge_event_id TEXT
+            );
+            CREATE TABLE notes (
+                id TEXT PRIMARY KEY, namespace TEXT NOT NULL, kind TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active', name TEXT,
+                content TEXT NOT NULL DEFAULT '', salience REAL, decay_factor REAL,
+                expires_at INTEGER, properties TEXT, created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, deleted_at INTEGER
+            );
+            CREATE TABLE events (
+                id TEXT PRIMARY KEY, namespace TEXT NOT NULL, verb TEXT NOT NULL,
+                substrate TEXT NOT NULL, actor TEXT NOT NULL, outcome TEXT NOT NULL,
+                data TEXT, duration_us INTEGER NOT NULL DEFAULT 0, target_id TEXT,
+                created_at INTEGER NOT NULL, kind TEXT NOT NULL DEFAULT 'audit',
+                payload TEXT NOT NULL DEFAULT '{}',
+                payload_schema_version INTEGER NOT NULL DEFAULT 1,
+                profile_state_version INTEGER, session_id TEXT,
+                aggregate_kind TEXT, aggregate_id TEXT
+            );
+            CREATE TABLE graph_edges (
+                namespace TEXT NOT NULL, id TEXT NOT NULL, source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL, relation TEXT NOT NULL,
+                weight REAL NOT NULL DEFAULT 1.0, created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, deleted_at INTEGER, metadata TEXT,
+                target_backend TEXT, PRIMARY KEY (namespace, id)
+            );
+            INSERT INTO entities
+                (id, namespace, kind, name, description, properties, tags,
+                 created_at, updated_at, deleted_at, entity_type)
+            VALUES
+                ('e-fixture-1', 'local', 'concept', 'X', NULL, '{}', '[]',
+                 0, 0, NULL, NULL);
+            INSERT INTO notes
+                (id, namespace, kind, status, name, content, salience,
+                 decay_factor, expires_at, properties, created_at, updated_at,
+                 deleted_at)
+            VALUES
+                ('n-fixture-1', 'local', 'observation', 'active', 'X', 'body',
+                 NULL, NULL, NULL, '{}', 0, 0, NULL);",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn run(conn: &Connection, compiled: &CompiledQuery) -> Vec<String> {
+        let db_params: Vec<Box<dyn rusqlite::ToSql>> = compiled
+            .params
+            .iter()
+            .map(|p| -> Box<dyn rusqlite::ToSql> {
+                match p {
+                    QueryValue::Null => Box::new(Option::<i64>::None),
+                    QueryValue::Integer(n) => Box::new(*n),
+                    QueryValue::Float(n) => Box::new(*n),
+                    QueryValue::Text(s) => Box::new(s.clone()),
+                    QueryValue::Blob(b) => Box::new(b.clone()),
+                }
+            })
+            .collect();
+        let param_refs: Vec<&dyn rusqlite::ToSql> = db_params.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&compiled.sql).unwrap();
+        stmt.query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn entity_substrate_label_compiles_without_unsatisfiable_kind_filter() {
+        let q = parse(
+            QueryLanguage::Gql,
+            "MATCH (e:entity) WHERE e.name = 'X' RETURN e.id",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.sql.contains("substrate_kind = ?"),
+            "substrate label 'entity' must filter substrate_kind, not kind; sql: {}",
+            compiled.sql
+        );
+        assert!(
+            !compiled.sql.contains("n0.kind = ?"),
+            "substrate label 'entity' must not also emit an unsatisfiable kind filter; sql: {}",
+            compiled.sql
+        );
+
+        let conn = fixture_db();
+        let rows = run(&conn, &compiled);
+        assert_eq!(
+            rows,
+            vec!["e-fixture-1".to_string()],
+            "MATCH (e:entity) WHERE e.name = 'X' must return the existing entity row; sql: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn note_substrate_label_compiles_without_unsatisfiable_kind_filter() {
+        let q = parse(
+            QueryLanguage::Gql,
+            "MATCH (n:note) WHERE n.name = 'X' RETURN n.id",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.sql.contains("substrate_kind = ?"),
+            "substrate label 'note' must filter substrate_kind, not kind; sql: {}",
+            compiled.sql
+        );
+
+        let conn = fixture_db();
+        let rows = run(&conn, &compiled);
+        assert_eq!(
+            rows,
+            vec!["n-fixture-1".to_string()],
+            "MATCH (n:note) WHERE n.name = 'X' must return the existing note row; sql: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn granular_label_still_filters_kind_column() {
+        let q = parse(QueryLanguage::Gql, "MATCH (e:concept) RETURN e.id").unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.sql.contains("n0.kind = ?"),
+            "granular label 'concept' must still emit kind = ?; sql: {}",
+            compiled.sql
+        );
+        let has_concept_param = compiled
+            .params
+            .iter()
+            .any(|p| matches!(p, QueryValue::Text(s) if s == "concept"));
+        assert!(has_concept_param, "params: {:?}", compiled.params);
+
+        let conn = fixture_db();
+        let rows = run(&conn, &compiled);
+        assert_eq!(
+            rows,
+            vec!["e-fixture-1".to_string()],
+            "MATCH (e:concept) must still return the concept-kind entity row; sql: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn sparql_entity_substrate_label_compiles_and_returns_row() {
+        let q = parse(
+            QueryLanguage::Sparql,
+            "SELECT ?e WHERE { ?e a :entity . ?e :name \"X\" . }",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.sql.contains("substrate_kind = ?"),
+            "SPARQL 'a :entity' must filter substrate_kind, not kind (frontend parity); sql: {}",
+            compiled.sql
+        );
+
+        let conn = fixture_db();
+        let db_params: Vec<Box<dyn rusqlite::ToSql>> = compiled
+            .params
+            .iter()
+            .map(|p| -> Box<dyn rusqlite::ToSql> {
+                match p {
+                    QueryValue::Null => Box::new(Option::<i64>::None),
+                    QueryValue::Integer(n) => Box::new(*n),
+                    QueryValue::Float(n) => Box::new(*n),
+                    QueryValue::Text(s) => Box::new(s.clone()),
+                    QueryValue::Blob(b) => Box::new(b.clone()),
+                }
+            })
+            .collect();
+        let param_refs: Vec<&dyn rusqlite::ToSql> = db_params.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&compiled.sql).unwrap();
+        let ids: Vec<String> = stmt
+            .query_map(param_refs.as_slice(), |row| row.get::<_, String>("e_id"))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            ids,
+            vec!["e-fixture-1".to_string()],
+            "SPARQL entity-substrate query must return the existing entity row; sql: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn variable_length_entity_substrate_label_filters_substrate_kind() {
+        let q = parse(
+            QueryLanguage::Gql,
+            "MATCH (a:entity)-[:extends*1..2]->(b) RETURN b LIMIT 5",
+        )
+        .unwrap();
+        let compiled = compile(&q, &opts()).unwrap();
+        assert!(
+            compiled.sql.contains("s.substrate_kind = ?"),
+            "variable-length seed with substrate label 'entity' must filter \
+             s.substrate_kind, not s.kind; sql: {}",
+            compiled.sql
+        );
+    }
 }

--- a/crates/khive-query/tests/compile_integration.rs
+++ b/crates/khive-query/tests/compile_integration.rs
@@ -1119,6 +1119,31 @@ mod substrate_labels {
             .unwrap()
     }
 
+    /// `fixture_db()` plus a second entity and a `graph_edges` row connecting
+    /// it to `e-fixture-1`. SPARQL requires at least one variable-to-variable
+    /// relation triple to parse (`no edge patterns found` otherwise), so any
+    /// SPARQL regression test needs a connected graph, unlike the single-node
+    /// GQL substrate-label tests below.
+    fn fixture_db_with_edge() -> Connection {
+        let conn = fixture_db();
+        conn.execute_batch(
+            "INSERT INTO entities
+                (id, namespace, kind, name, description, properties, tags,
+                 created_at, updated_at, deleted_at, entity_type)
+            VALUES
+                ('e-fixture-2', 'local', 'document', 'Y', NULL, '{}', '[]',
+                 0, 0, NULL, NULL);
+            INSERT INTO graph_edges
+                (namespace, id, source_id, target_id, relation, weight,
+                 created_at, updated_at, deleted_at, metadata, target_backend)
+            VALUES
+                ('local', 'edge-fixture-1', 'e-fixture-1', 'e-fixture-2',
+                 'extends', 1.0, 0, 0, NULL, NULL, NULL);",
+        )
+        .unwrap();
+        conn
+    }
+
     #[test]
     fn entity_substrate_label_compiles_without_unsatisfiable_kind_filter() {
         let q = parse(
@@ -1201,7 +1226,7 @@ mod substrate_labels {
     fn sparql_entity_substrate_label_compiles_and_returns_row() {
         let q = parse(
             QueryLanguage::Sparql,
-            "SELECT ?e WHERE { ?e a :entity . ?e :name \"X\" . }",
+            "SELECT ?e WHERE { ?e a :entity . ?e :name \"X\" . ?e :extends ?c . }",
         )
         .unwrap();
         let compiled = compile(&q, &opts()).unwrap();
@@ -1211,7 +1236,7 @@ mod substrate_labels {
             compiled.sql
         );
 
-        let conn = fixture_db();
+        let conn = fixture_db_with_edge();
         let db_params: Vec<Box<dyn rusqlite::ToSql>> = compiled
             .params
             .iter()


### PR DESCRIPTION
## Root cause

The SQL compiler emitted every node label directly as a `kind = <label>` equality (`crates/khive-query/src/compilers/sql.rs`, fixed-length path and the CTE variable-length twin). Stored `kind` values are always granular (`concept`, `task`, `observation`, ...), so any GQL or SPARQL query using a substrate label such as `MATCH (e:entity)` was unsatisfiable by construction, for every predicate.

## Fix

Substrate labels (`entity`/`note`/`event`/`edge`) now compile against the union source's `substrate_kind` column (or to no filter where the FROM source is already that substrate's table), mirroring the substrate/granular split `resolve_kind_spec` applies on the verb-dispatch surface. Granular labels keep the existing `kind = <label>` emission. Applies to both GQL and SPARQL, which share these compiler sites.

## Behavior change

Queries with substrate labels that previously returned empty results now return rows. This is the intended correction of #849.

## Tests

Compiler-level regression tests in `tests/compile_integration.rs`: substrate label satisfiability against fixture data, granular-label emission unchanged, note parity, SPARQL equivalent.

## Verification status

The implementation session was interrupted before its full test run completed; `cargo fmt` and clippy pass locally. CI on this PR is the authoritative gate, and an independent review pass follows before ready.

Co-Authored-By: Leo <noreply@khive.ai>