### PR TITLE
chore(runtime): comment hygiene sweep across khive-runtime

### DIFF
--- a/crates/khive-runtime/src/actor_identity.rs
+++ b/crates/khive-runtime/src/actor_identity.rs
@@ -1,12 +1,9 @@
 //! Shared actor-identity resolution (issue #567).
 //!
-//! Actor selection was independently reimplemented at four call sites: the
-//! runtime dispatch gate check, storage-token minting, comm attribution, and
-//! MCP strict-mode enforcement. Because the gate's actor identity, the
-//! storage token's actor identity, comm attribution, and strict-mode
-//! enforcement all need to agree on "who is the caller", drift between the
-//! four copies is a silent trust-boundary bug waiting to happen. This module
-//! is the single source of truth all four sites consume.
+//! Single source of truth for "who is the caller", consumed by the gate
+//! check, storage-token minting, comm attribution, and MCP strict-mode
+//! enforcement — those four sites must agree, so drift here is a silent
+//! trust-boundary bug.
 
 use khive_gate::ActorRef;
 
@@ -67,8 +64,7 @@ mod tests {
 
     #[test]
     fn resolve_actor_preserves_untrimmed_id() {
-        // Non-blank strings are used verbatim (not trimmed) — matches the
-        // pre-existing inline match expressions this module replaces.
+        // Trim only decides emptiness; the id itself is stored verbatim.
         let actor = resolve_actor(Some(" lambda:khive "));
         assert_eq!(actor.id, " lambda:khive ");
     }

--- a/crates/khive-runtime/src/actor_identity.rs
+++ b/crates/khive-runtime/src/actor_identity.rs
@@ -2,7 +2,7 @@
 //!
 //! Single source of truth for "who is the caller", consumed by the gate
 //! check, storage-token minting, comm attribution, and MCP strict-mode
-//! enforcement — those four sites must agree, so drift here is a silent
+//! enforcement: those four sites must agree, so drift here is a silent
 //! trust-boundary bug.
 
 use khive_gate::ActorRef;

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -1,19 +1,14 @@
 //! ADR-099 (cross-op atomicity for bulk apply) — prepared write-plan types.
 //!
-//! Migration step 1 (ADR-099) calls for a per-verb `prepare`/apply seam: the
-//! async prepare pass materializes a synchronous write plan outside any
-//! transaction, and the commit pass later applies that plan's statements as
-//! DML under a per-op SAVEPOINT. This module defines the plan *shapes* only —
-//! one family per v1 admissible verb group (`update`, `delete`, `link`,
-//! `merge`, `gtd.transition`, `gtd.complete`, the governance verbs). Nothing
-//! in this module is wired into a live handler or the dispatch path yet; that
-//! wiring (the actual `prepare` implementations, the atomic runner, and the
-//! `--atomic` CLI surface) is later ADR-099 migration work (steps 1 cont'd,
-//! 3, 4). These types exist so that work has a shared, plain-data target.
+//! Async prepare materializes a synchronous write plan outside any
+//! transaction; commit later applies its statements as DML under a per-op
+//! SAVEPOINT. This module defines the plan *shapes* only, one family per
+//! admissible verb group (`update`, `delete`, `link`, `merge`,
+//! `gtd.transition`, `gtd.complete`, the governance verbs) — not yet wired
+//! into a live handler or the dispatch path.
 //!
-//! Every plan is deliberately inert: plain data, no async, no embedding
-//! reference. See ADR-099 D1's two validation-staleness rules, which every
-//! plan's fields exist to satisfy:
+//! Every plan is deliberately inert (plain data, no async, no embedding
+//! reference) and exists to satisfy two validation-staleness rules:
 //!
 //! 1. **Predicate-based plans** — a plan whose effect covers "all rows
 //!    matching a condition" carries that condition as a statement evaluated
@@ -25,15 +20,13 @@
 //!    (`PlanStatement::guard`).
 //!
 //! A guard is attached to the exact [`PlanStatement`] it validates, never to
-//! the plan as a whole: the storage layer returns affected-row counts
-//! per-statement (`SqlWriter::execute`) or as a batch total
-//! (`SqlWriter::execute_batch`), so a plan-level guard field cannot tell a
-//! future runner which statement's count it is checking without an implicit
-//! ordering convention. Each plan therefore carries `Vec<PlanStatement>`
-//! (or, for `merge`, the split `rewires`/`lifecycle` fields below) so the
-//! runner contract is: apply each statement individually, and where
-//! `guard.is_some()`, check that *statement's own* affected-row count before
-//! moving to the next.
+//! the plan as a whole: affected-row counts come back per-statement or as a
+//! batch total, so a plan-level guard field could not tell a runner which
+//! statement's count it is checking. Each plan therefore carries
+//! `Vec<PlanStatement>` (or, for `merge`, the split `rewires`/`lifecycle`
+//! fields below), and the runner applies each statement individually,
+//! checking any present guard against that statement's own affected-row
+//! count before moving to the next.
 
 use uuid::Uuid;
 
@@ -450,11 +443,9 @@ mod tests {
             statements: vec![guarded("update-status", AffectedRowGuard::exactly(1))],
             post_commit: PostCommitEffect::None,
         };
-        // Property-only status mutation — the type carries no *reindex*
-        // post-commit variant it can ever construct (ADR-099 D3: task
-        // transitions "trigger no reindex"); it carries only the best-effort
-        // `GtdAudit` lifecycle-audit effect added in the B3 fix round
-        // (GAP-5), which triggers no embedding/reindex work either.
+        // A status-only transition never triggers a reindex: the type has no
+        // *reindex* post-commit variant to construct, only the best-effort
+        // `GtdAudit` lifecycle-audit effect, which itself does no embedding work.
         assert_eq!(plan.statements.len(), 1);
         assert!(plan.statements[0].guard.is_some());
         assert_eq!(plan.post_commit, PostCommitEffect::None);
@@ -462,10 +453,8 @@ mod tests {
 
     #[test]
     fn gtd_transition_plan_idempotent_noop_carries_no_statements_and_no_audit() {
-        // GAP-6 (B3 fix round 4): current == target after normalize_status
-        // is an idempotent no-op — canonical performs no write and (since it
-        // never reaches its own `write_audit_record` call) writes no audit
-        // row either.
+        // current == target after normalization is an idempotent no-op:
+        // canonical performs no write and never reaches its audit-record call.
         let plan = GtdTransitionPlan {
             task_id: Uuid::new_v4(),
             statements: vec![],
@@ -536,11 +525,10 @@ mod tests {
 
     #[test]
     fn plans_are_plain_data_no_async_no_embedding() {
-        // Compile-time property, asserted here as documentation: every plan
-        // type above derives only Debug/Clone/PartialEq, never Future or any
-        // embedding-provider trait. If a future edit adds an async method or
-        // an embedding-model field to one of these types, this comment is
-        // the marker to revert it — plans must stay inert data (ADR-099 D1).
+        // Documents a compile-time property: every plan type above derives
+        // only Debug/Clone/PartialEq, never Future or an embedding-provider
+        // trait. Plans must stay inert data — flag any edit that adds an
+        // async method or embedding-model field to one of these types.
         let _ = PostCommitEffect::None;
     }
 }

--- a/crates/khive-runtime/src/atomic_plan.rs
+++ b/crates/khive-runtime/src/atomic_plan.rs
@@ -4,7 +4,7 @@
 //! transaction; commit later applies its statements as DML under a per-op
 //! SAVEPOINT. This module defines the plan *shapes* only, one family per
 //! admissible verb group (`update`, `delete`, `link`, `merge`,
-//! `gtd.transition`, `gtd.complete`, the governance verbs) — not yet wired
+//! `gtd.transition`, `gtd.complete`, the governance verbs): not yet wired
 //! into a live handler or the dispatch path.
 //!
 //! Every plan is deliberately inert (plain data, no async, no embedding
@@ -527,7 +527,7 @@ mod tests {
     fn plans_are_plain_data_no_async_no_embedding() {
         // Documents a compile-time property: every plan type above derives
         // only Debug/Clone/PartialEq, never Future or an embedding-provider
-        // trait. Plans must stay inert data — flag any edit that adds an
+        // trait. Plans must stay inert data: flag any edit that adds an
         // async method or embedding-model field to one of these types.
         let _ = PostCommitEffect::None;
     }

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1,36 +1,34 @@
-//! ADR-099 migration step 1 (cont'd) / B3 — the per-verb async prepare pass
-//! for the KG-substrate v1 admissible verbs (`update`, `delete`, `link`,
-//! `merge`). Each `prepare_*` function reads current state (async, outside
-//! any transaction) and returns a plain-data [`crate::atomic_runner::AtomicOpPlan`]
-//! ([`crate::atomic_plan`], B1) for the synchronous commit pass ([`crate::
-//! atomic_runner::run_atomic_unit`], B2) to apply.
+//! ADR-099 — the per-verb async prepare pass for the KG-substrate v1
+//! admissible verbs (`update`, `delete`, `link`, `merge`). Each `prepare_*`
+//! function reads current state (async, outside any transaction) and
+//! returns a plain-data [`crate::atomic_runner::AtomicOpPlan`]
+//! ([`crate::atomic_plan`]) for the synchronous commit pass
+//! ([`crate::atomic_runner::run_atomic_unit`]) to apply.
 //!
 //! `gtd.transition` / `gtd.complete` prepare is deliberately **not** here:
 //! their lifecycle vocabulary (`is_terminal`, `can_transition`, ...) lives in
-//! `khive-pack-gtd`, a crate that depends on `khive-runtime` — not the other
-//! way around. Reproducing that dependency here would invert the crate
-//! graph, so their prepare functions live in `kkernel` (which already
-//! depends on both `khive-runtime` and `khive-pack-gtd`), calling back into
-//! the plain [`PlanStatement`]/[`AffectedRowGuard`] shapes exported from this
-//! module's sibling, [`crate::atomic_plan`].
+//! `khive-pack-gtd`, which depends on `khive-runtime` — not the other way
+//! around. Reproducing that dependency here would invert the crate graph, so
+//! their prepare functions live in `kkernel` (which already depends on both
+//! crates), calling back into the plain [`PlanStatement`]/[`AffectedRowGuard`]
+//! shapes exported from this module's sibling, [`crate::atomic_plan`].
 //!
-//! `propose` / `review` / `withdraw` (the ADR-046 event-sourced governance
-//! lifecycle) are on the v1 admissible list ([`khive_types::pack::
+//! `propose` / `review` / `withdraw` (the event-sourced governance lifecycle)
+//! are on the v1 admissible list ([`khive_types::pack::
 //! ATOMIC_ADMISSIBLE_VERBS`]) but have no prepare implementation here: their
 //! apply path is a changeset-interpreter (`apply_worker`) over a dedicated
 //! `proposals_open` table, not a small number of guarded DML statements — a
 //! faithful, non-stub atomic prepare for them is separate follow-on work.
-//! `prepare_governance_unimplemented` fails loudly, before any write,
-//! naming this as a known scope gap rather than silently no-opping.
+//! `prepare_governance_unimplemented` fails loudly, before any write, naming
+//! this as a known scope gap rather than silently no-opping.
 //!
-//! `merge` is likewise on the v1 admissible list but is deferred (B3 fix
-//! round, Leo refinement 2026-07-07): full-parity field folding, survivor
-//! index reindex, loser index purge, provenance, and same-kind rejection are
-//! achievable as static DML, but `curation::merge_entity_sql`'s graceful
-//! edge-conflict resolution is not (it is per-row procedural, incompatible
-//! with ADR-099 D1's static predicate/guard plan shape) — rather than ship a
-//! partially-scoped atomic merge, it is rejected at the same pre-runtime
-//! static guard as governance
+//! `merge` is likewise on the v1 admissible list but is deferred: full-parity
+//! field folding, survivor index reindex, loser index purge, provenance, and
+//! same-kind rejection are achievable as static DML, but
+//! `curation::merge_entity_sql`'s graceful edge-conflict resolution is not
+//! (it is per-row procedural, incompatible with the static predicate/guard
+//! plan shape) — rather than ship a partially-scoped atomic merge, it is
+//! rejected at the same pre-runtime static guard as governance
 //! ([`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`]). `prepare_merge`
 //! below is therefore unreachable through `--atomic`; it remains only as the
 //! pre-fix-round direct-prepare implementation, exercised by this module's
@@ -95,24 +93,19 @@ fn optional_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
     obj(args).ok()?.get(key).and_then(|v| v.as_str())
 }
 
-/// Nullable-string patch semantics (ADR-099 B3 fix round 5, finding 2 —
-/// codex r3 REJECT). Mirrors the *actually reachable* behavior of
-/// `khive-pack-kg::handlers::common::optional_string_patch`/
+/// Nullable-string patch semantics mirroring the actually-reachable behavior
+/// of `khive-pack-kg::handlers::common::optional_string_patch`/
 /// `description_patch`, reimplemented here rather than imported (that
-/// module is `pub(crate)` to a sibling crate with no dependency edge back to
-/// `khive-runtime`). Canonical's field type is `Option<Value>`
-/// (`UpdateParams.name`/`.description`); serde_json's derived
-/// `Deserialize` for `Option<T>` intercepts a literal JSON `null` at the
-/// OUTER Option boundary and maps it straight to Rust `None` — REGARDLESS
-/// of the inner type `T` — so canonical's own `Some(Value::Null) =>
-/// Ok(Some(None))` "clear" arm is unreachable through normal struct
-/// deserialization (empirically verified against the live `handle_update`:
-/// `update(name=null)` / `update(description=null)` are no-ops, not
-/// clears). This module reads raw, un-deserialized JSON, so it must
-/// replicate that collapse explicitly: key absent OR JSON `null` -> `None`
-/// (leave unchanged, no-op); key present as a string -> `Some(Some(s))`
-/// (set); any other JSON type -> a hard error (canonical's still-reachable
-/// non-null-non-string rejection).
+/// module has no dependency edge back to `khive-runtime`). Canonical's field
+/// type is `Option<Value>` (`UpdateParams.name`/`.description`); serde_json's
+/// derived `Deserialize` for `Option<T>` intercepts a literal JSON `null` at
+/// the outer `Option` boundary and maps it straight to Rust `None`
+/// regardless of the inner type, so canonical's own "clear" arm is
+/// unreachable through normal struct deserialization — `update(name=null)` /
+/// `update(description=null)` are no-ops, not clears. This module reads raw,
+/// un-deserialized JSON, so it must replicate that collapse explicitly: key
+/// absent OR JSON `null` -> `None` (leave unchanged, no-op); key present as a
+/// string -> `Some(Some(s))` (set); any other JSON type -> a hard error.
 fn optional_string_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<String>>> {
     match obj(args)?.get(key) {
         None | Some(Value::Null) => Ok(None),
@@ -123,16 +116,16 @@ fn optional_string_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option
     }
 }
 
-/// Strict string-or-absent-or-null patch for entity `name` (ADR-099 B3 fix
-/// round 5, finding 1 of codex r3's High finding 2 — the actual violation:
-/// `optional_str`'s `.as_str()` silently drops a non-string, non-null value
-/// like `name: 123` as absent, reporting success for an invalid update.
-/// Canonical validates entity `name` via `string_value` (common.rs:819) on
-/// `UpdateParams.name: Option<Value>` — null collapses to absent at the
-/// struct-deserialize boundary (see `optional_string_patch` doc above), so
-/// `string_value`'s reachable behavior is: absent/null -> unchanged;
-/// non-null string -> set; any other JSON type -> hard error. This mirrors
-/// exactly that, reading raw JSON instead of a deserialized struct.
+/// Strict string-or-absent-or-null patch for entity `name`. Unlike
+/// `optional_str`'s `.as_str()`, this does not silently drop a non-string,
+/// non-null value like `name: 123` as absent — it rejects it instead of
+/// reporting success for an invalid update. Canonical validates entity
+/// `name` via `string_value` on `UpdateParams.name: Option<Value>` — null
+/// collapses to absent at the struct-deserialize boundary (see
+/// `optional_string_patch` doc above), so the reachable behavior is:
+/// absent/null -> unchanged; non-null string -> set; any other JSON type ->
+/// hard error. This mirrors that exactly, reading raw JSON instead of a
+/// deserialized struct.
 fn entity_name_patch(args: &Value) -> RuntimeResult<Option<String>> {
     match obj(args)?.get("name") {
         None | Some(Value::Null) => Ok(None),
@@ -143,16 +136,14 @@ fn entity_name_patch(args: &Value) -> RuntimeResult<Option<String>> {
     }
 }
 
-/// Nullable-JSON-value patch for `properties` (ADR-099 B3 fix round 5,
-/// finding 2): canonical `properties: Option<Value>` on `UpdateParams`
-/// collapses a literal JSON `null` to Rust `None` at the struct-deserialize
-/// boundary (same gotcha as `optional_string_patch` above), so
-/// `properties=null` is canonically a no-op (leave existing properties
-/// unchanged) — NOT a stored JSON `null`. This module reads raw JSON, so it
-/// must replicate that collapse: key absent OR JSON `null` -> `None` (no
-/// merge); any other JSON value -> `Some(value)` (merge), matching
-/// canonical's un-typed pass-through (no further shape validation at this
-/// layer either way).
+/// Nullable-JSON-value patch for `properties`: canonical
+/// `properties: Option<Value>` on `UpdateParams` collapses a literal JSON
+/// `null` to Rust `None` at the struct-deserialize boundary (same collapse
+/// as `optional_string_patch` above), so `properties=null` is canonically a
+/// no-op (leave existing properties unchanged) — not a stored JSON `null`.
+/// This module reads raw JSON, so it must replicate that collapse: key
+/// absent OR JSON `null` -> `None` (no merge); any other JSON value ->
+/// `Some(value)` (merge), with no further shape validation at this layer.
 fn optional_properties(args: &Value, key: &str) -> RuntimeResult<Option<Value>> {
     match obj(args)?.get(key) {
         None | Some(Value::Null) => Ok(None),
@@ -160,14 +151,12 @@ fn optional_properties(args: &Value, key: &str) -> RuntimeResult<Option<Value>> 
     }
 }
 
-/// `tags` patch (ADR-099 B3 fix round 5, finding 2): canonical
-/// `tags: Option<Vec<String>>` on `UpdateParams` collapses a literal JSON
-/// `null` to Rust `None` at the struct-deserialize boundary (same gotcha),
-/// so `tags=null` is canonically a no-op (leave existing tags unchanged) —
-/// the pre-fix version of this function instead ERRORED on null, which is
-/// the exact divergence codex flagged. A non-array, non-null value is still
-/// a hard error (mirrors the type failure `UpdateParams` deserialization
-/// would itself produce for a malformed `tags`).
+/// `tags` patch: canonical `tags: Option<Vec<String>>` on `UpdateParams`
+/// collapses a literal JSON `null` to Rust `None` at the struct-deserialize
+/// boundary (same collapse as above), so `tags=null` is canonically a no-op
+/// (leave existing tags unchanged). A non-array, non-null value is still a
+/// hard error (mirrors the type failure `UpdateParams` deserialization would
+/// itself produce for a malformed `tags`).
 fn optional_tags(args: &Value) -> RuntimeResult<Option<Vec<String>>> {
     match obj(args)?.get("tags") {
         None | Some(Value::Null) => Ok(None),
@@ -201,9 +190,8 @@ fn optional_f64(args: &Value, key: &str) -> RuntimeResult<Option<f64>> {
 /// Tri-state patch extraction for `Option<Option<f64>>`-shaped fields
 /// (`NotePatch::salience` / `NotePatch::decay_factor`): key absent -> `None`
 /// (untouched), key present as JSON `null` -> `Some(None)` (clear), key
-/// present as a number -> `Some(Some(v))` (set). Preserves the atomic path's
-/// pre-existing `contains_key`-based clear/set/untouched semantics now that
-/// range validation itself has moved into curation.rs's `prepare_update_note`.
+/// present as a number -> `Some(Some(v))` (set). Range validation lives in
+/// curation.rs's `prepare_update_note`, not here.
 fn optional_f64_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option<f64>>> {
     match obj(args)?.get(key) {
         None => Ok(None),
@@ -272,22 +260,19 @@ async fn vector_table_exists(runtime: &KhiveRuntime, table: &str) -> RuntimeResu
 
 /// Append the FTS + every registered model's vector-row purge for `subject_id`
 /// (scoped to the RECORD's own namespace, matching `delete_entity`/
-/// `delete_note`'s `record_tok`/`record_ns` convention — NOT the caller
-/// token's namespace, ADR-007 rule 2 by-ID namespace-agnosticism) onto
-/// `statements`.
+/// `delete_note`'s `record_tok`/`record_ns` convention — not the caller
+/// token's namespace, per by-ID namespace-agnosticism) onto `statements`.
 ///
 /// FTS tables (`fts_entities`/`fts_notes`) always exist (created at schema
 /// migration time) so their purge is unconditional. `vec_*` tables are
-/// created LAZILY on first vector-store open (`vectors_for_model` ->
-/// `CREATE VIRTUAL TABLE IF NOT EXISTS`, khive-db backend.rs) — a default
-/// runtime registers embedding models before any vector table necessarily
-/// exists, so a raw unconditional `DELETE FROM vec_*` can hit `no such
-/// table` on a fresh DB (codex r2 Blocker 1). Only push the vec purge for
-/// tables that actually exist: absence means the record definitionally has
-/// no vector row for that model, so skipping is data-parity-correct (the
-/// non-atomic path would lazily create the table then delete zero rows —
-/// same DATA outcome, the only difference is an init side-effect this
-/// read-only prepare pass must not perform).
+/// created lazily on first vector-store open, so a default runtime can
+/// register embedding models before any vector table necessarily exists —
+/// a raw unconditional `DELETE FROM vec_*` can hit `no such table` on a
+/// fresh DB. Only push the vec purge for tables that actually exist:
+/// absence means the record definitionally has no vector row for that
+/// model, so skipping is data-parity-correct (the non-atomic path would
+/// lazily create the table then delete zero rows — same data outcome,
+/// without this read-only prepare pass performing an init side effect).
 async fn push_index_purge_statements(
     runtime: &KhiveRuntime,
     statements: &mut Vec<PlanStatement>,
@@ -316,46 +301,33 @@ async fn push_index_purge_statements(
 }
 
 /// Event-store append parity for the canonical handlers that emit a
-/// lifecycle event AFTER their row mutation: `update_entity` -> `EntityUpdated`
-/// (curation.rs:257-273), `delete_entity` -> `EntityDeleted`
-/// (operations.rs:3543-3558), `delete_note` -> `NoteDeleted`
-/// (operations.rs:3326-3340), `update_edge` -> `EdgeUpdated`
-/// (operations.rs:3968-3983), `delete_edge` -> `EdgeDeleted`
-/// (operations.rs:4042-4056). `update_note` and `link` append no event
-/// (parity boundary verified by the GAP-1 sweep) and must never call this.
+/// lifecycle event after their row mutation: `update_entity` ->
+/// `EntityUpdated`, `delete_entity` -> `EntityDeleted`, `delete_note` ->
+/// `NoteDeleted`, `update_edge` -> `EdgeUpdated`, `delete_edge` ->
+/// `EdgeDeleted`. `update_note` and `link` append no event and must never
+/// call this.
 ///
-/// ADR-099 B3 r6 (Leo condition 2, "one event implementation"): builds the
-/// `Event` exactly as each canonical site does
-/// (`khive_storage::event::Event::new(...).with_target(...).with_payload(...)`)
-/// and turns it into plain-data `SqlStatement`s via
-/// [`khive_db::stores::event::event_insert_statements`] — the SAME builder
-/// [`khive_db::stores::event::append_event_on_writer`] (the async execution
-/// path every canonical `event_store.append_event(...)` call ultimately
-/// reaches) uses. There is exactly one place that knows the
+/// Builds the `Event` exactly as each canonical site does and turns it into
+/// plain-data `SqlStatement`s via
+/// [`khive_db::stores::event::event_insert_statements`] — the same builder
+/// the async execution path every canonical `event_store.append_event(...)`
+/// call reaches uses. There is exactly one place that knows the
 /// `events`/`event_observations` insert shape; this function only adapts its
 /// output into unguarded [`PlanStatement`]s for the atomic-unit plan.
 ///
-/// Placement decision (matches canonical's error semantics, ADR-099 B3 GAP-1
-/// fix round): all canonical sites call
-/// `event_store.append_event(event).await.map_err(...)?` — the `?` makes a
-/// failed append a hard `RuntimeError`, never swallowed/logged-and-continue.
-/// The insert is two-to-N plain, deterministic `INSERT`s (`events`, then
-/// `event_observations` for the target-row observation) computed entirely
-/// from data already on hand at prepare time — no embedding call, no other
-/// suspending/async computation, unlike the `ReindexEntity`/`ReindexNote`
-/// post-commit effects this same module defers for exactly that reason. A
-/// fatal, purely-SQL-expressible effect is the `PlanStatement`-inside-the-
-/// atomic-unit case (not `PostCommitEffect`, which this module reserves for
-/// best-effort or non-SQL work): committing the event row atomically with
-/// the mutation it describes only STRENGTHENS canonical's guarantee (the
-/// non-atomic handlers write the event in a *separate* transaction, ordered
-/// but not atomic with the row mutation).
+/// This is a `PlanStatement` inside the atomic unit, not a `PostCommitEffect`
+/// (reserved for best-effort or non-SQL work): the insert is a small number
+/// of plain, deterministic `INSERT`s computed entirely from data already on
+/// hand at prepare time, unlike the `ReindexEntity`/`ReindexNote`
+/// post-commit effects this module defers because those need an embedding
+/// call. Committing the event row atomically with the mutation it describes
+/// strengthens canonical's guarantee: the non-atomic handlers write the
+/// event in a separate transaction, ordered but not atomic with the row
+/// mutation.
 ///
 /// Returned statements are unguarded — appended after the plan's own guarded
 /// row statement, so [`apply_plan`]'s stop-on-first-failure contract means
-/// they are only reached once that row mutation's guard has already held
-/// (mirroring canonical's `if deleted { append_event(...) }` /
-/// unconditional-after-`upsert_entity` shape).
+/// they are only reached once that row mutation's guard has already held.
 fn event_append_statements(
     namespace: &str,
     verb: &str,
@@ -395,25 +367,22 @@ pub async fn prepare_op(
 ) -> RuntimeResult<AtomicOpPlan> {
     match tool {
         // `expected_kind: None` here — same reasoning as the `"delete"` arm
-        // immediately below: callers that need `update(kind=...)` parity
-        // (ADR-099 B3 r7, codex r7 Blocker finding 1) must resolve the kind
-        // spec themselves (it needs a `VerbRegistry`, unreachable from this
-        // crate — see `AtomicUpdateKind`'s doc comment) and call
+        // below: callers that need `update(kind=...)` parity must resolve
+        // the kind spec themselves (it needs a `VerbRegistry`, unreachable
+        // from this crate — see `AtomicUpdateKind`'s doc comment) and call
         // `prepare_update` directly with the resolved value; `kkernel`'s
-        // `--atomic` seam does exactly this and bypasses this dispatch arm
-        // for "update". A caller reaching `prepare_op("update", ...)`
-        // without going through that seam gets kind-unchecked behavior,
-        // same as delete's pre-existing arm.
+        // `--atomic` seam does exactly this and bypasses this dispatch arm.
+        // A caller reaching `prepare_op("update", ...)` without going
+        // through that seam gets kind-unchecked behavior.
         "update" => prepare_update(runtime, token, args, None).await,
         // `expected_kind: None` here — callers that need `delete(kind=...)`
-        // parity (ADR-099 B3 fix round 5, finding 1) must resolve the kind
-        // spec themselves (it needs a `VerbRegistry`, unreachable from this
-        // crate — see `AtomicDeleteKind`'s doc comment) and call
-        // `prepare_delete` directly with the resolved value; `kkernel`'s
-        // `--atomic` seam does exactly this and bypasses this dispatch arm
-        // for "delete". A caller reaching `prepare_op("delete", ...)`
-        // without going through that seam gets kind-unchecked behavior,
-        // same as before this fix round.
+        // parity must resolve the kind spec themselves (it needs a
+        // `VerbRegistry`, unreachable from this crate — see
+        // `AtomicDeleteKind`'s doc comment) and call `prepare_delete`
+        // directly with the resolved value; `kkernel`'s `--atomic` seam does
+        // exactly this and bypasses this dispatch arm. A caller reaching
+        // `prepare_op("delete", ...)` without going through that seam gets
+        // kind-unchecked behavior.
         "delete" => prepare_delete(runtime, token, args, None).await,
         "link" => prepare_link(runtime, token, args).await,
         "merge" => prepare_merge(runtime, token, args).await,
@@ -440,18 +409,16 @@ fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
 // update
 // ---------------------------------------------------------------------------
 
-/// Mirrors `khive-pack-kg::handlers::update::reject_inapplicable_fields`
-/// (GAP-4, B3 fix round 4): a hard `InvalidInput` when a caller passes a
-/// field that does not apply to the resolved substrate (e.g. `salience` on
-/// an entity, or `description`/`tags` on a note). That function is
-/// `pub(crate)` to a sibling crate with no dependency edge back to
-/// `khive-runtime` (`khive-pack-kg` depends on `khive-runtime`, not the
-/// other way around), so its exact field-applicability check list and error
-/// message shape are reimplemented here rather than imported — same pattern
-/// as `optional_string_patch` above. Presence is checked directly on the raw
-/// args object (this module has no `UpdateParams` struct); a JSON `null`
-/// value is treated as absent, matching `Option<T>` deserialization
-/// semantics for the fields update.rs's checklist covers.
+/// Mirrors `khive-pack-kg::handlers::update::reject_inapplicable_fields`: a
+/// hard `InvalidInput` when a caller passes a field that does not apply to
+/// the resolved substrate (e.g. `salience` on an entity, or
+/// `description`/`tags` on a note). That function has no dependency edge
+/// back to `khive-runtime`, so its exact field-applicability check list and
+/// error message shape are reimplemented here rather than imported — same
+/// pattern as `optional_string_patch` above. Presence is checked directly on
+/// the raw args object (this module has no `UpdateParams` struct); a JSON
+/// `null` value is treated as absent, matching `Option<T>` deserialization
+/// semantics.
 fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeResult<()> {
     let o = obj(args)?;
     let present = |k: &str| o.get(k).is_some_and(|v| !v.is_null());
@@ -486,11 +453,9 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
             };
             (bad, "name, content, salience, decay_factor, properties")
         }
-        // ADR-099 B3 r6: closes the round-4 codex REJECT (High) — `update`
-        // admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS` but this
-        // validator previously had no "edge" arm at all, so an edge update
-        // carrying an entity/note-only field (e.g. `name`) silently skipped
-        // the guard instead of being rejected, mirroring
+        // `update` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`, so
+        // this arm must reject entity/note-only fields (e.g. `name`) on an
+        // edge update rather than silently skip the guard, mirroring
         // `khive-pack-kg::handlers::update::reject_inapplicable_fields`'s
         // `KindSpec::Edge` arm.
         "edge" => {
@@ -528,15 +493,14 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
 }
 
 /// Caller-supplied update-kind expectation, resolved via the canonical
-/// `resolve_kind_spec` at the kkernel `--atomic` seam — the exact same
-/// pattern [`AtomicDeleteKind`] uses (ADR-099 B3 r7, codex r7 Blocker
-/// finding 1: `update(kind="document", id=<concept>)` was canonically
-/// `NotFound` but the atomic path ignored the explicit kind and mutated the
-/// resolved entity anyway). `khive-runtime` must not depend on
-/// `khive-pack-kg`, so this is a plain substrate-level shape rather than
-/// `khive_pack_kg::handlers::KindSpec` itself — the kkernel seam does the
-/// pack-aware resolution and passes down only what `prepare_update` needs
-/// to enforce the mismatch check.
+/// `resolve_kind_spec` at the kkernel `--atomic` seam — the same pattern
+/// [`AtomicDeleteKind`] uses. Without this check, `update(kind="document",
+/// id=<concept>)` would be canonically `NotFound` but the atomic path would
+/// ignore the explicit kind and mutate the resolved entity anyway.
+/// `khive-runtime` must not depend on `khive-pack-kg`, so this is a plain
+/// substrate-level shape rather than `khive_pack_kg::handlers::KindSpec`
+/// itself — the kkernel seam does the pack-aware resolution and passes down
+/// only what `prepare_update` needs to enforce the mismatch check.
 pub enum AtomicUpdateKind {
     Entity { specific: Option<String> },
     Note { specific: Option<String> },
@@ -556,10 +520,9 @@ pub async fn prepare_update(
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
 
-    // GAP-4 (B3 fix round 4): mirrors update.rs's entity_kind immutability
-    // guard (update.rs:160-164), which the pre-fix atomic prepare never
-    // checked at all — entity_kind is a legacy top-level field, independent
-    // of the `kind` substrate discriminator handled elsewhere.
+    // Mirrors update.rs's entity_kind immutability guard — entity_kind is a
+    // legacy top-level field, independent of the `kind` substrate
+    // discriminator handled elsewhere.
     if obj(args)?.get("entity_kind").is_some_and(|v| !v.is_null()) {
         return Err(RuntimeError::InvalidInput(
             "entity_kind is immutable; to change kind, delete then re-create the entity, \
@@ -615,10 +578,10 @@ pub async fn prepare_update(
                 statement: entity_upsert_statement(&entity),
                 guard: Some(AffectedRowGuard::exactly(1)),
             }];
-            // GAP-1 (B3 fix round): curation.rs's `update_entity` appends an
-            // `EntityUpdated` event unconditionally after `upsert_entity`
-            // succeeds, regardless of `text_changed` — match that here, not
-            // just on the reindex-triggering subset of updates.
+            // curation.rs's `update_entity` appends an `EntityUpdated` event
+            // unconditionally after `upsert_entity` succeeds, regardless of
+            // `text_changed` — match that here, not just on the
+            // reindex-triggering subset of updates.
             statements.extend(event_append_statements(
                 &entity.namespace,
                 "update",
@@ -662,11 +625,11 @@ pub async fn prepare_update(
                 }
             }
             // Decide step lives in curation.rs's `prepare_update_note` — the
-            // SAME function canonical `update_note` calls, including the
+            // same function canonical `update_note` calls, including the
             // salience/decay_factor range validation. `optional_f64_patch`
-            // below preserves the pre-existing atomic tri-state semantics
-            // (key absent = untouched, key null = clear, key present = set)
-            // when constructing the `NotePatch`.
+            // below preserves tri-state patch semantics (key absent =
+            // untouched, key null = clear, key present = set) when
+            // constructing the `NotePatch`.
             reject_inapplicable_update_fields(args, "note")?;
             let name = optional_string_patch(args, "name")?;
             let content = optional_str(args, "content").map(|s| s.to_string());
@@ -710,10 +673,8 @@ pub async fn prepare_update(
         // id that isn't an entity/note/pack-private/event record is checked
         // against the graph store directly, mirroring
         // `khive-pack-kg::handlers::KgPack::infer_kind_from_uuid`'s own
-        // entity/note-then-edge fallback order (ADR-099 B3 r6, closes the
-        // round-4 codex REJECT: `update` admits `kind="edge"` but this
-        // function previously had no path that could ever build a plan for
-        // one).
+        // entity/note-then-edge fallback order. `update` admits
+        // `kind="edge"`, so this arm must be able to build a plan for one.
         None => match &expected_kind {
             Some(AtomicUpdateKind::Entity { .. }) => {
                 Err(RuntimeError::NotFound(format!("entity/note {id}")))
@@ -729,7 +690,7 @@ pub async fn prepare_update(
     }
 }
 
-/// Edge branch of `prepare_update` (ADR-099 B3 r6). Mirrors
+/// Edge branch of `prepare_update`. Mirrors
 /// `khive-runtime::operations::KhiveRuntime::update_edge`'s patch semantics
 /// exactly: `relation`/`weight`/`properties` are the only applicable fields
 /// (`reject_inapplicable_update_fields`'s `"edge"` arm enforces this before
@@ -740,32 +701,30 @@ pub async fn prepare_update(
 ///
 /// DML shape:
 /// - non-symmetric relation: a single [`edge_upsert_statement`] call on the
-///   patched `Edge` — bit-for-bit the same builder `update_edge`'s own
-///   non-symmetric branch calls via `graph.upsert_edge(edge.clone())`
+///   patched `Edge` — the same builder `update_edge`'s own non-symmetric
+///   branch calls via `graph.upsert_edge(edge.clone())`
 ///   (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is
 ///   exact by construction.
 /// - symmetric relation (`competes_with`, `composed_with`): `update_edge`
-///   does NOT use the upsert builder here — its comment explains why
-///   (`upsert_edge` resolves `ON CONFLICT(namespace, id)` first and cannot
-///   detect a natural-key collision with a *different* id). Canonical
-///   (`update_edge_symmetric_dml`) runs a conflict probe and branches in
-///   Rust inside a single uninterrupted transaction, which is safe there.
-///   This atomic path (ADR-099 B3 r7, codex r7 High finding 3) does NOT
-///   branch on a prepare-time probe: the prepare/commit phase split means a
-///   different op in the SAME atomic unit could change the conflict
-///   landscape between this probe and commit, so a Rust-level branch here
-///   would be stale by construction. Instead it always emits BOTH
+///   does NOT use the upsert builder here, because `upsert_edge` resolves
+///   `ON CONFLICT(namespace, id)` first and cannot detect a natural-key
+///   collision with a *different* id. Canonical (`update_edge_symmetric_dml`)
+///   runs a conflict probe and branches in Rust inside a single
+///   uninterrupted transaction, which is safe there. This atomic path
+///   cannot branch on a prepare-time probe: the prepare/commit phase split
+///   means a different op in the same atomic unit could change the
+///   conflict landscape between probe and commit, so a Rust-level branch
+///   here would be stale by construction. Instead it always emits BOTH
 ///   statements from [`edge_symmetric_delete_if_conflict_statement`] and
 ///   [`edge_symmetric_refresh_or_update_inplace_statement`] — each carries
 ///   its own commit-time `WHERE`/`CASE WHEN` predicate that re-evaluates the
 ///   conflict condition fresh inside the transaction, so the write is
-///   correct regardless of prepare-time state. ADR-099 B3 r9 (codex r8
-///   Blocker finding 1) removed the prepare-time conflict probe entirely —
-///   this function no longer reads any state to guess a surviving id; the
-///   plan instead carries `edge_natural_key` (the plain canonicalized
-///   endpoints/relation this update targets), letting a post-commit caller
-///   derive the actual surviving id from the committed row, never from a
-///   value computed before the rest of this atomic unit has even run.
+///   correct regardless of prepare-time state. This function reads no state
+///   to guess a surviving id; the plan instead carries `edge_natural_key`
+///   (the canonicalized endpoints/relation this update targets), letting a
+///   post-commit caller derive the actual surviving id from the committed
+///   row, never from a value computed before the rest of this atomic unit
+///   has even run.
 async fn prepare_update_edge(
     runtime: &KhiveRuntime,
     id: Uuid,
@@ -819,16 +778,15 @@ async fn prepare_update_edge(
     let mut edge_natural_key: Option<EdgeNaturalKey> = None;
 
     if edge.relation.is_symmetric() {
-        // ADR-099 B3 r7 (codex r7 High finding 3): the WRITE for a symmetric
-        // relation no longer branches on a prepare-time probe result — it
-        // ALWAYS carries both self-guarding, commit-time-predicate
-        // statements (see their doc comment in khive-db's graph.rs for the
-        // full rationale). This closes the staleness window a prepare-time
-        // probe exposed atomic to (an earlier op in the SAME atomic unit
-        // could change the conflict landscape before commit) without
-        // touching canonical's own probe-then-branch `update_edge_symmetric_dml`
-        // (which has no such exposure — single transaction, no interleaving
-        // — and stays as the control-group, tests untouched).
+        // The write for a symmetric relation never branches on a
+        // prepare-time probe result — it always carries both self-guarding,
+        // commit-time-predicate statements (see their doc comment in
+        // khive-db's graph.rs for the full rationale). This avoids the
+        // staleness window a prepare-time probe would expose: an earlier op
+        // in the same atomic unit could change the conflict landscape before
+        // commit. Canonical's own probe-then-branch
+        // `update_edge_symmetric_dml` has no such exposure (single
+        // transaction, no interleaving) and is unaffected.
         let metadata_str = edge
             .metadata
             .as_ref()
@@ -883,9 +841,9 @@ async fn prepare_update_edge(
     }
 
     // Mirrors `update_edge`'s unconditional post-mutation `EdgeUpdated`
-    // event append (operations.rs:3968-3983), keyed on the ORIGINAL
-    // `edge_id` the caller supplied — canonical does the same (the event
-    // target is `edge_id`, not the post-absorption surviving id).
+    // event append, keyed on the original `edge_id` the caller supplied —
+    // canonical does the same (the event target is `edge_id`, not the
+    // post-absorption surviving id).
     statements.extend(event_append_statements(
         &namespace,
         "update",
@@ -908,21 +866,17 @@ async fn prepare_update_edge(
 // ---------------------------------------------------------------------------
 
 /// Caller-supplied delete-kind expectation, resolved via the canonical
-/// `resolve_kind_spec` at the kkernel `--atomic` seam (ADR-099 B3 fix round
-/// 5, finding 1 — codex r3 REJECT Blocker). `khive-runtime` must not depend
-/// on `khive-pack-kg` (packs depend on the runtime, not the other way
-/// around), so this is a plain substrate-level shape rather than
+/// `resolve_kind_spec` at the kkernel `--atomic` seam. `khive-runtime` must
+/// not depend on `khive-pack-kg` (packs depend on the runtime, not the other
+/// way around), so this is a plain substrate-level shape rather than
 /// `khive_pack_kg::handlers::KindSpec` itself: the kkernel seam does the
 /// pack-aware `resolve_kind_spec` resolution (which needs a `VerbRegistry`,
 /// unreachable from this crate) and passes down only what `prepare_delete`
 /// needs to enforce the mismatch check.
 ///
-/// `Edge` was added in ADR-099 B3 r6, closing the round-4 codex REJECT
-/// (High): `delete` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`, but
-/// this enum previously had no variant for it, so the kkernel seam rejected
-/// `delete(kind="edge", ...)` before `prepare_delete` was ever reached —
-/// admissible-but-unimplemented. `Event`/`Proposal` remain rejected at the
-/// kkernel seam (not v1-admissible for atomic delete at all).
+/// `delete` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`, hence the
+/// `Edge` variant. `Event`/`Proposal` remain rejected at the kkernel seam
+/// (not v1-admissible for atomic delete at all).
 pub enum AtomicDeleteKind {
     Entity { specific: Option<String> },
     Note { specific: Option<String> },
@@ -932,9 +886,8 @@ pub enum AtomicDeleteKind {
 /// `expected_kind`: `None` when the caller omitted `kind` (no check, parity
 /// with canonical's own optional discriminator); `Some(_)` enforces an
 /// exact-parity mismatch check against the resolved record's actual
-/// substrate/specific kind (ADR-099 B3 fix round 5, finding 1), mirroring
-/// `handle_delete`'s `entity.kind != *expected` / `note.kind != *expected`
-/// checks (update.rs:319, :348).
+/// substrate/specific kind, mirroring `handle_delete`'s
+/// `entity.kind != *expected` / `note.kind != *expected` checks.
 pub async fn prepare_delete(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -947,13 +900,11 @@ pub async fn prepare_delete(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // codex r2 High finding 2: `delete(id, hard=true)` is the public purge
-    // route AFTER a prior soft delete (operations.rs hard-delete resolves
-    // INCLUDING already-tombstoned rows). Live-only `resolve_by_id` would
-    // never find an already-soft-deleted record, so hard delete must resolve
-    // through the including-deleted variant; soft delete keeps the live-only
-    // resolve (a soft delete of an already-tombstoned row is a no-op,
-    // matching non-atomic behavior).
+    // `delete(id, hard=true)` is the public purge route after a prior soft
+    // delete, so it must resolve including already-tombstoned rows (a
+    // live-only resolve would never find one). Soft delete keeps the
+    // live-only resolve — a soft delete of an already-tombstoned row is a
+    // no-op, matching non-atomic behavior.
     let resolved = if hard {
         runtime.resolve_by_id_including_deleted(token, id).await?
     } else {
@@ -1004,11 +955,10 @@ pub async fn prepare_delete(
                     guard: None,
                 });
             }
-            // FTS + vector index purge (operations.rs delete_entity parity,
-            // codex REJECT Blocker 1): both soft AND hard delete clean
-            // indexes (hard delete of an already-tombstoned record must
-            // still purge indexes — Finding 2); only hard additionally
-            // cascades edges above.
+            // FTS + vector index purge, matching operations.rs
+            // `delete_entity`: both soft and hard delete clean indexes (a
+            // hard delete of an already-tombstoned record must still purge
+            // them); only hard additionally cascades edges above.
             push_index_purge_statements(
                 runtime,
                 &mut statements,
@@ -1018,12 +968,11 @@ pub async fn prepare_delete(
                 "atomic-delete-entity",
             )
             .await?;
-            // GAP-1 (B3 fix round): operations.rs's `delete_entity` appends
-            // an `EntityDeleted` event after a successful row delete, on
-            // BOTH soft and hard delete (`if deleted { append_event(...) }`,
-            // where `deleted` is true whenever the guarded row statement
-            // above affected a row — `apply_plan` never reaches this
-            // statement otherwise, so no `if` is needed here).
+            // operations.rs's `delete_entity` appends an `EntityDeleted`
+            // event after a successful row delete, on both soft and hard
+            // delete. `apply_plan` never reaches this statement unless the
+            // guarded row statement above affected a row, so no extra `if`
+            // is needed here.
             statements.extend(event_append_statements(
                 &namespace,
                 "delete",
@@ -1078,11 +1027,10 @@ pub async fn prepare_delete(
                     guard: None,
                 });
             }
-            // FTS + vector index purge (operations.rs delete_note parity,
-            // codex REJECT Blocker 1): both soft AND hard delete clean
-            // indexes (hard delete of an already-tombstoned record must
-            // still purge indexes — Finding 2); only hard additionally
-            // cascades edges above.
+            // FTS + vector index purge, matching operations.rs
+            // `delete_note`: both soft and hard delete clean indexes (a hard
+            // delete of an already-tombstoned record must still purge
+            // them); only hard additionally cascades edges above.
             push_index_purge_statements(
                 runtime,
                 &mut statements,
@@ -1092,10 +1040,9 @@ pub async fn prepare_delete(
                 "atomic-delete-note",
             )
             .await?;
-            // GAP-1 (B3 fix round): operations.rs's `delete_note` appends a
-            // `NoteDeleted` event after a successful row delete, on BOTH
-            // soft and hard delete — same reasoning as the entity branch
-            // above.
+            // operations.rs's `delete_note` appends a `NoteDeleted` event
+            // after a successful row delete, on both soft and hard delete —
+            // same reasoning as the entity branch above.
             statements.extend(event_append_statements(
                 &namespace,
                 "delete",
@@ -1107,11 +1054,10 @@ pub async fn prepare_delete(
             Ok(AtomicOpPlan::Delete(DeletePlan {
                 target_id: id,
                 statements,
-                // #750 fix-round 2 (codex r2 High 2): a committed atomic
-                // note delete must fire the same pack-installed
-                // note-mutation hook `operations.rs::delete_note` fires,
-                // so a warm ANN cache sees the deletion even when the
-                // mutation went through the atomic-plan path instead.
+                // A committed atomic note delete must fire the same
+                // pack-installed note-mutation hook `operations.rs::
+                // delete_note` fires, so a warm ANN cache sees the deletion
+                // even when the mutation went through the atomic-plan path.
                 post_commit: PostCommitEffect::NoteDeleted {
                     note_id: id,
                     kind: note.kind.clone(),
@@ -1123,7 +1069,7 @@ pub async fn prepare_delete(
         ))),
         // `Resolved` has no `Edge` variant (same reasoning as
         // `prepare_update`'s fallback above) — probe the graph store
-        // directly. ADR-099 B3 r6: closes the round-4 codex REJECT (High).
+        // directly.
         None => match &expected_kind {
             Some(AtomicDeleteKind::Entity { .. }) => {
                 Err(RuntimeError::NotFound(format!("entity/note {id}")))
@@ -1146,7 +1092,7 @@ pub async fn prepare_delete(
     }
 }
 
-/// Edge branch of `prepare_delete` (ADR-099 B3 r6). Mirrors
+/// Edge branch of `prepare_delete`. Mirrors
 /// `khive-runtime::operations::KhiveRuntime::delete_edge` exactly: hard
 /// delete cascades `purge_incident_edges` (any `annotates` edge — or any
 /// other edge — pointing AT this edge as a node) BEFORE deleting the edge
@@ -1220,11 +1166,10 @@ async fn prepare_link(
     let metadata = obj(args)?.get("metadata").cloned();
 
     // Top-level `dependency_kind` param merges into `metadata`: only fills
-    // the key when metadata doesn't already carry one. Calls the SAME
+    // the key when metadata doesn't already carry one. Calls the same
     // `khive_runtime::merge_entry_metadata` `khive-pack-kg`'s canonical
-    // `handle_link` calls — relocated down to this crate (ADR-099 B3 r6
-    // second pass) so both sides depend on one function instead of each
-    // maintaining their own copy.
+    // `handle_link` calls, so both sides depend on one function instead of
+    // each maintaining their own copy.
     let mut metadata = crate::merge_entry_metadata(
         metadata,
         optional_str(args, "dependency_kind").map(String::from),
@@ -1237,12 +1182,12 @@ async fn prepare_link(
 
     let (canon_source, canon_target) = canonical_edge_endpoints(relation, source_id, target_id);
 
-    // Endpoint-kind `dependency_kind` inference for `depends_on` edges
-    // (codex REJECT High finding — operations.rs `link()` parity): only
-    // applies when both endpoints resolve as entities and the key is still
-    // absent after the top-level-param merge above. Runs against the
-    // CANONICAL endpoints, exactly mirroring `KhiveRuntime::link`'s own
-    // ordering (canonicalize, then infer).
+    // Endpoint-kind `dependency_kind` inference for `depends_on` edges,
+    // matching operations.rs `link()`: only applies when both endpoints
+    // resolve as entities and the key is still absent after the
+    // top-level-param merge above. Runs against the canonical endpoints,
+    // mirroring `KhiveRuntime::link`'s own ordering (canonicalize, then
+    // infer).
     if relation == EdgeRelation::DependsOn {
         metadata = match (
             runtime.resolve_edge_endpoint(token, canon_source).await?,
@@ -1261,20 +1206,18 @@ async fn prepare_link(
     let now = chrono::Utc::now().timestamp_micros();
     let metadata_str = metadata.map(|m| serde_json::to_string(&m).unwrap_or_default());
 
-    // ADR-099 B3 r7 (codex r7 High finding 2): the guarded `INSERT ...
-    // SELECT ... WHERE EXISTS(...)` shape is kept (it is load-bearing —
-    // `LinkPlan`'s own doc comment records why: it re-probes both endpoints
-    // INSIDE the transaction, closing the intra-batch hazard where an
-    // earlier op in the SAME atomic unit, e.g. `delete(X, hard)`, could
-    // invalidate this op's prepare-time endpoint validation before commit).
-    // What changed: the conflict-arm SET list is no longer a second
-    // hand-assembled literal — `edge_insert_guarded_by_endpoints_statement`
-    // shares the SAME `EDGE_NATURAL_KEY_CONFLICT_SET` text
-    // `edge_upsert_statement` (canonical `link`'s builder) uses, so the two
-    // cannot silently diverge again (the prior bug: this atomic literal
-    // never set `target_backend = excluded.target_backend`, so a re-link of
-    // an edge carrying a cross-backend `target_backend` stamp behaved
-    // differently under `--atomic`).
+    // The guarded `INSERT ... SELECT ... WHERE EXISTS(...)` shape is
+    // load-bearing (see `LinkPlan`'s own doc comment): it re-probes both
+    // endpoints inside the transaction, closing the intra-batch hazard
+    // where an earlier op in the same atomic unit, e.g. `delete(X, hard)`,
+    // could invalidate this op's prepare-time endpoint validation before
+    // commit. The conflict-arm SET list shares the same
+    // `EDGE_NATURAL_KEY_CONFLICT_SET` text `edge_upsert_statement`
+    // (canonical `link`'s builder) uses, so the two cannot silently diverge
+    // (a prior bug: this atomic literal never set
+    // `target_backend = excluded.target_backend`, so a re-link of an edge
+    // carrying a cross-backend `target_backend` stamp behaved differently
+    // under `--atomic`).
     let statement = edge_insert_guarded_by_endpoints_statement(
         &namespace,
         edge_id,
@@ -1297,20 +1240,18 @@ async fn prepare_link(
 }
 
 // ---------------------------------------------------------------------------
-// merge (entity-only, ADR-099 B3 scope decision — see final report)
+// merge (entity-only)
 // ---------------------------------------------------------------------------
 
-// NOTE (B3 fix round, Leo refinement 2026-07-07): full atomic-merge parity
-// (field folding, survivor FTS/vector reindex, loser index purge, merge
-// provenance, same-kind rejection) was drafted and unit-tested in this round,
-// but was reverted in favor of deferring atomic `merge` entirely at the
-// pre-runtime admissibility guard (`khive_types::pack::
-// ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`, alongside `propose`/`review`/`withdraw`)
-// — see the fix-round report for the full rationale. This function is
-// therefore back to its pre-fix-round shape: it still produces a plan (kept
-// for the existing direct-prepare test coverage below and as defense in
-// depth), but the CLI's `--atomic` surface never reaches it, since
-// `check_atomic_admissible` rejects `merge` before any runtime is built.
+// Full atomic-merge parity (field folding, survivor FTS/vector reindex,
+// loser index purge, merge provenance, same-kind rejection) is deferred:
+// atomic `merge` is rejected entirely at the pre-runtime admissibility
+// guard (`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`, alongside
+// `propose`/`review`/`withdraw`). This function still produces a plan
+// (kept for the existing direct-prepare test coverage below and as
+// defense in depth), but the CLI's `--atomic` surface never reaches it,
+// since `check_atomic_admissible` rejects `merge` before any runtime is
+// built.
 async fn prepare_merge(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -1391,9 +1332,9 @@ async fn prepare_merge(
 // ---------------------------------------------------------------------------
 
 /// Run every deferred [`PostCommitEffect`] after a committed atomic unit,
-/// outside any transaction (ADR-099 D1 phase 3). Re-fetches each target's
-/// now-committed row and reuses the existing `reindex_entity`/`reindex_note`
-/// (FTS + embedding, same as the non-atomic path) for exact parity.
+/// outside any transaction. Re-fetches each target's now-committed row and
+/// reuses the existing `reindex_entity`/`reindex_note` (FTS + embedding,
+/// same as the non-atomic path) for exact parity.
 pub async fn apply_post_commit_effects(
     runtime: &KhiveRuntime,
     token: &NamespaceToken,
@@ -1410,38 +1351,34 @@ pub async fn apply_post_commit_effects(
             PostCommitEffect::ReindexNote { note_id } => {
                 if let Some(note) = runtime.notes(token)?.get_note(note_id).await? {
                     runtime.reindex_note(token, &note).await?;
-                    // #750 fix-round 2 (codex r2 High 2): this handler
-                    // called `reindex_note` directly, bypassing
-                    // `update_note()` entirely — the note-mutation hook
-                    // `update_note` fires after its own reindex (see
-                    // `curation.rs`) was never reached for an atomic
-                    // update. Fire it here so any in-process consumer
-                    // (e.g. khive-pack-memory's warm ANN cache) sees a
-                    // bumped generation after a committed atomic note
-                    // update, matching the non-atomic path.
+                    // This handler calls `reindex_note` directly, bypassing
+                    // `update_note()` and the note-mutation hook it fires
+                    // after its own reindex (see `curation.rs`). Fire it
+                    // here so any in-process consumer (e.g.
+                    // khive-pack-memory's warm ANN cache) sees a bumped
+                    // generation after a committed atomic note update,
+                    // matching the non-atomic path.
                     runtime.fire_note_mutation_hook(&note.kind, note.id).await;
                 }
             }
             PostCommitEffect::NoteDeleted { note_id, kind } => {
-                // #750 fix-round 2 (codex r2 High 2): `DeletePlan` had no
-                // `post_commit` slot at all prior to this round, so an
-                // atomic note delete never reached
-                // `fire_note_mutation_hook` — unlike `operations.rs`'s
-                // `delete_note`, which fires it directly (with the
-                // already-known kind, no refetch) after a successful row
-                // delete. The note row is gone (hard delete) or tombstoned
-                // (soft delete) by the time this post-commit pass runs, so
-                // this mirrors `delete_note`'s direct-fire shape rather
-                // than `ReindexNote`'s refetch-then-fire shape.
+                // Unlike `operations.rs`'s `delete_note`, which fires
+                // `fire_note_mutation_hook` directly (with the already-known
+                // kind, no refetch) after a successful row delete, an atomic
+                // note delete needs this post-commit pass to reach it. The
+                // note row is gone (hard delete) or tombstoned (soft
+                // delete) by the time this runs, so it mirrors
+                // `delete_note`'s direct-fire shape rather than
+                // `ReindexNote`'s refetch-then-fire shape.
                 runtime.fire_note_mutation_hook(&kind, note_id).await;
             }
             PostCommitEffect::GtdAudit { .. } => {
-                // GAP-5 (B3 fix round 4): applied by the `kkernel` caller's
-                // own post-commit pass, not here — `khive-pack-gtd` (owner
-                // of `ensure_audit_schema`/`write_audit_record`) depends on
+                // Applied by the `kkernel` caller's own post-commit pass,
+                // not here — `khive-pack-gtd` (owner of
+                // `ensure_audit_schema`/`write_audit_record`) depends on
                 // `khive-runtime`, not the other way around, so this crate
-                // cannot act on the effect itself. See `PostCommitEffect::
-                // GtdAudit`'s doc comment.
+                // cannot act on the effect itself. See
+                // `PostCommitEffect::GtdAudit`'s doc comment.
             }
         }
     }
@@ -1516,13 +1453,13 @@ mod tests {
         rt
     }
 
-    /// GAP-4 (B3 fix round 4): atomic `update` must reject a field that
-    /// does not apply to the resolved substrate — parity with
-    /// `khive-pack-kg::handlers::update::reject_inapplicable_fields`
-    /// (update.rs:195). The pre-fix atomic prepare silently ignored
-    /// `salience` on an entity: it would set every entity field to its
-    /// CURRENT value, bump `updated_at`, satisfy the `exactly(1)` guard,
-    /// and commit — a spurious no-op reported as success.
+    /// Atomic `update` must reject a field that does not apply to the
+    /// resolved substrate — parity with
+    /// `khive-pack-kg::handlers::update::reject_inapplicable_fields`.
+    /// Without this check, atomic prepare would silently ignore `salience`
+    /// on an entity: it would set every entity field to its current value,
+    /// bump `updated_at`, satisfy the `exactly(1)` guard, and commit — a
+    /// spurious no-op reported as success.
     #[tokio::test]
     async fn atomic_update_entity_rejects_note_only_field_salience() {
         let runtime = scratch_runtime();
@@ -1579,9 +1516,9 @@ mod tests {
         assert_eq!(entity.name, "GapFourEntity-renamed");
     }
 
-    /// GAP-4 (B3 fix round 4): symmetric note-substrate case — `description`
-    /// and `tags` are entity-only fields; passing either for a note must be
-    /// rejected the same way update.rs rejects them.
+    /// Symmetric note-substrate case: `description` and `tags` are
+    /// entity-only fields; passing either for a note must be rejected the
+    /// same way update.rs rejects them.
     #[tokio::test]
     async fn atomic_update_note_rejects_entity_only_field_description() {
         let runtime = scratch_runtime();
@@ -1629,10 +1566,10 @@ mod tests {
         ));
     }
 
-    /// ADR-099 B3 acceptance test 3: updating a note's content inside an
-    /// atomic unit must, after commit, leave the note recallable via FTS
-    /// under its NEW content and its vector row refreshed — parity with the
-    /// non-atomic `update_note` -> `reindex_note` path.
+    /// Updating a note's content inside an atomic unit must, after commit,
+    /// leave the note recallable via FTS under its new content and its
+    /// vector row refreshed — parity with the non-atomic
+    /// `update_note` -> `reindex_note` path.
     #[tokio::test]
     async fn atomic_update_note_content_is_fts_and_vector_reindexed_post_commit() {
         let runtime = scratch_runtime();
@@ -1705,21 +1642,17 @@ mod tests {
         );
     }
 
-    /// #750 fix-round 2 (codex r2 High 2, in-process portion): the
-    /// atomic-plan path never fired the pack-installed note-mutation hook
-    /// for either an atomic note UPDATE (`PostCommitEffect::ReindexNote`'s
-    /// handler called `reindex_note` directly, bypassing `update_note()`,
-    /// which is where the hook fires on the non-atomic path) or an atomic
-    /// note DELETE (`DeletePlan` carried no `post_commit` slot at all
-    /// before this round, so nothing could fire there regardless). Both
-    /// are fixed in this round: `ReindexNote`'s handler now fires the hook
-    /// after its own reindex, and `DeletePlan` now carries a
-    /// `PostCommitEffect::NoteDeleted` that `apply_post_commit_effects`
-    /// dispatches directly (mirroring `operations.rs::delete_note`'s
-    /// direct-fire, no-refetch shape — the row may already be gone by the
-    /// time this runs, for a hard delete). A minimal counting hook proves
-    /// both fire; no `khive-pack-memory` dependency is needed at this
-    /// layer, since the hook itself is generic.
+    /// The atomic-plan path must fire the pack-installed note-mutation hook
+    /// for both an atomic note UPDATE (`PostCommitEffect::ReindexNote`'s
+    /// handler fires it after its own reindex, mirroring `update_note()`
+    /// on the non-atomic path) and an atomic note DELETE (`DeletePlan`
+    /// carries a `PostCommitEffect::NoteDeleted` that
+    /// `apply_post_commit_effects` dispatches directly, mirroring
+    /// `operations.rs::delete_note`'s direct-fire, no-refetch shape — the
+    /// row may already be gone by the time this runs, for a hard delete).
+    /// A minimal counting hook proves both fire; no `khive-pack-memory`
+    /// dependency is needed at this layer, since the hook itself is
+    /// generic.
     #[tokio::test]
     async fn atomic_note_update_and_delete_post_commit_fire_the_note_mutation_hook() {
         let runtime = scratch_runtime();
@@ -1769,7 +1702,7 @@ mod tests {
             .await
             .expect("apply post-commit effects (update)");
 
-        // Delete path (soft delete — the row still exists, but the fix
+        // Delete path (soft delete — the row still exists, but the hook
         // fires directly from the captured kind rather than refetching).
         let mut del_note =
             khive_storage::note::Note::new("local", "observation", "hook-delete-target");
@@ -1820,9 +1753,9 @@ mod tests {
         );
     }
 
-    /// B3 fix round (codex REJECT Blocker 1): atomic delete must purge the
-    /// note's FTS row and vector row for BOTH soft and hard delete — parity
-    /// with `KhiveRuntime::delete_note`'s index-cleanup contract.
+    /// Atomic delete must purge the note's FTS row and vector row for both
+    /// soft and hard delete — parity with `KhiveRuntime::delete_note`'s
+    /// index-cleanup contract.
     #[tokio::test]
     async fn atomic_delete_note_purges_fts_and_vector_indexes_soft_and_hard() {
         let runtime = scratch_runtime();
@@ -1903,9 +1836,9 @@ mod tests {
         }
     }
 
-    /// B3 fix round (codex REJECT Blocker 1): atomic delete must purge the
-    /// entity's FTS row and vector row for BOTH soft and hard delete — parity
-    /// with `KhiveRuntime::delete_entity`'s index-cleanup contract.
+    /// Atomic delete must purge the entity's FTS row and vector row for
+    /// both soft and hard delete — parity with
+    /// `KhiveRuntime::delete_entity`'s index-cleanup contract.
     #[tokio::test]
     async fn atomic_delete_entity_purges_fts_and_vector_indexes_soft_and_hard() {
         let runtime = scratch_runtime();
@@ -1985,9 +1918,9 @@ mod tests {
         }
     }
 
-    /// B3 fix round (codex REJECT High finding): atomic link must persist an
-    /// explicit top-level `dependency_kind` param into edge metadata, and
-    /// must infer one for `depends_on` edges when absent — parity with
+    /// Atomic link must persist an explicit top-level `dependency_kind`
+    /// param into edge metadata, and must infer one for `depends_on` edges
+    /// when absent — parity with
     /// `link.rs`'s `merge_entry_metadata` and `operations.rs`'s
     /// `infer_dependency_kind` table.
     #[tokio::test]
@@ -2111,11 +2044,11 @@ mod tests {
         (count, weight, metadata, deleted_at)
     }
 
-    /// GAP-2 (B3 fix round 4): atomic `link` must be an upsert, exactly like
-    /// canonical `link` -> `upsert_edge`'s natural-key `ON CONFLICT` arm —
-    /// re-linking an already-linked triple must SUCCEED and update
-    /// weight/metadata, not hit the `UNIQUE(namespace, source_id, target_id,
-    /// relation)` constraint and roll back the whole atomic unit.
+    /// Atomic `link` must be an upsert, exactly like canonical `link` ->
+    /// `upsert_edge`'s natural-key `ON CONFLICT` arm — re-linking an
+    /// already-linked triple must succeed and update weight/metadata, not
+    /// hit the `UNIQUE(namespace, source_id, target_id, relation)`
+    /// constraint and roll back the whole atomic unit.
     #[tokio::test]
     async fn atomic_link_of_already_linked_triple_upserts_weight_and_metadata() {
         let runtime = scratch_runtime();
@@ -2201,9 +2134,9 @@ mod tests {
         assert!(deleted_at.is_none());
     }
 
-    /// GAP-2 (B3 fix round 4): atomic `link` of a SOFT-DELETED triple must
-    /// resurrect it (`deleted_at = NULL`), matching `upsert_edge`'s
-    /// natural-key `ON CONFLICT ... DO UPDATE SET deleted_at = NULL`.
+    /// Atomic `link` of a soft-deleted triple must resurrect it
+    /// (`deleted_at = NULL`), matching `upsert_edge`'s natural-key
+    /// `ON CONFLICT ... DO UPDATE SET deleted_at = NULL`.
     #[tokio::test]
     async fn atomic_link_of_soft_deleted_triple_resurrects_it() {
         let runtime = scratch_runtime();
@@ -2301,13 +2234,13 @@ mod tests {
         );
     }
 
-    /// B3 fix round 3 (codex r2 Blocker 1): atomic delete of an entity AND a
-    /// note must SUCCEED even when the registered embedding model's `vec_*`
-    /// table has never been lazily created (a fresh DB registers models
-    /// before any vector store is opened) — the raw purge DML must skip
-    /// tables that don't exist rather than hit `no such table` and roll
-    /// back the whole atomic unit. FTS purge still fires (those tables
-    /// always exist) and the delete itself is a clean commit.
+    /// Atomic delete of an entity and a note must succeed even when the
+    /// registered embedding model's `vec_*` table has never been lazily
+    /// created (a fresh DB registers models before any vector store is
+    /// opened) — the raw purge DML must skip tables that don't exist
+    /// rather than hit `no such table` and roll back the whole atomic
+    /// unit. FTS purge still fires (those tables always exist) and the
+    /// delete itself is a clean commit.
     #[tokio::test]
     async fn atomic_delete_succeeds_when_vec_table_never_created() {
         let runtime = scratch_runtime();
@@ -2378,11 +2311,11 @@ mod tests {
         );
     }
 
-    /// B3 fix round 3 (codex r2 High finding 2): atomic hard delete must be
-    /// able to purge a record that was ALREADY soft-deleted — parity with
-    /// `delete(id, hard=true)` being the public purge route after a prior
-    /// soft delete (the non-atomic hard path resolves including deleted
-    /// rows and its DML carries no `deleted_at` predicate).
+    /// Atomic hard delete must be able to purge a record that was already
+    /// soft-deleted — parity with `delete(id, hard=true)` being the public
+    /// purge route after a prior soft delete (the non-atomic hard path
+    /// resolves including deleted rows and its DML carries no `deleted_at`
+    /// predicate).
     #[tokio::test]
     async fn atomic_hard_delete_purges_already_soft_deleted_entity_and_note() {
         let runtime = scratch_runtime();
@@ -2529,7 +2462,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // GAP-1 (B3 fix round): event-store append parity
+    // event-store append parity
     // ------------------------------------------------------------------
 
     /// Fetch every event of `kind` targeting `target_id`, via the same
@@ -2556,10 +2489,10 @@ mod tests {
             .collect()
     }
 
-    /// GAP-1: atomic `update(id=<entity>, name=...)` must append an
-    /// `EntityUpdated` event, matching `curation::update_entity`
-    /// (curation.rs:257-273) — the event is appended unconditionally after
-    /// a successful row update, not only on the reindex-triggering subset.
+    /// Atomic `update(id=<entity>, name=...)` must append an
+    /// `EntityUpdated` event, matching `curation::update_entity` — the
+    /// event is appended unconditionally after a successful row update,
+    /// not only on the reindex-triggering subset.
     #[tokio::test]
     async fn atomic_update_entity_appends_entity_updated_event() {
         let runtime = scratch_runtime();
@@ -2606,9 +2539,9 @@ mod tests {
         );
     }
 
-    /// GAP-1: atomic soft AND hard delete of an entity must each append an
-    /// `EntityDeleted` event, matching `operations::delete_entity`
-    /// (operations.rs:3543-3558), which fires on both delete modes.
+    /// Atomic soft and hard delete of an entity must each append an
+    /// `EntityDeleted` event, matching `operations::delete_entity`, which
+    /// fires on both delete modes.
     #[tokio::test]
     async fn atomic_delete_entity_appends_entity_deleted_event_soft_and_hard() {
         let runtime = scratch_runtime();
@@ -2657,9 +2590,9 @@ mod tests {
         }
     }
 
-    /// GAP-1: atomic soft AND hard delete of a note must each append a
-    /// `NoteDeleted` event, matching `operations::delete_note`
-    /// (operations.rs:3326-3340), which fires on both delete modes.
+    /// Atomic soft and hard delete of a note must each append a
+    /// `NoteDeleted` event, matching `operations::delete_note`, which
+    /// fires on both delete modes.
     #[tokio::test]
     async fn atomic_delete_note_appends_note_deleted_event_soft_and_hard() {
         let runtime = scratch_runtime();
@@ -2711,13 +2644,12 @@ mod tests {
         }
     }
 
-    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `update`
-    /// admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this asserts
-    /// `prepare_update` actually builds a plan for one — a non-symmetric
-    /// relation (`extends`) exercises the `edge_upsert_statement` reuse
-    /// branch — and that the committed row + `EdgeUpdated` event match
-    /// canonical `update_edge`'s shape (weight persisted, relation
-    /// unchanged, exactly one event).
+    /// `update` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this
+    /// asserts `prepare_update` actually builds a plan for one — a
+    /// non-symmetric relation (`extends`) exercises the
+    /// `edge_upsert_statement` reuse branch — and that the committed row +
+    /// `EdgeUpdated` event match canonical `update_edge`'s shape (weight
+    /// persisted, relation unchanged, exactly one event).
     #[tokio::test]
     async fn atomic_update_edge_patches_weight_and_appends_edge_updated_event() {
         let runtime = scratch_runtime();
@@ -2777,7 +2709,7 @@ mod tests {
         );
     }
 
-    /// ADR-099 B3 r6: the symmetric-relation conflict-absorption branch of
+    /// The symmetric-relation conflict-absorption branch of
     /// `prepare_update_edge` — mirrors `update_edge_symmetric_dml`'s case
     /// (b): changing a non-symmetric edge's `relation` to a symmetric one
     /// whose canonical natural key collides with an ALREADY-EXISTING
@@ -2821,12 +2753,12 @@ mod tests {
         )
         .await
         .expect("prepare update edge (symmetric conflict)");
-        // ADR-099 B3 r9: the plan no longer computes a prepare-time
-        // advisory surviving id (`target_id` is just the requested id) —
-        // it carries `edge_natural_key` so a post-commit caller can derive
-        // the real surviving id itself. Assert the plan carries the RIGHT
-        // natural key to look up; the actual surviving row's identity is
-        // verified against the DB after commit, below.
+        // The plan does not compute a prepare-time advisory surviving id
+        // (`target_id` is just the requested id) — it carries
+        // `edge_natural_key` so a post-commit caller can derive the real
+        // surviving id itself. Assert the plan carries the right natural
+        // key to look up; the actual surviving row's identity is verified
+        // against the DB after commit, below.
         let (canon_src, canon_tgt) =
             canonical_edge_endpoints(EdgeRelation::CompetesWith, a_id, b_id);
         match &plan {
@@ -2881,18 +2813,17 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
-    /// ADR-099 B3 r9 (codex r8 Blocker finding 1): the same-unit race codex
-    /// named — `[delete(X), update(X -> competes_with)]` where an
-    /// ALREADY-EXISTING canonical row sits at the post-update natural key.
-    /// Both ops' async prepare passes run before either commits, so at
+    /// The same-unit race: `[delete(X), update(X -> competes_with)]` where
+    /// an already-existing canonical row sits at the post-update natural
+    /// key. Both ops' async prepare passes run before either commits, so at
     /// prepare time `X` still exists and both plans build. At commit time
-    /// `delete(X)` removes it FIRST; `update(X -> competes_with)`'s own
+    /// `delete(X)` removes it first; `update(X -> competes_with)`'s own
     /// commit-time statements must then fail loud (its target no longer
     /// exists) rather than silently absorbing into the pre-existing
     /// canonical row it never causally touched. The whole atomic unit must
     /// roll back — parity with canonical `update_edge`'s `NotFound` for a
-    /// missing edge, expressed here as the unit-level abort ADR-099
-    /// specifies for any op whose commit-time guard fails.
+    /// missing edge, expressed here as the unit-level abort for any op
+    /// whose commit-time guard fails.
     #[tokio::test]
     async fn atomic_update_edge_symmetric_same_unit_delete_race_aborts_the_unit() {
         let runtime = scratch_runtime();
@@ -2977,11 +2908,10 @@ mod tests {
         );
     }
 
-    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `update`
-    /// rejects an entity/note-only field (`name`) on an edge target,
-    /// mirroring `khive-pack-kg::handlers::update::reject_inapplicable_fields`'s
-    /// `KindSpec::Edge` arm — before this fix `reject_inapplicable_update_fields`
-    /// had no `"edge"` match arm at all, so the field was silently dropped.
+    /// `update` rejects an entity/note-only field (`name`) on an edge
+    /// target, mirroring
+    /// `khive-pack-kg::handlers::update::reject_inapplicable_fields`'s
+    /// `KindSpec::Edge` arm.
     #[tokio::test]
     async fn atomic_update_edge_rejects_entity_only_field_name() {
         let runtime = scratch_runtime();
@@ -3015,11 +2945,10 @@ mod tests {
         );
     }
 
-    /// ADR-099 B3 r6 (closes the round-4 codex REJECT, High): `delete`
-    /// admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this asserts
-    /// `prepare_delete` actually builds a plan for one on both soft and
-    /// hard delete, matching `operations::delete_edge`'s row-mode DML and
-    /// unconditional `EdgeDeleted` event.
+    /// `delete` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this
+    /// asserts `prepare_delete` actually builds a plan for one on both soft
+    /// and hard delete, matching `operations::delete_edge`'s row-mode DML
+    /// and unconditional `EdgeDeleted` event.
     #[tokio::test]
     async fn atomic_delete_edge_soft_and_hard_appends_edge_deleted_event() {
         let runtime = scratch_runtime();
@@ -3082,9 +3011,9 @@ mod tests {
         }
     }
 
-    /// GAP-1 parity boundary: atomic `update` of a NOTE must append NO
-    /// event — canonical `update_note` never calls `append_event` (verified
-    /// by the sweep; unlike `update_entity`, which always does).
+    /// Parity boundary: atomic `update` of a note must append no event —
+    /// canonical `update_note` never calls `append_event` (unlike
+    /// `update_entity`, which always does).
     #[tokio::test]
     async fn atomic_update_note_appends_no_event() {
         let runtime = scratch_runtime();
@@ -3135,8 +3064,8 @@ mod tests {
         );
     }
 
-    /// GAP-1 parity boundary: atomic `link` must append NO event —
-    /// canonical `link` never calls `append_event` (verified by the sweep).
+    /// Parity boundary: atomic `link` must append no event — canonical
+    /// `link` never calls `append_event`.
     #[tokio::test]
     async fn atomic_link_appends_no_event() {
         let runtime = scratch_runtime();

--- a/crates/khive-runtime/src/atomic_prepare.rs
+++ b/crates/khive-runtime/src/atomic_prepare.rs
@@ -1,4 +1,4 @@
-//! ADR-099 — the per-verb async prepare pass for the KG-substrate v1
+//! ADR-099: the per-verb async prepare pass for the KG-substrate v1
 //! admissible verbs (`update`, `delete`, `link`, `merge`). Each `prepare_*`
 //! function reads current state (async, outside any transaction) and
 //! returns a plain-data [`crate::atomic_runner::AtomicOpPlan`]
@@ -7,7 +7,7 @@
 //!
 //! `gtd.transition` / `gtd.complete` prepare is deliberately **not** here:
 //! their lifecycle vocabulary (`is_terminal`, `can_transition`, ...) lives in
-//! `khive-pack-gtd`, which depends on `khive-runtime` — not the other way
+//! `khive-pack-gtd`, which depends on `khive-runtime`: not the other way
 //! around. Reproducing that dependency here would invert the crate graph, so
 //! their prepare functions live in `kkernel` (which already depends on both
 //! crates), calling back into the plain [`PlanStatement`]/[`AffectedRowGuard`]
@@ -27,7 +27,7 @@
 //! same-kind rejection are achievable as static DML, but
 //! `curation::merge_entity_sql`'s graceful edge-conflict resolution is not
 //! (it is per-row procedural, incompatible with the static predicate/guard
-//! plan shape) — rather than ship a partially-scoped atomic merge, it is
+//! plan shape): rather than ship a partially-scoped atomic merge, it is
 //! rejected at the same pre-runtime static guard as governance
 //! ([`khive_types::pack::ATOMIC_KNOWN_UNIMPLEMENTED_VERBS`]). `prepare_merge`
 //! below is therefore unreachable through `--atomic`; it remains only as the
@@ -101,7 +101,7 @@ fn optional_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
 /// derived `Deserialize` for `Option<T>` intercepts a literal JSON `null` at
 /// the outer `Option` boundary and maps it straight to Rust `None`
 /// regardless of the inner type, so canonical's own "clear" arm is
-/// unreachable through normal struct deserialization — `update(name=null)` /
+/// unreachable through normal struct deserialization: `update(name=null)` /
 /// `update(description=null)` are no-ops, not clears. This module reads raw,
 /// un-deserialized JSON, so it must replicate that collapse explicitly: key
 /// absent OR JSON `null` -> `None` (leave unchanged, no-op); key present as a
@@ -118,9 +118,9 @@ fn optional_string_patch(args: &Value, key: &str) -> RuntimeResult<Option<Option
 
 /// Strict string-or-absent-or-null patch for entity `name`. Unlike
 /// `optional_str`'s `.as_str()`, this does not silently drop a non-string,
-/// non-null value like `name: 123` as absent — it rejects it instead of
+/// non-null value like `name: 123` as absent: it rejects it instead of
 /// reporting success for an invalid update. Canonical validates entity
-/// `name` via `string_value` on `UpdateParams.name: Option<Value>` — null
+/// `name` via `string_value` on `UpdateParams.name: Option<Value>`: null
 /// collapses to absent at the struct-deserialize boundary (see
 /// `optional_string_patch` doc above), so the reachable behavior is:
 /// absent/null -> unchanged; non-null string -> set; any other JSON type ->
@@ -140,7 +140,7 @@ fn entity_name_patch(args: &Value) -> RuntimeResult<Option<String>> {
 /// `properties: Option<Value>` on `UpdateParams` collapses a literal JSON
 /// `null` to Rust `None` at the struct-deserialize boundary (same collapse
 /// as `optional_string_patch` above), so `properties=null` is canonically a
-/// no-op (leave existing properties unchanged) — not a stored JSON `null`.
+/// no-op (leave existing properties unchanged): not a stored JSON `null`.
 /// This module reads raw JSON, so it must replicate that collapse: key
 /// absent OR JSON `null` -> `None` (no merge); any other JSON value ->
 /// `Some(value)` (merge), with no further shape validation at this layer.
@@ -260,18 +260,18 @@ async fn vector_table_exists(runtime: &KhiveRuntime, table: &str) -> RuntimeResu
 
 /// Append the FTS + every registered model's vector-row purge for `subject_id`
 /// (scoped to the RECORD's own namespace, matching `delete_entity`/
-/// `delete_note`'s `record_tok`/`record_ns` convention — not the caller
+/// `delete_note`'s `record_tok`/`record_ns` convention: not the caller
 /// token's namespace, per by-ID namespace-agnosticism) onto `statements`.
 ///
 /// FTS tables (`fts_entities`/`fts_notes`) always exist (created at schema
 /// migration time) so their purge is unconditional. `vec_*` tables are
 /// created lazily on first vector-store open, so a default runtime can
-/// register embedding models before any vector table necessarily exists —
+/// register embedding models before any vector table necessarily exists:
 /// a raw unconditional `DELETE FROM vec_*` can hit `no such table` on a
 /// fresh DB. Only push the vec purge for tables that actually exist:
 /// absence means the record definitionally has no vector row for that
 /// model, so skipping is data-parity-correct (the non-atomic path would
-/// lazily create the table then delete zero rows — same data outcome,
+/// lazily create the table then delete zero rows: same data outcome,
 /// without this read-only prepare pass performing an init side effect).
 async fn push_index_purge_statements(
     runtime: &KhiveRuntime,
@@ -309,7 +309,7 @@ async fn push_index_purge_statements(
 ///
 /// Builds the `Event` exactly as each canonical site does and turns it into
 /// plain-data `SqlStatement`s via
-/// [`khive_db::stores::event::event_insert_statements`] — the same builder
+/// [`khive_db::stores::event::event_insert_statements`]: the same builder
 /// the async execution path every canonical `event_store.append_event(...)`
 /// call reaches uses. There is exactly one place that knows the
 /// `events`/`event_observations` insert shape; this function only adapts its
@@ -369,7 +369,7 @@ pub async fn prepare_op(
         // `expected_kind: None` here — same reasoning as the `"delete"` arm
         // below: callers that need `update(kind=...)` parity must resolve
         // the kind spec themselves (it needs a `VerbRegistry`, unreachable
-        // from this crate — see `AtomicUpdateKind`'s doc comment) and call
+        // from this crate: see `AtomicUpdateKind`'s doc comment) and call
         // `prepare_update` directly with the resolved value; `kkernel`'s
         // `--atomic` seam does exactly this and bypasses this dispatch arm.
         // A caller reaching `prepare_op("update", ...)` without going
@@ -377,7 +377,7 @@ pub async fn prepare_op(
         "update" => prepare_update(runtime, token, args, None).await,
         // `expected_kind: None` here — callers that need `delete(kind=...)`
         // parity must resolve the kind spec themselves (it needs a
-        // `VerbRegistry`, unreachable from this crate — see
+        // `VerbRegistry`, unreachable from this crate: see
         // `AtomicDeleteKind`'s doc comment) and call `prepare_delete`
         // directly with the resolved value; `kkernel`'s `--atomic` seam does
         // exactly this and bypasses this dispatch arm. A caller reaching
@@ -414,7 +414,7 @@ fn prepare_governance_unimplemented(tool: &str) -> RuntimeResult<AtomicOpPlan> {
 /// the resolved substrate (e.g. `salience` on an entity, or
 /// `description`/`tags` on a note). That function has no dependency edge
 /// back to `khive-runtime`, so its exact field-applicability check list and
-/// error message shape are reimplemented here rather than imported — same
+/// error message shape are reimplemented here rather than imported: same
 /// pattern as `optional_string_patch` above. Presence is checked directly on
 /// the raw args object (this module has no `UpdateParams` struct); a JSON
 /// `null` value is treated as absent, matching `Option<T>` deserialization
@@ -493,13 +493,13 @@ fn reject_inapplicable_update_fields(args: &Value, substrate: &str) -> RuntimeRe
 }
 
 /// Caller-supplied update-kind expectation, resolved via the canonical
-/// `resolve_kind_spec` at the kkernel `--atomic` seam — the same pattern
+/// `resolve_kind_spec` at the kkernel `--atomic` seam: the same pattern
 /// [`AtomicDeleteKind`] uses. Without this check, `update(kind="document",
 /// id=<concept>)` would be canonically `NotFound` but the atomic path would
 /// ignore the explicit kind and mutate the resolved entity anyway.
 /// `khive-runtime` must not depend on `khive-pack-kg`, so this is a plain
 /// substrate-level shape rather than `khive_pack_kg::handlers::KindSpec`
-/// itself — the kkernel seam does the pack-aware resolution and passes down
+/// itself: the kkernel seam does the pack-aware resolution and passes down
 /// only what `prepare_update` needs to enforce the mismatch check.
 pub enum AtomicUpdateKind {
     Entity { specific: Option<String> },
@@ -520,7 +520,7 @@ pub async fn prepare_update(
 ) -> RuntimeResult<AtomicOpPlan> {
     let id = require_uuid(args, "id")?;
 
-    // Mirrors update.rs's entity_kind immutability guard — entity_kind is a
+    // Mirrors update.rs's entity_kind immutability guard: entity_kind is a
     // legacy top-level field, independent of the `kind` substrate
     // discriminator handled elsewhere.
     if obj(args)?.get("entity_kind").is_some_and(|v| !v.is_null()) {
@@ -580,7 +580,7 @@ pub async fn prepare_update(
             }];
             // curation.rs's `update_entity` appends an `EntityUpdated` event
             // unconditionally after `upsert_entity` succeeds, regardless of
-            // `text_changed` — match that here, not just on the
+            // `text_changed`: match that here, not just on the
             // reindex-triggering subset of updates.
             statements.extend(event_append_statements(
                 &entity.namespace,
@@ -701,7 +701,7 @@ pub async fn prepare_update(
 ///
 /// DML shape:
 /// - non-symmetric relation: a single [`edge_upsert_statement`] call on the
-///   patched `Edge` — the same builder `update_edge`'s own non-symmetric
+///   patched `Edge`: the same builder `update_edge`'s own non-symmetric
 ///   branch calls via `graph.upsert_edge(edge.clone())`
 ///   (`khive-db::stores::graph::SqlGraphStore::upsert_edge`), so parity is
 ///   exact by construction.
@@ -779,7 +779,7 @@ async fn prepare_update_edge(
 
     if edge.relation.is_symmetric() {
         // The write for a symmetric relation never branches on a
-        // prepare-time probe result — it always carries both self-guarding,
+        // prepare-time probe result: it always carries both self-guarding,
         // commit-time-predicate statements (see their doc comment in
         // khive-db's graph.rs for the full rationale). This avoids the
         // staleness window a prepare-time probe would expose: an earlier op
@@ -841,7 +841,7 @@ async fn prepare_update_edge(
     }
 
     // Mirrors `update_edge`'s unconditional post-mutation `EdgeUpdated`
-    // event append, keyed on the original `edge_id` the caller supplied —
+    // event append, keyed on the original `edge_id` the caller supplied:
     // canonical does the same (the event target is `edge_id`, not the
     // post-absorption surviving id).
     statements.extend(event_append_statements(
@@ -903,7 +903,7 @@ pub async fn prepare_delete(
     // `delete(id, hard=true)` is the public purge route after a prior soft
     // delete, so it must resolve including already-tombstoned rows (a
     // live-only resolve would never find one). Soft delete keeps the
-    // live-only resolve — a soft delete of an already-tombstoned row is a
+    // live-only resolve: a soft delete of an already-tombstoned row is a
     // no-op, matching non-atomic behavior.
     let resolved = if hard {
         runtime.resolve_by_id_including_deleted(token, id).await?
@@ -1041,7 +1041,7 @@ pub async fn prepare_delete(
             )
             .await?;
             // operations.rs's `delete_note` appends a `NoteDeleted` event
-            // after a successful row delete, on both soft and hard delete —
+            // after a successful row delete, on both soft and hard delete:
             // same reasoning as the entity branch above.
             statements.extend(event_append_statements(
                 &namespace,
@@ -1374,7 +1374,7 @@ pub async fn apply_post_commit_effects(
             }
             PostCommitEffect::GtdAudit { .. } => {
                 // Applied by the `kkernel` caller's own post-commit pass,
-                // not here — `khive-pack-gtd` (owner of
+                // not here: `khive-pack-gtd` (owner of
                 // `ensure_audit_schema`/`write_audit_record`) depends on
                 // `khive-runtime`, not the other way around, so this crate
                 // cannot act on the effect itself. See
@@ -1454,11 +1454,11 @@ mod tests {
     }
 
     /// Atomic `update` must reject a field that does not apply to the
-    /// resolved substrate — parity with
+    /// resolved substrate: parity with
     /// `khive-pack-kg::handlers::update::reject_inapplicable_fields`.
     /// Without this check, atomic prepare would silently ignore `salience`
     /// on an entity: it would set every entity field to its current value,
-    /// bump `updated_at`, satisfy the `exactly(1)` guard, and commit — a
+    /// bump `updated_at`, satisfy the `exactly(1)` guard, and commit: a
     /// spurious no-op reported as success.
     #[tokio::test]
     async fn atomic_update_entity_rejects_note_only_field_salience() {
@@ -1568,7 +1568,7 @@ mod tests {
 
     /// Updating a note's content inside an atomic unit must, after commit,
     /// leave the note recallable via FTS under its new content and its
-    /// vector row refreshed — parity with the non-atomic
+    /// vector row refreshed: parity with the non-atomic
     /// `update_note` -> `reindex_note` path.
     #[tokio::test]
     async fn atomic_update_note_content_is_fts_and_vector_reindexed_post_commit() {
@@ -1648,7 +1648,7 @@ mod tests {
     /// on the non-atomic path) and an atomic note DELETE (`DeletePlan`
     /// carries a `PostCommitEffect::NoteDeleted` that
     /// `apply_post_commit_effects` dispatches directly, mirroring
-    /// `operations.rs::delete_note`'s direct-fire, no-refetch shape — the
+    /// `operations.rs::delete_note`'s direct-fire, no-refetch shape: the
     /// row may already be gone by the time this runs, for a hard delete).
     /// A minimal counting hook proves both fire; no `khive-pack-memory`
     /// dependency is needed at this layer, since the hook itself is
@@ -1702,7 +1702,7 @@ mod tests {
             .await
             .expect("apply post-commit effects (update)");
 
-        // Delete path (soft delete — the row still exists, but the hook
+        // Delete path (soft delete: the row still exists, but the hook
         // fires directly from the captured kind rather than refetching).
         let mut del_note =
             khive_storage::note::Note::new("local", "observation", "hook-delete-target");
@@ -1754,7 +1754,7 @@ mod tests {
     }
 
     /// Atomic delete must purge the note's FTS row and vector row for both
-    /// soft and hard delete — parity with `KhiveRuntime::delete_note`'s
+    /// soft and hard delete: parity with `KhiveRuntime::delete_note`'s
     /// index-cleanup contract.
     #[tokio::test]
     async fn atomic_delete_note_purges_fts_and_vector_indexes_soft_and_hard() {
@@ -1837,7 +1837,7 @@ mod tests {
     }
 
     /// Atomic delete must purge the entity's FTS row and vector row for
-    /// both soft and hard delete — parity with
+    /// both soft and hard delete: parity with
     /// `KhiveRuntime::delete_entity`'s index-cleanup contract.
     #[tokio::test]
     async fn atomic_delete_entity_purges_fts_and_vector_indexes_soft_and_hard() {
@@ -1920,7 +1920,7 @@ mod tests {
 
     /// Atomic link must persist an explicit top-level `dependency_kind`
     /// param into edge metadata, and must infer one for `depends_on` edges
-    /// when absent — parity with
+    /// when absent: parity with
     /// `link.rs`'s `merge_entry_metadata` and `operations.rs`'s
     /// `infer_dependency_kind` table.
     #[tokio::test]
@@ -2045,7 +2045,7 @@ mod tests {
     }
 
     /// Atomic `link` must be an upsert, exactly like canonical `link` ->
-    /// `upsert_edge`'s natural-key `ON CONFLICT` arm — re-linking an
+    /// `upsert_edge`'s natural-key `ON CONFLICT` arm: re-linking an
     /// already-linked triple must succeed and update weight/metadata, not
     /// hit the `UNIQUE(namespace, source_id, target_id, relation)`
     /// constraint and roll back the whole atomic unit.
@@ -2237,7 +2237,7 @@ mod tests {
     /// Atomic delete of an entity and a note must succeed even when the
     /// registered embedding model's `vec_*` table has never been lazily
     /// created (a fresh DB registers models before any vector store is
-    /// opened) — the raw purge DML must skip tables that don't exist
+    /// opened): the raw purge DML must skip tables that don't exist
     /// rather than hit `no such table` and roll back the whole atomic
     /// unit. FTS purge still fires (those tables always exist) and the
     /// delete itself is a clean commit.
@@ -2312,7 +2312,7 @@ mod tests {
     }
 
     /// Atomic hard delete must be able to purge a record that was already
-    /// soft-deleted — parity with `delete(id, hard=true)` being the public
+    /// soft-deleted: parity with `delete(id, hard=true)` being the public
     /// purge route after a prior soft delete (the non-atomic hard path
     /// resolves including deleted rows and its DML carries no `deleted_at`
     /// predicate).
@@ -2490,7 +2490,7 @@ mod tests {
     }
 
     /// Atomic `update(id=<entity>, name=...)` must append an
-    /// `EntityUpdated` event, matching `curation::update_entity` — the
+    /// `EntityUpdated` event, matching `curation::update_entity`: the
     /// event is appended unconditionally after a successful row update,
     /// not only on the reindex-triggering subset.
     #[tokio::test]
@@ -2645,9 +2645,9 @@ mod tests {
     }
 
     /// `update` admits `kind="edge"` per `ATOMIC_ADMISSIBLE_VERBS`; this
-    /// asserts `prepare_update` actually builds a plan for one — a
+    /// asserts `prepare_update` actually builds a plan for one, a
     /// non-symmetric relation (`extends`) exercises the
-    /// `edge_upsert_statement` reuse branch — and that the committed row +
+    /// `edge_upsert_statement` reuse branch, and that the committed row +
     /// `EdgeUpdated` event match canonical `update_edge`'s shape (weight
     /// persisted, relation unchanged, exactly one event).
     #[tokio::test]
@@ -2754,7 +2754,7 @@ mod tests {
         .await
         .expect("prepare update edge (symmetric conflict)");
         // The plan does not compute a prepare-time advisory surviving id
-        // (`target_id` is just the requested id) — it carries
+        // (`target_id` is just the requested id): it carries
         // `edge_natural_key` so a post-commit caller can derive the real
         // surviving id itself. Assert the plan carries the right natural
         // key to look up; the actual surviving row's identity is verified
@@ -3011,7 +3011,7 @@ mod tests {
         }
     }
 
-    /// Parity boundary: atomic `update` of a note must append no event —
+    /// Parity boundary: atomic `update` of a note must append no event:
     /// canonical `update_note` never calls `append_event` (unlike
     /// `update_entity`, which always does).
     #[tokio::test]
@@ -3064,7 +3064,7 @@ mod tests {
         );
     }
 
-    /// Parity boundary: atomic `link` must append no event — canonical
+    /// Parity boundary: atomic `link` must append no event: canonical
     /// `link` never calls `append_event`.
     #[tokio::test]
     async fn atomic_link_appends_no_event() {

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -161,25 +161,13 @@ impl NamespaceToken {
 
     /// Return a new token with the same actor but a different namespace.
     ///
-    /// The visible set is replaced with `[ns]` — the minted token has
-    /// `namespace = ns` and `visible = [ns]`. This is a full read+write token
-    /// for `ns`: public runtime APIs (`list_notes`, `update_note`, `delete_note`,
-    /// etc.) accept it and will operate on `ns`. It is NOT a type-enforced
-    /// write-only or append-only capability. This is a capability-transfer
-    /// primitive, not a policy gate: the caller is responsible for enforcing any
-    /// ACL check before calling this method and for using the minted token only
-    /// in the intended narrow scope (e.g. a single `create_note` call).
-    ///
-    /// Callers today:
-    /// - `khive-pack-memory` FTS fanout: iterates token's own visible set; no escalation.
-    /// - `khive-pack-comm` inbound delivery: mints a token for the recipient ns,
-    ///   gated by `actor.allowed_outbound_namespaces` allowlist check immediately
-    ///   before, and uses it for exactly one `create_note` call (append-only by
-    ///   convention, not by type enforcement).
-    ///
-    /// Under a security model (cloud, mutual auth), replace this call pattern with a
-    /// type-enforced append-only capability or a `comm.ingest` Subhandler dispatch
-    /// (see ADR-056/ADR-053) that goes through the Gate.
+    /// The visible set is replaced with `[ns]` — this is a full read+write token
+    /// for `ns`, not a type-enforced write-only or append-only capability. It is
+    /// a capability-transfer primitive, not a policy gate: callers must enforce
+    /// any ACL check before calling this and use the minted token only within
+    /// the intended narrow scope (e.g. a single `create_note` call). A future
+    /// security model should replace this pattern with a type-enforced
+    /// append-only capability that goes through the Gate.
     pub fn with_namespace(&self, ns: Namespace) -> Self {
         Self::mint_authorized(ns, self.actor.clone())
     }
@@ -342,28 +330,22 @@ impl Default for RuntimeConfig {
 }
 
 impl RuntimeConfig {
-    /// Build a `RuntimeConfig` with embedding disabled entirely (issue #396).
+    /// Build a `RuntimeConfig` with embedding disabled entirely.
     ///
     /// `embedding_model` and `additional_embedding_models` are computed
-    /// *independently* inside [`Default::default`] (see above): the former from
-    /// `KHIVE_EMBEDDING_MODEL`, the latter from `KHIVE_ADDITIONAL_EMBEDDING_MODELS`
-    /// (falling back to seeding `ParaphraseMultilingualMiniLmL12V2` when that var
-    /// is unset). Writing `RuntimeConfig { embedding_model: None,
-    /// ..RuntimeConfig::default() }` therefore does *not* produce a model-less
-    /// runtime: `additional_embedding_models` still carries the env-driven
-    /// fallback seed, `configured_embedding_models` still reports it, and the
-    /// note-write path fans out embedding to every *registered* model regardless
-    /// of `embedding_model` — so the first `memory.remember` on a machine without
-    /// local model files hard-fails instead of degrading to FTS-only.
+    /// independently inside [`Default::default`], so `RuntimeConfig {
+    /// embedding_model: None, ..RuntimeConfig::default() }` does NOT produce a
+    /// model-less runtime: `additional_embedding_models` still carries its
+    /// env-driven fallback seed, and the note-write path fans out embedding to
+    /// every registered model regardless of `embedding_model` — so the first
+    /// `memory.remember` on a machine without local model files hard-fails
+    /// instead of degrading to FTS-only.
     ///
-    /// This constructor clears both fields together and is the one ergonomic,
-    /// correct spelling for "no embed runtime". Model-less machines (CI runners,
-    /// fresh installs without local model files) should use it instead of the
-    /// two-field struct-update form above.
-    ///
-    /// Deliberately ignores `KHIVE_ADDITIONAL_EMBEDDING_MODELS`: a caller
-    /// reaching for `no_embeddings()` wants zero embedders unconditionally, not
-    /// "zero unless the environment happens to disagree".
+    /// This constructor clears both fields together and ignores
+    /// `KHIVE_ADDITIONAL_EMBEDDING_MODELS` unconditionally — the caller wants
+    /// zero embedders, not "zero unless the environment disagrees". Use it on
+    /// model-less machines (CI runners, fresh installs without local model
+    /// files) instead of the two-field struct-update form.
     pub fn no_embeddings() -> Self {
         Self {
             embedding_model: None,
@@ -373,26 +355,18 @@ impl RuntimeConfig {
     }
 }
 
-/// Resolve the `--db`/`KHIVE_DB` value into the db path used to ANCHOR tier-3
-/// project-local `.khive/config.toml` discovery (`KhiveConfig::load_with_home_fallback`'s
-/// `db_path` parameter), mirroring the precedence `kkernel mcp`'s and `kkernel exec`'s
-/// two call sites use to open the database itself: `:memory:` has no file to anchor on
-/// (`None`); an explicit path anchors on that path; an unset value falls back to
-/// `$HOME/.khive/khive.db`, or the relative path `./.khive/khive.db` when `HOME` is unset —
-/// matching those two call sites' own pre-existing `unwrap_or_else(|_| ".".into())` handling.
+/// Resolve the `--db`/`KHIVE_DB` value into the anchor path used for tier-3
+/// project-local `.khive/config.toml` discovery, mirroring the precedence
+/// `kkernel mcp` and `kkernel exec` use to open the database itself:
+/// `:memory:` has no file to anchor on (`None`); an explicit path anchors on
+/// that path; an unset value falls back to `$HOME/.khive/khive.db`, or
+/// `./.khive/khive.db` when `HOME` is unset.
 ///
-/// This is distinct from a plain override resolver that answers "does the caller want to
-/// override `RuntimeConfig::default().db_path`?" (2-arm, `None` meaning "keep the default").
-/// `resolve_db_anchor` always resolves to a concrete anchor value (3-arm) — it materializes
-/// an anchor path unconditionally rather than asking whether to override one.
-///
-/// Note one deliberate divergence from `RuntimeConfig::default()`: when `HOME` is unset,
-/// `RuntimeConfig::default()` maps its own `db_path` to `None` (`.ok()` on the failed env
-/// lookup short-circuits the following `Option::map`), whereas this function falls back to
-/// `./.khive/khive.db` instead. A caller anchoring config-file discovery wants a concrete
-/// directory to search even without `HOME`; this function is not a stand-in for
-/// `RuntimeConfig::default()`'s own db-path default, only for the two call sites' shared
-/// anchor-derivation logic.
+/// Always resolves to a concrete anchor (unlike a 2-arm "override the
+/// default?" resolver): when `HOME` is unset this falls back to
+/// `./.khive/khive.db` rather than `None`, deliberately diverging from
+/// `RuntimeConfig::default()` — a caller anchoring config discovery needs a
+/// concrete directory to search even without `HOME`.
 pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
     match db {
         Some(":memory:") => None,
@@ -404,23 +378,16 @@ pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
     }
 }
 
-/// Assert that a resolved `db_path` — the path a runtime is about to open, and
-/// the same value `compute_config_id` folds into a process's `config_id` — agrees
-/// with what [`resolve_db_anchor`] derives from the same explicit `--db` /
-/// `KHIVE_DB` input. Call this at each construction boundary right after the
-/// `db_path` that boundary is about to use has been resolved.
+/// Assert that a resolved `db_path` — which `compute_config_id` folds into a
+/// process's `config_id` — agrees with what [`resolve_db_anchor`] derives from
+/// the same `--db`/`KHIVE_DB` input. Call this right after `db_path` is
+/// resolved at each construction boundary.
 ///
-/// A construction path that recomputes `db_path` independently of
-/// `resolve_db_anchor` (instead of routing through it, directly or via
-/// `resolve_runtime_config`) would otherwise diverge only silently: its
-/// `config_id` would carry the wrong db path, so it would stop matching a
-/// daemon or peer process anchored on the same database, and would silently
-/// fall back to a disconnected, out-of-sync runtime instead of failing loud.
-/// This turns that divergence into a hard error at the point it is introduced.
-///
-/// When `resolve_db_anchor(args_db)` itself resolves to `None` (the
-/// `:memory:` sentinel), there is no canonical anchor path to compare
-/// against, so the guard is inert and returns `Ok(())` unconditionally.
+/// Guards against a construction path recomputing `db_path` independently of
+/// `resolve_db_anchor`: left unchecked, that would silently desync
+/// `config_id` from a daemon or peer sharing the same database instead of
+/// failing loud. Inert (`Ok(())`) when the anchor itself is `None` (the
+/// `:memory:` sentinel) since there is nothing to compare against.
 pub fn assert_db_anchor_consistent(
     resolved_db_path: Option<&std::path::Path>,
     args_db: Option<&str>,
@@ -444,35 +411,27 @@ pub fn assert_db_anchor_consistent(
 }
 
 /// Resolve the per-connection attribution actor from the project/cwd-anchored
-/// config tier, independently of the database-anchored config load that governs
-/// `config_id` (ADR-096 Fork 2).
+/// config tier, independently of the database-anchored config load that
+/// governs `config_id`.
 ///
-/// Anchoring tier-3 `.khive/config.toml` discovery to the resolved database's own
-/// directory (commit 10d9c92c, #651) keeps `config_id` coherent between a
-/// short-lived client and a long-running daemon that share one database — that is
-/// correct for the fields that make up `config_id` (packs/db/embed/backend/
-/// outbound policy). It also relocated discovery of the project-local `[actor]`
-/// block, though. When many per-project connections share one database under a
-/// single `HOME` (the daemon-multiplexed fleet case), the shared database-anchored
-/// config carries no `[actor]`, so every connection's write-stamp attribution
-/// collapses to the default identity.
+/// The database-anchored config load keeps `config_id` coherent between a
+/// short-lived client and a long-running daemon sharing one database, but
+/// when many per-project connections share one database under a single
+/// `HOME` (the daemon-multiplexed fleet case), that shared config carries no
+/// `[actor]` block, so every connection's write-stamp attribution collapses
+/// to the default identity.
 ///
-/// This performs a SEPARATE, cwd-anchored lookup (`db_path: None`, matching the
-/// pre-#651 tier-3 search) and reads only `[actor].id`. It intentionally does not
-/// read or return anything else from the resolved `KhiveConfig` — `config_id`,
-/// `default_namespace` remain governed exclusively by the existing
-/// database-anchored load and must not be perturbed by this tier: `actor_id`
-/// and identity-derived `visible_namespaces` are not part of
-/// `compute_config_id` (`khive-mcp` `server.rs`), and ADR-007 Rev 4 Rule 0
-/// already keeps `[actor].id` out of `default_namespace`.
+/// This performs a separate, cwd-anchored lookup (`db_path: None`) and reads
+/// only `[actor].id` — it must not perturb `config_id` or `default_namespace`,
+/// which remain governed exclusively by the database-anchored load.
 ///
-/// `config_path` is the same explicit `--config` / `KHIVE_CONFIG` override the
-/// caller's database-anchored load receives — tier 1 short-circuits identically
-/// in both loads, so an explicit override still wins here too.
+/// `config_path` is the same explicit `--config`/`KHIVE_CONFIG` override the
+/// caller's database-anchored load receives, so an explicit override wins
+/// here too.
 ///
-/// Returns `Ok(None)` when no project-anchored config exists, or it exists but
-/// carries no non-empty `[actor].id` — callers fall through to their own env /
-/// anonymous tiers in that case.
+/// Returns `Ok(None)` when no project-anchored config exists, or it exists
+/// but carries no non-empty `[actor].id` — callers fall through to their own
+/// env/anonymous tiers in that case.
 pub fn resolve_project_actor_id(
     config_path: Option<&std::path::Path>,
 ) -> Result<Option<String>, crate::engine_config::ConfigError> {
@@ -556,14 +515,12 @@ pub fn runtime_config_from_khive_config(
     khive_cfg: &crate::engine_config::KhiveConfig,
     base: RuntimeConfig,
 ) -> RuntimeConfig {
-    // ADR-007 Rev 4 Rule 0: `[actor] id` does NOT become the storage namespace
-    // (writes always pin to `local`). `default_namespace` is whatever the caller
-    // resolved into `base` (explicit `--namespace` / `KHIVE_NAMESPACE`, else `local`).
-    // `actor.id` contributes to the read visible-set only (see fold-in below).
+    // `[actor] id` never becomes the storage namespace (writes always pin to
+    // `local`); it only widens the read visible-set below.
     let default_namespace = base.default_namespace.clone();
 
-    // base.brain_profile must carry ONLY the explicit CLI tier — never an env
-    // value (env sits BELOW toml per ADR-035; the MCP resolver applies it after).
+    // base.brain_profile must carry only the explicit CLI tier, never an env
+    // value — env sits below toml in precedence and is applied later by the MCP resolver.
     let brain_profile = base.brain_profile.clone().or_else(|| {
         khive_cfg
             .runtime
@@ -587,11 +544,9 @@ pub fn runtime_config_from_khive_config(
         })
         .collect();
 
-    // ADR-007 Rev 4: fold actor.id's namespace into visible_namespaces so that
-    // default reads widen to {local} ∪ {actor namespace}. Skipped when actor.id
-    // parses to `local` (mint already includes primary=local on the default path,
-    // adding it here would create a duplicate). Also skipped when it is already
-    // present from actor.visible_namespaces above.
+    // Fold actor.id's namespace into visible_namespaces so default reads widen
+    // to {local} ∪ {actor namespace}; skipped when it parses to `local` (would
+    // duplicate the primary namespace already minted) or is already present.
     let visible_namespaces = if let Some(id) = khive_cfg.actor.id.as_deref() {
         match Namespace::parse(id) {
             Ok(actor_ns) if actor_ns != Namespace::local() => {
@@ -607,9 +562,9 @@ pub fn runtime_config_from_khive_config(
         visible_namespaces
     };
 
-    // KhiveConfig::validate() guarantees every entry in allowed_outbound_namespaces is a
-    // structurally valid Namespace string, so Namespace::parse failures here are unreachable
-    // for validated configs. We still filter_map with a warn so a runtime bug doesn't panic.
+    // KhiveConfig::validate() guarantees these are valid Namespace strings, so
+    // parse failures here are unreachable for validated configs; filter_map+warn
+    // guards against a validation bug panicking instead.
     let allowed_outbound_namespaces: Vec<Namespace> = khive_cfg
         .actor
         .allowed_outbound_namespaces
@@ -623,14 +578,11 @@ pub fn runtime_config_from_khive_config(
         })
         .collect();
 
-    // ADR-057: store actor.id as actor_id for token minting. Precedence is
-    // TOML `[actor] id` > `base.actor_id` (the env/CLI-resolved value the
-    // caller already put in `base`) > anonymous. When `[actor] id` is absent
-    // or empty, fall back to `base.actor_id` instead of clobbering it with
-    // `None` — otherwise an env-resolved actor (e.g. `KHIVE_ACTOR`) is
-    // silently dropped whenever a project config is found without an
-    // `[actor]` block, in both the engines-empty and engines-present arms
-    // below.
+    // Precedence: TOML `[actor] id` > `base.actor_id` (env/CLI-resolved) >
+    // anonymous. Falls back to `base.actor_id` rather than `None` when
+    // `[actor] id` is absent — otherwise an env-resolved actor like
+    // `KHIVE_ACTOR` is silently dropped whenever a project config exists
+    // without an `[actor]` block.
     let actor_id = khive_cfg
         .actor
         .id
@@ -778,11 +730,10 @@ mod assert_db_anchor_consistent_tests {
 
     #[test]
     fn normal_boot_with_db_unset_passes_silently() {
-        // Mirrors a normal boot: `--db` unset. `resolve_db_anchor(None)` always
-        // resolves to `Some(..)` (HOME-set or HOME-unset both produce a
-        // concrete anchor — see `absent_maps_to_home_default` above and the
-        // `resolve_db_anchor` doc comment on the HOME-unset arm), so a runtime
-        // whose resolved `db_path` equals that anchor passes silently.
+        // Mirrors a normal boot with `--db` unset: `resolve_db_anchor(None)`
+        // always resolves to `Some(..)` (HOME-set or -unset both produce a
+        // concrete anchor), so a runtime whose resolved `db_path` matches
+        // passes silently.
         let anchor = resolve_db_anchor(None);
         assert!(assert_db_anchor_consistent(anchor.as_deref(), None).is_ok());
     }
@@ -821,10 +772,9 @@ mod resolve_project_actor_id_tests {
 
     #[test]
     fn propagates_load_error_for_invalid_actor_id() {
-        // `KhiveConfig::load`'s `validate()` rejects an empty `[actor] id` at load
-        // time (`ConfigError::InvalidActorId`) before the emptiness filter in
-        // `resolve_project_actor_id` would ever see it — this asserts the error
-        // surfaces rather than being silently swallowed into `Ok(None)`.
+        // `KhiveConfig::load`'s `validate()` rejects an empty `[actor] id` before
+        // the emptiness filter in `resolve_project_actor_id` ever sees it; this
+        // asserts the error surfaces rather than being swallowed into `Ok(None)`.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = write_toml(&dir, "[actor]\nid = \"\"\n");
 
@@ -887,10 +837,9 @@ mod no_embeddings_tests {
     #[test]
     #[serial]
     fn default_still_seeds_additional_models_when_env_unset() {
-        // Regression guard for issue #396's root cause: `Default` must keep
-        // computing `embedding_model` and `additional_embedding_models`
-        // independently. `no_embeddings()` is a new opt-out constructor, not a
-        // change to `Default`'s existing (env-driven) seeding behavior.
+        // `Default` must keep computing `embedding_model` and
+        // `additional_embedding_models` independently; `no_embeddings()` is a
+        // separate opt-out constructor, not a change to `Default`'s seeding.
         std::env::remove_var("KHIVE_ADDITIONAL_EMBEDDING_MODELS");
         let config = RuntimeConfig::default();
 
@@ -899,8 +848,8 @@ mod no_embeddings_tests {
             vec![EmbeddingModel::ParaphraseMultilingualMiniLmL12V2]
         );
 
-        // The bug shape from #396: overriding only `embedding_model` via
-        // struct-update syntax does not clear `additional_embedding_models`.
+        // Overriding only `embedding_model` via struct-update syntax does not
+        // clear `additional_embedding_models`.
         let buggy_form = RuntimeConfig {
             embedding_model: None,
             ..RuntimeConfig::default()

--- a/crates/khive-runtime/src/config.rs
+++ b/crates/khive-runtime/src/config.rs
@@ -161,7 +161,7 @@ impl NamespaceToken {
 
     /// Return a new token with the same actor but a different namespace.
     ///
-    /// The visible set is replaced with `[ns]` — this is a full read+write token
+    /// The visible set is replaced with `[ns]`: this is a full read+write token
     /// for `ns`, not a type-enforced write-only or append-only capability. It is
     /// a capability-transfer primitive, not a policy gate: callers must enforce
     /// any ACL check before calling this and use the minted token only within
@@ -337,12 +337,12 @@ impl RuntimeConfig {
     /// embedding_model: None, ..RuntimeConfig::default() }` does NOT produce a
     /// model-less runtime: `additional_embedding_models` still carries its
     /// env-driven fallback seed, and the note-write path fans out embedding to
-    /// every registered model regardless of `embedding_model` — so the first
+    /// every registered model regardless of `embedding_model`: so the first
     /// `memory.remember` on a machine without local model files hard-fails
     /// instead of degrading to FTS-only.
     ///
     /// This constructor clears both fields together and ignores
-    /// `KHIVE_ADDITIONAL_EMBEDDING_MODELS` unconditionally — the caller wants
+    /// `KHIVE_ADDITIONAL_EMBEDDING_MODELS` unconditionally: the caller wants
     /// zero embedders, not "zero unless the environment disagrees". Use it on
     /// model-less machines (CI runners, fresh installs without local model
     /// files) instead of the two-field struct-update form.
@@ -365,7 +365,7 @@ impl RuntimeConfig {
 /// Always resolves to a concrete anchor (unlike a 2-arm "override the
 /// default?" resolver): when `HOME` is unset this falls back to
 /// `./.khive/khive.db` rather than `None`, deliberately diverging from
-/// `RuntimeConfig::default()` — a caller anchoring config discovery needs a
+/// `RuntimeConfig::default()`: a caller anchoring config discovery needs a
 /// concrete directory to search even without `HOME`.
 pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
     match db {
@@ -378,8 +378,8 @@ pub fn resolve_db_anchor(db: Option<&str>) -> Option<std::path::PathBuf> {
     }
 }
 
-/// Assert that a resolved `db_path` — which `compute_config_id` folds into a
-/// process's `config_id` — agrees with what [`resolve_db_anchor`] derives from
+/// Assert that a resolved `db_path`: which `compute_config_id` folds into a
+/// process's `config_id`: agrees with what [`resolve_db_anchor`] derives from
 /// the same `--db`/`KHIVE_DB` input. Call this right after `db_path` is
 /// resolved at each construction boundary.
 ///
@@ -422,7 +422,7 @@ pub fn assert_db_anchor_consistent(
 /// to the default identity.
 ///
 /// This performs a separate, cwd-anchored lookup (`db_path: None`) and reads
-/// only `[actor].id` — it must not perturb `config_id` or `default_namespace`,
+/// only `[actor].id`: it must not perturb `config_id` or `default_namespace`,
 /// which remain governed exclusively by the database-anchored load.
 ///
 /// `config_path` is the same explicit `--config`/`KHIVE_CONFIG` override the
@@ -430,7 +430,7 @@ pub fn assert_db_anchor_consistent(
 /// here too.
 ///
 /// Returns `Ok(None)` when no project-anchored config exists, or it exists
-/// but carries no non-empty `[actor].id` — callers fall through to their own
+/// but carries no non-empty `[actor].id`: callers fall through to their own
 /// env/anonymous tiers in that case.
 pub fn resolve_project_actor_id(
     config_path: Option<&std::path::Path>,
@@ -520,7 +520,7 @@ pub fn runtime_config_from_khive_config(
     let default_namespace = base.default_namespace.clone();
 
     // base.brain_profile must carry only the explicit CLI tier, never an env
-    // value — env sits below toml in precedence and is applied later by the MCP resolver.
+    // value: env sits below toml in precedence and is applied later by the MCP resolver.
     let brain_profile = base.brain_profile.clone().or_else(|| {
         khive_cfg
             .runtime
@@ -580,7 +580,7 @@ pub fn runtime_config_from_khive_config(
 
     // Precedence: TOML `[actor] id` > `base.actor_id` (env/CLI-resolved) >
     // anonymous. Falls back to `base.actor_id` rather than `None` when
-    // `[actor] id` is absent — otherwise an env-resolved actor like
+    // `[actor] id` is absent: otherwise an env-resolved actor like
     // `KHIVE_ACTOR` is silently dropped whenever a project config exists
     // without an `[actor]` block.
     let actor_id = khive_cfg

--- a/crates/khive-runtime/src/config_ledger.rs
+++ b/crates/khive-runtime/src/config_ledger.rs
@@ -93,9 +93,9 @@ mod tests {
         );
     }
 
-    /// Mirrors the `VerbRegistry::dispatch` fast path (ADR-094): rows drain
-    /// exactly once via the atomic swap-and-check, and a second dispatch
-    /// observes no pending work without needing to lock `LEDGER`.
+    /// Mirrors the dispatch fast path: rows drain exactly once via the atomic
+    /// swap-and-check, and a second dispatch observes no pending work without
+    /// needing to lock `LEDGER`.
     #[test]
     #[serial(config_ledger)]
     fn dispatch_fast_path_drains_exactly_once_then_reports_no_pending() {

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -195,25 +195,15 @@ impl KhiveRuntime {
     ///
     /// Returns `RuntimeError::NotFound` if the entity does not exist or belongs to a different
     /// namespace. Namespace isolation is enforced at the runtime layer.
-    /// Decide step of `update_entity` (ADR-099 B3 r6 second pass): secret-gates
-    /// the patch, fetches the current row, and computes the resulting `Entity`
-    /// plus `text_changed` (drives reindex) and `changed_fields` (the event
-    /// payload) — WITHOUT writing anything. This is the ONE place that decides
-    /// what a patched entity looks like: `update_entity` below calls it then
-    /// applies the result via `store.upsert_entity` (unchanged execution
-    /// mechanism), and the ADR-099 `--atomic` prepare path
-    /// (`khive-runtime::atomic_prepare::prepare_update`) calls this SAME
-    /// function, turning the result into a `PlanStatement` via
-    /// `khive_db::stores::entity::entity_upsert_statement` — the identical
-    /// builder `upsert_entity` calls internally. No entity-patch decision
-    /// logic is duplicated between the two paths.
+    /// Computes the patched `Entity`, `text_changed`, and `changed_fields` without
+    /// writing anything, so both the normal write path and the atomic-prepare path
+    /// share one source of truth for what a patched entity looks like.
     pub(crate) async fn prepare_update_entity(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         patch: EntityPatch,
     ) -> RuntimeResult<(Entity, bool, Vec<&'static str>)> {
-        // Secret gate: scan incoming text fields, properties, and tags.
         if let Some(ref name) = patch.name {
             crate::secret_gate::check(name)?;
         }
@@ -326,9 +316,8 @@ impl KhiveRuntime {
                 "cannot merge an entity into itself".into(),
             ));
         }
-        // H2 fix: enforce same-kind constraint at the runtime layer.
-        // The handler also checks this, but any direct runtime caller (CLI, tests,
-        // future SDK) would bypass the handler guard without this check here.
+        // Enforce the same-kind constraint here too: any direct runtime caller
+        // (CLI, tests, future SDK) would bypass the handler-level guard otherwise.
         {
             let into_entity = self.get_entity(token, into_id).await?;
             let from_entity = self.get_entity(token, from_id).await?;
@@ -348,24 +337,20 @@ impl KhiveRuntime {
             .map(|name| format!("vec_{}", crate::config::sanitize_key(name)))
             .collect();
 
-        // Ensure all required tables exist before entering the transaction.
-        // Each accessor applies its DDL idempotently via `CREATE TABLE IF NOT EXISTS`.
+        // Ensure all required tables exist (idempotent DDL) before the transaction.
         let _ = self.entities(token)?;
         let _ = self.graph(token)?;
         let _ = self.text(token)?;
-        // Prime DDL for every registered model's vec table.  Use vectors_for_model
-        // (not the default-model-only self.vectors()) so that custom-only runtimes
-        // (embedding_model: None but custom providers registered) work correctly.
+        // vectors_for_model (not the default-model-only self.vectors()) so
+        // custom-only runtimes (no default embedding_model) still get DDL primed.
         for model_name in &self.registered_embedding_model_names() {
             let _ = self.vectors_for_model(token, model_name)?;
         }
 
         let pool = self.backend().pool_arc();
-        // ADR-067 Component A: when the write queue is enabled, route this
-        // multi-statement merge through the single-writer task instead of the
-        // pool's writer mutex. Best-effort lookup mirrors every other migrated
-        // store: a lookup failure (no runtime context) degrades to the legacy
-        // mutex path rather than failing the merge outright.
+        // When the write queue is enabled, route this multi-statement merge through
+        // the single-writer task instead of the pool's writer mutex. A lookup
+        // failure degrades to the legacy mutex path rather than failing the merge.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
         let (summary, updated_entity) = if let Some(writer_task) = writer_task {
@@ -413,9 +398,8 @@ impl KhiveRuntime {
             .map_err(|e| RuntimeError::Internal(e.to_string()))??
         };
 
-        // If vectors are configured, reindex into_entity (requires async embedding).
-        // FTS and vec-deletes for all registered models were already committed inside
-        // the transaction above.
+        // FTS and vec-deletes already committed inside the transaction above;
+        // only the embedding re-insert needs an async step outside it.
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_entity(token, &updated_entity).await?;
         }
@@ -598,20 +582,15 @@ impl KhiveRuntime {
         Ok(())
     }
 
-    /// Decide step of `update_note` (ADR-099 B3 r6 second pass) — same split
-    /// as `prepare_update_entity` above: secret-gates the patch, fetches the
-    /// current row, computes the resulting `Note` plus `text_changed`
-    /// (drives reindex), without writing. `update_note` and the ADR-099
-    /// `--atomic` `prepare_update` Note branch both call this ONE function;
-    /// the DML itself is `khive_db::stores::note::note_upsert_statement`,
-    /// the same builder `upsert_note` calls internally.
+    /// Computes the patched `Note` and `text_changed` without writing, mirroring
+    /// `prepare_update_entity` so both the normal write path and the
+    /// atomic-prepare path share one source of truth.
     pub(crate) async fn prepare_update_note(
         &self,
         token: &NamespaceToken,
         id: Uuid,
         patch: NotePatch,
     ) -> RuntimeResult<(khive_storage::note::Note, bool)> {
-        // Secret gate: scan incoming text fields and structured properties.
         if let Some(ref content) = patch.content {
             crate::secret_gate::check(content)?;
         }
@@ -638,8 +617,7 @@ impl KhiveRuntime {
             note.content = content;
         }
         if let Some(salience_patch) = patch.salience {
-            // Reject non-finite or out-of-range salience at the runtime boundary
-            // rather than silently clamping invalid caller input (coding-standards §608-622).
+            // Reject invalid salience rather than silently clamping caller input.
             if let Some(s) = salience_patch {
                 if !s.is_finite() || !(0.0..=1.0).contains(&s) {
                     return Err(crate::RuntimeError::InvalidInput(format!(
@@ -650,7 +628,7 @@ impl KhiveRuntime {
             note.salience = salience_patch;
         }
         if let Some(decay_patch) = patch.decay_factor {
-            // Reject non-finite or negative decay_factor at the runtime boundary.
+            // Reject invalid decay_factor rather than silently clamping caller input.
             if let Some(d) = decay_patch {
                 if !d.is_finite() || d < 0.0 {
                     return Err(crate::RuntimeError::InvalidInput(format!(
@@ -690,12 +668,9 @@ impl KhiveRuntime {
 
         if text_changed {
             self.reindex_note(token, &note).await?;
-            // #750 fix-round 1: text_changed means the note's embedding was
-            // just reindexed, which any pack-owned vector-derived cache
-            // (e.g. khive-pack-memory's warm ANN index) needs to know about —
-            // reached via this generic hook so khive-runtime/khive-pack-kg
-            // never take a dependency on khive-pack-memory. No-op when no
-            // pack has installed a hook.
+            // Notify any pack-owned vector cache (e.g. a warm ANN index) that this
+            // note's embedding changed, via a generic hook so khive-runtime/pack-kg
+            // never take a dependency on the consuming pack. No-op if unregistered.
             self.fire_note_mutation_hook(&note.kind, note.id).await;
         }
 
@@ -747,13 +722,11 @@ impl KhiveRuntime {
 
         let _ = self.graph(token)?;
         let _ = self.text_for_notes(token)?;
-        // Prime DDL for every registered model's vec table (mirrors merge_entity fix).
         for model_name in &self.registered_embedding_model_names() {
             let _ = self.vectors_for_model(token, model_name)?;
         }
 
         let pool = self.backend().pool_arc();
-        // ADR-067 Component A: same writer-task routing as merge_entity above.
         let writer_task = pool.writer_task_handle().ok().flatten();
 
         let (summary, updated_note) = if let Some(writer_task) = writer_task {
@@ -803,14 +776,9 @@ impl KhiveRuntime {
 
         if !dry_run && !self.registered_embedding_model_names().is_empty() {
             self.reindex_note(token, &updated_note).await?;
-            // #750 fix-round 2 (codex r2 High 1): a merge changes the same
-            // ANN corpus as update_note's text_changed branch — the
-            // surviving note gets a new vector via reindex_note above, and
-            // the source note is tombstoned by merge_note_sql. Fire the
-            // same hook update_note fires after its own reindex (see
-            // ~line 670 above) so a pack-owned vector cache (e.g.
-            // khive-pack-memory's warm ANN index) is notified regardless of
-            // which public write path reached the corpus change.
+            // A merge changes the same ANN corpus as update_note's text_changed
+            // branch, so fire the same mutation hook regardless of which public
+            // write path reached the corpus change.
             self.fire_note_mutation_hook(&updated_note.kind, updated_note.id)
                 .await;
         }
@@ -1116,10 +1084,8 @@ fn merge_entity_sql(
         .map(|v| serde_json::to_string(v).unwrap_or_default());
     let tags_json = serde_json::to_string(&merged_tags).unwrap_or_else(|_| "[]".to_string());
 
-    // --- Rewire edges ---
     // Writes are gated on `!dry_run` below, but the loop itself always runs so a
-    // dry-run response reports a predictive `edges_rewired` count (the number of
-    // incident edges that would be rewired) instead of always reporting zero.
+    // dry-run response reports a predictive `edges_rewired` count instead of zero.
     let mut edges_rewired = 0usize;
     for edge in all_edges {
         let raw_src = if edge.source_id == from_id {
@@ -1156,18 +1122,10 @@ fn merge_entity_sql(
         }
 
         let now_ts = chrono::Utc::now().timestamp();
-        // H3 fix: preserve the original edge ID by updating
-        // source_id/target_id in-place when no conflict exists.
-        //
-        // Two-step approach to handle all cases while keeping the original ID:
-        //   (a) No conflict (new triple): UPDATE source_id/target_id in-place.
-        //       The edge retains its original UUID — callers can still get() it
-        //       by the ID they received from link().
-        //   (b) Conflict: into_id already has an edge with this (source,target,
-        //       relation). Delete the from-edge (it is superseded) and UPDATE
-        //       the existing into-edge to refresh weight/metadata/deleted_at.
-        //       The surviving edge is the into-entity's original edge (correct).
-        //
+        // Preserve the original edge ID where possible so callers can still get()
+        // it by the ID returned from link(): update in-place when there's no
+        // conflict; when into_id already owns this (source,target,relation), drop
+        // the from-edge instead and refresh the existing into-edge.
         // Check for a conflict: does into_id already have this natural key?
         let conflict_id: Option<String> = {
             let conflict_src = new_src.to_string();
@@ -1188,8 +1146,7 @@ fn merge_entity_sql(
         };
 
         let changed = if let Some(existing_id) = conflict_id {
-            // Case (b): a live or soft-deleted row already owns this natural key.
-            // Delete the from-edge and refresh the existing row.
+            // A live or soft-deleted row already owns this natural key.
             conn.execute(
                 khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                 rusqlite::params![&namespace, edge.id.to_string()],
@@ -1206,8 +1163,6 @@ fn merge_entity_sql(
                 ],
             )?
         } else {
-            // Case (a): no conflict — update source_id/target_id in-place,
-            // preserving the original edge ID for callers.
             conn.execute(
                 "UPDATE graph_edges SET \
                      source_id = ?1, target_id = ?2, updated_at = ?3 \
@@ -1227,7 +1182,6 @@ fn merge_entity_sql(
     }
 
     if !dry_run {
-        // --- Upsert merged entity ---
         conn.execute(
             "INSERT OR REPLACE INTO entities \
              (id, namespace, kind, name, description, properties, tags, \
@@ -1249,10 +1203,9 @@ fn merge_entity_sql(
             ],
         )?;
 
-        // --- Reindex into_id in FTS (delete existing, insert updated) ---
-        // Body formula mirrors entity_fts_document (the canonical constructor) —
-        // this path is sync/spawn_blocking so it cannot call entity_fts_document
-        // directly, but must stay field-identical.
+        // Body formula mirrors entity_fts_document (the canonical constructor):
+        // this path is sync/spawn_blocking so it can't call it directly, but
+        // must stay field-identical.
         let fts_body = match &merged_description {
             Some(d) if !d.is_empty() => format!("{} {}", merged_name, d),
             _ => merged_name.clone(),
@@ -1285,7 +1238,6 @@ fn merge_entity_sql(
             ],
         )?;
 
-        // --- Delete from_id from FTS ---
         conn.execute(
             &format!(
                 "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
@@ -1294,7 +1246,6 @@ fn merge_entity_sql(
             rusqlite::params![&namespace, &from_str],
         )?;
 
-        // --- Delete from_id from all registered model vector tables ---
         khive_db::stores::vectors::delete_subject_from_vector_tables(
             conn,
             &vec_tables,
@@ -1302,7 +1253,6 @@ fn merge_entity_sql(
             &namespace,
         )?;
 
-        // --- Tombstone from entity (soft-delete with provenance) ---
         let merge_event_id = Uuid::new_v4();
         conn.execute(
             "UPDATE entities \
@@ -1556,7 +1506,6 @@ fn merge_note_sql(
     let (merged_props, properties_merged) =
         merge_properties(&into_note.properties, &from_note.properties, strategy);
 
-    // Append merge history to properties.
     let merge_history_entry = serde_json::json!({
         "merged_from": from_id.to_string(),
         "merged_at": now,
@@ -1579,7 +1528,6 @@ fn merge_note_sql(
 
     let mut edges_rewired = 0usize;
     if !dry_run {
-        // Rewire and upsert.
         for edge in all_edges {
             let raw_src = if edge.source_id == from_id {
                 into_id
@@ -1604,8 +1552,6 @@ fn merge_note_sql(
                 continue;
             }
             let now_ts = chrono::Utc::now().timestamp();
-            // Same two-step approach as entity merge rewire: preserve original edge ID
-            // when no conflict, merge into existing row when conflict exists.
             let conflict_id: Option<String> = {
                 let conflict_src = new_src.to_string();
                 let conflict_tgt = new_tgt.to_string();
@@ -1659,7 +1605,6 @@ fn merge_note_sql(
             }
         }
 
-        // Upsert merged into-note.
         conn.execute(
             "INSERT OR REPLACE INTO notes \
              (id, namespace, kind, status, name, content, salience, decay_factor, \
@@ -1682,7 +1627,6 @@ fn merge_note_sql(
             ],
         )?;
 
-        // Update FTS for into-note.
         conn.execute(
             &format!(
                 "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
@@ -1690,11 +1634,10 @@ fn merge_note_sql(
             ),
             rusqlite::params![&namespace, &into_str],
         )?;
-        // Derive FTS scalars through the shared constructor so this raw SQL
-        // path is field-identical to TextSearch::upsert_document.  Critically,
-        // `title` is an empty string (not SQL NULL) for nameless notes —
-        // matching the unwrap_or("") in Fts5TextSearch::upsert_document and
-        // allowing get_document to round-trip None ↔ "" correctly.
+        // Derive FTS scalars through the shared constructor so this raw SQL path
+        // is field-identical to TextSearch::upsert_document — critically, `title`
+        // is an empty string (not SQL NULL) for nameless notes, so get_document
+        // round-trips None <-> "" correctly.
         let fts_merged = {
             let mut merged_note = Note::new(&namespace, &*into_note.kind, &*merged_content);
             merged_note.id = into_id;
@@ -1722,7 +1665,6 @@ fn merge_note_sql(
             ],
         )?;
 
-        // Delete from-note from FTS.
         conn.execute(
             &format!(
                 "DELETE FROM {} WHERE namespace = ?1 AND subject_id = ?2",
@@ -1731,7 +1673,6 @@ fn merge_note_sql(
             rusqlite::params![&namespace, &from_str],
         )?;
 
-        // Delete from-note from all registered model vector tables.
         khive_db::stores::vectors::delete_subject_from_vector_tables(
             conn,
             &vec_tables,
@@ -1739,7 +1680,6 @@ fn merge_note_sql(
             &namespace,
         )?;
 
-        // Tombstone the from-note.
         conn.execute(
             "UPDATE notes SET status = 'deleted', deleted_at = ?1, updated_at = ?1 \
              WHERE namespace = ?2 AND id = ?3 AND deleted_at IS NULL",
@@ -1781,8 +1721,8 @@ fn merge_note_sql(
 // Merge helpers (pure functions — easier to unit test)
 // ---------------------------------------------------------------------------
 
-/// `pub(crate)` (widened, ADR-099 B3 fix round): `crate::atomic_prepare::prepare_merge`
-/// reuses this exact field-fold semantics for atomic/non-atomic parity.
+/// `pub(crate)` so `crate::atomic_prepare::prepare_merge` can reuse this exact
+/// field-fold semantics for atomic/non-atomic parity.
 pub(crate) fn merge_string_field(
     into: &str,
     from: &str,
@@ -1795,10 +1735,9 @@ pub(crate) fn merge_string_field(
 }
 
 /// Merge two property objects. Returns (merged, count_of_fields_from_from_that_were_added).
-/// `pub(crate)` (widened from private, ADR-099 B3): the atomic prepare pass
-/// (`crate::atomic_prepare`) reuses this exact properties-merge semantics when
-/// building an `update` write plan's row statement, matching `update_entity`/
-/// `update_note`'s own patch behavior byte-for-byte.
+/// `pub(crate)` so `crate::atomic_prepare` can reuse this exact properties-merge
+/// semantics when building an `update` write plan's row statement, matching
+/// `update_entity`/`update_note`'s own patch behavior byte-for-byte.
 pub(crate) fn merge_properties(
     into: &Option<Value>,
     from: &Option<Value>,
@@ -1865,8 +1804,8 @@ fn merge_json(into: &Value, from: &Value, strategy: EntityDedupMergePolicy) -> (
     }
 }
 
-/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
-/// `crate::atomic_prepare::prepare_merge` for atomic/non-atomic parity.
+/// `pub(crate)` so `crate::atomic_prepare::prepare_merge` can reuse this for
+/// atomic/non-atomic parity.
 pub(crate) fn union_tags(into: &[String], from: &[String]) -> (Vec<String>, usize) {
     let mut seen: HashSet<&str> = into.iter().map(|s| s.as_str()).collect();
     let mut result: Vec<String> = into.to_vec();
@@ -1998,7 +1937,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Old name is findable.
         let hits_before = fts_hit(&rt, &tok, "OldName").await;
         assert!(
             hits_before.contains(&entity.id),
@@ -2019,7 +1957,6 @@ mod tests {
         let hits_old = fts_hit(&rt, &tok, "OldName").await;
         let hits_new = fts_hit(&rt, &tok, "NewName").await;
 
-        // After rename, old name no longer matches this entity (FTS index updated).
         assert!(
             !hits_old.contains(&entity.id),
             "old name should no longer match after rename"
@@ -2081,11 +2018,9 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify it's in the index before.
         let hits_before = fts_hit(&rt, &tok, "StableIndexed").await;
         assert!(hits_before.contains(&entity.id));
 
-        // Only patch properties — text index should be untouched (still findable).
         rt.update_entity(
             &tok,
             entity.id,
@@ -2149,7 +2084,6 @@ mod tests {
         assert_eq!(summary.removed_id, b.id);
         assert_eq!(summary.edges_rewired, 2);
 
-        // Verify edges now point to D.
         let a_neighbors = rt
             .neighbors(&tok, a.id, Direction::Out, None, None)
             .await
@@ -2419,7 +2353,7 @@ mod tests {
         assert!(a_out.is_empty(), "no self-loop should remain");
     }
 
-    // ---- #778: content_strategy for entity merge ----
+    // ---- content_strategy for entity merge ----
 
     #[tokio::test]
     async fn merge_entity_append_strategy_concatenates_descriptions() {
@@ -2557,10 +2491,10 @@ mod tests {
         );
     }
 
-    /// Regression test for the codex PR #814 High finding: `content_strategy`
-    /// must be followed directly, independent of the entity-field `strategy`.
-    /// With the default entity policy `prefer_into`, an explicit
-    /// `content_strategy=prefer_from` must still keep the from-description.
+    /// `content_strategy` must be followed directly, independent of the
+    /// entity-field `strategy`: with the default entity policy `prefer_into`,
+    /// an explicit `content_strategy=prefer_from` must still keep the
+    /// from-description.
     #[tokio::test]
     async fn merge_entity_prefer_from_content_strategy_wins_over_default_entity_policy() {
         let rt = rt();
@@ -2636,9 +2570,8 @@ mod tests {
         );
     }
 
-    /// Codex PR #814 Medium finding: dry-run must be a read-only, accurate preview —
-    /// it must predict `edges_rewired` without writing, and must not append an
-    /// `EntityMerged` event.
+    /// Dry-run must be a read-only, accurate preview: it must predict
+    /// `edges_rewired` without writing, and must not append an `EntityMerged` event.
     #[tokio::test]
     async fn merge_entity_dry_run_predicts_edges_rewired_without_writing() {
         use khive_storage::EdgeRelation;
@@ -2680,7 +2613,6 @@ mod tests {
             "dry-run must predict the edge that would be rewired, not report zero"
         );
 
-        // The edge must not actually have been rewired.
         let a_neighbors = rt
             .neighbors(&tok, a.id, Direction::Out, None, None)
             .await
@@ -2691,7 +2623,6 @@ mod tests {
             "dry_run=true must not rewire any edges"
         );
 
-        // No EntityMerged event should have been appended.
         let events = rt
             .events(&tok)
             .unwrap()
@@ -2766,13 +2697,11 @@ mod tests {
         .await
         .unwrap();
 
-        // After merge, get_entity returns an error (soft-deleted rows are excluded).
         assert!(
             rt.get_entity(&tok, from_id).await.is_err(),
             "tombstoned source should not be returned by get_entity"
         );
 
-        // Verify the source row still exists in SQL with provenance.
         let pool = rt.backend().pool_arc();
         let (deleted_at, merged_into): (Option<i64>, Option<String>) =
             tokio::task::spawn_blocking(move || {
@@ -2846,7 +2775,6 @@ mod tests {
         assert!(summary.content_appended);
         assert!(!summary.dry_run);
 
-        // Source is no longer findable.
         let from_store = rt.notes(&tok).unwrap();
         assert!(
             from_store.get_note(from_id).await.unwrap().is_none(),
@@ -2854,10 +2782,8 @@ mod tests {
         );
     }
 
-    // #690 regression: after routing merge_note's conflict-probe/delete/refresh
-    // arms through the shared khive-db EDGE_SYMMETRIC_*_SQL constants, note merge
-    // must still absorb a conflicting edge natural key exactly as before —
-    // mirrors merge_entity_survives_shared_edge_to_third_party for the note path.
+    // Note merge must absorb a conflicting edge natural key exactly like entity
+    // merge does, since both route through the shared EDGE_SYMMETRIC_*_SQL arms.
     #[tokio::test]
     async fn merge_note_survives_shared_edge_to_third_party() {
         use khive_storage::EdgeRelation;
@@ -2994,7 +2920,6 @@ mod tests {
 
         assert!(summary.dry_run);
 
-        // Both notes still exist unchanged.
         let store = rt.notes(&tok).unwrap();
         let into_after = store.get_note(into_id).await.unwrap().unwrap();
         let from_after = store.get_note(from_id).await.unwrap().unwrap();
@@ -3008,12 +2933,10 @@ mod tests {
         );
     }
 
-    // Regression: merge two NAMELESS notes with no embedding model configured.
-    // Before this fix, the raw SQL FTS INSERT bound &merged_name directly — for a
-    // nameless note that is SQL NULL, while Fts5TextSearch::upsert_document stores
-    // an empty string.  The mismatch caused get_document to diverge (or fail) for
-    // nameless merged notes.  After the fix, note_fts_scalars drives every scalar
-    // and the round-trip is field-identical.
+    // Merging two nameless notes with no embedding model configured: a raw SQL FTS
+    // INSERT binding &merged_name directly would store SQL NULL for a nameless
+    // note, while Fts5TextSearch::upsert_document stores an empty string —
+    // note_fts_scalars must keep the round-trip field-identical.
     #[tokio::test]
     async fn merge_nameless_notes_fts_document_is_parity_correct() {
         use khive_storage::types::TextSearchRequest;
@@ -3060,7 +2983,6 @@ mod tests {
         .await
         .expect("merge_note must succeed");
 
-        // Fetch the merged note from the note store to get its current state.
         let note_store = rt.notes(&tok).expect("note store");
         let merged_note = note_store
             .get_note(into_id)
@@ -3068,10 +2990,8 @@ mod tests {
             .expect("get_note")
             .expect("merged note must exist");
 
-        // Compute the expected FTS document via the shared constructor.
         let expected = note_fts_document(&merged_note);
 
-        // Fetch the stored FTS document and verify field parity.
         let fts = rt.text_for_notes(&tok).expect("FTS store");
         let stored = fts
             .get_document("local", into_id)
@@ -3079,7 +2999,6 @@ mod tests {
             .expect("get_document must not error")
             .expect("FTS document must exist after merge");
 
-        // Core parity: subject_id, title (must be None, not Some("")), body.
         assert_eq!(stored.subject_id, expected.subject_id, "subject_id");
         assert_eq!(
             stored.title, expected.title,
@@ -3089,7 +3008,6 @@ mod tests {
         assert_eq!(stored.namespace, expected.namespace, "namespace");
         assert_eq!(stored.kind, expected.kind, "kind");
 
-        // The merged note is nameless — title must be None, matching the shared path.
         assert!(
             stored.title.is_none(),
             "nameless merged note must have title=None in FTS (was NULL before fix)"
@@ -3147,18 +3065,17 @@ mod tests {
         assert!((updated.weight - 0.5).abs() < 0.001, "weight unchanged");
     }
 
-    // scenario-kg-maintenance C1 regression: merge must not crash when both
-    // entities share a common third-party edge (duplicate triple after rewire).
-    // Before the fix, the double-ON-CONFLICT INSERT raised a UNIQUE constraint
-    // error at the SQLite layer and the merge aborted mid-transaction.
+    // Merge must not crash when both entities share a common third-party edge
+    // (duplicate triple after rewire): a double-ON-CONFLICT INSERT would
+    // otherwise raise a UNIQUE constraint error and abort mid-transaction.
     #[tokio::test]
     async fn merge_entity_survives_shared_edge_to_third_party() {
         use khive_storage::EdgeRelation;
         let rt = rt();
         let tok = NamespaceToken::local();
 
-        // Create three entities: A and B will be merged; shared is the common target.
-        // Use `extends` (concept→concept) which is a valid endpoint combination.
+        // A and B will be merged; shared is the common target. `extends` is used
+        // since concept→concept is a valid endpoint combination.
         let a = rt
             .create_entity(&tok, "concept", None, "A", None, None, vec![])
             .await
@@ -3181,7 +3098,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Before the fix this would return Err with "UNIQUE constraint failed".
         let summary = rt
             .merge_entity(
                 &tok,
@@ -3198,13 +3114,10 @@ mod tests {
 
         assert_eq!(summary.kept_id, a.id);
         assert_eq!(summary.removed_id, b.id);
-        // A already had the Extends edge to shared; when B→shared is rewired to
-        // A→shared, the ON CONFLICT DO UPDATE refreshes the existing row (clears
-        // deleted_at, updates weight). rusqlite reports this as 1 change, so
-        // edges_rewired will be >= 0. The important invariant is that the merge
-        // did NOT crash and exactly one live edge A→shared remains.
-
-        // One live edge A→shared must exist after merge.
+        // A already had the Extends edge to shared; rewiring B->shared onto it
+        // refreshes the existing row via ON CONFLICT DO UPDATE rather than
+        // erroring. The invariant checked below is that exactly one live edge
+        // A->shared remains.
         let a_edges = rt
             .list_edges(
                 &tok,
@@ -3225,7 +3138,6 @@ mod tests {
             "C1: exactly one live A→shared Extends edge must exist after merge; got: {a_edges:?}"
         );
 
-        // Tombstone check: B must be soft-deleted after successful merge (C3).
         // get_entity filters deleted_at IS NULL, so a tombstoned entity returns None.
         let b_after = rt.entities(&tok).unwrap().get_entity(b.id).await.unwrap();
         assert!(
@@ -3234,9 +3146,9 @@ mod tests {
         );
     }
 
-    // H2 regression: merge_entity at the runtime level must reject cross-kind merges.
-    // Before the H2 fix, only the pack handler had this guard; a direct runtime caller
-    // could still merge concept+project, silently tombstoning the source entity.
+    // merge_entity at the runtime level must reject cross-kind merges: without this
+    // guard, a direct runtime caller could merge concept+project, silently
+    // tombstoning the source entity, even though the pack handler also checks it.
     #[tokio::test]
     async fn merge_entity_cross_kind_rejected_at_runtime() {
         let rt = rt();
@@ -3251,7 +3163,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Cross-kind merge must return InvalidInput at the runtime level.
         let err = rt
             .merge_entity(
                 &tok,
@@ -3268,7 +3179,6 @@ mod tests {
             "H2: expected InvalidInput, got: {err:?}"
         );
 
-        // Both entities must survive the failed merge attempt with no tombstone.
         let concept_after = rt.get_entity(&tok, concept.id).await;
         let project_after = rt.get_entity(&tok, project.id).await;
         assert!(
@@ -3281,7 +3191,7 @@ mod tests {
         );
     }
 
-    // scenario-kg-maintenance C2 regression: same-kind merge must succeed.
+    // Same-kind merge must succeed.
     #[tokio::test]
     async fn merge_entity_same_kind_succeeds() {
         let rt = rt();
@@ -3310,12 +3220,11 @@ mod tests {
         assert_eq!(summary.kept_id, c1.id);
         assert_eq!(summary.removed_id, c2.id);
 
-        // c2 must be tombstoned.
         let c2_after = rt.entities(&tok).unwrap().get_entity(c2.id).await.unwrap();
         assert!(c2_after.is_none(), "from_entity must be tombstoned");
     }
 
-    // ── #567 regression: cross-namespace merge_note must be denied on either ID ──
+    // Cross-namespace merge_note must be denied on either ID.
 
     #[tokio::test]
     async fn merge_note_cross_namespace_either_id_returns_not_found() {
@@ -3372,7 +3281,7 @@ mod tests {
         );
     }
 
-    // ADR-007 PR-A1: cross-namespace update now succeeds (shared-brain model).
+    // Cross-namespace update now succeeds (shared-brain model).
 
     #[tokio::test]
     async fn update_entity_cross_namespace_succeeds() {
@@ -3395,7 +3304,6 @@ mod tests {
             .await
             .unwrap();
 
-        // ADR-007 PR-A1: update from ns_b token must now succeed on an ns_a entity.
         let result = rt
             .update_entity(
                 &ns_b,
@@ -3592,13 +3500,10 @@ mod tests {
         assert_eq!(stored.body, expected.body, "body after update");
     }
 
-    // ── Fix #135 regression tests ────────────────────────────────────────────
-    //
     // Verify that merge_entity / merge_note delete from_id vectors from ALL
-    // registered model vec tables, not just the default-model table.
-    //
-    // Uses the same ConstVecProvider/ConstVecService pattern as operations.rs
-    // so no real model files are required.
+    // registered model vec tables, not just the default-model table. Uses the
+    // same ConstVecProvider/ConstVecService pattern as operations.rs so no
+    // real model files are required.
 
     struct MergeTestVecService {
         dims: usize,
@@ -3750,7 +3655,6 @@ mod tests {
         .await
         .expect("merge_entity");
 
-        // from_id must have ZERO rows in EITHER model table after merge.
         let post_a = vs_a
             .search(VectorSearchRequest {
                 query_vectors: vec![query.clone()],
@@ -3889,7 +3793,6 @@ mod tests {
         .await
         .expect("merge_note");
 
-        // from_id must have ZERO rows in EITHER model table after merge.
         let post_a = vs_a
             .search(VectorSearchRequest {
                 query_vectors: vec![query.clone()],

--- a/crates/khive-runtime/src/curation.rs
+++ b/crates/khive-runtime/src/curation.rs
@@ -1635,7 +1635,7 @@ fn merge_note_sql(
             rusqlite::params![&namespace, &into_str],
         )?;
         // Derive FTS scalars through the shared constructor so this raw SQL path
-        // is field-identical to TextSearch::upsert_document — critically, `title`
+        // is field-identical to TextSearch::upsert_document: critically, `title`
         // is an empty string (not SQL NULL) for nameless notes, so get_document
         // round-trips None <-> "" correctly.
         let fts_merged = {
@@ -2935,7 +2935,7 @@ mod tests {
 
     // Merging two nameless notes with no embedding model configured: a raw SQL FTS
     // INSERT binding &merged_name directly would store SQL NULL for a nameless
-    // note, while Fts5TextSearch::upsert_document stores an empty string —
+    // note, while Fts5TextSearch::upsert_document stores an empty string:
     // note_fts_scalars must keep the round-trip field-identical.
     #[tokio::test]
     async fn merge_nameless_notes_fts_document_is_parity_correct() {

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -44,9 +44,9 @@ pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 ///       added `probe_only` request field + probe-ack sentinel shape in response
 ///   2 — gate subhandler verbs by wire origin (`from_wire` request field)
 ///   3 — added per-request identity context to the request frame (`actor_id`,
-///       `visible_namespaces`, ADR-096 Fork 1); the daemon now serves a request
-///       under the frame's identity instead of rejecting on `namespace_mismatch`
-///       (the `config_id` equality reject stays hard)
+///       `visible_namespaces`); the daemon now serves a request under the
+///       frame's identity instead of rejecting on `namespace_mismatch` (the
+///       `config_id` equality reject stays hard)
 pub const PROTOCOL_VERSION: u32 = 3;
 
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 10;
@@ -98,10 +98,10 @@ pub fn lock_path() -> PathBuf {
 /// Advisory lock file used to serialize RECOVERY (kill+respawn) attempts
 /// across concurrent clients only — the daemon's own boot sequence never
 /// acquires this file ([`lock_path`] / [`acquire_daemon_boot_guard`] is the
-/// boot-side lock).  A recoverer holding this lock across dead-confirmation
-/// → kill → spawn (khive-mcp's `kill_and_respawn`, #838 round-1 Finding 1)
-/// therefore can never deadlock against a peer daemon's boot, unlike holding
-/// the shared boot lock for that whole span would.
+/// boot-side lock). A recoverer holding this lock across dead-confirmation
+/// → kill → spawn (khive-mcp's `kill_and_respawn`) therefore can never
+/// deadlock against a peer daemon's boot, unlike holding the shared boot
+/// lock for that whole span would.
 ///
 /// Overridable via the `KHIVE_RECOVERER_LOCK` env var (for tests).
 pub fn recoverer_lock_path() -> PathBuf {
@@ -161,8 +161,7 @@ pub fn acquire_recovery_lock() -> Option<std::fs::File> {
 /// blocking `flock`, correct for the daemon's own boot sequence where waiting
 /// until quiescence IS the desired behavior), a caller only trying to *detect*
 /// whether a lock is currently free — without committing to wait forever for
-/// a possibly-wedged holder — needs a deadline instead (#838 round-1
-/// Finding 2). Returns:
+/// a possibly-wedged holder — needs a deadline instead. Returns:
 ///   - `Ok(Some(file))` — the lock was free within the deadline.
 ///   - `Ok(None)` — `deadline` elapsed while the lock stayed held; an
 ///     explicit "could not confirm" outcome, distinct from a hard I/O error.
@@ -200,9 +199,8 @@ fn try_acquire_flock_until(
 /// the SAME boot/recovery lock ([`lock_path`]) but gives up at `deadline`
 /// instead of blocking forever. For callers that need to detect "is a boot in
 /// progress right now" without risking an unbounded wait behind a wedged
-/// holder (#838 round-1 Finding 2) — e.g. khive-mcp's `confirm_genuinely_dead`
-/// re-probing rounds, where `DEAD_CONFIRM_ROUNDS` must bound elapsed time, not
-/// just probe count.
+/// holder — e.g. khive-mcp's `confirm_genuinely_dead` re-probing rounds,
+/// where `DEAD_CONFIRM_ROUNDS` must bound elapsed time, not just probe count.
 #[cfg(unix)]
 pub fn try_acquire_daemon_boot_guard_until(
     deadline: std::time::Instant,
@@ -230,13 +228,13 @@ pub type DaemonBootGuard = std::fs::File;
 
 /// Acquire the recovery/boot lock, treating failure as fatal.
 ///
-/// #667: unlike [`acquire_recovery_lock`] (best-effort, `None` on failure —
-/// used by shutdown cleanup, where skipping unlink is safer than blocking
-/// forever), daemon-mode boot must hold this lock across migrations/FTS DDL
-/// through bind+pid-write. Silently continuing with no lock reopens the
-/// cold-boot FTS race this guard exists to close, so callers that are about
-/// to run daemon-mode boot (or wait for one to quiesce) must fail loudly
-/// instead of proceeding unguarded.
+/// Unlike [`acquire_recovery_lock`] (best-effort, `None` on failure — used by
+/// shutdown cleanup, where skipping unlink is safer than blocking forever),
+/// daemon-mode boot must hold this lock across migrations/FTS DDL through
+/// bind+pid-write. Silently continuing with no lock reopens the cold-boot FTS
+/// race this guard exists to close, so callers that are about to run
+/// daemon-mode boot (or wait for one to quiesce) must fail loudly instead of
+/// proceeding unguarded.
 #[cfg(unix)]
 pub fn acquire_daemon_boot_guard() -> anyhow::Result<DaemonBootGuard> {
     acquire_recovery_lock()
@@ -246,7 +244,7 @@ pub fn acquire_daemon_boot_guard() -> anyhow::Result<DaemonBootGuard> {
 /// Identity of a bound Unix socket path, used to tell "the socket I bound" apart
 /// from "a same-path socket some other daemon bound after mine was removed".
 ///
-/// #645: a socket path can be recreated by a different process between the time
+/// A socket path can be recreated by a different process between the time
 /// this daemon captures its identity and the time it later checks it, so `dev`
 /// and `ino` (not the path) are what must match for cleanup to be safe.
 #[cfg(unix)]
@@ -276,25 +274,21 @@ pub struct DaemonRequestFrame {
     pub presentation_per_op: Option<Vec<Option<String>>>,
     /// The client's resolved storage/gate default namespace for this request.
     ///
-    /// Historically rejected outright when it differed from the daemon's own
-    /// construction-baked namespace (`namespace_mismatch`). As of protocol
-    /// version 3 (ADR-096 Fork 1) the daemon instead serves the request under
-    /// this namespace — the field is a per-request identity input, not a
-    /// same-process-identity assertion.
+    /// As of protocol version 3 (ADR-096) the daemon serves the request under
+    /// this namespace instead of rejecting on mismatch — a per-request
+    /// identity input, not a same-process-identity assertion.
     pub namespace: String,
     /// The client's resolved write-stamp / gate actor identity (ADR-057),
     /// carried on the frame so the warm daemon stamps writes with the
-    /// *caller's* actor instead of the daemon's own baked `actor_id`
-    /// (ADR-096 Fork 1). `None` mints `ActorRef::anonymous()`, matching an
-    /// unconfigured actor. Pre-Fork-1 clients cannot send this field (an older
-    /// protocol version rejects at the version check before it would matter).
+    /// *caller's* actor instead of its own baked `actor_id` (ADR-096). `None`
+    /// mints `ActorRef::anonymous()`, matching an unconfigured actor.
     #[serde(default)]
     pub actor_id: Option<String>,
-    /// The client's resolved extra read-visibility namespaces (ADR-007 Rev 4
-    /// Rule 3b), carried on the frame so the warm daemon widens read scope to
-    /// match the caller's own configuration rather than the daemon's baked
-    /// `visible_namespaces` (ADR-096 Fork 1). Empty means no extra visibility
-    /// beyond `namespace` itself.
+    /// The client's resolved extra read-visibility namespaces (ADR-007 Rule
+    /// 3b), carried on the frame so the warm daemon widens read scope to
+    /// match the caller's own configuration rather than its own baked
+    /// `visible_namespaces` (ADR-096). Empty means no extra visibility beyond
+    /// `namespace` itself.
     #[serde(default)]
     pub visible_namespaces: Vec<String>,
     /// Fingerprint of the client's engine-coherence config: packs, db target,
@@ -336,17 +330,15 @@ pub struct DaemonRequestFrame {
     #[serde(default)]
     pub format_per_op: Option<Vec<Option<String>>>,
     /// Whether this request originated from the agent-facing MCP `request`
-    /// tool (the wire surface). When `true`, the daemon enforces verb
-    /// visibility — `Visibility::Subhandler` verbs are rejected because agents
-    /// must not invoke internal subhandlers. When `false` (the default, and the
-    /// only value any operator path sends), subhandlers are allowed: `kkernel
-    /// exec` and other in-process callers are trusted operator surfaces.
+    /// tool (the wire surface). When `true`, the daemon rejects
+    /// `Visibility::Subhandler` verbs — agents must not invoke internal
+    /// subhandlers. When `false` (the default, and the only value any
+    /// operator path sends), subhandlers are allowed: `kkernel exec` and
+    /// other in-process callers are trusted operator surfaces.
     ///
     /// This is the origin discriminator, not a daemon-vs-local one: operator
-    /// requests flow through the daemon by default too, so the gate cannot key
-    /// on transport. Pre-versioning clients omit this field (deserializes to
-    /// `false` → ungated), which is safe: the only way to reach the gated wire
-    /// surface is the MCP `request` tool, which always sets it explicitly.
+    /// requests flow through the daemon by default too, so the gate cannot
+    /// key on transport.
     #[serde(default)]
     pub from_wire: bool,
 }
@@ -503,7 +495,7 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
     /// the request is from a trusted operator surface and subhandlers pass.
     ///
     /// `identity` is the per-request identity context threaded from the frame
-    /// (ADR-096 Fork 1): `Some(..)` when serving a request forwarded over the
+    /// (ADR-096): `Some(..)` when serving a request forwarded over the
     /// daemon socket (built from `frame.namespace` / `frame.actor_id` /
     /// `frame.visible_namespaces` by the connection handler), `None` for any
     /// other dispatch path. Implementors should mint the storage/gate token from
@@ -560,15 +552,15 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
 
 // ── tracked background tasks ─────────────────────────────────────────────────
 //
-// Pack handlers (e.g. memory.recall's ADR-081 §5 serve-ledger append) fire
+// Pack handlers (e.g. memory.recall's ADR-081 serve-ledger append) fire
 // fire-and-forget `tokio::spawn`ed work off the response path so the caller
 // never waits on a cross-pack dispatch or a SQL write. Left untracked, that
 // work is invisible to `drain()`: a SIGTERM landing between the response
 // returning and the spawned task completing can abort it mid-flight with no
-// log and no row (internal review PR #583 round-1 Medium). `track_background_task`
-// gives such spawns a process-wide presence that `drain()` waits on, exactly
-// like the `active` counter does for in-flight connections — the caller still
-// only pays for the spawn + counter increment, never the task's own work.
+// log and no row. `track_background_task` gives such spawns a process-wide
+// presence that `drain()` waits on, exactly like the `active` counter does
+// for in-flight connections — the caller still only pays for the spawn +
+// counter increment, never the task's own work.
 static BACKGROUND_TASKS: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>> =
     std::sync::OnceLock::new();
 
@@ -579,8 +571,8 @@ fn background_tasks() -> &'static Arc<std::sync::atomic::AtomicUsize> {
 /// Decrements the shared background-task counter from `Drop`, so the count
 /// comes back down whether the tracked future returns normally, panics, or
 /// is cancelled — a plain post-`await` `fetch_sub` only covers the return
-/// path and leaks the count forever on a panic (internal review PR #583 round-2
-/// Medium), since unwinding skips every statement after the panic point.
+/// path and leaks the count forever on a panic, since unwinding skips every
+/// statement after the panic point.
 struct BackgroundTaskGuard {
     counter: Arc<std::sync::atomic::AtomicUsize>,
 }
@@ -618,7 +610,7 @@ pub fn background_task_count() -> usize {
     background_tasks().load(std::sync::atomic::Ordering::Relaxed)
 }
 
-// ── active background phase names (ADR-103 Stage 1 / issue #723 ask 2) ────────
+// ── active background phase names (ADR-103) ──────────────────────────────────
 //
 // A lightweight, best-effort process-wide gauge of which named background
 // phases (e.g. `ann_warm`) are in flight right now, read by `comm.health`'s
@@ -787,15 +779,15 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             daemon_protocol_version: PROTOCOL_VERSION,
             metrics: Some(build_metrics_snapshot(&dispatcher)),
         }
-    // ADR-096 Fork 1: there is no `frame.namespace != dispatcher.namespace()`
-    // reject here. The daemon accepts and serves the request under the
-    // frame's own identity (namespace / actor / visible_namespaces, built
-    // into a `RequestIdentity` below) over its one shared warm registry,
-    // rather than rejecting a differently-attributed same-uid connection to
-    // a cold local-dispatch fallback. `config_id` — which governs
-    // packs/db/embed coherence for the shared warm engine — remains a hard
-    // reject; it is not an identity field and softening it would let a
-    // restricted client dispatch through an incompatible broader daemon.
+    // There is no `frame.namespace != dispatcher.namespace()` reject here.
+    // The daemon accepts and serves the request under the frame's own
+    // identity (namespace / actor / visible_namespaces, built into a
+    // `RequestIdentity` below) over its one shared warm registry, rather
+    // than rejecting a differently-attributed same-uid connection to a cold
+    // local-dispatch fallback. `config_id` — which governs packs/db/embed
+    // coherence for the shared warm engine — remains a hard reject; it is
+    // not an identity field and softening it would let a restricted client
+    // dispatch through an incompatible broader daemon.
     } else if frame.config_id != dispatcher.config_id() {
         DaemonResponseFrame {
             ok: false,
@@ -824,15 +816,14 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
             metrics: None,
         }
     } else {
-        // Build the per-request identity context from the frame (ADR-096
-        // Fork 1) so the implementor mints the storage/gate token from the
-        // CALLER's identity, not the dispatcher's own construction-baked
-        // scalars. This is always `Some` here: every frame that reaches
-        // this arm carries a `namespace` (required on the wire) plus
-        // whatever `actor_id`/`visible_namespaces` the client resolved
-        // (defaulting to `None`/`vec![]` for a pre-Fork-1 field-absent
-        // payload, which is exactly the prior anonymous/no-extra-visibility
-        // behavior).
+        // Build the per-request identity context from the frame so the
+        // implementor mints the storage/gate token from the CALLER's
+        // identity, not the dispatcher's own construction-baked scalars.
+        // This is always `Some` here: every frame that reaches this arm
+        // carries a `namespace` (required on the wire) plus whatever
+        // `actor_id`/`visible_namespaces` the client resolved (defaulting to
+        // `None`/`vec![]` for an older, field-absent payload, which is
+        // exactly the prior anonymous/no-extra-visibility behavior).
         let identity = RequestIdentity {
             namespace: frame.namespace.clone(),
             actor_id: frame.actor_id.clone(),
@@ -920,7 +911,7 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
 /// Run the daemon: bind the socket, warm in the background, serve request
 /// frames until SIGTERM/SIGINT.
 ///
-/// Fatally acquires its own startup lock. #667: this only protects
+/// Fatally acquires its own startup lock. This only protects
 /// cleanup→bind→pid-write; by the time this function runs, `dispatcher` (a
 /// `DaemonDispatch` built from a `KhiveMcpServer`) has *already* run
 /// migrations and applied pack schema plans while constructing itself,
@@ -942,13 +933,13 @@ pub async fn run_daemon<D: DaemonDispatch>(dispatcher: D) -> anyhow::Result<()> 
 /// Run the daemon using a startup lock acquired by the caller *before*
 /// building `dispatcher`.
 ///
-/// #667: cold-boot schema initialization (migrations, pack schema plans /
-/// FTS DDL) happens while `dispatcher` is being constructed, i.e. before this
+/// Cold-boot schema initialization (migrations, pack schema plans / FTS DDL)
+/// happens while `dispatcher` is being constructed, i.e. before this
 /// function is ever called. Passing an already-held `boot_guard` in lets the
 /// caller extend that same lock backward over construction, so a second
 /// process racing to boot (e.g. two `kkernel mcp --daemon` spawns before
-/// either has bound its socket, per #645) cannot run migrations/FTS DDL
-/// concurrently against the same database file. On unix every daemon-mode
+/// either has bound its socket) cannot run migrations/FTS DDL concurrently
+/// against the same database file. On unix every daemon-mode
 /// caller passes `Some` — `run_daemon` and the production entry points
 /// (`serve.rs`, `kkernel`) all acquire the guard fatally via
 /// `acquire_daemon_boot_guard` before constructing `dispatcher`. `boot_guard`
@@ -999,7 +990,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     if let Err(e) = std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600)) {
         tracing::warn!(error = %e, path = ?sock, "failed to chmod 0600 socket");
     }
-    // #645: captured while still holding the startup lock, immediately after
+    // Captured while still holding the startup lock, immediately after
     // bind, so shutdown cleanup can later prove "this is still the same socket
     // I bound" rather than trusting the path alone.
     #[cfg(unix)]
@@ -1008,7 +999,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
     #[cfg(unix)]
     if let Err(e) = write_pid_file_exclusive(&pid_file) {
         if e.kind() == std::io::ErrorKind::AlreadyExists {
-            // #645: a PID file appeared between our own `cleanup_stale_daemon`
+            // A PID file appeared between our own `cleanup_stale_daemon`
             // removing it and this write — only possible if the boot lock did
             // not actually exclude a concurrent booter (e.g. `acquire_recovery_lock`
             // failed for one side). Never touch the winner's files: drop only
@@ -1048,7 +1039,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
         });
     }
 
-    // #774: the checkpoint task's own strong-count-based exit is unreachable
+    // The checkpoint task's own strong-count-based exit is unreachable
     // whenever `event_store_for_checkpoint()` returns `Some` (the ordinary
     // production shape), because the `SqlEventStore` it wraps retains its
     // own clone of the same pool. An explicit watch channel replaces that
@@ -1113,7 +1104,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 
     drain(&active).await;
 
-    // #645: a concurrent client's `kill_and_respawn` may have already decided
+    // A concurrent client's `kill_and_respawn` may have already decided
     // this daemon looked stale, killed it, and spawned a replacement that
     // bound the same socket/PID paths while this daemon was draining above.
     // Reacquire the recovery lock (the same one that serializes startup) and
@@ -1149,7 +1140,7 @@ pub async fn run_daemon_with_boot_guard<D: DaemonDispatch>(
 /// still be the exact one identified by `bound_identity` (dev/ino, not path).
 ///
 /// Returns `true` if cleanup ran, `false` if it was skipped because a
-/// replacement daemon already owns those paths (#645). The caller must hold
+/// replacement daemon already owns those paths. The caller must hold
 /// the recovery lock across this call — the same lock daemon startup holds
 /// across cleanup+bind+pid-write — so no replacement can bind between this
 /// function's checks and its unlinks.
@@ -1254,7 +1245,7 @@ async fn cleanup_stale_daemon(sock: &std::path::Path, pid_file: &std::path::Path
 
 /// Create `pid_file` exclusively (`O_EXCL`) and write this process's PID.
 ///
-/// #645: uses `create_new(true)` rather than `create(true).truncate(true)` so
+/// Uses `create_new(true)` rather than `create(true).truncate(true)` so
 /// this can never silently overwrite a PID file another process created —
 /// under normal operation the boot lock already serializes cleanup → bind →
 /// pid-write across processes, but that guarantee depends on
@@ -1371,8 +1362,8 @@ mod tests {
         );
     }
 
-    // #645 fix: EPERM (process exists, no permission to signal it) must not
-    // be misread as "not running" during stale-daemon cleanup.
+    // EPERM (process exists, no permission to signal it) must not be
+    // misread as "not running" during stale-daemon cleanup.
 
     #[test]
     fn classify_kill_result_zero_is_alive() {
@@ -1404,10 +1395,10 @@ mod tests {
         // PID 1 (init/launchd) always exists. An unprivileged process gets
         // EPERM signaling it (never ESRCH); running as root would get 0
         // instead. Either way `is_process_running` must report true — this
-        // is the live regression guard for the #645 bug (EPERM misread as
-        // dead); `classify_kill_result` above is the pure-function unit
-        // coverage for the same mapping, kept independent of process
-        // ownership so it is never flaky in CI.
+        // is the live regression guard for EPERM being misread as dead;
+        // `classify_kill_result` above is the pure-function unit coverage
+        // for the same mapping, kept independent of process ownership so
+        // it is never flaky in CI.
         assert!(
             is_process_running(1),
             "PID 1 always exists; EPERM must not read as dead"
@@ -1431,19 +1422,18 @@ mod tests {
         std::env::remove_var(key);
     }
 
-    // internal review PR #583 round-1 Medium: `drain()` must wait for tracked background
-    // tasks (e.g. memory.recall's serve-ledger append), not just in-flight
-    // connections, or a SIGTERM lands mid-flight with no log and no row.
+    // `drain()` must wait for tracked background tasks (e.g. memory.recall's
+    // serve-ledger append), not just in-flight connections, or a SIGTERM
+    // lands mid-flight with no log and no row.
     //
     // `#[serial(background_tasks)]`: this test reads/asserts on the
     // process-wide `BACKGROUND_TASKS` static shared with the two counter
     // tests below. Under default parallel execution one test's increment
-    // leaks into another's snapshot-then-assert window (internal review PR #583
-    // round-3 Medium, reproduced: both counter tests failed together,
-    // passed with `--test-threads=1`). Serializing just this named group
-    // isolates them from each other without forcing the whole test binary
-    // (including unrelated `#[serial]` tests elsewhere in this crate) onto
-    // one thread.
+    // leaks into another's snapshot-then-assert window (reproduced: both
+    // counter tests failed together, passed with `--test-threads=1`).
+    // Serializing just this named group isolates them from each other
+    // without forcing the whole test binary (including unrelated
+    // `#[serial]` tests elsewhere in this crate) onto one thread.
     #[tokio::test]
     #[serial(background_tasks)]
     async fn drain_waits_for_tracked_background_tasks_before_returning() {
@@ -1509,9 +1499,9 @@ mod tests {
     #[tokio::test]
     #[serial(background_tasks)]
     async fn track_background_task_count_returns_to_baseline_after_panic() {
-        // internal review PR #583 round-2 Medium: a panic inside the tracked future must
-        // still decrement the counter (via BackgroundTaskGuard's Drop), not
-        // leak it forever. `track_background_task` discards the spawned
+        // A panic inside the tracked future must still decrement the
+        // counter (via BackgroundTaskGuard's Drop), not leak it forever.
+        // `track_background_task` discards the spawned
         // task's `JoinHandle` (it is fire-and-forget by design — the caller
         // never awaits it), so this test does not await the panic directly;
         // tokio isolates the panic to the spawned task instead of aborting
@@ -1541,13 +1531,13 @@ mod tests {
         );
     }
 
-    // ── active background phase names (ADR-103 Stage 1 / issue #723 ask 2) ──
+    // ── active background phase names (ADR-103) ──────────────────────────
 
     // `#[serial(active_phases)]`: these tests read/assert on the process-wide
     // `ACTIVE_PHASES` static. No other test in this crate touches it today,
     // but the group mirrors the `background_tasks` precedent above so a
     // future addition does not silently reintroduce the same interleaving
-    // hazard (internal review PR #583 round-3 Medium) that motivated it there.
+    // hazard that motivated it there.
     #[test]
     #[serial(active_phases)]
     fn register_active_phase_appears_and_disappears_with_the_guard() {
@@ -1769,7 +1759,7 @@ mod tests {
             snapshot.wal_pages.is_some(),
             "wal_pages must be observed after a real checkpoint tick, got {snapshot:?}"
         );
-        // #646: the snapshot carries the checkpoint-pressure fields read-only
+        // The snapshot carries the checkpoint-pressure fields read-only
         // (no mutation path reachable through `MetricsSnapshot`/`DaemonRequestFrame`);
         // an observed tick (not a skip) must report a zero-length skip streak.
         assert_eq!(
@@ -1934,7 +1924,7 @@ mod tests {
         );
     }
 
-    // ── #645: owner-checked shutdown cleanup ──────────────────────────────────
+    // ── owner-checked shutdown cleanup ────────────────────────────────────────
     //
     // A draining daemon must not unlink a socket/PID pair that a replacement
     // daemon has already bound. These tests exercise `shutdown_cleanup_if_owned`
@@ -2049,7 +2039,7 @@ mod tests {
         );
     }
 
-    // ── #667: the recovery lock actually serializes two boot sequences ───────
+    // ── the recovery lock actually serializes two boot sequences ─────────────
     //
     // Production wiring (`khive_mcp::serve::run` / `serve_server`) now acquires
     // this same lock *before* building a `KhiveMcpServer` (which runs
@@ -2099,7 +2089,7 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
-    // ── #667: acquire_daemon_boot_guard treats lock failure as fatal ─────────
+    // ── acquire_daemon_boot_guard treats lock failure as fatal ───────────────
     // (unlike best-effort acquire_recovery_lock, whose `None` on failure is
     // correct for its own best-effort callers).
 
@@ -2128,7 +2118,7 @@ mod tests {
         // with `write(true)` fails (EISDIR), so `acquire_recovery_lock`
         // returns `None` here — the exact failure mode
         // `acquire_daemon_boot_guard` must turn into a hard `Err` instead of
-        // silently letting daemon-mode boot proceed unguarded (#667).
+        // silently letting daemon-mode boot proceed unguarded.
         std::env::set_var("KHIVE_LOCK", dir.path());
 
         let result = acquire_daemon_boot_guard();
@@ -2141,7 +2131,7 @@ mod tests {
         std::env::remove_var("KHIVE_LOCK");
     }
 
-    // ── #645: write_pid_file_exclusive never truncates a winner's pid file ───
+    // ── write_pid_file_exclusive never truncates a winner's pid file ────────
 
     #[test]
     fn write_pid_file_exclusive_creates_new_file_with_own_pid() {
@@ -2174,8 +2164,8 @@ mod tests {
     // Real (not simulated) concurrency: two OS threads race to `create_new`
     // the exact same path, synchronized with a `Barrier` so they genuinely
     // overlap at the syscall rather than relying on a sleep-based ordering
-    // guess. This is the deterministic race oracle for the #645 convergence
-    // requirement at the atomic-creation primitive `write_pid_file_exclusive`
+    // guess. This is the deterministic race oracle for the convergence
+    // requirement the atomic-creation primitive `write_pid_file_exclusive`
     // is built on: exactly one of two simultaneous daemon starters may claim
     // the pid file, and the loser must see `AlreadyExists`, never silently
     // clobber the winner's content.

--- a/crates/khive-runtime/src/daemon.rs
+++ b/crates/khive-runtime/src/daemon.rs
@@ -161,7 +161,7 @@ pub fn acquire_recovery_lock() -> Option<std::fs::File> {
 /// blocking `flock`, correct for the daemon's own boot sequence where waiting
 /// until quiescence IS the desired behavior), a caller only trying to *detect*
 /// whether a lock is currently free — without committing to wait forever for
-/// a possibly-wedged holder — needs a deadline instead. Returns:
+/// a possibly-wedged holder: needs a deadline instead. Returns:
 ///   - `Ok(Some(file))` — the lock was free within the deadline.
 ///   - `Ok(None)` — `deadline` elapsed while the lock stayed held; an
 ///     explicit "could not confirm" outcome, distinct from a hard I/O error.
@@ -199,7 +199,7 @@ fn try_acquire_flock_until(
 /// the SAME boot/recovery lock ([`lock_path`]) but gives up at `deadline`
 /// instead of blocking forever. For callers that need to detect "is a boot in
 /// progress right now" without risking an unbounded wait behind a wedged
-/// holder — e.g. khive-mcp's `confirm_genuinely_dead` re-probing rounds,
+/// holder: e.g. khive-mcp's `confirm_genuinely_dead` re-probing rounds,
 /// where `DEAD_CONFIRM_ROUNDS` must bound elapsed time, not just probe count.
 #[cfg(unix)]
 pub fn try_acquire_daemon_boot_guard_until(
@@ -228,7 +228,7 @@ pub type DaemonBootGuard = std::fs::File;
 
 /// Acquire the recovery/boot lock, treating failure as fatal.
 ///
-/// Unlike [`acquire_recovery_lock`] (best-effort, `None` on failure — used by
+/// Unlike [`acquire_recovery_lock`] (best-effort, `None` on failure: used by
 /// shutdown cleanup, where skipping unlink is safer than blocking forever),
 /// daemon-mode boot must hold this lock across migrations/FTS DDL through
 /// bind+pid-write. Silently continuing with no lock reopens the cold-boot FTS
@@ -275,7 +275,7 @@ pub struct DaemonRequestFrame {
     /// The client's resolved storage/gate default namespace for this request.
     ///
     /// As of protocol version 3 (ADR-096) the daemon serves the request under
-    /// this namespace instead of rejecting on mismatch — a per-request
+    /// this namespace instead of rejecting on mismatch: a per-request
     /// identity input, not a same-process-identity assertion.
     pub namespace: String,
     /// The client's resolved write-stamp / gate actor identity (ADR-057),
@@ -331,7 +331,7 @@ pub struct DaemonRequestFrame {
     pub format_per_op: Option<Vec<Option<String>>>,
     /// Whether this request originated from the agent-facing MCP `request`
     /// tool (the wire surface). When `true`, the daemon rejects
-    /// `Visibility::Subhandler` verbs — agents must not invoke internal
+    /// `Visibility::Subhandler` verbs: agents must not invoke internal
     /// subhandlers. When `false` (the default, and the only value any
     /// operator path sends), subhandlers are allowed: `kkernel exec` and
     /// other in-process callers are trusted operator surfaces.
@@ -559,7 +559,7 @@ pub trait DaemonDispatch: Clone + Send + Sync + 'static {
 // returning and the spawned task completing can abort it mid-flight with no
 // log and no row. `track_background_task` gives such spawns a process-wide
 // presence that `drain()` waits on, exactly like the `active` counter does
-// for in-flight connections — the caller still only pays for the spawn +
+// for in-flight connections: the caller still only pays for the spawn +
 // counter increment, never the task's own work.
 static BACKGROUND_TASKS: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>> =
     std::sync::OnceLock::new();
@@ -784,8 +784,8 @@ async fn handle_conn<D: DaemonDispatch>(mut stream: UnixStream, dispatcher: D) {
     // identity (namespace / actor / visible_namespaces, built into a
     // `RequestIdentity` below) over its one shared warm registry, rather
     // than rejecting a differently-attributed same-uid connection to a cold
-    // local-dispatch fallback. `config_id` — which governs packs/db/embed
-    // coherence for the shared warm engine — remains a hard reject; it is
+    // local-dispatch fallback. `config_id`: which governs packs/db/embed
+    // coherence for the shared warm engine: remains a hard reject; it is
     // not an identity field and softening it would let a restricted client
     // dispatch through an incompatible broader daemon.
     } else if frame.config_id != dispatcher.config_id() {

--- a/crates/khive-runtime/src/embedder_registry.rs
+++ b/crates/khive-runtime/src/embedder_registry.rs
@@ -86,15 +86,10 @@ impl EmbedderRegistry {
     /// Register a provider.
     ///
     /// If a provider with the same [`name`](EmbedderProvider::name) already
-    /// exists, the new provider **replaces** the existing one (last-writer wins).
-    /// The previously cached service instance (if any) is discarded — the
-    /// replacement provider's [`build`](EmbedderProvider::build) will be
-    /// called lazily on the next access.
-    ///
-    /// **Last-wins** is chosen over rejection because pack registration order
-    /// is not guaranteed and packs may legitimately override a default model
-    /// with a custom implementation of the same logical name. Operators who
-    /// need strict collision detection should inspect
+    /// exists, it is replaced (last-writer wins) and any cached service is
+    /// discarded, since pack registration order is not guaranteed and packs
+    /// may legitimately override a default model under the same name.
+    /// Callers needing strict collision detection should check
     /// [`names`](Self::names) before registering.
     pub fn register<P: EmbedderProvider + 'static>(&mut self, provider: P) {
         let name = provider.name().to_owned();
@@ -158,11 +153,8 @@ impl EmbedderEntry {
     ///
     /// Returns `RuntimeError` if `build()` fails, rather than panicking.
     pub(crate) async fn resolve(self) -> RuntimeResult<Arc<dyn EmbeddingService>> {
-        // `OnceCell` does not expose a fallible init; we work around this by
-        // checking if the cell is already populated (cheap), and if not, calling
-        // `build()` ourselves, storing on success, and propagating on failure.
-        // Races are benign: at worst two callers both call `build()` and the
-        // loser's result is discarded — both outcomes are identical services.
+        // `OnceCell` has no fallible init, so failure is handled manually; a losing
+        // racer's build() result is simply discarded since both are equivalent.
         if let Some(svc) = self.cell.get() {
             return Ok(Arc::clone(svc));
         }
@@ -172,8 +164,7 @@ impl EmbedderEntry {
                 self.provider.name()
             ))
         })?;
-        // `set` may fail if another task raced us to initialise; that is fine —
-        // we just return our freshly-built instance (functionally identical).
+        // A losing `set` (raced by another task) is fine — the two results are equivalent.
         let _ = self.cell.set(Arc::clone(&svc));
         Ok(svc)
     }
@@ -225,8 +216,6 @@ impl EmbedderProvider for LatticeEmbedderProvider {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
-
-    // ---- minimal mock provider ----
 
     struct ConstVecProvider {
         name: String,
@@ -286,8 +275,6 @@ mod tests {
         }
     }
 
-    // ---- test: register + get round-trip ----
-
     #[test]
     fn register_and_get_provider_round_trip() {
         let mut reg = EmbedderRegistry::new();
@@ -298,8 +285,6 @@ mod tests {
         assert_eq!(provider.name(), "mock-384");
         assert_eq!(provider.dimensions(), 384);
     }
-
-    // ---- test: duplicate name is last-wins (not an error) ----
 
     #[test]
     fn duplicate_name_last_wins() {
@@ -315,8 +300,6 @@ mod tests {
         );
     }
 
-    // ---- test: names() returns all registered names ----
-
     #[test]
     fn names_returns_all_registered() {
         let mut reg = EmbedderRegistry::new();
@@ -329,8 +312,6 @@ mod tests {
         assert_eq!(names, vec!["model-a", "model-b", "model-c"]);
     }
 
-    // ---- test: get_service returns UnknownModel for unregistered name ----
-
     #[tokio::test]
     async fn get_service_unknown_name_returns_error() {
         let reg = EmbedderRegistry::new();
@@ -341,8 +322,6 @@ mod tests {
             "expected UnknownModel, got {err:?}"
         );
     }
-
-    // ---- test: get_service calls build once (lazy, cached) ----
 
     #[tokio::test]
     async fn get_service_calls_build_once() {

--- a/crates/khive-runtime/src/embedder_registry.rs
+++ b/crates/khive-runtime/src/embedder_registry.rs
@@ -164,7 +164,7 @@ impl EmbedderEntry {
                 self.provider.name()
             ))
         })?;
-        // A losing `set` (raced by another task) is fine — the two results are equivalent.
+        // A losing `set` (raced by another task) is fine: the two results are equivalent.
         let _ = self.cell.set(Arc::clone(&svc));
         Ok(svc)
     }

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -473,11 +473,10 @@ impl KhiveConfig {
     /// Model name validity is checked lazily at runtime (the config loader does
     /// not import `lattice_embed` directly to keep the dep surface minimal).
     pub fn validate(&self) -> Result<(), ConfigError> {
-        // Reject a top-level `db` key loudly (#689) instead of letting serde's
-        // forward-compatible unknown-key tolerance silently swallow it: a config
-        // author who writes `db = "..."` expecting it to select the database
-        // would otherwise get silent divergence from the actual database opened
-        // via `--db`/`KHIVE_DB`.
+        // Reject a top-level `db` key loudly instead of letting serde's
+        // forward-compatible unknown-key tolerance silently swallow it — a
+        // config author expecting `db=` to select the database would
+        // otherwise get silent divergence from `--db`/`KHIVE_DB`.
         if let Some(value) = self.db.as_deref() {
             if !value.is_empty() {
                 return Err(ConfigError::UnsupportedTopLevelDb {
@@ -502,7 +501,6 @@ impl KhiveConfig {
             })?;
         }
 
-        // Validate actor.visible_namespaces when present.
         if let Some(ref vis) = self.actor.visible_namespaces {
             for ns_str in vis {
                 if ns_str.is_empty() {
@@ -532,7 +530,7 @@ impl KhiveConfig {
             })?;
         }
 
-        // Validate [[backends]]: unique names (ADR-028).
+        // Backend names must be unique.
         if !self.backends.is_empty() {
             let mut seen_backends = std::collections::HashSet::new();
             for backend in &self.backends {
@@ -542,9 +540,8 @@ impl KhiveConfig {
                     });
                 }
 
-                // Reject fields that are parsed but not yet supported (ADR-028 §1).
-                // An operator setting cache_mb or journal_mode would get silently
-                // ignored — reject loudly so misconfiguration is caught at startup.
+                // Reject fields that are parsed but not yet implemented — silently
+                // accepting them would let misconfiguration slip past startup.
                 if backend.cache_mb.is_some() {
                     return Err(ConfigError::UnsupportedBackendField {
                         name: backend.name.clone(),
@@ -559,7 +556,7 @@ impl KhiveConfig {
                 }
             }
 
-            // Validate [packs.<name>].backend references (ADR-028).
+            // Every pack-referenced backend name must be declared in `backends`.
             let defined: Vec<&str> = self.backends.iter().map(|b| b.name.as_str()).collect();
             for (pack_name, pack_cfg) in &self.packs {
                 if !defined.contains(&pack_cfg.backend.as_str()) {
@@ -576,7 +573,6 @@ impl KhiveConfig {
             return Ok(());
         }
 
-        // Unique names
         let mut seen_names = std::collections::HashSet::new();
         for engine in &self.engines {
             if !seen_names.insert(engine.name.clone()) {
@@ -586,7 +582,6 @@ impl KhiveConfig {
             }
         }
 
-        // Exactly one default
         let default_count = self.engines.iter().filter(|e| e.default).count();
         if default_count != 1 {
             return Err(ConfigError::DefaultCount {
@@ -594,9 +589,8 @@ impl KhiveConfig {
             });
         }
 
-        // Positive, finite fusion_weight when present.
-        // NaN does not satisfy `w <= 0.0`, and positive infinity is unbounded,
-        // so reject all non-finite values explicitly before the range check.
+        // Reject non-finite fusion_weight explicitly: NaN doesn't satisfy `w <= 0.0`
+        // and +inf is unbounded, so neither is caught by the range check alone.
         for engine in &self.engines {
             if let Some(w) = engine.fusion_weight {
                 if !w.is_finite() || w <= 0.0 {
@@ -682,22 +676,18 @@ pub fn config_from_env() -> KhiveConfig {
 
 // ---- Tests ----
 
-// INLINE TEST JUSTIFICATION: tests here cover config validation error paths that
-// rely on private ConfigError variants and temp-file helpers shared with the
-// config loader. Moving them to tests/ would require pub-exporting ConfigError
-// internals that are not part of the stable public API.
+// Kept inline (not tests/): exercises private ConfigError variants not part
+// of the public API.
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Helper: write a temp file and return the path.
     fn write_toml(dir: &tempfile::TempDir, content: &str) -> PathBuf {
         let path = dir.path().join("config.toml");
         std::fs::write(&path, content).unwrap();
         path
     }
 
-    // 1. Minimal config parses successfully.
     #[test]
     fn test_load_minimal_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -719,7 +709,6 @@ default = true
         assert!(cfg.engines[0].default);
     }
 
-    // 2. Zero default-flagged engines -> error.
     #[test]
     fn test_default_engine_required_when_engines_present() {
         let dir = tempfile::tempdir().unwrap();
@@ -738,7 +727,6 @@ model = "all-minilm-l6-v2"
         );
     }
 
-    // 3. Two engines both flagged default -> error.
     #[test]
     fn test_multiple_default_rejected() {
         let dir = tempfile::tempdir().unwrap();
@@ -763,7 +751,6 @@ default = true
         );
     }
 
-    // 4. Negative or zero fusion_weight -> error.
     #[test]
     fn test_fusion_weight_validation() {
         let dir = tempfile::tempdir().unwrap();
@@ -802,19 +789,16 @@ fusion_weight = 0.0
         );
     }
 
-    // 5. File absent + env vars set -> constructs equivalent KhiveConfig.
     #[test]
     fn test_env_var_fallback() {
         let dir = tempfile::tempdir().unwrap();
         let absent = dir.path().join("missing.toml");
 
-        // File does not exist -> KhiveConfig::load returns None.
         let loaded = KhiveConfig::load(Some(&absent)).unwrap();
         assert!(loaded.is_none());
 
-        // With env vars set, config_from_env builds a synthetic config.
-        // We can't set env vars safely in a parallel test suite, so test via
-        // the direct construction path instead.
+        // Can't safely set env vars in a parallel test suite, so exercise the
+        // direct construction path instead.
         let primary = "all-minilm-l6-v2".to_string();
         let additional = vec!["paraphrase-multilingual-minilm-l12-v2".to_string()];
 
@@ -844,7 +828,6 @@ fusion_weight = 0.0
         assert_eq!(cfg.default_engine().unwrap().name, "default");
     }
 
-    // 6. File present + env vars set -> file wins; test via RuntimeConfig.
     #[test]
     fn test_file_overrides_env() {
         let dir = tempfile::tempdir().unwrap();
@@ -858,17 +841,14 @@ default = true
 "#,
         );
 
-        // File load succeeds even if env vars would provide a different model.
-        // The caller (RuntimeConfig::from_khive_config) is responsible for
-        // checking whether env vars are also present and emitting the warning.
-        // Here we verify that KhiveConfig::load returns the file config.
+        // KhiveConfig::load returns the file config regardless of env vars;
+        // warning-on-conflict is the caller's responsibility.
         let cfg = KhiveConfig::load(Some(&path))
             .expect("load should succeed")
             .expect("file should be present");
         assert_eq!(cfg.engines[0].name, "file-engine");
     }
 
-    // 7. Duplicate engine names -> error.
     #[test]
     fn test_duplicate_engine_names_rejected() {
         let dir = tempfile::tempdir().unwrap();
@@ -892,7 +872,6 @@ model = "paraphrase-multilingual-minilm-l12-v2"
         );
     }
 
-    // 8. Empty config file -> no engines; validate succeeds.
     #[test]
     fn test_empty_config_is_valid() {
         let dir = tempfile::tempdir().unwrap();
@@ -904,7 +883,6 @@ model = "paraphrase-multilingual-minilm-l12-v2"
         cfg.validate().expect("empty config should be valid");
     }
 
-    // 9. Multi-engine config with valid positive fusion_weight -> succeeds.
     #[test]
     fn test_multi_engine_positive_fusion_weight() {
         let dir = tempfile::tempdir().unwrap();
@@ -931,7 +909,6 @@ fusion_weight = 0.3
         assert_eq!(cfg.engines[1].fusion_weight, Some(0.3));
     }
 
-    // 10. [actor] section with id -> parsed correctly.
     #[test]
     fn test_actor_id_parsed() {
         let dir = tempfile::tempdir().unwrap();
@@ -951,7 +928,6 @@ display_name = "example actor"
         assert!(cfg.engines.is_empty());
     }
 
-    // 11. [actor] section with engines -> both parsed.
     #[test]
     fn test_actor_and_engines_together() {
         let dir = tempfile::tempdir().unwrap();
@@ -974,7 +950,6 @@ default = true
         assert_eq!(cfg.engines.len(), 1);
     }
 
-    // 12. Missing [actor] section -> defaults to None id (backward compat).
     #[test]
     fn test_actor_absent_defaults_to_none() {
         let dir = tempfile::tempdir().unwrap();
@@ -996,7 +971,6 @@ default = true
         );
     }
 
-    // 13. load_with_roots returns None when no files exist in the given roots.
     #[test]
     fn test_load_with_home_fallback_no_files() {
         let project_dir = tempfile::tempdir().unwrap();
@@ -1008,7 +982,6 @@ default = true
         );
     }
 
-    // 14. load_with_home_fallback explicit path overrides search.
     #[test]
     fn test_load_with_home_fallback_explicit_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -1025,7 +998,6 @@ id = "lambda:explicit"
         assert_eq!(cfg.actor.id.as_deref(), Some("lambda:explicit"));
     }
 
-    // 15. actor.id with an invalid namespace string -> ConfigError::InvalidActorId at load time.
     #[test]
     fn test_invalid_actor_id_rejected_at_load() {
         let dir = tempfile::tempdir().unwrap();
@@ -1043,7 +1015,6 @@ id = "bad namespace"
         );
     }
 
-    // 16. actor.id = "" (empty string) -> ConfigError::InvalidActorId.
     #[test]
     fn test_empty_actor_id_rejected() {
         let dir = tempfile::tempdir().unwrap();
@@ -1061,7 +1032,6 @@ id = ""
         );
     }
 
-    // 17. actor.id = "lambda:" (structurally invalid — no slug) -> ConfigError::InvalidActorId.
     #[test]
     fn test_malformed_actor_id_lambda_colon_only() {
         let dir = tempfile::tempdir().unwrap();
@@ -1080,10 +1050,8 @@ id = "lambda:"
         );
     }
 
-    // 18. ADR-007 Rev 4 Rule 0: actor.id must NOT become default_namespace — writes
-    //     stay pinned to `local`. A non-`'local'` actor.id IS folded into the
-    //     default READ visible-set (ADR-007 Rev 4 Rule 3b), but that does not affect
-    //     default_namespace. This test asserts the write-routing invariant only.
+    // actor.id must not become default_namespace — writes stay pinned to `local`
+    // even though a non-local actor.id widens the default read visible-set.
     #[test]
     fn test_runtime_config_actor_id_does_not_override_namespace() {
         use crate::runtime::runtime_config_from_khive_config;
@@ -1109,9 +1077,8 @@ id = "lambda:"
             "actor.id must NOT become default_namespace (ADR-007 Rev 4 Rule 0); \
              writes stay pinned to local"
         );
-        // Also assert the fold-in: actor.id MUST appear in visible_namespaces so that
-        // default reads widen to {local} ∪ {actor namespace} (ADR-007 Rev 4 Rule 3b,
-        // config.rs:~444). This is the load-bearing side-effect of the actor id config.
+        // actor.id must also appear in visible_namespaces — the load-bearing
+        // side effect that widens default reads to {local} ∪ {actor namespace}.
         assert!(
             result
                 .visible_namespaces
@@ -1122,7 +1089,6 @@ id = "lambda:"
         );
     }
 
-    // 19. runtime_config_from_khive_config with no actor preserves base namespace.
     #[test]
     fn test_runtime_config_no_actor_preserves_base() {
         use crate::runtime::runtime_config_from_khive_config;
@@ -1152,7 +1118,6 @@ id = "lambda:"
         );
     }
 
-    // 20. load_with_roots: khive.toml (tier 2) wins over .khive/config.toml (tier 3).
     #[test]
     fn test_load_with_home_fallback_project_root_over_hidden() {
         let dir = tempfile::tempdir().unwrap();
@@ -1182,7 +1147,6 @@ id = "lambda:"
         );
     }
 
-    // 21. load_with_roots: .khive/config.toml (tier 3) wins when khive.toml absent.
     #[test]
     fn test_load_with_home_fallback_hidden_over_absent_root() {
         let dir = tempfile::tempdir().unwrap();
@@ -1205,7 +1169,6 @@ id = "lambda:"
         );
     }
 
-    // 22. load_with_roots: ~/.khive/config.toml (tier 4) found when project files absent.
     #[test]
     fn test_load_with_roots_home_tier_found() {
         let project_dir = tempfile::tempdir().unwrap();
@@ -1229,7 +1192,6 @@ id = "lambda:"
         );
     }
 
-    // 23. load_with_roots: project tier wins over home tier.
     #[test]
     fn test_load_with_roots_project_wins_over_home() {
         let project_dir = tempfile::tempdir().unwrap();
@@ -1434,7 +1396,6 @@ id = "lambda:"
 
     // ── ADR-028 backend / pack config tests ─────────────────────────────────
 
-    // 22. No [[backends]] → empty vecs, no validation error.
     #[test]
     fn test_no_backends_section_is_valid() {
         let dir = tempfile::tempdir().unwrap();
@@ -1454,7 +1415,6 @@ default = true
         assert!(cfg.packs.is_empty());
     }
 
-    // 23. Single Sqlite backend deserializes correctly.
     #[test]
     fn test_single_sqlite_backend_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -1480,7 +1440,6 @@ path = "/tmp/knowledge.db"
         );
     }
 
-    // 24. Memory backend parses correctly.
     #[test]
     fn test_memory_backend_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -1499,7 +1458,6 @@ kind = "memory"
         assert!(matches!(cfg.backends[0].kind, BackendKind::Memory));
     }
 
-    // 25. Pack config backend assignment parses correctly.
     #[test]
     fn test_pack_backend_assignment_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -1522,7 +1480,6 @@ backend = "knowledge"
         assert_eq!(pc.backend, "knowledge");
     }
 
-    // 26. Duplicate backend names → DuplicateBackendName error.
     #[test]
     fn test_duplicate_backend_name_rejected() {
         let dir = tempfile::tempdir().unwrap();
@@ -1545,7 +1502,6 @@ kind = "memory"
         );
     }
 
-    // 27. Pack referencing undefined backend → UnknownPackBackend error.
     #[test]
     fn test_pack_referencing_undefined_backend_rejected() {
         let dir = tempfile::tempdir().unwrap();
@@ -1569,12 +1525,11 @@ backend = "nonexistent"
         );
     }
 
-    // 28. Pack config with no [[backends]] → packs section validated only when backends present.
     #[test]
     fn test_pack_config_without_backends_section_is_allowed() {
         let dir = tempfile::tempdir().unwrap();
-        // Per the spec: when [[backends]] is absent/empty, packs are not validated
-        // (all packs fall through to the implicit main backend).
+        // When [[backends]] is absent/empty, packs are not validated — all
+        // packs fall through to the implicit main backend.
         let path = write_toml(
             &dir,
             r#"
@@ -1582,7 +1537,6 @@ backend = "nonexistent"
 backend = "main"
 "#,
         );
-        // This should succeed: no backends declared → no validation of packs.
         let cfg = KhiveConfig::load(Some(&path))
             .expect("no error expected")
             .expect("file found");
@@ -1590,7 +1544,6 @@ backend = "main"
         assert_eq!(cfg.packs.len(), 1);
     }
 
-    // B-SHOULD-FIX-1: cache_mb in [[backends]] must be rejected at validate() with a clear error.
     #[test]
     fn test_backend_cache_mb_rejected_at_validate() {
         let dir = tempfile::tempdir().unwrap();
@@ -1610,7 +1563,6 @@ cache_mb = 128
         );
     }
 
-    // B-SHOULD-FIX-1: journal_mode in [[backends]] must be rejected at validate() with a clear error.
     #[test]
     fn test_backend_journal_mode_rejected_at_validate() {
         let dir = tempfile::tempdir().unwrap();
@@ -1630,9 +1582,8 @@ journal_mode = "wal"
         );
     }
 
-    // #689: a top-level `db` key must be rejected loudly at validate() instead
-    // of being silently ignored as an unknown key (serde's forward-compatible
-    // default) — the exact incident class the tier-3 discovery fix closes.
+    // A top-level `db` key must be rejected loudly instead of silently
+    // ignored as an unknown key by serde's forward-compatible default.
     #[test]
     fn test_top_level_db_rejected_at_validate() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/khive-runtime/src/engine_config.rs
+++ b/crates/khive-runtime/src/engine_config.rs
@@ -474,7 +474,7 @@ impl KhiveConfig {
     /// not import `lattice_embed` directly to keep the dep surface minimal).
     pub fn validate(&self) -> Result<(), ConfigError> {
         // Reject a top-level `db` key loudly instead of letting serde's
-        // forward-compatible unknown-key tolerance silently swallow it — a
+        // forward-compatible unknown-key tolerance silently swallow it: a
         // config author expecting `db=` to select the database would
         // otherwise get silent divergence from `--db`/`KHIVE_DB`.
         if let Some(value) = self.db.as_deref() {
@@ -540,7 +540,7 @@ impl KhiveConfig {
                     });
                 }
 
-                // Reject fields that are parsed but not yet implemented — silently
+                // Reject fields that are parsed but not yet implemented: silently
                 // accepting them would let misconfiguration slip past startup.
                 if backend.cache_mb.is_some() {
                     return Err(ConfigError::UnsupportedBackendField {
@@ -1050,7 +1050,7 @@ id = "lambda:"
         );
     }
 
-    // actor.id must not become default_namespace — writes stay pinned to `local`
+    // actor.id must not become default_namespace: writes stay pinned to `local`
     // even though a non-local actor.id widens the default read visible-set.
     #[test]
     fn test_runtime_config_actor_id_does_not_override_namespace() {
@@ -1077,7 +1077,7 @@ id = "lambda:"
             "actor.id must NOT become default_namespace (ADR-007 Rev 4 Rule 0); \
              writes stay pinned to local"
         );
-        // actor.id must also appear in visible_namespaces — the load-bearing
+        // actor.id must also appear in visible_namespaces: the load-bearing
         // side effect that widens default reads to {local} ∪ {actor namespace}.
         assert!(
             result
@@ -1528,7 +1528,7 @@ backend = "nonexistent"
     #[test]
     fn test_pack_config_without_backends_section_is_allowed() {
         let dir = tempfile::tempdir().unwrap();
-        // When [[backends]] is absent/empty, packs are not validated — all
+        // When [[backends]] is absent/empty, packs are not validated: all
         // packs fall through to the implicit main backend.
         let path = write_toml(
             &dir,

--- a/crates/khive-runtime/src/error.rs
+++ b/crates/khive-runtime/src/error.rs
@@ -9,9 +9,9 @@ use uuid::Uuid;
 pub type RuntimeResult<T> = Result<T, RuntimeError>;
 
 /// A guarded edge write (`link`/`link_many`) was refused because one or both
-/// endpoints no longer existed at write time (#769). Names the exact
-/// endpoint(s) missing instead of a generic "source or target" message, and,
-/// for a batch write, which entry in the batch failed first.
+/// endpoints no longer existed at write time. Names the exact endpoint(s)
+/// missing instead of a generic "source or target" message, and, for a batch
+/// write, which entry in the batch failed first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GuardedWriteFailure {
     /// Index of the failing entry within a `link_many` batch. `None` for the
@@ -269,7 +269,7 @@ pub enum RuntimeError {
 }
 
 /// Resolve an FTS text-leg search result, failing loud on parser syntax
-/// errors instead of silently degrading to vector-only fusion (#569).
+/// errors instead of silently degrading to vector-only fusion.
 ///
 /// A genuine backend outage (pool exhaustion, connection failure, etc.) is
 /// NOT a bad query and is returned as-is via the fallthrough `Err(e)` arm;
@@ -305,9 +305,8 @@ fn format_uuid_list(uuids: &[uuid::Uuid]) -> String {
 }
 
 /// Maps the dependency-light `khive-types` entity-type resolution error onto
-/// `RuntimeError::InvalidInput` at the pack boundary (#571): `khive-types`
-/// cannot depend on `khive-runtime`, so it cannot produce `RuntimeError`
-/// directly.
+/// `RuntimeError::InvalidInput` at the pack boundary: `khive-types` cannot
+/// depend on `khive-runtime`, so it cannot produce `RuntimeError` directly.
 impl From<khive_types::EntityTypeError> for RuntimeError {
     fn from(e: khive_types::EntityTypeError) -> Self {
         Self::InvalidInput(e.to_string())

--- a/crates/khive-runtime/src/fusion.rs
+++ b/crates/khive-runtime/src/fusion.rs
@@ -148,12 +148,10 @@ impl KhiveRuntime {
         let candidates = limit.saturating_mul(CANDIDATE_MULTIPLIER).max(limit);
 
         let ns = token.namespace().as_str().to_owned();
-        // FTS5 parser syntax errors (#388, #389 round-2 High): sanitize_fts5_query
-        // already strips known-unsafe FTS5 metacharacters, but if the lexical
-        // leg still errors at runtime on residual punctuation the sanitizer
-        // does not strip, per #569 this now fails loud instead of degrading
-        // to vector-only fusion. Errors from any other leg (vector search)
-        // still propagate normally.
+        // sanitize_fts5_query strips known-unsafe metacharacters, but residual
+        // punctuation can still trip the FTS5 parser at runtime; that error must
+        // fail loud rather than silently degrade to vector-only fusion. Errors
+        // from other legs (vector search) still propagate normally.
         let text_search_result = self
             .text(token)?
             .search(TextSearchRequest {
@@ -242,13 +240,9 @@ mod tests {
     fn rrf_custom_k_differs_from_k60() {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
-        // With k=1, top rank contributes 1/(1+1)=0.5 vs rank-2 1/(1+2)=0.333 — bigger gap
-        // With k=60, top rank contributes 1/61 vs 1/62 — much smaller gap
-        // Use a case where combining one source forces a=rank1, b=rank2 in text, reversed in vector
-        // k=1: a from text rank1 + vector rank2 = 1/2 + 1/3 = 5/6
-        //       b from text rank2 + vector rank1 = 1/3 + 1/2 = 5/6 (tie, broken by UUID)
-        // k=60: same math, but: 1/61 + 1/62 ≈ 0.0326 each — same tie
-        // Instead verify k=1 produces larger absolute score differences for rank differences
+        // Single-source input makes a and b tie in relative order at both k values,
+        // so assert on raw score magnitude (smaller k widens the rank-1-vs-rank-2 gap)
+        // rather than ordering.
         let text = vec![text_hit(a, 0.9, "a"), text_hit(b, 0.1, "b")];
         let hits_k1 =
             fuse_with_strategy(text.clone(), vec![], &FusionStrategy::Rrf { k: 1 }, 10).unwrap();
@@ -419,12 +413,10 @@ mod tests {
         }
     }
 
-    // 10. #388 regression: hybrid_search_with_strategy must not hard-fail on a query
-    // containing FTS5 metacharacters like `$`. After this test was first written,
-    // sanitize_fts5_query (khive-db) already strips `$`, so this alone takes the `Ok`
-    // path and does not exercise the runtime-level fail-open `Err` arm (PR #389 internal review
-    // round-1 Medium finding) — kept as a sanitizer-path regression; see test 11 below
-    // for the fail-open-branch regression.
+    // 10. hybrid_search_with_strategy must not hard-fail on a query containing FTS5
+    // metacharacters like `$`, since sanitize_fts5_query strips them before the query
+    // reaches SQLite. This covers the sanitizer path; test 11 covers the fail-loud
+    // path for characters the sanitizer does not strip.
     #[tokio::test]
     async fn hybrid_search_with_strategy_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -452,14 +444,10 @@ mod tests {
         );
     }
 
-    // 11. #569 regression: unlike `$`, `@` is NOT stripped by sanitize_fts5_query
-    // (by design — the sanitizer stays minimal per #388 scope). SQLite FTS5's
-    // bareword parser still rejects `@` unconditionally, so this query reaches
-    // the runtime-level `Err` arm in hybrid_search_with_strategy, which must
-    // now fail loud (`RuntimeError::InvalidInput`) instead of silently
-    // degrading to vector-only fusion as it did before #569. This assertion
-    // fails against the pre-#569 fail-open behavior (which returned `Ok`
-    // here) and passes once the FTS leg fails closed.
+    // 11. Unlike `$`, `@` is not stripped by sanitize_fts5_query (kept minimal by
+    // design), and SQLite FTS5's bareword parser rejects it unconditionally. That
+    // parser error must surface as RuntimeError::InvalidInput rather than silently
+    // degrading to vector-only fusion.
     #[tokio::test]
     async fn hybrid_search_with_strategy_residual_fts5_char_fails_loud() {
         let rt = KhiveRuntime::memory().unwrap();

--- a/crates/khive-runtime/src/graph_traversal.rs
+++ b/crates/khive-runtime/src/graph_traversal.rs
@@ -55,7 +55,6 @@ impl KhiveRuntime {
 
         let mut visited: HashSet<Uuid> = HashSet::new();
         let mut results: Vec<PathNode> = Vec::new();
-        // Current BFS frontier: nodes whose neighbors we have not yet explored.
         let mut frontier: Vec<Uuid> = Vec::new();
 
         visited.insert(start);
@@ -79,14 +78,12 @@ impl KhiveRuntime {
             // One DB round-trip for all nodes in the current frontier.
             let all_hits = graph.batch_neighbors(&frontier, query).await?;
 
-            // Collect unvisited (node_id, edge_id) pairs for this level.
             let mut level_new: Vec<(Uuid, Uuid)> = Vec::new();
             for (_src, hit) in &all_hits {
                 if visited.contains(&hit.node_id) {
                     continue;
                 }
-                // Insert into visited eagerly so duplicate edges within the same
-                // level do not produce duplicate PathNodes.
+                // Mark visited before pushing so duplicate edges in the same level don't duplicate PathNodes.
                 if visited.insert(hit.node_id) {
                     level_new.push((hit.node_id, hit.edge_id));
                 }
@@ -109,10 +106,8 @@ impl KhiveRuntime {
             frontier.clear();
             for (node_id, edge_id) in level_new {
                 let via_edge = edge_map.get(&edge_id).cloned().or(None);
-                // via_edge being None here means the edge was soft-deleted between
-                // the neighbors call and the get_edges call. Return NotFound rather
-                // than silently dropping the node, so the concurrent-delete race
-                // surfaces instead of yielding a misleadingly-incomplete path.
+                // A missing edge here means it was soft-deleted between the neighbors and get_edges calls;
+                // error out rather than silently returning an incomplete path.
                 if via_edge.is_none() {
                     return Err(RuntimeError::NotFound(format!("edge {} missing", edge_id)));
                 }
@@ -178,7 +173,6 @@ impl KhiveRuntime {
         let mut current_depth = 0usize;
 
         while (!fwd_frontier.is_empty() || !bwd_frontier.is_empty()) && current_depth <= max_depth {
-            // Expand the forward frontier one level (one batch_neighbors call).
             if !fwd_frontier.is_empty() {
                 let hits = graph
                     .batch_neighbors(
@@ -217,7 +211,6 @@ impl KhiveRuntime {
                 break;
             }
 
-            // Expand the backward frontier one level (one batch_neighbors call).
             if !bwd_frontier.is_empty() {
                 let hits = graph
                     .batch_neighbors(
@@ -264,7 +257,6 @@ impl KhiveRuntime {
             Some(m) => m,
         };
 
-        // Reconstruct path: walk fwd map back from mid to `from`, then walk bwd map forward to `to`.
         let mut fwd_chain: Vec<(Uuid, Option<Uuid>)> = Vec::new();
         {
             let mut cur = mid;
@@ -288,7 +280,7 @@ impl KhiveRuntime {
             }
         }
 
-        // Collect all edge IDs we need to fetch for the path in one batch call.
+        // Fetch all path edges in one batch call rather than one round-trip per edge.
         let path_edge_ids: Vec<LinkId> = fwd_chain
             .iter()
             .chain(bwd_chain.iter())
@@ -301,7 +293,6 @@ impl KhiveRuntime {
             .map(|e| (Uuid::from(e.id), e))
             .collect();
 
-        // Build PathNode slice.
         let mut path: Vec<PathNode> = Vec::new();
         for (i, (node_id, edge_id)) in fwd_chain.iter().enumerate() {
             let via_edge = if i == 0 {
@@ -330,9 +321,8 @@ impl KhiveRuntime {
     }
 }
 
-// INLINE TEST JUSTIFICATION: tests here exercise graph traversal helper functions
-// (BFS ordering, cycle detection) that access private traversal state. Moving them
-// to tests/ would require pub-exporting that state, widening the API surface.
+// Kept inline (not in tests/) because these tests exercise private traversal state that
+// would otherwise need to be made pub.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -560,7 +550,6 @@ mod tests {
             .create_entity(&tok, "concept", None, "B", None, None, vec![])
             .await
             .unwrap();
-        // No edges between them.
 
         let path = rt.shortest_path(&tok, a.id, b.id, 5).await.unwrap();
         assert!(path.is_none());
@@ -643,25 +632,8 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Query-count proof: verify the new batched traversal issues O(max_depth)
-    // round-trips, not O(nodes) or O(edges).
-    //
-    // Graph: a balanced binary tree of depth 3.
-    //
-    //           root
-    //          /    \
-    //        n1      n2
-    //       /  \    /  \
-    //     n3   n4  n5  n6
-    //    / \  / \  / \ / \
-    //   l1 l2 l3 l4 l5 l6 l7 l8
-    //
-    // 15 nodes, 14 edges.  BFS at max_depth=3:
-    //   - old code: 14 `neighbors` + 14 `get_edge` = 28 round-trips (O(nodes+edges))
-    //   - new code: 3 `batch_neighbors` + 3 `get_edges` = 6 round-trips (O(depth))
-    // -------------------------------------------------------------------------
-
+    // Proves batched BFS issues O(max_depth) round-trips, not O(nodes+edges), over a
+    // 15-node/14-edge depth-3 binary tree (root -> n1,n2 -> n3..n6 -> l1..l8).
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -669,12 +641,9 @@ mod tests {
     async fn bfs_query_count_is_o_depth_not_o_nodes() {
         use crate::runtime::KhiveRuntime;
 
-        // Build the in-memory runtime (includes graph store) and a plain RT for
-        // inserting nodes/edges.
         let rt = KhiveRuntime::memory().expect("memory runtime");
         let tok = NamespaceToken::local();
 
-        // Build a 3-level binary tree: root -> {n1,n2} -> {n3..n6} -> {l1..l8}.
         let root = rt
             .create_entity(&tok, "concept", None, "root", None, None, vec![])
             .await
@@ -705,12 +674,8 @@ mod tests {
             .unwrap();
         let leaves: Vec<_> = ["l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8"]
             .iter()
-            .map(|n| {
-                // We need to block on this in the test; use a local variable to avoid async issues.
-                n.to_string()
-            })
+            .map(|n| n.to_string())
             .collect();
-        // Create leaves synchronously within the async context.
         let mut leaf_ids = Vec::new();
         for name in &leaves {
             let e = rt
@@ -720,14 +685,12 @@ mod tests {
             leaf_ids.push(e);
         }
 
-        // Wire depth-1 edges.
         rt.link(&tok, root.id, n1.id, EdgeRelation::Extends, 1.0, None)
             .await
             .unwrap();
         rt.link(&tok, root.id, n2.id, EdgeRelation::Extends, 1.0, None)
             .await
             .unwrap();
-        // depth-2
         rt.link(&tok, n1.id, n3.id, EdgeRelation::Extends, 1.0, None)
             .await
             .unwrap();
@@ -740,7 +703,6 @@ mod tests {
         rt.link(&tok, n2.id, n6.id, EdgeRelation::Extends, 1.0, None)
             .await
             .unwrap();
-        // depth-3 (leaves)
         let depth2 = [n3.id, n4.id, n5.id, n6.id];
         for (i, parent) in depth2.iter().enumerate() {
             rt.link(
@@ -765,7 +727,6 @@ mod tests {
             .unwrap();
         }
 
-        // Run bfs_traverse and verify correctness (15 nodes: root + 2 + 4 + 8).
         let opts = TraversalOptions {
             max_depth: 3,
             ..Default::default()
@@ -773,7 +734,6 @@ mod tests {
         let nodes = rt.bfs_traverse(&tok, root.id, opts).await.unwrap();
         assert_eq!(nodes.len(), 15, "all 15 nodes in the tree must be returned");
 
-        // Verify depth assignments.
         assert_eq!(nodes[0].depth, 0);
         let depth1_count = nodes.iter().filter(|n| n.depth == 1).count();
         let depth2_count = nodes.iter().filter(|n| n.depth == 2).count();
@@ -782,7 +742,6 @@ mod tests {
         assert_eq!(depth2_count, 4);
         assert_eq!(depth3_count, 8);
 
-        // Verify all non-root nodes have a via_edge.
         for node in nodes.iter().skip(1) {
             assert!(
                 node.via_edge.is_some(),
@@ -791,11 +750,8 @@ mod tests {
             );
         }
 
-        // The definitive proof of O(depth) call count:
-        // We obtain the GraphStore from the same runtime (which backs the BFS above)
-        // and manually simulate the level-batched algorithm, counting each call.
-        // Since the runtime's bfs_traverse uses the same GraphStore under the hood,
-        // this proves the algorithm issues O(max_depth) calls, not O(nodes).
+        // No call-counting hook exists on bfs_traverse itself, so the same GraphStore
+        // is driven manually, level by level, to count round-trips directly.
         let graph = rt.graph(&tok).expect("graph store");
 
         let get_edge_counter = Arc::new(AtomicUsize::new(0));
@@ -803,8 +759,6 @@ mod tests {
         let neighbors_counter = Arc::new(AtomicUsize::new(0));
         let batch_neighbors_counter = Arc::new(AtomicUsize::new(0));
 
-        // Manually simulate bfs_traverse level-by-level using the raw counters
-        // to prove O(depth) behavior.
         let mut sim_visited: HashSet<Uuid> = HashSet::new();
         let mut sim_results: Vec<Uuid> = Vec::new();
         let mut sim_frontier: Vec<Uuid> = vec![root.id];
@@ -847,16 +801,13 @@ mod tests {
             sim_depth += 1;
         }
 
-        // The simulation visited the same 15 nodes.
         assert_eq!(sim_results.len(), 15, "simulation must find all 15 nodes");
 
-        // KEY ASSERTION: O(max_depth) calls, not O(nodes) or O(edges).
         let bn_calls = batch_neighbors_counter.load(Ordering::Relaxed);
         let ge_calls = get_edges_counter.load(Ordering::Relaxed);
         let n_calls = neighbors_counter.load(Ordering::Relaxed);
         let ges_calls = get_edge_counter.load(Ordering::Relaxed);
 
-        // Exact expected counts for a 3-level binary tree with max_depth=3:
         assert_eq!(
             bn_calls, 3,
             "batch_neighbors must be called once per BFS level (3 levels)"

--- a/crates/khive-runtime/src/objectives.rs
+++ b/crates/khive-runtime/src/objectives.rs
@@ -213,7 +213,6 @@ impl DecayAwareSalienceObjective {
 impl Objective<NoteCandidate> for DecayAwareSalienceObjective {
     #[inline]
     fn score(&self, candidate: &NoteCandidate, _context: &ObjectiveContext) -> f64 {
-        // effective_salience = salience * exp(-decay_factor * age_days)
         candidate.salience * (-candidate.decay_factor * candidate.age_days).exp()
     }
 
@@ -256,9 +255,8 @@ impl AmplifiedDecayAwareSalienceObjective {
 impl Objective<NoteCandidate> for AmplifiedDecayAwareSalienceObjective {
     #[inline]
     fn score(&self, candidate: &NoteCandidate, _context: &ObjectiveContext) -> f64 {
-        // Use the pre-computed effective_salience which was produced by the caller
-        // via DecayModel::apply(). This respects all four DecayModel variants
-        // (Exponential, Hyperbolic, PowerLaw, None) instead of hardcoding exponential.
+        // effective_salience is pre-computed via the caller's DecayModel, so this
+        // works for all decay model variants, not just exponential.
         candidate.effective_salience.powf(self.alpha)
     }
 
@@ -312,7 +310,6 @@ impl Objective<NoteCandidate> for TemporalRecencyObjective {
 /// reranker was not run (key absent) — callers should gate on
 /// `RecallConfig.reranker_weights[name] > 0.0` before including this objective
 /// in a `WeightedObjective` composition.
-///
 pub struct RerankerObjective {
     /// Name of the reranker to look up in `candidate.rerank_scores`.
     pub reranker_name: String,
@@ -402,9 +399,8 @@ impl MemoryRecallPipeline {
 
 // ────────────────────────────────────────────────────────────────────────────
 
-// INLINE TEST JUSTIFICATION: tests here exercise the scoring math on internal
-// NoteCandidate fields (raw_score, salience, recency) that are not exported.
-// Moving them to tests/ would require pub-exporting those fields.
+// Kept inline: these tests exercise internal NoteCandidate fields that would
+// otherwise need to be made pub just to reach them from tests/.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -437,7 +433,7 @@ mod tests {
         decay_factor: f64,
         age_days: f64,
     ) -> NoteCandidate {
-        // For tests, compute effective_salience using the default Exponential formula.
+        // Mirrors the caller-side DecayModel::apply() default (Exponential) for test data.
         let effective_salience = salience * (-decay_factor * age_days).exp();
         NoteCandidate {
             id: Uuid::new_v4(),
@@ -490,7 +486,6 @@ mod tests {
 
     #[test]
     fn graph_anchor_hit_scores_one() {
-        // d=0 → score = 1.0 − 0/max = 1.0
         let c = candidate(None, None, Some(0), None);
         let obj = GraphProximityObjective { max_distance: 3 };
         assert!((obj.score(&c, &ctx()) - 1.0).abs() < 1e-12);
@@ -498,7 +493,6 @@ mod tests {
 
     #[test]
     fn graph_midpoint_scores_half() {
-        // d=1, max=2 → score = 1.0 − 1/2 = 0.5
         let c = candidate(None, None, Some(1), None);
         let obj = GraphProximityObjective { max_distance: 2 };
         assert!((obj.score(&c, &ctx()) - 0.5).abs() < 1e-12);
@@ -506,7 +500,6 @@ mod tests {
 
     #[test]
     fn graph_at_boundary_scores_zero() {
-        // d == max_distance → score = 0.0 (boundary excluded)
         let c = candidate(None, None, Some(3), None);
         let obj = GraphProximityObjective { max_distance: 3 };
         assert_eq!(obj.score(&c, &ctx()), 0.0);
@@ -528,7 +521,7 @@ mod tests {
 
     #[test]
     fn graph_max_distance_zero_always_scores_zero() {
-        // max_distance=0 is degenerate; guard against divide-by-zero.
+        // Guards the divide-by-zero case: max_distance=0 must not panic.
         let c = candidate(None, None, Some(0), None);
         let obj = GraphProximityObjective { max_distance: 0 };
         assert_eq!(obj.score(&c, &ctx()), 0.0);
@@ -553,8 +546,6 @@ mod tests {
 
     #[test]
     fn weighted_composition_vector_and_text() {
-        // Candidate with vector=0.8, text=0.6
-        // Weighted(0.5*vector + 0.5*text) = 0.5*0.8 + 0.5*0.6 = 0.7
         let c = candidate(Some(0.8), Some(0.6), None, None);
 
         let obj = WeightedObjective::<RetrievalCandidate>::new()
@@ -562,15 +553,12 @@ mod tests {
             .add(Box::new(TextRelevanceObjective), 0.5);
 
         let score = obj.score(&c, &ctx());
-        // WeightedObjective divides by total weight (1.0), so result is 0.7
+        // Weights here already sum to 1.0, so normalization is a no-op.
         assert!((score - 0.7).abs() < 1e-12);
     }
 
     #[test]
     fn weighted_composition_with_graph() {
-        // vector=1.0, text=0.0, graph d=1/max=4 → proximity = 1 - 1/4 = 0.75
-        // weights: vector=0.4, text=0.3, graph=0.3
-        // weighted sum = (0.4*1.0 + 0.3*0.0 + 0.3*0.75) / 1.0 = 0.4 + 0.0 + 0.225 = 0.625
         let c = candidate(Some(1.0), Some(0.0), Some(1), None);
 
         let obj = WeightedObjective::<RetrievalCandidate>::new()
@@ -657,9 +645,8 @@ mod tests {
 
     #[test]
     fn decay_aware_uses_note_decay_factor_not_field() {
-        // uses the note's own decay_factor, not the objective's field
+        // Scoring uses the note's own decay_factor, not the objective's field.
         let obj = DecayAwareSalienceObjective::new(0.99); // obj.decay_rate ignored
-                                                          // Note's decay_factor = 0.01, age=100 days → exp(-0.01*100) ≈ 0.368
         let c = note_candidate(None, 1.0, 0.01, 100.0);
         let score = obj.score(&c, &ctx());
         let expected = (-0.01_f64 * 100.0).exp();
@@ -671,7 +658,6 @@ mod tests {
 
     #[test]
     fn decay_aware_high_decay_reduces_score_faster() {
-        // High decay note should score lower at same age
         let obj = DecayAwareSalienceObjective::new(0.0);
         let slow = note_candidate(None, 1.0, 0.001, 100.0);
         let fast = note_candidate(None, 1.0, 0.1, 100.0);
@@ -757,16 +743,14 @@ mod tests {
 
     #[test]
     fn memory_pipeline_weighted_composition() {
-        // Reproduce decay formula via WeightedObjective:
-        // score = rrf * 0.70 + salience_decayed * 0.20 + temporal * 0.10
-        // At age=0: salience_decayed = salience, temporal = 1.0
+        // Verifies WeightedObjective reproduces the same formula MemoryRecallPipeline builds.
         let c = NoteCandidate {
             id: Uuid::new_v4(),
             rrf_score: Some(0.5),
             salience: 0.8,
             decay_factor: 0.01,
             age_days: 0.0,
-            effective_salience: 0.8, // age=0, so effective_salience == salience
+            effective_salience: 0.8,
             rerank_scores: HashMap::new(),
         };
         let pipeline = WeightedObjective::<NoteCandidate>::new()
@@ -779,7 +763,6 @@ mod tests {
                 0.10,
             );
         let score = pipeline.score(&c, &ctx());
-        // (0.7*0.5 + 0.2*0.8 + 0.1*1.0) / 1.0 = 0.35 + 0.16 + 0.10 = 0.61
         assert!((score - 0.61).abs() < 1e-10, "got {score}");
     }
 }

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -36,23 +36,11 @@ use crate::curation::{entity_fts_document, note_fts_document};
 use crate::error::{GuardedWriteFailure, RuntimeError, RuntimeResult};
 use crate::runtime::{KhiveRuntime, NamespaceToken};
 
-// Test-only failure injection for `create_note_inner`.
-//
-// A test sets `LINK_FAIL_AFTER` to N > 0 before calling `create_note`.  The
-// Nth `link` call inside the loop returns `RuntimeError::Internal("injected
-// link failure")` instead of calling the real implementation.  The counter is
-// reset to 0 after each call regardless of whether it triggered, so tests are
-// isolated from one another.
-//
-// `FTS_FAIL_NS` / `VECTOR_FAIL_NS`: namespace-targeted injection mutexes, armed via
-// `arm_fts_fail(ns)` / `arm_vector_fail(ns)`.  Gated behind
-// `cfg(any(test, feature = "fault-injection"))` so they compile out of release builds
-// entirely — no lock acquisitions on the hot path in production, and no fault-injection
-// surface in published binaries.  Namespace-targeting means only `create_note` calls
-// for the armed namespace fire the injection; concurrent tests on other namespaces are
-// unaffected, eliminating cross-test races without requiring `#[serial]`.
-// External integration test crates enable the feature via a dev-dependency:
-//   khive-runtime = { ..., features = ["fault-injection"] }
+// Test-only failure injection for `create_note_inner`. Namespace-targeted so only
+// calls for the armed namespace fire, avoiding cross-test races without `#[serial]`.
+// Gated behind `cfg(any(test, feature = "fault-injection"))` so no lock acquisitions
+// or injection surface exist in production/published binaries. External integration
+// test crates enable it via a dev-dependency: khive-runtime = { ..., features = ["fault-injection"] }
 #[cfg(test)]
 std::thread_local! {
     static LINK_FAIL_AFTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
@@ -60,13 +48,12 @@ std::thread_local! {
 
 // Count-targetable vector-INSERT fault injection: when set to N (N > 0), the next N
 // vector insert calls (entity or note, single- or multi-model) succeed and the
-// (N+1)-th returns an injected error.  After triggering the counter resets to 0.
-// `thread_local!` provides per-thread isolation; `#[tokio::test]` uses a
-// current-thread runtime so there is no thread migration mid-test.  This lets
-// T-E3 let model-a's insert succeed and fail on model-b's, and lets any caller
-// whose test suite shares one default namespace across concurrently-running
-// tests (so `VECTOR_FAIL_NS`'s namespace match could be won by an unrelated
-// test's note/entity create) get a deterministic, race-free injection instead.
+// (N+1)-th returns an injected error, then the counter resets to 0.
+// `thread_local!` provides per-thread isolation (`#[tokio::test]` uses a
+// current-thread runtime, so there is no thread migration mid-test), letting a
+// test fail one specific model's insert in a multi-model fan-out and giving any
+// caller whose test suite shares a default namespace a deterministic, race-free
+// injection instead of depending on `VECTOR_FAIL_NS`'s namespace match.
 #[cfg(any(test, feature = "fault-injection"))]
 std::thread_local! {
     static VECTOR_FAIL_AFTER: std::cell::Cell<Option<usize>> =
@@ -98,12 +85,12 @@ static FTS_FAIL_MANY_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::ne
 /// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
-/// Non-parser FTS *search*-leg failure injection for `search_notes` (issue #389
-/// round-2 High regression coverage) — distinct from `FTS_FAIL_NS` (which
-/// injects at the FTS *upsert*/write step of `create_note_inner`). Injects a
-/// `StorageError::Timeout` at the `search()` call the FTS fail-open arm
-/// guards, so the arm's `is_fts5_syntax_error()` gate can be exercised against
-/// a genuine non-parser failure and asserted to propagate rather than degrade.
+/// Non-parser FTS *search*-leg failure injection for `search_notes` — distinct
+/// from `FTS_FAIL_NS` (which injects at the FTS *upsert*/write step of
+/// `create_note_inner`). Injects a `StorageError::Timeout` at the `search()`
+/// call the FTS fail-open arm guards, so the arm's `is_fts5_syntax_error()`
+/// gate can be exercised against a genuine non-parser failure and asserted to
+/// propagate rather than degrade.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_SEARCH_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
@@ -147,8 +134,8 @@ pub fn arm_fts_fail_many_partial(ns: &str) {
 /// The next `search_notes` call touching `ns` returns `StorageError::Timeout` from
 /// the FTS leg instead of calling the real `TextSearch::search`, then disarms.
 /// Used to prove the fail-open arm in `search_notes` propagates non-parser
-/// `StorageError`s (issue #389 round-2 High) instead of silently degrading them
-/// the way a genuine FTS5 parser syntax error is degraded.
+/// `StorageError`s instead of silently degrading them the way a genuine FTS5
+/// parser syntax error is degraded.
 /// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_fts_search_fail(ns: &str) {
@@ -167,9 +154,9 @@ pub fn arm_vector_fail(ns: &str) {
 }
 
 /// Failure injection for `delete_note_row_first_for_compensation`'s post-row-removal
-/// cleanup step (issue #460) — distinct from `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, which
-/// target `create_note_inner`. Lets tests prove that a rollback compensation's
-/// cleanup failure still leaves the note row (and thus the live message) gone.
+/// cleanup step — distinct from `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, which target
+/// `create_note_inner`. Lets tests prove that a rollback compensation's cleanup
+/// failure still leaves the note row (and thus the live message) gone.
 #[cfg(any(test, feature = "fault-injection"))]
 static ROLLBACK_CLEANUP_FAIL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
@@ -195,7 +182,7 @@ pub struct NoteSearchHit {
 
 /// Re-insert hyphens at canonical UUID positions (8-4-4-4-12) into a
 /// hyphen-free hex prefix, so a `LIKE '<pattern>%'` scan against the
-/// hyphenated `id` column matches correctly (#773). Prefixes that already
+/// hyphenated `id` column matches correctly. Prefixes that already
 /// contain a hyphen are passed through unchanged. No-op for len <= 8
 /// (already correct). Input longer than 32 hex chars is NOT truncated: the
 /// extra hex chars are appended past the canonical 12-char final segment
@@ -520,9 +507,9 @@ pub(crate) fn canonical_edge_endpoints(
 
 /// Infer the default `dependency_kind` from endpoint entity kinds.
 ///
-/// `pub(crate)` (widened, ADR-099 B3 fix round): `crate::atomic_prepare::prepare_link`
-/// reuses this exact inference table so `--atomic link` matches the non-atomic
-/// `link()` byte-for-byte, rather than re-deriving the table.
+/// `pub(crate)` so `crate::atomic_prepare::prepare_link` can reuse this exact
+/// inference table, keeping `--atomic link` byte-for-byte consistent with the
+/// non-atomic `link()` rather than re-deriving the table.
 pub(crate) fn infer_dependency_kind(src_kind: &str, tgt_kind: &str) -> Option<&'static str> {
     match (src_kind, tgt_kind) {
         ("project", "project") => Some("build"),
@@ -542,8 +529,8 @@ pub(crate) fn infer_dependency_kind(src_kind: &str, tgt_kind: &str) -> Option<&'
 /// the inferred value is added. Returns `metadata` unchanged for all other
 /// cases (no matching default, or metadata already has the key).
 ///
-/// `pub(crate)` (widened, ADR-099 B3 fix round): reused by
-/// `crate::atomic_prepare::prepare_link` for atomic/non-atomic parity.
+/// `pub(crate)` so `crate::atomic_prepare::prepare_link` can reuse it for
+/// atomic/non-atomic parity.
 pub(crate) fn merge_dependency_kind(
     src_kind: &str,
     tgt_kind: &str,
@@ -569,16 +556,12 @@ pub(crate) fn merge_dependency_kind(
 /// given at all) — this one folds in an EXPLICIT `dependency_kind` argument
 /// the caller passed alongside `metadata`.
 ///
-/// `pub` (ADR-099 B3 r6 second pass): the single source both
-/// `khive-pack-kg::handlers::link::handle_link` (via `khive_runtime::
-/// merge_entry_metadata`) and `crate::atomic_prepare::prepare_link` call —
-/// previously duplicated as a hand-copied 8-line block in `atomic_prepare.rs`
-/// (pack-kg's copy lived at `handlers/common.rs`, a `pub(crate)` fn in a
-/// crate `khive-runtime` cannot depend on, so it was re-typed by hand rather
-/// than imported). Relocating the canonical copy down to `khive-runtime`
-/// lets `khive-pack-kg` depend on it instead (packs depend on
-/// `khive-runtime`, never the reverse), closing the duplication in the
-/// direction the crate graph actually allows.
+/// `pub`: the single source both `khive-pack-kg::handlers::link::handle_link`
+/// (via `khive_runtime::merge_entry_metadata`) and
+/// `crate::atomic_prepare::prepare_link` call. Lives in `khive-runtime` (not
+/// pack-kg) because packs depend on `khive-runtime`, never the reverse — the
+/// only direction that lets both call sites share one copy instead of a
+/// hand-duplicated block.
 pub fn merge_entry_metadata(
     metadata: Option<serde_json::Value>,
     dependency_kind: Option<String>,
@@ -893,7 +876,7 @@ impl KhiveRuntime {
             // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors) {
-                // Count-targetable fault injection for multi-model insert path (T-E3).
+                // Count-targetable fault injection for multi-model insert path.
                 #[cfg(any(test, feature = "fault-injection"))]
                 let count_inject = VECTOR_FAIL_AFTER.with(|cell| match cell.get() {
                     Some(0) => {
@@ -971,7 +954,7 @@ impl KhiveRuntime {
 
     /// Retrieve an entity by ID.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
     pub async fn get_entity(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<Entity> {
         self.entities(token)?
             .get_entity(id)
@@ -981,7 +964,7 @@ impl KhiveRuntime {
 
     /// Retrieve an entity by ID including soft-deleted rows.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
     pub async fn get_entity_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -995,7 +978,7 @@ impl KhiveRuntime {
 
     /// Retrieve a note by ID including soft-deleted rows.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
     pub async fn get_note_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -1257,10 +1240,9 @@ impl KhiveRuntime {
     /// Returns `Ok(())` when valid; otherwise `InvalidInput` or `NotFound` with
     /// the same messages as the previous inline block (byte-identical behaviour).
     ///
-    /// `pub(crate)` (widened from private, ADR-099 B3): the atomic prepare pass
-    /// (`crate::atomic_prepare`) reuses this exact endpoint-type validation
-    /// during its async prepare step, before building a `LinkPlan` — see
-    /// ADR-099 D1's "reusing the handler's existing compute" principle.
+    /// `pub(crate)`: the atomic prepare pass (`crate::atomic_prepare`) reuses
+    /// this exact endpoint-type validation during its async prepare step,
+    /// before building a `LinkPlan`, rather than re-deriving the checks.
     pub(crate) async fn validate_edge_relation_endpoints(
         &self,
         token: &NamespaceToken,
@@ -1274,9 +1256,9 @@ impl KhiveRuntime {
             ));
         }
         if relation == EdgeRelation::Annotates {
-            // Source must be a note. By-ID endpoint resolution is namespace-agnostic
-            // (ADR-007 Rule 2; #631) — link consumes two by-ID endpoints, so it must
-            // resolve exactly what get() resolves, regardless of caller namespace.
+            // Source must be a note. By-ID endpoint resolution is namespace-agnostic —
+            // link consumes two by-ID endpoints, so it must resolve exactly what
+            // get() resolves, regardless of caller namespace.
             match self.resolve_edge_endpoint(token, source_id).await? {
                 Some(Resolved::Note(_)) => {}
                 Some(_) => {
@@ -1308,7 +1290,7 @@ impl KhiveRuntime {
         ) {
             // supersedes / supports / refutes: same-substrate only (note→note or entity→entity).
             // Event and edge endpoints are invalid regardless of the other endpoint.
-            // Endpoint resolution is by-ID and namespace-agnostic (ADR-007 Rule 2; #631).
+            // Endpoint resolution is by-ID and namespace-agnostic.
             let rel_name = relation.as_str();
             let src = match self.resolve_edge_endpoint(token, source_id).await? {
                 Some(r) => r,
@@ -1387,9 +1369,8 @@ impl KhiveRuntime {
             // restrictions (see base allowlist). Packs may extend the allowlist
             // additively via EDGE_RULES.
             //
-            // Strategy: resolve both endpoints once (by-ID, unfiltered — ADR-007 Rule 2;
-            // #631), consult pack rules; on miss, fall through to the original base-rule
-            // error messages.
+            // Strategy: resolve both endpoints once (by-ID, unfiltered), consult pack
+            // rules; on miss, fall through to the original base-rule error messages.
             let src_res = self.resolve_edge_endpoint(token, source_id).await?;
             let tgt_res = self.resolve_edge_endpoint(token, target_id).await?;
 
@@ -1454,7 +1435,7 @@ impl KhiveRuntime {
         Ok(())
     }
 
-    /// Public delegator for cross-backend link validation (ADR-029 D3).
+    /// Public delegator for cross-backend link validation.
     ///
     /// Exposes `validate_edge_relation_endpoints` for the `SubstrateCoordinator`
     /// so it can validate the relation before writing the edge on the source backend.
@@ -1469,11 +1450,11 @@ impl KhiveRuntime {
             .await
     }
 
-    /// Validate an edge relation using pre-fetched endpoint records (ADR-029 D3).
+    /// Validate an edge relation using pre-fetched endpoint records.
     ///
     /// For cross-backend links the source and target live on different backends —
     /// the source runtime cannot resolve the target. The coordinator fetches each
-    /// endpoint from its own backend, then calls this method to enforce ADR-002
+    /// endpoint from its own backend, then calls this method to enforce the
     /// kind-pairing rules without a second DB round-trip.
     ///
     /// `src` and `tgt` are the `resolve_edge_endpoint` results from each backend. The
@@ -1618,15 +1599,14 @@ impl KhiveRuntime {
         Ok(())
     }
 
-    /// Validate an `annotates` edge relation using pre-located endpoint kinds
-    /// (ADR-029 D3, #674).
+    /// Validate an `annotates` edge relation using pre-located endpoint kinds.
     ///
     /// Sibling of [`Self::validate_link_endpoints_by_resolved`] for callers that
     /// only have an [`EdgeEndpointKind`] (entity/note/event/edge) rather than a
     /// full [`Resolved`] record — the `SubstrateCoordinator`'s cross-backend
     /// `locate_endpoint` resolves edge-substrate UUIDs too (matching `get`'s
-    /// by-ID resolution order per ADR-002 rule 1), but edges have no `Resolved`
-    /// variant, so `validate_link_endpoints_by_resolved` cannot express them.
+    /// by-ID resolution order), but edges have no `Resolved` variant, so
+    /// `validate_link_endpoints_by_resolved` cannot express them.
     ///
     /// `annotates` is the only relation this covers: source must be a note,
     /// target may be any substrate (entity, note, event, or edge).
@@ -1670,18 +1650,18 @@ impl KhiveRuntime {
     ///
     /// For symmetric relations (`competes_with`, `composed_with`) the endpoint
     /// pair is canonicalised to `source_uuid < target_uuid` so that A→B and B→A
-    /// deduplicate to one row (F012).
+    /// deduplicate to one row.
     ///
     /// `metadata` is validated against governed keys; `dependency_kind` is
-    /// inferred for `depends_on` edges when absent (F013).
+    /// inferred for `depends_on` edges when absent.
     ///
     /// `target_backend` is always `None` for locally-routed edges written through
     /// this path. Both endpoints must exist in the local namespace, so setting
-    /// `target_backend = None` is the only valid choice (F161).
+    /// `target_backend = None` is the only valid choice.
     ///
-    /// Endpoint existence is a by-ID check and namespace-agnostic (ADR-007
-    /// Rule 2; #631): a record that exists in a different namespace than the
-    /// caller still resolves, exactly as `get()` would.
+    /// Endpoint existence is a by-ID check and namespace-agnostic: a record
+    /// that exists in a different namespace than the caller still resolves,
+    /// exactly as `get()` would.
     pub async fn link(
         &self,
         token: &NamespaceToken,
@@ -1697,7 +1677,7 @@ impl KhiveRuntime {
         let (source_id, target_id) = canonical_edge_endpoints(relation, source_id, target_id);
         let metadata = if relation == EdgeRelation::DependsOn {
             // By-ID, unfiltered — matches the namespace-agnostic endpoint validation
-            // above (#631). The visible-set-scoped `resolve` would silently drop the
+            // above. The visible-set-scoped `resolve` would silently drop the
             // dependency_kind inference for endpoints validation now allows outside
             // the caller's visible set.
             match (
@@ -1728,16 +1708,15 @@ impl KhiveRuntime {
             metadata,
             target_backend: None,
         };
-        // #769: `upsert_edge_guarded` re-checks both endpoints exist as part
-        // of the same write, not the separate `validate_edge_relation_endpoints`
-        // read above — a concurrent hard-delete landing between that read and
-        // this write can no longer create a durably dangling edge. Which
-        // endpoint(s) were missing is reported by the guard's own
-        // in-transaction probe (`GuardedWriteOutcome::Refused`), not
-        // reconstructed here by re-reading the endpoints after the fact: a
-        // second concurrent write landing between the refusal and a
-        // post-hoc read could otherwise misreport which endpoint was
-        // actually missing at write time (round-2 codex Medium 1).
+        // `upsert_edge_guarded` re-checks both endpoints exist as part of the same
+        // write, not the separate `validate_edge_relation_endpoints` read above — a
+        // concurrent hard-delete landing between that read and this write can no
+        // longer create a durably dangling edge. Which endpoint(s) were missing is
+        // reported by the guard's own in-transaction probe (`GuardedWriteOutcome::
+        // Refused`), not reconstructed here by re-reading the endpoints after the
+        // fact: a second concurrent write landing between the refusal and a
+        // post-hoc read could otherwise misreport which endpoint was actually
+        // missing at write time.
         match self.graph(token)?.upsert_edge_guarded(edge).await? {
             khive_storage::GuardedWriteOutcome::Written => {}
             khive_storage::GuardedWriteOutcome::Refused(missing) => {
@@ -1749,7 +1728,7 @@ impl KhiveRuntime {
             }
         }
 
-        // H1 fix: read back the persisted row by natural key so the returned
+        // Read back the persisted row by natural key so the returned
         // edge ID is always the one stored in the database, not the locally
         // generated UUID that was displaced by an ON CONFLICT DO UPDATE.
         // Under parallel calls for the same triple, every caller now returns
@@ -1862,8 +1841,7 @@ impl KhiveRuntime {
     ///
     /// Used from `annotates` endpoint validation (`link` and `create`'s
     /// `annotates` targets), which consume a by-ID endpoint and so must follow
-    /// the same namespace-agnostic by-ID contract as `get()` (ADR-007 Rule 2;
-    /// #631).
+    /// the same namespace-agnostic by-ID contract as `get()`.
     pub(crate) async fn substrate_exists_by_id(
         &self,
         token: &NamespaceToken,
@@ -1916,7 +1894,7 @@ impl KhiveRuntime {
     ///
     /// Soft-deleted entity nodes are excluded from results unless the caller
     /// explicitly requested them (future: `include_deleted` flag; currently
-    /// always false per Fix 2).
+    /// always false).
     pub async fn neighbors_with_query(
         &self,
         token: &NamespaceToken,
@@ -1938,7 +1916,7 @@ impl KhiveRuntime {
         hits.sort_by_key(|h| (h.node_id, h.edge_id));
         hits.dedup_by_key(|h| (h.node_id, h.edge_id));
         self.enrich_neighbor_hits(token, &mut hits).await;
-        // Filter out soft-deleted entity nodes (Fix 2).
+        // Filter out soft-deleted entity nodes.
         let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.node_id).collect();
         let deleted = self.deleted_entity_ids(candidate_ids).await;
         if !deleted.is_empty() {
@@ -1948,9 +1926,8 @@ impl KhiveRuntime {
         // layer established (khive-db graph.rs `ORDER BY weight DESC, node_id
         // ASC`) — the (node_id, edge_id) sort above exists only to make
         // `dedup_by_key` adjacent-comparable and otherwise discards it. This
-        // is the ADR-089 amended neighbor-ordering contract and must hold at
-        // every call site of this op (context and neighbors verb alike),
-        // for every direction (ADR-089 context-verb review, internal review round 2, High).
+        // ordering contract must hold at every call site of this op (context
+        // and neighbors verb alike), for every direction.
         hits.sort_by(|a, b| {
             b.weight
                 .partial_cmp(&a.weight)
@@ -1963,9 +1940,8 @@ impl KhiveRuntime {
     /// Get both-direction neighbors, each tagged with the direction (`Out`/
     /// `In`) it was found in, via a single storage query per visible
     /// namespace instead of two separate direction-scoped `neighbors_with_query`
-    /// calls (ADR-089 context-verb optimization — halves the neighbor SELECT
-    /// count for `context(direction="both")` expansion). `query.direction` is
-    /// ignored — always both.
+    /// calls — halving the neighbor SELECT count for `context(direction="both")`
+    /// expansion. `query.direction` is ignored — always both.
     ///
     /// Mirrors `neighbors_with_query`'s dedup/enrich/soft-delete-filter/order
     /// pipeline exactly, carrying the per-hit direction tag through unchanged.
@@ -1990,8 +1966,7 @@ impl KhiveRuntime {
         }
         // Direction is part of the key (not just node_id/edge_id) so a
         // self-loop's Out row and In row — same node_id and edge_id, opposite
-        // direction — sort adjacent but distinct and both survive dedup
-        // (internal review round 2, High).
+        // direction — sort adjacent but distinct and both survive dedup.
         hits.sort_by_key(|h| {
             (
                 h.hit.node_id,
@@ -2013,16 +1988,15 @@ impl KhiveRuntime {
             dh.hit = enriched;
         }
 
-        // Filter out soft-deleted entity nodes (Fix 2).
+        // Filter out soft-deleted entity nodes.
         let candidate_ids: Vec<Uuid> = hits.iter().map(|h| h.hit.node_id).collect();
         let deleted = self.deleted_entity_ids(candidate_ids).await;
         if !deleted.is_empty() {
             hits.retain(|h| !deleted.contains(&h.hit.node_id));
         }
         // Same global weight-descending/node_id-ascending restore as
-        // `neighbors_with_query` (ADR-089 context-verb review, internal review
-        // round 2, High) — the (node_id, edge_id, direction) sort above exists
-        // only to make `dedup_by_key` adjacent-comparable.
+        // `neighbors_with_query` — the (node_id, edge_id, direction) sort above
+        // exists only to make `dedup_by_key` adjacent-comparable.
         hits.sort_by(|a, b| {
             b.hit
                 .weight
@@ -2036,7 +2010,7 @@ impl KhiveRuntime {
     /// Traverse the graph from a set of root nodes.
     ///
     /// Roots in a foreign namespace are silently filtered before storage expansion.
-    /// Soft-deleted entity nodes are excluded from results (Fix 2).
+    /// Soft-deleted entity nodes are excluded from results.
     pub async fn traverse(
         &self,
         token: &NamespaceToken,
@@ -2062,7 +2036,7 @@ impl KhiveRuntime {
         }
         self.enrich_path_nodes(token, &mut paths, request.include_properties)
             .await;
-        // Filter out soft-deleted entity nodes from all path nodes (Fix 2).
+        // Filter out soft-deleted entity nodes from all path nodes.
         let all_node_ids: Vec<Uuid> = paths
             .iter()
             .flat_map(|p| p.nodes.iter().map(|n| n.node_id))
@@ -2081,10 +2055,10 @@ impl KhiveRuntime {
     /// and notes tables.
     ///
     /// Neighbor/traverse candidates can be note-kind nodes (e.g. reached via
-    /// `annotates` edges) as well as entities; the original Fix-2 screen only
-    /// consulted `entities`, so soft-deleted note targets leaked through and
-    /// hydrated as blank/missing hits (#748). This is a view-layer read-only
-    /// screen — it does not touch edges or mutate any data.
+    /// `annotates` edges) as well as entities; a screen that only consults
+    /// `entities` lets soft-deleted note targets leak through and hydrate as
+    /// blank/missing hits. This is a view-layer read-only screen — it does
+    /// not touch edges or mutate any data.
     ///
     /// Returns the subset of `ids` that have `deleted_at IS NOT NULL` in
     /// either table. Takes `Vec<Uuid>` (not an iterator) so the async state
@@ -2223,7 +2197,7 @@ impl KhiveRuntime {
     }
 
     /// Populate `name` and `kind` on each `PathNode` from the corresponding
-    /// entity record (#162). Same best-effort policy as `enrich_neighbor_hits`.
+    /// entity record. Same best-effort policy as `enrich_neighbor_hits`.
     ///
     /// Uses `get_entities_by_ids_visible` so that path nodes whose entities
     /// live in extra-visible namespaces are enriched correctly. Node IDs that
@@ -2311,7 +2285,7 @@ impl KhiveRuntime {
 
     /// Like [`Self::create_note`], but lets the caller supply a smaller text
     /// to send to the vector embedder while the note's stored/FTS-indexed
-    /// `content` remains the full text (issue #764).
+    /// `content` remains the full text.
     ///
     /// `embedding_content`, when `Some`, must be non-empty and a proper
     /// prefix of `content` — anything else is rejected with `InvalidInput`
@@ -2530,10 +2504,10 @@ impl KhiveRuntime {
             crate::secret_gate::check_json(p)?;
         }
         // `embedding_content` is a caller-supplied alternate vector-embedding
-        // input (issue #764) — it must be a non-empty proper prefix of
-        // `content` (never a superset, an unrelated string, or the full
-        // text) and passes the same secret gate as any other stored/embedded
-        // text. Rejected before any write, same as the checks above.
+        // input — it must be a non-empty proper prefix of `content` (never a
+        // superset, an unrelated string, or the full text) and passes the
+        // same secret gate as any other stored/embedded text. Rejected
+        // before any write, same as the checks above.
         if let Some(ec) = embedding_content {
             if ec.is_empty() {
                 return Err(RuntimeError::InvalidInput(
@@ -2550,7 +2524,7 @@ impl KhiveRuntime {
         let ns = token.namespace().as_str();
 
         // Validate all annotates targets before any write (atomicity: all-or-nothing).
-        // Endpoint resolution is by-ID and namespace-agnostic (ADR-007 Rule 2; #631).
+        // Endpoint resolution is by-ID and namespace-agnostic.
         for &target_id in &annotates {
             if !self.substrate_exists_by_id(token, target_id).await? {
                 return Err(RuntimeError::NotFound(format!(
@@ -2576,10 +2550,9 @@ impl KhiveRuntime {
             }
         }
 
-        // internal review round 2 Medium (PR #407): resolve embedding_model BEFORE any
-        // note/FTS/vector write so unknown-model errors are atomic at the
-        // runtime layer, not just at one pack handler. Direct Rust callers
-        // (other packs, integration tests) get the same guarantee.
+        // Resolve embedding_model BEFORE any note/FTS/vector write so unknown-model
+        // errors are atomic at the runtime layer, not just at one pack handler.
+        // Direct Rust callers (other packs, integration tests) get the same guarantee.
         if let Some(model_name) = embedding_model {
             self.resolve_embedding_model(Some(model_name))?;
         }
@@ -2601,14 +2574,7 @@ impl KhiveRuntime {
 
         // From here on, any error must compensate by removing the note row, its
         // FTS document, and any vector entries already inserted — the same
-        // cleanup used by the annotates-edge block below.  A local closure
-        // captures those operations so both this block and the edge block share
-        // the same cleanup path without duplication.
-        //
-        // Note: the closure borrows `self`, `token`, `ns`, `note`, and
-        // `embed_model_names` (populated after the FTS step); because the
-        // vector-model list is only known after embedding is decided, we collect
-        // it once before the FTS step and thread it through.
+        // cleanup used by the annotates-edge block below.
 
         // Decide which embedding models to use (before touching FTS/vectors).
         let embed_model_names: Vec<String> = if let Some(m) = embedding_model {
@@ -2616,9 +2582,9 @@ impl KhiveRuntime {
         } else {
             // Fan out to ALL registered models — includes both lattice models
             // from RuntimeConfig and any custom providers added via
-            // register_embedder() (internal review High #1, PR #444).
-            // Gate on the registry, not config().embedding_model, so that
-            // custom-only runtimes (no lattice model in config) also fan out.
+            // register_embedder(). Gate on the registry, not
+            // config().embedding_model, so that custom-only runtimes (no
+            // lattice model in config) also fan out.
             let names = self.registered_embedding_model_names();
             if names.is_empty() {
                 // No models configured at all — skip vector embedding.
@@ -2676,7 +2642,7 @@ impl KhiveRuntime {
         // The effective text sent to every embedder: the caller-supplied
         // capped override when present, otherwise the full stored content.
         // FTS indexing above always used the full `note.content` — this cap
-        // affects only the vector-embedding input (issue #764).
+        // affects only the vector-embedding input.
         let embed_text: &str = embedding_content.unwrap_or(content);
 
         if embed_model_names.len() == 1 {
@@ -2796,7 +2762,7 @@ impl KhiveRuntime {
                     Ok(Ok(vec)) => vectors.push(vec),
                 }
             }
-            // TODO(P2): parallelize vector inserts (internal review #444)
+            // TODO(P2): parallelize vector inserts
             let mut inserted_models: Vec<String> = Vec::with_capacity(embed_model_names.len());
             for (model_name, vector) in embed_model_names.iter().zip(vectors) {
                 let insert_result = match self.vectors_for_model(token, model_name) {
@@ -2981,7 +2947,7 @@ impl KhiveRuntime {
     /// 5. Filter soft-deleted notes, apply optional kind / tag / properties predicates.
     ///    Tags and properties are pushed into the per-note fetch loop BEFORE truncation
     ///    so that matching notes ranked beyond `limit` in the raw fusion are not silently
-    ///    dropped (fix for issue #225).
+    ///    dropped.
     /// 6. Truncate to `limit`.
     ///
     /// `tags_any`: when non-empty, only notes that have at least one of these tags
@@ -3012,18 +2978,16 @@ impl KhiveRuntime {
 
         // FTS5 over the notes index — search all visible namespaces.
         //
-        // FTS5 parser syntax errors (#388, #389 round 2, #389 round-2 High):
-        // sanitize_fts5_query strips known-unsafe FTS5 metacharacters, but
+        // `sanitize_fts5_query` strips known-unsafe FTS5 metacharacters, but
         // residual punctuation the sanitizer does not strip can still reach
-        // the FTS5 parser and error. Per #569 this now fails loud instead of
-        // degrading to vector-only fusion, so callers see the bad query
-        // instead of silently losing the lexical leg. Errors from any other
-        // leg (vector search, note hydration) still propagate normally.
+        // the FTS5 parser and error. This fails loud instead of degrading to
+        // vector-only fusion, so callers see the bad query instead of
+        // silently losing the lexical leg. Errors from any other leg (vector
+        // search, note hydration) still propagate normally.
         //
-        // Injection: check FTS_SEARCH_FAIL_NS (armed by `arm_fts_search_fail(ns)`)
-        // — issue #389 round-2 High regression coverage for the propagate branch.
-        // Fires only when the armed namespace is among this call's visible
-        // namespaces, then clears (one-shot).
+        // Injection: check FTS_SEARCH_FAIL_NS (armed by `arm_fts_search_fail(ns)`),
+        // exercising the propagate branch above. Fires only when the armed
+        // namespace is among this call's visible namespaces, then clears (one-shot).
         #[cfg(any(test, feature = "fault-injection"))]
         let fts_search_inject = {
             let mut g = FTS_SEARCH_FAIL_NS.lock().unwrap();
@@ -3081,7 +3045,7 @@ impl KhiveRuntime {
         // soft-delete/kind filtering happen *after* this, and the final
         // `hits.truncate(limit)` is the only result-limiting cut. Truncating to
         // `candidates` here would drop a high-salience note ranked just outside
-        // the raw RRF cutoff before salience ever applied (review #526).
+        // the raw RRF cutoff before salience ever applied.
         let fuse_k = text_hits.len() + vector_hits.len();
         let fused = crate::fusion::rrf_fuse_k(text_hits, vector_hits, RRF_K, fuse_k)?;
 
@@ -3109,7 +3073,7 @@ impl KhiveRuntime {
                 // Apply tag predicate before adding to alive set: tags on notes live
                 // inside `properties["tags"]` (a JSON array). This pushes the filter
                 // before truncation so matching notes ranked beyond `limit` in the raw
-                // fusion are not silently dropped (fix for issue #225).
+                // fusion are not silently dropped.
                 if !tags_any.is_empty() {
                     let note_tags: Vec<String> = note
                         .properties
@@ -3130,7 +3094,7 @@ impl KhiveRuntime {
                         continue;
                     }
                 }
-                // Apply properties predicate before truncation (fix for issue #225).
+                // Apply properties predicate before truncation, same reasoning as tags above.
                 if let Some(pf) = properties_filter {
                     if !note_props_match(note.properties.as_ref(), pf) {
                         continue;
@@ -3213,19 +3177,18 @@ impl KhiveRuntime {
     }
 
     /// Resolve a short UUID prefix (8+ hex chars) to a full UUID with NO
-    /// namespace filter at all — mirrors `resolve_by_id`'s by-ID contract
-    /// (ADR-007 Rev 6: by-ID resolution is namespace-agnostic; the Gate, not
-    /// storage-layer filtering, is the authz seam). Used by the four by-ID
+    /// namespace filter at all — mirrors `resolve_by_id`'s by-ID contract:
+    /// by-ID resolution is namespace-agnostic, since the Gate (not
+    /// storage-layer filtering) is the authz seam. Used by the four by-ID
     /// CRUD verbs (get/update/delete/merge) so their prefix path matches
-    /// their already-unfiltered full-UUID path (#391 §3). No token param:
-    /// unlike `resolve_prefix`, there is no
-    /// namespace to derive from one.
+    /// their already-unfiltered full-UUID path. No token param: unlike
+    /// `resolve_prefix`, there is no namespace to derive from one.
     pub async fn resolve_prefix_unfiltered(&self, prefix: &str) -> RuntimeResult<Option<Uuid>> {
         self.resolve_prefix_inner(None, prefix, false).await
     }
 
     /// `resolve_prefix_unfiltered`, including soft-deleted rows — used by the
-    /// hard-delete by-ID path (#391 §3).
+    /// hard-delete by-ID path.
     pub async fn resolve_prefix_unfiltered_including_deleted(
         &self,
         prefix: &str,
@@ -3252,10 +3215,10 @@ impl KhiveRuntime {
     ) -> RuntimeResult<Option<Uuid>> {
         use khive_storage::types::{SqlStatement, SqlValue};
 
-        // Resolver-boundary gate (#816 Minor): every caller is expected to
-        // pre-validate hex-only input, but this is the single choke point
-        // every `resolve_prefix*` variant funnels through, so re-validate
-        // here too. A prefix containing anything other than hex digits and
+        // Every caller is expected to pre-validate hex-only input, but this is
+        // the single choke point every `resolve_prefix*` variant funnels
+        // through, so re-validate here too. A prefix containing anything other
+        // than hex digits and
         // canonical hyphen separators (`%`, `_`, or other LIKE-wildcard /
         // injection-shaped input) never matches a real id and is rejected
         // before it can reach the LIKE pattern, instead of relying on bound
@@ -3278,7 +3241,7 @@ impl KhiveRuntime {
             format!(" AND namespace IN ({})", placeholders.join(", "))
         });
 
-        // #749: a UUID can legitimately exist in more than one scanned table
+        // A UUID can legitimately exist in more than one scanned table
         // (e.g. an entity id string that also happens to be an edge id — the
         // scan is purely a text-prefix LIKE across independent tables, not a
         // substrate-exclusive lookup). Without dedup, a single record hit
@@ -3355,10 +3318,10 @@ impl KhiveRuntime {
 
     /// Resolve a UUID to its substrate kind with NO namespace filter.
     ///
-    /// By-ID contract (ADR-007): UUID v4 is globally unique — by-ID substrate
+    /// By-ID contract: UUID v4 is globally unique — by-ID substrate
     /// inference must return the record regardless of caller namespace.  Used by
     /// the public `update` and `delete` verb handlers when no explicit `kind` is
-    /// supplied (PR-A1).
+    /// supplied.
     ///
     /// Does NOT consult the visible set or the primary-namespace check.  The
     /// token is still required to route to the correct backend pool but its
@@ -3449,9 +3412,9 @@ impl KhiveRuntime {
     /// endpoint validation.
     ///
     /// `link` and `create`'s `annotates` targets consume by-ID endpoints, so
-    /// their existence check must follow the same by-ID contract as `get()`
-    /// (ADR-007 Rule 2: by-ID ops are namespace-agnostic — the Gate, not
-    /// storage-layer filtering, is the authz seam). Mirrors `resolve_by_id`
+    /// their existence check must follow the same by-ID contract as `get()`:
+    /// by-ID ops are namespace-agnostic — the Gate, not storage-layer
+    /// filtering, is the authz seam. Mirrors `resolve_by_id`
     /// (entity + note, unfiltered) and additionally resolves events,
     /// unfiltered, so edge endpoint validation resolves exactly what `get()`
     /// resolves regardless of the caller's namespace.
@@ -3543,7 +3506,7 @@ impl KhiveRuntime {
     /// Hard-delete a single graph node (entity, note, or edge-as-node row)
     /// AND purge its incident edges in ONE write transaction.
     ///
-    /// #768/#769: the endpoint row delete and the incident-edge cascade used
+    /// The endpoint row delete and the incident-edge cascade used
     /// to run as two independently-committing storage calls. A concurrent
     /// guarded write (`upsert_edge_guarded`/`upsert_edges_guarded`) landing
     /// between them could see the endpoint still live, insert a fresh edge
@@ -3602,19 +3565,16 @@ impl KhiveRuntime {
         }
     }
 
-    /// Delete a note by ID, enforcing namespace isolation.
+    /// Soft-delete or hard-delete a note by ID.
     ///
     /// On hard delete, cascades to remove all incident edges (both inbound and
     /// outbound) and cleans up FTS and vector indexes, preventing dangling
     /// references for `annotates` edges that target this note.
     /// Soft delete also cleans FTS and vector indexes; edges are left in place.
     ///
-    /// Returns `Ok(false)` if the note does not exist or belongs to a different
-    /// namespace (wrong-namespace is indistinguishable from absent).
-    /// Soft-delete or hard-delete a note by ID.
-    ///
-    /// PR-A1: UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
     /// Cascade and index cleanup target the RECORD's stored namespace, not the caller token's.
+    /// Returns `Ok(false)` if the note does not exist.
     pub async fn delete_note(
         &self,
         token: &NamespaceToken,
@@ -3647,8 +3607,8 @@ impl KhiveRuntime {
         let record_ns = note.namespace.clone();
 
         // On hard delete, the row delete and the incident-edge cascade (including
-        // already-soft-deleted edges) run as ONE write transaction (#768/#769) —
-        // see `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
+        // already-soft-deleted edges) run as ONE write transaction — see
+        // `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
             let deleted = self
@@ -3657,9 +3617,8 @@ impl KhiveRuntime {
             self.text_for_notes(&record_tok)?
                 .delete_document(&record_ns, id)
                 .await?;
-            // internal review High 2 (PR #407): scoped delete — iterate over EVERY
-            // registered embedding model's vector store so non-default vectors
-            // don't orphan when the note is deleted.
+            // Scoped delete — iterate over EVERY registered embedding model's
+            // vector store so non-default vectors don't orphan when the note is deleted.
             for model_name in self.registered_embedding_model_names() {
                 self.vectors_for_model(&record_tok, &model_name)?
                     .delete(id)
@@ -3694,20 +3653,20 @@ impl KhiveRuntime {
             event_store.append_event(event).await.map_err(|e| {
                 RuntimeError::Internal(format!("delete_note: event store write failed: {e}"))
             })?;
-            // #750 fix-round 1: a soft OR hard delete removes the note's
-            // vectors/FTS document above — any pack-owned vector-derived
-            // cache (e.g. khive-pack-memory's warm ANN index) needs to know
-            // the corpus changed, reached via this generic hook so
-            // khive-runtime never takes a dependency on khive-pack-memory.
-            // No-op when no pack has installed a hook.
+            // A soft OR hard delete removes the note's vectors/FTS document
+            // above — any pack-owned vector-derived cache (e.g.
+            // khive-pack-memory's warm ANN index) needs to know the corpus
+            // changed, reached via this generic hook so khive-runtime never
+            // takes a dependency on khive-pack-memory. No-op when no pack has
+            // installed a hook.
             self.fire_note_mutation_hook(&note.kind, id).await;
         }
         Ok(deleted)
     }
 
     /// Row-first compensating delete for rolling back a partially-written note
-    /// (issue #460 — `dual_write_message` rollback after a later delivery step
-    /// fails). Unlike [`KhiveRuntime::delete_note`], which cleans up graph/FTS/
+    /// (e.g. `dual_write_message` rollback after a later delivery step fails).
+    /// Unlike [`KhiveRuntime::delete_note`], which cleans up graph/FTS/
     /// vector indexes *before* removing the row, this removes the row first so
     /// that a cleanup failure afterward cannot leave the compensated note live.
     ///
@@ -3721,9 +3680,8 @@ impl KhiveRuntime {
     /// does not exist (nothing to compensate).
     ///
     /// Not a general-purpose replacement for `delete_note(..., hard=true)`:
-    /// normal hard delete still needs cleanup-first semantics (ADR-002
-    /// no-dangling-references) since a caller-visible error there should not
-    /// remove the row.
+    /// normal hard delete still needs cleanup-first semantics (no dangling
+    /// references) since a caller-visible error there should not remove the row.
     pub async fn delete_note_row_first_for_compensation(
         &self,
         token: &NamespaceToken,
@@ -3851,8 +3809,8 @@ impl KhiveRuntime {
         // When the server-side cap was the binding constraint, the compiled
         // SQL asked for one extra (sentinel) row. Its presence in the actual
         // result set — not the requested LIMIT — is the truncation signal
-        // (issue #777): a `LIMIT 1000` that only matches 20 rows must not
-        // warn, and a query with no `LIMIT` that matches 501+ rows must.
+        // — a `LIMIT 1000` that only matches 20 rows must not warn, and a
+        // query with no `LIMIT` that matches 501+ rows must.
         if let Some(check) = truncation_check {
             if rows.len() > check.max_limit {
                 rows.truncate(check.max_limit);
@@ -3874,15 +3832,13 @@ impl KhiveRuntime {
         Ok(QueryResult { rows, warnings })
     }
 
-    /// Delete an entity by ID (soft delete by default).
+    /// Soft-delete or hard-delete an entity by ID (soft delete by default).
     ///
     /// On hard delete, cascades to remove all incident edges (both inbound and
     /// outbound) to prevent dangling references. Soft delete also cleans FTS
     /// and vector indexes; edges are left in place.
     ///
-    /// Soft-delete or hard-delete an entity by ID.
-    ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops (ADR-007 rule 2).
+    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
     pub async fn delete_entity(
         &self,
         token: &NamespaceToken,
@@ -3917,8 +3873,8 @@ impl KhiveRuntime {
         );
 
         // On hard delete, the row delete and the incident-edge cascade (including
-        // already-soft-deleted edges) run as ONE write transaction (#768/#769) —
-        // see `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
+        // already-soft-deleted edges) run as ONE write transaction — see
+        // `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
             let deleted = self
@@ -3975,7 +3931,7 @@ impl KhiveRuntime {
 
     /// Fetch a single edge by id.
     ///
-    /// PR-A1: UUID v4 is globally unique — returns the edge regardless of which
+    /// UUID v4 is globally unique — returns the edge regardless of which
     /// namespace the token carries. `Ok(None)` means the edge does not exist at all.
     pub async fn get_edge(
         &self,
@@ -3997,7 +3953,7 @@ impl KhiveRuntime {
             return Ok(None);
         };
         // Route the storage fetch through the record's own namespace — the token is
-        // just the caller context; by-ID ops cross namespace boundaries (ADR-007).
+        // just the caller context; by-ID ops cross namespace boundaries.
         let record_tok = NamespaceToken::for_namespace(
             khive_types::Namespace::parse(&record_ns)
                 .map_err(|e| RuntimeError::Internal(format!("edge namespace invalid: {e}")))?,
@@ -4010,8 +3966,8 @@ impl KhiveRuntime {
 
     /// Fetch a single edge by id.
     ///
-    /// PR-A1: delegates to `get_edge` — visible-set check removed.  By-ID ops are
-    /// namespace-agnostic; UUID v4 is globally unique (ADR-007 rule 2).
+    /// Delegates to `get_edge` — no visible-set check.  By-ID ops are
+    /// namespace-agnostic; UUID v4 is globally unique.
     pub async fn get_edge_visible(
         &self,
         token: &NamespaceToken,
@@ -4022,7 +3978,7 @@ impl KhiveRuntime {
 
     /// Fetch an edge by UUID including soft-deleted rows.
     ///
-    /// PR-A1: returns the edge regardless of which namespace the token carries —
+    /// Returns the edge regardless of which namespace the token carries —
     /// UUID v4 is globally unique. Used by the hard-delete path so that a
     /// soft-deleted edge can still be purged via its edge ID.
     pub async fn get_edge_including_deleted(
@@ -4062,8 +4018,8 @@ impl KhiveRuntime {
     /// List edges matching `filter`, paging by `offset`. `limit` is capped at
     /// [`Self::EDGE_LIST_MAX_LIMIT`]; defaults to 100.
     ///
-    /// `offset` pages through the full matching set (#701 — previously
-    /// hard-coded to 0, so every page returned the same first rows). For
+    /// `offset` pages through the full matching set (previously hard-coded to
+    /// 0, so every page returned the same first rows). For
     /// O(1)-at-depth walks over large edge populations, prefer
     /// [`Self::list_edges_after`] instead of paging offset deep.
     pub async fn list_edges(
@@ -4135,8 +4091,8 @@ impl KhiveRuntime {
     ///
     /// Unlike [`Self::list_edges`], this is O(log n + limit) at any depth: the
     /// underlying store issues an indexed `id > ?` range scan instead of an
-    /// `OFFSET` skip (#702.2 — the fix for the O(offset) daemon CPU cost
-    /// reported against #701's broken-offset paging loop).
+    /// `OFFSET` skip, avoiding the O(offset) daemon CPU cost of a naive
+    /// offset-based paging loop over a large edge population.
     pub async fn list_edges_after(
         &self,
         token: &NamespaceToken,
@@ -4184,7 +4140,7 @@ impl KhiveRuntime {
         Ok((results, next_after))
     }
 
-    /// Count edges by relation, ignoring soft-deleted rows (#702.3). Used by
+    /// Count edges by relation, ignoring soft-deleted rows. Used by
     /// `stats()` to report the true per-relation population so full-graph
     /// audits know what they're sampling from before they walk it.
     pub async fn count_edges_by_relation(
@@ -4202,8 +4158,8 @@ impl KhiveRuntime {
     }
 
     /// DML-only body of the symmetric-relation conflict-resolution path in
-    /// [`Self::update_edge`] (ADR-067 Component A). Runs the conflict-check SELECT,
-    /// then either the DELETE+UPDATE (case b, a canonical row already exists) or the
+    /// [`Self::update_edge`]. Runs the conflict-check SELECT, then either the
+    /// DELETE+UPDATE (case b, a canonical row already exists) or the
     /// in-place UPDATE (case a, no conflict). Callers own the surrounding transaction
     /// boundary — this function issues DML only, no `BEGIN`/`COMMIT`/`ROLLBACK`.
     ///
@@ -4211,7 +4167,7 @@ impl KhiveRuntime {
     /// requested edge was deleted, the existing canonical row refreshed), or
     /// `Ok(None)` when the requested edge was updated in place.
     ///
-    /// DML text is the single source of truth shared with ADR-099's atomic
+    /// DML text is the single source of truth shared with the atomic
     /// `prepare_update_edge` symmetric branch:
     /// [`khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL`] /
     /// `EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL` /
@@ -4238,14 +4194,12 @@ impl KhiveRuntime {
         // uses `timestamp_micros()`; the column is read back via
         // `micros_to_datetime`). `timestamp()` (seconds) here was a
         // pre-existing bug in this raw-SQL path, found while unifying it with
-        // the ADR-099 atomic builder (which already used `timestamp_micros()`
-        // correctly) — fixed as part of this extraction, not a behavior the
-        // atomic path needed to special-case around.
+        // the atomic builder (which already used `timestamp_micros()`
+        // correctly).
         let now_ts = chrono::Utc::now().timestamp_micros();
 
         // Check for a conflicting canonical row (same namespace + natural key,
-        // different id). This catches conflicts whether or not endpoints were
-        // flipped — Bug 2 fix.
+        // different id). This catches conflicts whether or not endpoints were flipped.
         let conflict_id: Option<String> = conn
             .query_row(
                 khive_db::stores::graph::EDGE_SYMMETRIC_CONFLICT_PROBE_SQL,
@@ -4264,8 +4218,7 @@ impl KhiveRuntime {
         if let Some(existing_id) = conflict_id {
             // Case (b): canonical row already exists — delete the non-canonical
             // edge and refresh the existing canonical row. Return the surviving
-            // id so the caller can re-fetch it (Bug 1 fix: do not return the
-            // deleted edge's id).
+            // id so the caller can re-fetch it (never the deleted edge's id).
             conn.execute(
                 khive_db::stores::graph::EDGE_SYMMETRIC_DELETE_NONCANONICAL_SQL,
                 rusqlite::params![&ns, &edge_id_str],
@@ -4331,7 +4284,7 @@ impl KhiveRuntime {
         edge_id: Uuid,
         patch: crate::curation::EdgePatch,
     ) -> RuntimeResult<Edge> {
-        // Fetch the edge by UUID — ID-only, no namespace check (PR-A1).
+        // Fetch the edge by UUID — ID-only, no namespace check.
         // get_edge already uses the record's stored namespace internally.
         let graph_for_fetch = self.graph(token)?;
         let mut edge = graph_for_fetch
@@ -4339,7 +4292,7 @@ impl KhiveRuntime {
             .await?
             .ok_or_else(|| crate::RuntimeError::NotFound(format!("edge {edge_id}")))?;
 
-        // PR-A1: after fetching, all mutations and validation must use the
+        // After fetching, all mutations and validation must use the
         // RECORD's namespace, not the caller's.  Derive record_tok from the stored edge
         // namespace so that endpoint validation, raw-SQL predicates, and graph routing
         // all address the correct backend partition.
@@ -4352,7 +4305,6 @@ impl KhiveRuntime {
 
         let mut changed_fields: Vec<&'static str> = Vec::new();
         if let Some(r) = patch.relation {
-            // Validate before mutating — use the existing endpoints with the new relation.
             // Validate before mutating — use the existing endpoints with the new relation.
             // Use record_tok so that endpoint existence checks look in the edge's own namespace.
             self.validate_edge_relation_endpoints(&record_tok, edge.source_id, edge.target_id, r)
@@ -4404,9 +4356,9 @@ impl KhiveRuntime {
             let target_backend = edge.target_backend.clone();
 
             let pool = self.backend().pool_arc();
-            // ADR-067 Component A: route through the single-writer task when the
-            // write queue is enabled; best-effort lookup degrades to the legacy
-            // pool-mutex path (mirrors merge_entity/merge_note above).
+            // Route through the single-writer task when the write queue is
+            // enabled; best-effort lookup degrades to the legacy pool-mutex
+            // path (mirrors merge_entity/merge_note above).
             let writer_task = pool.writer_task_handle().ok().flatten();
 
             // Some(surviving_id) when a canonical conflict was absorbed (the requested
@@ -4462,7 +4414,7 @@ impl KhiveRuntime {
 
             if let Some(sid) = surviving_id {
                 // A conflict was absorbed: re-fetch the surviving canonical row so the
-                // caller receives its real id (Bug 1 fix).
+                // caller receives its real id.
                 // Use record_tok — the surviving row lives in the same namespace as the original.
                 let surviving_uuid = Uuid::parse_str(&sid).map_err(|e| {
                     RuntimeError::Internal(format!("update_edge: surviving id parse failed: {e}"))
@@ -4529,7 +4481,7 @@ impl KhiveRuntime {
             DeleteMode::Soft
         };
 
-        // PR-A1: fetch the edge first to obtain the record's own namespace.
+        // Fetch the edge first to obtain the record's own namespace.
         // By-ID ops cross namespace boundaries; all graph routing and audit
         // events must use the record namespace, not the caller's (mirrors update_edge).
         // For hard delete we also check soft-deleted rows so a soft-deleted edge
@@ -4543,7 +4495,7 @@ impl KhiveRuntime {
             return Ok(false);
         };
 
-        // Derive record_ns / record_tok from the fetched edge (mirrors update_edge at ~2762-2767).
+        // Derive record_ns / record_tok from the fetched edge (mirrors update_edge).
         let record_ns: String = edge.namespace.clone();
         let record_tok = NamespaceToken::for_namespace(
             khive_types::Namespace::parse(&record_ns)
@@ -4552,8 +4504,8 @@ impl KhiveRuntime {
         let graph = self.graph(&record_tok)?;
 
         // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
-        // already-soft-deleted ones — to prevent dangling graph_edges rows (ADR-002). The row
-        // delete and the cascade purge run as ONE write transaction (#768/#769) — see
+        // already-soft-deleted ones — to prevent dangling graph_edges rows. The row
+        // delete and the cascade purge run as ONE write transaction — see
         // `atomic_hard_delete_with_edge_purge`.
         // On soft delete the cascade is skipped (data-vs-view principle: soft-deleting the base
         // edge does not cascade to annotation edges; only a hard purge cleans up incident rows).
@@ -4621,7 +4573,7 @@ impl KhiveRuntime {
             canonical_edge_endpoints(spec.relation, spec.source_id, spec.target_id);
         let metadata = if spec.relation == EdgeRelation::DependsOn {
             // By-ID, unfiltered — matches the namespace-agnostic endpoint validation
-            // above (#631). The visible-set-scoped `resolve` would silently drop the
+            // above. The visible-set-scoped `resolve` would silently drop the
             // dependency_kind inference for endpoints validation now allows outside
             // the caller's visible set.
             match (
@@ -4664,8 +4616,8 @@ impl KhiveRuntime {
     /// (namespace, source_id, target_id, relation) so that the returned IDs
     /// are always the persisted row IDs, not the locally-generated UUIDs that
     /// may have been displaced by an ON CONFLICT DO UPDATE. This mirrors the
-    /// H1 fix applied to singleton `link()` and prevents phantom-ID exposure
-    /// when callers upsert overlapping triples with `verbose=true`.
+    /// same read-back applied to singleton `link()` and prevents phantom-ID
+    /// exposure when callers upsert overlapping triples with `verbose=true`.
     ///
     /// All specs must share the same namespace; the namespace is taken from
     /// `token` (or validated against it if `spec.namespace` is set).
@@ -4681,15 +4633,14 @@ impl KhiveRuntime {
         for spec in &specs {
             edges.push(self.build_edge(token, spec).await?);
         }
-        // #769: `upsert_edges_guarded` re-checks every edge's endpoints as
-        // part of the same write, not the separate per-spec `build_edge`
-        // validation reads above. A concurrent hard-delete of any endpoint
-        // landing between those reads and this write aborts the whole batch
-        // (all-or-nothing, no partial write) instead of persisting a
-        // dangling edge. The failing entry's index and its missing
-        // endpoint(s) come from the guard's own in-transaction pre-check
-        // (`GuardedBatchOutcome::refused`), not a post-hoc re-read of the
-        // batch after the write already failed (round-2 codex Medium 1).
+        // `upsert_edges_guarded` re-checks every edge's endpoints as part of the
+        // same write, not the separate per-spec `build_edge` validation reads
+        // above. A concurrent hard-delete of any endpoint landing between those
+        // reads and this write aborts the whole batch (all-or-nothing, no
+        // partial write) instead of persisting a dangling edge. The failing
+        // entry's index and its missing endpoint(s) come from the guard's own
+        // in-transaction pre-check (`GuardedBatchOutcome::refused`), not a
+        // post-hoc re-read of the batch after the write already failed.
         let outcome = self
             .graph(token)?
             .upsert_edges_guarded(edges.clone())
@@ -4714,8 +4665,8 @@ impl KhiveRuntime {
             )));
         }
 
-        // H1-bulk fix: read back each persisted edge by natural key so callers
-        // always receive the stored row ID, not the pre-upsert generated UUID.
+        // Read back each persisted edge by natural key so callers always
+        // receive the stored row ID, not the pre-upsert generated UUID.
         let mut persisted = Vec::with_capacity(edges.len());
         for edge in &edges {
             let row = self
@@ -4769,13 +4720,13 @@ impl KhiveRuntime {
         }
         let ns = token.namespace().as_str();
 
-        // Phase 1: validate ALL specs before any write (ADR-004).
+        // Phase 1: validate ALL specs before any write.
         // Includes entity-type validation via the pack-installed validator when available.
         // Any validation failure here guarantees zero rows are written.
         let mut entities = Vec::with_capacity(specs.len());
         for spec in &specs {
             self.validate_entity_kind(&spec.kind)?;
-            // High-2: validate entity_type at the runtime layer via pack-installed callback.
+            // Validate entity_type at the runtime layer via pack-installed callback.
             // When no validator is installed (bare runtime, unit tests without packs),
             // the type passes through unchanged — same skip-when-absent pattern as
             // validate_entity_kind. The handler layer remains the primary enforcement point.
@@ -4808,7 +4759,7 @@ impl KhiveRuntime {
         }
 
         // Phase 2: single bulk entity write.
-        // High-1: capture the BatchWriteSummary to detect partial failures.
+        // Capture the BatchWriteSummary to detect partial failures.
         // The store commits the transaction even when some rows fail (per-row error
         // isolation). If any row failed, compensate by hard-deleting the rows that DID
         // land, then return Err so the caller sees zero net writes.
@@ -4959,7 +4910,7 @@ pub struct LinkSpec {
 /// Fully specified entity creation request — input to [`KhiveRuntime::create_many`].
 ///
 /// `entity_type` is validated at the runtime layer by the pack-installed
-/// entity-type validator (ADR-004 §runtime-layer validation). When a validator
+/// entity-type validator. When a validator
 /// is installed (e.g. by `KgPack`), unknown types are rejected with the valid
 /// set listed. When no validator is installed (bare runtime without packs),
 /// the value passes through — the handler layer is the primary enforcement point.
@@ -4996,7 +4947,7 @@ mod tests {
         KhiveRuntime::memory().unwrap()
     }
 
-    // ── Fix-1 regression (internal review High #1, PR #444) ────────────────────────────
+    // ── Custom embedder fan-out regression ──────────────────────────────────
     // A runtime with no `config.embedding_model` but a custom registered
     // embedder must fan out create_note through that embedder and store a
     // vector so recall can find the note.
@@ -5060,14 +5011,10 @@ mod tests {
         }
     }
 
-    /// Fix 1 regression: custom embedder with no lattice model in config must
-    /// participate in fan-out.
-    ///
-    /// This test was previously broken because the fan-out gate checked
-    /// `config().embedding_model.is_some()`.  With only a custom provider
-    /// registered and `embedding_model = None` in config, the gate fell through
-    /// to `vec![]` and no vector was written.  After the fix the gate checks
-    /// `registered_embedding_model_names()` instead.
+    /// Custom embedder with no lattice model in config must participate in
+    /// fan-out: the gate must check `registered_embedding_model_names()`, not
+    /// `config().embedding_model.is_some()` — the latter falls through to
+    /// `vec![]` when only a custom provider is registered.
     #[tokio::test]
     async fn custom_embedder_only_runtime_fanout_stores_vector() {
         const MODEL_NAME: &str = "test-custom-encoder";
@@ -5125,13 +5072,10 @@ mod tests {
         );
     }
 
-    /// Fix 1 regression (recall path): custom-only embedder participates in
-    /// embed_with_model so recall fan-out also works.
-    ///
-    /// Previously `embed_with_model` called `resolve_embedding_model` which
-    /// required a lattice alias; custom provider names were rejected with
-    /// `UnknownModel`.  After the fix, the lattice alias parse is optional
-    /// and the embedder registry is consulted directly.
+    /// Custom-only embedder participates in `embed_with_model` so recall
+    /// fan-out also works: the lattice alias parse must be optional, with
+    /// the embedder registry consulted directly, since requiring a lattice
+    /// alias would reject valid custom provider names with `UnknownModel`.
     #[tokio::test]
     async fn embed_with_model_accepts_custom_provider_name() {
         const MODEL_NAME: &str = "my-custom-enc";
@@ -5157,8 +5101,8 @@ mod tests {
         );
     }
 
-    /// Fix 1 regression: embed_with_model must still reject names that are not
-    /// in the registry (neither lattice aliases nor custom providers).
+    /// `embed_with_model` must still reject names that are not in the
+    /// registry (neither lattice aliases nor custom providers).
     #[tokio::test]
     async fn embed_with_model_rejects_unregistered_name() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -5169,11 +5113,11 @@ mod tests {
         );
     }
 
-    // ── Issue #396 regression ────────────────────────────────────────────────
+    // ── No-embeddings config regression ─────────────────────────────────────
     // `RuntimeConfig::no_embeddings()` must register zero embedders, so
     // `create_note` never attempts to lazily build a lattice embedding model —
     // this is what lets `memory.remember` succeed on a machine with no local
-    // model files present (the exact failure mode reported in #396).
+    // model files present.
 
     #[tokio::test]
     async fn no_embeddings_config_registers_zero_embedders() {
@@ -5203,7 +5147,7 @@ mod tests {
 
         // With zero registered embedders, create_note's embed fan-out list is
         // empty and no lattice model build is ever attempted -- the write must
-        // succeed (degrading to FTS-only) exactly as #396 requires.
+        // succeed, degrading to FTS-only.
         let note = rt
             .create_note(
                 &tok,
@@ -5255,15 +5199,15 @@ mod tests {
         assert!((updated.weight - 0.5).abs() < 0.001);
     }
 
-    /// Regression test (ADR-099 B3 r6 second pass): `update_edge_symmetric_dml`
-    /// previously stored `updated_at` via `chrono::Utc::now().timestamp()`
-    /// (SECONDS) while every other `graph_edges` write path
-    /// (`edge_upsert_statement`, `edge_soft_delete_statement`) uses
-    /// `timestamp_micros()` — a genuine pre-existing bug, found while
-    /// unifying this raw-SQL path with the ADR-099 atomic builder (which
-    /// already used `timestamp_micros()` correctly) onto the shared
-    /// `EDGE_SYMMETRIC_*_SQL` text. A seconds value misread as microseconds
-    /// round-trips to a date a few minutes after the Unix epoch, not "now".
+    /// Regression test: `update_edge_symmetric_dml` previously stored
+    /// `updated_at` via `chrono::Utc::now().timestamp()` (SECONDS) while every
+    /// other `graph_edges` write path (`edge_upsert_statement`,
+    /// `edge_soft_delete_statement`) uses `timestamp_micros()` — a genuine
+    /// pre-existing bug, found while unifying this raw-SQL path with the
+    /// atomic builder (which already used `timestamp_micros()` correctly)
+    /// onto the shared `EDGE_SYMMETRIC_*_SQL` text. A seconds value misread as
+    /// microseconds round-trips to a date a few minutes after the Unix epoch,
+    /// not "now".
     #[tokio::test]
     async fn update_edge_symmetric_relation_stores_microsecond_updated_at() {
         let rt = rt();
@@ -5337,7 +5281,7 @@ mod tests {
         assert_eq!(updated.relation, EdgeRelation::VariantOf);
     }
 
-    // ---- Round-5 tests: update_edge endpoint validation (bypass fix) ----
+    // ---- update_edge endpoint validation ----
 
     // update_edge: note→entity annotates → set relation=Supersedes → InvalidInput (crossing).
     // Edge must NOT be mutated in the store.
@@ -5597,7 +5541,7 @@ mod tests {
         assert_eq!(src, a.id);
     }
 
-    /// #701 regression: `offset` was hard-coded to 0 in `list_edges`, so every
+    /// Regression: `offset` was hard-coded to 0 in `list_edges`, so every
     /// page returned the identical first rows. Pages must now tile the full
     /// matching set with no gaps or duplicates, and an out-of-range offset
     /// must return empty rather than page 1.
@@ -5651,7 +5595,7 @@ mod tests {
         );
     }
 
-    /// #702.2: `list_edges_after` seeks via `id > cursor` against the
+    /// `list_edges_after` seeks via `id > cursor` against the
     /// `(namespace, id)` primary key index instead of paging through OFFSET,
     /// so cost does not grow with how deep the walk goes.
     #[tokio::test]
@@ -5831,7 +5775,7 @@ mod tests {
         );
     }
 
-    /// #702.3: `stats()` should be able to report a per-relation breakdown so
+    /// `stats()` should be able to report a per-relation breakdown so
     /// auditors know the true population per relation before sampling.
     #[tokio::test]
     async fn count_edges_by_relation_matches_fixtures() {
@@ -5933,7 +5877,7 @@ mod tests {
         assert_eq!(just_extends, 1);
     }
 
-    // ---- Finding 4 regression: substrate_exists_in_ns must use get_edge_visible ----
+    // ---- substrate_exists_in_ns must use get_edge_visible ----
 
     /// An edge owned by a visible (non-primary) namespace must be found by
     /// `substrate_exists_in_ns` and therefore usable as a graph root in
@@ -5984,9 +5928,9 @@ mod tests {
         );
     }
 
-    // ADR-007 PR-A1: by-ID ops no longer enforce namespace isolation.
-    // Shared-brain OSS model: UUID is globally unique; get/update/delete
-    // find the record regardless of caller's token namespace.
+    // By-ID ops do not enforce namespace isolation. Shared-brain OSS model:
+    // UUID is globally unique; get/update/delete find the record regardless
+    // of caller's token namespace.
     #[tokio::test]
     async fn get_entity_cross_namespace_no_longer_denied() {
         let rt = rt();
@@ -6001,7 +5945,7 @@ mod tests {
         let found = rt.get_entity(&ns_a, entity.id).await;
         assert!(found.is_ok(), "same-namespace get must succeed");
 
-        // Different namespace: now also returns the entity (shared brain, ADR-007).
+        // Different namespace: now also returns the entity (shared brain).
         let cross = rt.get_entity(&ns_b, entity.id).await;
         assert!(
             cross.is_ok(),
@@ -6020,7 +5964,7 @@ mod tests {
             .await
             .unwrap();
 
-        // ADR-007 PR-A1: cross-namespace delete now succeeds (shared brain).
+        // Cross-namespace delete now succeeds (shared brain).
         let cross_ns_result = rt.delete_entity(&ns_b, entity.id, true).await;
         assert!(
             cross_ns_result.is_ok(),
@@ -6077,14 +6021,12 @@ mod tests {
         );
     }
 
-    /// #569 regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
-    /// (by design — the sanitizer stays minimal per #388 scope). SQLite FTS5's
-    /// bareword parser still rejects `@` unconditionally, so this query
-    /// reaches the runtime-level `Err` arm in `search_notes`, which must fail
-    /// loud (`RuntimeError::InvalidInput`) instead of silently degrading to
-    /// vector-only fusion. This assertion fails against the pre-#569
-    /// fail-open behavior (which returned `Ok` with an empty text leg here)
-    /// and passes once the FTS leg fails closed.
+    /// Regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
+    /// (by design — the sanitizer stays minimal). SQLite FTS5's bareword
+    /// parser still rejects `@` unconditionally, so this query reaches the
+    /// runtime-level `Err` arm in `search_notes`, which must fail loud
+    /// (`RuntimeError::InvalidInput`) instead of silently degrading to
+    /// vector-only fusion.
     #[tokio::test]
     async fn search_notes_with_residual_fts5_char_fails_loud() {
         let rt = rt();
@@ -6117,23 +6059,14 @@ mod tests {
         );
     }
 
-    /// #389 round-2 High regression: the `search_notes` FTS fail-open arm must
-    /// only degrade genuine FTS5 parser syntax errors (see
-    /// `handler_search_note_residual_fts5_char_does_not_error` in
-    /// khive-pack-kg for that case). A non-parser `StorageError` — e.g. a pool
+    /// The `search_notes` FTS fail-open arm must only degrade genuine FTS5
+    /// parser syntax errors. A non-parser `StorageError` — e.g. a pool
     /// exhaustion or connection timeout on the text-search backend — is not a
     /// bad query and must propagate as `Err`, not be silently swallowed into
-    /// an empty (falsely "successful") result set. This is the representative
-    /// site for the four fail-open arms named in the finding: `search_notes`
-    /// (khive-runtime/operations.rs), `hybrid_search`
-    /// (khive-runtime/retrieval.rs), `hybrid_search_with_strategy`
-    /// (khive-runtime/fusion.rs), and `collect_recall_text_hits`
-    /// (khive-pack-memory/handlers/common.rs) all share the exact same
-    /// `is_fts5_syntax_error()` gate added to `StorageError` — proving the
-    /// predicate propagates a non-parser error at one call site generalizes to
-    /// the other three, which route through the identical `match ... Err(e)
-    /// if e.is_fts5_syntax_error() => degrade, Err(e) => return Err(e.into())`
-    /// shape.
+    /// an empty (falsely "successful") result set. `search_notes`,
+    /// `hybrid_search`, `hybrid_search_with_strategy`, and
+    /// `collect_recall_text_hits` all share the same `is_fts5_syntax_error()`
+    /// gate on `StorageError`, so this case generalizes to all four call sites.
     #[tokio::test]
     async fn search_notes_propagates_non_parser_fts_error() {
         let rt = rt();
@@ -6316,7 +6249,7 @@ mod tests {
         assert_eq!(filtered[0].relation, EdgeRelation::Extends);
     }
 
-    /// Self-loop direction parity (internal review round 2, High):
+    /// Self-loop direction parity:
     /// `neighbors_with_query_directed`'s post-merge dedup must not collapse a
     /// self-loop edge's Out row and In row into one — they share `(node_id,
     /// edge_id)` but are opposite directions, matching what a separate `Out`
@@ -6458,13 +6391,12 @@ mod tests {
         );
     }
 
-    // ---- issue #225 regression: predicate pushdown before truncation (note branch) ----
+    // ---- predicate pushdown before truncation (note branch) ----
 
-    /// Regression test for issue #225 (note branch, tag filter).
-    ///
-    /// Notes store tags inside `properties["tags"]` — there is no separate tags column.
-    /// Without pushdown, the tag filter is applied after `hits.truncate(limit)`, so a
-    /// tag-matching note ranked beyond `limit` in the raw RRF fusion is silently dropped.
+    /// Regression: notes store tags inside `properties["tags"]` — there is no
+    /// separate tags column. Without pushdown, the tag filter is applied after
+    /// `hits.truncate(limit)`, so a tag-matching note ranked beyond `limit` in
+    /// the raw RRF fusion is silently dropped.
     ///
     /// Scenario: `limit=1`, tags_any=["note-target-tag"]. Two notes are inserted:
     ///   - decoy: high FTS rank (repeats query terms), NO target tag.
@@ -6472,9 +6404,6 @@ mod tests {
     ///
     /// Without pushdown: decoy occupies the slot, target is dropped.
     /// With pushdown: decoy is excluded in the alive-note loop, target survives, returned.
-    ///
-    /// Isomorphism: removing the `tags_any` check from the alive-note loop in
-    /// `search_notes` re-breaks this test.
     #[tokio::test]
     async fn search_notes_tag_filter_pushed_before_truncation() {
         let rt = rt();
@@ -6534,9 +6463,7 @@ mod tests {
         );
     }
 
-    /// Regression test for issue #225 (note branch, properties filter).
-    ///
-    /// Without pushdown, the properties filter is applied after truncation; a matching
+    /// Regression: without pushdown, the properties filter is applied after truncation; a matching
     /// note ranked beyond `limit` is silently dropped.
     ///
     /// Scenario: `limit=1`, properties_filter={{"source": "target"}}. Two notes:
@@ -6699,8 +6626,8 @@ mod tests {
         );
     }
 
-    /// PR #816 Minor finding 3: input longer than 32 hex chars is NOT
-    /// truncated — the extra chars land past the canonical 12-char final
+    /// Input longer than 32 hex chars is NOT truncated — the extra chars land
+    /// past the canonical 12-char final
     /// segment with no further hyphen, so the pattern can never match a real
     /// (36-char) stored `id`, instead of silently truncating down to a
     /// pattern that matches the valid 32-char UUID.
@@ -6772,9 +6699,8 @@ mod tests {
         assert_eq!(resolved, Some(entity.id));
     }
 
-    /// PR #816 Minor finding 3 (integration level): a valid 32-char compact
-    /// id with extra trailing hex chars appended must fail to resolve, not
-    /// silently resolve to the valid entity via truncation.
+    /// A valid 32-char compact id with extra trailing hex chars appended must
+    /// fail to resolve, not silently resolve to the valid entity via truncation.
     #[tokio::test]
     async fn resolve_prefix_rejects_overlong_all_hex_input() {
         let rt = rt();
@@ -6794,7 +6720,7 @@ mod tests {
         );
     }
 
-    /// PR #816 Minor finding 4: the `resolve_prefix*` boundary rejects
+    /// The `resolve_prefix*` boundary rejects
     /// non-hex/non-hyphen input (e.g. LIKE wildcards `%`/`_`) instead of
     /// letting it reach the bound `LIKE` pattern unfiltered — covers callers
     /// (like khive-pack-git/src/ingest.rs) that resolve raw input without
@@ -6917,11 +6843,10 @@ mod tests {
         );
     }
 
-    /// #749: a single UUID legitimately present in TWO scanned tables
-    /// (entities and notes here) must resolve cleanly to that one UUID, not
-    /// a false `AmbiguousPrefix` naming the same UUID twice. Before the fix,
-    /// `resolve_prefix_inner` pushed every table hit into `matches` with no
-    /// cross-table dedup, so `matches.len()` became 2 for a single record.
+    /// A single UUID legitimately present in TWO scanned tables (entities and
+    /// notes here) must resolve cleanly to that one UUID, not a false
+    /// `AmbiguousPrefix` naming the same UUID twice — without cross-table
+    /// dedup, `matches.len()` becomes 2 for a single record.
     #[tokio::test]
     async fn resolve_prefix_cross_table_duplicate_uuid_resolves_cleanly() {
         use khive_storage::entity::Entity;
@@ -6953,7 +6878,7 @@ mod tests {
         );
     }
 
-    /// #749: the early-exit inside the per-table scan loop (`if matches.len()
+    /// The early-exit inside the per-table scan loop (`if matches.len()
     /// > 1 { break }`) must also operate on DEDUPED state — otherwise a
     /// cross-table duplicate could still short-circuit the scan before a
     /// later table contributes the SAME UUID again, which would have masked
@@ -6991,7 +6916,7 @@ mod tests {
         assert_eq!(resolved, Some(shared_id));
     }
 
-    // ---- Event resolution tests (issue #30) ----
+    // ---- Event resolution tests ----
     //
     // resolve_prefix and handle_get already include events; these tests are
     // regression coverage confirming event UUIDs are resolvable and that get()
@@ -7049,7 +6974,7 @@ mod tests {
         );
     }
 
-    // ---- Referential integrity tests (fix/link-referential-integrity) ----
+    // ---- Referential integrity tests ----
 
     #[tokio::test]
     async fn link_phantom_source_returns_not_found() {
@@ -7121,7 +7046,7 @@ mod tests {
         assert_eq!(edge.relation, EdgeRelation::Extends);
     }
 
-    // ---- #769: commit-time endpoint guard vs concurrent hard-delete ----
+    // ---- commit-time endpoint guard vs concurrent hard-delete ----
 
     /// Deterministic form of the regression, exercised directly at the
     /// write step `link` performs after prepare-time validation: build the
@@ -7277,7 +7202,7 @@ mod tests {
         );
     }
 
-    // ---- #768/#769: hard-delete row + incident-edge purge is ONE transaction ----
+    // ---- hard-delete row + incident-edge purge is ONE transaction ----
     //
     // Six tests below cover both orderings (write-then-delete, and a
     // concurrent write raced against delete via `tokio::join!`) across all
@@ -7577,7 +7502,7 @@ mod tests {
         assert_no_edges_touch(&rt, &tok, base_edge_id).await;
     }
 
-    // ---- #769 round-2 codex Medium 3: file-backed, both write-queue configs ----
+    // ---- file-backed, both write-queue configs ----
     //
     // The six tests above run against `KhiveRuntime::memory()` and race
     // delete against the guarded write via `tokio::join!` with no explicit
@@ -7821,11 +7746,8 @@ mod tests {
     }
 
     /// `link` endpoint existence is a by-ID check and therefore namespace-agnostic
-    /// (ADR-007 Rule 2; #631) — a target living in a different namespace than the
-    /// caller must still resolve, exactly as `get()` would. This supersedes the prior
-    /// `link_target_in_different_namespace_returns_not_found` expectation, which
-    /// asserted the pre-#631 bug (endpoint existence gated on `token.namespace()`)
-    /// as intentional fail-closed behavior.
+    /// — a target living in a different namespace than the caller must still
+    /// resolve, exactly as `get()` would.
     #[tokio::test]
     async fn link_target_in_different_namespace_succeeds() {
         let rt = rt();
@@ -7870,7 +7792,7 @@ mod tests {
         }
     }
 
-    // ---- Round-2 tests: edge target coverage + atomicity ----
+    // ---- edge target coverage + atomicity ----
 
     #[tokio::test]
     async fn link_note_to_edge_annotates_succeeds() {
@@ -8003,7 +7925,7 @@ mod tests {
         // harness has none, so no vector assertion is needed here.
     }
 
-    // ---- Round-3 tests: relation-aware endpoint contract ----
+    // ---- relation-aware endpoint contract ----
 
     // Test #2: entity→entity with non-annotates rejects an edge UUID as target.
     #[tokio::test]
@@ -8224,7 +8146,7 @@ mod tests {
         assert_eq!(neighbors[0].node_id, event_id);
     }
 
-    // ---- Round-4 tests: supersedes same-substrate contract ----
+    // ---- supersedes same-substrate contract ----
 
     // Headline regression: note→note supersedes must succeed (was wrongly rejected before this fix).
     #[tokio::test]
@@ -8580,13 +8502,7 @@ mod tests {
     }
 
     /// The canonical `remember | supersedes` chain: a `supersedes` source note living
-    /// in a different namespace than the caller must still resolve as a by-ID endpoint
-    /// (ADR-007 Rule 2; #631). This supersedes the prior
-    /// `link_supersedes_cross_namespace_source_returns_not_found` expectation, which
-    /// asserted the pre-#631 bug (endpoint existence gated on `token.namespace()`) as
-    /// intentional fail-closed behavior — the exact failure reported in #631 for
-    /// `memory.remember(...) | link(source_id=$prev.id, ..., relation="supersedes")`
-    /// from a namespace-stamped caller.
+    /// in a different namespace than the caller must still resolve as a by-ID endpoint.
     #[tokio::test]
     async fn link_supersedes_cross_namespace_source_succeeds() {
         let rt = rt();
@@ -9106,7 +9022,7 @@ mod tests {
 
         // The edge itself must survive the soft delete — checked at the
         // storage/edge layer directly (`get_edge`), not through `neighbors()`.
-        // `neighbors()` is a VIEW query and, per #748, now correctly screens
+        // `neighbors()` is a VIEW query and correctly screens
         // out soft-deleted note targets — so it no longer surfaces this edge
         // once note_target is soft-deleted, even though the edge row itself
         // is untouched (data-vs-view principle: the edge is data, what
@@ -9134,7 +9050,7 @@ mod tests {
         );
     }
 
-    // ---- delete_edge public-API safety (fix/annotates round-3) ----
+    // ---- delete_edge public-API safety ----
 
     // Passing an entity/note UUID to `delete_edge` must return Ok(false) with no
     // side effects — it must NOT delete inbound annotates edges targeting that record.
@@ -9210,7 +9126,7 @@ mod tests {
         );
     }
 
-    // ---- create_note compensation branch (fix/annotates round-3) ----
+    // ---- create_note compensation branch ----
 
     // This test injects a deterministic failure on the second `link` call inside
     // `create_note_inner` (the one that would create the second annotates edge).
@@ -9317,7 +9233,7 @@ mod tests {
         // below must be consumable only by THIS test's create_note. Sharing the
         // "local" namespace let a concurrent "local" create_note consume the
         // armed flag, flaking this test and its victim under parallel
-        // `cargo test` (latent since #129; surfaced by #131 CI timing).
+        // `cargo test`.
         let ns = Namespace::parse("fault-fts-rollback").unwrap();
         let tok = NamespaceToken::for_namespace(ns.clone());
 
@@ -9404,7 +9320,7 @@ mod tests {
         );
     }
 
-    // #764: the `embedding_content` override must not bypass the same
+    // The `embedding_content` override must not bypass the same
     // FTS/vector compensation the plain `create_note` path already has —
     // both use `create_note_inner` underneath, but these tests exercise it
     // through `create_note_with_embedding_content` with a real Some(head)
@@ -9502,7 +9418,7 @@ mod tests {
         );
     }
 
-    // ---- #232 soft-delete index cleanup tests ----
+    // ---- soft-delete index cleanup tests ----
 
     #[tokio::test]
     async fn soft_delete_entity_removes_indexes() {
@@ -9606,8 +9522,8 @@ mod tests {
         );
     }
 
-    // F010 (CRIT): base endpoint allowlist — unlisted triples must fail closed.
-    // Document->Document Extends is not in the allowlist; current generic fallthrough accepts it.
+    // Base endpoint allowlist — unlisted triples must fail closed.
+    // Document->Document Extends is not in the allowlist.
     #[tokio::test]
     async fn link_extends_document_to_document_returns_invalid_input() {
         let rt = rt();
@@ -9630,7 +9546,7 @@ mod tests {
         );
     }
 
-    // F010 happy path: Concept->Concept Extends is in the base allowlist and must succeed.
+    // Happy path: Concept->Concept Extends is in the base allowlist and must succeed.
     #[tokio::test]
     async fn link_extends_concept_to_concept_succeeds() {
         let rt = rt();
@@ -9652,8 +9568,7 @@ mod tests {
         );
     }
 
-    // F012 (CRIT): CompetesWith is symmetric; reversed pair must deduplicate to one canonical row.
-    // Current code stores both directions as distinct rows (no canonicalization).
+    // CompetesWith is symmetric; reversed pair must deduplicate to one canonical row.
     #[tokio::test]
     async fn link_symmetric_relation_canonicalizes_endpoint_order() {
         use khive_storage::EdgeFilter;
@@ -9688,7 +9603,7 @@ mod tests {
         );
     }
 
-    // F010: Supersedes — positive tests for all 5 allowed entity kinds.
+    // Supersedes — positive tests for all 5 allowed entity kinds.
     #[tokio::test]
     async fn f010_supersedes_document_to_document_allowed() {
         let rt = rt();
@@ -9773,7 +9688,7 @@ mod tests {
         );
     }
 
-    // F010: Supersedes — negative tests for rejected entity kinds.
+    // Supersedes — negative tests for rejected entity kinds.
     #[tokio::test]
     async fn f010_supersedes_project_to_project_rejected() {
         let rt = rt();
@@ -9837,7 +9752,7 @@ mod tests {
         );
     }
 
-    // Fix 1: Supersedes entity→entity — same kind (concept→concept) must be allowed.
+    // Supersedes entity→entity — same kind (concept→concept) must be allowed.
     #[tokio::test]
     async fn f010_supersedes_same_kind_entity_allowed() {
         let rt = rt();
@@ -9859,7 +9774,7 @@ mod tests {
         );
     }
 
-    // F161: target_backend invariant — all edges written through link() must have
+    // target_backend invariant — all edges written through link() must have
     // target_backend = None because validate_edge_relation_endpoints already ensured the
     // target exists locally.
     #[tokio::test]
@@ -9885,7 +9800,7 @@ mod tests {
         );
     }
 
-    // F161: link_many must also write null target_backend for all local edges.
+    // link_many must also write null target_backend for all local edges.
     #[tokio::test]
     async fn f161_link_many_always_writes_null_target_backend() {
         let rt = rt();
@@ -9930,7 +9845,7 @@ mod tests {
         }
     }
 
-    // F012: symmetric relation neighbors — competes_with queried from the non-canonical
+    // Symmetric relation neighbors — competes_with queried from the non-canonical
     // endpoint must still return results when direction=Out is requested.
     #[tokio::test]
     async fn f012_symmetric_neighbors_visible_from_both_endpoints() {
@@ -10010,8 +9925,8 @@ mod tests {
         );
     }
 
-    // PR-A1: cross-namespace delete_note now succeeds (UUID v4 is globally unique,
-    // no namespace isolation on by-ID ops — ADR-007 rule 2).
+    // Cross-namespace delete_note now succeeds (UUID v4 is globally unique,
+    // no namespace isolation on by-ID ops).
     #[tokio::test]
     async fn delete_note_cross_namespace_succeeds() {
         let rt = rt();
@@ -10073,7 +9988,7 @@ mod tests {
         );
     }
 
-    // H1-bulk regression: parallel link_many calls with overlapping triples must
+    // Regression: parallel link_many calls with overlapping triples must
     // return the identical persisted edge ID, not locally-generated phantom IDs.
     //
     // Sequence:
@@ -10194,7 +10109,7 @@ mod tests {
         );
     }
 
-    // High-2: entity_type validated at runtime layer when validator is installed.
+    // entity_type validated at runtime layer when validator is installed.
     #[tokio::test]
     async fn create_many_rejects_unknown_entity_type_when_validator_installed() {
         let rt = rt();
@@ -10237,7 +10152,7 @@ mod tests {
         );
     }
 
-    // High-2: valid entity_type passes through and is normalised by the validator.
+    // Valid entity_type passes through and is normalised by the validator.
     #[tokio::test]
     async fn create_many_accepts_valid_entity_type_via_validator() {
         let rt = rt();
@@ -10273,7 +10188,7 @@ mod tests {
         );
     }
 
-    // High-1: FTS failure in create_many rolls back both substrates.
+    // FTS failure in create_many rolls back both substrates.
     //
     // Arm `arm_fts_fail_many` before the call; the FTS phase returns an injected
     // error; the test asserts zero rows in both `entities` and `fts_entities`.
@@ -10336,8 +10251,8 @@ mod tests {
         );
     }
 
-    // Round-3 Medium: FTS partial-failure (Ok(summary) with summary.failed > 0)
-    // rolls back both substrates.
+    // FTS partial-failure (Ok(summary) with summary.failed > 0) rolls back
+    // both substrates.
     //
     // The production code has a distinct arm:
     //   Ok(summary) if summary.failed > 0 => return Err(...)
@@ -10401,7 +10316,7 @@ mod tests {
         );
     }
 
-    // ── PR-A1: cross-namespace get_edge now succeeds (UUID v4 is globally unique) ──
+    // ── Cross-namespace get_edge now succeeds (UUID v4 is globally unique) ──
 
     #[tokio::test]
     async fn get_edge_cross_namespace_succeeds() {
@@ -10429,7 +10344,7 @@ mod tests {
             "edge must be visible in its own namespace"
         );
 
-        // PR-A1: foreign namespace must now SUCCEED — by-ID get is namespace-agnostic.
+        // Foreign namespace must now SUCCEED — by-ID get is namespace-agnostic.
         let cross_ns = rt.get_edge(&ns_b, Uuid::from(edge.id)).await;
         assert!(
             matches!(cross_ns, Ok(Some(_))),
@@ -10444,13 +10359,12 @@ mod tests {
         );
     }
 
-    // ── ADR-007 PR-A1: traversal across namespace labels now succeeds ────────
+    // ── Traversal across namespace labels now succeeds ────────────────────────
     //
-    // Pre-fix (#568): traverse with ns_b token + ns_a root was silently empty
+    // Previously, traverse with ns_b token + ns_a root was silently empty
     // because substrate_exists_in_ns → get_entity rejected cross-namespace lookups.
-    // Post-fix: get_entity finds any entity by UUID; traverse finds the root and
+    // Now: get_entity finds any entity by UUID; traverse finds the root and
     // returns paths scoped to the graph store's namespace filter for ns_b.
-    // Full visible-set removal (PR-B) will collapse the namespace filter to "local".
     #[tokio::test]
     async fn traverse_cross_namespace_root_is_accepted() {
         use khive_storage::types::TraversalOptions;
@@ -10470,7 +10384,7 @@ mod tests {
             .await
             .ok(); // may conflict with self-loop check; we just need an entity
 
-        // With PR-A1: substrate_exists_in_ns finds the ns_a root via get_entity
+        // substrate_exists_in_ns finds the ns_a root via get_entity
         // (UUID-global lookup). The traverse proceeds; no panic.
         let result = rt
             .traverse(
@@ -10490,11 +10404,11 @@ mod tests {
         assert!(result.is_ok(), "traverse must not error; got {:?}", result);
     }
 
-    // ---- PR #82 regression: purge cascade must include already-soft-deleted edges ----
+    // ---- purge cascade must include already-soft-deleted edges ----
     //
-    // ADR-002 requires hard delete to cascade ALL incident edges synchronously. The old
-    // implementation drove the cascade through `neighbors()`, which filters `deleted_at IS NULL`,
-    // so incident edges that were already soft-deleted survived endpoint purge as dangling rows.
+    // Hard delete must cascade ALL incident edges synchronously. A cascade driven
+    // through `neighbors()`, which filters `deleted_at IS NULL`, would let incident
+    // edges that were already soft-deleted survive endpoint purge as dangling rows.
     // `purge_incident_edges` issues a single DELETE without a `deleted_at` guard.
 
     /// Count ALL `graph_edges` rows for a given UUID (source OR target), including soft-deleted.
@@ -10631,10 +10545,11 @@ mod tests {
         );
     }
 
-    // ---- PR #148 High-#2 regression: cross-namespace entity hard-delete purges ALL incident edges ----
+    // ---- cross-namespace entity hard-delete purges ALL incident edges ----
     //
-    // Before this fix: purge_incident_edges used `WHERE namespace = caller_ns AND ...`, so a
-    // foreign-namespace entity's incident edges in ITS namespace survived the cascade as dangling rows.
+    // `purge_incident_edges` must not scope its DELETE by `WHERE namespace = caller_ns`,
+    // or a foreign-namespace entity's incident edges in ITS namespace would survive
+    // the cascade as dangling rows.
 
     /// Count ALL `graph_edges` rows for a given node UUID, across every namespace.
     async fn count_all_incident_edges_global(rt: &KhiveRuntime, node_id: Uuid) -> u64 {
@@ -10716,7 +10631,7 @@ mod tests {
         );
     }
 
-    // ---- PR #82 round-2 regression: edge-ID hard-delete path ----
+    // ---- edge-ID hard-delete path ----
     //
     // Bug class: delete_edge drove the primary-edge guard through get_edge()
     // (live-only) and the cascade through neighbors() (live-only). Two reachable holes:
@@ -10868,9 +10783,9 @@ mod tests {
         );
     }
 
-    // ---- Issue #10: entity create/update multi-model embed fan-out tests ----
+    // ---- entity create/update multi-model embed fan-out tests ----
 
-    // T-E1: FTS failure after entity row commit rolls back the entity row.
+    // FTS failure after entity row commit rolls back the entity row.
     // Mirrors create_note_fts_failure_rolls_back_note_row but for entities.
     // Uses a unique namespace so the process-global FTS_FAIL_NS one-shot is
     // consumed only by this test's create_entity call.
@@ -10911,7 +10826,7 @@ mod tests {
         );
     }
 
-    // T-E2: Vector insert failure after entity row + FTS commit rolls back both.
+    // Vector insert failure after entity row + FTS commit rolls back both.
     // Uses a unique namespace to avoid consuming the VECTOR_FAIL_NS flag from
     // a concurrent test's create_entity or create_note.
     #[tokio::test]
@@ -10979,7 +10894,7 @@ mod tests {
         );
     }
 
-    // T-E3: Multi-model create_entity — second model's vector INSERT fails after the
+    // Multi-model create_entity — second model's vector INSERT fails after the
     // first model's insert succeeds, triggering inserted_models rollback.
     // Uses arm_vector_fail_after(1) so the first insert passes and the second fails,
     // exercising the inserted_models compensation path in create_entity.
@@ -11068,7 +10983,7 @@ mod tests {
         );
     }
 
-    // T-U1: update_entity fans out to ALL registered models.
+    // update_entity fans out to ALL registered models.
     // After create + update with a changed description, both model-a and model-b
     // vector stores hold a row for the entity id.
     #[tokio::test]
@@ -11148,7 +11063,7 @@ mod tests {
         );
     }
 
-    // T-U2: update_note fans out to ALL registered models.
+    // update_note fans out to ALL registered models.
     // After create + update with changed content, both embed-a and embed-b
     // vector stores hold a row for the note id.
     #[tokio::test]
@@ -11228,11 +11143,11 @@ mod tests {
         );
     }
 
-    // ── ADR-007 PR-A1 regression (V3): by-ID ops must not filter by namespace ──
+    // ── By-ID ops must not filter by namespace ──────────────────────────────
     //
-    // Pre-fix: get/update/delete on an entity stamped "lambda:leo" from a "local"
-    // token returned NotFound, causing the gtd.complete / update blindness.
-    // Post-fix: UUID is globally unique; by-ID ops find the record regardless of
+    // A namespace-gated by-ID op on an entity stamped "lambda:leo" from a "local"
+    // token would return NotFound, causing gtd.complete / update blindness.
+    // UUID is globally unique; by-ID ops find the record regardless of
     // which namespace the caller's token carries.
 
     #[tokio::test]
@@ -11346,7 +11261,7 @@ mod tests {
         );
     }
 
-    // ── PackByIdResolver unit tests (ADR-061, #158) ───────────────────────────
+    // ── PackByIdResolver unit tests ──────────────────────────────────────────
 
     use crate::pack::PackByIdResolver;
     use tokio::sync::Mutex as TokioMutex;
@@ -11526,7 +11441,7 @@ mod tests {
             et
         ));
 
-        // The silently-inert trap (ADR-069 A7): EntityOfKind sees only the BASE
+        // The silently-inert trap: EntityOfKind sees only the BASE
         // kind, so EntityOfKind("theorem") never matches a concept/theorem.
         assert!(!endpoint_matches(
             &EndpointKind::EntityOfKind("theorem"),
@@ -11683,7 +11598,7 @@ mod tests {
         assert!(matches!(pr, Resolved::PackRecord { .. }));
     }
 
-    // ── #249 regression: batched enrich_neighbor_hits / enrich_path_nodes ────
+    // ── Batched enrich_neighbor_hits / enrich_path_nodes ────────────────────
 
     fn neighbor_hit(node_id: Uuid) -> NeighborHit {
         NeighborHit {
@@ -11827,7 +11742,7 @@ mod tests {
     /// enrich_neighbor_hits and enrich_path_nodes must resolve entities whose
     /// namespace is in the token's extra-visible set (not only the primary).
     ///
-    /// Regression for PR #253 review finding: the old `get_entities_by_ids`
+    /// Regression: the old `get_entities_by_ids`
     /// call left `filter.namespaces` unset, which collapses to
     /// `namespace = primary` in `build_entity_where`.  Graph expansion already
     /// crosses visible namespaces, so enrichment must match that scope.
@@ -12269,11 +12184,11 @@ mod tests {
         );
     }
 
-    // ── ADR-002 2026-07-08 provenance amendment ─────────────────────────────────
-    // Four new base endpoint pairs: document->person and document->org (document
+    // ── Provenance endpoint pairs ────────────────────────────────────────────
+    // Four base endpoint pairs: document->person and document->org (document
     // authorship), concept->org (concept origination by an org), and
     // document->document (normative document dependency). Positive links for
-    // each new pair, plus a direction-matters negative guard.
+    // each pair, plus a direction-matters negative guard.
 
     #[tokio::test]
     async fn link_document_introduced_by_person_allowed() {
@@ -12422,7 +12337,7 @@ mod tests {
         );
     }
 
-    // ── #764: create_note_with_embedding_content ────────────────────────────
+    // ── create_note_with_embedding_content ──────────────────────────────────
 
     /// Like `ConstVecService`/`ConstVecProvider` above, but records every text
     /// it is asked to embed so a test can assert exactly what reached the

--- a/crates/khive-runtime/src/operations.rs
+++ b/crates/khive-runtime/src/operations.rs
@@ -85,7 +85,7 @@ static FTS_FAIL_MANY_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::ne
 /// Distinct from `FTS_FAIL_MANY_NS` which injects a hard `Err`.
 #[cfg(any(test, feature = "fault-injection"))]
 static FTS_FAIL_MANY_PARTIAL_NS: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
-/// Non-parser FTS *search*-leg failure injection for `search_notes` — distinct
+/// Non-parser FTS *search*-leg failure injection for `search_notes`: distinct
 /// from `FTS_FAIL_NS` (which injects at the FTS *upsert*/write step of
 /// `create_note_inner`). Injects a `StorageError::Timeout` at the `search()`
 /// call the FTS fail-open arm guards, so the arm's `is_fts5_syntax_error()`
@@ -154,7 +154,7 @@ pub fn arm_vector_fail(ns: &str) {
 }
 
 /// Failure injection for `delete_note_row_first_for_compensation`'s post-row-removal
-/// cleanup step — distinct from `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, which target
+/// cleanup step: distinct from `FTS_FAIL_NS`/`VECTOR_FAIL_NS`, which target
 /// `create_note_inner`. Lets tests prove that a rollback compensation's cleanup
 /// failure still leaves the note row (and thus the live message) gone.
 #[cfg(any(test, feature = "fault-injection"))]
@@ -559,7 +559,7 @@ pub(crate) fn merge_dependency_kind(
 /// `pub`: the single source both `khive-pack-kg::handlers::link::handle_link`
 /// (via `khive_runtime::merge_entry_metadata`) and
 /// `crate::atomic_prepare::prepare_link` call. Lives in `khive-runtime` (not
-/// pack-kg) because packs depend on `khive-runtime`, never the reverse — the
+/// pack-kg) because packs depend on `khive-runtime`, never the reverse: the
 /// only direction that lets both call sites share one copy instead of a
 /// hand-duplicated block.
 pub fn merge_entry_metadata(
@@ -954,7 +954,7 @@ impl KhiveRuntime {
 
     /// Retrieve an entity by ID.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
+    /// UUID v4 is globally unique: no namespace filter on by-ID ops.
     pub async fn get_entity(&self, token: &NamespaceToken, id: Uuid) -> RuntimeResult<Entity> {
         self.entities(token)?
             .get_entity(id)
@@ -964,7 +964,7 @@ impl KhiveRuntime {
 
     /// Retrieve an entity by ID including soft-deleted rows.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
+    /// UUID v4 is globally unique: no namespace filter on by-ID ops.
     pub async fn get_entity_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -978,7 +978,7 @@ impl KhiveRuntime {
 
     /// Retrieve a note by ID including soft-deleted rows.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
+    /// UUID v4 is globally unique: no namespace filter on by-ID ops.
     pub async fn get_note_including_deleted(
         &self,
         token: &NamespaceToken,
@@ -1256,7 +1256,7 @@ impl KhiveRuntime {
             ));
         }
         if relation == EdgeRelation::Annotates {
-            // Source must be a note. By-ID endpoint resolution is namespace-agnostic —
+            // Source must be a note. By-ID endpoint resolution is namespace-agnostic:
             // link consumes two by-ID endpoints, so it must resolve exactly what
             // get() resolves, regardless of caller namespace.
             match self.resolve_edge_endpoint(token, source_id).await? {
@@ -1709,7 +1709,7 @@ impl KhiveRuntime {
             target_backend: None,
         };
         // `upsert_edge_guarded` re-checks both endpoints exist as part of the same
-        // write, not the separate `validate_edge_relation_endpoints` read above — a
+        // write, not the separate `validate_edge_relation_endpoints` read above: a
         // concurrent hard-delete landing between that read and this write can no
         // longer create a durably dangling edge. Which endpoint(s) were missing is
         // reported by the guard's own in-transaction probe (`GuardedWriteOutcome::
@@ -1940,8 +1940,8 @@ impl KhiveRuntime {
     /// Get both-direction neighbors, each tagged with the direction (`Out`/
     /// `In`) it was found in, via a single storage query per visible
     /// namespace instead of two separate direction-scoped `neighbors_with_query`
-    /// calls — halving the neighbor SELECT count for `context(direction="both")`
-    /// expansion. `query.direction` is ignored — always both.
+    /// calls: halving the neighbor SELECT count for `context(direction="both")`
+    /// expansion. `query.direction` is ignored: always both.
     ///
     /// Mirrors `neighbors_with_query`'s dedup/enrich/soft-delete-filter/order
     /// pipeline exactly, carrying the per-hit direction tag through unchanged.
@@ -1966,7 +1966,7 @@ impl KhiveRuntime {
         }
         // Direction is part of the key (not just node_id/edge_id) so a
         // self-loop's Out row and In row — same node_id and edge_id, opposite
-        // direction — sort adjacent but distinct and both survive dedup.
+        // direction: sort adjacent but distinct and both survive dedup.
         hits.sort_by_key(|h| {
             (
                 h.hit.node_id,
@@ -1995,7 +1995,7 @@ impl KhiveRuntime {
             hits.retain(|h| !deleted.contains(&h.hit.node_id));
         }
         // Same global weight-descending/node_id-ascending restore as
-        // `neighbors_with_query` — the (node_id, edge_id, direction) sort above
+        // `neighbors_with_query`: the (node_id, edge_id, direction) sort above
         // exists only to make `dedup_by_key` adjacent-comparable.
         hits.sort_by(|a, b| {
             b.hit
@@ -2057,7 +2057,7 @@ impl KhiveRuntime {
     /// Neighbor/traverse candidates can be note-kind nodes (e.g. reached via
     /// `annotates` edges) as well as entities; a screen that only consults
     /// `entities` lets soft-deleted note targets leak through and hydrate as
-    /// blank/missing hits. This is a view-layer read-only screen — it does
+    /// blank/missing hits. This is a view-layer read-only screen: it does
     /// not touch edges or mutate any data.
     ///
     /// Returns the subset of `ids` that have `deleted_at IS NOT NULL` in
@@ -2504,7 +2504,7 @@ impl KhiveRuntime {
             crate::secret_gate::check_json(p)?;
         }
         // `embedding_content` is a caller-supplied alternate vector-embedding
-        // input — it must be a non-empty proper prefix of `content` (never a
+        // input: it must be a non-empty proper prefix of `content` (never a
         // superset, an unrelated string, or the full text) and passes the
         // same secret gate as any other stored/embedded text. Rejected
         // before any write, same as the checks above.
@@ -3177,7 +3177,7 @@ impl KhiveRuntime {
     }
 
     /// Resolve a short UUID prefix (8+ hex chars) to a full UUID with NO
-    /// namespace filter at all — mirrors `resolve_by_id`'s by-ID contract:
+    /// namespace filter at all: mirrors `resolve_by_id`'s by-ID contract:
     /// by-ID resolution is namespace-agnostic, since the Gate (not
     /// storage-layer filtering) is the authz seam. Used by the four by-ID
     /// CRUD verbs (get/update/delete/merge) so their prefix path matches
@@ -3318,7 +3318,7 @@ impl KhiveRuntime {
 
     /// Resolve a UUID to its substrate kind with NO namespace filter.
     ///
-    /// By-ID contract: UUID v4 is globally unique — by-ID substrate
+    /// By-ID contract: UUID v4 is globally unique: by-ID substrate
     /// inference must return the record regardless of caller namespace.  Used by
     /// the public `update` and `delete` verb handlers when no explicit `kind` is
     /// supplied.
@@ -3413,7 +3413,7 @@ impl KhiveRuntime {
     ///
     /// `link` and `create`'s `annotates` targets consume by-ID endpoints, so
     /// their existence check must follow the same by-ID contract as `get()`:
-    /// by-ID ops are namespace-agnostic — the Gate, not storage-layer
+    /// by-ID ops are namespace-agnostic: the Gate, not storage-layer
     /// filtering, is the authz seam. Mirrors `resolve_by_id`
     /// (entity + note, unfiltered) and additionally resolves events,
     /// unfiltered, so edge endpoint validation resolves exactly what `get()`
@@ -3572,7 +3572,7 @@ impl KhiveRuntime {
     /// references for `annotates` edges that target this note.
     /// Soft delete also cleans FTS and vector indexes; edges are left in place.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
+    /// UUID v4 is globally unique: no namespace filter on by-ID ops.
     /// Cascade and index cleanup target the RECORD's stored namespace, not the caller token's.
     /// Returns `Ok(false)` if the note does not exist.
     pub async fn delete_note(
@@ -3607,7 +3607,7 @@ impl KhiveRuntime {
         let record_ns = note.namespace.clone();
 
         // On hard delete, the row delete and the incident-edge cascade (including
-        // already-soft-deleted edges) run as ONE write transaction — see
+        // already-soft-deleted edges) run as ONE write transaction: see
         // `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
@@ -3617,7 +3617,7 @@ impl KhiveRuntime {
             self.text_for_notes(&record_tok)?
                 .delete_document(&record_ns, id)
                 .await?;
-            // Scoped delete — iterate over EVERY registered embedding model's
+            // Scoped delete: iterate over EVERY registered embedding model's
             // vector store so non-default vectors don't orphan when the note is deleted.
             for model_name in self.registered_embedding_model_names() {
                 self.vectors_for_model(&record_tok, &model_name)?
@@ -3654,7 +3654,7 @@ impl KhiveRuntime {
                 RuntimeError::Internal(format!("delete_note: event store write failed: {e}"))
             })?;
             // A soft OR hard delete removes the note's vectors/FTS document
-            // above — any pack-owned vector-derived cache (e.g.
+            // above: any pack-owned vector-derived cache (e.g.
             // khive-pack-memory's warm ANN index) needs to know the corpus
             // changed, reached via this generic hook so khive-runtime never
             // takes a dependency on khive-pack-memory. No-op when no pack has
@@ -3809,8 +3809,8 @@ impl KhiveRuntime {
         // When the server-side cap was the binding constraint, the compiled
         // SQL asked for one extra (sentinel) row. Its presence in the actual
         // result set — not the requested LIMIT — is the truncation signal
-        // — a `LIMIT 1000` that only matches 20 rows must not warn, and a
-        // query with no `LIMIT` that matches 501+ rows must.
+        // (a `LIMIT 1000` that only matches 20 rows must not warn, and a
+        // query with no `LIMIT` that matches 501+ rows must).
         if let Some(check) = truncation_check {
             if rows.len() > check.max_limit {
                 rows.truncate(check.max_limit);
@@ -3838,7 +3838,7 @@ impl KhiveRuntime {
     /// outbound) to prevent dangling references. Soft delete also cleans FTS
     /// and vector indexes; edges are left in place.
     ///
-    /// UUID v4 is globally unique — no namespace filter on by-ID ops.
+    /// UUID v4 is globally unique: no namespace filter on by-ID ops.
     pub async fn delete_entity(
         &self,
         token: &NamespaceToken,
@@ -3873,7 +3873,7 @@ impl KhiveRuntime {
         );
 
         // On hard delete, the row delete and the incident-edge cascade (including
-        // already-soft-deleted edges) run as ONE write transaction — see
+        // already-soft-deleted edges) run as ONE write transaction: see
         // `atomic_hard_delete_with_edge_purge`. Index cleanup follows the
         // commit; it is best-effort and idempotent, unlike the row/edge pair.
         let deleted = if hard {
@@ -3931,7 +3931,7 @@ impl KhiveRuntime {
 
     /// Fetch a single edge by id.
     ///
-    /// UUID v4 is globally unique — returns the edge regardless of which
+    /// UUID v4 is globally unique: returns the edge regardless of which
     /// namespace the token carries. `Ok(None)` means the edge does not exist at all.
     pub async fn get_edge(
         &self,
@@ -3966,7 +3966,7 @@ impl KhiveRuntime {
 
     /// Fetch a single edge by id.
     ///
-    /// Delegates to `get_edge` — no visible-set check.  By-ID ops are
+    /// Delegates to `get_edge`: no visible-set check.  By-ID ops are
     /// namespace-agnostic; UUID v4 is globally unique.
     pub async fn get_edge_visible(
         &self,
@@ -3978,7 +3978,7 @@ impl KhiveRuntime {
 
     /// Fetch an edge by UUID including soft-deleted rows.
     ///
-    /// Returns the edge regardless of which namespace the token carries —
+    /// Returns the edge regardless of which namespace the token carries:
     /// UUID v4 is globally unique. Used by the hard-delete path so that a
     /// soft-deleted edge can still be purged via its edge ID.
     pub async fn get_edge_including_deleted(
@@ -4284,7 +4284,7 @@ impl KhiveRuntime {
         edge_id: Uuid,
         patch: crate::curation::EdgePatch,
     ) -> RuntimeResult<Edge> {
-        // Fetch the edge by UUID — ID-only, no namespace check.
+        // Fetch the edge by UUID: ID-only, no namespace check.
         // get_edge already uses the record's stored namespace internally.
         let graph_for_fetch = self.graph(token)?;
         let mut edge = graph_for_fetch
@@ -4504,8 +4504,8 @@ impl KhiveRuntime {
         let graph = self.graph(&record_tok)?;
 
         // Cascade: on hard delete, remove ALL annotates edges targeting this edge — including
-        // already-soft-deleted ones — to prevent dangling graph_edges rows. The row
-        // delete and the cascade purge run as ONE write transaction — see
+        // already-soft-deleted ones: to prevent dangling graph_edges rows. The row
+        // delete and the cascade purge run as ONE write transaction: see
         // `atomic_hard_delete_with_edge_purge`.
         // On soft delete the cascade is skipped (data-vs-view principle: soft-deleting the base
         // edge does not cascade to annotation edges; only a hard purge cleans up incident rows).
@@ -5013,7 +5013,7 @@ mod tests {
 
     /// Custom embedder with no lattice model in config must participate in
     /// fan-out: the gate must check `registered_embedding_model_names()`, not
-    /// `config().embedding_model.is_some()` — the latter falls through to
+    /// `config().embedding_model.is_some()`: the latter falls through to
     /// `vec![]` when only a custom provider is registered.
     #[tokio::test]
     async fn custom_embedder_only_runtime_fanout_stores_vector() {
@@ -5202,7 +5202,7 @@ mod tests {
     /// Regression test: `update_edge_symmetric_dml` previously stored
     /// `updated_at` via `chrono::Utc::now().timestamp()` (SECONDS) while every
     /// other `graph_edges` write path (`edge_upsert_statement`,
-    /// `edge_soft_delete_statement`) uses `timestamp_micros()` — a genuine
+    /// `edge_soft_delete_statement`) uses `timestamp_micros()`: a genuine
     /// pre-existing bug, found while unifying this raw-SQL path with the
     /// atomic builder (which already used `timestamp_micros()` correctly)
     /// onto the shared `EDGE_SYMMETRIC_*_SQL` text. A seconds value misread as
@@ -6022,7 +6022,7 @@ mod tests {
     }
 
     /// Regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
-    /// (by design — the sanitizer stays minimal). SQLite FTS5's bareword
+    /// (by design: the sanitizer stays minimal). SQLite FTS5's bareword
     /// parser still rejects `@` unconditionally, so this query reaches the
     /// runtime-level `Err` arm in `search_notes`, which must fail loud
     /// (`RuntimeError::InvalidInput`) instead of silently degrading to
@@ -6060,7 +6060,7 @@ mod tests {
     }
 
     /// The `search_notes` FTS fail-open arm must only degrade genuine FTS5
-    /// parser syntax errors. A non-parser `StorageError` — e.g. a pool
+    /// parser syntax errors. A non-parser `StorageError`: e.g. a pool
     /// exhaustion or connection timeout on the text-search backend — is not a
     /// bad query and must propagate as `Err`, not be silently swallowed into
     /// an empty (falsely "successful") result set. `search_notes`,
@@ -6393,7 +6393,7 @@ mod tests {
 
     // ---- predicate pushdown before truncation (note branch) ----
 
-    /// Regression: notes store tags inside `properties["tags"]` — there is no
+    /// Regression: notes store tags inside `properties["tags"]`: there is no
     /// separate tags column. Without pushdown, the tag filter is applied after
     /// `hits.truncate(limit)`, so a tag-matching note ranked beyond `limit` in
     /// the raw RRF fusion is silently dropped.
@@ -6626,7 +6626,7 @@ mod tests {
         );
     }
 
-    /// Input longer than 32 hex chars is NOT truncated — the extra chars land
+    /// Input longer than 32 hex chars is NOT truncated: the extra chars land
     /// past the canonical 12-char final
     /// segment with no further hyphen, so the pattern can never match a real
     /// (36-char) stored `id`, instead of silently truncating down to a
@@ -6845,7 +6845,7 @@ mod tests {
 
     /// A single UUID legitimately present in TWO scanned tables (entities and
     /// notes here) must resolve cleanly to that one UUID, not a false
-    /// `AmbiguousPrefix` naming the same UUID twice — without cross-table
+    /// `AmbiguousPrefix` naming the same UUID twice: without cross-table
     /// dedup, `matches.len()` becomes 2 for a single record.
     #[tokio::test]
     async fn resolve_prefix_cross_table_duplicate_uuid_resolves_cleanly() {
@@ -7745,8 +7745,8 @@ mod tests {
         assert!(target_ids.contains(&t2.id));
     }
 
-    /// `link` endpoint existence is a by-ID check and therefore namespace-agnostic
-    /// — a target living in a different namespace than the caller must still
+    /// `link` endpoint existence is a by-ID check and therefore namespace-agnostic:
+    /// a target living in a different namespace than the caller must still
     /// resolve, exactly as `get()` would.
     #[tokio::test]
     async fn link_target_in_different_namespace_succeeds() {
@@ -9522,7 +9522,7 @@ mod tests {
         );
     }
 
-    // Base endpoint allowlist — unlisted triples must fail closed.
+    // Base endpoint allowlist: unlisted triples must fail closed.
     // Document->Document Extends is not in the allowlist.
     #[tokio::test]
     async fn link_extends_document_to_document_returns_invalid_input() {
@@ -9603,7 +9603,7 @@ mod tests {
         );
     }
 
-    // Supersedes — positive tests for all 5 allowed entity kinds.
+    // Supersedes: positive tests for all 5 allowed entity kinds.
     #[tokio::test]
     async fn f010_supersedes_document_to_document_allowed() {
         let rt = rt();
@@ -9688,7 +9688,7 @@ mod tests {
         );
     }
 
-    // Supersedes — negative tests for rejected entity kinds.
+    // Supersedes: negative tests for rejected entity kinds.
     #[tokio::test]
     async fn f010_supersedes_project_to_project_rejected() {
         let rt = rt();
@@ -9752,7 +9752,7 @@ mod tests {
         );
     }
 
-    // Supersedes entity→entity — same kind (concept→concept) must be allowed.
+    // Supersedes entity→entity: same kind (concept→concept) must be allowed.
     #[tokio::test]
     async fn f010_supersedes_same_kind_entity_allowed() {
         let rt = rt();
@@ -9774,7 +9774,7 @@ mod tests {
         );
     }
 
-    // target_backend invariant — all edges written through link() must have
+    // target_backend invariant: all edges written through link() must have
     // target_backend = None because validate_edge_relation_endpoints already ensured the
     // target exists locally.
     #[tokio::test]
@@ -9845,7 +9845,7 @@ mod tests {
         }
     }
 
-    // Symmetric relation neighbors — competes_with queried from the non-canonical
+    // Symmetric relation neighbors: competes_with queried from the non-canonical
     // endpoint must still return results when direction=Out is requested.
     #[tokio::test]
     async fn f012_symmetric_neighbors_visible_from_both_endpoints() {
@@ -10344,7 +10344,7 @@ mod tests {
             "edge must be visible in its own namespace"
         );
 
-        // Foreign namespace must now SUCCEED — by-ID get is namespace-agnostic.
+        // Foreign namespace must now SUCCEED: by-ID get is namespace-agnostic.
         let cross_ns = rt.get_edge(&ns_b, Uuid::from(edge.id)).await;
         assert!(
             matches!(cross_ns, Ok(Some(_))),
@@ -10894,7 +10894,7 @@ mod tests {
         );
     }
 
-    // Multi-model create_entity — second model's vector INSERT fails after the
+    // Multi-model create_entity: second model's vector INSERT fails after the
     // first model's insert succeeds, triggering inserted_models rollback.
     // Uses arm_vector_fail_after(1) so the first insert passes and the second fails,
     // exercising the inserted_models compensation path in create_entity.
@@ -11145,7 +11145,7 @@ mod tests {
 
     // ── By-ID ops must not filter by namespace ──────────────────────────────
     //
-    // A namespace-gated by-ID op on an entity stamped "lambda:leo" from a "local"
+    // A namespace-gated by-ID op on an entity stamped "foreign" from a "local"
     // token would return NotFound, causing gtd.complete / update blindness.
     // UUID is globally unique; by-ID ops find the record regardless of
     // which namespace the caller's token carries.

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -731,7 +731,7 @@ pub struct VerbRegistry {
     actor_id: Option<String>,
     /// Audit event sink — `None` means tracing-only (v0.2 default).
     event_store: Option<Arc<dyn EventStore>>,
-    /// Post-dispatch hook — `None` means no real-time observation.
+    /// Post-dispatch hook: `None` means no real-time observation.
     dispatch_hook: Option<Arc<dyn DispatchHook>>,
     /// Names of all `Visibility::Verb` handlers across all packs, precomputed
     /// once at `build()` time. Used only to render the unknown-verb error
@@ -994,7 +994,7 @@ impl VerbRegistry {
         params: Value,
         identity: Option<RequestIdentity>,
     ) -> Result<Value, RuntimeError> {
-        // help=true interception — short-circuit before gate/pack.
+        // help=true interception: short-circuit before gate/pack.
         if params.get("help").and_then(Value::as_bool) == Some(true) {
             return self.describe_verb(verb);
         }
@@ -1049,7 +1049,7 @@ impl VerbRegistry {
                 // since the last dispatch and persist them as `ConfigLocked`
                 // events, riding this same audit-persistence gate. The
                 // namespace/actor stamped on these rows are whichever
-                // dispatch happens to observe the queue non-empty first —
+                // dispatch happens to observe the queue non-empty first:
                 // an accepted provenance quirk, preferred over threading an
                 // `EventStore` handle into every synchronous
                 // `OnceLock::get_or_init` call site.
@@ -1084,7 +1084,7 @@ impl VerbRegistry {
                 //
                 // Accepted trade-off: a crash between this Allow decision and
                 // the deferred append below (post-dispatch, further down this
-                // function) loses that dispatch's audit row entirely — a
+                // function) loses that dispatch's audit row entirely: a
                 // deliberate choice, not an oversight.
                 let defer_audit = !is_deny;
 
@@ -1128,7 +1128,7 @@ impl VerbRegistry {
         // Mint the authorized storage token at the dispatch boundary.
         //
         // Writes pin to `local` by default. Actor identity and config
-        // `[actor] id` are attribution and gate-context inputs only — they
+        // `[actor] id` are attribution and gate-context inputs only: they
         // never route storage. The explicit `namespace=` request param is a
         // precise single-namespace escape: the caller deliberately
         // reads/writes exactly that one set; it is NOT widened by `visible_namespaces`.
@@ -1147,7 +1147,7 @@ impl VerbRegistry {
         // (mint_with_visibility deduplicates). Writes remain pinned to
         // `'local'`. Per-actor distinctions use view-layer tag filters
         // (assignee, actor_id, from/to), not namespace partitions. `ns`/
-        // `explicit_namespace` were already validated above — reuse them
+        // `explicit_namespace` were already validated above: reuse them
         // instead of re-reading `params["namespace"]` with `as_str()`, which
         // would silently drop malformed non-string values again.
         let token = if explicit_namespace {
@@ -1322,11 +1322,11 @@ impl VerbRegistry {
                 // Keyed on `token.namespace()`, NOT `ns`: `ns` is the
                 // gate-resolved namespace, which on the default
                 // (non-explicit) dispatch path can be a non-local
-                // `default_namespace` (e.g. "lambda:leo") while the storage
+                // `default_namespace` (e.g. "foreign") while the storage
                 // token that actually created/touched the record is pinned
                 // to `local`. The ring must be keyed on the namespace the
-                // record actually lives in — the same namespace
-                // `resolve_reference`'s ring lookup uses — or admission and
+                // record actually lives in: the same namespace
+                // `resolve_reference`'s ring lookup uses: or admission and
                 // lookup silently diverge on any non-local `default_namespace`
                 // config.
                 if let Ok(ref ok_val) = result {
@@ -2967,7 +2967,7 @@ mod tests {
     }
 
     /// The gate's actor and the storage token's actor must be the exact same
-    /// resolved value — both come from one `resolve_actor` call
+    /// resolved value: both come from one `resolve_actor` call
     /// (`resolved_actor`) instead of two independently hand-synchronized
     /// `match` expressions, so a future edit to one copy but not the other
     /// cannot silently desynchronize "who the gate thinks the caller is" from
@@ -5340,7 +5340,7 @@ mod help_tests {
     // ── Unknown-verb error must not leak subhandler names ─────────
 
     /// `describe_verb` on an unknown verb must list only Verb-visibility names
-    /// in the "available" list — never subhandler names like `recall.embed`.
+    /// in the "available" list: never subhandler names like `recall.embed`.
     #[tokio::test]
     async fn help_true_unknown_verb_available_list_excludes_subhandlers() {
         let reg = build_help_registry(Arc::new(AtomicUsize::new(0)));
@@ -5576,7 +5576,7 @@ mod help_tests {
 
     // ADR-028: two packs declaring the same auxiliary table on the same
     // backend must cause apply_schema_plans_with_map to return an error that
-    // names both packs and the table — it is a boot-time failure, not a
+    // names both packs and the table: it is a boot-time failure, not a
     // silent DDL race.
     #[test]
     fn apply_schema_plans_with_map_collision_is_an_error() {

--- a/crates/khive-runtime/src/pack.rs
+++ b/crates/khive-runtime/src/pack.rs
@@ -68,7 +68,7 @@ impl SchemaPlan {
     }
 }
 
-/// Hook called after every successful verb dispatch (Issue #158).
+/// Hook called after every successful verb dispatch.
 ///
 /// Packs observe enriched event views so provenance-aware consumers can use
 /// `view.observations` while legacy folds can still consume `view.event`.
@@ -154,7 +154,7 @@ pub trait PackRuntime: Send + Sync {
     /// substrate tables (entities, notes, edges, events) return this default.
     ///
     /// Plans are aggregated via [`VerbRegistry::all_schema_plans`] and applied
-    /// at startup via `KhiveMcpServer::with_packs` (c12). Packs that need their
+    /// at startup via `KhiveMcpServer::with_packs`. Packs that need their
     /// schema present (e.g. GTD) also self-bootstrap lazily on first call for
     /// robustness in test contexts that create fresh in-memory databases.
     fn schema_plan(&self) -> SchemaPlan {
@@ -203,7 +203,7 @@ pub trait PackRuntime: Send + Sync {
     /// is the correct behaviour for bare runtimes without packs.
     fn register_entity_type_validator(&self, _runtime: &KhiveRuntime) {}
 
-    /// Install a pack-owned note-mutation hook on the runtime (#750 fix-round 1).
+    /// Install a pack-owned note-mutation hook on the runtime.
     ///
     /// Called by the transport during pack initialisation, after the registry
     /// is built and before the first verb dispatch — same timing as
@@ -364,7 +364,7 @@ pub struct VerbRegistryBuilder {
     /// registry does not depend on the full `KhiveRuntime` surface — only the
     /// audit-persistence capability is needed here.
     event_store: Option<Arc<dyn EventStore>>,
-    /// Optional post-dispatch hook (Issue #158).
+    /// Optional post-dispatch hook.
     ///
     /// When set, every successful pack dispatch calls `hook.on_dispatch(event)`
     /// with a synthesized Event describing the outcome. Opt-in: when None,
@@ -474,7 +474,7 @@ impl VerbRegistryBuilder {
         self
     }
 
-    /// Register a post-dispatch hook (Issue #158).
+    /// Register a post-dispatch hook.
     ///
     /// When set, every successful pack dispatch calls `hook.on_dispatch(event)`
     /// with a synthesized [`Event`] describing the verb outcome. The hook is
@@ -596,7 +596,7 @@ impl VerbRegistryBuilder {
     }
 }
 
-/// Validate that no two packs declare the same note kind (F073).
+/// Validate that no two packs declare the same note kind.
 ///
 /// Boot-time duplicate detection prevents pack configuration errors from
 /// silently corrupting note kind routing. Returns an error naming the
@@ -616,8 +616,7 @@ fn validate_unique_note_kinds(packs: &[Box<dyn PackRuntime>]) -> Result<(), Runt
     Ok(())
 }
 
-/// Validate that no two packs declare the same `Visibility::Verb` handler name
-/// (F093).
+/// Validate that no two packs declare the same `Visibility::Verb` handler name.
 ///
 /// `Visibility::Subhandler` entries are pack-prefixed by convention and excluded
 /// from cross-pack collision detection. Two packs declaring the same subhandler
@@ -732,7 +731,7 @@ pub struct VerbRegistry {
     actor_id: Option<String>,
     /// Audit event sink — `None` means tracing-only (v0.2 default).
     event_store: Option<Arc<dyn EventStore>>,
-    /// Post-dispatch hook — `None` means no real-time observation (Issue #158).
+    /// Post-dispatch hook — `None` means no real-time observation.
     dispatch_hook: Option<Arc<dyn DispatchHook>>,
     /// Names of all `Visibility::Verb` handlers across all packs, precomputed
     /// once at `build()` time. Used only to render the unknown-verb error
@@ -879,7 +878,7 @@ impl VerbRegistry {
         self.event_store.clone()
     }
 
-    /// Return the help schema envelope for a verb (issue #287).
+    /// Return the help schema envelope for a verb.
     ///
     /// Walks registered packs for the first matching `HandlerDef` and returns a
     /// structured JSON envelope. Subhandlers carry `callable_via_mcp: false`.
@@ -902,10 +901,10 @@ impl VerbRegistry {
                             })
                         })
                         .collect();
-                    // ue-help-introspection C1: subhandlers are not callable via
-                    // the MCP request surface.  The help payload must match the
-                    // behaviour the dispatch path enforces so that agents who
-                    // read `help=true` before probing see accurate availability.
+                    // Subhandlers are not callable via the MCP request surface;
+                    // the help payload must match the behaviour the dispatch
+                    // path enforces so callers reading `help=true` before
+                    // probing see accurate availability.
                     if matches!(handler.visibility, Visibility::Subhandler) {
                         return Ok(serde_json::json!({
                             "verb": verb,
@@ -932,7 +931,7 @@ impl VerbRegistry {
         }
         // Verb-visibility handler names, precomputed at build() time (internal
         // subhandlers are excluded so they are not advertised in the
-        // unknown-verb error — ue-help-introspection C1 / internal review High).
+        // unknown-verb error).
         Err(RuntimeError::InvalidInput(format!(
             "unknown verb {verb:?}; available: {}",
             self.available_verbs.join(", ")
@@ -995,22 +994,22 @@ impl VerbRegistry {
         params: Value,
         identity: Option<RequestIdentity>,
     ) -> Result<Value, RuntimeError> {
-        // help=true interception (issue #287) — short-circuit before gate/pack.
+        // help=true interception — short-circuit before gate/pack.
         if params.get("help").and_then(Value::as_bool) == Some(true) {
             return self.describe_verb(verb);
         }
         // Resolve namespace before `params` is moved into pack.dispatch, so the
         // post-dispatch hook can reference it.
         //
-        // RUNTIME-AUD-002 (#433): absent `namespace` and a present-but-malformed
-        // `namespace` are different cases. A present non-string value (null,
-        // number, bool, array, object) is explicit caller input that failed to
-        // parse — ADR-018 requires it fail closed, not silently coerce to the
-        // default namespace. Only a genuinely absent key defaults. Shared with
-        // the multi-backend coordinator intercept via `resolve_explicit_namespace`
-        // so every MCP ingress path applies the same fail-closed rule.
+        // Absent `namespace` and a present-but-malformed `namespace` are
+        // different cases. A present non-string value (null, number, bool,
+        // array, object) is explicit caller input that failed to parse and
+        // must fail closed, not silently coerce to the default namespace.
+        // Only a genuinely absent key defaults. Shared with the multi-backend
+        // coordinator intercept via `resolve_explicit_namespace` so every MCP
+        // ingress path applies the same fail-closed rule.
         let explicit_namespace = params.get("namespace").is_some_and(Value::is_string);
-        // ADR-096 Fork 1: a supplied per-request identity overrides the baked
+        // A supplied per-request identity overrides the baked
         // default_namespace/actor_id/visible_namespaces for this call only.
         let default_namespace_str: &str = identity
             .as_ref()
@@ -1021,10 +1020,10 @@ impl VerbRegistry {
             Some(id) => id.actor_id.as_deref(),
             None => self.actor_id.as_deref(),
         };
-        // ADR-057: thread the configured actor identity into the gate request so
-        // the gate can distinguish human vs agent callers at the dispatch seam.
-        // Resolved once via the shared actor-identity policy (#567) and reused
-        // for token minting below, so the gate's notion of "who is the caller"
+        // Thread the configured actor identity into the gate request so the
+        // gate can distinguish human vs agent callers at the dispatch seam.
+        // Resolved once via the shared actor-identity policy and reused for
+        // token minting below, so the gate's notion of "who is the caller"
         // and the storage token's notion can never drift apart.
         let resolved_actor = crate::actor_identity::resolve_actor(actor_id_str);
         let gate_req = GateRequest::new(resolved_actor.clone(), ns.clone(), verb, params.clone());
@@ -1046,13 +1045,13 @@ impl VerbRegistry {
                     "gate.check"
                 );
 
-                // #623 (ADR-094): drain any process-lifetime `OnceLock` config
-                // locks queued since the last dispatch and persist them as
-                // `ConfigLocked` events, riding this same audit-persistence
-                // gate. The namespace/actor stamped on these rows are
-                // whichever dispatch happens to observe the queue non-empty
-                // first — an accepted provenance quirk (ADR-094) rather than
-                // threading an `EventStore` handle into every synchronous
+                // Drain any process-lifetime `OnceLock` config locks queued
+                // since the last dispatch and persist them as `ConfigLocked`
+                // events, riding this same audit-persistence gate. The
+                // namespace/actor stamped on these rows are whichever
+                // dispatch happens to observe the queue non-empty first —
+                // an accepted provenance quirk, preferred over threading an
+                // `EventStore` handle into every synchronous
                 // `OnceLock::get_or_init` call site.
                 if let Some(store) = &self.event_store {
                     if crate::config_ledger::PENDING
@@ -1073,23 +1072,20 @@ impl VerbRegistry {
                     }
                 }
 
-                // ADR-103 Stage 1 / #676: every Allow-outcome audit row defers
-                // its append until pack dispatch returns, so the row can carry
-                // the measured dispatch time in `duration_us` (previously the
-                // row was persisted before dispatch ran, so the persisted
-                // `duration_us` was always the `Event::new` default of 0 — see
-                // ADR-103 Stage 1). A singleton `link` call (no `links` bulk
-                // array) additionally enriches the deferred row with the
-                // created/resolved edge fields (schema v2) once dispatch
-                // resolves. Denied calls have no dispatch to wait for and keep
-                // the immediate v1 append below.
+                // Every Allow-outcome audit row defers its append until pack
+                // dispatch returns, so the row can carry the measured
+                // dispatch time in `duration_us` (persisting before dispatch
+                // ran always recorded the `Event::new` default of 0). A
+                // singleton `link` call (no `links` bulk array) additionally
+                // enriches the deferred row with the created/resolved edge
+                // fields (schema v2) once dispatch resolves. Denied calls
+                // have no dispatch to wait for and keep the immediate v1
+                // append below.
                 //
                 // Accepted trade-off: a crash between this Allow decision and
                 // the deferred append below (post-dispatch, further down this
-                // function) loses that dispatch's audit row entirely. This is
-                // deliberate, not an oversight — see ADR-103, "Stage 1
-                // clarification: audit-row write timing" for the rationale
-                // and the recorded upgrade path.
+                // function) loses that dispatch's audit row entirely — a
+                // deliberate choice, not an oversight.
                 let defer_audit = !is_deny;
 
                 // Persist to EventStore immediately only for denied calls.
@@ -1131,33 +1127,34 @@ impl VerbRegistry {
 
         // Mint the authorized storage token at the dispatch boundary.
         //
-        // ADR-007 Rev 4 Rule 0/3/3b: writes pin to `local` by default. Actor
-        // identity and config `[actor] id` are attribution and gate-context inputs
-        // only — they never route storage. The explicit `namespace=` request param
-        // is a precise single-namespace escape (Rule 3): the caller deliberately
+        // Writes pin to `local` by default. Actor identity and config
+        // `[actor] id` are attribution and gate-context inputs only — they
+        // never route storage. The explicit `namespace=` request param is a
+        // precise single-namespace escape: the caller deliberately
         // reads/writes exactly that one set; it is NOT widened by `visible_namespaces`.
         //
-        // When actor_id is configured (ADR-057), mint a token carrying that actor
+        // When actor_id is configured, mint a token carrying that actor
         // label so that comm.inbox applies the to_actor filter for directed delivery.
         // Otherwise, use ActorRef::anonymous() and inbox falls back to party-line.
-        // ADR-096 Fork 1: `actor_id_str` already reflects the per-request identity
-        // override when supplied (resolved above into `resolved_actor`, mirrored
-        // into the gate request). Reusing the same value here (#567) guarantees
-        // the gate's actor and the storage token's actor can never diverge.
+        // `actor_id_str` already reflects the per-request identity override
+        // when supplied (resolved above into `resolved_actor`, mirrored into
+        // the gate request). Reusing the same value here guarantees the
+        // gate's actor and the storage token's actor can never diverge.
         //
-        // Rule 3b (Rev 4): on the default (no explicit `namespace=`) path, the read
-        // scope widens to `['local'] ∪ visible_namespaces` (baked, or the per-request
-        // override — ADR-096 Fork 1). `'local'` is always included (mint_with_visibility
-        // deduplicates). Writes remain pinned to `'local'`. Per-actor distinctions use
-        // view-layer tag filters (assignee, actor_id, from/to), not namespace partitions.
-        // `ns`/`explicit_namespace` were already validated above (RUNTIME-AUD-002 /
-        // #433) — reuse them instead of re-reading `params["namespace"]` with
-        // `as_str()`, which would silently drop malformed non-string values again.
+        // On the default (no explicit `namespace=`) path, the read scope
+        // widens to `['local'] ∪ visible_namespaces` (baked, or the
+        // per-request override). `'local'` is always included
+        // (mint_with_visibility deduplicates). Writes remain pinned to
+        // `'local'`. Per-actor distinctions use view-layer tag filters
+        // (assignee, actor_id, from/to), not namespace partitions. `ns`/
+        // `explicit_namespace` were already validated above — reuse them
+        // instead of re-reading `params["namespace"]` with `as_str()`, which
+        // would silently drop malformed non-string values again.
         let token = if explicit_namespace {
-            // Rule 3 explicit escape: precise single-namespace scope, read+write. NOT widened.
+            // Explicit escape: precise single-namespace scope, read+write. NOT widened.
             NamespaceToken::mint_with_visibility(ns.clone(), vec![], resolved_actor)
         } else {
-            // Rule 3b: default path. Write namespace = local; read scope = ['local'] ∪ visible_namespaces.
+            // Default path: write namespace = local; read scope = ['local'] ∪ visible_namespaces.
             let primary = Namespace::local();
             let mut extra_visible: Vec<Namespace> = match identity.as_ref() {
                 Some(id) => id
@@ -1209,15 +1206,14 @@ impl VerbRegistry {
                 let result = pack.dispatch(verb, params, self, &token).await;
                 let dispatch_us = dispatch_start.elapsed().as_micros() as i64;
 
-                // ADR-103 Stage 1 / #676: append the deferred Allow-outcome
-                // audit row now that dispatch has resolved, so `duration_us`
-                // carries the measured `dispatch_us` instead of the
-                // `Event::new` default of 0. A successful singleton `link`
-                // call enriches the row with the created/resolved edge
-                // (schema v2); anything that cannot be enriched, or is not a
-                // singleton `link` call, falls back to the generic v1 audit
-                // shape so no audit row is ever dropped for the deferred
-                // path.
+                // Append the deferred Allow-outcome audit row now that
+                // dispatch has resolved, so `duration_us` carries the
+                // measured `dispatch_us` instead of the `Event::new` default
+                // of 0. A successful singleton `link` call enriches the row
+                // with the created/resolved edge (schema v2); anything that
+                // cannot be enriched, or is not a singleton `link` call,
+                // falls back to the generic v1 audit shape so no audit row
+                // is ever dropped for the deferred path.
                 if let Some(audit) = deferred_audit.take() {
                     if let Some(store) = &self.event_store {
                         let is_link_singleton =
@@ -1262,9 +1258,8 @@ impl VerbRegistry {
                                 }
                             }
                             _ => {
-                                // Review finding (issue #723 fix-round): the
-                                // persisted audit outcome must reflect the
-                                // dispatch result, not be hardcoded to
+                                // The persisted audit outcome must reflect
+                                // the dispatch result, not be hardcoded to
                                 // Success — otherwise a failed dispatch is
                                 // recorded as successful work and disappears
                                 // from `outcome=error` queries.
@@ -1282,7 +1277,7 @@ impl VerbRegistry {
                     }
                 }
 
-                // Post-dispatch hook: fires on success, opt-in (Issue #158).
+                // Post-dispatch hook: fires on success, opt-in.
                 if let (Ok(ref ok_val), Some(hook)) = (&result, &self.dispatch_hook) {
                     let mut dispatch_event = Event::new(
                         ns.as_str(),
@@ -1296,7 +1291,7 @@ impl VerbRegistry {
 
                     // For recall verbs: extract the first result's id as
                     // target_id so the brain temporal posterior can observe
-                    // real hit/miss and latency (fix for internal review P12 Major).
+                    // real hit/miss and latency.
                     if verb == "memory.recall" {
                         let first_note_id = ok_val
                             .as_array()
@@ -1319,22 +1314,21 @@ impl VerbRegistry {
                     hook.on_dispatch(&dispatch_view).await;
                 }
 
-                // Recently-referenced ring admission (unified-verb draft ADR,
-                // Slice 1 — gate condition, 2026-07-09): only by-id touches
-                // admit an id. Runs unconditionally (not gated on
-                // `dispatch_hook`, which is opt-in) because the ring is a
-                // core dispatch-boundary capability, not an observer.
+                // Recently-referenced ring admission: only by-id touches admit
+                // an id. Runs unconditionally (not gated on `dispatch_hook`,
+                // which is opt-in) because the ring is a core
+                // dispatch-boundary capability, not an observer.
                 //
-                // Keyed on `token.namespace()`, NOT `ns` (review finding,
-                // 2026-07-09 fix round): `ns` is the gate-resolved namespace,
-                // which on the default (non-explicit) dispatch path can be a
-                // non-local `default_namespace` (e.g. "lambda:leo") while the
-                // storage token that actually created/touched the record is
-                // pinned to `local` per ADR-007 Rule 0/3b. The ring must be
-                // keyed on the namespace the record actually lives in — the
-                // same namespace `resolve_reference`'s ring lookup uses —
-                // or admission and lookup silently diverge on any non-local
-                // `default_namespace` config.
+                // Keyed on `token.namespace()`, NOT `ns`: `ns` is the
+                // gate-resolved namespace, which on the default
+                // (non-explicit) dispatch path can be a non-local
+                // `default_namespace` (e.g. "lambda:leo") while the storage
+                // token that actually created/touched the record is pinned
+                // to `local`. The ring must be keyed on the namespace the
+                // record actually lives in — the same namespace
+                // `resolve_reference`'s ring lookup uses — or admission and
+                // lookup silently diverge on any non-local `default_namespace`
+                // config.
                 if let Ok(ref ok_val) = result {
                     let admissions = crate::reference_ring::ring_admissions_for(verb, ok_val);
                     if !admissions.is_empty() {
@@ -1361,9 +1355,9 @@ impl VerbRegistry {
         // trail (matches the "no audit row is ever dropped" contract above).
         if let Some(audit) = deferred_audit.take() {
             if let Some(store) = &self.event_store {
-                // Review finding (issue #723 fix-round): dispatch is about to
-                // return `InvalidInput` below (no pack owns this verb), so
-                // the persisted outcome must be `Error`, not `Success`.
+                // Dispatch is about to return `InvalidInput` below (no pack
+                // owns this verb), so the persisted outcome must be `Error`,
+                // not `Success`.
                 let storage_event =
                     build_audit_storage_event(&gate_req, &audit, EventOutcome::Error);
                 append_audit_event_best_effort(store, storage_event, verb).await;
@@ -1372,7 +1366,7 @@ impl VerbRegistry {
 
         // Verb-visibility handler names, precomputed at build() time (internal
         // subhandlers are excluded so they are not advertised in the
-        // unknown-verb error — ue-help-introspection C1 / internal review High).
+        // unknown-verb error).
         Err(RuntimeError::InvalidInput(format!(
             "unknown verb {verb:?}; available: {}",
             self.available_verbs.join(", ")
@@ -1417,7 +1411,7 @@ impl VerbRegistry {
     /// All MCP-exposed handlers across all registered packs (`Visibility::Verb` only).
     ///
     /// Subhandlers (`Visibility::Subhandler`) are excluded — they are internal
-    /// pipeline steps not surfaced on the MCP wire (F118). Returned with `'static`
+    /// pipeline steps not surfaced on the MCP wire. Returned with `'static`
     /// lifetime since pack handlers are `&'static [HandlerDef]` constants.
     pub fn all_verbs(&self) -> Vec<&'static HandlerDef> {
         self.packs
@@ -1431,7 +1425,7 @@ impl VerbRegistry {
     /// (`Visibility::Verb` only).
     ///
     /// Subhandlers (`Visibility::Subhandler`) are excluded from the MCP catalog
-    /// (F118-F123). Use `all_handlers_with_names` when internal handlers must
+    /// Use `all_handlers_with_names` when internal handlers must
     /// also be enumerated (e.g. runtime introspection).
     pub fn all_verbs_with_names(&self) -> Vec<(&str, &'static HandlerDef)> {
         self.packs
@@ -1595,8 +1589,7 @@ impl VerbRegistry {
         }
     }
 
-    /// Invoke `PackRuntime::register_note_mutation_hook` on every registered pack
-    /// (#750 fix-round 1).
+    /// Invoke `PackRuntime::register_note_mutation_hook` on every registered pack.
     ///
     /// Called by the transport during startup, after the registry is built and
     /// before the first verb dispatch, so that note-mutation notifications at
@@ -1651,8 +1644,7 @@ impl VerbRegistry {
         false
     }
 
-    /// Apply all non-empty pack-auxiliary schema plans to the given backend
-    /// (c12 startup application).
+    /// Apply all non-empty pack-auxiliary schema plans to the given backend.
     ///
     /// This is the centralized startup hook that replaced the previous lazy
     /// per-pack self-bootstrap pattern. Each pack's `SchemaPlan` carries
@@ -2006,7 +1998,7 @@ fn target_id_from_args(args: &serde_json::Value) -> Option<uuid::Uuid> {
 /// Build a v1-shape audit storage event from a gate check outcome.
 ///
 /// Shared by the immediate-append path (all verbs, denied calls, bulk
-/// `links`) and the deferred singleton-`link` fallback (#676) so both audit
+/// `links`) and the deferred singleton-`link` fallback so both audit
 /// shapes are produced by one code path.
 fn build_audit_storage_event(
     gate_req: &GateRequest,
@@ -2046,7 +2038,7 @@ async fn append_audit_event_best_effort(store: &Arc<dyn EventStore>, event: Even
     }
 }
 
-/// Schema v2 audit payload for a successful singleton `link` call (#676).
+/// Schema v2 audit payload for a successful singleton `link` call.
 ///
 /// Additive over the v1 `AuditEvent` shape: every v1 field is preserved via
 /// `#[serde(flatten)]`, and the edge identity/relation/weight the caller
@@ -2098,7 +2090,7 @@ fn link_audit_success_from_result(
 }
 
 /// Resolve and validate a caller-supplied `namespace` argument the same way
-/// on every MCP ingress path (RUNTIME-AUD-002 / #433).
+/// on every MCP ingress path.
 ///
 /// - Absent `namespace` key → parse `default_namespace`.
 /// - Present `namespace: "<string>"` → parse the caller's value.
@@ -2127,8 +2119,8 @@ pub fn resolve_explicit_namespace(
     }
 }
 
-/// JSON type name for error messages (RUNTIME-AUD-002 / #433): describes a
-/// present-but-malformed `namespace` value without echoing its contents.
+/// JSON type name for error messages: describes a present-but-malformed
+/// `namespace` value without echoing its contents.
 pub fn json_type_name(v: &Value) -> &'static str {
     match v {
         Value::Null => "null",
@@ -2361,7 +2353,7 @@ mod tests {
         assert_eq!(res["pack"], "beta");
     }
 
-    /// F093/F094: two packs declaring the same `Visibility::Verb` handler must be
+    /// Two packs declaring the same `Visibility::Verb` handler must be
     /// rejected at build time — the old "first registered wins" behaviour is
     /// replaced by a boot error.
     #[test]
@@ -2448,7 +2440,7 @@ mod tests {
         assert!(msg.contains("create"));
     }
 
-    /// `all_verbs` returns only `Visibility::Verb` entries (F118).
+    /// `all_verbs` returns only `Visibility::Verb` entries.
     ///
     /// BetaPack's `create` is `Visibility::Subhandler` — it must NOT appear
     /// in `all_verbs()` even though it has the same name as a Verb in AlphaPack.
@@ -2658,7 +2650,7 @@ mod tests {
     }
 
     // Captures the namespace each call sees so we can assert what the gate
-    // actually receives — internal review round 1 caught us hard-wiring `default_ns()`.
+    // actually receives, rather than assuming a hard-wired `default_ns()`.
     #[derive(Default, Debug)]
     struct NamespaceCapturingGate {
         seen: std::sync::Mutex<Vec<String>>,
@@ -2717,8 +2709,8 @@ mod tests {
         assert_eq!(seen, vec!["local"]);
     }
 
-    /// RUNTIME-AUD-002 (#433): a present-but-malformed `namespace` value must
-    /// never reach the gate as the default namespace. Table-driven over every
+    /// A present-but-malformed `namespace` value must never reach the gate as
+    /// the default namespace. Table-driven over every
     /// non-string JSON type; the gate-spy proves no call is ever recorded (the
     /// dispatch must short-circuit with `InvalidInput` before `GateRequest` is
     /// built), so the default namespace can never appear as a coerced stand-in.
@@ -2974,17 +2966,14 @@ mod tests {
         }
     }
 
-    /// #567: the gate's actor and the storage token's actor must be the exact
-    /// same resolved value — both now come from one `resolve_actor` call
+    /// The gate's actor and the storage token's actor must be the exact same
+    /// resolved value — both come from one `resolve_actor` call
     /// (`resolved_actor`) instead of two independently hand-synchronized
-    /// `match` expressions. This is the drift `#567` warns about: before the
-    /// unification, a future edit to one copy but not the other would silently
-    /// desynchronize "who the gate thinks the caller is" from "who the
-    /// storage layer thinks the caller is".
-    ///
-    /// FAILURE MODE: reintroducing a second independent actor-resolution copy
-    /// for the token (instead of reusing the gate's resolved value) could
-    /// diverge under a future edit and this test would catch it.
+    /// `match` expressions, so a future edit to one copy but not the other
+    /// cannot silently desynchronize "who the gate thinks the caller is" from
+    /// "who the storage layer thinks the caller is". Reintroducing a second
+    /// independent actor-resolution copy for the token would regress this and
+    /// this test would catch it.
     #[tokio::test]
     async fn gate_actor_and_token_actor_are_identical_when_actor_id_is_set() {
         let gate = Arc::new(ActorCapturingGate::default());
@@ -3046,13 +3035,14 @@ mod tests {
         assert_eq!(gate_actor.id, "local");
     }
 
-    // ---- Rego gate: fail-closed end-to-end (issue #30) ----
+    // ---- Rego gate: fail-closed end-to-end ----
 
     /// A `RegoGate` whose policy lacks the named entrypoint rule must cause
     /// `VerbRegistry::dispatch` to return `RuntimeError::PermissionDenied` —
     /// never to proceed to the pack handler.
     ///
-    /// This is the runtime-level assertion for the fix to security issue #30.
+    /// This is the runtime-level assertion that a gate evaluation failure
+    /// fails closed rather than opening a security hole.
     /// `RegoGate::check` converts all evaluation failures (missing rule,
     /// undefined result, serialization error, poisoned engine) to
     /// `Ok(GateDecision::Deny)`, so dispatch is blocked. The runtime's
@@ -3484,11 +3474,11 @@ mod tests {
 
     #[tokio::test]
     async fn audit_event_duration_us_reflects_measured_dispatch_time() {
-        // ADR-103 Stage 1: the persisted audit row's `duration_us` must carry
-        // the measured pack-dispatch time, not the `Event::new` default of 0
-        // (the bug this stage fixes — the row used to be persisted before
-        // dispatch ran at all). `SleepingPack` sleeps 20ms so the assertion
-        // has a wide, non-flaky margin over scheduling jitter.
+        // The persisted audit row's `duration_us` must carry the measured
+        // pack-dispatch time, not the `Event::new` default of 0 (persisting
+        // the row before dispatch ran always yielded 0). `SleepingPack`
+        // sleeps 20ms so the assertion has a wide, non-flaky margin over
+        // scheduling jitter.
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(SleepingPack);
@@ -3520,11 +3510,10 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_unknown_verb_allowed_by_gate_still_persists_audit_row() {
-        // ADR-103 Stage 1: generalizing audit-row deferral to every
-        // Allow-outcome verb (not just singleton `link`) must not silently
-        // drop the audit row for a verb the gate allows but no pack owns.
-        // `duration_us` stays at the `Event::new` default of 0 here since no
-        // dispatch ever ran to measure.
+        // Generalizing audit-row deferral to every Allow-outcome verb (not
+        // just singleton `link`) must not silently drop the audit row for a
+        // verb the gate allows but no pack owns. `duration_us` stays at the
+        // `Event::new` default of 0 here since no dispatch ever ran to measure.
         let store = Arc::new(MemoryEventStore::default());
         let mut builder = VerbRegistryBuilder::new();
         builder.register(AlphaPack);
@@ -3550,9 +3539,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page.items[0].duration_us, 0);
-        // Review finding (issue #723 fix-round): dispatch returns
-        // InvalidInput for an unknown verb, so the persisted outcome must be
-        // Error, not the previously-hardcoded Success.
+        // Dispatch returns InvalidInput for an unknown verb, so the
+        // persisted outcome must be Error, not the previously-hardcoded
+        // Success.
         assert_eq!(page.items[0].outcome, EventOutcome::Error);
     }
 
@@ -3695,10 +3684,9 @@ mod tests {
 
     // ---- EventStore audit envelope round-trip ----
     //
-    // internal review finding (Major #1): EventStore was persisting a summary
-    // Event without the full AuditEvent fields (deny_reason, gate_impl,
-    // obligations). This test verifies the complete envelope survives
-    // append_event → query_events.
+    // EventStore must not persist a summary Event without the full
+    // AuditEvent fields (deny_reason, gate_impl, obligations). This test
+    // verifies the complete envelope survives append_event → query_events.
 
     #[tokio::test]
     async fn audit_envelope_round_trips_deny_reason_and_gate_impl_through_event_store() {
@@ -4120,7 +4108,7 @@ mod tests {
         );
     }
 
-    // #282: registry audit event must carry target_id when dispatch params include it.
+    // Registry audit event must carry target_id when dispatch params include it.
     #[tokio::test]
     async fn audit_event_threads_target_id_from_dispatch_args() {
         let store = Arc::new(MemoryEventStore::default());
@@ -4155,7 +4143,7 @@ mod tests {
         );
     }
 
-    // ---- #676: link-verb audit enrichment ----
+    // ---- Link-verb audit enrichment ----
 
     /// Test pack exposing a single `link` verb whose one-shot result is
     /// configured up front — lets tests drive both the success and failure
@@ -4335,9 +4323,8 @@ mod tests {
             ev.payload_schema_version, 1,
             "failed link keeps the v1 audit shape"
         );
-        // Review finding (issue #723 fix-round): the persisted outcome must
-        // reflect the dispatch result (Err → Error), not be hardcoded to
-        // Success from the gate's Allow decision.
+        // The persisted outcome must reflect the dispatch result (Err →
+        // Error), not be hardcoded to Success from the gate's Allow decision.
         assert_eq!(
             ev.outcome,
             EventOutcome::Error,
@@ -4818,7 +4805,7 @@ mod dep_tests {
     }
 }
 
-// ── Dispatch hook tests (Issue #158) ─────────────────────────────────────────
+// ── Dispatch hook tests ─────────────────────────────────────────
 
 #[cfg(test)]
 mod hook_tests {
@@ -5019,7 +5006,7 @@ mod hook_tests {
     }
 }
 
-// ── help=true tests (issue #287) ──────────────────────────────────────────────
+// ── help=true tests ──────────────────────────────────────────────
 
 #[cfg(test)]
 mod help_tests {
@@ -5092,8 +5079,8 @@ mod help_tests {
                 category: VerbCategory::Assertive,
                 params: &RECALL_PARAMS,
             },
-            // ue-help-introspection C1: a Subhandler used to test that
-            // help=true returns callable_via_mcp: false for internal verbs.
+            // A Subhandler used to test that help=true returns
+            // callable_via_mcp: false for internal verbs.
             HandlerDef {
                 name: "recall.embed",
                 description: "Return the embedding vector used by memory recall",
@@ -5253,7 +5240,7 @@ mod help_tests {
         );
     }
 
-    // ── ue-help-introspection C1 regressions ─────────────────────────────────
+    // ── Subhandler help-schema regressions ─────────────────────────────────
     //
     // Subhandler verbs must return `callable_via_mcp: false` in their help
     // schema so agents who read help=true before probing see accurate
@@ -5340,7 +5327,7 @@ mod help_tests {
             .await
             .expect("help=true on subhandler must succeed");
 
-        // params must always be present (H1: consistent shape).
+        // params must always be present (consistent shape).
         let params = result
             .get("params")
             .expect("subhandler help must include 'params' field");
@@ -5350,11 +5337,10 @@ mod help_tests {
         );
     }
 
-    // ── internal review High: unknown-verb error must not leak subhandler names ─────────
+    // ── Unknown-verb error must not leak subhandler names ─────────
 
     /// `describe_verb` on an unknown verb must list only Verb-visibility names
-    /// in the "available" list — never subhandler names like `recall.embed`
-    /// (internal review High — ue-help-introspection C1 / unknown-verb path).
+    /// in the "available" list — never subhandler names like `recall.embed`.
     #[tokio::test]
     async fn help_true_unknown_verb_available_list_excludes_subhandlers() {
         let reg = build_help_registry(Arc::new(AtomicUsize::new(0)));
@@ -5588,10 +5574,10 @@ mod help_tests {
         );
     }
 
-    // ADR-028 B-SHOULD-FIX-3: two packs declaring the same auxiliary table on
-    // the same backend must cause apply_schema_plans_with_map to return an
-    // error that names both packs and the table — it is a boot-time failure,
-    // not a silent DDL race.
+    // ADR-028: two packs declaring the same auxiliary table on the same
+    // backend must cause apply_schema_plans_with_map to return an error that
+    // names both packs and the table — it is a boot-time failure, not a
+    // silent DDL race.
     #[test]
     fn apply_schema_plans_with_map_collision_is_an_error() {
         let backend = khive_db::StorageBackend::memory().expect("memory backend");

--- a/crates/khive-runtime/src/portability.rs
+++ b/crates/khive-runtime/src/portability.rs
@@ -62,7 +62,7 @@ pub struct ExportedEdge {
     pub edge_id: Uuid,
     pub source: Uuid,
     pub target: Uuid,
-    /// One of the 15 canonical edge relations.
+    /// One of the canonical edge relations (closed enum).
     pub relation: EdgeRelation,
     pub weight: f64,
 }
@@ -91,7 +91,6 @@ impl KhiveRuntime {
     pub async fn export_kg(&self, token: &NamespaceToken) -> RuntimeResult<KgArchive> {
         let ns = token.namespace().as_str().to_owned();
 
-        // 1. Collect all entities in the namespace.
         let entity_page = self
             .entities(token)?
             .query_entities(
@@ -126,7 +125,6 @@ impl KhiveRuntime {
             })
             .collect();
 
-        // 2. Collect edges whose source is any entity in this namespace.
         let source_ids: Vec<Uuid> = entities.iter().map(|e| e.id).collect();
         let edges = if source_ids.is_empty() {
             Vec::new()
@@ -191,7 +189,6 @@ impl KhiveRuntime {
         archive: &KgArchive,
         token: &NamespaceToken,
     ) -> RuntimeResult<ImportSummary> {
-        // Format validation.
         if archive.format != "khive-kg" {
             return Err(RuntimeError::InvalidInput(format!(
                 "unsupported archive format {:?}; expected \"khive-kg\"",
@@ -207,7 +204,6 @@ impl KhiveRuntime {
 
         let ns = token.namespace().as_str().to_owned();
 
-        // Import entities — validate kind against pack registry.
         let store = self.entities(token)?;
         let mut entities_imported = 0usize;
         for ee in &archive.entities {
@@ -230,19 +226,14 @@ impl KhiveRuntime {
                 merge_event_id: None,
             };
             store.upsert_entity(entity.clone()).await?;
-            // Index into FTS5 (and vector store if a model is configured) so that
-            // imported entities are visible to hybrid_search immediately.
+            // Reindex so imported entities are searchable via hybrid_search immediately.
             self.reindex_entity(token, &entity).await?;
             entities_imported += 1;
         }
 
-        // Import edges — validate both endpoints before inserting.
-        //
-        // An untrusted archive may contain edges whose source or target UUIDs
-        // do not correspond to any entity in the target namespace. Inserting
-        // such edges would leave dangling references in the graph store. We
-        // therefore check each endpoint with `get_entity` (namespace-scoped,
-        // fail-closed) and skip any edge whose source or target is absent.
+        // Untrusted archives may reference entities absent from the target namespace;
+        // check both endpoints and skip edges with a missing source or target to avoid
+        // dangling references in the graph store.
         let graph = self.graph(token)?;
         let mut edges_imported = 0usize;
         let mut edges_skipped = 0usize;
@@ -317,9 +308,8 @@ impl KhiveRuntime {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-// INLINE TEST JUSTIFICATION: tests here exercise portability serialisation
-// helpers and byte-level round-trip invariants that access private encoding
-// functions. Moving them to tests/ would require pub-exporting those helpers.
+// Kept inline: these tests exercise round-trip invariants over private encoding
+// helpers that would otherwise need to be made pub to test from tests/.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -390,7 +380,6 @@ mod tests {
         assert_eq!(summary.entities_imported, 3);
         assert_eq!(summary.edges_imported, 2);
 
-        // Spot-check: the imported entity is retrievable.
         let got = dst.get_entity(&tok, e1.id).await.unwrap();
         assert_eq!(got.name, "FlashAttention");
         assert_eq!(got.description.as_deref(), Some("fast attention"));
@@ -451,21 +440,17 @@ mod tests {
         let archive = src.export_kg(&tok_a).await.unwrap();
         assert_eq!(archive.namespace, "a");
 
-        // Import into a fresh runtime, targeting namespace "b".
         let dst = make_rt().await;
         let summary = dst.import_kg(&archive, &tok_b).await.unwrap();
         assert_eq!(summary.entities_imported, 1);
 
-        // Entity is in "b" on the destination runtime.
         let in_b = dst.list_entities(&tok_b, None, None, 100, 0).await.unwrap();
         assert_eq!(in_b.len(), 1);
         assert_eq!(in_b[0].name, "Sinkhorn");
 
-        // Namespace "a" on the source runtime is unchanged.
         let in_a = src.list_entities(&tok_a, None, None, 100, 0).await.unwrap();
         assert_eq!(in_a.len(), 1);
 
-        // Namespace "a" on the destination runtime has nothing (only "b" was written).
         let dst_a = dst.list_entities(&tok_a, None, None, 100, 0).await.unwrap();
         assert_eq!(dst_a.len(), 0);
     }
@@ -532,7 +517,7 @@ mod tests {
         );
     }
 
-    // ── Dangling-edge validation tests (issue #28) ────────────────────────────
+    // ── Dangling-edge validation tests ────────────────────────────────────────
 
     /// 6. Edge with dangling source (source UUID not in entity table) is skipped.
     ///
@@ -544,13 +529,11 @@ mod tests {
 
         let rt = make_rt().await;
         let tok = NamespaceToken::local();
-        // Create an entity that will be the real target.
         let real = rt
             .create_entity(&tok, "concept", None, "Real", None, None, vec![])
             .await
             .unwrap();
 
-        // Build archive manually: one real entity, one edge with phantom source.
         let archive = KgArchive {
             format: "khive-kg".to_string(),
             version: "0.1".to_string(),
@@ -665,7 +648,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Build archive with 3 entities and 3 edges: 2 valid, 1 dangling.
         let archive = KgArchive {
             format: "khive-kg".to_string(),
             version: "0.1".to_string(),
@@ -707,7 +689,6 @@ mod tests {
                 },
             ],
             edges: vec![
-                // Valid: A → B
                 ExportedEdge {
                     edge_id: Uuid::new_v4(),
                     source: a.id,
@@ -715,7 +696,6 @@ mod tests {
                     relation: EdgeRelation::Extends,
                     weight: 1.0,
                 },
-                // Valid: B → C
                 ExportedEdge {
                     edge_id: Uuid::new_v4(),
                     source: b.id,
@@ -723,7 +703,6 @@ mod tests {
                     relation: EdgeRelation::DependsOn,
                     weight: 0.9,
                 },
-                // Dangling: A → phantom
                 ExportedEdge {
                     edge_id: Uuid::new_v4(),
                     source: a.id,
@@ -826,7 +805,6 @@ mod tests {
         let dst = make_rt().await;
         dst.import_kg(&archive, &tok).await.unwrap();
 
-        // The imported edge must carry the same UUID as the original.
         let imported_edge = dst.get_edge(&tok, original_id).await.unwrap();
         assert!(
             imported_edge.is_some(),
@@ -846,7 +824,6 @@ mod tests {
     ///     The fixture includes two entities so the edge is not skipped during import.
     #[tokio::test]
     async fn old_archive_missing_edge_id_round_trips() {
-        // Two entity UUIDs that will appear in both the fixture and the entity list.
         let src_id = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
         let tgt_id = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
 
@@ -872,7 +849,7 @@ mod tests {
             }}"#
         );
 
-        // Deserialize: serde(default) must assign a non-nil UUID.
+        // serde(default) must assign a fresh non-nil UUID when edge_id is absent.
         let archive: KgArchive = serde_json::from_str(&json)
             .expect("old archive without edge_id must deserialize successfully");
         assert_eq!(archive.edges.len(), 1);
@@ -883,7 +860,6 @@ mod tests {
             "missing edge_id in old archive must get a fresh non-nil UUID"
         );
 
-        // Import into a fresh runtime and verify the generated ID is persisted.
         let rt = make_rt().await;
         let tok = NamespaceToken::local();
         let summary = rt.import_kg(&archive, &tok).await.unwrap();
@@ -904,7 +880,6 @@ mod tests {
             "stored edge id must equal the generated edge_id"
         );
 
-        // Re-export and verify the same UUID appears in the archive.
         let re_archive = rt.export_kg(&tok).await.unwrap();
         assert_eq!(re_archive.edges.len(), 1);
         assert_eq!(
@@ -919,7 +894,6 @@ mod tests {
     ///     Verifies by (source, target, relation) key that re-export emits the original ID.
     #[tokio::test]
     async fn export_import_export_edge_id_equality() {
-        // Build a graph on the source runtime.
         let src = make_rt().await;
         let tok = NamespaceToken::local();
         let a = src
@@ -936,7 +910,6 @@ mod tests {
             .unwrap();
         let original_edge_id: Uuid = stored.id.into();
 
-        // First export.
         let archive1 = src.export_kg(&tok).await.unwrap();
         assert_eq!(archive1.edges.len(), 1);
         assert_eq!(
@@ -944,15 +917,12 @@ mod tests {
             "first export must carry the stored edge_id"
         );
 
-        // Import into a fresh runtime.
         let dst = make_rt().await;
         dst.import_kg(&archive1, &tok).await.unwrap();
 
-        // Second export from the destination runtime.
         let archive2 = dst.export_kg(&tok).await.unwrap();
         assert_eq!(archive2.edges.len(), 1);
 
-        // Find the edge by (source, target, relation) and assert the ID is unchanged.
         let re_edge = archive2
             .edges
             .iter()

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -62,7 +62,7 @@ pub fn render_format(value: Value, format: OutputFormat, presentation: Presentat
     match format {
         OutputFormat::Json => serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string()),
         OutputFormat::Auto | OutputFormat::Table => {
-            // Skip the redundancy-reduction pre-pass in Verbose mode — full
+            // Skip the redundancy-reduction pre-pass in Verbose mode: full
             // canonical shape must pass through unchanged.
             let reduced = if presentation == PresentationMode::Verbose {
                 value
@@ -176,7 +176,7 @@ fn render_table_forced(value: Value) -> String {
     if let Some((records, keys)) = find_record_array(&value) {
         return render_table(&records, &keys);
     }
-    // No record array detected — fall back to compact JSON.
+    // No record array detected: fall back to compact JSON.
     serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())
 }
 
@@ -809,7 +809,7 @@ mod tests {
         assert!((s - 1.0).abs() < 1e-9);
     }
 
-    // full_id must never be shortened in Agent mode — it's the caller's
+    // full_id must never be shortened in Agent mode: it's the caller's
     // stable chaining handle.
     #[test]
     fn agent_preserves_full_id_as_36_chars() {
@@ -1077,7 +1077,7 @@ mod tests {
     fn redundancy_drop_does_not_corrupt_error_shape() {
         let v = json!({"ok": false, "error": "something failed", "namespace": "local"});
         // apply_redundancy_drop is a pure value transform with no knowledge of
-        // `ok` — bypassing it for error envelopes is the caller's job
+        // `ok`: bypassing it for error envelopes is the caller's job
         // (render_result in server.rs). This only checks the pre-pass itself
         // doesn't lose the error field.
         let reduced = apply_redundancy_drop(v.clone());

--- a/crates/khive-runtime/src/presentation.rs
+++ b/crates/khive-runtime/src/presentation.rs
@@ -62,7 +62,8 @@ pub fn render_format(value: Value, format: OutputFormat, presentation: Presentat
     match format {
         OutputFormat::Json => serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string()),
         OutputFormat::Auto | OutputFormat::Table => {
-            // Redundancy-reduction pre-pass (§7): skipped in Verbose mode.
+            // Skip the redundancy-reduction pre-pass in Verbose mode — full
+            // canonical shape must pass through unchanged.
             let reduced = if presentation == PresentationMode::Verbose {
                 value
             } else {
@@ -105,16 +106,16 @@ fn drop_record(value: Value) -> Value {
         return value;
     };
 
-    // §7.1: suppress `full_id`.
+    // `full_id` is a chaining handle, not needed in view-only output.
     map.remove("full_id");
 
-    // §7.3: elide `namespace` when its value is `"local"`.
+    // `"local"` is the common case, so only surface `namespace` when it isn't.
     if map.get("namespace").and_then(Value::as_str) == Some("local") {
         map.remove("namespace");
     }
 
-    // §7.2: properties dedup — remove key-value pairs from `properties` that
-    // have an identical counterpart at the top level of this record.
+    // Properties dedup: drop key-value pairs from `properties` that
+    // duplicate an identical top-level sibling.
     let props_val = map.remove("properties");
     if let Some(Value::Object(props)) = props_val {
         let mut new_props = Map::new();
@@ -175,7 +176,7 @@ fn render_table_forced(value: Value) -> String {
     if let Some((records, keys)) = find_record_array(&value) {
         return render_table(&records, &keys);
     }
-    // No record array detected — fallback to compact JSON per §8.3.
+    // No record array detected — fall back to compact JSON.
     serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())
 }
 
@@ -229,7 +230,6 @@ fn collect_keys(records: &[Value]) -> Vec<String> {
 fn render_table(records: &[Value], keys: &[String]) -> String {
     let mut out = String::new();
 
-    // Header row.
     out.push('|');
     for k in keys {
         out.push(' ');
@@ -238,14 +238,12 @@ fn render_table(records: &[Value], keys: &[String]) -> String {
     }
     out.push('\n');
 
-    // Separator row.
     out.push('|');
     for _ in keys {
         out.push_str("---|");
     }
     out.push('\n');
 
-    // Data rows.
     for record in records {
         out.push('|');
         for k in keys {
@@ -393,7 +391,7 @@ const UUID_CANONICAL_LEN: usize = 36;
 /// Agent mode. Content-like fields are intentionally excluded even when their
 /// value happens to be UUID-shaped.
 ///
-/// `full_id` is explicitly excluded (P-C1): its purpose is to give callers a
+/// `full_id` is explicitly excluded: its purpose is to give callers a
 /// stable chaining handle, so shortening it makes it identical to `id` and
 /// defeats the field entirely.
 fn should_shorten_uuid_field(key: &str) -> bool {
@@ -434,7 +432,7 @@ pub fn present(value: Value, mode: PresentationMode, now_unix_seconds: i64) -> V
 ///
 /// `inside_properties` is `true` when recursing inside a `"properties"` object.
 /// Caller-supplied payload timestamps (e.g. `trigger_at`) must not be compacted
-/// because they encode domain semantics the agent may need to round-trip (#546).
+/// because they encode domain semantics the agent may need to round-trip.
 fn transform_agent(
     value: Value,
     lifecycle: &HashSet<&str>,
@@ -811,7 +809,8 @@ mod tests {
         assert!((s - 1.0).abs() < 1e-9);
     }
 
-    // P-C1 regression: full_id must never be shortened in Agent mode.
+    // full_id must never be shortened in Agent mode — it's the caller's
+    // stable chaining handle.
     #[test]
     fn agent_preserves_full_id_as_36_chars() {
         let uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
@@ -931,7 +930,7 @@ mod tests {
         });
         let rendered = render_format(v.clone(), OutputFormat::Json, PresentationMode::Agent);
         let parsed: Value = serde_json::from_str(&rendered).unwrap();
-        // full_id must NOT be dropped in json mode (§P-C1, §4).
+        // full_id must not be dropped in json mode.
         assert!(
             parsed.get("full_id").is_some(),
             "json mode must keep full_id"
@@ -965,7 +964,7 @@ mod tests {
             json_parsed.get("namespace").and_then(Value::as_str),
             Some("local")
         );
-        // Auto mode: namespace should be elided (redundancy §7.3), full_id dropped (§7.1).
+        // Auto mode elides namespace=local and drops full_id.
         // The value itself is a single record → rendered as kv block.
         assert!(
             !auto_rendered.contains("full_id"),
@@ -985,16 +984,13 @@ mod tests {
             {"id": "def", "title": "Second"}
         ]);
         let rendered = render_format(v, OutputFormat::Auto, PresentationMode::Agent);
-        // Header row.
         assert!(rendered.starts_with('|'), "must start with |");
         assert!(
             rendered.contains("| id |") || rendered.contains("| id"),
             "must have id column"
         );
         assert!(rendered.contains("title"), "must have title column");
-        // Separator row.
         assert!(rendered.contains("|---|"), "must have separator row");
-        // Data rows.
         assert!(rendered.contains("abc"), "must have first row data");
         assert!(rendered.contains("Second"), "must have second row data");
     }
@@ -1074,19 +1070,15 @@ mod tests {
         );
     }
 
-    /// (e) error envelope invariant: ok=false entries must stay compact json under auto.
-    ///
-    /// This tests the render_result logic via the redundancy-drop + render path.
-    /// The server-level render_result function is tested indirectly: we verify that
-    /// apply_redundancy_drop does NOT touch "ok: false" envelopes (the actual
-    /// invariant is enforced by render_result checking the ok flag before dispatching).
+    /// Indirect check that the redundancy pre-pass doesn't corrupt an error
+    /// envelope's shape; the actual ok=false bypass is enforced by
+    /// `render_result`, not by this pre-pass.
     #[test]
     fn redundancy_drop_does_not_corrupt_error_shape() {
-        // An error envelope that might be passed to the pre-pass in a batch.
         let v = json!({"ok": false, "error": "something failed", "namespace": "local"});
-        // apply_redundancy_drop is a pure value transform; it doesn't know about ok.
-        // The caller (render_result in server.rs) is responsible for bypassing
-        // auto-render on ok=false entries. Here we just verify the pre-pass
+        // apply_redundancy_drop is a pure value transform with no knowledge of
+        // `ok` — bypassing it for error envelopes is the caller's job
+        // (render_result in server.rs). This only checks the pre-pass itself
         // doesn't lose the error field.
         let reduced = apply_redundancy_drop(v.clone());
         assert!(
@@ -1140,7 +1132,7 @@ mod tests {
         );
     }
 
-    /// Cell truncation must not panic on multi-byte UTF-8 characters (High 3).
+    /// Cell truncation must not panic on multi-byte UTF-8 characters.
     ///
     /// A string of 119 ASCII bytes followed by a 3-byte CJK character and more
     /// text has `len() > 120` but byte index 120 falls inside the CJK char.
@@ -1169,7 +1161,7 @@ mod tests {
         );
     }
 
-    // --- parse_iso8601_unix / relative-time offset handling (#754) ---
+    // --- parse_iso8601_unix / relative-time offset handling ---
 
     #[test]
     fn parse_iso8601_unix_negative_offset_matches_equivalent_utc() {
@@ -1259,11 +1251,9 @@ mod tests {
 
     #[test]
     fn compact_timestamp_offset_bearing_future_time_not_shown_as_ago() {
-        // Regression for #754: a wall-clock-identical-to-NOW timestamp that
-        // carries a "-02:00" offset is actually 2h in the future relative to
-        // NOW (2025-05-23T16:08:00Z). The old offset-naive parser treated
-        // the wall-clock digits as UTC and reported "0s ago"; the fixed
-        // parser must not.
+        // A wall-clock-identical-to-NOW timestamp carrying a "-02:00" offset
+        // is actually 2h in the future; an offset-naive parser would misread
+        // the wall-clock digits as UTC and report "0s ago".
         let out = compact_timestamp("2025-05-23T16:08:00-02:00", NOW);
         assert_ne!(out, "0s ago");
         assert_eq!(out, "2025-05-23T16:08");

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -39,7 +39,7 @@ pub struct ReferenceCandidate {
 }
 
 /// Outcome of `resolve_reference`. Never a silent pick among close
-/// candidates — `Ambiguous` always lists what it found instead of guessing.
+/// candidates: `Ambiguous` always lists what it found instead of guessing.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReferenceResolution {
     Resolved { id: Uuid, confidence: f64 },
@@ -54,7 +54,7 @@ const RING_SUBSTRING_CONFIDENCE: f64 = 0.7;
 /// A single ring candidate auto-resolves only at or above this bar; below
 /// it the candidate is still surfaced as `Ambiguous` rather than silently
 /// accepted or dropped. Ring scores are fixed constants on a 0..1 scale, so
-/// a fixed bar is meaningful here — the search stage below needs a
+/// a fixed bar is meaningful here: the search stage below needs a
 /// different rule (`SEARCH_RESOLVED_CONFIDENCE`) because RRF scores aren't
 /// on that scale.
 const RING_AUTO_RESOLVE_CONFIDENCE: f64 = 0.7;
@@ -66,7 +66,7 @@ const RING_AUTO_RESOLVE_CONFIDENCE: f64 = 0.7;
 const SEARCH_MARGIN_RATIO: f64 = 2.0;
 /// Hybrid-search hits below this score never enter the candidate set at all.
 const SEARCH_SCORE_FLOOR: f64 = 0.0;
-/// Confidence reported on a search-stage `Resolved` outcome — not the raw
+/// Confidence reported on a search-stage `Resolved` outcome: not the raw
 /// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
 /// ~0.016-0.033) and would never clear a 0..1 confidence bar. Fixed below
 /// both ring bands so callers can tell "the ring recognized this" from
@@ -97,11 +97,11 @@ pub async fn resolve_reference(
 
     // Stage 1: id-string passthrough (UUID / 8+ hex prefix) via the existing
     // by-ID path. A ref shaped like an id but absent from storage is
-    // NotFound, not a fallthrough to ring/search — the caller named a
+    // NotFound, not a fallthrough to ring/search: the caller named a
     // specific id, so a miss there is the true answer. Scoped to entity ids
     // only (both full-UUID and prefix forms) to match the ring's entity-only
     // contract (`reference_ring::substrate_admits_as_entity`); a non-entity
-    // id-string is `NotFound` here — callers needing those already have `get`.
+    // id-string is `NotFound` here: callers needing those already have `get`.
     if let Ok(uuid) = Uuid::from_str(trimmed) {
         return match runtime.resolve_by_id(token, uuid).await? {
             Some(Resolved::Entity(_)) => Ok(ReferenceResolution::Resolved {

--- a/crates/khive-runtime/src/reference_resolution.rs
+++ b/crates/khive-runtime/src/reference_resolution.rs
@@ -39,8 +39,7 @@ pub struct ReferenceCandidate {
 }
 
 /// Outcome of `resolve_reference`. Never a silent pick among close
-/// candidates (F7 of the unified-verb draft ADR) — `Ambiguous` always lists
-/// what it found instead of guessing.
+/// candidates — `Ambiguous` always lists what it found instead of guessing.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReferenceResolution {
     Resolved { id: Uuid, confidence: f64 },
@@ -53,12 +52,11 @@ const RING_EXACT_CONFIDENCE: f64 = 0.95;
 /// Ring-match confidence for a substring match (either direction).
 const RING_SUBSTRING_CONFIDENCE: f64 = 0.7;
 /// A single ring candidate auto-resolves only at or above this bar; below
-/// it, the sole candidate is still surfaced, just as `Ambiguous` (never
-/// silently accepted, never silently dropped — see F7). Ring-stage only:
-/// ring scores are fixed constants on this same 0..1 scale
-/// (`RING_EXACT_CONFIDENCE` / `RING_SUBSTRING_CONFIDENCE`), so comparing them
-/// against a fixed bar is meaningful. The search stage below uses its own,
-/// deliberately separate rule — see `SEARCH_RESOLVED_CONFIDENCE`.
+/// it the candidate is still surfaced as `Ambiguous` rather than silently
+/// accepted or dropped. Ring scores are fixed constants on a 0..1 scale, so
+/// a fixed bar is meaningful here — the search stage below needs a
+/// different rule (`SEARCH_RESOLVED_CONFIDENCE`) because RRF scores aren't
+/// on that scale.
 const RING_AUTO_RESOLVE_CONFIDENCE: f64 = 0.7;
 /// Hybrid-search fallback: the top hit auto-resolves over a runner-up only
 /// when it leads by at least this ratio — RRF scores are not on a fixed
@@ -68,18 +66,12 @@ const RING_AUTO_RESOLVE_CONFIDENCE: f64 = 0.7;
 const SEARCH_MARGIN_RATIO: f64 = 2.0;
 /// Hybrid-search hits below this score never enter the candidate set at all.
 const SEARCH_SCORE_FLOOR: f64 = 0.0;
-/// Confidence reported on a search-stage `Resolved` outcome. NOT the raw RRF
-/// score — RRF is `sum 1/(k + rank)` (`khive-fusion::rrf`), so a rank-1
-/// single-source hit scores ~1/61 (~0.0164) and a strong two-source hit
-/// ~2/61 (~0.0328): comparing that against a 0..1 "confidence" bar the way
-/// the ring stage does would make the search fallback functionally never
-/// resolve (the bug this constant fixes). Instead, a lone hybrid-search
-/// candidate (nothing to be ambiguous against) or a decisive-margin winner
-/// (see `SEARCH_MARGIN_RATIO`) resolves at this fixed, documented
-/// search-stage confidence — deliberately below both ring bands, so callers
-/// can distinguish "the ring recognized this" from "search picked this out"
-/// by confidence alone. The raw RRF value is never discarded: it is exactly
-/// what `ReferenceCandidate.score` carries in `Ambiguous` listings.
+/// Confidence reported on a search-stage `Resolved` outcome — not the raw
+/// RRF score, which lives on a much smaller scale (`sum 1/(k + rank)`, e.g.
+/// ~0.016-0.033) and would never clear a 0..1 confidence bar. Fixed below
+/// both ring bands so callers can tell "the ring recognized this" from
+/// "search picked this out" by confidence alone; the raw RRF value is still
+/// preserved in `ReferenceCandidate.score` for `Ambiguous` listings.
 const SEARCH_RESOLVED_CONFIDENCE: f64 = 0.6;
 
 /// Resolve one natural-language reference for `token`'s actor.
@@ -103,20 +95,13 @@ pub async fn resolve_reference(
         return Ok(ReferenceResolution::NotFound);
     }
 
-    // Stage 1: id-string passthrough (UUID / 8+ hex prefix) — the existing
-    // by-ID path, never reimplemented. A ref shaped like an id but absent
-    // from storage is NotFound, not a fall-through to ring/search: the
-    // caller named a specific id, so a miss there is the true answer.
-    //
-    // Scope: entity ids only, both branches identically (review finding,
-    // 2026-07-09 fix round). `resolve_by_id` alone (entity + note) and
-    // `resolve_prefix_unfiltered` alone (entity + note + event + edge) used
-    // to disagree — a graph edge's full UUID returned `NotFound` while its
-    // short prefix resolved. The ring is entity-only by the same S1 contract
-    // (`reference_ring::substrate_admits_as_entity`), so id-string
-    // passthrough is narrowed to match: an edge or event id-string is
-    // `NotFound` here regardless of whether it arrived full or as a prefix.
-    // A caller that needs to resolve a non-entity id already has `get`.
+    // Stage 1: id-string passthrough (UUID / 8+ hex prefix) via the existing
+    // by-ID path. A ref shaped like an id but absent from storage is
+    // NotFound, not a fallthrough to ring/search — the caller named a
+    // specific id, so a miss there is the true answer. Scoped to entity ids
+    // only (both full-UUID and prefix forms) to match the ring's entity-only
+    // contract (`reference_ring::substrate_admits_as_entity`); a non-entity
+    // id-string is `NotFound` here — callers needing those already have `get`.
     if let Ok(uuid) = Uuid::from_str(trimmed) {
         return match runtime.resolve_by_id(token, uuid).await? {
             Some(Resolved::Entity(_)) => Ok(ReferenceResolution::Resolved {

--- a/crates/khive-runtime/src/reference_ring.rs
+++ b/crates/khive-runtime/src/reference_ring.rs
@@ -93,7 +93,7 @@ impl ReferenceRing {
     }
 
     /// Lock the shared state, recovering from mutex poisoning instead of
-    /// panicking — ring admission is best-effort cache maintenance and must
+    /// panicking: ring admission is best-effort cache maintenance and must
     /// never turn an unrelated panic into a failure for every future caller.
     fn lock_state(&self) -> std::sync::MutexGuard<'_, RingState> {
         match self.state.lock() {
@@ -123,7 +123,7 @@ impl ReferenceRing {
     /// Drop empty/aged-out outer-map keys, then if still over `max_outer_keys`
     /// evict the least-recently-touched surviving keys until back within
     /// budget. `exempt` (the key that triggered this admission) is never
-    /// evicted — admitting an id must never immediately evict its own ring.
+    /// evicted: admitting an id must never immediately evict its own ring.
     fn prune_outer_map(
         rings: &mut HashMap<RingKey, VecDeque<RingEntry>>,
         ttl: Duration,
@@ -178,11 +178,11 @@ impl ReferenceRing {
 
     /// Snapshot the live (non-stale) entries for `(namespace, actor)`,
     /// most-recently-touched first. Returns an empty vec for an unknown or
-    /// empty key — never an error, since a ring miss is always legitimate
+    /// empty key: never an error, since a ring miss is always legitimate
     /// (fresh session, restarted daemon, cross-actor query).
     ///
     /// Also runs `prune_outer_map` over the whole outer map, not just the
-    /// queried key — otherwise a daemon that only ever reads (never admits)
+    /// queried key: otherwise a daemon that only ever reads (never admits)
     /// would never prune any other actor's stale key.
     pub fn snapshot(&self, namespace: &str, actor: &str) -> Vec<RingEntry> {
         let now = Instant::now();
@@ -201,7 +201,7 @@ impl ReferenceRing {
 }
 
 /// Display name extracted from a dispatch result's `name` field. No fallback
-/// to a note's `content` — the ring only ever admits entities, and free text
+/// to a note's `content`: the ring only ever admits entities, and free text
 /// must never stand in for an entity's actual name.
 fn display_name(result: &Value) -> Option<String> {
     let name = result.get("name").and_then(Value::as_str)?;
@@ -225,14 +225,14 @@ fn is_entity_kind_value(v: &str) -> bool {
 /// handlers already return.
 ///
 /// - `edge`/`event` results carry an explicit top-level `"kind": "edge"` /
-///   `"kind": "event"` — never entities.
+///   `"kind": "event"`: never entities.
 /// - `create`/`get`/`update` return the raw storage record: entities always
 ///   serialize an `entity_type` key (even as `null`), notes always serialize
-///   a `content` key — the two shapes never overlap, so key presence alone
+///   a `content` key: the two shapes never overlap, so key presence alone
 ///   is a reliable substrate discriminator.
 /// - `delete` returns a synthetic `{deleted, id, kind}` summary carrying
 ///   neither field; its `kind` is the caller-supplied request param verbatim,
-///   which may be absent/ambiguous. Absent or ambiguous `kind` never admits —
+///   which may be absent/ambiguous. Absent or ambiguous `kind` never admits:
 ///   a delete admission is a nice-to-have, so skipping is always the safe
 ///   choice over guessing.
 fn substrate_admits_as_entity(obj: &serde_json::Map<String, Value>) -> bool {
@@ -257,7 +257,7 @@ fn substrate_admits_as_entity(obj: &serde_json::Map<String, Value>) -> bool {
 /// ring, from its already-serialized JSON `result` alone — no extra storage
 /// reads, so admission stays cheap on the Tier-1 latency budget.
 ///
-/// Only singleton by-id touches admit — `create`, `get`, `update`, `delete`,
+/// Only singleton by-id touches admit: `create`, `get`, `update`, `delete`,
 /// `merge`, and `link` (both endpoints). Bulk shapes (`items=[...]`,
 /// `links=[...]`) are identifiable by an `attempted` count in their response
 /// and are excluded: they name multiple ids, not the one-caller-named-id
@@ -285,7 +285,7 @@ pub(crate) fn ring_admissions_for(verb: &str, result: &Value) -> Vec<(Uuid, Opti
                 None => Vec::new(),
             }
         }
-        // merge is entity-only by construction — no substrate check needed;
+        // merge is entity-only by construction: no substrate check needed;
         // `MergeSummary` carries no `kind` field to check even if one were wanted.
         "merge" => match parse_id("kept_id") {
             Some(id) => vec![(id, None)],
@@ -342,7 +342,7 @@ mod tests {
     fn ring_admissions_for_note_result_is_empty() {
         let id = Uuid::new_v4();
         // Real note get/create/update responses carry `content`, never
-        // `entity_type` — the ring only ever admits entity ids.
+        // `entity_type`: the ring only ever admits entity ids.
         let result = json!({"id": id.to_string(), "name": "a note", "content": "body text"});
         assert!(ring_admissions_for("create", &result).is_empty());
         assert!(ring_admissions_for("get", &result).is_empty());
@@ -496,7 +496,7 @@ mod tests {
     }
 
     /// Regression: `snapshot` must sweep the whole outer map, not just the
-    /// queried key — otherwise a read-only daemon (one that only ever calls
+    /// queried key: otherwise a read-only daemon (one that only ever calls
     /// `snapshot`, never `admit`) never prunes any other actor's stale key.
     /// Two actors age out; only `actor:queried` is snapshotted, but
     /// `actor:other`'s stale key must be removed too.

--- a/crates/khive-runtime/src/reference_ring.rs
+++ b/crates/khive-runtime/src/reference_ring.rs
@@ -48,7 +48,7 @@ struct RingState {
     rings: HashMap<RingKey, VecDeque<RingEntry>>,
 }
 
-/// Daemon-warm, actor-scoped recently-referenced ring (ADR draft "unified-verb" Slice 1).
+/// Daemon-warm, actor-scoped recently-referenced ring.
 ///
 /// Privacy is structural: rings are keyed by `(namespace, actor)` and a
 /// snapshot for one actor never observes another actor's entries, even
@@ -93,13 +93,8 @@ impl ReferenceRing {
     }
 
     /// Lock the shared state, recovering from mutex poisoning instead of
-    /// panicking. Admission/lookup here is best-effort daemon-warm cache
-    /// maintenance riding on the back of an already-successful dispatch — a
-    /// panic in some unrelated ring-holding call must never turn a
-    /// successful op's return into a panic for every future caller. On
-    /// poison, log once at warn and take the inner (possibly
-    /// mid-mutation-but-structurally-valid, since std collections don't
-    /// leave torn state on panic) state and carry on.
+    /// panicking — ring admission is best-effort cache maintenance and must
+    /// never turn an unrelated panic into a failure for every future caller.
     fn lock_state(&self) -> std::sync::MutexGuard<'_, RingState> {
         match self.state.lock() {
             Ok(guard) => guard,
@@ -125,12 +120,10 @@ impl ReferenceRing {
         }
     }
 
-    /// Drop outer-map keys whose ring is empty or fully aged out, then, if
-    /// still over `max_outer_keys`, evict the globally least-recently-touched
-    /// surviving keys (by each key's newest entry) until back within budget.
-    /// `exempt` (the key that triggered this admission) is never evicted by
-    /// the budget pass — admitting an id must never immediately evict the
-    /// ring it was just admitted to.
+    /// Drop empty/aged-out outer-map keys, then if still over `max_outer_keys`
+    /// evict the least-recently-touched surviving keys until back within
+    /// budget. `exempt` (the key that triggered this admission) is never
+    /// evicted — admitting an id must never immediately evict its own ring.
     fn prune_outer_map(
         rings: &mut HashMap<RingKey, VecDeque<RingEntry>>,
         ttl: Duration,
@@ -160,11 +153,9 @@ impl ReferenceRing {
     /// Admit `id` into the `(namespace, actor)` ring, touching it to "now".
     ///
     /// Re-admitting an id already present moves it to the back (most-recent)
-    /// instead of duplicating the entry. Eviction is size-or-age: stale
-    /// entries are dropped first, then the oldest surviving entry is dropped
-    /// if the ring is still over capacity. The outer `(namespace, actor)` map
-    /// is pruned on every admission (see `prune_outer_map`) so a daemon
-    /// serving many transient actor ids never grows it without bound.
+    /// instead of duplicating the entry. Eviction is size-or-age, then the
+    /// outer map itself is pruned (see `prune_outer_map`) so it never grows
+    /// without bound.
     pub fn admit(&self, namespace: &str, actor: &str, id: Uuid, name: Option<String>) {
         let now = Instant::now();
         let mut state = self.lock_state();
@@ -187,16 +178,12 @@ impl ReferenceRing {
 
     /// Snapshot the live (non-stale) entries for `(namespace, actor)`,
     /// most-recently-touched first. Returns an empty vec for an unknown or
-    /// empty key — never an error, since a ring miss is always a legitimate
-    /// state (fresh session, restarted daemon, cross-actor query).
+    /// empty key — never an error, since a ring miss is always legitimate
+    /// (fresh session, restarted daemon, cross-actor query).
     ///
-    /// Also runs `prune_outer_map` over the WHOLE outer map, not just the
-    /// queried key (review r2 finding, 2026-07-09): a daemon that only ever
-    /// reads (never admits) would otherwise never prune any OTHER actor's
-    /// stale key — `admit` was the sole `prune_outer_map` call site, so a
-    /// read-only period left every unqueried stale key sitting in the map
-    /// forever. Snapshotting now sweeps the whole map on every read, same as
-    /// every write.
+    /// Also runs `prune_outer_map` over the whole outer map, not just the
+    /// queried key — otherwise a daemon that only ever reads (never admits)
+    /// would never prune any other actor's stale key.
     pub fn snapshot(&self, namespace: &str, actor: &str) -> Vec<RingEntry> {
         let now = Instant::now();
         let mut state = self.lock_state();
@@ -213,21 +200,17 @@ impl ReferenceRing {
     }
 }
 
-/// Display name extracted from a dispatch result's `name` field. S1's ring
-/// contract is entity ids only (see `substrate_admits_as_entity`), so there
-/// is no note-content fallback here — a note is never admitted in the first
-/// place, and using its `content` as a ring name would let free text stand
-/// in for an entity's actual name.
+/// Display name extracted from a dispatch result's `name` field. No fallback
+/// to a note's `content` — the ring only ever admits entities, and free text
+/// must never stand in for an entity's actual name.
 fn display_name(result: &Value) -> Option<String> {
     let name = result.get("name").and_then(Value::as_str)?;
     let trimmed = name.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-/// The nine closed entity kinds (ADR-001 base 8 + ADR-048 `resource`).
-/// Duplicated here (rather than depending on khive-pack-kg's vocab, which
-/// would invert the crate dependency direction) because this check only
-/// needs the closed set's membership, not the pack's full vocabulary.
+/// The nine closed entity kinds. Duplicated here rather than depending on
+/// khive-pack-kg's vocab, which would invert the crate dependency direction.
 const ENTITY_KINDS: [&str; 9] = [
     "concept", "document", "dataset", "project", "person", "org", "artifact", "service", "resource",
 ];
@@ -237,24 +220,21 @@ fn is_entity_kind_value(v: &str) -> bool {
 }
 
 /// Whether a `create`/`get`/`update`/`delete` result JSON denotes an entity
-/// (S1's ring contract: entity ids only, plus `link` endpoints — see module
-/// docs). No extra storage read: the discriminator is read off the shape
-/// khive-pack-kg's handlers already return.
+/// (the ring only ever admits entity ids, plus `link` endpoints). No extra
+/// storage read: the discriminator is read off the shape khive-pack-kg's
+/// handlers already return.
 ///
 /// - `edge`/`event` results carry an explicit top-level `"kind": "edge"` /
-///   `"kind": "event"` (injected by `flatten_get_result`) — never entities.
-/// - `create`/`get`/`update` on an entity or note return the raw storage
-///   record: entities always serialize an `entity_type` key (even as
-///   `null`), notes always serialize a `content` key — the two shapes never
-///   overlap, so key presence alone is a reliable substrate discriminator.
+///   `"kind": "event"` — never entities.
+/// - `create`/`get`/`update` return the raw storage record: entities always
+///   serialize an `entity_type` key (even as `null`), notes always serialize
+///   a `content` key — the two shapes never overlap, so key presence alone
+///   is a reliable substrate discriminator.
 /// - `delete` returns a synthetic `{deleted, id, kind}` summary carrying
-///   neither field; its `kind` is the caller-supplied request param verbatim
-///   (may be the generic `"entity"`/`"note"` keyword, a specific closed
-///   entity kind, a specific note kind, or absent/`null` when the caller let
-///   `delete` infer it). Absent or ambiguous `kind` never admits — a delete
-///   admission is a nice-to-have, not required for correctness, and S1's
-///   "never mutates, never guesses" bias makes skipping always the safe
-///   choice.
+///   neither field; its `kind` is the caller-supplied request param verbatim,
+///   which may be absent/ambiguous. Absent or ambiguous `kind` never admits —
+///   a delete admission is a nice-to-have, so skipping is always the safe
+///   choice over guessing.
 fn substrate_admits_as_entity(obj: &serde_json::Map<String, Value>) -> bool {
     if matches!(
         obj.get("kind").and_then(Value::as_str),
@@ -277,11 +257,10 @@ fn substrate_admits_as_entity(obj: &serde_json::Map<String, Value>) -> bool {
 /// ring, from its already-serialized JSON `result` alone — no extra storage
 /// reads, so admission stays cheap on the Tier-1 latency budget.
 ///
-/// Strict admission rule (gate condition, 2026-07-09): only singleton by-id
-/// touches admit — `create`, `get`, `update`, `delete`, `merge`, and `link`
-/// (both endpoints). Bulk shapes (`items=[...]`, `links=[...]`) are
-/// identifiable by an `attempted` count in their response and are excluded
-/// from S1's scope: they name multiple ids, not the one-caller-named-id
+/// Only singleton by-id touches admit — `create`, `get`, `update`, `delete`,
+/// `merge`, and `link` (both endpoints). Bulk shapes (`items=[...]`,
+/// `links=[...]`) are identifiable by an `attempted` count in their response
+/// and are excluded: they name multiple ids, not the one-caller-named-id
 /// semantic the ring exists to serve. `search`/`list` never reach this
 /// function — they are not in the verb match below.
 pub(crate) fn ring_admissions_for(verb: &str, result: &Value) -> Vec<(Uuid, Option<String>)> {
@@ -306,9 +285,8 @@ pub(crate) fn ring_admissions_for(verb: &str, result: &Value) -> Vec<(Uuid, Opti
                 None => Vec::new(),
             }
         }
-        // merge is entity-only by construction (v0.1 scope, ADR-046) — no
-        // substrate check needed; `MergeSummary` carries no `kind` field to
-        // check even if one were wanted.
+        // merge is entity-only by construction — no substrate check needed;
+        // `MergeSummary` carries no `kind` field to check even if one were wanted.
         "merge" => match parse_id("kept_id") {
             Some(id) => vec![(id, None)],
             None => Vec::new(),
@@ -364,7 +342,7 @@ mod tests {
     fn ring_admissions_for_note_result_is_empty() {
         let id = Uuid::new_v4();
         // Real note get/create/update responses carry `content`, never
-        // `entity_type` — S1's ring contract is entity ids only.
+        // `entity_type` — the ring only ever admits entity ids.
         let result = json!({"id": id.to_string(), "name": "a note", "content": "body text"});
         assert!(ring_admissions_for("create", &result).is_empty());
         assert!(ring_admissions_for("get", &result).is_empty());
@@ -517,12 +495,11 @@ mod tests {
         );
     }
 
-    /// Regression (review r2 finding, 2026-07-09): `snapshot` must sweep the
-    /// WHOLE outer map, not just the queried key — otherwise a read-only
-    /// daemon (one that only ever calls `snapshot`, never `admit`) never
-    /// prunes any OTHER actor's stale key at all. Two actors age out; only
-    /// `actor:queried` is snapshotted, but `actor:other`'s stale key must be
-    /// removed too.
+    /// Regression: `snapshot` must sweep the whole outer map, not just the
+    /// queried key — otherwise a read-only daemon (one that only ever calls
+    /// `snapshot`, never `admit`) never prunes any other actor's stale key.
+    /// Two actors age out; only `actor:queried` is snapshotted, but
+    /// `actor:other`'s stale key must be removed too.
     #[test]
     fn snapshot_prunes_other_stale_keys_it_did_not_query() {
         let ring = ReferenceRing::with_bounds(64, Duration::from_millis(20));
@@ -583,7 +560,7 @@ mod tests {
     /// A prior panic while holding the ring's mutex must never turn a
     /// later, unrelated `admit`/`snapshot` call into a panic too — admission
     /// is best-effort cache maintenance riding on an already-successful
-    /// dispatch (finding 4, 2026-07-09 fix round).
+    /// dispatch.
     #[test]
     fn admit_and_snapshot_recover_from_poisoned_mutex() {
         let ring = std::sync::Arc::new(ReferenceRing::new());

--- a/crates/khive-runtime/src/resource.rs
+++ b/crates/khive-runtime/src/resource.rs
@@ -37,8 +37,7 @@ pub fn process_resource_usage() -> Option<ProcessResourceUsage> {
     };
     let user_us = usage.ru_utime.tv_sec * 1_000_000 + i64::from(usage.ru_utime.tv_usec as i32);
     let sys_us = usage.ru_stime.tv_sec * 1_000_000 + i64::from(usage.ru_stime.tv_usec as i32);
-    // `ru_maxrss` is bytes on macOS/Darwin and KiB on Linux — the two
-    // platforms this fleet actually ships on (see CLAUDE.md toolchain rules).
+    // `ru_maxrss` is bytes on macOS/Darwin and KiB on Linux.
     let rss_bytes: i64 = if cfg!(target_os = "macos") {
         usage.ru_maxrss as i64
     } else {
@@ -59,15 +58,11 @@ pub fn process_resource_usage() -> Option<ProcessResourceUsage> {
 /// CPU time consumed strictly between two [`ProcessResourceUsage`] snapshots,
 /// in microseconds.
 ///
-/// Review finding (issue #723 fix-round): `cpu_us` on a snapshot is
-/// cumulative process CPU time since process start, not CPU consumed by any
-/// one phase. Callers that want a per-phase attribution must capture a
-/// snapshot at phase entry and another at phase exit and take the delta —
-/// this helper does that subtraction and floors at zero (via `saturating_sub`
-/// followed by `.max(0)`, since a plain `i64::saturating_sub` only guards
-/// against integer overflow/underflow, not against a negative *result* — a
-/// spurious (should-never-happen) decrease in cumulative CPU between two
-/// reads must never surface as a negative delta).
+/// `cpu_us` on a snapshot is cumulative process CPU time since process
+/// start, not CPU consumed by any one phase, so per-phase attribution needs
+/// the delta between an entry and exit snapshot. The result is floored at
+/// zero so a spurious (should-never-happen) decrease in cumulative CPU
+/// between two reads never surfaces as a negative delta.
 pub fn cpu_delta_us(
     start: Option<ProcessResourceUsage>,
     end: Option<ProcessResourceUsage>,
@@ -100,13 +95,10 @@ mod tests {
         );
     }
 
-    // Review finding (issue #723 fix-round): `cpu_delta_us` must report the
-    // difference between two snapshots, not either snapshot's raw
-    // (cumulative-since-process-start) value. This test uses synthetic
-    // snapshots rather than real `getrusage` reads so it fails deterministically
-    // if someone reverts the caller to reporting `end.cpu_us` directly —
-    // a huge cumulative value in `end` alone would otherwise pass a merely
-    // "non-negative" check.
+    // `cpu_delta_us` must report the difference between two snapshots, not
+    // either snapshot's raw cumulative value. Synthetic snapshots (rather
+    // than real `getrusage` reads) make this fail deterministically if the
+    // caller regresses to reporting `end.cpu_us` directly.
     #[test]
     fn cpu_delta_us_reports_the_difference_not_the_cumulative_end_value() {
         let start = ProcessResourceUsage {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -353,7 +353,7 @@ impl KhiveRuntime {
     /// Rationale: each namespace owns a separate FTS table (`fts_entities_{ns}`)
     /// and a separate ANN index instance. Cross-namespace entity-search fanout
     /// requires iterating over every visible namespace's store, issuing parallel
-    /// search requests, and fusing the results — this is deferred.
+    /// search requests, and fusing the results: this is deferred.
     ///
     /// Note: this is distinct from `memory.recall`'s cross-namespace fanout, which
     /// already iterates `visible_namespaces` across both the FTS and vector legs.
@@ -1373,7 +1373,7 @@ mod tests {
     ///     HAS "target-tag".
     ///
     /// Without predicate pushdown, `fused.truncate(1)` keeps only the decoy and the
-    /// tag-matching entity is invisible — this requires `tags_any` to be passed into
+    /// tag-matching entity is invisible: this requires `tags_any` to be passed into
     /// `query_entities`'s `EntityFilter` so the decoy is excluded before truncation.
     #[tokio::test]
     async fn hybrid_search_tag_filter_pushed_before_truncation() {

--- a/crates/khive-runtime/src/retrieval.rs
+++ b/crates/khive-runtime/src/retrieval.rs
@@ -16,21 +16,17 @@ use khive_storage::types::{
 use khive_storage::EntityFilter;
 use khive_types::SubstrateKind;
 
-// Fault-injection point for backfill reader errors. When set, the next
-// `backfill_missing_embeddings` call substitutes a `StorageError::Pool` for the
-// result of `sql.reader().await`, then resets to false. Available in test builds
-// and the `fault-injection` feature for integration testing.
+// Fault-injection flag for backfill reader errors (test / `fault-injection` builds only).
 #[cfg(any(test, feature = "fault-injection"))]
 std::thread_local! {
     static BACKFILL_READER_FAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// Arm the backfill reader fault injection. When set, the next call to
-/// `backfill_missing_embeddings` will substitute a `StorageError::Pool` for the
-/// result of `sql.reader().await`, then reset the flag. The injected error
-/// passes through `map_err(RuntimeError::Storage)?` — the same path as a real
-/// reader failure — so it exercises the fail-closed guard rather than bypassing it.
-/// Available when compiled with `cfg(test)` or `feature = "fault-injection"`.
+/// Arm the backfill reader fault injection: the next `backfill_missing_embeddings`
+/// call substitutes a `StorageError::Pool` for `sql.reader().await`'s result, then
+/// resets the flag. The injected error passes through the same
+/// `map_err(RuntimeError::Storage)?` path as a real reader failure, exercising the
+/// fail-closed guard rather than bypassing it.
 #[cfg(any(test, feature = "fault-injection"))]
 pub fn arm_backfill_reader_fail() {
     BACKFILL_READER_FAIL.with(|c| c.set(true));
@@ -56,11 +52,10 @@ pub enum SearchSource {
 
 /// RRF constant. Controls how strongly top ranks dominate.
 ///
-/// The original paper uses k=60 for large-scale document retrieval. For a knowledge
-/// graph with tens to thousands of entities, k=60 over-compresses scores into a
-/// narrow band (rank 1 ≈ 0.016, rank 10 ≈ 0.014, spread ≈ 0.002). k=10 produces
+/// The paper's k=60 over-compresses scores at KG scale (tens–thousands of
+/// entities): rank 1 ≈ 0.016, rank 10 ≈ 0.014, spread ≈ 0.002. k=10 gives
 /// rank 1 ≈ 0.091, rank 10 ≈ 0.050, spread ≈ 0.041 — 20× better discrimination,
-/// making dedup-before-create reliable at graph sizes of 50–2700 entities.
+/// which dedup-before-create needs at graph sizes of 50–2700 entities.
 const RRF_K: usize = 10;
 
 /// Candidates pulled per path before fusion. Higher = better recall, more work.
@@ -95,9 +90,6 @@ impl KhiveRuntime {
     ///
     /// Returns `UnknownModel` if `model_name` is not in the embedder registry.
     pub async fn embed_with_model(&self, model_name: &str, text: &str) -> RuntimeResult<Vec<f32>> {
-        // Try to resolve as a lattice alias. If that succeeds, use the enum to
-        // inform the service which model to run. If not, fall through to the
-        // custom-provider path — custom services ignore the EmbeddingModel arg.
         let model = parse_embedding_model_alias(model_name);
         let service = self.embedder(model_name).await?;
         let emb_model = model.unwrap_or_default();
@@ -352,9 +344,6 @@ impl KhiveRuntime {
     ///   superset of the given JSON object survive. Applied BEFORE truncation.
     ///
     /// `limit` caps the final returned list; internally pulls `limit * 4` candidates per path.
-    /// The fused candidate set is kept untruncated until after the alive + kind + tag +
-    /// properties filter so that matching hits ranked below `limit` in the raw fusion
-    /// still surface when higher-ranked candidates are excluded by any filter.
     ///
     /// # Cross-namespace visibility (entity search — primary namespace only; deferred)
     ///
@@ -364,13 +353,12 @@ impl KhiveRuntime {
     /// Rationale: each namespace owns a separate FTS table (`fts_entities_{ns}`)
     /// and a separate ANN index instance. Cross-namespace entity-search fanout
     /// requires iterating over every visible namespace's store, issuing parallel
-    /// search requests, and fusing the results — this is deferred (entity-search
-    /// cross-namespace fanout is the outstanding follow-up).
+    /// search requests, and fusing the results — this is deferred.
     ///
-    /// Note: this is distinct from memory recall's cross-namespace fanout, which
-    /// ships in ADR-007 Rev 4 (`memory.recall` iterates `visible_namespaces` across
-    /// both the FTS and vector legs). Entity search fanout is the remaining deferred
-    /// piece; memory recall fanout is not deferred.
+    /// Note: this is distinct from `memory.recall`'s cross-namespace fanout, which
+    /// already iterates `visible_namespaces` across both the FTS and vector legs.
+    /// Entity search fanout is the remaining deferred piece; memory recall fanout
+    /// is not deferred.
     ///
     /// The `visible_ns` list is forwarded in the `TextFilter.namespaces` field,
     /// which limits results to those namespaces within the primary store. Because
@@ -399,12 +387,9 @@ impl KhiveRuntime {
             .iter()
             .map(|ns| ns.as_str().to_owned())
             .collect();
-        // FTS5 parser syntax errors (#388, #389 round-2 High): sanitize_fts5_query
-        // already strips known-unsafe FTS5 metacharacters, but if the lexical
-        // leg still errors at runtime on residual punctuation the sanitizer
-        // does not strip, per #569 this now fails loud instead of degrading
-        // to vector-only fusion. Errors from any other leg (vector search,
-        // entity hydration) still propagate normally.
+        // sanitize_fts5_query strips known-unsafe FTS5 metacharacters up front, but if
+        // the lexical leg still errors at runtime on residual punctuation the sanitizer
+        // doesn't strip, this fails loud instead of degrading to vector-only fusion.
         let text_search_result = self
             .text(token)?
             .search(TextSearchRequest {
@@ -437,17 +422,13 @@ impl KhiveRuntime {
             Vec::new()
         };
 
-        // Fuse without truncating: keep the full candidate pool through the
-        // alive/kind/tag/property filter so matching hits below rank `limit`
-        // aren't lost when higher-ranked candidates are excluded.
+        // Keep the full candidate pool (untruncated) through the alive/kind/tag/property
+        // filter below, so matching hits ranked below `limit` in the raw fusion aren't
+        // lost when higher-ranked candidates get excluded by a filter.
         let mut fused = rrf_fuse(text_hits, vector_hits, candidates as usize, query_text);
 
-        // Filter to alive entities (and optionally to a specific kind, tags, or
-        // properties). A single query fetches all alive IDs that match the kind
-        // and tag constraints from the fused set; any ID absent has been
-        // soft-deleted or doesn't match. The SQL-level `tags_any` filter is
-        // pushed into `query_entities`; properties filtering (no SQL column)
-        // is applied at the Rust level using the entity records already fetched.
+        // tags_any has a SQL column and is pushed into query_entities; properties
+        // filtering has no SQL column and is applied in Rust below on the fetched records.
         if !fused.is_empty() {
             let candidate_ids: Vec<Uuid> = fused.iter().map(|h| h.entity_id).collect();
             let alive_page = self
@@ -468,13 +449,11 @@ impl KhiveRuntime {
                     },
                 )
                 .await?;
-            // Keep entity metadata to enrich hits that had no FTS5 title/snippet,
-            // and to apply the properties filter before truncation.
             let mut entity_meta: HashMap<Uuid, (String, Option<String>)> = HashMap::new();
             let mut alive: HashSet<Uuid> = HashSet::new();
             for e in alive_page.items {
-                // Apply properties predicate here — before adding to the alive set —
-                // so that non-matching candidates are dropped before truncation.
+                // Drop non-matching candidates here, before the alive set is built,
+                // so they're excluded ahead of truncation.
                 if let Some(pf) = properties_filter {
                     if !entity_props_match(e.properties.as_ref(), pf) {
                         continue;
@@ -591,13 +570,12 @@ impl KhiveRuntime {
         let mut total_backfilled = 0u64;
 
         for model_name in &model_names {
-            // Derive the vec table name from the model name (must match vec_model_key logic).
+            // Must match vec_model_key's naming logic.
             let vec_table = format!("vec_{}", sanitize_key(model_name));
 
             // --- Entities: embed description where no vector entry exists ---
-            // Loop until a batch returns fewer than PAGE_SIZE rows. Because the query uses
-            // NOT IN (SELECT subject_id FROM vec_table ...), each successfully inserted row is
-            // excluded from subsequent pages — no OFFSET needed.
+            // Each inserted row satisfies the NOT IN (SELECT subject_id FROM vec_table ...)
+            // clause going forward, so no OFFSET is needed between pages.
             const PAGE_SIZE: usize = 500;
             let mut entity_total = 0usize;
             loop {
@@ -714,9 +692,8 @@ impl KhiveRuntime {
             let note_store = self.notes(token).ok();
             let mut note_total = 0usize;
             loop {
-                // Select only the id here; the full Note is fetched below so that
-                // note_fts_document receives all fields (name, properties, updated_at)
-                // and produces a parity-correct document rather than a stripped one.
+                // Only the id is selected here; the full Note is fetched below so
+                // note_fts_document gets all fields and stays parity-correct.
                 let note_sql = SqlStatement {
                     sql: format!(
                         "SELECT id FROM notes \
@@ -772,9 +749,6 @@ impl KhiveRuntime {
                         continue;
                     };
 
-                    // Fetch the full Note so that note_fts_document has all fields
-                    // (name, properties, updated_at) — prevents overwriting a correct
-                    // FTS row with a stripped content-only document.
                     let note = match &note_store {
                         Some(store) => match store.get_note(id).await {
                             Ok(Some(n)) => n,
@@ -1288,7 +1262,7 @@ mod tests {
         assert_eq!(embeddings[0].len(), model.dimensions());
     }
 
-    // ---- hybrid_search enrichment (issue #147 / #160) ----
+    // ---- hybrid_search enrichment ----
 
     #[tokio::test]
     async fn hybrid_search_entity_hit_has_title() {
@@ -1320,13 +1294,10 @@ mod tests {
         );
     }
 
-    /// #388 regression: `hybrid_search` must not hard-fail on a query containing FTS5
-    /// metacharacters like `$` (e.g. the DSL doc query `$prev.id`). After this test was
-    /// first written, `sanitize_fts5_query` (khive-db) already strips `$`, so this alone
-    /// takes the `Ok` path and does not exercise the runtime-level fail-open `Err` arm
-    /// (PR #389 internal review round 1 Medium finding) — it stays as a sanitizer-path regression;
-    /// see `hybrid_search_with_residual_fts5_char_degrades_to_vector_only` below for the
-    /// fail-open-branch regression.
+    /// `hybrid_search` must not hard-fail on a query containing FTS5 metacharacters
+    /// like `$` (e.g. the DSL doc query `$prev.id`). `sanitize_fts5_query` (khive-db)
+    /// strips `$`, so this exercises the sanitizer path and takes the `Ok` arm; see
+    /// `hybrid_search_with_residual_fts5_char_fails_loud` below for the fail-loud arm.
     #[tokio::test]
     async fn hybrid_search_with_dollar_sign_query_does_not_error() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -1354,14 +1325,11 @@ mod tests {
         );
     }
 
-    /// #569 regression: unlike `$`, `@` is NOT stripped by `sanitize_fts5_query`
-    /// (by design — the sanitizer stays minimal per #388 scope). SQLite FTS5's
-    /// bareword parser still rejects `@` unconditionally, so this query reaches
-    /// the runtime-level `Err` arm in `hybrid_search`, which must now fail loud
-    /// (`RuntimeError::InvalidInput`) instead of silently degrading to
-    /// vector-only fusion as it did before #569. This assertion fails against
-    /// the pre-#569 fail-open behavior (which returned `Ok` here) and passes
-    /// once the FTS leg fails closed.
+    /// Unlike `$`, `@` is NOT stripped by `sanitize_fts5_query` (the sanitizer stays
+    /// minimal by design). SQLite FTS5's bareword parser still rejects `@`
+    /// unconditionally, so this query reaches the runtime-level `Err` arm in
+    /// `hybrid_search`, which must fail loud (`RuntimeError::InvalidInput`) instead
+    /// of silently degrading to vector-only fusion.
     #[tokio::test]
     async fn hybrid_search_with_residual_fts5_char_fails_loud() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -1394,9 +1362,9 @@ mod tests {
         );
     }
 
-    // ---- issue #225 regression: predicate pushdown before truncation ----
+    // ---- predicate pushdown before truncation ----
 
-    /// Regression test for issue #225 (entity branch).
+    /// Entity-branch tag-filter regression.
     ///
     /// Scenario: `limit=1`, tag_filter=["target-tag"]. Two entities are inserted:
     ///   - "decoy_alpha_beta_gamma": many query tokens → ranks 1 in FTS (dominates).
@@ -1404,14 +1372,9 @@ mod tests {
     ///   - "alpha_beta_gamma target": fewer query tokens → ranks 2 in FTS.
     ///     HAS "target-tag".
     ///
-    /// Without predicate pushdown: `fused.truncate(1)` keeps only the decoy. The
-    /// tag-matching entity is invisible. The test asserts the matching entity IS
-    /// returned — this assertion fails on the unfixed code (where tags_any is not
-    /// passed into `query_entities`) and passes after the fix.
-    ///
-    /// Isomorphism: reverting `tags_any: tags_any.to_vec()` in the `EntityFilter`
-    /// inside `hybrid_search` re-breaks this test (the decoy survives `retain` and
-    /// occupies the single slot, dropping the target).
+    /// Without predicate pushdown, `fused.truncate(1)` keeps only the decoy and the
+    /// tag-matching entity is invisible — this requires `tags_any` to be passed into
+    /// `query_entities`'s `EntityFilter` so the decoy is excluded before truncation.
     #[tokio::test]
     async fn hybrid_search_tag_filter_pushed_before_truncation() {
         let rt = KhiveRuntime::memory().unwrap();
@@ -1472,7 +1435,7 @@ mod tests {
         );
     }
 
-    /// Regression test for issue #225 (entity branch, properties predicate).
+    /// Entity-branch properties-filter regression (analogous to the tag-filter test above).
     ///
     /// Scenario: `limit=1`, properties_filter={{"domain": "target"}}. Two entities:
     ///   - decoy: high FTS rank, properties {{"domain": "other"}}.
@@ -1532,7 +1495,7 @@ mod tests {
         );
     }
 
-    // ---- embed intent tests (issue #93) ----
+    // ---- embed intent tests ----
 
     #[test]
     #[ignore = "loads ~80 MB model; run with --include-ignored"]
@@ -1604,7 +1567,7 @@ mod tests {
         );
     }
 
-    // ---- M-07 regression: backfill reader error must be propagated, not swallowed ----
+    // ---- backfill reader error must be propagated, not swallowed ----
 
     use crate::embedder_registry::EmbedderProvider;
     use lattice_embed::EmbeddingService;
@@ -1649,17 +1612,13 @@ mod tests {
         }
     }
 
-    /// Regression test for M-07: `backfill_missing_embeddings` must propagate a
-    /// reader error rather than treating it as "zero rows to embed" (silent swallow).
-    ///
-    /// Before the fix: `Err(_) => vec![]` caused the caller to receive `Ok(0)`,
-    /// silently skipping all embeddings. After the fix: the error is returned via `?`.
+    /// `backfill_missing_embeddings` must propagate a reader error rather than
+    /// treating it as "zero rows to embed" (a silent `Err(_) => vec![]` would
+    /// return `Ok(0)` and skip all embeddings without any signal).
     ///
     /// The fault injection substitutes a `StorageError::Pool` for the result of
-    /// `sql.reader().await` (i.e., the error originates AT the reader boundary, not
-    /// before it), so the test exercises the exact `map_err(RuntimeError::Storage)?`
-    /// lines that the fix introduced. Reverting those lines to `unwrap_or_default()`
-    /// would swallow the injected error and cause this test to fail.
+    /// `sql.reader().await`, exercising the `map_err(RuntimeError::Storage)?` path;
+    /// falling back to `unwrap_or_default()` there would swallow the injected error.
     #[tokio::test]
     async fn backfill_reader_error_is_propagated_not_swallowed() {
         let rt = KhiveRuntime::memory().unwrap();

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -34,7 +34,7 @@ pub type EntityTypeValidatorFn =
 /// after the mutation has been durably applied. Returns a boxed future so
 /// the hook can await async cache-invalidation work (e.g.
 /// `khive-pack-memory`'s ANN warm-cache generation bump) without
-/// `khive-runtime` depending on any pack crate — dependencies point the
+/// `khive-runtime` depending on any pack crate: dependencies point the
 /// other way, so the runtime exposes an extension point and the pack
 /// installs into it, same shape as `EntityTypeValidatorFn`, just async.
 pub type NoteMutationHookFn = Arc<
@@ -280,7 +280,7 @@ impl KhiveRuntime {
     /// Return the extra-visible namespaces assembled at config load.
     ///
     /// OSS dispatch uses this set to widen the default multi-record read scope
-    /// to `['local'] ∪ visible_namespaces`. Writes are unchanged — always
+    /// to `['local'] ∪ visible_namespaces`. Writes are unchanged: always
     /// pinned to `'local'`. This set is also available as gate/cloud policy
     /// input.
     pub fn visible_namespaces(&self) -> &[Namespace] {
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn runtime_config_from_khive_config_actor_id_does_not_override_default_namespace() {
-        // `[actor] id` must not set `default_namespace` — writes stay pinned to
+        // `[actor] id` must not set `default_namespace`: writes stay pinned to
         // `local`. A non-`'local'` actor.id is folded into the default read
         // visible-set, but that does not change default_namespace. This test
         // asserts the write-routing invariant only.

--- a/crates/khive-runtime/src/runtime.rs
+++ b/crates/khive-runtime/src/runtime.rs
@@ -19,9 +19,6 @@ use crate::config::{
 };
 use crate::error::{RuntimeError, RuntimeResult};
 
-/// Callback type for pack-installed entity-type validation (ADR-004).
-///
-/// `(kind, entity_type) → Ok(normalised_type | None)` or `InvalidInput`.
 /// Callback type for pack-installed entity-type validators.
 ///
 /// Receives `(kind, entity_type)` and returns the normalised type string,
@@ -30,18 +27,16 @@ use crate::error::{RuntimeError, RuntimeResult};
 pub type EntityTypeValidatorFn =
     Arc<dyn Fn(&str, Option<&str>) -> Result<Option<String>, RuntimeError> + Send + Sync>;
 
-/// Callback type for a pack-installed note-mutation hook (#750 fix-round 1).
+/// Callback type for a pack-installed note-mutation hook.
 ///
 /// Invoked by `update_note` (when the note's text/embedding actually
 /// changed) and `delete_note` (soft or hard) with `(note_kind, note_id)`,
-/// AFTER the mutation has been durably applied. Returns a boxed future so
+/// after the mutation has been durably applied. Returns a boxed future so
 /// the hook can await async cache-invalidation work (e.g.
-/// `khive-pack-memory`'s ANN warm-cache generation bump) without the
-/// `KhiveRuntime`/`khive-runtime` crate depending on any pack crate — the
-/// dependency points the other way (packs depend on `khive-runtime`, not
-/// vice versa), so this is the same "runtime exposes an extension point,
-/// pack installs into it" shape as `EntityTypeValidatorFn` /
-/// `install_edge_rules`, just async.
+/// `khive-pack-memory`'s ANN warm-cache generation bump) without
+/// `khive-runtime` depending on any pack crate — dependencies point the
+/// other way, so the runtime exposes an extension point and the pack
+/// installs into it, same shape as `EntityTypeValidatorFn`, just async.
 pub type NoteMutationHookFn = Arc<
     dyn Fn(String, uuid::Uuid) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
         + Send
@@ -88,14 +83,14 @@ pub struct KhiveRuntime {
     /// handler layer is the primary enforcement point.
     valid_entity_kinds: Arc<RwLock<Vec<String>>>,
     valid_note_kinds: Arc<RwLock<Vec<String>>>,
-    /// Pack-installed entity-type validator (ADR-004 §runtime-layer validation).
+    /// Pack-installed entity-type validator.
     ///
     /// When `Some`, `create_many` calls this function to validate and normalise
     /// each `(kind, entity_type)` pair before writing. When `None` (bare runtime
     /// without packs), entity-type validation is skipped — the pack handler layer
     /// is the primary enforcement point, same as for `valid_entity_kinds`.
     entity_type_validator: Arc<RwLock<Option<EntityTypeValidatorFn>>>,
-    /// Pack-installed note-mutation hook (#750 fix-round 1).
+    /// Pack-installed note-mutation hook.
     ///
     /// When `Some`, `update_note` (on text change) and `delete_note` (soft
     /// or hard) call this after the mutation is durably applied, so a pack
@@ -125,12 +120,8 @@ impl KhiveRuntime {
             }
             None => StorageBackend::memory()?,
         };
-        // Run versioned migrations (V1..V17) at startup so file-backed and
-        // in-memory DBs both have proposals_open (V15) and the embedding_model
-        // columns (V16/V17) before any pack handler runs.  Migration is
-        // idempotent — already-applied versions are skipped.  A failure here
-        // aborts construction so the caller sees a clear error rather than a
-        // cryptic "no such table" on the first verb dispatch.
+        // Migrations must run before any pack handler touches the DB; idempotent;
+        // failure aborts construction with a clear error.
         {
             let mut writer = backend.pool().try_writer()?;
             khive_db::run_migrations(writer.conn_mut())?;
@@ -288,10 +279,10 @@ impl KhiveRuntime {
 
     /// Return the extra-visible namespaces assembled at config load.
     ///
-    /// OSS dispatch uses this set to widen the DEFAULT multi-record read scope
-    /// to `['local'] ∪ visible_namespaces` (ADR-007 Rev 4 Rule 3b). Writes are
-    /// unchanged — always pinned to `'local'`. This set is also available as
-    /// gate/cloud policy input.
+    /// OSS dispatch uses this set to widen the default multi-record read scope
+    /// to `['local'] ∪ visible_namespaces`. Writes are unchanged — always
+    /// pinned to `'local'`. This set is also available as gate/cloud policy
+    /// input.
     pub fn visible_namespaces(&self) -> &[Namespace] {
         &self.config.visible_namespaces
     }
@@ -370,7 +361,6 @@ impl KhiveRuntime {
         token: &NamespaceToken,
         model_name: &str,
     ) -> RuntimeResult<Arc<dyn khive_storage::VectorStore>> {
-        // Try the lattice enum path first (handles aliases like "paraphrase").
         if let Some(model) = parse_embedding_model_alias(model_name) {
             // Only proceed via the lattice path if this model is actually in the
             // registry; otherwise fall through to the custom-provider path.
@@ -384,8 +374,6 @@ impl KhiveRuntime {
                 return self.vectors_for_embedding_model(token, model);
             }
         }
-        // Custom provider path: look up dimensions from the registry and build
-        // the vector store using the sanitized provider name as the table key.
         let dims = {
             let registry = self.embedder_registry.read().map_err(|_| {
                 crate::RuntimeError::Internal("embedder registry lock poisoned".into())
@@ -447,7 +435,7 @@ impl KhiveRuntime {
     /// to mint a token that can read additional namespaces.
     ///
     /// When `actor_id` is configured in `RuntimeConfig`, the token carries that
-    /// actor label so that `comm.inbox` filters by `to_actor` (ADR-057). When
+    /// actor label so that `comm.inbox` filters by `to_actor`. When
     /// unconfigured, the token carries `ActorRef::anonymous()` and inbox falls
     /// back to party-line behavior.
     pub fn authorize(&self, ns: Namespace) -> RuntimeResult<NamespaceToken> {
@@ -613,7 +601,7 @@ impl KhiveRuntime {
         }
     }
 
-    /// Install a pack-supplied entity-type validator (ADR-004 §runtime-layer validation).
+    /// Install a pack-supplied entity-type validator.
     ///
     /// Called by the `KgPack` during registration so that `create_many` can validate
     /// `entity_type` values at the runtime layer, closing the hole where direct Rust
@@ -646,7 +634,7 @@ impl KhiveRuntime {
         }
     }
 
-    /// Install a pack-owned note-mutation hook (#750 fix-round 1).
+    /// Install a pack-owned note-mutation hook.
     ///
     /// Overwrites any previously-installed hook, same single-slot semantics
     /// as [`install_entity_type_validator`](Self::install_entity_type_validator).
@@ -680,12 +668,12 @@ impl KhiveRuntime {
 
     /// Snapshot of currently-installed pack edge rules.
     ///
-    /// This is the SAME composed rule set `validate_edge_relation_endpoints`
-    /// consults via `pack_rule_allows` when accepting/rejecting an edge (issue
-    /// #543). Public so pack-layer error-hint code (e.g.
-    /// `khive-pack-kg`'s `valid_relations_for_entity_pair`) can derive hints
-    /// from the exact source the validator uses, rather than maintaining a
-    /// separate hand-authored table that can drift out of sync (issue #60).
+    /// This is the same composed rule set `validate_edge_relation_endpoints`
+    /// consults via `pack_rule_allows` when accepting/rejecting an edge. Public
+    /// so pack-layer error-hint code (e.g. `khive-pack-kg`'s
+    /// `valid_relations_for_entity_pair`) can derive hints from the exact
+    /// source the validator uses, rather than maintaining a separate
+    /// hand-authored table that can drift out of sync.
     pub fn pack_edge_rules(&self) -> Vec<EdgeEndpointRule> {
         self.edge_rules
             .read()
@@ -732,8 +720,7 @@ impl KhiveRuntime {
     /// Includes both built-in lattice models and any custom embedders
     /// registered by packs via [`register_embedder`](Self::register_embedder).
     /// Useful for operations that must touch every model's storage (e.g.,
-    /// scoped vector deletion on note delete — internal review High 2 (PR #407)).
-    /// The default model is included.
+    /// scoped vector deletion on note delete). The default model is included.
     pub fn registered_embedding_model_names(&self) -> Vec<String> {
         self.embedder_registry
             .read()
@@ -754,16 +741,14 @@ impl KhiveRuntime {
     /// First call for any name loads the underlying service (cold start cost);
     /// subsequent calls are cheap (registry caches the `Arc`).
     pub async fn embedder(&self, name: &str) -> RuntimeResult<Arc<dyn EmbeddingService>> {
-        // Try to resolve as a lattice alias first (normalises "paraphrase" →
-        // "paraphrase-multilingual-minilm-l12-v2", etc.).  If that succeeds,
-        // use the canonical key; otherwise fall back to the literal name so
-        // custom providers registered with non-lattice names are reachable.
+        // Fall back to the literal name (not the alias table) so custom
+        // providers registered with non-lattice names stay reachable.
         let canonical_key = match parse_embedding_model_alias(name) {
             Some(model) => model.to_string(),
             None => name.to_owned(),
         };
-        // Clone the entry before releasing the lock so we don't hold a
-        // RwLockGuard across the async OnceCell initialisation (Send bound).
+        // Clone the entry so we don't hold the RwLockGuard across the
+        // async OnceCell initialisation (Send bound).
         let entry = {
             let registry = self.embedder_registry.read().map_err(|_| {
                 crate::RuntimeError::Internal("embedder registry lock poisoned".into())
@@ -1148,10 +1133,10 @@ mod tests {
 
     #[test]
     fn runtime_config_from_khive_config_actor_id_does_not_override_default_namespace() {
-        // ADR-007 Rev 4 Rule 0: `[actor] id` must NOT set `default_namespace` —
-        // writes stay pinned to `local`. Note: a non-`'local'` actor.id IS folded
-        // into the default READ visible-set (Rule 3b), but that does not change
-        // default_namespace. This test asserts the write-routing invariant only.
+        // `[actor] id` must not set `default_namespace` — writes stay pinned to
+        // `local`. A non-`'local'` actor.id is folded into the default read
+        // visible-set, but that does not change default_namespace. This test
+        // asserts the write-routing invariant only.
         let base = RuntimeConfig {
             db_path: None,
             default_namespace: Namespace::local(),
@@ -1378,7 +1363,7 @@ mod tests {
 
     // ---- list_embedding_models tests ----
 
-    // ---- ADR-073: core_backend accessor tests ----
+    // ---- core_backend accessor tests ----
 
     /// Create a migrated in-memory backend (for tests that need raw Arc<StorageBackend>).
     fn migrated_memory_backend() -> Arc<StorageBackend> {
@@ -1449,7 +1434,7 @@ mod tests {
         );
     }
 
-    /// Decisive ADR-073 test: proves note→main and aux→secondary are each isolated.
+    /// Proves note→main and aux→secondary writes are each isolated.
     ///
     /// Backend A = main; backend B = secondary.
     /// rt_secondary is bound to B with core_backend = Some(A).
@@ -1464,7 +1449,6 @@ mod tests {
     async fn cross_backend_split_note_to_main_aux_to_secondary() {
         use khive_storage::{SqlStatement, SqlValue};
 
-        // Two independent in-memory SQLite databases.
         let main_arc = migrated_memory_backend();
         let secondary_arc = migrated_memory_backend();
 
@@ -1531,7 +1515,6 @@ mod tests {
 
         // ── Direction 2: aux write via rt_secondary.sql() lands in B, not A ──
 
-        // Create a test-only table in B and insert a sentinel row.
         {
             let mut writer = rt_secondary.sql().writer().await.expect("secondary writer");
             writer

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -1,4 +1,4 @@
-//! Write-time secret detection gate (issue #76).
+//! Write-time secret detection gate.
 //!
 //! Scans caller-supplied content strings before any storage write.  A match
 //! causes a hard `RuntimeError::SecretDetected` that names the detector and
@@ -27,11 +27,7 @@
 //! word in the surrounding window always dominates.** A UUID or a
 //! sha-prefixed content hash sitting directly beside "api_key"/"secret"/"auth"
 //! is exactly as ambiguous as any other high-entropy candidate and falls
-//! through to explicit detection instead of being silently allowed. A corpus
-//! replay of ~19k real notes and docs measured exactly one benign token newly
-//! blocked under this rule (an internal task UUID field incidentally
-//! co-occurring with the word "auth") — accepted as a small, traced tradeoff
-//! rather than leaving the allowlists unconditionally bypassable.
+//! through to explicit detection instead of being silently allowed.
 //! - Pure hex strings (sha256, git SHA) — passed when not near a trigger.
 //! - UUID canonical form (`xxxxxxxx-xxxx-…`) — passed when not near a trigger.
 //! - Base64/base64url content hashes with an explicit `sha<N>-` prefix (SRI
@@ -69,135 +65,65 @@
 //!   check and remains subject to the entropy heuristic below.
 //!
 //!   **This exemption applies ONLY outside an explicit credential trigger
-//!   context (round-4 decision).** Two narrower attempts to keep some form of
-//!   this exemption alive inside `near_trigger` context were tried and both
-//!   defeated: a trailing file-extension check (`.md`/`.rs`; internal review round 2
-//!   Critical — appending an extension to any random credential re-enabled
-//!   the exemption), and a dual-signal check requiring both a run-shape count
-//!   and an average per-run letters-only Shannon entropy below a threshold
-//!   (internal review round 3 Critical — an attacker who splits a credential into short
-//!   runs, or pads it with extra short/digit-bearing runs, drives the
-//!   reported entropy for every run toward `log2(run_len)`, which ordinary
-//!   short English path segments already sit at or near; e.g. a 9-char
-//!   all-distinct-letter run and the word `relations` are numerically
-//!   identical Shannon entropy). Because the attacker fully controls where
-//!   the token's separators fall, no aggregation (mean, max, or otherwise)
-//!   over per-run or whole-token letters-only entropy can be made sound —
-//!   the measure only sees a character-frequency histogram, never word
-//!   semantics, so it cannot be pinned to reject "chopped credential" while
-//!   admitting "real short word" at the same run length. Rather than ship
-//!   another attacker-suppliable signal, the exemption is dropped entirely in
-//!   trigger context: near a trigger word, a structured-identifier-shaped
-//!   token falls through to the entropy heuristic like any other token. This
-//!   is an accepted false-positive tradeoff on a small number of genuine
+//!   context.** Signals that measure Shannon entropy over an attacker-chosen
+//!   run boundary (e.g. requiring a trailing file extension, or an average
+//!   per-run letter entropy below a threshold) are not sound near a trigger
+//!   word: an attacker who controls where a credential's separators fall can
+//!   always choose run lengths whose entropy reads no higher than an ordinary
+//!   short English path segment, since the measure only sees a
+//!   character-frequency histogram, never word semantics. So near a trigger
+//!   word, a structured-identifier-shaped token gets no exemption at all and
+//!   falls through to the entropy heuristic like any other token. This is an
+//!   accepted false-positive tradeoff on a small number of genuine
 //!   paths/doc-slugs that happen to sit near a trigger word AND read above
 //!   the entropy threshold on their own — see
 //!   `accepted_false_positive_adr_draft_path_near_trigger` and its siblings
-//!   for the specific repro cases this now blocks, and the call site in
+//!   for the specific repro cases this blocks, and the call site in
 //!   `check_entropy_heuristic`.
 //!
-//! **Round 5 (issues #632 / #577 — trigger-word matching, not the exemption
-//! itself): measured, not assumed.** The round-4 accepted-FP class turned out
-//! to be systemic in practice: agents routinely cite file paths while
-//! discussing auth/secret/scanner topics, and a 26.6k-row production-corpus
-//! replay (real note content + entity descriptions) found the trigger check
-//! itself was over-broad in one specific, fixable way — `TRIGGER_WORDS` were
-//! matched as a plain substring, so `auth` fired inside `authorized` and
-//! `authentication`, `key` inside `monkey`/`keyword`, etc. This is a pure
-//! substring collision, distinct from a genuine (if topical) mention of the
-//! word, and is NOT attacker-relevant: it is a false match on prose that never
-//! mentions credentials, not a signal an adversary can weaponize by adding
-//! filler words near a real payload. Bare trigger words (`key`, `secret`,
-//! `password`, `passwd`, `credential`, `bearer`, `auth`, `apikey`) are now
-//! matched at a word boundary (`contains_bounded_word`) instead of a plain
-//! substring; the three compound entries that already embed an underscore
-//! (`api_key`, `access_key`, `private_key`) are unchanged (plain substring),
-//! since the underscore already disambiguates them and word-boundary matching
-//! would only weaken them (e.g. `secret_access_key` no longer needs the bare
+//! Trigger-word matching only fires on genuine mentions, not substring
+//! collisions: bare trigger words (`key`, `secret`, `password`, `passwd`,
+//! `credential`, `bearer`, `auth`, `apikey`) are matched at a word boundary
+//! (`contains_bounded_word`), so `auth` does not fire inside `authorized` or
+//! `authentication`, nor `key` inside `monkey`/`keyword`. The three compound
+//! entries that already embed an underscore (`api_key`, `access_key`,
+//! `private_key`) are matched as a plain substring instead, since the
+//! underscore already disambiguates them and word-boundary matching would
+//! only weaken them (e.g. `secret_access_key` no longer needs the bare
 //! `secret`/`key` matches once `access_key` fires on its own).
 //!
-//! This closes exactly the substring-collision false positive
-//! (`allows_internal_area_id_uuid_near_auth_substring_round5`, formerly
-//! `accepted_false_positive_internal_area_id_uuid_near_auth_substring`) and
-//! measurably reduced the production corpus block count from 29/26593 to
-//! 18/26601 in the same replay (~38% fewer blocks; the remaining blocks
-//! include genuine credentials — real `postgresql://user:pass@host` strings —
-//! plus the round-4 accepted-FP class that this round does NOT close: a
-//! structured-identifier-shaped token sitting near a **genuinely standalone**
-//! trigger word, e.g. `auth work saved at .../R1-repo-audit.md`, where `auth`
-//! is not a substring collision but an actual topical mention.
+//! A structured-identifier-shaped token sitting near a **genuinely standalone**
+//! trigger word (e.g. `auth work saved at .../repo-audit.md`, where `auth` is
+//! an actual topical mention rather than a substring collision) is an accepted
+//! false positive: no window-narrowing or exemption-widening scheme survives
+//! the adversarial regression corpus without also reopening a real bypass,
+//! because the caller (or an attacker) fully controls the prose between a
+//! trigger word and a payload — narrowing `TRIGGER_WINDOW` or reinstating the
+//! structured-identifier exemption near "bare" trigger mentions both fail the
+//! same known bypass strings that motivated closing them.
 //!
-//! Two other candidate directions were evaluated and REJECTED for the same
-//! reason as rounds 2–3: both are attacker-defeatable by inserting filler
-//! prose, which is exactly the failure mode the round-4 decision already
-//! ruled out for shape-based signals, and it applies identically here because
-//! the caller (or an attacker) fully controls the prose between a trigger
-//! word and a payload.
-//! - **Narrowing `TRIGGER_WINDOW` to reduce topical-prose false positives.**
-//!   Measured against every existing adversarial regression test:
-//!   round-1/2/3 bypass strings place the payload immediately adjacent to the
-//!   trigger word (0–1 byte gap: `secret_access_key <value>`, `token=<value>`),
-//!   while the accepted-FP repro paths sit only ~8–20 bytes away
-//!   (`api_key handling in <path>`, `key: see <path>`). No window cutoff
-//!   separates these classes without being trivially defeated by an attacker
-//!   inserting 1–2 filler words to push their payload just past whatever
-//!   narrower cutoff is chosen — the identical "attacker controls placement"
-//!   defeat as rounds 2–3, just measured in bytes-of-window instead of
-//!   run-shape. Window narrowing was not implemented.
-//! - **Reinstating the structured-identifier exemption for "bare"/topical
-//!   trigger mentions while keeping full strength only for assignment-shaped
-//!   triggers (`key=`, `secret:`).** This was checked against the round-1/3
-//!   bypass corpus directly: `secret_access_key abcdefghij/klmnopqrst/…` is
-//!   syntactically indistinguishable from `api_key handling in <path>` (both
-//!   are `TRIGGER_WORD <space> candidate-token`, no assignment operator
-//!   present), and the bypass payload independently decomposes into
-//!   `is_structured_identifier`-shaped runs — so this direction would have
-//!   silently re-opened the round-1/3 bypasses it was supposed to leave shut.
-//!   Not implemented.
+//! The caller-visible block message (`SecretMatch`'s `Display` impl) also
+//! carries actionable guidance (`block_guidance`) to split or reword the
+//! flagged token.
 //!
-//! The caller-visible block message (`SecretMatch`'s `Display` impl) now also
-//! carries actionable guidance (`block_guidance`) — split or reword the
-//! flagged token — regardless of which detector direction shipped, since this
-//! part carries no soundness risk.
-//!
-//! **Round 5b (recall regression caught in PR review — underscore boundary
-//! semantics): measured against both branches, not assumed.** Round 5's
-//! `contains_bounded_word` copied its boundary rule from the pre-existing
-//! `has_standalone_token` check, which treats underscore as a word character
-//! (a continuation, not a boundary) — a rule that makes sense for `token`
-//! specifically (see `has_standalone_token`'s own doc: it deliberately keeps
-//! `tokenizer`/`next_token`/`token_count` exempt). Applied to the bare
-//! `TRIGGER_WORDS` set, that same rule was wrong: it silently dropped
-//! detection of extremely common underscore-joined credential-config
-//! compounds that the pre-round-5 substring check (i.e. `main`) caught —
+//! The word-boundary rule above treats underscore as a BOUNDARY for bare
+//! `TRIGGER_WORDS` (`contains_bounded_word`) — deliberately different from
+//! `has_standalone_token`'s rule for the word `token`, which treats
+//! underscore as a continuation so `tokenizer`/`next_token`/`token_count`
+//! stay exempt. Treating underscore as a boundary for the bare set is what
+//! lets common underscore-joined credential-config compounds keep firing:
 //! `SECRET_KEY=...` (Django/Flask-style config), `auth_token=...`,
-//! `session_secret_...`, `signing_key=...` — because `secret`/`key`/`auth`
-//! were never bounded by the following/preceding `_` under that rule, and
-//! none of these are in `COMPOUND_TRIGGER_WORDS`. Confirmed empirically with
-//! probes run against both `main` and this branch before fixing: `main`
-//! blocks all four shapes via plain substring; the pre-round-5b branch state
-//! let all four pass.
+//! `session_secret_...`, `signing_key=...` all match on the `secret`/`key`/
+//! `auth` half even though none of them is in `COMPOUND_TRIGGER_WORDS`. This
+//! is implemented by parameterizing the boundary rule (`contains_word`'s
+//! `underscore_is_word_char` argument) rather than sharing one rule between
+//! the two callers.
 //!
-//! Fixed by parameterizing the boundary rule (`contains_word`'s
-//! `underscore_is_word_char` argument) instead of unifying it:
-//! `contains_bounded_word` (bare `TRIGGER_WORDS`) now treats `_` as a
-//! BOUNDARY — only ASCII alphanumerics count as continuations — which
-//! restores detection of the compounds above while leaving the round-5 win
-//! intact (`authorized`, `authentication`, `monkey`, `keyword` are
-//! letter-joined, not underscore-joined, so they are unaffected by this
-//! change). `has_standalone_token`'s underscore-is-continuation rule for
-//! `token` is deliberately left unchanged — that exemption was a prior,
-//! separate decision and is out of scope here. Regression tests:
-//! `blocks_django_style_secret_key_assignment_round5b`,
-//! `blocks_auth_token_assignment_round5b`,
-//! `blocks_session_secret_and_signing_key_compounds_round5b`,
-//! `allows_authorized_authentication_keyword_prose_unaffected_by_round5b`.
-//!
-//! Re-measured against the same 26.6k-row production corpus replay after this
-//! fix: see the harness's own output for current numbers (`corpus_replay`,
-//! `#[ignore]`d, run via `KHIVE_REPLAY_DB=<path> cargo test ... -- --ignored
-//! --nocapture`) — this doc intentionally does not restate a point-in-time
-//! count here to avoid it drifting from the harness as the corpus changes.
+//! A production-corpus replay harness (`corpus_replay`, `#[ignore]`d, run via
+//! `KHIVE_REPLAY_DB=<path> cargo test ... -- --ignored --nocapture`) measures
+//! the detector's block rate against real note/entity content; see the
+//! harness's own output for current numbers rather than a point-in-time count
+//! here, which would drift as the corpus changes.
 
 use crate::error::{RuntimeError, RuntimeResult};
 
@@ -228,8 +154,7 @@ impl std::fmt::Display for SecretMatch {
 }
 
 /// Actionable, caller-visible guidance for a hard block, keyed by detector
-/// name (candidate 3 from issue #577: cheap regardless of which detector
-/// change ships). If the content genuinely is a credential, remove it. If it
+/// name. If the content genuinely is a credential, remove it. If it
 /// is not — the common case for the detectors below, which key off SHAPE
 /// near a trigger word rather than a known credential prefix — the fix is to
 /// break up the flagged token so it no longer reads as one contiguous
@@ -866,34 +791,15 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
 
         // Structured identifiers (file paths, branch names, ADR/doc slugs,
         // snake_case identifiers) are exempted from the entropy check — see
-        // the module doc and `is_structured_identifier`. This must come after
-        // the UUID/content-hash allowlist and the hex-credential-token check
-        // above (neither of which it weakens) and before the entropy
-        // computation, since a legitimate path can exceed ENTROPY_THRESHOLD
-        // on Shannon entropy alone.
-        //
-        // Round-4 decision (internal review round 3 Critical): this exemption applies
-        // ONLY outside an explicit credential trigger context. Two prior
-        // attempts to narrow it for `near_trigger` instead of dropping it
-        // — a trailing file-extension check (round 1→2 bypass) and a
-        // dual-signal run-shape + average-per-run-letter-entropy check
-        // (round 2→3 bypass) — were both defeated, because every variant
-        // measured Shannon entropy over an attacker-CHOSEN run boundary, and
-        // entropy over a run of length `k` has a hard ceiling of `log2(k)`
-        // that ordinary short English words already sit at or near: a 9-char
-        // all-distinct-letter run (`relations`) and a 9-char chunk chopped
-        // out of a random credential are numerically IDENTICAL Shannon
-        // entropy, because the measure only sees the character-frequency
-        // histogram, never word semantics. An attacker who controls the
-        // token can always pick run lengths that drive per-run entropy at or
-        // below whatever a genuine short path segment reads at — no
-        // aggregation function (mean, max, or otherwise) over that
-        // attacker-chosen-boundary measure is sound. In trigger context,
-        // therefore, `is_structured_identifier` grants NO exemption: the
-        // token falls through to the entropy heuristic below unconditionally.
-        // This is an accepted false-positive tradeoff — see
-        // `accepted_false_positive_adr_draft_path_near_trigger` and its two
-        // sibling tests for the specific repro paths this now blocks.
+        // the module doc and `is_structured_identifier`. Must come after the
+        // UUID/content-hash and hex-credential-token checks above (neither of
+        // which it weakens) and before the entropy computation, since a
+        // legitimate path can exceed ENTROPY_THRESHOLD on Shannon entropy
+        // alone. The exemption applies ONLY outside trigger context — see the
+        // module doc for why no shape-based signal can be made sound near a
+        // trigger word; in trigger context this falls through to the entropy
+        // heuristic below unconditionally, an accepted false-positive
+        // tradeoff for genuine paths that happen to score high entropy.
         if !near_trigger && is_structured_identifier(token) {
             continue;
         }
@@ -969,8 +875,8 @@ fn contains_bounded_word(low_window: &str, needle: &str) -> bool {
 /// word, with underscore treated as a WORD CHARACTER / continuation (see
 /// [`contains_word`]) — but NOT as part of compound identifiers such as
 /// `tokenizer`, `token_count`, or `next_token`. This underscore-as-
-/// continuation rule is unchanged from before round 5 and deliberately
-/// different from [`contains_bounded_word`]: `token` alone is not a
+/// continuation rule is deliberately different from
+/// [`contains_bounded_word`]: `token` alone is not a
 /// credential trigger (it fires on too many benign technical terms), so it
 /// needs the narrower, underscore-inclusive standalone-word definition,
 /// whereas the bare `TRIGGER_WORDS` need underscore-joined compounds like
@@ -1136,8 +1042,8 @@ const MAX_CASE_TRANSITION_DENSITY: f64 = 0.3;
 ///
 /// Outside credential-trigger context this shape check alone is sufficient to
 /// exempt a token from the entropy heuristic. In trigger context the caller
-/// grants NO exemption at all — see the round-4 decision in the module doc
-/// comment and the call site in [`check_entropy_heuristic`].
+/// grants NO exemption at all — see the module doc and the call site in
+/// [`check_entropy_heuristic`].
 fn is_structured_identifier(token: &str) -> bool {
     if !token.contains(|c: char| STRUCTURAL_SEPARATORS.contains(&c)) {
         return false;
@@ -1729,7 +1635,7 @@ mod tests {
 
     #[test]
     fn known_prefix_secret_glued_after_cjk_is_still_flagged() {
-        // Round-2 regression: a Layer-1 known-prefix secret glued directly after
+        // A Layer-1 known-prefix secret glued directly after
         // CJK prose (no ASCII whitespace) was missed, because the prefix boundary
         // check used `is_alphanumeric` — which Rust counts true for CJK — so the
         // preceding ideograph was not treated as a delimiter.  These credentials
@@ -1750,7 +1656,7 @@ mod tests {
 
     #[test]
     fn url_userinfo_after_cjk_does_not_panic_and_is_flagged() {
-        // Round-3 regression: a credential URL glued after CJK prose panicked,
+        // A credential URL glued after CJK prose panicked,
         // because scheme_start was (separator byte index + 1) — one byte into a
         // multibyte CJK separator — and the slice fell on a non-char boundary.
         // The public check() API must return a controlled error, never panic.
@@ -1769,7 +1675,7 @@ mod tests {
 
     #[test]
     fn non_ascii_glued_token_trigger_is_still_flagged() {
-        // Round-4 regression: `token=`/`token:`/standalone `token` glued directly
+        // `token=`/`token:`/standalone `token` glued directly
         // after non-ASCII prose was missed because has_standalone_token /
         // has_token_assignment used is_alphanumeric for the word boundary — CJK,
         // accented letters, and fullwidth digits all count as alphanumeric in
@@ -2078,7 +1984,7 @@ mod tests {
         );
     }
 
-    // ── Finding 6: boundary-aware token= / token: — compound identifiers must pass ──
+    // ── Boundary-aware token= / token: — compound identifiers must pass ─────
 
     #[test]
     fn allows_next_token_high_entropy_cursor() {
@@ -2107,7 +2013,7 @@ mod tests {
         );
     }
 
-    // ── Finding 5: hex allowlist is not applied when trigger context is present ─
+    // ── Hex allowlist is not applied when trigger context is present ────────
     //
     // Pure hex strings have a theoretical maximum entropy of log2(16) = 4.0 bits/char,
     // which is below the ENTROPY_THRESHOLD of 4.5.  That means pure hex tokens cannot
@@ -2246,7 +2152,7 @@ mod tests {
         );
     }
 
-    // ── Finding 4: check_json scans object keys ───────────────────────────────
+    // ── check_json scans object keys ─────────────────────────────────────────
 
     #[test]
     fn check_json_blocks_secret_in_object_key() {
@@ -2494,8 +2400,8 @@ mod tests {
 
     #[test]
     fn mask_secrets_redacts_shapes_the_old_mirror_regex_missed() {
-        // These are exactly the detectors the session mirror's local regex did
-        // NOT cover — the Critical finding driving the move to this shared masker.
+        // These are exactly the detectors the session mirror's previous local
+        // regex did NOT cover, which is why it now shares this masker.
         let cases = [
             "key: sk-proj-FAKEKEY00000000000000000000000000000000", // gitleaks:allow
             "cred ASIAFAKEKEY00000000000",                          // gitleaks:allow
@@ -2568,11 +2474,9 @@ mod tests {
 
     #[test]
     fn github_app_token_families_are_masked() {
-        // review #368 round-2 [Critical]: ghu_ (user-to-server), ghs_
-        // (server-to-server), and ghr_ (refresh) GitHub App tokens are real
-        // credential families that previously bypassed the prefix detector and
-        // leaked through the mirror. They are context-free — no trigger word
-        // needed.
+        // ghu_ (user-to-server), ghs_ (server-to-server), and ghr_ (refresh)
+        // GitHub App tokens are real credential families. They are
+        // context-free — no trigger word needed.
         let cases = [
             "ghu_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // gitleaks:allow
             "ghs_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",  // gitleaks:allow
@@ -2598,7 +2502,7 @@ mod tests {
 
     #[test]
     fn mask_secrets_redacts_entropy_token_whose_trigger_is_left_of_earlier_secret() {
-        // review #368 round-2 [Critical]: the entropy detector only fires near a
+        // The entropy detector only fires near a
         // trigger word. When the trigger (`api_key`) sits to the LEFT of an
         // earlier known-prefix secret (`ghp_…`), a masker that rescans only the
         // suffix after each redaction loses that context and leaks the later
@@ -2628,26 +2532,19 @@ mod tests {
 
     // ── Structured-identifier exemption: file paths / branch names ──────────
     //
-    // Root cause (production false positives, 2026-07-01): the entropy
-    // heuristic tokenizes on whitespace, so a full file path is one long
-    // token; trigger detection is substring-based, so "auth"/"key" match
-    // inside ordinary words; and mixed-case+digit+punctuation paths
-    // legitimately exceed the Shannon-entropy threshold. The exemption
-    // originally applied in trigger context too, but round-4 (see the module
-    // doc comment) dropped it there entirely — no sound signal separates a
-    // real path from an attacker-chopped/padded credential once Shannon
-    // entropy is the only measure and the attacker controls run boundaries.
-    // The three cases below are accepted false positives post round-4: their
-    // own full-token entropy exceeds ENTROPY_THRESHOLD, so they now block
-    // near a trigger word (see `accepted_false_positive_*` for the
-    // authoritative "must block" assertions; kept here renamed to document
-    // the flip rather than silently deleted).
+    // The entropy heuristic tokenizes on whitespace, so a full file path is
+    // one long token, and mixed-case+digit+punctuation paths can legitimately
+    // exceed the Shannon-entropy threshold. The structured-identifier
+    // exemption does not apply in trigger context (see the module doc): no
+    // sound signal separates a real path from an attacker-chopped/padded
+    // credential once Shannon entropy is the only measure and the attacker
+    // controls run boundaries. The three cases below are accepted false
+    // positives: their own full-token entropy exceeds ENTROPY_THRESHOLD, so
+    // they block near a trigger word.
 
     #[test]
     fn blocks_file_path_near_secret_word_accepted_fp_round4() {
-        // Was `allows_file_path_near_secret_word` pre round-4 (structured-
-        // identifier exemption applied in trigger context). Full-token
-        // entropy 4.5994 > ENTROPY_THRESHOLD (4.5) — now an accepted FP.
+        // Full-token entropy 4.5994 > ENTROPY_THRESHOLD (4.5).
         let content =
             "workspace path fable-ops/ADR-DRAFT-adr079-slices234.md for the secret gate bug";
         assert!(
@@ -2660,8 +2557,7 @@ mod tests {
 
     #[test]
     fn blocks_workspace_path_near_key_word_accepted_fp_round4() {
-        // Was `allows_workspace_path_near_key_word` pre round-4. Full-token
-        // entropy 4.7938 > 4.5 — now an accepted FP.
+        // Full-token entropy 4.7938 > 4.5.
         let content = "key: see internal/workspaces/20260701/adr079-slices234/PACKET.md";
         assert!(
             check(content).is_err(),
@@ -2673,8 +2569,7 @@ mod tests {
 
     #[test]
     fn blocks_short_run_path_near_auth_word_accepted_fp_round4() {
-        // Was `allows_short_run_path_near_auth_word` pre round-4. Full-token
-        // entropy 4.5955 > 4.5 — now an accepted FP.
+        // Full-token entropy 4.5955 > 4.5.
         let content =
             "auth work saved at internal/workspaces/20260701/cloud-rebuild/R1-repo-audit.md";
         assert!(
@@ -2792,31 +2687,27 @@ mod tests {
         assert!(!is_structured_identifier(&token));
     }
 
-    // ── Round-4 decision: drop the structured-identifier exemption entirely
-    //    in trigger context (internal review round 3 Critical) ─────────────────────────
+    // ── Structured-identifier exemption drops entirely in trigger context ───
     //
-    // Two narrower fixes were tried in trigger context and both defeated:
-    //   round 1: required a trailing file-extension run       -> bypassed by
-    //            appending `.md`/`.rs` to any random credential (round-2).
-    //   round 2: required >= 2 path-shaped runs AND average
-    //            per-run letters-only entropy below a threshold -> bypassed
-    //            by padding with extra short/digit runs (dilutes the mean) or
-    //            by splitting the credential itself into short runs (drives
-    //            every run's own entropy toward its length ceiling,
-    //            log2(run_len), which real short path words already sit at)
-    //            (round-3).
-    // Root cause: Shannon entropy over an attacker-chosen run boundary cannot
+    // Narrower fixes that keep some exemption alive in trigger context (e.g.
+    // requiring a trailing file-extension run, or requiring >= 2 path-shaped
+    // runs with a low average per-run letters-only entropy) are all
+    // attacker-defeatable: a random credential can be extension-suffixed, or
+    // split/padded into short runs that drive each run's own entropy toward
+    // its length ceiling (log2(run_len)), which real short path words already
+    // sit at. Shannon entropy over an attacker-chosen run boundary cannot
     // distinguish "distinct letters that spell an English word" from
     // "distinct letters chosen adversarially" — both hit the same
-    // log2(length) ceiling. No aggregation is sound. The exemption is now
-    // dropped unconditionally in trigger context: a structured-identifier
-    // shaped token near a trigger word is entropy-checked like any other
-    // token, with 3 known false positives accepted (see
-    // `accepted_false_positive_*` below).
+    // log2(length) ceiling, so no aggregation is sound. The exemption is
+    // therefore dropped unconditionally in trigger context: a
+    // structured-identifier-shaped token near a trigger word is
+    // entropy-checked like any other token, with 3 known false positives
+    // accepted (see `accepted_false_positive_*` below).
 
     #[test]
     fn blocks_separator_secret_access_key_bypass() {
-        // The exact bypass string from the round-1 Critical finding.
+        // Adversarial bypass shape: an AWS-secret-key-like value split into
+        // separator-delimited word-shaped runs to dodge the entropy check.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk";
         assert!(
             check(content).is_err(),
@@ -2862,8 +2753,8 @@ mod tests {
 
     #[test]
     fn blocks_extension_suffix_bypass_secret_access_key() {
-        // The round-1 bypass string with `.md` appended — this is what
-        // slipped through the round-1 extension-based exemption.
+        // A file-extension check alone would exempt this — appending `.md`
+        // to a random credential must not bypass detection.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk.md";
         assert!(
             check(content).is_err(),
@@ -2914,12 +2805,10 @@ mod tests {
 
     #[test]
     fn blocks_round3_padding_run_bypass_attempts() {
-        // internal review round 3 Critical repro: a low-entropy padding run (`aaaa`)
-        // inserted before short/digit-shaped runs used to drag the round-2
-        // AVERAGE per-run letters-only entropy below its threshold while
-        // `has_low_entropy_run_signal` was satisfied by the trailing
-        // `R1`/extension runs. With the exemption dropped entirely, these
-        // must be blocked purely on full-token entropy, same as any other
+        // A low-entropy padding run (`aaaa`) inserted before short/digit-shaped
+        // runs would drag any AVERAGE per-run entropy signal below its
+        // threshold. With the exemption dropped entirely, these must be
+        // blocked purely on full-token entropy, same as any other
         // near-trigger high-entropy token.
         let cases = [
             "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk/aaaa/R1.md",
@@ -2938,14 +2827,12 @@ mod tests {
 
     #[test]
     fn blocks_run_splitting_bypass_attempts() {
-        // A further adversarial construction found while stress-testing the
-        // round-3 fix, proving the general
-        // unsoundness): splitting a credential into short (4-6 char) runs
-        // drives EVERY run's own letters-only entropy toward log2(run_len),
-        // which ordinary short English path words already sit at or near —
-        // this is exactly why round 3 (and any per-run entropy ceiling) is
-        // unfixable. With the exemption dropped, these are blocked on
-        // full-token entropy regardless of run shape.
+        // Splitting a credential into short (4-6 char) runs drives EVERY
+        // run's own letters-only entropy toward log2(run_len), which ordinary
+        // short English path words already sit at or near — this is exactly
+        // why any per-run entropy ceiling is unsound as an exemption signal.
+        // With the exemption dropped, these are blocked on full-token entropy
+        // regardless of run shape.
         let cases = [
             "secret_access_key abcd/efgh/ijkl/mnop/qrst/uvwx/yzab/cdef.md",
             "secret_access_key abcde/fghij/klmno/pqrst/uvwxy/zabcd.md",
@@ -2986,14 +2873,13 @@ mod tests {
 
     #[test]
     fn accepted_false_positive_adr_draft_path_near_trigger() {
-        // Round-4 accepted tradeoff: this path's full-token Shannon entropy
-        // (4.5994) exceeds ENTROPY_THRESHOLD (4.5) on its own. With the
+        // Accepted tradeoff: this path's full-token Shannon entropy (4.5994)
+        // exceeds ENTROPY_THRESHOLD (4.5) on its own. With the
         // structured-identifier exemption dropped in trigger context, it is
-        // now blocked near an explicit credential trigger word. This is a
-        // deliberate, documented false positive — not a regression to fix —
-        // per the round-4 decision that no sound signal exists to
-        // distinguish this from a chopped/padded credential of the same
-        // shape.
+        // blocked near an explicit credential trigger word — a deliberate,
+        // documented false positive, not a regression to fix, since no sound
+        // signal exists to distinguish this from a chopped/padded credential
+        // of the same shape.
         let content = "api_key handling in fable-ops/ADR-DRAFT-adr079-slices234.md";
         assert!(
             check(content).is_err(),
@@ -3087,17 +2973,14 @@ mod tests {
 
     #[test]
     fn allows_internal_area_id_uuid_near_auth_substring_round5() {
-        // Was `accepted_false_positive_internal_area_id_uuid_near_auth_substring`
-        // pre round-5 (measured corpus regression, 1 of ~19,300 real notes/docs
-        // replayed): an internal task `area_id` UUID field sitting within the
-        // trigger window of the SUBSTRING "auth" inside
-        // `authorized_write_requires_dominance` — not a genuine mention of the
-        // word "auth" at all, a pure substring collision with "authorized".
-        // Round-5 (see the module doc and `contains_bounded_word`) requires
-        // bare trigger words to match at a word boundary; `auth` no longer
-        // matches inside `authorized`, so this UUID has no trigger in its
-        // window and passes via the ordinary out-of-context UUID allowlist.
-        // This is the fix for issue #577's root cause, not a new tradeoff.
+        // An internal task `area_id` UUID field sitting within the trigger
+        // window of the SUBSTRING "auth" inside
+        // `authorized_write_requires_dominance` is not a genuine mention of
+        // the word "auth" — it is a pure substring collision with
+        // "authorized". Bare trigger words match at a word boundary (see
+        // `contains_bounded_word`), so `auth` does not match inside
+        // `authorized`; this UUID has no trigger in its window and passes via
+        // the ordinary out-of-context UUID allowlist.
         let content = "area_id: cfcea31d-6f50-4fd1-ad6d-5f160de1694c\n\n## Problem\nReduce Lion microkernel axioms. Converted authorized_write_requires_dominance from axiom to theorem.";
         assert!(
             check(content).is_ok(),
@@ -3296,12 +3179,12 @@ mod tests {
 
     #[test]
     fn allows_benign_url_with_scheme_and_path_separators() {
-        // Adversarial self-check (internal review round 8 guidance): any-suffix
-        // semantics must not newly block ordinary URLs, whose `://` and
-        // `/` characters produce several suffix candidates but none of
-        // them are UUID- or content-hash-shaped. Placed near a real
-        // trigger word ("key") so the check actually exercises the
-        // trigger-context path rather than being skipped outright.
+        // `value_candidates`'s any-suffix semantics must not block ordinary
+        // URLs, whose `://` and `/` characters produce several suffix
+        // candidates but none of them are UUID- or content-hash-shaped.
+        // Placed near a real trigger word ("key") so the check actually
+        // exercises the trigger-context path rather than being skipped
+        // outright.
         let content = "api_key endpoint=https://example.test/resource/for/testing";
         assert!(
             check(content).is_ok(),
@@ -3310,7 +3193,7 @@ mod tests {
         );
     }
 
-    // ── Round 5 (issues #632 / #577): trigger word-boundary matching ────────
+    // ── Trigger word-boundary matching ──────────────────────────────────────
 
     #[test]
     fn allows_authorized_and_authentication_prose_near_uuid() {
@@ -3352,8 +3235,8 @@ mod tests {
 
     #[test]
     fn blocks_standalone_auth_and_key_words_unchanged_by_round5() {
-        // Round 5 only removes SUBSTRING collisions; a genuine standalone
-        // trigger word must still dominate exactly as before.
+        // Word-boundary matching only removes SUBSTRING collisions; a genuine
+        // standalone trigger word must still dominate exactly as before.
         let opaque = "Xk9mZ2vQpLrT8nJwYuAeHfBsDcGiONvMabcdef"; // gitleaks:allow
         let cases = [
             format!("auth header {opaque}"),
@@ -3372,14 +3255,13 @@ mod tests {
 
     #[test]
     fn accepted_false_positive_workspace_artifact_path_near_standalone_secret_round5() {
-        // Repro shape from issue #632: a dot-prefixed root + date segment +
-        // hyphenated topic dir + SCREAMING_SNAKE filename, discussed in
-        // prose that genuinely (not by substring collision) mentions
-        // "secret". Round 5 does not change this: `secret` here is a real
+        // A dot-prefixed root + date segment + hyphenated topic dir +
+        // SCREAMING_SNAKE filename, discussed in prose that genuinely (not by
+        // substring collision) mentions "secret". `secret` here is a real
         // standalone word, not a substring collision, so it still dominates
         // and the path still falls through to the entropy heuristic like any
-        // other near-trigger token. Documented as a still-accepted tradeoff,
-        // not a regression.
+        // other near-trigger token. A documented accepted tradeoff, not a
+        // regression.
         let content = "writing up the secret gate false positive repro: \
              .workspace/20260101/fix-secret-gate-trigger-false-positive/MEASUREMENT_REPORT.md";
         assert!(
@@ -3392,8 +3274,8 @@ mod tests {
 
     #[test]
     fn accepted_false_positive_archive_doc_path_near_standalone_secret_round5() {
-        // Repro shape from issue #577 case 1: a docs/_archive-style path
-        // discussed near a genuine standalone "secret" mention.
+        // An archive-style doc path discussed near a genuine standalone
+        // "secret" mention.
         let content =
             "secret scanner archive notes: docs/_archive/ADR051-TenantEncryption-v2Notes.md";
         assert!(
@@ -3406,9 +3288,9 @@ mod tests {
 
     #[test]
     fn accepted_false_positive_absolute_path_near_standalone_auth_round5() {
-        // Repro shape from issue #577 case 3: an absolute path written as one
-        // unbroken token, with the surrounding message genuinely (not via
-        // substring collision) discussing "auth".
+        // An absolute path written as one unbroken token, with the
+        // surrounding message genuinely (not via substring collision)
+        // discussing "auth".
         let content = "the auth scanner flagged this file: /home/user/projects/workspace/SessionNotes20260107/AuthGateFollowup2.md";
         assert!(
             check(content).is_err(),
@@ -3420,14 +3302,13 @@ mod tests {
 
     #[test]
     fn blocks_assignment_shaped_credential_disguised_as_path_near_api_key() {
-        // Adversarial negative (must NOT be newly exempted by round 5): a
-        // credential-shaped value glued via '=' directly to a trigger word,
-        // even though it is path-shaped (separator-delimited, word-shaped
-        // runs) and looks superficially like the accepted-FP repro paths
-        // above. The compound entry `api_key` is unaffected by the
-        // word-boundary change (still a plain substring match), and the
-        // structured-identifier exemption is still unconditionally dropped in
-        // trigger context (round 4), so this must still block.
+        // Adversarial negative: a credential-shaped value glued via '='
+        // directly to a trigger word must not be exempted just because it is
+        // path-shaped (separator-delimited, word-shaped runs) and looks
+        // superficially like the accepted-FP repro paths above. The compound
+        // entry `api_key` is a plain substring match regardless of
+        // word-boundary rules, and the structured-identifier exemption is
+        // unconditionally dropped in trigger context, so this must block.
         let content = "api_key=/home/user/workspaces/2026/topic-name-example/SECRET_VALUE_HERE.md";
         assert!(
             check(content).is_err(),
@@ -3439,15 +3320,15 @@ mod tests {
 
     #[test]
     fn blocks_secret_access_key_bypass_compound_entry_unaffected_by_round5() {
-        // Adversarial negative: the round-1/3 bypass must still be blocked
-        // post round-5b. It now fires via TWO independent paths: the
-        // compound `access_key` entry (`COMPOUND_TRIGGER_WORDS`, plain
-        // substring, always matched regardless of word-boundary rules), AND
-        // the bare `secret` entry, because round-5b treats underscore as a
-        // BOUNDARY for bare `TRIGGER_WORDS` — so `secret` in
-        // `secret_access_key` is itself a bounded word (bounded by the
-        // following `_`), not merely a substring collision. Either path
-        // alone is sufficient; this asserts the end-to-end outcome.
+        // Adversarial negative: a separator-split bypass shape must still be
+        // blocked. It fires via TWO independent paths: the compound
+        // `access_key` entry (`COMPOUND_TRIGGER_WORDS`, plain substring,
+        // always matched regardless of word-boundary rules), AND the bare
+        // `secret` entry, because underscore is a BOUNDARY for bare
+        // `TRIGGER_WORDS` — so `secret` in `secret_access_key` is itself a
+        // bounded word (bounded by the following `_`), not merely a
+        // substring collision. Either path alone is sufficient; this asserts
+        // the end-to-end outcome.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk.md";
         assert!(
             check(content).is_err(),
@@ -3457,28 +3338,26 @@ mod tests {
         );
     }
 
-    // ── Round 5b (recall regression vs main): underscore is a BOUNDARY for
-    //    bare TRIGGER_WORDS, not a continuation ─────────────────────────────
+    // ── Underscore is a BOUNDARY for bare TRIGGER_WORDS, not a continuation ─
     //
-    // Round 5 (above) made bare TRIGGER_WORDS word-boundary-aware but treated
-    // underscore as a word character (continuation), matching
-    // `has_standalone_token`'s existing rule for `token`. That was wrong for
-    // the bare credential words: it silently dropped detection of extremely
-    // common underscore-joined credential-config compounds that main caught
-    // via plain substring (`SECRET_KEY=`, `auth_token=`, `signing_key=`,
-    // `session_secret_...`), because `secret`/`key`/`auth` were never bounded
-    // by `_` under that rule. Fixed by treating `_` as a boundary for the
-    // bare `TRIGGER_WORDS` check specifically (see `contains_word`'s
+    // Bare TRIGGER_WORDS are word-boundary-aware, but underscore must be
+    // treated as a boundary rather than a word character (continuation) for
+    // this set specifically — the opposite of `has_standalone_token`'s rule
+    // for `token`. Treating underscore as a continuation would silently drop
+    // detection of extremely common underscore-joined credential-config
+    // compounds (`SECRET_KEY=`, `auth_token=`, `signing_key=`,
+    // `session_secret_...`), since `secret`/`key`/`auth` would never be
+    // bounded by `_` under that rule. Fixed by treating `_` as a boundary for
+    // the bare `TRIGGER_WORDS` check specifically (see `contains_word`'s
     // `underscore_is_word_char` parameter), while leaving
     // `has_standalone_token`'s `token`-specific underscore-as-continuation
     // rule (the `tokenizer`/`next_token`/`token_count` exemption) unchanged.
 
     #[test]
     fn blocks_django_style_secret_key_assignment_round5b() {
-        // Regression found in PR review: on main, `SECRET_KEY=<value>` blocks
-        // via the plain-substring `secret` trigger. Round 5's word-boundary
-        // change (with underscore as a continuation) silently dropped this,
-        // since `secret` is followed by `_`, not a boundary under that rule.
+        // `SECRET_KEY=<value>` must block via the plain-substring `secret`
+        // trigger even though `secret` is followed by `_` rather than a
+        // non-word-char boundary.
         let content = "SECRET_KEY=dGhpc2lzYXNlY3JldGtleXZhbHVlMTIzNDU2Nzg5MA=="; // gitleaks:allow
         assert!(
             check(content).is_err(),
@@ -3518,9 +3397,9 @@ mod tests {
 
     #[test]
     fn allows_authorized_authentication_keyword_prose_unaffected_by_round5b() {
-        // The round-5 win (letter-joined substring collisions) must survive
-        // round-5b's underscore-as-boundary change, since that change only
-        // affects the underscore character, not letter-joined words.
+        // The letter-joined substring-collision exemption must survive the
+        // underscore-as-boundary change, since that change only affects the
+        // underscore character, not letter-joined words.
         let cases = [
             "authorized_write_requires_dominance was converted from axiom to theorem, id 550e8400-e29b-41d4-a716-446655440000",
             "authentication flow diagram lives at 550e8400-e29b-41d4-a716-446655440000",
@@ -3565,7 +3444,7 @@ mod tests {
 //
 // Measures how many real note/entity strings the gate blocks, so a detector
 // change can be evaluated against production content rather than intuition
-// (see the module doc and issues #632 / #577). Opens the target database
+// (see the module doc). Opens the target database
 // STRICTLY read-only (`SQLITE_OPEN_READ_ONLY`) and never mutates it. Point
 // `KHIVE_REPLAY_DB` at a copy or a live KG database file path; the harness
 // never writes, locks aggressively, or deletes anything.

--- a/crates/khive-runtime/src/secret_gate.rs
+++ b/crates/khive-runtime/src/secret_gate.rs
@@ -98,7 +98,7 @@
 //! false positive: no window-narrowing or exemption-widening scheme survives
 //! the adversarial regression corpus without also reopening a real bypass,
 //! because the caller (or an attacker) fully controls the prose between a
-//! trigger word and a payload — narrowing `TRIGGER_WINDOW` or reinstating the
+//! trigger word and a payload: narrowing `TRIGGER_WINDOW` or reinstating the
 //! structured-identifier exemption near "bare" trigger mentions both fail the
 //! same known bypass strings that motivated closing them.
 //!
@@ -107,7 +107,7 @@
 //! flagged token.
 //!
 //! The word-boundary rule above treats underscore as a BOUNDARY for bare
-//! `TRIGGER_WORDS` (`contains_bounded_word`) — deliberately different from
+//! `TRIGGER_WORDS` (`contains_bounded_word`): deliberately different from
 //! `has_standalone_token`'s rule for the word `token`, which treats
 //! underscore as a continuation so `tokenizer`/`next_token`/`token_count`
 //! stay exempt. Treating underscore as a boundary for the bare set is what
@@ -795,7 +795,7 @@ fn check_entropy_heuristic(text: &str, from: usize) -> Option<(&str, &'static st
         // UUID/content-hash and hex-credential-token checks above (neither of
         // which it weakens) and before the entropy computation, since a
         // legitimate path can exceed ENTROPY_THRESHOLD on Shannon entropy
-        // alone. The exemption applies ONLY outside trigger context — see the
+        // alone. The exemption applies ONLY outside trigger context: see the
         // module doc for why no shape-based signal can be made sound near a
         // trigger word; in trigger context this falls through to the entropy
         // heuristic below unconditionally, an accepted false-positive
@@ -1042,7 +1042,7 @@ const MAX_CASE_TRANSITION_DENSITY: f64 = 0.3;
 ///
 /// Outside credential-trigger context this shape check alone is sufficient to
 /// exempt a token from the entropy heuristic. In trigger context the caller
-/// grants NO exemption at all — see the module doc and the call site in
+/// grants NO exemption at all: see the module doc and the call site in
 /// [`check_entropy_heuristic`].
 fn is_structured_identifier(token: &str) -> bool {
     if !token.contains(|c: char| STRUCTURAL_SEPARATORS.contains(&c)) {
@@ -1984,7 +1984,7 @@ mod tests {
         );
     }
 
-    // ── Boundary-aware token= / token: — compound identifiers must pass ─────
+    // ── Boundary-aware token= / token: (compound identifiers must pass) ─────
 
     #[test]
     fn allows_next_token_high_entropy_cursor() {
@@ -2476,7 +2476,7 @@ mod tests {
     fn github_app_token_families_are_masked() {
         // ghu_ (user-to-server), ghs_ (server-to-server), and ghr_ (refresh)
         // GitHub App tokens are real credential families. They are
-        // context-free — no trigger word needed.
+        // context-free: no trigger word needed.
         let cases = [
             "ghu_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // gitleaks:allow
             "ghs_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",  // gitleaks:allow
@@ -2753,7 +2753,7 @@ mod tests {
 
     #[test]
     fn blocks_extension_suffix_bypass_secret_access_key() {
-        // A file-extension check alone would exempt this — appending `.md`
+        // A file-extension check alone would exempt this: appending `.md`
         // to a random credential must not bypass detection.
         let content = "secret_access_key abcdefghij/klmnopqrst/uvwxyzabcd/efghijk.md";
         assert!(
@@ -2829,7 +2829,7 @@ mod tests {
     fn blocks_run_splitting_bypass_attempts() {
         // Splitting a credential into short (4-6 char) runs drives EVERY
         // run's own letters-only entropy toward log2(run_len), which ordinary
-        // short English path words already sit at or near — this is exactly
+        // short English path words already sit at or near: this is exactly
         // why any per-run entropy ceiling is unsound as an exemption signal.
         // With the exemption dropped, these are blocked on full-token entropy
         // regardless of run shape.
@@ -2876,7 +2876,7 @@ mod tests {
         // Accepted tradeoff: this path's full-token Shannon entropy (4.5994)
         // exceeds ENTROPY_THRESHOLD (4.5) on its own. With the
         // structured-identifier exemption dropped in trigger context, it is
-        // blocked near an explicit credential trigger word — a deliberate,
+        // blocked near an explicit credential trigger word: a deliberate,
         // documented false positive, not a regression to fix, since no sound
         // signal exists to distinguish this from a chopped/padded credential
         // of the same shape.
@@ -2976,7 +2976,7 @@ mod tests {
         // An internal task `area_id` UUID field sitting within the trigger
         // window of the SUBSTRING "auth" inside
         // `authorized_write_requires_dominance` is not a genuine mention of
-        // the word "auth" — it is a pure substring collision with
+        // the word "auth": it is a pure substring collision with
         // "authorized". Bare trigger words match at a word boundary (see
         // `contains_bounded_word`), so `auth` does not match inside
         // `authorized`; this UUID has no trigger in its window and passes via
@@ -3325,7 +3325,7 @@ mod tests {
         // `access_key` entry (`COMPOUND_TRIGGER_WORDS`, plain substring,
         // always matched regardless of word-boundary rules), AND the bare
         // `secret` entry, because underscore is a BOUNDARY for bare
-        // `TRIGGER_WORDS` — so `secret` in `secret_access_key` is itself a
+        // `TRIGGER_WORDS`: so `secret` in `secret_access_key` is itself a
         // bounded word (bounded by the following `_`), not merely a
         // substring collision. Either path alone is sufficient; this asserts
         // the end-to-end outcome.
@@ -3342,7 +3342,7 @@ mod tests {
     //
     // Bare TRIGGER_WORDS are word-boundary-aware, but underscore must be
     // treated as a boundary rather than a word character (continuation) for
-    // this set specifically — the opposite of `has_standalone_token`'s rule
+    // this set specifically: the opposite of `has_standalone_token`'s rule
     // for `token`. Treating underscore as a continuation would silently drop
     // detection of extremely common underscore-joined credential-config
     // compounds (`SECRET_KEY=`, `auth_token=`, `signing_key=`,


### PR DESCRIPTION
Removes narration comments (restating what the next line does, stale notes) across 23 khive-runtime source files, keeping only comments that state constraints the code cannot show. A few multi-line closures collapse to single lines where comment removal made that the rustfmt-normal form. No behavior changes intended.

## Verification status

The sweep session was interrupted before its full workspace test run; CI on this PR is the authoritative gate and an independent review pass follows before ready.

Co-Authored-By: Leo <noreply@khive.ai>